### PR TITLE
fix: scope Telegram update offset to bot token

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -1,12 +1,12 @@
 import { type RunOptions, run } from "@grammyjs/runner";
-import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
 import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -135,6 +135,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
 
     let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,
+      botToken: token,
     });
     const persistUpdateId = async (updateId: number) => {
       if (lastUpdateId !== null && updateId <= lastUpdateId) {
@@ -145,6 +146,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         await writeTelegramUpdateOffset({
           accountId: account.accountId,
           updateId,
+          botToken: token,
         });
       } catch (err) {
         (opts.runtime?.error ?? console.error)(

--- a/src/telegram/update-offset-store.test.ts
+++ b/src/telegram/update-offset-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
   deleteTelegramUpdateOffset,
+  extractBotIdFromToken,
   readTelegramUpdateOffset,
   writeTelegramUpdateOffset,
 } from "./update-offset-store.js";
@@ -33,5 +34,145 @@ describe("deleteTelegramUpdateOffset", () => {
       expect(await readTelegramUpdateOffset({ accountId: "default" })).toBeNull();
       expect(await readTelegramUpdateOffset({ accountId: "alerts" })).toBe(200);
     });
+  });
+});
+
+describe("bot token scoping", () => {
+  it("persists and reloads the last update id with token", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      const token = "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+      expect(await readTelegramUpdateOffset({ accountId: "primary", botToken: token })).toBeNull();
+
+      await writeTelegramUpdateOffset({ accountId: "primary", updateId: 421, botToken: token });
+
+      expect(await readTelegramUpdateOffset({ accountId: "primary", botToken: token })).toBe(421);
+    });
+  });
+
+  it("invalidates offset when bot token changes", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      const oldToken = "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+      const newToken = "222222222:AAFyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 432_527_632,
+        botToken: oldToken,
+      });
+
+      // Same token reads back fine
+      expect(await readTelegramUpdateOffset({ accountId: "default", botToken: oldToken })).toBe(
+        432_527_632,
+      );
+
+      // Different token invalidates the offset
+      expect(
+        await readTelegramUpdateOffset({ accountId: "default", botToken: newToken }),
+      ).toBeNull();
+    });
+  });
+
+  it("reads offset when no botToken provided (backward compat)", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 12345,
+        botToken: "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      });
+
+      // No token provided — should still return the offset (no validation)
+      expect(await readTelegramUpdateOffset({ accountId: "default" })).toBe(12345);
+    });
+  });
+
+  it("reads legacy offset files without botId field", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      // Write a legacy-format file (no botId, no botToken)
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 99999,
+      });
+
+      // Should read fine with a valid token (no stored botId to compare against)
+      expect(
+        await readTelegramUpdateOffset({
+          accountId: "default",
+          botToken: "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        }),
+      ).toBe(99999);
+    });
+  });
+});
+
+describe("malformed token guard", () => {
+  it("discards offset when new token is malformed and stored botId exists", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 999_999,
+        botToken: "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      });
+
+      // Malformed token can't extract a botId — should discard stale offset
+      expect(
+        await readTelegramUpdateOffset({ accountId: "default", botToken: "malformed-token" }),
+      ).toBeNull();
+    });
+  });
+
+  it("discards offset when token is malformed even without stored botId (legacy file)", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      // Write a legacy-format file (no botId stored)
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 888_888,
+      });
+
+      // Malformed token — should still discard because we cannot verify identity
+      expect(
+        await readTelegramUpdateOffset({ accountId: "default", botToken: "not-a-valid-token" }),
+      ).toBeNull();
+    });
+  });
+
+  it("discards offset when token is empty string", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 777_777,
+        botToken: "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      });
+
+      expect(await readTelegramUpdateOffset({ accountId: "default", botToken: "" })).toBeNull();
+    });
+  });
+
+  it("discards offset when token has no numeric prefix", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 666_666,
+        botToken: "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      });
+
+      expect(
+        await readTelegramUpdateOffset({ accountId: "default", botToken: ":AAFsecretpart" }),
+      ).toBeNull();
+    });
+  });
+});
+
+describe("extractBotIdFromToken", () => {
+  it("extracts bot ID from valid token", () => {
+    expect(extractBotIdFromToken("8125167982:AAF35OFUg31nrRW0H60qglgZXfQm5D4xGE0")).toBe(
+      "8125167982",
+    );
+  });
+
+  it("returns undefined for invalid tokens", () => {
+    expect(extractBotIdFromToken("not-a-token")).toBeUndefined();
+    expect(extractBotIdFromToken("")).toBeUndefined();
+    expect(extractBotIdFromToken(":secret")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Problem

The update offset file (`~/.openclaw/telegram/update-offset-{account}.json`) was keyed only by account name, not by bot token. When a bot token changed (common during initial setup or debugging), the persisted `lastUpdateId` from the old token would silently reject **all** inbound messages from the new bot.

`shouldSkipUpdate()` saw `updateId <= lastUpdateId` as always true because the old offset (e.g. 432M) was far ahead of the new bot's actual update IDs (e.g. 363M).

## Root Cause

Discovered while debugging #11011. The offset file had no awareness of which bot it belonged to. Token changes left a stale, impossibly-high offset that caused every inbound message to be dedupe-skipped.

## Changes

- **`update-offset-store.ts`**: Store `botId` (extracted from token) in the offset JSON. On read, validate `botId` matches the current token — discard offset if mismatched.
- **`monitor.ts`**: Pass `botToken` through `readTelegramUpdateOffset` and `writeTelegramUpdateOffset` calls.
- **Backward compatible**: Legacy files without `botId` field still work (no forced migration).
- **Tests**: Added 5 new tests covering token change invalidation, backward compat, legacy file reads, and `extractBotIdFromToken`.

## Test Results

```
48 test files | 405 tests — all passing ✅
```

Fixes #11337
Related: #11011

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a Telegram polling edge case where the persisted `lastUpdateId` offset was keyed only by account id. It now stores the bot’s numeric id (derived from the bot token) alongside the offset, and on read discards the stored offset if the current token belongs to a different bot. The monitor passes the token through to the offset store, and new tests cover token-change invalidation, backward-compat reads, legacy files, and bot-id extraction.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge once the token-parse mismatch case is addressed.
- The change is localized and well-tested, but the current invalidation logic can still accept a stale offset when a `botToken` is provided but can’t be parsed into a bot id while the stored file has a `botId` (leading to the original skip-all-updates failure mode).
- src/telegram/update-offset-store.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->