### PR TITLE
CI: skip heavy jobs on docs-only changes

### DIFF
--- a/.github/actions/detect-docs-only/action.yml
+++ b/.github/actions/detect-docs-only/action.yml
@@ -1,0 +1,41 @@
+name: Detect docs-only changes
+description: >
+  Outputs docs_only=true when all changed files are under docs/ or are
+  markdown (.md/.mdx). Fail-safe: if detection fails, outputs false (run
+  everything). Uses git diff — no API calls, no extra permissions needed.
+
+outputs:
+  docs_only:
+    description: "'true' if all changes are docs/markdown, 'false' otherwise"
+    value: ${{ steps.check.outputs.docs_only }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect docs-only changes
+      id: check
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "push" ]; then
+          BASE="${{ github.event.before }}"
+        else
+          # Use the exact base SHA from the event payload — stable regardless
+          # of base branch movement (avoids origin/<ref> drift).
+          BASE="${{ github.event.pull_request.base.sha }}"
+        fi
+
+        # Fail-safe: if we can't diff, assume non-docs (run everything)
+        CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
+        if [ "$CHANGED" = "UNKNOWN" ] || [ -z "$CHANGED" ]; then
+          echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Check if all changed files are docs or markdown
+        NON_DOCS=$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)
+        if [ -z "$NON_DOCS" ]; then
+          echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          echo "Docs-only change detected — skipping heavy jobs"
+        else
+          echo "docs_only=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect docs-only changes to skip heavy jobs (test, build, Windows, macOS, Android).
+  # Lint and format always run. Fail-safe: if detection fails, run everything.
+  docs-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Check if docs-only
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BASE="${{ github.event.before }}"
+          else
+            BASE="origin/${{ github.event.pull_request.base.ref }}"
+          fi
+
+          # Fail-safe: if we can't diff, assume non-docs (run everything)
+          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
+          if [ "$CHANGED" = "UNKNOWN" ] || [ -z "$CHANGED" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Check if all changed files are docs or markdown
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)
+          if [ -z "$NON_DOCS" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change detected — skipping heavy jobs"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   install-check:
+    needs: [docs-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -71,6 +111,8 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
 
   checks:
+    needs: [docs-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -80,17 +122,11 @@ jobs:
             task: tsgo
             command: pnpm tsgo
           - runtime: node
-            task: lint
-            command: pnpm build && pnpm lint
-          - runtime: node
             task: test
             command: pnpm canvas:a2ui:bundle && pnpm test
           - runtime: node
             task: protocol
             command: pnpm protocol:check
-          - runtime: node
-            task: format
-            command: pnpm format
           - runtime: bun
             task: test
             command: pnpm canvas:a2ui:bundle && bunx vitest run
@@ -161,6 +197,84 @@ jobs:
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
         run: ${{ matrix.command }}
 
+  # Lint and format always run, even on docs-only changes.
+  checks-lint:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: lint
+            command: pnpm build && pnpm lint
+          - task: format
+            command: pnpm format
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Checkout submodules (retry)
+        run: |
+          set -euo pipefail
+          git submodule sync --recursive
+          for attempt in 1 2 3 4 5; do
+            if git -c protocol.version=2 submodule update --init --force --depth=1 --recursive; then
+              exit 0
+            fi
+            echo "Submodule update failed (attempt $attempt/5). Retrying…"
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          check-latest: true
+
+      - name: Setup pnpm (corepack retry)
+        run: |
+          set -euo pipefail
+          corepack enable
+          for attempt in 1 2 3; do
+            if corepack prepare pnpm@10.23.0 --activate; then
+              pnpm -v
+              exit 0
+            fi
+            echo "corepack prepare failed (attempt $attempt/3). Retrying..."
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Runtime versions
+        run: |
+          node -v
+          npm -v
+          bun -v
+          pnpm -v
+
+      - name: Capture node path
+        run: echo "NODE_BIN=$(dirname \"$(node -p \"process.execPath\")\")" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        env:
+          CI: true
+        run: |
+          export PATH="$NODE_BIN:$PATH"
+          which node
+          node -v
+          pnpm -v
+          pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true || pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
+
+      - name: Run ${{ matrix.task }}
+        run: ${{ matrix.command }}
+
   secrets:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -187,6 +301,8 @@ jobs:
           fi
 
   checks-windows:
+    needs: [docs-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     env:
       NODE_OPTIONS: --max-old-space-size=4096
@@ -300,7 +416,8 @@ jobs:
   # running 4 separate jobs per PR (as before) starved the queue. One job
   # per PR allows 5 PRs to run macOS checks simultaneously.
   macos:
-    if: github.event_name == 'pull_request'
+    needs: [docs-scope]
+    if: github.event_name == 'pull_request' && needs.docs-scope.outputs.docs_only != 'true'
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -585,6 +702,8 @@ jobs:
           PY
 
   android:
+    needs: [docs-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             BASE="${{ github.event.before }}"
           else
-            BASE="origin/${{ github.event.pull_request.base.ref }}"
+            # Use the exact base SHA from the event payload — stable regardless
+            # of base branch movement (avoids origin/<ref> drift).
+            BASE="${{ github.event.pull_request.base.sha }}"
           fi
 
           # Fail-safe: if we can't diff, assume non-docs (run everything)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,32 +23,9 @@ jobs:
           fetch-depth: 0
           submodules: false
 
-      - name: Check if docs-only
+      - name: Detect docs-only changes
         id: check
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
-          else
-            # Use the exact base SHA from the event payload — stable regardless
-            # of base branch movement (avoids origin/<ref> drift).
-            BASE="${{ github.event.pull_request.base.sha }}"
-          fi
-
-          # Fail-safe: if we can't diff, assume non-docs (run everything)
-          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
-          if [ "$CHANGED" = "UNKNOWN" ] || [ -z "$CHANGED" ]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Check if all changed files are docs or markdown
-          NON_DOCS=$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)
-          if [ -z "$NON_DOCS" ]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
-            echo "Docs-only change detected — skipping heavy jobs"
-          else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/detect-docs-only
 
   install-check:
     needs: [docs-scope]

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -11,7 +11,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  docs-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect docs-only changes
+        id: check
+        uses: ./.github/actions/detect-docs-only
+
   install-smoke:
+    needs: [docs-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CLI


### PR DESCRIPTION
Builds on #11263's approach (reusable composite action + per-job gating) with a simpler detection method.

## What

Docs-only PRs (changes limited to `docs/` and `*.md`/`*.mdx` files) now skip heavy CI jobs while still running lint, format, and secret scanning.

## How

- **Reusable `.github/actions/detect-docs-only` composite action** — uses `git diff` against the base SHA to detect docs-only changes. No API calls, no extra permissions needed. Fail-safe: if diff fails, assumes non-docs and runs everything.
- **Heavy jobs gated** in `ci.yml` — `install-check`, `checks` (tsgo, test, protocol, bun test), `checks-windows`, `macos`, `android` all require `needs.docs-scope.outputs.docs_only != 'true'`.
- **`checks-lint` job (always runs)** — new ungated job running lint + format on all PRs, including docs-only.
- **`secrets` job (always runs)** — ungated, cheap.
- **`install-smoke.yml` gated** — docker install tests skip on docs-only changes.
- **Lint/format removed from gated `checks` matrix** — avoids redundant runs; they always run via `checks-lint`.

## Differences from #11263

| | #11263 | This PR |
|---|---|---|
| Detection | `actions/github-script` calling `pulls.listFiles` REST API | `git diff --name-only` against base SHA |
| Permissions | Requires `pull-requests: read` | None needed |
| Scope | `docs/` only | `docs/` + `*.md`/`*.mdx` anywhere |
| Reusable | Yes (composite action) | Yes (composite action) |
| Workflows gated | ci, install-smoke, workflow-sanity, formal-conformance | ci, install-smoke (cheap workflows left ungated) |

## Why not `paths-ignore`?

`paths-ignore` is a workflow-level trigger filter — it prevents the entire workflow from firing. If any skipped job is a required status check in branch protection, docs-only PRs would be permanently blocked (the check never reports). The detection-job + `if`-gate pattern causes skipped jobs to report as \"skipped\" (passing), so required checks still work.

## Savings

Docs-only PRs skip: 4 Ubuntu matrix runs, 3 Windows matrix runs, 1 macOS job (including Swift build), 2 Android jobs, 1 lockfile check, 1 install-smoke test. Only lightweight jobs run: docs-scope detection, lint, format, and secrets. The main benefit is faster feedback: docs PRs finish in under a minute instead of waiting 15 minutes for macOS.

Closes #11263 — thanks @sebslight for surfacing this and establishing the pattern.