### PR TITLE
fix #11246 - Cron job update calculates nextRunAtMs 24 hours late

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -118,10 +118,14 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
       job.state.runningAtMs = undefined;
       changed = true;
     }
-    const newNext = computeJobNextRunAtMs(job, now);
-    if (job.state.nextRunAtMs !== newNext) {
-      job.state.nextRunAtMs = newNext;
-      changed = true;
+    const nextRun = job.state.nextRunAtMs;
+    const isDueOrMissing = nextRun === undefined || now >= nextRun;
+    if (isDueOrMissing) {
+      const newNext = computeJobNextRunAtMs(job, now);
+      if (job.state.nextRunAtMs !== newNext) {
+        job.state.nextRunAtMs = newNext;
+        changed = true;
+      }
     }
   }
   return changed;


### PR DESCRIPTION
## Description
Fixes issue #11246 

## Changes made
fixed a bug where cron jobs could be scheduled 24 hours late if they were updated or if the service restarted exactly at their scheduled run time.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts cron next-run computation to avoid a boundary case where jobs scheduled exactly at `now` could be pushed out (reported as “24 hours late”), including:

- `computeNextRunAtMs()` now uses a 1ms lookback when calling Croner’s `nextRun()` to catch schedules that match exactly at the current time.
- `recomputeNextRuns()` only recomputes `nextRunAtMs` when the job is due or missing.
- `ops.list()` replaces `toSorted()` with a `sort()` on a copied array.
- `ops.update()` only recalculates `nextRunAtMs` when `schedule`/`enabled` are patched.

Main concerns are behavioral changes around timezone defaulting and swallowing cron parse errors, plus `recomputeNextRuns()` no longer being authoritative which can leave stale `nextRunAtMs` values intact.


<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but includes a couple behavioral changes that can mis-schedule jobs if not addressed.
- The boundary fix in `computeNextRunAtMs()` is plausible, but the patch also changes timezone fallback semantics and starts swallowing cron parsing errors, both of which can silently shift or disable schedules. Additionally, `recomputeNextRuns()` is no longer authoritative and can preserve stale `nextRunAtMs` values under realistic state-update scenarios.
- src/cron/schedule.ts and src/cron/service/jobs.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->