### PR TITLE
fix(discord): Apply historyLimit to channel/group sessions to prevent compaction bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - CLI: lazily load outbound provider dependencies and remove forced success-path exits so commands terminate naturally without killing intentional long-running foreground actions. (#12906) Thanks @DrCrinkle.
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
+- Discord/Agents: apply channel/group `historyLimit` during embedded-runner history compaction to prevent long-running channel sessions from bypassing truncation and overflowing context windows. (#11224) Thanks @shadril238.
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.
 - TUI/Streaming: preserve richer streamed assistant text when final payload drops pre-tool-call text blocks, while keeping non-empty final payload authoritative for plain-text updates. (#15452) Thanks @TsekaLuk.
 - Inbound/Web UI: preserve literal `\n` sequences when normalizing inbound text so Windows paths like `C:\\Work\\nxxx\\README.md` are not corrupted. (#11547) Thanks @mcaxtr.

--- a/src/agents/pi-embedded-runner.history-limit-from-session-key.test.ts
+++ b/src/agents/pi-embedded-runner.history-limit-from-session-key.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { getDmHistoryLimitFromSessionKey } from "./pi-embedded-runner.js";
+
+describe("getDmHistoryLimitFromSessionKey", () => {
+  it("keeps backward compatibility for dm/direct session kinds", () => {
+    const config = {
+      channels: { telegram: { dmHistoryLimit: 10 } },
+    } as OpenClawConfig;
+
+    expect(getDmHistoryLimitFromSessionKey("telegram:dm:123", config)).toBe(10);
+    expect(getDmHistoryLimitFromSessionKey("telegram:direct:123", config)).toBe(10);
+  });
+
+  it("returns historyLimit for channel and group session kinds", () => {
+    const config = {
+      channels: { discord: { historyLimit: 12, dmHistoryLimit: 5 } },
+    } as OpenClawConfig;
+
+    expect(getDmHistoryLimitFromSessionKey("discord:channel:123", config)).toBe(12);
+    expect(getDmHistoryLimitFromSessionKey("discord:group:456", config)).toBe(12);
+  });
+
+  it("returns undefined for unsupported session kinds", () => {
+    const config = {
+      channels: { discord: { historyLimit: 12, dmHistoryLimit: 5 } },
+    } as OpenClawConfig;
+
+    expect(getDmHistoryLimitFromSessionKey("discord:slash:123", config)).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -5,6 +5,7 @@ export { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runne
 export { applyGoogleTurnOrderingFix } from "./pi-embedded-runner/google.js";
 export {
   getDmHistoryLimitFromSessionKey,
+  getHistoryLimitFromSessionKey,
   limitHistoryTurns,
 } from "./pi-embedded-runner/history.js";
 export { resolveEmbeddedSessionLane } from "./pi-embedded-runner/lanes.js";

--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -38,8 +38,9 @@ export function limitHistoryTurns(
 /**
  * Extract provider + user ID from a session key and look up dmHistoryLimit.
  * Supports per-DM overrides and provider defaults.
+ * For channel/group sessions, uses historyLimit from provider config.
  */
-export function getDmHistoryLimitFromSessionKey(
+export function getHistoryLimitFromSessionKey(
   sessionKey: string | undefined,
   config: OpenClawConfig | undefined,
 ): number | undefined {
@@ -58,32 +59,17 @@ export function getDmHistoryLimitFromSessionKey(
   const kind = providerParts[1]?.toLowerCase();
   const userIdRaw = providerParts.slice(2).join(":");
   const userId = stripThreadSuffix(userIdRaw);
-  // Accept both "direct" (new) and "dm" (legacy) for backward compat
-  if (kind !== "direct" && kind !== "dm") {
-    return undefined;
-  }
-
-  const getLimit = (
-    providerConfig:
-      | {
-          dmHistoryLimit?: number;
-          dms?: Record<string, { historyLimit?: number }>;
-        }
-      | undefined,
-  ): number | undefined => {
-    if (!providerConfig) {
-      return undefined;
-    }
-    if (userId && providerConfig.dms?.[userId]?.historyLimit !== undefined) {
-      return providerConfig.dms[userId].historyLimit;
-    }
-    return providerConfig.dmHistoryLimit;
-  };
 
   const resolveProviderConfig = (
     cfg: OpenClawConfig | undefined,
     providerId: string,
-  ): { dmHistoryLimit?: number; dms?: Record<string, { historyLimit?: number }> } | undefined => {
+  ):
+    | {
+        historyLimit?: number;
+        dmHistoryLimit?: number;
+        dms?: Record<string, { historyLimit?: number }>;
+      }
+    | undefined => {
     const channels = cfg?.channels;
     if (!channels || typeof channels !== "object") {
       return undefined;
@@ -92,8 +78,38 @@ export function getDmHistoryLimitFromSessionKey(
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
       return undefined;
     }
-    return entry as { dmHistoryLimit?: number; dms?: Record<string, { historyLimit?: number }> };
+    return entry as {
+      historyLimit?: number;
+      dmHistoryLimit?: number;
+      dms?: Record<string, { historyLimit?: number }>;
+    };
   };
 
-  return getLimit(resolveProviderConfig(config, provider));
+  const providerConfig = resolveProviderConfig(config, provider);
+  if (!providerConfig) {
+    return undefined;
+  }
+
+  // For DM sessions: per-DM override -> dmHistoryLimit.
+  // Accept both "direct" (new) and "dm" (legacy) for backward compat.
+  if (kind === "dm" || kind === "direct") {
+    if (userId && providerConfig.dms?.[userId]?.historyLimit !== undefined) {
+      return providerConfig.dms[userId].historyLimit;
+    }
+    return providerConfig.dmHistoryLimit;
+  }
+
+  // For channel/group sessions: use historyLimit from provider config
+  // This prevents context overflow in long-running channel sessions
+  if (kind === "channel" || kind === "group") {
+    return providerConfig.historyLimit;
+  }
+
+  return undefined;
 }
+
+/**
+ * @deprecated Use getHistoryLimitFromSessionKey instead.
+ * Alias for backward compatibility.
+ */
+export const getDmHistoryLimitFromSessionKey = getHistoryLimitFromSessionKey;


### PR DESCRIPTION
## Summary

Fixes #11224 - Discord channel sessions were bypassing compaction, leading to context overflow errors.

## Problem

Discord channel sessions accumulated tokens indefinitely, ignoring the `contextTokens` limit and compaction settings. This resulted in context overflow errors when sessions exceeded the model's context window (e.g., 211k tokens > 200k limit).

## Root Cause

The `getDmHistoryLimitFromSessionKey` function in [history.ts](cci:7://file:///c:/Users/BS01431/Desktop/openclaw/src/agents/pi-embedded-runner/history.ts:0:0-0:0) explicitly skipped all non-DM sessions:

```typescript
if (kind !== "dm") {
  return undefined;  // Channel sessions got no history limit!
}

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change extends the session-key history-limit lookup so that Discord (and other providers) apply `historyLimit` to `channel`/`group` sessions (in addition to existing DM behavior), preventing long-running channel sessions from bypassing compaction and overflowing the model context window. It also introduces a new exported helper `getHistoryLimitFromSessionKey` while keeping `getDmHistoryLimitFromSessionKey` as a deprecated alias.

The only must-fix issue spotted in this PR is the addition of a brand-new `package-lock.json`, which is a large unrelated change and may alter dependency resolution; it should be removed unless the project explicitly wants to start tracking it in this PR.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the lockfile change is resolved.
- Core logic change is narrow, covered by updated tests, and call sites already use the (aliased) helper for limiting history. The main risk is the new `package-lock.json` addition, which is large and unrelated to the stated fix and can change dependency resolution; removing or explicitly justifying it would reduce merge risk.
- package-lock.json

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->