### PR TITLE
docs(zh-CN): add missing translations for providers and start guides

### DIFF
--- a/docs/zh-CN/providers/cloudflare-ai-gateway.md
+++ b/docs/zh-CN/providers/cloudflare-ai-gateway.md
@@ -1,0 +1,71 @@
+---
+title: "Cloudflare AI Gateway"
+summary: "Cloudflare AI Gateway 配置（认证 + 模型选择）"
+read_when:
+  - 你想在 OpenClaw 中使用 Cloudflare AI Gateway
+  - 你需要账户 ID、网关 ID 或 API 密钥环境变量
+---
+
+# Cloudflare AI Gateway
+
+Cloudflare AI Gateway 位于服务商 API 前端，可为你添加分析、缓存和访问控制。对于 Anthropic，OpenClaw 通过你的 Gateway 端点使用 Anthropic Messages API。
+
+- 服务商：`cloudflare-ai-gateway`
+- 基础 URL：`https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/anthropic`
+- 默认模型：`cloudflare-ai-gateway/claude-sonnet-4-5`
+- API 密钥：`CLOUDFLARE_AI_GATEWAY_API_KEY`（用于通过 Gateway 发送请求的服务商 API 密钥）
+
+对于 Anthropic 模型，请使用你的 Anthropic API 密钥。
+
+## 快速开始
+
+1. 设置服务商 API 密钥和 Gateway 详情：
+
+```bash
+openclaw onboard --auth-choice cloudflare-ai-gateway-api-key
+```
+
+2. 设置默认模型：
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "cloudflare-ai-gateway/claude-sonnet-4-5" },
+    },
+  },
+}
+```
+
+## 非交互式示例
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice cloudflare-ai-gateway-api-key \
+  --cloudflare-ai-gateway-account-id "your-account-id" \
+  --cloudflare-ai-gateway-gateway-id "your-gateway-id" \
+  --cloudflare-ai-gateway-api-key "$CLOUDFLARE_AI_GATEWAY_API_KEY"
+```
+
+## 认证网关
+
+如果你在 Cloudflare 中启用了 Gateway 认证，需要添加 `cf-aig-authorization` 头（这是额外的，与服务商 API 密钥一起使用）。
+
+```json5
+{
+  models: {
+    providers: {
+      "cloudflare-ai-gateway": {
+        headers: {
+          "cf-aig-authorization": "Bearer <cloudflare-ai-gateway-token>",
+        },
+      },
+    },
+  },
+}
+```
+
+## 环境变量注意事项
+
+如果 Gateway 作为守护进程运行（launchd/systemd），请确保 `CLOUDFLARE_AI_GATEWAY_API_KEY` 对该进程可用（例如，在 `~/.openclaw/.env` 中或通过 `env.shellEnv`）。

--- a/docs/zh-CN/providers/qianfan.md
+++ b/docs/zh-CN/providers/qianfan.md
@@ -1,8 +1,37 @@
 ---
-summary: 使用千帆统一 API 在 OpenClaw 中接入多种模型
-title: 千帆（Qianfan）
+summary: "使用千帆的统一 API 在 OpenClaw 中访问多种模型"
+read_when:
+  - 你想用一个 API 密钥访问多种大语言模型
+  - 你需要百度千帆的配置指南
+title: "千帆"
 ---
 
-# 千帆（Qianfan）
+# 千帆服务商指南
 
