### PR TITLE
fix(browser): respect fullPage=false for viewport-only screenshots

### DIFF
--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -70,7 +70,7 @@ export async function captureScreenshot(opts: {
       format,
       ...(quality !== undefined ? { quality } : {}),
       fromSurface: true,
-      captureBeyondViewport: true,
+      captureBeyondViewport: Boolean(opts.fullPage),
       ...(clip ? { clip } : {}),
     })) as { data?: string };
 


### PR DESCRIPTION
## Summary

The `captureBeyondViewport` CDP parameter was hardcoded to `true`, causing all screenshots to capture the full scrollable page regardless of the `fullPage` option.

## The Bug

When calling `browser screenshot` with `fullPage=false` (the default), screenshots still captured the entire scrollable page instead of just the viewport.

**Expected:** A 1280×800 viewport screenshot  
**Actual:** A 316×2000 full-page screenshot (scaled down)

## The Fix

Make `captureBeyondViewport` conditional on the `fullPage` parameter:

```diff
-      captureBeyondViewport: true,
+      captureBeyondViewport: Boolean(opts.fullPage),
```

## Testing

Tested locally with:
```bash
openclaw browser screenshot  # viewport only
openclaw browser screenshot --full-page  # full page
```

Before fix: Both captured full page
After fix: First captures viewport only, second captures full page

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes screenshot capture behavior in `src/browser/cdp.ts` by making the Chrome DevTools Protocol `Page.captureScreenshot` option `captureBeyondViewport` depend on the caller’s `fullPage` flag. Previously it was hardcoded to `true`, so even the default `fullPage=false` path could capture content beyond the visible viewport.

The change aligns viewport-only screenshots with expectations while preserving the existing full-page codepath (which already computes a content-sized `clip` via `Page.getLayoutMetrics`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (one CDP parameter), matches the documented intent of `fullPage`, and does not alter surrounding logic besides gating `captureBeyondViewport` on `opts.fullPage`. No other call sites or types are affected, and the previous behavior was clearly incorrect per PR description.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->