### PR TITLE
Agent fallback: check agent-scoped fallbacks and forward fallbacksOverride to runEmbeddedPiAgent (#11218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agent fallback: check agent-scoped fallbacks when determining if fallback is configured; forward `fallbacksOverride` to `runEmbeddedPiAgent` at all call sites. (#11218)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -113,6 +113,7 @@ export async function runEmbeddedPiAgent(
       const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
       const fallbackConfigured =
+        (params.fallbacksOverride?.length ?? 0) > 0 ||
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
       await ensureOpenClawModelsJson(params.config, agentDir);
 

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -69,6 +69,8 @@ export type RunEmbeddedPiAgentParams = {
   model?: string;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
+  /** Agent-level model fallbacks override (from agents.{agentId}.model.fallbacks). */
+  fallbacksOverride?: string[];
   thinkLevel?: ThinkLevel;
   verboseLevel?: VerboseLevel;
   reasoningLevel?: ReasoningLevel;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -143,15 +143,16 @@ export async function runAgentTurnWithFallback(params: {
       };
       const blockReplyPipeline = params.blockReplyPipeline;
       const onToolResult = params.opts?.onToolResult;
+      const agentFallbacksOverride = resolveAgentModelFallbacksOverride(
+        params.followupRun.run.config,
+        resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
+      );
       const fallbackResult = await runWithModelFallback({
         cfg: params.followupRun.run.config,
         provider: params.followupRun.run.provider,
         model: params.followupRun.run.model,
         agentDir: params.followupRun.run.agentDir,
-        fallbacksOverride: resolveAgentModelFallbacksOverride(
-          params.followupRun.run.config,
-          resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
-        ),
+        fallbacksOverride: agentFallbacksOverride,
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.
@@ -256,6 +257,7 @@ export async function runAgentTurnWithFallback(params: {
           return runEmbeddedPiAgent({
             sessionId: params.followupRun.run.sessionId,
             sessionKey: params.sessionKey,
+            fallbacksOverride: agentFallbacksOverride,
             agentId: params.followupRun.run.agentId,
             messageProvider: params.sessionCtx.Provider?.trim().toLowerCase() || undefined,
             agentAccountId: params.sessionCtx.AccountId,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -96,15 +96,16 @@ export async function runMemoryFlushIfNeeded(params: {
     .filter(Boolean)
     .join("\n\n");
   try {
+    const agentFallbacksOverride = resolveAgentModelFallbacksOverride(
+      params.followupRun.run.config,
+      resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
+    );
     await runWithModelFallback({
       cfg: params.followupRun.run.config,
       provider: params.followupRun.run.provider,
       model: params.followupRun.run.model,
       agentDir: params.followupRun.run.agentDir,
-      fallbacksOverride: resolveAgentModelFallbacksOverride(
-        params.followupRun.run.config,
-        resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
-      ),
+      fallbacksOverride: agentFallbacksOverride,
       run: (provider, model) => {
         const authProfileId =
           provider === params.followupRun.run.provider
@@ -113,6 +114,7 @@ export async function runMemoryFlushIfNeeded(params: {
         return runEmbeddedPiAgent({
           sessionId: params.followupRun.run.sessionId,
           sessionKey: params.sessionKey,
+          fallbacksOverride: agentFallbacksOverride,
           agentId: params.followupRun.run.agentId,
           messageProvider: params.sessionCtx.Provider?.trim().toLowerCase() || undefined,
           agentAccountId: params.sessionCtx.AccountId,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -125,21 +125,23 @@ export function createFollowupRunner(params: {
       let fallbackProvider = queued.run.provider;
       let fallbackModel = queued.run.model;
       try {
+        const agentFallbacksOverride = resolveAgentModelFallbacksOverride(
+          queued.run.config,
+          resolveAgentIdFromSessionKey(queued.run.sessionKey),
+        );
         const fallbackResult = await runWithModelFallback({
           cfg: queued.run.config,
           provider: queued.run.provider,
           model: queued.run.model,
           agentDir: queued.run.agentDir,
-          fallbacksOverride: resolveAgentModelFallbacksOverride(
-            queued.run.config,
-            resolveAgentIdFromSessionKey(queued.run.sessionKey),
-          ),
+          fallbacksOverride: agentFallbacksOverride,
           run: (provider, model) => {
             const authProfileId =
               provider === queued.run.provider ? queued.run.authProfileId : undefined;
             return runEmbeddedPiAgent({
               sessionId: queued.run.sessionId,
               sessionKey: queued.run.sessionKey,
+              fallbacksOverride: agentFallbacksOverride,
               agentId: queued.run.agentId,
               messageProvider: queued.run.messageProvider,
               agentAccountId: queued.run.agentAccountId,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -386,12 +386,13 @@ export async function agentCommand(
         opts.replyChannel ?? opts.channel,
       );
       const spawnedBy = opts.spawnedBy ?? sessionEntry?.spawnedBy;
+      const agentFallbacksOverride = resolveAgentModelFallbacksOverride(cfg, sessionAgentId);
       const fallbackResult = await runWithModelFallback({
         cfg,
         provider,
         model,
         agentDir,
-        fallbacksOverride: resolveAgentModelFallbacksOverride(cfg, sessionAgentId),
+        fallbacksOverride: agentFallbacksOverride,
         run: (providerOverride, modelOverride) => {
           if (isCliProvider(providerOverride, cfg)) {
             const cliSessionId = getCliSessionId(sessionEntry, providerOverride);
@@ -419,6 +420,7 @@ export async function agentCommand(
           return runEmbeddedPiAgent({
             sessionId,
             sessionKey,
+            fallbacksOverride: agentFallbacksOverride,
             agentId: sessionAgentId,
             messageChannel,
             agentAccountId: runContext.accountId,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -369,12 +369,13 @@ export async function runCronIsolatedAgentTurn(params: {
       verboseLevel: resolvedVerboseLevel,
     });
     const messageChannel = resolvedDelivery.channel;
+    const agentFallbacksOverride = resolveAgentModelFallbacksOverride(params.cfg, agentId);
     const fallbackResult = await runWithModelFallback({
       cfg: cfgWithAgentDefaults,
       provider,
       model,
       agentDir,
-      fallbacksOverride: resolveAgentModelFallbacksOverride(params.cfg, agentId),
+      fallbacksOverride: agentFallbacksOverride,
       run: (providerOverride, modelOverride) => {
         if (isCliProvider(providerOverride, cfgWithAgentDefaults)) {
           const cliSessionId = getCliSessionId(cronSession.sessionEntry, providerOverride);
@@ -397,6 +398,7 @@ export async function runCronIsolatedAgentTurn(params: {
         return runEmbeddedPiAgent({
           sessionId: cronSession.sessionEntry.sessionId,
           sessionKey: agentSessionKey,
+          fallbacksOverride: agentFallbacksOverride,
           agentId,
           messageChannel,
           agentAccountId: resolvedDelivery.accountId,


### PR DESCRIPTION
## Fix

Model fallback mechanism fails when fallbacks are configured at the agent level (`agents.<id>.model.fallbacks`) instead of the global level (`agents.defaults.model.fallbacks`).

**Root cause** (two parts):

1. `fallbackConfigured` in `runEmbeddedPiAgent` only checked `params.config.agents.defaults.model.fallbacks` (global), ignoring `params.fallbacksOverride` (agent-scoped). When `fallbackConfigured` is `false`, prompt errors are returned directly instead of throwing `FailoverError`, so `runWithModelFallback` never gets a chance to retry with the fallback model.

2. `fallbacksOverride` was computed by callers for `runWithModelFallback` but **never forwarded** to `runEmbeddedPiAgent`, so the parameter was always `undefined` inside the runner.

## Changes

- `src/agents/pi-embedded-runner/run/params.ts`: Add `fallbacksOverride` to `RunEmbeddedPiAgentParams`
- `src/agents/pi-embedded-runner/run.ts`: Check `params.fallbacksOverride` in `fallbackConfigured`
- `src/auto-reply/reply/agent-runner-execution.ts`: Forward `fallbacksOverride`
- `src/auto-reply/reply/agent-runner-memory.ts`: Forward `fallbacksOverride`
- `src/auto-reply/reply/followup-runner.ts`: Forward `fallbacksOverride`
- `src/commands/agent.ts`: Forward `fallbacksOverride`
- `src/cron/isolated-agent/run.ts`: Forward `fallbacksOverride`
- `CHANGELOG.md`: Add entry

## Verification

- Build passes (`pnpm build`)
- All 5028 tests pass (`pnpm test`)
- **End-to-end verification** using `runWithModelFallback` with real API calls:
  - Config: no global `agents.defaults.model.fallbacks` — only agent-level `fallbacksOverride`
  - Primary: `openai/gpt-4.1-mini` with invalid API key → 401 auth error
  - Fallback (agent-scoped): `openai/qwen-max` via DashScope API → success ("Hello")
  - Call order: `[openai/gpt-4.1-mini (401 fail), openai/qwen-max (success)]`

Fixes #11218

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes agent-scoped model fallback handling by (1) teaching the embedded PI runner to treat `params.fallbacksOverride` as “fallback configured” (so failover-worthy prompt/auth errors throw `FailoverError` and can be retried), and (2) forwarding `fallbacksOverride` from all `runWithModelFallback` call sites into `runEmbeddedPiAgent`. Updates span the embedded runner params/type, several auto-reply runners, the `openclaw agent` CLI command, and cron isolated-agent execution, plus a changelog entry.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and consistent: a new optional param is threaded through existing call sites and used only to decide whether to throw `FailoverError` for retry. No behavior changes occur unless agent-scoped fallbacks are configured. The modifications are type-safe and match the stated root cause.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->