-该页面是英文文档的中文占位版本，完整内容请先参考英文版：[Qianfan](/providers/qianfan)。
+千帆是百度的 MaaS 平台，提供**统一 API**，可将请求路由到单一端点和 API 密钥背后的多种模型。它兼容 OpenAI API，因此大多数 OpenAI SDK 只需更换 base URL 即可使用。
+
+## 前提条件
+
+1. 拥有千帆 API 访问权限的百度云账号
+2. 来自千帆控制台的 API 密钥
+3. 系统已安装 OpenClaw
+
+## 获取 API 密钥
+
+1. 访问 [千帆控制台](https://console.bce.baidu.com/qianfan/ais/console/apiKey)
+2. 创建新应用或选择已有应用
+3. 生成 API 密钥（格式：`bce-v3/ALTAK-...`）
+4. 复制 API 密钥用于 OpenClaw
+
+## CLI 配置
+
+```bash
+openclaw onboard --auth-choice qianfan-api-key
+```
+
+## 相关文档
+
+- [OpenClaw 配置](/configuration)
+- [模型服务商](/concepts/model-providers)
+- [Agent 配置](/concepts/agent)
+- [千帆 API 文档](https://cloud.baidu.com/doc/qianfan-api/s/3m7of64lb)

--- a/docs/zh-CN/start/bootstrapping.md
+++ b/docs/zh-CN/start/bootstrapping.md
@@ -1,9 +1,35 @@
 ---
-summary: 智能体引导流程：首次运行时如何初始化工作区与身份文件
-title: 智能体引导
-sidebarTitle: 引导
+summary: "Agent 引导仪式，用于创建工作空间和身份文件"
+read_when:
+  - 了解首次运行 agent 时发生的事情
+  - 了解引导文件的存放位置
+  - 调试入门身份设置
+title: "Agent 引导"
+sidebarTitle: "引导"
 ---
 
-# 智能体引导
+# Agent 引导
 
-该页面是英文文档的中文占位版本，完整内容请先参考英文版：[Agent Bootstrapping](/start/bootstrapping)。
+引导（Bootstrapping）是**首次运行**时的仪式，用于准备 agent 工作空间并收集身份信息。它在入门配置完成后、agent 首次启动时进行。
+
+## 引导做什么
+
+首次运行 agent 时，OpenClaw 会引导工作空间（默认 `~/.openclaw/workspace`）：
+
+- 创建 `AGENTS.md`、`BOOTSTRAP.md`、`IDENTITY.md`、`USER.md`。
+- 运行简短的问答仪式（每次一个问题）。
+- 将身份和偏好写入 `IDENTITY.md`、`USER.md`、`SOUL.md`。
+- 完成后删除 `BOOTSTRAP.md`，确保只运行一次。
+
+## 运行位置
+
+引导始终在 **gateway 主机** 上运行。如果 macOS 应用连接到远程 Gateway，工作空间和引导文件将位于该远程机器上。
+
+<Note>
+当 Gateway 运行在另一台机器上时，请在 gateway 主机上编辑工作空间文件（例如 `user@gateway-host:~/.openclaw/workspace`）。
+</Note>
+
+## 相关文档
+
+- macOS 应用入门：[入门配置](/start/onboarding)
+- 工作空间布局：[Agent 工作空间](/concepts/agent-workspace)

--- a/docs/zh-CN/start/wizard-cli-automation.md
+++ b/docs/zh-CN/start/wizard-cli-automation.md
@@ -1,0 +1,140 @@
+---
+summary: "用于 OpenClaw CLI 的脚本化入门和 agent 配置"
+read_when:
+  - 你正在脚本或 CI 中自动化入门流程
+  - 你需要针对特定服务商的非交互式示例
+title: "CLI 自动化"
+sidebarTitle: "CLI 自动化"
+---
+
+# CLI 自动化
+
+使用 `--non-interactive` 参数自动化 `openclaw onboard`。
+
+<Note>
+`--json` 不意味着非交互模式。脚本中请使用 `--non-interactive`（以及 `--workspace`）。
+</Note>
+
+## 基础非交互式示例
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice apiKey \
+  --anthropic-api-key "$ANTHROPIC_API_KEY" \
+  --gateway-port 18789 \
+  --gateway-bind loopback \
+  --install-daemon \
+  --daemon-runtime node \
+  --skip-skills
+```
+
+添加 `--json` 可获得机器可读的摘要。
+
+## 不同服务商示例
+
+<AccordionGroup>
+  <Accordion title="Gemini 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice gemini-api-key \
+      --gemini-api-key "$GEMINI_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  <Accordion title="Z.AI 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice zai-api-key \
+      --zai-api-key "$ZAI_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  <Accordion title="Vercel AI Gateway 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice ai-gateway-api-key \
+      --ai-gateway-api-key "$AI_GATEWAY_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  <Accordion title="Cloudflare AI Gateway 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice cloudflare-ai-gateway-api-key \
+      --cloudflare-ai-gateway-account-id "your-account-id" \
+      --cloudflare-ai-gateway-gateway-id "your-gateway-id" \
+      --cloudflare-ai-gateway-api-key "$CLOUDFLARE_AI_GATEWAY_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  <Accordion title="Moonshot 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice moonshot-api-key \
+      --moonshot-api-key "$MOONSHOT_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  <Accordion title="Synthetic 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice synthetic-api-key \
+      --synthetic-api-key "$SYNTHETIC_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  <Accordion title="OpenCode Zen 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice opencode-zen \
+      --opencode-zen-api-key "$OPENCODE_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## 添加其他 agent
+
+使用 `openclaw agents add <name>` 创建一个独立的 agent，拥有自己的工作空间、会话和认证配置。不带 `--workspace` 运行会启动向导。
+
+```bash
+openclaw agents add work \
+  --workspace ~/.openclaw/workspace-work \
+  --model openai/gpt-5.2 \
+  --bind whatsapp:biz \
+  --non-interactive \
+  --json
+```
+
+设置的内容：
+
+- `agents.list[].name`
+- `agents.list[].workspace`
+- `agents.list[].agentDir`
+
+注意事项：
+
+- 默认工作空间遵循 `~/.openclaw/workspace-<agentId>` 格式。
+- 添加 `bindings` 来路由入站消息（向导可以完成此操作）。
+- 非交互式参数：`--model`、`--agent-dir`、`--bind`、`--non-interactive`。
+
+## 相关文档
+
+- 入门中心：[入门向导 (CLI)](/start/wizard)
+- 完整参考：[CLI 入门参考](/start/wizard-cli-reference)
+- 命令参考：[`openclaw onboard`](/cli/onboard)

--- a/docs/zh-CN/start/wizard-cli-reference.md
+++ b/docs/zh-CN/start/wizard-cli-reference.md
@@ -1,0 +1,245 @@
+---
+summary: "CLI 入门流程、认证/模型设置、输出和内部机制的完整参考"
+read_when:
+  - 你需要 openclaw onboard 的详细行为说明
+  - 你正在调试入门结果或集成入门客户端
+title: "CLI 入门参考"
+sidebarTitle: "CLI 参考"
+---
+
+# CLI 入门参考
+
+本页是 `openclaw onboard` 的完整参考。
+简短指南请参阅 [入门向导 (CLI)](/start/wizard)。
+
+## 向导功能
+
+本地模式（默认）会引导你完成：
+
+- 模型和认证设置（OpenAI Code 订阅 OAuth、Anthropic API 密钥或 setup token，以及 MiniMax、GLM、Moonshot 和 AI Gateway 选项）
+- 工作空间位置和引导文件
+- Gateway 设置（端口、绑定、认证、tailscale）
+- 渠道和服务商（Telegram、WhatsApp、Discord、Google Chat、Mattermost 插件、Signal）
+- 守护进程安装（LaunchAgent 或 systemd 用户单元）
+- 健康检查
+- Skills 配置
+
+远程模式配置本机连接到其他位置的 gateway。
+它不会在远程主机上安装或修改任何内容。
+
+## 本地流程详情
+
+<Steps>
+  <Step title="现有配置检测">
+    - 如果 `~/.openclaw/openclaw.json` 存在，选择保留、修改或重置。
+    - 重新运行向导不会清除任何内容，除非你明确选择重置（或传入 `--reset`）。
+    - 如果配置无效或包含遗留键，向导会停止并要求你运行 `openclaw doctor` 后再继续。
+    - 重置使用 `trash` 并提供范围选项：
+      - 仅配置
+      - 配置 + 凭证 + 会话
+      - 完全重置（也删除工作空间）
+  </Step>
+  <Step title="模型和认证">
+    - 完整选项矩阵见 [认证和模型选项](#认证和模型选项)。
+  </Step>
+  <Step title="工作空间">
+    - 默认 `~/.openclaw/workspace`（可配置）。
+    - 创建首次运行引导仪式所需的工作空间文件。
+    - 工作空间布局：[Agent 工作空间](/concepts/agent-workspace)。
+  </Step>
+  <Step title="Gateway">
+    - 提示输入端口、绑定、认证模式和 tailscale 暴露。
+    - 建议：即使对于 loopback 也保持 token 认证启用，以便本地 WS 客户端必须认证。
+    - 仅在完全信任每个本地进程时禁用认证。
+    - 非 loopback 绑定仍需要认证。
+  </Step>
+  <Step title="渠道">
+    - [WhatsApp](/channels/whatsapp)：可选 QR 登录
+    - [Telegram](/channels/telegram)：bot token
+    - [Discord](/channels/discord)：bot token
+    - [Google Chat](/channels/googlechat)：服务账号 JSON + webhook audience
+    - [Mattermost](/channels/mattermost) 插件：bot token + base URL
+    - [Signal](/channels/signal)：可选 `signal-cli` 安装 + 账号配置
+    - [BlueBubbles](/channels/bluebubbles)：推荐用于 iMessage；服务器 URL + 密码 + webhook
+    - [iMessage](/channels/imessage)：旧版 `imsg` CLI 路径 + 数据库访问
+    - DM 安全：默认为配对模式。首次 DM 发送验证码；通过 `openclaw pairing approve <channel> <code>` 批准或使用白名单。
+  </Step>
+  <Step title="守护进程安装">
+    - macOS：LaunchAgent
+      - 需要用户登录会话；对于无头服务器，使用自定义 LaunchDaemon（未附带）。
+    - Linux 和 Windows（通过 WSL2）：systemd 用户单元
+      - 向导尝试 `loginctl enable-linger <user>` 以便注销后 gateway 保持运行。
+      - 可能需要 sudo（写入 `/var/lib/systemd/linger`）；会先尝试不使用 sudo。
+    - 运行时选择：Node（推荐；WhatsApp 和 Telegram 必需）。不推荐 Bun。
+  </Step>
+  <Step title="健康检查">
+    - 启动 gateway（如需要）并运行 `openclaw health`。
+    - `openclaw status --deep` 在状态输出中添加 gateway 健康探测。
+  </Step>
+  <Step title="Skills">
+    - 读取可用 skills 并检查依赖。
+    - 让你选择 node 管理器：npm 或 pnpm（不推荐 bun）。
+    - 安装可选依赖（部分在 macOS 上使用 Homebrew）。
+  </Step>
+  <Step title="完成">
+    - 摘要和后续步骤，包括 iOS、Android 和 macOS 应用选项。
+  </Step>
+</Steps>
+
+<Note>
+如果未检测到 GUI，向导会打印用于 Control UI 的 SSH 端口转发指令，而不是打开浏览器。
+如果 Control UI 资源缺失，向导会尝试构建它们；备用方案是 `pnpm ui:build`（自动安装 UI 依赖）。
+</Note>
+
+## 远程模式详情
+
+远程模式配置本机连接到其他位置的 gateway。
+
+<Info>
+远程模式不会在远程主机上安装或修改任何内容。
+</Info>
+
+设置的内容：
+
+- 远程 gateway URL（`ws://...`）
+- Token（如果远程 gateway 需要认证，推荐）
+
+<Note>
+- 如果 gateway 仅限 loopback，使用 SSH 隧道或 tailnet。
+- 发现提示：
+  - macOS：Bonjour（`dns-sd`）
+  - Linux：Avahi（`avahi-browse`）
+</Note>
+
+## 认证和模型选项
+
+<AccordionGroup>
+  <Accordion title="Anthropic API 密钥（推荐）">
+    使用 `ANTHROPIC_API_KEY`（如存在）或提示输入密钥，然后保存供守护进程使用。
+  </Accordion>
+  <Accordion title="Anthropic OAuth (Claude Code CLI)">
+    - macOS：检查 Keychain 项 "Claude Code-credentials"
+    - Linux 和 Windows：重用 `~/.claude/.credentials.json`（如存在）
+
+    在 macOS 上，选择"始终允许"以便 launchd 启动不会阻塞。
+
+  </Accordion>
+  <Accordion title="Anthropic token (setup-token 粘贴)">
+    在任何机器上运行 `claude setup-token`，然后粘贴 token。
+    可以命名；留空使用默认值。
+  </Accordion>
+  <Accordion title="OpenAI Code 订阅 (Codex CLI 重用)">
+    如果 `~/.codex/auth.json` 存在，向导可以重用它。
+  </Accordion>
+  <Accordion title="OpenAI Code 订阅 (OAuth)">
+    浏览器流程；粘贴 `code#state`。
+
+    当模型未设置或为 `openai/*` 时，设置 `agents.defaults.model` 为 `openai-codex/gpt-5.3-codex`。
+
+  </Accordion>
+  <Accordion title="OpenAI API 密钥">
+    使用 `OPENAI_API_KEY`（如存在）或提示输入密钥，然后保存到
+    `~/.openclaw/.env` 以便 launchd 可以读取。
+
+    当模型未设置、为 `openai/*` 或 `openai-codex/*` 时，设置 `agents.defaults.model` 为 `openai/gpt-5.1-codex`。
+
+  </Accordion>
+  <Accordion title="xAI (Grok) API 密钥">
+    提示输入 `XAI_API_KEY` 并配置 xAI 作为模型服务商。
+  </Accordion>
+  <Accordion title="OpenCode Zen">
+    提示输入 `OPENCODE_API_KEY`（或 `OPENCODE_ZEN_API_KEY`）。
+    配置 URL：[opencode.ai/auth](https://opencode.ai/auth)。
+  </Accordion>
+  <Accordion title="API 密钥（通用）">
+    为你保存密钥。
+  </Accordion>
+  <Accordion title="Vercel AI Gateway">
+    提示输入 `AI_GATEWAY_API_KEY`。
+    更多详情：[Vercel AI Gateway](/providers/vercel-ai-gateway)。
+  </Accordion>
+  <Accordion title="Cloudflare AI Gateway">
+    提示输入账户 ID、网关 ID 和 `CLOUDFLARE_AI_GATEWAY_API_KEY`。
+    更多详情：[Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)。
+  </Accordion>
+  <Accordion title="MiniMax M2.1">
+    配置自动写入。
+    更多详情：[MiniMax](/providers/minimax)。
+  </Accordion>
+  <Accordion title="Synthetic (Anthropic 兼容)">
+    提示输入 `SYNTHETIC_API_KEY`。
+    更多详情：[Synthetic](/providers/synthetic)。
+  </Accordion>
+  <Accordion title="Moonshot 和 Kimi Coding">
+    Moonshot (Kimi K2) 和 Kimi Coding 配置自动写入。
+    更多详情：[Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)。
+  </Accordion>
+  <Accordion title="跳过">
+    保持认证未配置。
+  </Accordion>
+</AccordionGroup>
+
+模型行为：
+
+- 从检测到的选项中选择默认模型，或手动输入服务商和模型。
+- 向导运行模型检查，如果配置的模型未知或缺少认证会发出警告。
+
+凭证和配置文件路径：
+
+- OAuth 凭证：`~/.openclaw/credentials/oauth.json`
+- 认证配置文件（API 密钥 + OAuth）：`~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
+
+<Note>
+无头服务器提示：在有浏览器的机器上完成 OAuth，然后将
+`~/.openclaw/credentials/oauth.json`（或 `$OPENCLAW_STATE_DIR/credentials/oauth.json`）
+复制到 gateway 主机。
+</Note>
+
+## 输出和内部机制
+
+`~/.openclaw/openclaw.json` 中的典型字段：
+
+- `agents.defaults.workspace`
+- `agents.defaults.model` / `models.providers`（如果选择了 Minimax）
+- `gateway.*`（mode、bind、auth、tailscale）
+- `channels.telegram.botToken`、`channels.discord.token`、`channels.signal.*`、`channels.imessage.*`
+- 渠道白名单（Slack、Discord、Matrix、Microsoft Teams），在提示时选择加入（名称尽可能解析为 ID）
+- `skills.install.nodeManager`
+- `wizard.lastRunAt`
+- `wizard.lastRunVersion`
+- `wizard.lastRunCommit`
+- `wizard.lastRunCommand`
+- `wizard.lastRunMode`
+
+`openclaw agents add` 写入 `agents.list[]` 和可选的 `bindings`。
+
+WhatsApp 凭证存放在 `~/.openclaw/credentials/whatsapp/<accountId>/`。
+会话存储在 `~/.openclaw/agents/<agentId>/sessions/`。
+
+<Note>
+部分渠道作为插件提供。入门时选择后，向导会提示安装插件（npm 或本地路径），然后再进行渠道配置。
+</Note>
+
+Gateway 向导 RPC：
+
+- `wizard.start`
+- `wizard.next`
+- `wizard.cancel`
+- `wizard.status`
+
+客户端（macOS 应用和 Control UI）可以渲染步骤而无需重新实现入门逻辑。
+
+Signal 配置行为：
+
+- 下载相应的发布资源
+- 存储在 `~/.openclaw/tools/signal-cli/<version>/`
+- 在配置中写入 `channels.signal.cliPath`
+- JVM 构建需要 Java 21
+- 可用时使用原生构建
+- Windows 使用 WSL2，在 WSL 内遵循 Linux signal-cli 流程
+
+## 相关文档
+
+- 入门中心：[入门向导 (CLI)](/start/wizard)
+- 自动化和脚本：[CLI 自动化](/start/wizard-cli-automation)
+- 命令参考：[`openclaw onboard`](/cli/onboard)


### PR DESCRIPTION
## Summary

Add Chinese (zh-CN) translations for 5 missing documentation files to achieve parity with English docs.

## Added Translations

### Providers (2 files)
- `docs/zh-CN/providers/cloudflare-ai-gateway.md` - Cloudflare AI Gateway 配置指南
- `docs/zh-CN/providers/qianfan.md` - 百度千帆服务商指南

### Start Guides (3 files)
- `docs/zh-CN/start/bootstrapping.md` - Agent 引导流程
- `docs/zh-CN/start/wizard-cli-automation.md` - CLI 自动化入门
- `docs/zh-CN/start/wizard-cli-reference.md` - CLI 入门完整参考

## Stats

- 5 new files
- ~528 lines of translated documentation

## Notes

This PR brings the zh-CN documentation closer to parity with the English version.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds five new Simplified Chinese documentation pages under `docs/zh-CN/` to bring translations closer to parity with the existing English docs. The new pages cover two providers (Cloudflare AI Gateway, Baidu Qianfan) and three onboarding/start guides (bootstrapping, CLI automation, CLI onboarding reference). These files mirror the structure and examples of their English counterparts under `docs/` (non-localized).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to adding new zh-CN documentation files. The content closely matches existing English docs and uses the same commands/flags and internal paths; no code or configuration logic is modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->