### PR TITLE
fix: name parent shim processes for clarity in ps output

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -46,7 +46,14 @@ function ensureExperimentalWarningSuppressed(): boolean {
   process.env.OPENCLAW_NODE_OPTIONS_READY = "1";
 
   // Set parent shim title based on the subcommand (e.g. "openclaw-gateway-shim").
-  const subcommand = process.argv.slice(2).find((arg) => !arg.startsWith("-"));
+  // We normalize argv first because on Windows, raw process.argv can contain
+  // duplicate execPath entries, UNC prefixes (\\?\), and control characters
+  // injected by profile wrappers or the OS. Without normalization, the shim
+  // title could end up as something like "openclaw-C:\path\node.exe-shim"
+  // instead of the intended "openclaw-gateway-shim". On macOS/Linux this is
+  // a no-op passthrough — normalizeWindowsArgv is hoisted and safe to call here.
+  const normalizedArgv = normalizeWindowsArgv(process.argv);
+  const subcommand = normalizedArgv.slice(2).find((arg) => !arg.startsWith("-"));
   if (subcommand) {
     process.title = `openclaw-${subcommand}-shim`;
   }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -44,6 +44,13 @@ function ensureExperimentalWarningSuppressed(): boolean {
 
   // Respawn guard (and keep recursion bounded if something goes wrong).
   process.env.OPENCLAW_NODE_OPTIONS_READY = "1";
+
+  // Set parent shim title based on the subcommand (e.g. "openclaw-gateway-shim").
+  const subcommand = process.argv.slice(2).find((arg) => !arg.startsWith("-"));
+  if (subcommand) {
+    process.title = `openclaw-${subcommand}-shim`;
+  }
+
   // Pass flag as a Node CLI option, not via NODE_OPTIONS (--disable-warning is disallowed in NODE_OPTIONS).
   const child = spawn(
     process.execPath,

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -120,6 +120,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
 
     let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,
+      botToken: token,
     });
     const persistUpdateId = async (updateId: number) => {
       if (lastUpdateId !== null && updateId <= lastUpdateId) {
@@ -130,6 +131,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         await writeTelegramUpdateOffset({
           accountId: account.accountId,
           updateId,
+          botToken: token,
         });
       } catch (err) {
         (opts.runtime?.error ?? console.error)(

--- a/src/telegram/update-offset-store.test.ts
+++ b/src/telegram/update-offset-store.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
+import {
+  extractBotIdFromToken,
+  readTelegramUpdateOffset,
+  writeTelegramUpdateOffset,
+} from "./update-offset-store.js";
 
 async function withTempStateDir<T>(fn: (dir: string) => Promise<T>) {
   const previous = process.env.OPENCLAW_STATE_DIR;
@@ -32,5 +36,73 @@ describe("telegram update offset store", () => {
 
       expect(await readTelegramUpdateOffset({ accountId: "primary" })).toBe(421);
     });
+  });
+
+  it("invalidates offset when bot token changes", async () => {
+    await withTempStateDir(async () => {
+      const oldToken = "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+      const newToken = "222222222:AAFyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 432527632,
+        botToken: oldToken,
+      });
+
+      // Same token reads back fine
+      expect(await readTelegramUpdateOffset({ accountId: "default", botToken: oldToken })).toBe(
+        432527632,
+      );
+
+      // Different token invalidates the offset
+      expect(
+        await readTelegramUpdateOffset({ accountId: "default", botToken: newToken }),
+      ).toBeNull();
+    });
+  });
+
+  it("reads offset when no botToken provided (backward compat)", async () => {
+    await withTempStateDir(async () => {
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 12345,
+        botToken: "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      });
+
+      // No token provided — should still return the offset (no validation)
+      expect(await readTelegramUpdateOffset({ accountId: "default" })).toBe(12345);
+    });
+  });
+
+  it("reads legacy offset files without botId field", async () => {
+    await withTempStateDir(async () => {
+      // Write a legacy-format file (no botId)
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 99999,
+      });
+
+      // Should read fine even with a token (no stored botId to compare)
+      expect(
+        await readTelegramUpdateOffset({
+          accountId: "default",
+          botToken: "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        }),
+      ).toBe(99999);
+    });
+  });
+});
+
+describe("extractBotIdFromToken", () => {
+  it("extracts bot ID from valid token", () => {
+    expect(extractBotIdFromToken("8125167982:AAF35OFUg31nrRW0H60qglgZXfQm5D4xGE0")).toBe(
+      "8125167982",
+    );
+  });
+
+  it("returns undefined for invalid token", () => {
+    expect(extractBotIdFromToken("not-a-token")).toBeUndefined();
+    expect(extractBotIdFromToken("")).toBeUndefined();
+    expect(extractBotIdFromToken(":secret")).toBeUndefined();
   });
 });

--- a/src/telegram/update-offset-store.test.ts
+++ b/src/telegram/update-offset-store.test.ts
@@ -106,3 +106,20 @@ describe("extractBotIdFromToken", () => {
     expect(extractBotIdFromToken(":secret")).toBeUndefined();
   });
 });
