### PR TITLE
fix: resolve bundled hooks path on npm global install

### DIFF
--- a/src/hooks/bundled-dir.ts
+++ b/src/hooks/bundled-dir.ts
@@ -19,11 +19,11 @@ export function resolveBundledHooksDir(): string | undefined {
     // ignore
   }
 
-  // npm: resolve `<packageRoot>/dist/hooks/bundled` relative to this module (compiled hooks).
-  // This path works when installed via npm: node_modules/openclaw/dist/hooks/bundled-dir.js
+  // npm: resolve `<packageRoot>/dist/hooks/bundled` relative to this module.
+  // When bundled, import.meta.url resolves to dist/, so we need hooks/bundled.
   try {
     const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-    const distBundled = path.join(moduleDir, "bundled");
+    const distBundled = path.join(moduleDir, "hooks", "bundled");
     if (fs.existsSync(distBundled)) {
       return distBundled;
     }

--- a/src/hooks/bundled-dir.ts
+++ b/src/hooks/bundled-dir.ts
@@ -19,13 +19,18 @@ export function resolveBundledHooksDir(): string | undefined {
     // ignore
   }
 
-  // npm: resolve `<packageRoot>/dist/hooks/bundled` relative to this module.
-  // When bundled, import.meta.url resolves to dist/, so we need hooks/bundled.
+  // npm: resolve relative to this module. Handles both layouts:
+  // - Non-flattened: dist/hooks/bundled-dir.js -> moduleDir/bundled
+  // - Flattened bundle: dist/chunk.js -> moduleDir/hooks/bundled
   try {
     const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-    const distBundled = path.join(moduleDir, "hooks", "bundled");
-    if (fs.existsSync(distBundled)) {
-      return distBundled;
+    for (const candidate of [
+      path.join(moduleDir, "bundled"),
+      path.join(moduleDir, "hooks", "bundled"),
+    ]) {
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
     }
   } catch {
     // ignore


### PR DESCRIPTION
## Summary

Fixes #11331 (path resolution). The related build/packaging issue is tracked separately in #11348.

## Problem

On npm global installs, the build bundles bundled-dir.ts into a flat chunk in dist/, so import.meta.url resolves to dist/ rather than dist/hooks/bundled-dir.js. The existing code does path.join(moduleDir, "bundled") which looks for dist/bundled, but the hooks live at dist/hooks/bundled.

This causes all four bundled hooks (session-memory, boot-md, command-logger, soul-evil) to be undiscoverable.

## Fix

One-line change: add "hooks" to the path join so it correctly resolves to dist/hooks/bundled.

## Verification

Setting OPENCLAW_BUNDLED_HOOKS_DIR to the correct path manually confirms the gateway discovers all four hook directories. This fix makes that the default behavior.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `resolveBundledHooksDir()` to look for bundled hooks under `dist/hooks/bundled` when `import.meta.url` resolves to the flattened `dist/` directory (observed on npm global installs).

However, the new join logic uses `path.join(moduleDir, "hooks", "bundled")`, which breaks the standard (non-flattened) layout where `import.meta.url` points at `dist/hooks/bundled-dir.js` (it would resolve to `dist/hooks/hooks/bundled`). The resolver should account for both layouts (or resolve from the package root) to avoid regressing non-global installs.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a likely regression in bundled hook discovery for non-flattened installs.
- The change appears to fix the flattened dist/ bundle case, but it deterministically mis-resolves paths when `import.meta.url` points at `dist/hooks/bundled-dir.js` (standard output), causing bundled hooks to become undiscoverable in that scenario.
- src/hooks/bundled-dir.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->