### PR TITLE
fix(memory/qmd): prevent cascading failure when query fails or returns empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,6 @@ USER.md
 .serena/
 
 # Agent credentials and memory (NEVER COMMIT)
-memory/
+/memory/
 .agent/*.json
 !.agent/workflows/

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -234,22 +234,48 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
-    const args = ["query", trimmed, "--json", "-n", String(limit)];
+    // Read mode from the same env object used to spawn qmd to avoid surprises if the runtime injects env.
+    const modeRaw = this.env.OPENCLAW_QMD_MODE?.trim().toLowerCase();
+    const primaryCmd = modeRaw === "search" ? "search" : "query";
+    const args = [primaryCmd, trimmed, "--json", "-n", String(limit)];
+
     let stdout: string;
+    let stderr: string;
     try {
       const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
       stdout = result.stdout;
+      stderr = result.stderr;
     } catch (err) {
-      log.warn(`qmd query failed: ${String(err)}`);
-      throw err instanceof Error ? err : new Error(String(err));
+      // If qmd query is slow / unavailable (can trigger model downloads), fall back to the lighter BM25 search.
+      if (primaryCmd !== "search") {
+        try {
+          const result = await this.runQmd(["search", trimmed, "--json", "-n", String(limit)], {
+            timeoutMs: this.qmd.limits.timeoutMs,
+          });
+          stdout = result.stdout;
+          stderr = result.stderr;
+        } catch (fallbackErr) {
+          log.warn(`qmd ${primaryCmd} failed: ${String(err)}`);
+          log.warn(`qmd search fallback failed: ${String(fallbackErr)}`);
+          throw fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
+        }
+      } else {
+        log.warn(`qmd ${primaryCmd} failed: ${String(err)}`);
+        throw err instanceof Error ? err : new Error(String(err));
+      }
     }
+
     let parsed: QmdQueryResult[] = [];
     try {
       parsed = JSON.parse(stdout);
     } catch (err) {
+      // If JSON parse fails, check both stdout and stderr for "no results" (qmd may output to either).
+      if (stdout.toLowerCase().includes("no results found") || stderr.toLowerCase().includes("no results found")) {
+        return [];
+      }
       const message = err instanceof Error ? err.message : String(err);
-      log.warn(`qmd query returned invalid JSON: ${message}`);
-      throw new Error(`qmd query returned invalid JSON: ${message}`, { cause: err });
+      log.warn(`qmd returned invalid JSON: ${message}`);
+      throw new Error(`qmd returned invalid JSON: ${message}`, { cause: err });
     }
     const results: MemorySearchResult[] = [];
     for (const entry of parsed) {


### PR DESCRIPTION
- Allow qmd query mode with automatic fallback to search on failure
- Check both stdout and stderr for 'no results found' marker
- Read OPENCLAW_QMD_MODE from spawn env to avoid surprises
- Only ignore top-level /memory/ in .gitignore

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the `qmd` memory query path by (1) allowing an automatic fallback from query→search when the query invocation fails or produces empty output, (2) detecting the “no results found” marker in both stdout and stderr, and (3) ensuring `OPENCLAW_QMD_MODE` is read from the spawned process environment (rather than surprising defaults). It also tightens `.gitignore` to only ignore the top-level `/memory/` directory instead of broader patterns.

These changes fit into the memory subsystem by making the QMD manager more resilient to tool failures/empty-result edge cases while keeping repo hygiene around generated memory artifacts more precise.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but has a couple edge-case behaviors that can break intended fallback semantics.
- The changes are localized and improve robustness, but the fallback behavior is one-directional (query→search only) and the stderr/no-results handling relies on assumptions that can become brittle with small refactors. Fixing these would reduce surprising failures and align behavior with the PR intent.
- src/memory/qmd-manager.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->