### PR TITLE
Fix/qmd robust no results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,6 @@ USER.md
 .serena/
 
 # Agent credentials and memory (NEVER COMMIT)
-memory/
+/memory/
 .agent/*.json
 !.agent/workflows/

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -262,15 +262,14 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
     }
 
-    const outTrim = stdout.trim();
-    if (outTrim.toLowerCase().startsWith("no results found")) {
-      return [];
-    }
-
     let parsed: QmdQueryResult[] = [];
     try {
       parsed = JSON.parse(stdout);
     } catch (err) {
+      // If JSON parse fails, check if the output indicates "no results" (even with prefix/warnings).
+      if (stdout.toLowerCase().includes("no results found")) {
+        return [];
+      }
       const message = err instanceof Error ? err.message : String(err);
       log.warn(`qmd returned invalid JSON: ${message}`);
       throw new Error(`qmd returned invalid JSON: ${message}`, { cause: err });

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -234,7 +234,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
-    const modeRaw = process.env.OPENCLAW_QMD_MODE?.trim().toLowerCase();
+    // Read mode from the same env object used to spawn qmd to avoid surprises if the runtime injects env.
+    const modeRaw = this.env.OPENCLAW_QMD_MODE?.trim().toLowerCase();
     const primaryCmd = modeRaw === "search" ? "search" : "query";
     const args = [primaryCmd, trimmed, "--json", "-n", String(limit)];
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -240,9 +240,11 @@ export class QmdMemoryManager implements MemorySearchManager {
     const args = [primaryCmd, trimmed, "--json", "-n", String(limit)];
 
     let stdout: string;
+    let stderr: string;
     try {
       const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
       stdout = result.stdout;
+      stderr = result.stderr;
     } catch (err) {
       // If qmd query is slow / unavailable (can trigger model downloads), fall back to the lighter BM25 search.
       if (primaryCmd !== "search") {
@@ -251,6 +253,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             timeoutMs: this.qmd.limits.timeoutMs,
           });
           stdout = result.stdout;
+          stderr = result.stderr;
         } catch (fallbackErr) {
           log.warn(`qmd ${primaryCmd} failed: ${String(err)}`);
           log.warn(`qmd search fallback failed: ${String(fallbackErr)}`);

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -267,8 +267,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       parsed = JSON.parse(stdout);
     } catch (err) {
       // If JSON parse fails, check both stdout and stderr for "no results" (qmd may output to either).
-      const combined = (stdout + "\n" + stderr).toLowerCase();
-      if (combined.includes("no results found")) {
+      if (stdout.toLowerCase().includes("no results found") || stderr.toLowerCase().includes("no results found")) {
         return [];
       }
       const message = err instanceof Error ? err.message : String(err);

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -234,7 +234,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
-    const args = ["query", trimmed, "--json", "-n", String(limit)];
+    const args = ["search", trimmed, "--json", "-n", String(limit)];
     let stdout: string;
     try {
       const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
@@ -243,6 +243,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       log.warn(`qmd query failed: ${String(err)}`);
       throw err instanceof Error ? err : new Error(String(err));
     }
+    const outTrim = stdout.trim();
+    if (outTrim.toLowerCase().startsWith("no results found")) {
+      return [];
+    }
+
     let parsed: QmdQueryResult[] = [];
     try {
       parsed = JSON.parse(stdout);

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -266,8 +266,9 @@ export class QmdMemoryManager implements MemorySearchManager {
     try {
       parsed = JSON.parse(stdout);
     } catch (err) {
-      // If JSON parse fails, check if the output indicates "no results" (even with prefix/warnings).
-      if (stdout.toLowerCase().includes("no results found")) {
+      // If JSON parse fails, check both stdout and stderr for "no results" (qmd may output to either).
+      const combined = (stdout + "\n" + stderr).toLowerCase();
+      if (combined.includes("no results found")) {
         return [];
       }
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Added the ability to automatically fall back to the lighter QMD search when the query fails or times out when QMD is used as the backend for memory search. Fixed the issue that would trigger the OpenAI key check when the search results were empty (fixed the error cascading caused by "QMD no output" (invalid JSON → fallback → requires OpenAI/Google key)).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the QMD-backed memory search to (1) optionally fall back from `qmd query` to the lighter `qmd search` command when the primary invocation fails/times out, and (2) treat certain non-JSON QMD outputs as an empty result set to avoid cascading into other backends.

The main behavioral change is in `QmdMemoryManager.search`, where command selection is driven by `OPENCLAW_QMD_MODE` and failures of the primary command can trigger a `search` fallback. It also adds a “no results” string detection path when JSON parsing fails, returning `[]` instead of throwing.


<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge but has one correctness edge case around no-results detection.
- Core changes are small and localized, but the current no-results detection only inspects stdout on JSON parse failure; if qmd reports the marker via stderr, the code will still throw and may reintroduce the error cascade the PR aims to prevent.
- src/memory/qmd-manager.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->