### PR TITLE
fix(telegram): match DM allowFrom against sender user id

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -227,8 +227,9 @@ export const buildTelegramMessageContext = async ({
     }
 
     if (dmPolicy !== "open") {
-      const candidate = String(chatId);
       const senderUsername = msg.from?.username ?? "";
+      const senderUserId = msg.from?.id != null ? String(msg.from.id) : null;
+      const candidate = senderUserId ?? String(chatId);
       const allowMatch = resolveSenderAllowMatch({
         allow: effectiveDmAllow,
         senderId: candidate,


### PR DESCRIPTION
## Summary

Telegram DM access-control was matching  against the **chat id** instead of the **sender user id**.

In DMs, users typically configure  using Telegram user ids (e.g. ) and/or . Using  causes legitimate DMs to be rejected or silently dropped, even when users believe they configured  /  or are using allowlist mode.

## Root Cause

In  (DM branch), the allowlist candidate key was computed as:

- 

…but DM allowlists are meant to match the sender identity (), not the chat container id.

## Fix

- Prefer matching  against  (sender user id)
- Fallback to  only if the update lacks 

## Tests

Existing Telegram DM/thread routing tests pass:
- 
- 

Closes #4515

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Telegram DM access-control allowlist matching by using the sender’s Telegram user id (`msg.from.id`) rather than the DM chat id, with a fallback to `chatId` when `from.id` is unavailable. This aligns DM `allowFrom` configuration with how users typically specify allowlists (user ids / usernames) and keeps existing group/topic routing behavior unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing a small logging/telemetry correctness issue.
- The behavioral change is localized and aligns with Telegram semantics (DM sender identity vs chat container id). No other call sites appear affected, but one log record now uses an ambiguous/misnamed field that can mislead monitoring and debugging.
- src/telegram/bot-message-context.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->