### PR TITLE
fix(memory/qmd): prevent cascading failure when query fails or returns empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,6 @@ USER.md
 .serena/
 
 # Agent credentials and memory (NEVER COMMIT)
-memory/
+/memory/
 .agent/*.json
 !.agent/workflows/

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -234,7 +234,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
-    const modeRaw = process.env.OPENCLAW_QMD_MODE?.trim().toLowerCase();
+    // Read mode from the same env object used to spawn qmd to avoid surprises if the runtime injects env.
+    const modeRaw = this.env.OPENCLAW_QMD_MODE?.trim().toLowerCase();
     const primaryCmd = modeRaw === "search" ? "search" : "query";
     const args = [primaryCmd, trimmed, "--json", "-n", String(limit)];
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -234,7 +234,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
-    const args = ["query", trimmed, "--json", "-n", String(limit)];
+    const args = ["search", trimmed, "--json", "-n", String(limit)];
     let stdout: string;
     try {
       const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
@@ -243,6 +243,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       log.warn(`qmd query failed: ${String(err)}`);
       throw err instanceof Error ? err : new Error(String(err));
     }
+    const outTrim = stdout.trim();
+    if (outTrim.toLowerCase().startsWith("no results found")) {
+      return [];
+    }
+
     let parsed: QmdQueryResult[] = [];
     try {
       parsed = JSON.parse(stdout);


### PR DESCRIPTION
Added the ability to automatically fall back to the lighter QMD search when the query fails or times out when QMD is used as the backend for memory search. Fixed the issue that would trigger the OpenAI key check when the search results were empty (fixed the error cascading caused by "QMD no output" (invalid JSON → fallback → requires OpenAI/Google key)).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the QMD-backed memory search to (a) choose between `qmd query` vs `qmd search` based on `OPENCLAW_QMD_MODE`, and (b) fall back to `qmd search` when the primary command fails (e.g., timeout), plus a special-case for the "No results found" text to return an empty result set instead of cascading into a different backend.

The main remaining concern is that the fallback only triggers on process failure, not on “successful” runs that still produce non-JSON output; combined with a very strict empty-output string check, this can still throw and cascade in the scenarios this PR aims to fix.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but still has a couple of real failure modes in the QMD fallback path.
- Core change is small and localized, but the current implementation only falls back on non-zero exit/timeout and relies on a strict stdout prefix check; qmd producing non-JSON output with exit code 0 will still throw and can still trigger the cascade the PR intends to prevent.
- src/memory/qmd-manager.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->