### PR TITLE
fix: add sessionKey alias to sessions_spawn for backward compatibility

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -297,6 +297,7 @@ export function createSessionsSpawnTool(opts?: {
 
       return jsonResult({
         status: "accepted",
+        sessionKey: childSessionKey, // Backward compatibility alias
         childSessionKey,
         runId: childRunId,
         modelApplied: resolvedModel ? modelApplied : undefined,


### PR DESCRIPTION
## Problem

Cron jobs using spawn-worker.js were failing with 'No sessionKey in spawn result' because the sessions_spawn tool returns childSessionKey but callers expect sessionKey.

## Solution

Added sessionKey as an alias for childSessionKey in the sessions_spawn tool result. This ensures backward compatibility with existing callers while maintaining the more descriptive childSessionKey name.

## Testing

- Local testing confirmed the fix resolves cron spawn failures
- Both sessionKey and childSessionKey are now available in the result

## Related

This complements the local fix in spawn-worker.js that now accepts either field name for maximum compatibility.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the `sessions_spawn` tool response to include a `sessionKey` field as a backward-compatibility alias for the existing `childSessionKey`. The tool continues to return `childSessionKey` as the primary/explicit identifier, but now also returns `sessionKey` so older callers that expect `sessionKey` don’t fail.

Implementation-wise, the alias is added in the final `jsonResult({ status: "accepted", ... })` payload in `src/agents/tools/sessions-spawn-tool.ts`, and doesn’t alter spawn behavior (session key generation, gateway calls, registry bookkeeping) beyond expanding the returned result shape.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to adding an additional alias field in the `sessions_spawn` accepted response, preserving existing fields and behavior. No control flow or external side effects were modified, and the added field matches the already-generated `childSessionKey` value.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->