### PR TITLE
fix: cap NO_TIMEOUT_MS to prevent setTimeout overflow

### DIFF
--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -19,9 +19,10 @@ export function resolveAgentTimeoutMs(opts: {
 }): number {
   const minMs = Math.max(normalizeNumber(opts.minMs) ?? 1, 1);
   const defaultMs = resolveAgentTimeoutSeconds(opts.cfg) * 1000;
-  // Use a very large timeout value (30 days) to represent "no timeout"
-  // when explicitly set to 0. This avoids setTimeout issues with Infinity.
-  const NO_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
+  // Use a very large timeout value to represent "no timeout" when explicitly
+  // set to 0. Capped at 2^31-1 (max safe setTimeout value, ~24.8 days) to
+  // avoid Node.js TimeoutOverflowWarning which causes the timer to fire at 1ms.
+  const NO_TIMEOUT_MS = 2 ** 31 - 1;
   const overrideMs = normalizeNumber(opts.overrideMs);
   if (overrideMs !== undefined) {
     if (overrideMs === 0) {


### PR DESCRIPTION
## Problem

`NO_TIMEOUT_MS` is set to `30 * 24 * 60 * 60 * 1000` (2,592,000,000ms = 30 days), which exceeds Node.js's `setTimeout` max of `2^31 - 1` (2,147,483,647ms ≈ 24.8 days).

This causes:
- `TimeoutOverflowWarning: 2592010000 does not fit into a 32-bit signed integer`
- The timer fires at **1ms** instead of the intended ~30 day duration
- Subagent wait timeouts resolve immediately when no explicit `runTimeoutSeconds` is provided
- The parent session stops waiting for subagent completion

## Fix

Cap `NO_TIMEOUT_MS` to `2 ** 31 - 1` (2,147,483,647ms ≈ 24.8 days), which is the maximum safe value for `setTimeout`.

## Stack trace (from journalctl)

```
TimeoutOverflowWarning: 2592010000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
    at setTimeout (node:timers:138:19)
    at callGateway (call-BDMBg5WA.js:265:17)
    at waitForSubagentCompletion (loader-BAZoAqqR.js:20847:22)
    at registerSubagentRun (loader-BAZoAqqR.js:20842:2)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveAgentTimeoutMs` (`src/agents/timeout.ts`) to cap the “no timeout” sentinel value (`NO_TIMEOUT_MS`) at `2 ** 31 - 1`, which is the maximum safe duration for Node.js `setTimeout`. This prevents `TimeoutOverflowWarning` and avoids the timer firing immediately (1ms) when the previous 30-day value overflowed, which in turn caused the parent process to stop waiting for subagent completion when no explicit `runTimeoutSeconds` was provided.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to a single constant used as a sentinel for 'no timeout' and fixes a known Node.js setTimeout overflow behavior without altering the surrounding timeout resolution logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->