### PR TITLE
feat: add Mistral/Voxtral audio transcription provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- Media understanding: add Mistral Voxtral audio transcription provider wiring and default model mapping (`mistral: voxtral-mini-latest`). (#11334) Thanks @JamesEBall.
+
 ## 2026.2.6
 
 ### Changes

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -31,6 +31,7 @@ export const DEFAULT_AUDIO_MODELS: Record<string, string> = {
   groq: "whisper-large-v3-turbo",
   openai: "gpt-4o-mini-transcribe",
   deepgram: "nova-3",
+  mistral: "voxtral-mini-latest",
 };
 export const CLI_OUTPUT_MAX_BUFFER = 5 * MB;
 export const DEFAULT_MEDIA_CONCURRENCY = 2;

--- a/src/media-understanding/providers/index.ts
+++ b/src/media-understanding/providers/index.ts
@@ -5,6 +5,7 @@ import { deepgramProvider } from "./deepgram/index.js";
 import { googleProvider } from "./google/index.js";
 import { groqProvider } from "./groq/index.js";
 import { minimaxProvider } from "./minimax/index.js";
+import { mistralProvider } from "./mistral/index.js";
 import { openaiProvider } from "./openai/index.js";
 
 const PROVIDERS: MediaUnderstandingProvider[] = [
@@ -13,6 +14,7 @@ const PROVIDERS: MediaUnderstandingProvider[] = [
   googleProvider,
   anthropicProvider,
   minimaxProvider,
+  mistralProvider,
   deepgramProvider,
 ];
 

--- a/src/media-understanding/providers/mistral/index.test.ts
+++ b/src/media-understanding/providers/mistral/index.test.ts
@@ -5,83 +5,83 @@ import { mistralProvider } from "./index.js";
 const resolvePinnedHostname = ssrf.resolvePinnedHostname;
 const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
 const lookupMock = vi.fn();
-let resolvePinnedHostnameSpy: ReturnType<typeof vi.spyOn> = null;
-let resolvePinnedHostnameWithPolicySpy: ReturnType<typeof vi.spyOn> = null;
+let resolvePinnedHostnameSpy: ReturnType<typeof vi.spyOn> | null = null;
+let resolvePinnedHostnameWithPolicySpy: ReturnType<typeof vi.spyOn> | null = null;
 
 const resolveRequestUrl = (input: RequestInfo | URL) => {
-  if (typeof input === "string") return input;
-  if (input instanceof URL) return input.toString();
-  return input.url;
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	return input.url;
 };
 
 describe("mistralProvider", () => {
-  beforeEach(() => {
-    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
-    resolvePinnedHostnameSpy = vi
-      .spyOn(ssrf, "resolvePinnedHostname")
-      .mockImplementation((hostname) => resolvePinnedHostname(hostname, lookupMock));
-    resolvePinnedHostnameWithPolicySpy = vi
-      .spyOn(ssrf, "resolvePinnedHostnameWithPolicy")
-      .mockImplementation((hostname, params) =>
-        resolvePinnedHostnameWithPolicy(hostname, { ...params, lookupFn: lookupMock }),
-      );
-  });
+	beforeEach(() => {
+		lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+		resolvePinnedHostnameSpy = vi
+			.spyOn(ssrf, "resolvePinnedHostname")
+			.mockImplementation((hostname) => resolvePinnedHostname(hostname, lookupMock));
+		resolvePinnedHostnameWithPolicySpy = vi
+			.spyOn(ssrf, "resolvePinnedHostnameWithPolicy")
+			.mockImplementation((hostname, params) =>
+				resolvePinnedHostnameWithPolicy(hostname, { ...params, lookupFn: lookupMock }),
+			);
+	});
 
-  afterEach(() => {
-    lookupMock.mockReset();
-    resolvePinnedHostnameSpy?.mockRestore();
-    resolvePinnedHostnameWithPolicySpy?.mockRestore();
-    resolvePinnedHostnameSpy = null;
-    resolvePinnedHostnameWithPolicySpy = null;
-  });
+	afterEach(() => {
+		lookupMock.mockReset();
+		resolvePinnedHostnameSpy?.mockRestore();
+		resolvePinnedHostnameWithPolicySpy?.mockRestore();
+		resolvePinnedHostnameSpy = null;
+		resolvePinnedHostnameWithPolicySpy = null;
+	});
 
-  it("has correct id and capabilities", () => {
-    expect(mistralProvider.id).toBe("mistral");
-    expect(mistralProvider.capabilities).toEqual(["audio"]);
-    expect(mistralProvider.transcribeAudio).toBeDefined();
-  });
+	it("has correct id and capabilities", () => {
+		expect(mistralProvider.id).toBe("mistral");
+		expect(mistralProvider.capabilities).toEqual(["audio"]);
+		expect(mistralProvider.transcribeAudio).toBeDefined();
+	});
 
-  it("uses Mistral base URL by default", async () => {
-    let seenUrl: string | null = null;
-    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
-      seenUrl = resolveRequestUrl(input);
-      return new Response(JSON.stringify({ text: "bonjour" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    };
+	it("uses Mistral base URL by default", async () => {
+		let seenUrl: string | null = null;
+		const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+			seenUrl = resolveRequestUrl(input);
+			return new Response(JSON.stringify({ text: "bonjour" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
 
-    const result = await mistralProvider.transcribeAudio!({
-      buffer: Buffer.from("audio-bytes"),
-      fileName: "voice.ogg",
-      apiKey: "test-mistral-key",
-      timeoutMs: 5000,
-      fetchFn,
-    });
+		const result = await mistralProvider.transcribeAudio!({
+			buffer: Buffer.from("audio-bytes"),
+			fileName: "voice.ogg",
+			apiKey: "test-mistral-key",
+			timeoutMs: 5000,
+			fetchFn,
+		});
 
-    expect(seenUrl).toBe("https://api.mistral.ai/v1/audio/transcriptions");
-    expect(result.text).toBe("bonjour");
-  });
+		expect(seenUrl).toBe("https://api.mistral.ai/v1/audio/transcriptions");
+		expect(result.text).toBe("bonjour");
+	});
 
-  it("allows overriding baseUrl", async () => {
-    let seenUrl: string | null = null;
-    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
-      seenUrl = resolveRequestUrl(input);
-      return new Response(JSON.stringify({ text: "ok" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    };
+	it("allows overriding baseUrl", async () => {
+		let seenUrl: string | null = null;
+		const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+			seenUrl = resolveRequestUrl(input);
+			return new Response(JSON.stringify({ text: "ok" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
 
-    await mistralProvider.transcribeAudio!({
-      buffer: Buffer.from("audio"),
-      fileName: "note.mp3",
-      apiKey: "key",
-      timeoutMs: 1000,
-      baseUrl: "https://custom.mistral.example/v1",
-      fetchFn,
-    });
+		await mistralProvider.transcribeAudio!({
+			buffer: Buffer.from("audio"),
+			fileName: "note.mp3",
+			apiKey: "key",
+			timeoutMs: 1000,
+			baseUrl: "https://custom.mistral.example/v1",
+			fetchFn,
+		});
 
-    expect(seenUrl).toBe("https://custom.mistral.example/v1/audio/transcriptions");
-  });
+		expect(seenUrl).toBe("https://custom.mistral.example/v1/audio/transcriptions");
+	});
 });

--- a/src/media-understanding/providers/mistral/index.test.ts
+++ b/src/media-understanding/providers/mistral/index.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ssrf from "../../../infra/net/ssrf.js";
+import { mistralProvider } from "./index.js";
+
+const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+const lookupMock = vi.fn();
+let resolvePinnedHostnameSpy: ReturnType<typeof vi.spyOn> = null;
+let resolvePinnedHostnameWithPolicySpy: ReturnType<typeof vi.spyOn> = null;
+
+const resolveRequestUrl = (input: RequestInfo | URL) => {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+};
+
+describe("mistralProvider", () => {
+  beforeEach(() => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    resolvePinnedHostnameSpy = vi
+      .spyOn(ssrf, "resolvePinnedHostname")
+      .mockImplementation((hostname) => resolvePinnedHostname(hostname, lookupMock));
+    resolvePinnedHostnameWithPolicySpy = vi
+      .spyOn(ssrf, "resolvePinnedHostnameWithPolicy")
+      .mockImplementation((hostname, params) =>
+        resolvePinnedHostnameWithPolicy(hostname, { ...params, lookupFn: lookupMock }),
+      );
+  });
+
+  afterEach(() => {
+    lookupMock.mockReset();
+    resolvePinnedHostnameSpy?.mockRestore();
+    resolvePinnedHostnameWithPolicySpy?.mockRestore();
+    resolvePinnedHostnameSpy = null;
+    resolvePinnedHostnameWithPolicySpy = null;
+  });
+
+  it("has correct id and capabilities", () => {
+    expect(mistralProvider.id).toBe("mistral");
+    expect(mistralProvider.capabilities).toEqual(["audio"]);
+    expect(mistralProvider.transcribeAudio).toBeDefined();
+  });
+
+  it("uses Mistral base URL by default", async () => {
+    let seenUrl: string | null = null;
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      seenUrl = resolveRequestUrl(input);
+      return new Response(JSON.stringify({ text: "bonjour" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const result = await mistralProvider.transcribeAudio!({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "voice.ogg",
+      apiKey: "test-mistral-key",
+      timeoutMs: 5000,
+      fetchFn,
+    });
+
+    expect(seenUrl).toBe("https://api.mistral.ai/v1/audio/transcriptions");
+    expect(result.text).toBe("bonjour");
+  });
+
+  it("allows overriding baseUrl", async () => {
+    let seenUrl: string | null = null;
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      seenUrl = resolveRequestUrl(input);
+      return new Response(JSON.stringify({ text: "ok" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await mistralProvider.transcribeAudio!({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      apiKey: "key",
+      timeoutMs: 1000,
+      baseUrl: "https://custom.mistral.example/v1",
+      fetchFn,
+    });
+
+    expect(seenUrl).toBe("https://custom.mistral.example/v1/audio/transcriptions");
+  });
+});

--- a/src/media-understanding/providers/mistral/index.ts
+++ b/src/media-understanding/providers/mistral/index.ts
@@ -1,0 +1,14 @@
+import type { MediaUnderstandingProvider } from "../../types.js";
+import { transcribeOpenAiCompatibleAudio } from "../openai/audio.js";
+
+const DEFAULT_MISTRAL_AUDIO_BASE_URL = "https://api.mistral.ai/v1";
+
+export const mistralProvider: MediaUnderstandingProvider = {
+  id: "mistral",
+  capabilities: ["audio"],
+  transcribeAudio: (req) =>
+    transcribeOpenAiCompatibleAudio({
+      ...req,
+      baseUrl: req.baseUrl ?? DEFAULT_MISTRAL_AUDIO_BASE_URL,
+    }),
+};


### PR DESCRIPTION
## Summary

Add Mistral as a new audio transcription provider, enabling users to transcribe audio using Mistral's Voxtral model via their OpenAI-compatible API.

## Changes

- **New provider:** `src/media-understanding/providers/mistral/index.ts` — wraps `transcribeOpenAiCompatibleAudio` with Mistral's base URL (`https://api.mistral.ai/v1`), following the same pattern as the existing Groq provider.
- **Provider registry:** Registered `mistralProvider` in the PROVIDERS array.
- **Default model:** Added `mistral: "voxtral-mini-latest"` to `DEFAULT_AUDIO_MODELS`.
- **Tests:** Unit tests covering provider metadata, default URL routing, and custom base URL override.

## Details

Mistral's audio transcription API ([docs](https://docs.mistral.ai/capabilities/audio_transcription)) uses the same `multipart/form-data` format as OpenAI Whisper (`file` + `model` fields, Bearer auth), so no new transcription function was needed — we reuse `transcribeOpenAiCompatibleAudio` exactly like Groq does.

Users can configure it via:
```yaml
media_understanding:
  audio:
    provider: mistral
    # optional: model defaults to voxtral-mini-latest
```

Requires a Mistral API key configured in the provider backends.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `mistral` media-understanding provider that reuses the existing OpenAI-compatible multipart audio transcription implementation (`transcribeOpenAiCompatibleAudio`) with Mistral’s default base URL (`https://api.mistral.ai/v1`). It registers the provider in the provider registry and introduces a default audio model mapping (`mistral: voxtral-mini-latest`), along with unit tests validating default URL routing and baseUrl override behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, follow an existing provider pattern (OpenAI-compatible wrapper), and are covered by unit tests for default/override URL behavior. No functional issues were found in the added provider wiring or defaults.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->