### PR TITLE
feat(skills): add NotebookLM skill for knowledge synthesis

### DIFF
--- a/skills/notebooklm/SKILL.md
+++ b/skills/notebooklm/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: notebooklm
+description: Google NotebookLM for knowledge synthesis — create AI podcasts, reports, quizzes, flashcards, and mind maps from your sources. Triggers: NotebookLM, podcast, summarize sources, knowledge synthesis.
+homepage: https://notebooklm.google.com
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🎙️",
+        "requires": { "bins": ["nlm"] },
+        "install":
+          [
+            {
+              "id": "pipx",
+              "kind": "pipx",
+              "package": "notebooklm-cli",
+              "bins": ["nlm"],
+              "label": "Install notebooklm-cli (pipx)",
+            },
+            {
+              "id": "pip",
+              "kind": "pip",
+              "package": "notebooklm-cli",
+              "bins": ["nlm"],
+              "label": "Install notebooklm-cli (pip)",
+            },
+          ],
+      },
+  }
+---
+
+# NotebookLM
+
+Use Google NotebookLM to synthesize knowledge from multiple sources into AI-generated podcasts, reports, quizzes, flashcards, mind maps, and more.
+
+## Setup
+
+1. Install the CLI:
+   ```bash
+   pipx install notebooklm-cli
+   # or: pip install notebooklm-cli
+   ```
+
+2. Authenticate (opens Chrome, extracts session cookies):
+   ```bash
+   nlm login
+   ```
+
+3. Verify authentication:
+   ```bash
+   nlm auth status
+   ```
+
+Requirements: Python 3.10+, Google Chrome (for auth).
+
+## Core Workflow
+
+**List notebooks:**
+
+```bash
+nlm notebook list
+```
+
+**Create a notebook:**
+
+```bash
+nlm notebook create "My Research"
+# Output: Created notebook: abc123-def456-...
+```
+
+**Add sources to a notebook:**
+
+```bash
+# Add a URL
+nlm source add <notebook-id> --url "https://example.com/article"
+
+# Add a YouTube video
+nlm source add <notebook-id> --url "https://youtube.com/watch?v=..."
+
+# Add pasted text
+nlm source add <notebook-id> --text "Your content here" --title "My Notes"
+
+# Add from Google Drive
+nlm source add <notebook-id> --drive <doc-id>
+```
+
+**List sources in a notebook:**
+
+```bash
+nlm source list <notebook-id>
+```
+
+## Content Generation
+
+All generation commands require `--confirm` to execute:
+
+**Generate AI podcast:**
+
+```bash
+nlm audio create <notebook-id> --confirm
+```
+
+**Generate report:**
+
+```bash
+nlm report create <notebook-id> --confirm
+```
+
+**Generate study materials:**
+
+```bash
+nlm quiz create <notebook-id> --confirm
+nlm flashcards create <notebook-id> --confirm
+nlm mindmap create <notebook-id> --confirm
+nlm slides create <notebook-id> --confirm
+```
+
+**Check generation status:**
+
+```bash
+nlm studio status <notebook-id>
+```
+
+## Chat & Query
+
+**Ask questions about your sources:**
+
+```bash
+nlm notebook query <notebook-id> "What are the key findings?"
+```
+
+**Interactive chat session:**
+
+```bash
+nlm chat start <notebook-id>
+# REPL commands: /sources, /clear, /help, /exit
+```
+
+## Research (Discover New Sources)
+
+**Web search for sources:**
+
+```bash
+nlm research start "query" --notebook-id <id>
+nlm research start "query" --notebook-id <id> --mode deep
+```
+
+**Search Google Drive:**
+
+```bash
+nlm research start "query" --notebook-id <id> --source drive
+```
+
+**Import discovered sources:**
+
+```bash
+nlm research import <notebook-id> <task-id>
+```
+
+## Aliases (UUID Shortcuts)
+
+Create memorable names for notebook IDs:
+
+```bash
+nlm alias set myproject abc123-def456-...
+nlm notebook list  # Shows "myproject" instead of UUID
+nlm source add myproject --url "..."
+```
+
+## Output Formats
+
+```bash
+nlm notebook list --format json
+nlm notebook list --format quiet  # IDs only
+```
+
+## AI Integration
+
+Generate full documentation for AI assistants:
+
+```bash
+nlm --ai
+```
+
+## Notes
+
+- Session cookies expire; re-run `nlm login` if needed
+- Multiple profiles supported: `nlm login --profile work`
+- Config stored in `~/.config/nlm/`

--- a/skills/notebooklm/SKILL.md
+++ b/skills/notebooklm/SKILL.md
@@ -36,12 +36,14 @@ Use Google NotebookLM to synthesize knowledge from multiple sources into AI-gene
 ## Setup
 
 1. Install the CLI:
+
    ```bash
    pipx install notebooklm-cli
    # or: pip install notebooklm-cli
    ```
 
 2. Authenticate (opens Chrome, extracts session cookies):
+
    ```bash
    nlm login
    ```


### PR DESCRIPTION
## What

Adds a new `notebooklm` skill that integrates with Google NotebookLM via [notebooklm-cli](https://github.com/jacob-bd/notebooklm-cli).

## Why

NotebookLM is a powerful knowledge synthesis tool that can:
- 🎙️ Generate AI-powered audio podcasts from your sources
- 📄 Create study materials (quizzes, flashcards, mind maps)
- 📊 Produce summary reports and slides
- 💬 Enable interactive Q&A with your knowledge base

This skill makes these capabilities accessible directly from OpenClaw.

## How

- Uses `nlm` CLI (Python package `notebooklm-cli`)
- Follows existing skill patterns (YAML frontmatter, install instructions)
- Comprehensive command reference for all NotebookLM features

## Checklist

- [ ] AI-assisted development (Claude)
- [ ] Lightly tested
- [x] Follows existing skill structure

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `notebooklm` skill by introducing `skills/notebooklm/SKILL.md`, documenting how to use the external `nlm` CLI (`notebooklm-cli`) to interact with Google NotebookLM for source ingestion, generation (audio/report/quiz/etc.), and chat/query workflows.

The primary integration point is the SKILL.md frontmatter, which OpenClaw uses for skill discovery/metadata (name/description/homepage plus OpenClaw-specific install + required binaries).

<h3>Confidence Score: 5/5</h3>

- This PR is not safe to merge as-is because the new skill metadata is likely unparsable and the skill may not load.
- The only changed file is a new SKILL.md, but its YAML frontmatter uses inline JSON with trailing commas, which will fail in typical YAML frontmatter parsing and block skill discovery. There is also a definite stray trailing quote at EOF.
- skills/notebooklm/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->