### PR TITLE
Telegram: skip empty message text instead of throwing (#11238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: skip empty message text instead of throwing, preventing 400 Bad Request errors from Telegram API. (#11238)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/src/telegram/send.returns-undefined-empty-input.test.ts
+++ b/src/telegram/send.returns-undefined-empty-input.test.ts
@@ -94,6 +94,18 @@ describe("sendMessageTelegram", () => {
     botCtorSpy.mockReset();
   });
 
+  it("returns skipped result for empty text instead of throwing", async () => {
+    const res = await sendMessageTelegram("123", "", { token: "tok" });
+    expect(res).toEqual({ messageId: "skipped", chatId: "123" });
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns skipped result for whitespace-only text instead of throwing", async () => {
+    const res = await sendMessageTelegram("123", "   ", { token: "tok" });
+    expect(res).toEqual({ messageId: "skipped", chatId: "123" });
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("passes timeoutSeconds to grammY client when configured", async () => {
     loadConfig.mockReturnValue({
       channels: { telegram: { timeoutSeconds: 60 } },

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -436,7 +436,8 @@ export async function sendMessageTelegram(
   }
 
   if (!text || !text.trim()) {
-    throw new Error("Message must be non-empty for Telegram sends");
+    diagLogger.warn(`[telegram] skipping empty message to ${chatId}`);
+    return { messageId: "skipped", chatId };
   }
   const textParams =
     hasThreadParams || replyMarkup


### PR DESCRIPTION
## Fix

The Telegram adapter throws an error when `sendMessageTelegram` receives empty or whitespace-only text, which Telegram rejects with `400: Bad Request: message text is empty`. This causes silent failures across multiple codepaths (final reply, heartbeat, agent delivery) with **94 occurrences** reported over ~19 hours.

**Root cause:** `sendMessageTelegram` threw `Error("Message must be non-empty for Telegram sends")` for empty text. Callers (heartbeat responses, interrupted inference results, auth profile cooldown) sometimes produce empty text legitimately, and the throw propagated as an unhandled error.

## Changes

- `src/telegram/send.ts`: Replace `throw` with a warning log + safe no-op return (`{ messageId: "skipped", chatId }`) for empty/whitespace text
- `src/telegram/send.returns-undefined-empty-input.test.ts`: Add 2 regression tests (empty string, whitespace-only)
- `CHANGELOG.md`: Add entry

## Verification

- `pnpm build` passes
- All 33 telegram send tests pass (`npx vitest run src/telegram/send.returns-undefined-empty-input.test.ts`)
- New tests confirm empty and whitespace-only text returns `{ messageId: "skipped", chatId }` without calling `api.sendMessage`

Fixes #11238

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Telegram adapter’s `sendMessageTelegram` to treat empty or whitespace-only message text as a safe no-op: it logs a diagnostic warning and returns `{ messageId: "skipped", chatId }` rather than throwing. Regression tests were added to ensure empty/whitespace text does not call `api.sendMessage`, and the changelog documents the fix.

Overall this aligns Telegram behavior with other channel senders that treat empty content as “skipped”, preventing unhandled exceptions from bubbling through higher-level delivery paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (empty/whitespace text handling), adds targeted regression tests, and follows an existing pattern by other channel senders (returning a "skipped" result instead of throwing). No other logic paths were altered.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->