### PR TITLE
fix: add thinkingFormat 'qwen' compat for bailian/dashscope providers

### DIFF
--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -7,7 +7,9 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
   const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  const isBailian = model.provider === "bailian" || baseUrl.includes("dashscope.aliyuncs.com");
+
+  if ((!isZai && !isBailian) || !isOpenAiCompletionsModel(model)) {
     return model;
   }
 
@@ -17,8 +19,14 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     return model;
   }
 
-  openaiModel.compat = compat
-    ? { ...compat, supportsDeveloperRole: false }
-    : { supportsDeveloperRole: false };
+  if (isZai) {
+    openaiModel.compat = compat
+      ? { ...compat, supportsDeveloperRole: false }
+      : { supportsDeveloperRole: false };
+  } else if (isBailian) {
+    openaiModel.compat = compat
+      ? { ...compat, supportsDeveloperRole: false, thinkingFormat: "qwen" }
+      : { supportsDeveloperRole: false, thinkingFormat: "qwen" };
+  }
   return openaiModel;
 }

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -15,15 +15,14 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
 
   const openaiModel = model;
   const compat = openaiModel.compat ?? undefined;
-  if (compat?.supportsDeveloperRole === false) {
-    return model;
-  }
 
   if (isZai) {
+    // Z.ai only needs supportsDeveloperRole: false
     openaiModel.compat = compat
       ? { ...compat, supportsDeveloperRole: false }
       : { supportsDeveloperRole: false };
   } else if (isBailian) {
+    // Bailian/DashScope needs both supportsDeveloperRole: false and thinkingFormat: "qwen"
     openaiModel.compat = compat
       ? { ...compat, supportsDeveloperRole: false, thinkingFormat: "qwen" }
       : { supportsDeveloperRole: false, thinkingFormat: "qwen" };

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -11,6 +11,7 @@ export type ModelCompatConfig = {
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
+  thinkingFormat?: "openai" | "qwen" | "zai";
 };
 
 export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -18,6 +18,7 @@ export const ModelCompatSchema = z
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),
+    thinkingFormat: z.union([z.literal("openai"), z.literal("qwen"), z.literal("zai")]).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Add `thinkingFormat: "qwen"` to model compat for `bailian` provider and `dashscope.aliyuncs.com` base URLs
- DashScope models (e.g. kimi-k2.5) require `enable_thinking: true` instead of OpenAI-style `reasoning_effort` for thinking/reasoning mode

## Problem

When `reasoning: true` is set for a model using the bailian/dashscope provider, the system sends `reasoning_effort` (OpenAI style) which dashscope doesn't support. This causes API errors that are caught by the role-ordering error handler, resulting in a confusing "Message ordering conflict" error message to the user.

## Fix

In `normalizeModelCompat()`, detect bailian/dashscope providers (by provider name or base URL) and automatically set `thinkingFormat: "qwen"` in the model compat config. This ensures `pi-ai` sends `enable_thinking: true` instead of `reasoning_effort` for these providers, matching the existing pattern for Z.ai compat handling.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change extends `normalizeModelCompat()` (`src/agents/model-compat.ts`) to treat `bailian`/`dashscope.aliyuncs.com` like Z.ai models for compat normalization, and additionally attempts to set `thinkingFormat: "qwen"` so DashScope models use Qwen-style thinking (`enable_thinking`) instead of OpenAI-style `reasoning_effort`.

The intent fits the existing pattern where provider/baseUrl-specific compat is centralized in `normalizeModelCompat()`, but the current implementation introduces a schema/type mismatch for `thinkingFormat` and an early-return path that can prevent the bailian-specific compat from being applied when users set `supportsDeveloperRole: false` explicitly.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a compat schema/type mismatch and a logic path that can bypass the bailian fix.
- `thinkingFormat` is written into `model.compat` but is not part of `ModelCompatConfig` or the strict Zod `ModelCompatSchema`, which will cause validation failures where schema validation is applied. Additionally, the early return when `supportsDeveloperRole` is explicitly false prevents bailian models from receiving the intended `thinkingFormat` normalization in that configuration.
- src/agents/model-compat.ts; also update src/config/types.models.ts and src/config/zod-schema.core.ts if `thinkingFormat` is intended to be a supported compat key.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->