+
+describe("malformed token edge case", () => {
+  it("invalidates offset when new token is malformed but stored botId exists", async () => {
+    await withTempStateDir(async () => {
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 999999,
+        botToken: "111111111:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      });
+
+      // Malformed token can't extract a botId — should discard stale offset
+      expect(
+        await readTelegramUpdateOffset({ accountId: "default", botToken: "malformed-token" }),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/telegram/update-offset-store.ts
+++ b/src/telegram/update-offset-store.ts
@@ -9,7 +9,18 @@ const STORE_VERSION = 1;
 type TelegramUpdateOffsetState = {
   version: number;
   lastUpdateId: number | null;
+  botId?: string;
 };
+
+/**
+ * Extract the bot user ID from a Telegram bot token.
+ * Token format: "<botId>:<secretHash>"
+ */
+export function extractBotIdFromToken(token: string): string | undefined {
+  const parts = token.split(":");
+  const id = parts[0]?.trim();
+  return id && /^\d+$/.test(id) ? id : undefined;
+}
 
 function normalizeAccountId(accountId?: string) {
   const trimmed = accountId?.trim();
@@ -45,13 +56,25 @@ function safeParseState(raw: string): TelegramUpdateOffsetState | null {
 
 export async function readTelegramUpdateOffset(params: {
   accountId?: string;
+  botToken?: string;
   env?: NodeJS.ProcessEnv;
 }): Promise<number | null> {
   const filePath = resolveTelegramUpdateOffsetPath(params.accountId, params.env);
   try {
     const raw = await fs.readFile(filePath, "utf-8");
     const parsed = safeParseState(raw);
-    return parsed?.lastUpdateId ?? null;
+    if (!parsed) {
+      return null;
+    }
+    // If botId is stored and a token is provided, validate they match.
+    // If they don't match, the offset is stale from a different bot — discard it.
+    if (parsed.botId && params.botToken) {
+      const currentBotId = extractBotIdFromToken(params.botToken);
+      if (currentBotId && parsed.botId !== currentBotId) {
+        return null;
+      }
+    }
+    return parsed.lastUpdateId ?? null;
   } catch (err) {
     const code = (err as { code?: string }).code;
     if (code === "ENOENT") {
@@ -64,15 +87,18 @@ export async function readTelegramUpdateOffset(params: {
 export async function writeTelegramUpdateOffset(params: {
   accountId?: string;
   updateId: number;
+  botToken?: string;
   env?: NodeJS.ProcessEnv;
 }): Promise<void> {
   const filePath = resolveTelegramUpdateOffsetPath(params.accountId, params.env);
   const dir = path.dirname(filePath);
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   const tmp = path.join(dir, `${path.basename(filePath)}.${crypto.randomUUID()}.tmp`);
+  const botId = params.botToken ? extractBotIdFromToken(params.botToken) : undefined;
   const payload: TelegramUpdateOffsetState = {
     version: STORE_VERSION,
     lastUpdateId: params.updateId,
+    ...(botId ? { botId } : {}),
   };
   await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, {
     encoding: "utf-8",

--- a/src/telegram/update-offset-store.ts
+++ b/src/telegram/update-offset-store.ts
@@ -70,7 +70,7 @@ export async function readTelegramUpdateOffset(params: {
     // If they don't match, the offset is stale from a different bot — discard it.
     if (parsed.botId && params.botToken) {
       const currentBotId = extractBotIdFromToken(params.botToken);
-      if (currentBotId && parsed.botId !== currentBotId) {
+      if (!currentBotId || parsed.botId !== currentBotId) {
         return null;
       }
     }


### PR DESCRIPTION
## Problem

When OpenClaw respawns to inject `--disable-warning=ExperimentalWarning`, the parent process keeps the generic `openclaw` title. This makes `ps` output confusing:

```
5717  openclaw           ← which one is this?
5718  openclaw-gateway   ← the real gateway
7735  openclaw           ← and this?
7736  openclaw-tui       ← the real TUI
```

## Fix

Set the parent shim's `process.title` to `openclaw-{subcommand}-shim` before spawning the child:

```
5717  openclaw-gateway-shim   ← parent (signal forwarder)
5718  openclaw-gateway        ← actual gateway
7735  openclaw-tui-shim       ← parent (signal forwarder)
7736  openclaw-tui            ← actual TUI
```

One-line change in `entry.ts`. The subcommand is extracted from `process.argv` (first non-flag argument), which is already available before the respawn.

Fixes #11309

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves process visibility during CLI respawn by setting the parent shim’s `process.title` based on the invoked subcommand, so `ps` output distinguishes the shim from the actual child command.

It also changes Telegram update offset persistence to scope stored offsets to a specific bot by persisting the bot ID extracted from the bot token and validating it on read; the monitor now passes the bot token through to the offset store, and tests were expanded to cover token changes, legacy files, and malformed tokens.

<h3>Confidence Score: 2/5</h3>

- This PR needs fixes before merging due to a test file syntax/structure issue and an argv-derived title edge case.
- The Telegram offset scoping change is coherent and test-covered, but the updated test file appears to have unbalanced closing braces/parentheses that would break compilation, and the shim title extraction runs before argv normalization/rewrites done later in the same entrypoint, which can produce incorrect shim titles in some invocations (notably Windows / profile arg rewriting).
- src/telegram/update-offset-store.test.ts, src/entry.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->