### PR TITLE
feat(ci): activate staged pipeline — enable push triggers + ci.yml gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,18 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
+  workflow_call:
+    # Called by testing-strategy.yml for staged releases
+    inputs:
+      test_stage:
+        description: "Testing stage: develop, alpha, beta, or stable. Controls which platform tests run."
+        required: false
+        type: string
+        default: ""
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.sha }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -187,6 +193,10 @@ jobs:
           fi
 
   checks-windows:
+    # Windows tests: beta+ staging only (not on regular PRs to save compute)
+    if: |
+      inputs.test_stage == 'beta' ||
+      inputs.test_stage == 'stable'
     runs-on: blacksmith-4vcpu-windows-2025
     env:
       NODE_OPTIONS: --max-old-space-size=4096
@@ -295,12 +305,9 @@ jobs:
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
         run: ${{ matrix.command }}
 
-  # Consolidated macOS job: runs TS tests + Swift lint/build/test sequentially
-  # on a single runner. GitHub limits macOS concurrent jobs to 5 per org;
-  # running 4 separate jobs per PR (as before) starved the queue. One job
-  # per PR allows 5 PRs to run macOS checks simultaneously.
-  macos:
-    if: github.event_name == 'pull_request'
+  checks-macos:
+    # macOS tests: stable staging only (not on regular PRs to save compute)
+    if: inputs.test_stage == 'stable'
     runs-on: macos-latest
     steps:
       - name: Checkout

--- a/.github/workflows/feature-pr.yml
+++ b/.github/workflows/feature-pr.yml
@@ -3,15 +3,12 @@ name: Feature PR
 # Auto-create PR from dev/* branches to develop
 # This is the entry point for new features into the staging pipeline
 
-# NOTE: push triggers disabled until staging pipeline is activated.
-# To enable: uncomment the push block and remove workflow_dispatch.
-#   push:
-#     branches:
-#       - "dev/**"
-#       - "feature/**"
-#       - "fix/**"
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - "dev/**"
+      - "feature/**"
+      - "fix/**"
 
 concurrency:
   group: feature-pr-${{ github.ref_name }}

--- a/.github/workflows/hotfix-pr.yml
+++ b/.github/workflows/hotfix-pr.yml
@@ -5,13 +5,10 @@ name: Hotfix PR
 #
 # Flow: hotfix/* → main (directly, with expedited review)
 
-# NOTE: push triggers disabled until staging pipeline is activated.
-# To enable: uncomment the push block and remove workflow_dispatch.
-#   push:
-#     branches:
-#       - "hotfix/**"
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - "hotfix/**"
 
 concurrency:
   group: hotfix-${{ github.ref_name }}

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -11,17 +11,15 @@ name: Promote Branch
 #
 # Merging to main triggers a release (handled separately by release workflow)
 
-# NOTE: push triggers disabled until staging pipeline is activated.
-# To enable: uncomment the push block below.
-#   push:
-#     branches:
-#       - develop
-#       - alpha
-#       - beta
-#     paths-ignore:
-#       - "docs/**"
-#       - "*.md"
 on:
+  push:
+    branches:
+      - develop
+      - alpha
+      - beta
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
   workflow_dispatch:
     inputs:
       source_branch:

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -7,16 +7,15 @@ name: Release Orchestrator
 #
 # Flow: version → changelog → test → deploy → release
 
-# NOTE: push-to-main trigger disabled until staging pipeline is activated.
-# To enable: uncomment the push block below.
-#   push:
-#     branches:
-#       - main
-#     paths-ignore:
-#       - "docs/**"
-#       - "*.md"
-#       - ".github/workflows/docs-*.yml"
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - ".github/workflows/docs-*.yml"
+
   workflow_call:
     inputs:
       release_type:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,17 +97,13 @@ Skills submitted as PRs to this repo will be redirected to ClawHub. If the core 
 
 ## Branch Strategy
 
-> **Note:** The staged promotion pipeline is not yet active. Workflows are in
-> place but dormant. For now, open PRs targeting `main` as usual. Once the
-> pipeline is activated, the flow below will apply.
-
-We will use staged branch promotion to keep `main` stable:
+We use staged branch promotion to keep `main` stable:
 
 ```
 dev/* / feature/* / fix/*  →  develop  →  alpha  →  beta  →  main
 ```
 
-### For External Contributors (once pipeline is active)
+### For External Contributors
 
 1. Fork the repo
 2. Create your branch (`dev/my-feature`, `fix/some-bug`, etc.)
@@ -115,7 +111,9 @@ dev/* / feature/* / fix/*  →  develop  →  alpha  →  beta  →  main
 4. CI runs lightweight checks only — no heavy platform tests on your PR
 5. Once merged to `develop`, your changes promote through alpha → beta → main automatically
 
-### For Maintainers (once pipeline is active)
+**Do not target `main`** — PRs to `main` will be redirected to `develop`.
+
+### For Maintainers
 
 - **Regular changes**: merge to `develop`, let the pipeline promote
 - **Hotfixes**: use `hotfix/*` branches for emergency fixes that bypass staging directly to `main`


### PR DESCRIPTION
## Summary

**Part 2 of 2** — activates the staged pipeline from #11313.

> **Do not merge until:**
> 1. PR #11313 is merged
> 2. `develop`, `alpha`, and `beta` branches are created
> 3. The team is ready for the new workflow

### What this PR does

1. **Modifies `ci.yml`:**
   - Removes the `push: [main]` trigger (now handled by `release-orchestrator.yml`)
   - Adds `workflow_call` input so `testing-strategy.yml` can pass `test_stage`
   - Gates Windows tests to `beta+` staging only (saves compute on regular PRs)
   - Gates macOS tests to `stable` staging only
   - Updates concurrency group key

2. **Enables push triggers** on:
   - `feature-pr.yml` — fires on `dev/**`, `feature/**`, `fix/**` pushes
   - `hotfix-pr.yml` — fires on `hotfix/**` pushes
   - `promote-branch.yml` — fires on pushes to `develop`/`alpha`/`beta`
   - `release-orchestrator.yml` — fires on pushes to `main`

3. **Updates `CONTRIBUTING.md`** — removes "not yet active" caveat from branch strategy

### Impact

After merging:
- Regular PRs will no longer run Windows/macOS tests (only run at beta/stable promotion)
- Pushes to `dev/*` branches will auto-create PRs targeting `develop`
- Merging to `main` will trigger the release orchestrator
- The full `develop → alpha → beta → main` promotion pipeline goes live

### Testing

Workflow changes only — validated by CI on this PR. The `ci.yml` changes can be verified by checking that Linux tests still run on PRs (they do — no gates on Linux jobs).