### PR TITLE
Web UI: show Compaction divider in chat history

### DIFF
--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -28,6 +28,23 @@ export function readSessionMessages(
       const parsed = JSON.parse(line);
       if (parsed?.message) {
         messages.push(parsed.message);
+        continue;
+      }
+
+      // Compaction entries are not "message" records, but they're useful context for debugging.
+      // Emit a lightweight synthetic message that the Web UI can render as a divider.
+      if (parsed?.type === "compaction") {
+        const ts = typeof parsed.timestamp === "string" ? Date.parse(parsed.timestamp) : Number.NaN;
+        const timestamp = Number.isFinite(ts) ? ts : Date.now();
+        messages.push({
+          role: "system",
+          content: [{ type: "text", text: "Compaction" }],
+          timestamp,
+          __openclaw: {
+            kind: "compaction",
+            id: typeof parsed.id === "string" ? parsed.id : undefined,
+          },
+        });
       }
     } catch {
       // ignore bad lines

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -54,6 +54,33 @@
   opacity: 0.7;
 }
 
+/* Chat divider (e.g., compaction marker) */
+.chat-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 18px 8px;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.chat-divider__line {
+  flex: 1 1 0;
+  height: 1px;
+  background: var(--border);
+  opacity: 0.9;
+}
+
+.chat-divider__label {
+  padding: 2px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
 /* Avatar Styles */
 .chat-avatar {
   width: 40px;

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -5,6 +5,7 @@
 /** Union type for items in the chat thread */
 export type ChatItem =
   | { kind: "message"; key: string; message: unknown }
+  | { kind: "divider"; key: string; label: string; timestamp: number }
   | { kind: "stream"; key: string; text: string; startedAt: number }
   | { kind: "reading-indicator"; key: string };
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -224,6 +224,16 @@ export function renderChat(props: ChatProps) {
         buildChatItems(props),
         (item) => item.key,
         (item) => {
+          if (item.kind === "divider") {
+            return html`
+              <div class="chat-divider" role="separator" data-ts=${String(item.timestamp)}>
+                <span class="chat-divider__line"></span>
+                <span class="chat-divider__label">${item.label}</span>
+                <span class="chat-divider__line"></span>
+              </div>
+            `;
+          }
+
           if (item.kind === "reading-indicator") {
             return renderReadingIndicatorGroup(assistantIdentity);
           }
@@ -477,6 +487,20 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   for (let i = historyStart; i < history.length; i++) {
     const msg = history[i];
     const normalized = normalizeMessage(msg);
+    const raw = msg as Record<string, unknown>;
+    const marker = raw.__openclaw as Record<string, unknown> | undefined;
+    if (marker && marker.kind === "compaction") {
+      items.push({
+        kind: "divider",
+        key:
+          typeof marker.id === "string"
+            ? `divider:compaction:${marker.id}`
+            : `divider:compaction:${normalized.timestamp}:${i}`,
+        label: "Compaction",
+        timestamp: normalized.timestamp ?? Date.now(),
+      });
+      continue;
+    }
 
     if (!props.showThinking && normalized.role.toLowerCase() === "toolresult") {
       continue;


### PR DESCRIPTION
#### Summary
Show a clear "Compaction" divider in the Web UI chat history when a Pi session transcript includes a compaction entry.

Code word: lobster-biscuit

#### Behavior Changes
- Web UI: renders a horizontal divider labeled "Compaction" in the chat stream.
- Gateway `/chat` history: emits a lightweight synthetic `system` message for transcript `compaction` entries so the UI can render the divider.

#### Codebase and GitHub Search
- Codebase searches performed:
  - `rg "__openclaw"` (chat marker plumbing)
  - `rg "readSessionMessages"` (gateway transcript parsing)

#### Tests
- `pnpm check`
- `pnpm test src/gateway/session-utils.fs.test.ts`
- UI tests: blocked in this environment due to sandbox socket restrictions (`listen EPERM` on `::1`).

#### Manual Testing
### Steps
1. In Web UI, run a session that triggers compaction (or run `/compact`).
2. Refresh chat history.
3. Verify a "Compaction" divider appears at the compaction boundary.

**Sign-Off**
- Models used: GPT-5 Codex
- Submitter effort (self-reported): medium

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a “Compaction” divider to the Web UI chat stream by:

- Emitting a lightweight synthetic `system` message from the gateway’s transcript reader (`readSessionMessages`) when it encounters `type: "compaction"` entries.
- Extending the UI chat item union with a `divider` kind and rendering it in `ui/src/ui/views/chat.ts`.
- Adding CSS for the divider styling.

The change hooks into the existing `/chat.history` pathway (gateway reads transcript → sanitizes/caps → UI normalizes and renders), with the new `__openclaw.kind === "compaction"` marker used to convert the synthetic message into a visual separator.

<h3>Confidence Score: 3/5</h3>

- This PR is likely mergeable after fixing a couple runtime-safety and integration concerns around the new compaction markers.
- The UI divider feature is small and well-scoped, but the gateway change modifies `readSessionMessages` output shape/order and the UI’s marker detection currently has an unsafe cast that can throw if `__openclaw` is not an object. Addressing these should make the change low risk.
- src/gateway/session-utils.fs.ts, ui/src/ui/views/chat.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->