### PR TITLE
feishu: cache bot info to reduce probe API calls (feishu set low quota)

### DIFF
--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -1,6 +1,42 @@
 import type { FeishuProbeResult } from "./types.js";
 import { createFeishuClient, type FeishuClientCredentials } from "./client.js";
 
+// Cache bot info for 24 hours to minimize quota-consuming API calls.
+//
+// The Feishu free tier allows 10,000 basic API calls/month. Without caching,
+// periodic health probes (every 60s) would consume ~43,200 calls/month per account,
+// far exceeding the quota limit.
+//
+// Strategy:
+// - Cache hit (< 24h): Validate auth via token manager (quota-exempt endpoint)
+// - Cache miss (> 24h): Refresh bot info via GET /bot/v3/info (quota-consuming)
+//
+// This reduces quota usage to ~30 calls/month per account (99.9%+ reduction)
+// while ensuring bot info stays current (daily refresh) and auth health is
+// continuously monitored (every 60s via token validation).
+//
+// Cache key uses appId:domain (credential-based) so credential rotations
+// automatically invalidate stale entries via new cache key.
+type BotInfoCacheEntry = {
+  botName?: string;
+  botOpenId?: string;
+  expires: number;
+};
+
+const botInfoCache = new Map<string, BotInfoCacheEntry>();
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MAX_CACHE_SIZE = 64;
+
+/**
+ * Build cache key from credentials.
+ * Bot info is app-level (appId), not account-level.
+ * Domain matters because Feishu and Lark are separate endpoints.
+ */
+function buildCacheKey(creds: FeishuClientCredentials): string {
+  const domain = creds.domain ?? "feishu";
+  return `${creds.appId}:${domain}`;
+}
+
 export async function probeFeishu(creds?: FeishuClientCredentials): Promise<FeishuProbeResult> {
   if (!creds?.appId || !creds?.appSecret) {
     return {
@@ -11,7 +47,40 @@ export async function probeFeishu(creds?: FeishuClientCredentials): Promise<Feis
 
   try {
     const client = createFeishuClient(creds);
-    // Use bot/v3/info API to get bot information
+    const cacheKey = buildCacheKey(creds);
+
+    // After the first successful probe we cache bot metadata and switch to
+    // a lightweight token-validity check for subsequent calls.  The SDK's
+    // TokenManager keeps the tenant_access_token in memory (~2 h TTL) and
+    // only refreshes via POST /auth/v3/tenant_access_token/internal — an
+    // auth-infrastructure endpoint that does not consume the basic-API-call
+    // quota.
+    const cached = botInfoCache.get(cacheKey);
+    if (cached && cached.expires > Date.now()) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing internal SDK tokenManager
+        const token = await (client as any).tokenManager.getTenantAccessToken();
+        if (!token || typeof token !== "string" || token.trim().length === 0) {
+          // Token invalid - invalidate cache and re-probe
+          botInfoCache.delete(cacheKey);
+          // Fall through to full probe below
+        } else {
+          // Token valid - return cached bot info
+          return {
+            ok: true,
+            appId: creds.appId,
+            botName: cached.botName,
+            botOpenId: cached.botOpenId,
+          };
+        }
+      } catch (err) {
+        // Auth error (revoked credentials) - invalidate and re-probe
+        botInfoCache.delete(cacheKey);
+        // Fall through to full probe below
+      }
+    }
+
+    // First probe: use bot/v3/info API to get bot information
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK generic request method
     const response = await (client as any).request({
       method: "GET",
@@ -28,6 +97,22 @@ export async function probeFeishu(creds?: FeishuClientCredentials): Promise<Feis
     }
 
     const bot = response.bot || response.data?.bot;
+
+    // Cache bot info for future lightweight probes
+    botInfoCache.set(cacheKey, {
+      botName: bot?.bot_name,
+      botOpenId: bot?.open_id,
+      expires: Date.now() + CACHE_TTL_MS,
+    });
+
+    // Evict oldest entry if exceeds size cap (LRU-style)
+    if (botInfoCache.size > MAX_CACHE_SIZE) {
+      const oldest = botInfoCache.keys().next().value;
+      if (oldest !== undefined) {
+        botInfoCache.delete(oldest);
+      }
+    }
+
     return {
       ok: true,
       appId: creds.appId,
@@ -41,4 +126,12 @@ export async function probeFeishu(creds?: FeishuClientCredentials): Promise<Feis
       error: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+/**
+ * Clear the bot info cache (for testing).
+ * Exported to match pattern from BlueBubbles cache.
+ */
+export function clearBotInfoCache(): void {
+  botInfoCache.clear();
 }


### PR DESCRIPTION
Fixes #10549
  Fixes #10041

## Summary

  The gateway's periodic health refresh (`HEALTH_REFRESH_INTERVAL_MS = 60000`) calls `probeFeishu()` every 60 seconds, which hits `GET /open-apis/bot/v3/info`
  each time. On Feishu's free tier the monthly "basic API call" quota is 10,000 — the probe alone burns through ~43,200 calls/month (1,440/day), exhausting the
  quota in under a week and causing Error 99991403.

  ### Why Feishu needs this and other channels don't

  All channels (Discord, Telegram, Slack, etc.) share the same 60-second probe pattern, but only Feishu enforces a hard **monthly API call cap**. Discord,
  Telegram, and Slack use per-second rate limits with no monthly ceiling, so their probes are effectively free. Feishu's free tier counts every server API call
  toward a shared 10,000/month budget.

  ## What this PR does

  After the first successful `bot/v3/info` call per account, cache the bot metadata (`botName`, `botOpenId`) in memory. Subsequent probes validate connectivity
  via the Lark SDK's internal `TokenManager.getTenantAccessToken()`, which:

  - Returns from in-memory cache most of the time (~2 h TTL)
  - On cache miss, refreshes via `POST /auth/v3/tenant_access_token/internal` — an auth infrastructure endpoint that does not count toward the basic API call
  quota

  | | Before | After |
  |---|---|---|
  | `bot/v3/info` calls/day | ~1,440 | 1 (startup) |
  | Token refreshes/day | ~12 (SDK internal) | ~12 (unchanged, quota-exempt) |
  | Monthly quota usage | ~43,200 | ~1 |

  No change to bot metadata freshness — bot name and open_id are stable per app lifecycle and re-fetched on every gateway restart.

  ## Test plan

  - [x] `pnpm build` passes
  - [x] `pnpm lint` passes (0 warnings, 0 errors)
  - [x] `pnpm test` — 840 passed, 8 failed (pre-existing memory/LanceDB failures on main, unrelated)
  - [x] Deployed to live server, verified `openclaw channels status --probe` reports Feishu `works`
  - [x] Confirmed zero `bot/v3/info` calls in logs after initial startup probe (monitored 2+ minutes)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements TTL-based caching of Feishu bot info to reduce API quota consumption from ~43,200 calls/month to ~30 calls/month. After the first successful probe, cached bot metadata is reused and connectivity is validated via the SDK's internal token manager (quota-exempt). The cache key now properly uses `appId:domain` to handle credential rotations, and token validation explicitly checks for non-empty strings before returning success. Includes LRU-style eviction with a 64-entry cap and a `clearBotInfoCache()` export for testing.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation addresses the Feishu quota exhaustion issue with a well-reasoned caching strategy. Previous review concerns about token validation and cache key design have been resolved (explicit token validation on lines 63-66, credential-based cache key on lines 35-37). The fall-through pattern properly invalidates stale cache entries. Minor risk remains from relying on internal SDK APIs (`tokenManager.getTenantAccessToken()`), but this is mitigated by explicit validation and fallback to full probe on errors.
- No files require special attention

<sub>Last reviewed commit: ac74ea3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->