### PR TITLE
feat: wire up after_tool_call, message_sending, session, and gateway plugin hooks

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -705,7 +705,7 @@ export async function runEmbeddedAttempt(
         }
       }
 
-      // Get hook runner once for both before_agent_start and agent_end hooks
+      // Get hook runner once for before_agent_start, agent_end, and session hooks
       const hookRunner = getGlobalHookRunner();
       const hookAgentId =
         typeof params.agentId === "string" && params.agentId.trim()
@@ -714,6 +714,23 @@ export async function runEmbeddedAttempt(
               sessionKey: params.sessionKey,
               config: params.config,
             }).sessionAgentId;
+
+      // Run session_start plugin hook (fire-and-forget).
+      if (hookRunner?.hasHooks("session_start")) {
+        void hookRunner
+          .runSessionStart(
+            {
+              sessionId: params.sessionId,
+            },
+            {
+              agentId: hookAgentId,
+              sessionId: params.sessionId,
+            },
+          )
+          .catch((err) => {
+            log.warn(`session_start hook failed: ${String(err)}`);
+          });
+      }
 
       let promptError: unknown = null;
       try {
@@ -912,6 +929,24 @@ export async function runEmbeddedAttempt(
         clientToolCall: clientToolCallDetected ?? undefined,
       };
     } finally {
+      // Run session_end plugin hook (fire-and-forget) before teardown.
+      const sessionEndHookRunner = getGlobalHookRunner();
+      if (sessionEndHookRunner?.hasHooks("session_end")) {
+        void sessionEndHookRunner
+          .runSessionEnd(
+            {
+              sessionId: params.sessionId,
+            },
+            {
+              agentId: sessionAgentId,
+              sessionId: params.sessionId,
+            },
+          )
+          .catch((err) => {
+            log.warn(`session_end hook failed: ${String(err)}`);
+          });
+      }
+
       // Always tear down the session (and release the lock) before we leave this attempt.
       sessionManager?.flushPendingToolResults?.();
       session?.dispose();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -936,7 +936,7 @@ export async function runEmbeddedAttempt(
           .runSessionEnd(
             {
               sessionId: params.sessionId,
-              messageCount: activeSession.messages.length,
+              messageCount: session?.messages?.length ?? 0,
             },
             {
               agentId: sessionAgentId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -936,6 +936,7 @@ export async function runEmbeddedAttempt(
           .runSessionEnd(
             {
               sessionId: params.sessionId,
+              messageCount: messagesSnapshot.length,
             },
             {
               agentId: sessionAgentId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -936,7 +936,7 @@ export async function runEmbeddedAttempt(
           .runSessionEnd(
             {
               sessionId: params.sessionId,
-              messageCount: messagesSnapshot.length,
+              messageCount: activeSession.messages.length,
             },
             {
               agentId: sessionAgentId,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.after-tool-call-hook.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.after-tool-call-hook.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { handleToolExecutionEnd } from "./pi-embedded-subscribe.handlers.tools.js";
+
+vi.mock("../plugins/hook-runner-global.js");
+vi.mock("../infra/agent-events.js", () => ({
+  emitAgentEvent: vi.fn(),
+}));
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+function makeCtx(overrides?: Partial<{ runId: string }>) {
+  const runId = overrides?.runId ?? "agent-123:run-1";
+  return {
+    params: {
+      runId,
+      onAgentEvent: vi.fn(),
+      onToolResult: undefined,
+    },
+    state: {
+      toolMetaById: new Map<string, string | undefined>(),
+      toolSummaryById: new Set<string>(),
+      toolMetas: [] as Array<{ toolName?: string; meta?: string }>,
+      pendingMessagingTexts: new Map<string, string>(),
+      pendingMessagingTargets: new Map<string, unknown>(),
+      messagingToolSentTexts: [] as string[],
+      messagingToolSentTextsNormalized: [] as string[],
+      messagingToolSentTargets: [] as unknown[],
+    },
+    log: { debug: vi.fn(), warn: vi.fn() },
+    shouldEmitToolOutput: vi.fn().mockReturnValue(false),
+    shouldEmitToolResult: vi.fn().mockReturnValue(false),
+    emitToolOutput: vi.fn(),
+    trimMessagingToolSent: vi.fn(),
+    // oxlint-disable-next-line typescript/no-explicit-any
+  } as any;
+}
+
+function makeEvt(
+  overrides?: Partial<{ toolName: string; toolCallId: string; isError: boolean; result: unknown }>,
+) {
+  return {
+    type: "tool_execution_end",
+    toolName: overrides?.toolName ?? "Read",
+    toolCallId: overrides?.toolCallId ?? "call-1",
+    isError: overrides?.isError ?? false,
+    result: overrides?.result ?? { content: [{ type: "text", text: "file contents" }] },
+  };
+}
+
+describe("after_tool_call hook integration", () => {
+  let hookRunner: {
+    hasHooks: ReturnType<typeof vi.fn>;
+    runAfterToolCall: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    hookRunner = {
+      hasHooks: vi.fn(),
+      runAfterToolCall: vi.fn(),
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    mockGetGlobalHookRunner.mockReturnValue(hookRunner as any);
+  });
+
+  it("does not invoke hook when no hooks are registered", () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const ctx = makeCtx();
+    handleToolExecutionEnd(ctx, makeEvt());
+
+    expect(hookRunner.hasHooks).toHaveBeenCalledWith("after_tool_call");
+    expect(hookRunner.runAfterToolCall).not.toHaveBeenCalled();
+  });
+
+  it("fires hook with tool name and result on successful execution", () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockResolvedValue(undefined);
+    const ctx = makeCtx({ runId: "myagent:run-42" });
+    const result = { content: [{ type: "text", text: "ok" }] };
+    // "Bash" normalizes to "exec" via TOOL_NAME_ALIASES.
+    handleToolExecutionEnd(ctx, makeEvt({ toolName: "Bash", result }));
+
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "exec",
+        params: {},
+        error: undefined,
+      }),
+      expect.objectContaining({
+        toolName: "exec",
+        agentId: "myagent",
+      }),
+    );
+  });
+
+  it("includes error string when tool result is an error", () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockResolvedValue(undefined);
+    const ctx = makeCtx();
+    const errorResult = {
+      content: [{ type: "text", text: "Error: file not found" }],
+      isError: true,
+    };
+    handleToolExecutionEnd(ctx, makeEvt({ isError: true, result: errorResult }));
+
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.any(String),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("continues execution when hook rejects", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockRejectedValue(new Error("hook failure"));
+    const ctx = makeCtx();
+
+    // Should not throw - fire-and-forget pattern catches errors.
+    handleToolExecutionEnd(ctx, makeEvt());
+
+    // Give the microtask queue a tick so the .catch() handler runs.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("after_tool_call hook failed"),
+    );
+  });
+
+  it("does not invoke hook when hookRunner is null", () => {
+    mockGetGlobalHookRunner.mockReturnValue(null);
+    const ctx = makeCtx();
+
+    // Should not throw.
+    handleToolExecutionEnd(ctx, makeEvt());
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.tools.after-tool-call-hook.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.after-tool-call-hook.test.ts
@@ -19,6 +19,7 @@ function makeCtx(overrides?: Partial<{ runId: string }>) {
     },
     state: {
       toolMetaById: new Map<string, string | undefined>(),
+      toolArgsById: new Map<string, Record<string, unknown>>(),
       toolSummaryById: new Set<string>(),
       toolMetas: [] as Array<{ toolName?: string; meta?: string }>,
       pendingMessagingTexts: new Map<string, string>(),
@@ -133,5 +134,24 @@ describe("after_tool_call hook integration", () => {
 
     // Should not throw.
     handleToolExecutionEnd(ctx, makeEvt());
+  });
+
+  it("passes stored tool args from start to end via toolArgsById", () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockResolvedValue(undefined);
+    const ctx = makeCtx();
+    // Simulate handleToolExecutionStart having stored args for this toolCallId.
+    ctx.state.toolArgsById.set("call-1", { path: "/tmp/file", encoding: "utf-8" });
+
+    handleToolExecutionEnd(ctx, makeEvt({ toolCallId: "call-1", toolName: "Read" }));
+
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { path: "/tmp/file", encoding: "utf-8" },
+      }),
+      expect.anything(),
+    );
+    // Args should be cleaned up after use.
+    expect(ctx.state.toolArgsById.has("call-1")).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,6 +1,7 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
 import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
 import {
@@ -12,7 +13,6 @@ import {
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
 import { normalizeToolName } from "./tool-policy.js";
-import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 
 function extendExecMeta(toolName: string, args: unknown, meta?: string): string | undefined {
   const normalized = toolName.trim().toLowerCase();
@@ -228,10 +228,7 @@ export function handleToolExecutionEnd(
       .runAfterToolCall(
         {
           toolName,
-          params:
-            evt.args && typeof evt.args === "object"
-              ? (evt.args as Record<string, unknown>)
-              : {},
+          params: {},
           result: sanitizedResult,
           error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
           durationMs: undefined,

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -24,6 +24,7 @@ export type EmbeddedPiSubscribeState = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName?: string; meta?: string }>;
   toolMetaById: Map<string, string | undefined>;
+  toolArgsById: Map<string, Record<string, unknown>>;
   toolSummaryById: Set<string>;
   lastToolError?: ToolErrorSummary;
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -35,6 +35,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     assistantTexts: [],
     toolMetas: [],
     toolMetaById: new Map(),
+    toolArgsById: new Map(),
     toolSummaryById: new Set(),
     lastToolError: undefined,
     blockReplyBreak: params.blockReplyBreak ?? "text_end",

--- a/src/gateway/server-close.gateway-stop-hook.test.ts
+++ b/src/gateway/server-close.gateway-stop-hook.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createGatewayCloseHandler } from "./server-close.js";
+
+vi.mock("../plugins/hook-runner-global.js");
+vi.mock("../hooks/gmail-watcher.js", () => ({
+  stopGmailWatcher: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../channels/plugins/index.js", () => ({
+  listChannelPlugins: vi.fn().mockReturnValue([]),
+}));
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+function makeParams() {
+  const httpServer = {
+    close: vi.fn((cb: (err?: Error) => void) => cb()),
+    closeIdleConnections: vi.fn(),
+  };
+  return {
+    bonjourStop: null,
+    tailscaleCleanup: null,
+    canvasHost: null,
+    canvasHostServer: null,
+    stopChannel: vi.fn().mockResolvedValue(undefined),
+    pluginServices: null,
+    cron: { stop: vi.fn() },
+    heartbeatRunner: { stop: vi.fn() },
+    nodePresenceTimers: new Map(),
+    broadcast: vi.fn(),
+    tickInterval: setInterval(() => {}, 999999),
+    healthInterval: setInterval(() => {}, 999999),
+    dedupeCleanup: setInterval(() => {}, 999999),
+    agentUnsub: null,
+    heartbeatUnsub: null,
+    chatRunState: { clear: vi.fn() },
+    clients: new Set(),
+    configReloader: { stop: vi.fn().mockResolvedValue(undefined) },
+    browserControl: null,
+    wss: { close: vi.fn((cb: () => void) => cb()) },
+    httpServer,
+    httpServers: undefined,
+    // oxlint-disable-next-line typescript/no-explicit-any
+  } as any;
+}
+
+describe("gateway_stop hook integration", () => {
+  let hookRunner: {
+    hasHooks: ReturnType<typeof vi.fn>;
+    runGatewayStop: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    hookRunner = {
+      hasHooks: vi.fn(),
+      runGatewayStop: vi.fn(),
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    mockGetGlobalHookRunner.mockReturnValue(hookRunner as any);
+  });
+
+  it("fires gateway_stop hook with reason before shutdown", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runGatewayStop.mockResolvedValue(undefined);
+    const close = createGatewayCloseHandler(makeParams());
+
+    await close({ reason: "config reload" });
+
+    expect(hookRunner.hasHooks).toHaveBeenCalledWith("gateway_stop");
+    expect(hookRunner.runGatewayStop).toHaveBeenCalledWith({ reason: "config reload" }, {});
+  });
+
+  it("uses default reason when none is provided", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runGatewayStop.mockResolvedValue(undefined);
+    const close = createGatewayCloseHandler(makeParams());
+
+    await close();
+
+    expect(hookRunner.runGatewayStop).toHaveBeenCalledWith({ reason: "gateway stopping" }, {});
+  });
+
+  it("does not invoke hook when no hooks are registered", async () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const close = createGatewayCloseHandler(makeParams());
+
+    await close({ reason: "test" });
+
+    expect(hookRunner.runGatewayStop).not.toHaveBeenCalled();
+  });
+
+  it("continues shutdown when hook throws", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runGatewayStop.mockRejectedValue(new Error("plugin crash"));
+    const params = makeParams();
+    const close = createGatewayCloseHandler(params);
+
+    // Should not throw despite hook failure.
+    await close({ reason: "graceful" });
+
+    // Verify shutdown continued (cron stopped, clients cleared, etc.).
+    expect(params.cron.stop).toHaveBeenCalled();
+    expect(params.chatRunState.clear).toHaveBeenCalled();
+  });
+
+  it("does not invoke hook when hookRunner is null", async () => {
+    mockGetGlobalHookRunner.mockReturnValue(null);
+    const close = createGatewayCloseHandler(makeParams());
+
+    // Should not throw.
+    await close({ reason: "shutdown" });
+  });
+});

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -16,6 +16,7 @@ import {
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import {
@@ -28,6 +29,7 @@ export async function startGatewaySidecars(params: {
   pluginRegistry: ReturnType<typeof loadOpenClawPlugins>;
   defaultWorkspaceDir: string;
   deps: CliDeps;
+  port?: number;
   startChannels: () => Promise<void>;
   log: { warn: (msg: string) => void };
   logHooks: {
@@ -154,6 +156,17 @@ export async function startGatewaySidecars(params: {
     setTimeout(() => {
       void scheduleRestartSentinelWake({ deps: params.deps });
     }, 750);
+  }
+
+  // Run gateway_start plugin hook (fire-and-forget).
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("gateway_start")) {
+    const gatewayPort = params.port ?? 18789;
+    void hookRunner
+      .runGatewayStart({ port: gatewayPort }, { port: gatewayPort })
+      .catch((err) => {
+        params.log.warn(`gateway_start hook failed: ${String(err)}`);
+      });
   }
 
   return { browserControl, pluginServices };

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -162,11 +162,9 @@ export async function startGatewaySidecars(params: {
   const hookRunner = getGlobalHookRunner();
   if (hookRunner?.hasHooks("gateway_start")) {
     const gatewayPort = params.port ?? 18789;
-    void hookRunner
-      .runGatewayStart({ port: gatewayPort }, { port: gatewayPort })
-      .catch((err) => {
-        params.log.warn(`gateway_start hook failed: ${String(err)}`);
-      });
+    void hookRunner.runGatewayStart({ port: gatewayPort }, { port: gatewayPort }).catch((err) => {
+      params.log.warn(`gateway_start hook failed: ${String(err)}`);
+    });
   }
 
   return { browserControl, pluginServices };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -551,6 +551,7 @@ export async function startGatewayServer(
     pluginRegistry,
     defaultWorkspaceDir,
     deps,
+    port,
     startChannels,
     log,
     logHooks,


### PR DESCRIPTION
## Summary

The plugin hook infrastructure in `src/plugins/hooks.ts` defines runners for all lifecycle hooks with proper error handling, priority ordering, and result merging. However, several of these hooks are **never invoked** from the runtime, meaning plugins that register handlers for them silently do nothing.

This PR wires up the remaining dead hooks:

- **`after_tool_call`** - Fired in `handleToolExecutionEnd` after each tool completes. Allows plugins to observe tool results and errors (analytics, logging, rate-limit tracking).
- **`message_sending`** - Fired in `dispatchReplyFromConfig` before final replies are sent to the user. Allows plugins to modify outgoing content or cancel messages entirely (content filtering, compliance, analytics).
- **`session_start`** - Fired in `runEmbeddedAttempt` when a new agent session begins.
- **`session_end`** - Fired in `runEmbeddedAttempt`'s finally block when a session tears down.
- **`gateway_start`** - Fired at the end of `startGatewaySidecars` after all services are initialized.
- **`gateway_stop`** - Fired at the beginning of the gateway close handler before shutdown proceeds.

**Note:** `before_tool_call` was already wired via `wrapToolWithBeforeToolCallHook` in `pi-tools.ts`. This PR does not change that.

## Motivation

We discovered this while building the [A0X plugin](https://a0x.co) for OpenClaw. Our plugin needs:
- `before_tool_call` to rate-limit jessexbt API calls and auto-inject session state
- `message_sending` to enforce collective knowledge proposals and content filtering
- `after_tool_call` for usage analytics and error tracking
- Session/gateway hooks for lifecycle management

All these hooks have well-designed infrastructure already built (the `runModifyingHook`/`runVoidHook` pattern with merge functions), but since the runtime never calls them, plugin handlers are registered and then ignored.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-subscribe.handlers.tools.ts` | Added `after_tool_call` invocation in `handleToolExecutionEnd` |
| `src/auto-reply/reply/dispatch-from-config.ts` | Added `message_sending` invocation before final replies |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Added `session_start` and `session_end` invocations |
| `src/gateway/server-startup.ts` | Added `gateway_start` invocation + `port` param |
| `src/gateway/server-close.ts` | Added `gateway_stop` invocation |
| `src/gateway/server.impl.ts` | Passes `port` to `startGatewaySidecars` |

## Design decisions

- All new hook invocations use the same **fire-and-forget** pattern as existing hooks (`void hookRunner.runX(...).catch(...)`)
- **`message_sending`** is the only hook that `await`s the result, since it needs to check for `cancel` or modified `content` before proceeding
- Hook errors are caught and logged, never propagated to the caller (consistent with `catchErrors: true` in the global hook runner)
- The `hasHooks()` guard is checked before invoking to avoid unnecessary async work when no plugins are registered

## Test plan

- [ ] Verify existing tests pass (hooks are properly mocked in existing test files)
- [ ] Register a plugin with `after_tool_call` handler and verify it fires after tool execution
- [ ] Register a plugin with `message_sending` handler that returns `{ cancel: true }` and verify the message is not sent
- [ ] Register a plugin with `message_sending` handler that returns `{ content: "modified" }` and verify the content is changed
- [ ] Verify `gateway_start`/`gateway_stop` fire during gateway lifecycle
- [ ] Verify `session_start`/`session_end` fire during agent session lifecycle

Contributed by the A0X team (a0x.co) while building an agent plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires previously-defined plugin lifecycle hooks into the runtime:

- Fires `after_tool_call` after each tool completes in the embedded runner tooling subscription.
- Adds a `message_sending` hook before dispatching final replies so plugins can modify/cancel outgoing text.
- Adds `session_start`/`session_end` hook invocations around an embedded attempt lifecycle.
- Adds `gateway_start`/`gateway_stop` hook invocations in gateway startup/shutdown, and plumbs the gateway `port` through startup sidecars.

Overall, this aligns runtime behavior with the hook runner infrastructure in `src/plugins/hooks.ts`/`src/plugins/types.ts` so plugin handlers don’t silently never fire.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but currently fails type-checking due to hook event shape mismatches.
- The hook wiring is conceptually straightforward, but there are at least two definite TypeScript-level breakages: `after_tool_call` reads `evt.args` that isn’t present on the end event type, and `session_end` is invoked without the required `messageCount` field. Fixing these should make the changes low-risk.
- src/agents/pi-embedded-subscribe.handlers.tools.ts, src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->