### PR TITLE
Tests: add unit tests for sessions/session-key-utils.ts

### DIFF
--- a/src/sessions/session-key-utils.test.ts
+++ b/src/sessions/session-key-utils.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAcpSessionKey,
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+  resolveThreadParentSessionKey,
+} from "./session-key-utils.js";
+
+describe("parseAgentSessionKey", () => {
+  it("parses a valid agent session key", () => {
+    const result = parseAgentSessionKey("agent:mybot:main");
+    expect(result).toEqual({ agentId: "mybot", rest: "main" });
+  });
+
+  it("preserves colons in the rest segment", () => {
+    const result = parseAgentSessionKey("agent:mybot:telegram:12345");
+    expect(result).toEqual({ agentId: "mybot", rest: "telegram:12345" });
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseAgentSessionKey(undefined)).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(parseAgentSessionKey(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseAgentSessionKey("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(parseAgentSessionKey("   ")).toBeNull();
+  });
+
+  it("returns null when prefix is not 'agent'", () => {
+    expect(parseAgentSessionKey("session:mybot:main")).toBeNull();
+  });
+
+  it("returns null when there are fewer than 3 parts", () => {
+    expect(parseAgentSessionKey("agent:mybot")).toBeNull();
+  });
+
+  it("returns null for a single word", () => {
+    expect(parseAgentSessionKey("agent")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    const result = parseAgentSessionKey("  agent:mybot:main  ");
+    expect(result).toEqual({ agentId: "mybot", rest: "main" });
+  });
+});
+
+describe("isSubagentSessionKey", () => {
+  it("returns true for bare subagent prefix", () => {
+    expect(isSubagentSessionKey("subagent:task-123")).toBe(true);
+  });
+
+  it("returns true for agent-scoped subagent key", () => {
+    expect(isSubagentSessionKey("agent:mybot:subagent:task-123")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isSubagentSessionKey("Subagent:task-123")).toBe(true);
+    expect(isSubagentSessionKey("agent:mybot:SUBAGENT:task-123")).toBe(true);
+  });
+
+  it("returns false for a regular session key", () => {
+    expect(isSubagentSessionKey("agent:mybot:main")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSubagentSessionKey(undefined)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isSubagentSessionKey(null)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isSubagentSessionKey("")).toBe(false);
+  });
+});
+
+describe("isAcpSessionKey", () => {
+  it("returns true for bare acp prefix", () => {
+    expect(isAcpSessionKey("acp:session-1")).toBe(true);
+  });
+
+  it("returns true for agent-scoped acp key", () => {
+    expect(isAcpSessionKey("agent:mybot:acp:session-1")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isAcpSessionKey("ACP:session-1")).toBe(true);
+    expect(isAcpSessionKey("agent:mybot:ACP:session-1")).toBe(true);
+  });
+
+  it("returns false for a regular session key", () => {
+    expect(isAcpSessionKey("agent:mybot:main")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isAcpSessionKey(undefined)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isAcpSessionKey(null)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isAcpSessionKey("")).toBe(false);
+  });
+});
+
+describe("resolveThreadParentSessionKey", () => {
+  it("extracts parent from a :thread: session key", () => {
+    expect(resolveThreadParentSessionKey("telegram:12345:thread:99")).toBe("telegram:12345");
+  });
+
+  it("extracts parent from a :topic: session key", () => {
+    expect(resolveThreadParentSessionKey("telegram:12345:topic:99")).toBe("telegram:12345");
+  });
+
+  it("uses the last marker when multiple exist", () => {
+    expect(resolveThreadParentSessionKey("a:thread:b:topic:c")).toBe("a:thread:b");
+  });
+
+  it("is case-insensitive for markers", () => {
+    expect(resolveThreadParentSessionKey("telegram:12345:THREAD:99")).toBe("telegram:12345");
+    expect(resolveThreadParentSessionKey("telegram:12345:Topic:99")).toBe("telegram:12345");
+  });
+
+  it("returns null when no thread/topic marker is found", () => {
+    expect(resolveThreadParentSessionKey("telegram:12345")).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(resolveThreadParentSessionKey(undefined)).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(resolveThreadParentSessionKey(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(resolveThreadParentSessionKey("")).toBeNull();
+  });
+
+  it("returns null when marker is at position 0", () => {
+    expect(resolveThreadParentSessionKey(":thread:something")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for the previously untested `src/sessions/session-key-utils.ts` module. This module handles session key parsing, subagent/ACP detection, and thread parent resolution — all critical for correct session routing.

## Tests Added (33 tests)

- **parseAgentSessionKey** (10 tests): valid keys, colon preservation in rest segment, null/undefined/empty/whitespace inputs, wrong prefix, insufficient parts, whitespace trimming
- **isSubagentSessionKey** (7 tests): bare `subagent:` prefix, agent-scoped keys, case insensitivity, regular keys, null/undefined/empty
- **isAcpSessionKey** (7 tests): bare `acp:` prefix, agent-scoped keys, case insensitivity, regular keys, null/undefined/empty
- **resolveThreadParentSessionKey** (9 tests): `:thread:` and `:topic:` markers, last-marker precedence with multiple markers, case insensitivity, no marker, null/undefined/empty, marker at position 0

## Testing

- [x] All 33 tests passing
- [x] `pnpm build` — successful
- [x] Tests use no mocks — pure function testing

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest unit test suite for `src/sessions/session-key-utils.ts`, covering parsing of agent session keys, detection of `subagent:` and `acp:` keys (including agent-scoped forms and case-insensitivity), and parent-session resolution for `:thread:`/`:topic:` markers.

The tests exercise edge cases like null/undefined/empty inputs, whitespace trimming, wrong prefixes, insufficient segments, and multiple markers to validate the session key helpers used for session routing logic.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it adds isolated unit tests without changing production code.
- Only a new test file is added, and its assertions align with the current implementation of session-key-utils (trimming, filtering empty segments, case-insensitive marker detection). I couldn’t execute the test command in this environment because `pnpm` isn’t available, so confidence isn’t a full 5/5.
- src/sessions/session-key-utils.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->