### PR TITLE
fix(logging): remove redundant subsystem prefix from log output

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -133,11 +133,13 @@ export function getChildLogger(
   const base = getLogger();
   const minLevel = opts?.level ? levelToMinLevel(opts.level) : undefined;
   const name = bindings ? JSON.stringify(bindings) : undefined;
-  return base.getSubLogger({
+  const subOpts: { name?: string; minLevel?: number } = {
     name,
-    minLevel,
-    prefix: bindings ? [name ?? ""] : [],
-  });
+  };
+  if (minLevel !== undefined) {
+    subOpts.minLevel = minLevel;
+  }
+  return base.getSubLogger(subOpts);
 }
 
 // Baileys expects a pino-like logger shape. Provide a lightweight adapter.

--- a/src/logging/parse-log-line.test.ts
+++ b/src/logging/parse-log-line.test.ts
@@ -5,8 +5,7 @@ describe("parseLogLine", () => {
   it("parses structured JSON log lines", () => {
     const line = JSON.stringify({
       time: "2026-01-09T01:38:41.523Z",
-      0: '{"subsystem":"gateway/channels/whatsapp"}',
-      1: "connected",
+      0: "connected",
       _meta: {
         name: '{"subsystem":"gateway/channels/whatsapp"}',
         logLevelName: "INFO",
@@ -19,7 +18,7 @@ describe("parseLogLine", () => {
     expect(parsed?.time).toBe("2026-01-09T01:38:41.523Z");
     expect(parsed?.level).toBe("info");
     expect(parsed?.subsystem).toBe("gateway/channels/whatsapp");
-    expect(parsed?.message).toBe('{"subsystem":"gateway/channels/whatsapp"} connected');
+    expect(parsed?.message).toBe("connected");
     expect(parsed?.raw).toBe(line);
   });
 


### PR DESCRIPTION
## Summary

Removes duplicate subsystem display in `openclaw logs` output by eliminating tslog's `prefix` option from `getChildLogger()`.

## Problem

Each log line showed the subsystem twice:
```
17:20:00 info gateway/channels/feishu {"subsystem":"gateway/channels/feishu"} feishu[default]: received message...
```

The first occurrence is the label (correctly extracted from `_meta.name`). The second is redundant noise from tslog's prefix mechanism leaking into positional args.

## Root Cause

The `prefix` was added during the pino → tslog migration (commit `d463c82c9`) as an attempt to preserve pino's child logger binding behavior. However:

- `name` already captures the subsystem in `_meta.name`
- `parseLogLine` extracts subsystem from `_meta.name`
- `prefix` just injects redundant subsystem JSON into message body

## Changes

1. **src/logging/logger.ts** — Remove `prefix` from `getChildLogger()` options
2. **src/logging/parse-log-line.test.ts** — Update test to match new log format (no prefix in positional args)

## Result

```
17:20:00 info gateway/channels/feishu feishu[default]: received message...
```

Clean, readable logs with no duplication.

## Test Plan

- ✅ Unit tests pass: `pnpm test src/logging/parse-log-line.test.ts`
- ✅ Build succeeds: `pnpm build`
- ✅ Linters pass: `pnpm check`
- ✅ Verified log output shows no subsystem duplication

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes tslog’s `prefix` option from `getChildLogger()` so that child-logger bindings are carried only via `_meta.name` (and therefore the CLI’s label extraction), eliminating the duplicated subsystem string that previously appeared in positional log args.

Tests in `src/logging/parse-log-line.test.ts` are updated to reflect the new emitted JSON shape: the message is now just the original first positional argument (e.g. `"connected"`) rather than including the redundant `{"subsystem":...}` prefix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to removing tslog’s `prefix` injection for child loggers, and the corresponding unit test update aligns with how `parseLogLine` constructs the message from numeric positional fields. No other behavior changes were identified in the affected code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->