### PR TITLE
Tests: add unit tests for logging/redact-identifier.ts

### DIFF
--- a/src/logging/redact-identifier.test.ts
+++ b/src/logging/redact-identifier.test.ts
@@ -1,0 +1,89 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { redactIdentifier, sha256HexPrefix } from "./redact-identifier.js";
+
+describe("sha256HexPrefix", () => {
+  it("returns a hex string of the requested length", () => {
+    const result = sha256HexPrefix("hello", 8);
+    expect(result).toHaveLength(8);
+    expect(result).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("defaults to 12 characters", () => {
+    const result = sha256HexPrefix("hello");
+    expect(result).toHaveLength(12);
+  });
+
+  it("produces a valid sha256 prefix", () => {
+    const fullHash = crypto.createHash("sha256").update("hello").digest("hex");
+    expect(sha256HexPrefix("hello", 12)).toBe(fullHash.slice(0, 12));
+  });
+
+  it("returns different hashes for different inputs", () => {
+    expect(sha256HexPrefix("a")).not.toBe(sha256HexPrefix("b"));
+  });
+
+  it("returns the same hash for the same input", () => {
+    expect(sha256HexPrefix("test")).toBe(sha256HexPrefix("test"));
+  });
+
+  it("clamps len to at least 1", () => {
+    const result = sha256HexPrefix("hello", 0);
+    expect(result).toHaveLength(1);
+  });
+
+  it("clamps negative len to 1", () => {
+    const result = sha256HexPrefix("hello", -5);
+    expect(result).toHaveLength(1);
+  });
+
+  it("floors fractional len values", () => {
+    const result = sha256HexPrefix("hello", 5.9);
+    expect(result).toHaveLength(5);
+  });
+
+  it("falls back to 12 for non-finite len", () => {
+    expect(sha256HexPrefix("hello", NaN)).toHaveLength(12);
+    expect(sha256HexPrefix("hello", Infinity)).toHaveLength(12);
+  });
+});
+
+describe("redactIdentifier", () => {
+  it("returns a sha256-prefixed redaction", () => {
+    const result = redactIdentifier("user@example.com");
+    expect(result).toMatch(/^sha256:[0-9a-f]{12}$/);
+  });
+
+  it("returns '-' for undefined input", () => {
+    expect(redactIdentifier(undefined)).toBe("-");
+  });
+
+  it("returns '-' for empty string", () => {
+    expect(redactIdentifier("")).toBe("-");
+  });
+
+  it("returns '-' for whitespace-only string", () => {
+    expect(redactIdentifier("   ")).toBe("-");
+  });
+
+  it("trims whitespace before hashing", () => {
+    expect(redactIdentifier("  hello  ")).toBe(redactIdentifier("hello"));
+  });
+
+  it("respects custom len option", () => {
+    const result = redactIdentifier("user@example.com", { len: 6 });
+    expect(result).toMatch(/^sha256:[0-9a-f]{6}$/);
+  });
+
+  it("produces consistent output for the same input", () => {
+    const a = redactIdentifier("+1234567890");
+    const b = redactIdentifier("+1234567890");
+    expect(a).toBe(b);
+  });
+
+  it("produces different output for different inputs", () => {
+    const a = redactIdentifier("alice");
+    const b = redactIdentifier("bob");
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for the previously untested `src/logging/redact-identifier.ts` module. This module provides identifier redaction utilities used across the logging subsystem to prevent sensitive data (phone numbers, emails, user IDs) from appearing in logs.

## Tests Added (17 tests)

- **sha256HexPrefix** (9 tests): correct output length, hex format validation, verified against `crypto.createHash` directly, determinism, different inputs produce different hashes, `len` clamping for 0/negative/fractional values, NaN/Infinity fallback to default
- **redactIdentifier** (8 tests): `sha256:`-prefixed output format, undefined/empty/whitespace returns `"-"`, whitespace trimming before hashing, custom `len` option, consistency and uniqueness guarantees

## Testing

- [x] All 17 tests passing
- [x] `pnpm build` — successful
- [x] Tests use no mocks — pure function testing with `node:crypto` verification

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Vitest suite `src/logging/redact-identifier.test.ts` covering `sha256HexPrefix` and `redactIdentifier` in `src/logging/redact-identifier.ts`. The tests validate output format/length, determinism/uniqueness, len normalization (clamp/floor/non-finite fallback), and `redactIdentifier` behavior for empty/undefined/whitespace inputs and trimming prior to hashing. The import style and `.js` extension in local ESM imports match existing repo test conventions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is isolated to a new unit test file exercising existing pure functions; it follows existing ESM import conventions used across the repo and does not alter production code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->