### PR TITLE
Fix/qmd memory search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,6 @@ USER.md
 .serena/
 
 # Agent credentials and memory (NEVER COMMIT)
-memory/
+/memory/
 .agent/*.json
 !.agent/workflows/

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -262,15 +262,14 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
     }
 
-    const outTrim = stdout.trim();
-    if (outTrim.toLowerCase().startsWith("no results found")) {
-      return [];
-    }
-
     let parsed: QmdQueryResult[] = [];
     try {
       parsed = JSON.parse(stdout);
     } catch (err) {
+      // If JSON parse fails, check if the output indicates "no results" (even with prefix/warnings).
+      if (stdout.toLowerCase().includes("no results found")) {
+        return [];
+      }
       const message = err instanceof Error ? err.message : String(err);
       log.warn(`qmd returned invalid JSON: ${message}`);
       throw new Error(`qmd returned invalid JSON: ${message}`, { cause: err });

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -234,7 +234,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
-    const modeRaw = process.env.OPENCLAW_QMD_MODE?.trim().toLowerCase();
+    // Read mode from the same env object used to spawn qmd to avoid surprises if the runtime injects env.
+    const modeRaw = this.env.OPENCLAW_QMD_MODE?.trim().toLowerCase();
     const primaryCmd = modeRaw === "search" ? "search" : "query";
     const args = [primaryCmd, trimmed, "--json", "-n", String(limit)];
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -234,7 +234,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
-    const args = ["query", trimmed, "--json", "-n", String(limit)];
+    const args = ["search", trimmed, "--json", "-n", String(limit)];
     let stdout: string;
     try {
       const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
@@ -243,6 +243,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       log.warn(`qmd query failed: ${String(err)}`);
       throw err instanceof Error ? err : new Error(String(err));
     }
+    const outTrim = stdout.trim();
+    if (outTrim.toLowerCase().startsWith("no results found")) {
+      return [];
+    }
+
     let parsed: QmdQueryResult[] = [];
     try {
       parsed = JSON.parse(stdout);


### PR DESCRIPTION
修复 QMD / memory_search backend（qmd query 可降级为 qmd search + “No results found.” 兼容）

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the QMD memory search backend to support selecting between `qmd query` and `qmd search` (via an env flag), adds a fallback from `query` to `search` on failure/timeouts, and treats the CLI’s `No results found.` text output as an empty result set. It also tweaks `.gitignore` to only ignore the top-level `/memory/` directory.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one environment-consistency concern to address.
- The behavioral changes are localized to `QmdMemoryManager.search()` and appear intended (fallback + no-results handling). The main risk is that mode selection reads from global `process.env` while QMD is spawned with a separate `this.env`, which can lead to surprising mode behavior if the app relies on injected env/config instead of global env.
- src/memory/qmd-manager.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->