### PR TITLE
fix(doctor): skip config permission warning for symlinks

### DIFF
--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -222,8 +222,11 @@ export async function noteStateIntegrity(
 
   if (configPath && existsFile(configPath) && process.platform !== "win32") {
     try {
-      const stat = fs.statSync(configPath);
-      if ((stat.mode & 0o077) !== 0) {
+      const lstat = fs.lstatSync(configPath);
+      if (lstat.isSymbolicLink()) {
+        // Symlinks (e.g. Nix store) are intentionally world-readable;
+        // the containing directory provides access control.
+      } else if ((lstat.mode & 0o077) !== 0) {
         warnings.push(
           `- Config file is group/world readable (${displayConfigPath ?? configPath}). Recommend chmod 600.`,
         );


### PR DESCRIPTION
## Summary

On Nix-managed systems the config file (`~/.openclaw/openclaw.json`) is a symlink into the Nix store, which is intentionally world-readable (content-addressed, immutable). The containing `~/.openclaw/` directory (mode 700) provides the actual access control. `openclaw doctor` currently warns about group/world-readable permissions on these symlinks, which is a false positive.

## Changes

- Use `lstatSync` instead of `statSync` to detect symlinks before checking permissions
- Skip the permission warning when the config path is a symbolic link

## Testing

- [x] `pnpm build` — successful
- [x] Verified symlink detection logic matches Node.js `lstatSync` behavior
- [x] Non-symlink config files still get the permission warning as before

Fixes #11307

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adjusts `openclaw doctor`’s state integrity checks on non-Windows platforms to use `lstatSync` for the config file and skip the “group/world readable” warning when the config path is a symbolic link. The intent is to avoid false positives on Nix-managed setups where the config is symlinked into the world-readable Nix store and access control is enforced by the private `~/.openclaw` directory.


<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but suppresses a real warning for symlinked configs in some setups.
- The change is small and localized, but the new `isSymbolicLink()` branch unconditionally skips permission checks for any symlink, which can hide insecure configs when users point the config symlink at an overly-permissive file outside the protected state dir. Adjusting the logic to validate the target (or constrain the skip to known-safe cases) would make this more robust.
- src/commands/doctor-state-integrity.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->