### PR TITLE
Auth: cap rate-limit cooldown at 5 minutes; add maxCooldownMinutes config (#11352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auth: cap rate-limit cooldown at 5 minutes (was 1 hour); add `auth.cooldowns.maxCooldownMinutes` config option. (#11352)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
+++ b/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
@@ -2,11 +2,20 @@ import { describe, expect, it } from "vitest";
 import { calculateAuthProfileCooldownMs } from "./auth-profiles.js";
 
 describe("auth profile cooldowns", () => {
-  it("applies exponential backoff with a 1h cap", () => {
+  it("applies exponential backoff with a 5min default cap", () => {
     expect(calculateAuthProfileCooldownMs(1)).toBe(60_000);
     expect(calculateAuthProfileCooldownMs(2)).toBe(5 * 60_000);
-    expect(calculateAuthProfileCooldownMs(3)).toBe(25 * 60_000);
-    expect(calculateAuthProfileCooldownMs(4)).toBe(60 * 60_000);
-    expect(calculateAuthProfileCooldownMs(5)).toBe(60 * 60_000);
+    expect(calculateAuthProfileCooldownMs(3)).toBe(5 * 60_000);
+    expect(calculateAuthProfileCooldownMs(4)).toBe(5 * 60_000);
+    expect(calculateAuthProfileCooldownMs(100)).toBe(5 * 60_000);
+  });
+
+  it("respects custom maxMs parameter", () => {
+    const oneHour = 60 * 60_000;
+    expect(calculateAuthProfileCooldownMs(1, oneHour)).toBe(60_000);
+    expect(calculateAuthProfileCooldownMs(2, oneHour)).toBe(5 * 60_000);
+    expect(calculateAuthProfileCooldownMs(3, oneHour)).toBe(25 * 60_000);
+    expect(calculateAuthProfileCooldownMs(4, oneHour)).toBe(oneHour);
+    expect(calculateAuthProfileCooldownMs(5, oneHour)).toBe(oneHour);
   });
 });

--- a/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
+++ b/src/agents/auth-profiles.auth-profile-cooldowns.test.ts
@@ -10,6 +10,14 @@ describe("auth profile cooldowns", () => {
     expect(calculateAuthProfileCooldownMs(100)).toBe(5 * 60_000);
   });
 
+  it("falls back to default cap for invalid maxMs values", () => {
+    const defaultCap = 5 * 60_000;
+    expect(calculateAuthProfileCooldownMs(3, 0)).toBe(defaultCap);
+    expect(calculateAuthProfileCooldownMs(3, -1)).toBe(defaultCap);
+    expect(calculateAuthProfileCooldownMs(3, NaN)).toBe(defaultCap);
+    expect(calculateAuthProfileCooldownMs(3, Infinity)).toBe(defaultCap);
+  });
+
   it("respects custom maxMs parameter", () => {
     const oneHour = 60 * 60_000;
     expect(calculateAuthProfileCooldownMs(1, oneHour)).toBe(60_000);

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -75,18 +75,17 @@ export async function markAuthProfileUsed(params: {
   saveAuthProfileStore(store, agentDir);
 }
 
-export function calculateAuthProfileCooldownMs(errorCount: number): number {
+export function calculateAuthProfileCooldownMs(errorCount: number, maxMs?: number): number {
   const normalized = Math.max(1, errorCount);
-  return Math.min(
-    60 * 60 * 1000, // 1 hour max
-    60 * 1000 * 5 ** Math.min(normalized - 1, 3),
-  );
+  const cap = maxMs ?? 5 * 60 * 1000; // 5 minutes default
+  return Math.min(cap, 60 * 1000 * 5 ** Math.min(normalized - 1, 3));
 }
 
 type ResolvedAuthCooldownConfig = {
   billingBackoffMs: number;
   billingMaxMs: number;
   failureWindowMs: number;
+  maxCooldownMs: number;
 };
 
 function resolveAuthCooldownConfig(params: {
@@ -97,6 +96,7 @@ function resolveAuthCooldownConfig(params: {
     billingBackoffHours: 5,
     billingMaxHours: 24,
     failureWindowHours: 24,
+    maxCooldownMinutes: 5,
   } as const;
 
   const resolveHours = (value: unknown, fallback: number) =>
@@ -126,10 +126,18 @@ function resolveAuthCooldownConfig(params: {
     defaults.failureWindowHours,
   );
 
+  const resolveMinutes = (value: unknown, fallback: number) =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+  const maxCooldownMinutes = resolveMinutes(
+    cooldowns?.maxCooldownMinutes,
+    defaults.maxCooldownMinutes,
+  );
+
   return {
     billingBackoffMs: billingBackoffHours * 60 * 60 * 1000,
     billingMaxMs: billingMaxHours * 60 * 60 * 1000,
     failureWindowMs: failureWindowHours * 60 * 60 * 1000,
+    maxCooldownMs: maxCooldownMinutes * 60 * 1000,
   };
 }
 
@@ -191,7 +199,10 @@ function computeNextProfileUsageStats(params: {
     updatedStats.disabledUntil = params.now + backoffMs;
     updatedStats.disabledReason = "billing";
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    const backoffMs = calculateAuthProfileCooldownMs(
+      nextErrorCount,
+      params.cfgResolved.maxCooldownMs,
+    );
     updatedStats.cooldownUntil = params.now + backoffMs;
   }
 
@@ -264,7 +275,7 @@ export async function markAuthProfileFailure(params: {
 
 /**
  * Mark a profile as failed/rate-limited. Applies exponential backoff cooldown.
- * Cooldown times: 1min, 5min, 25min, max 1 hour.
+ * Cooldown times: 1min, max 5min (configurable via auth.cooldowns.maxCooldownMinutes).
  * Uses store lock to avoid overwriting concurrent usage updates.
  */
 export async function markAuthProfileCooldown(params: {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -77,7 +77,8 @@ export async function markAuthProfileUsed(params: {
 
 export function calculateAuthProfileCooldownMs(errorCount: number, maxMs?: number): number {
   const normalized = Math.max(1, errorCount);
-  const cap = maxMs ?? 5 * 60 * 1000; // 5 minutes default
+  const defaultCap = 5 * 60 * 1000;
+  const cap = typeof maxMs === "number" && Number.isFinite(maxMs) && maxMs > 0 ? maxMs : defaultCap;
   return Math.min(cap, 60 * 1000 * 5 ** Math.min(normalized - 1, 3));
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -283,6 +283,7 @@ const FIELD_LABELS: Record<string, string> = {
   "auth.cooldowns.billingBackoffHoursByProvider": "Billing Backoff Overrides",
   "auth.cooldowns.billingMaxHours": "Billing Backoff Cap (hours)",
   "auth.cooldowns.failureWindowHours": "Failover Window (hours)",
+  "auth.cooldowns.maxCooldownMinutes": "Max Cooldown (minutes)",
   "agents.defaults.models": "Models",
   "agents.defaults.model.primary": "Primary Model",
   "agents.defaults.model.fallbacks": "Model Fallbacks",
@@ -524,6 +525,8 @@ const FIELD_HELP: Record<string, string> = {
     "Optional per-provider overrides for billing backoff (hours).",
   "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
+  "auth.cooldowns.maxCooldownMinutes":
+    "Max cooldown duration (minutes) for rate-limit and transient failures (default: 5).",
   "agents.defaults.bootstrapMaxChars":
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
   "agents.defaults.repoRoot":

--- a/src/config/types.auth.ts
+++ b/src/config/types.auth.ts
@@ -25,5 +25,7 @@ export type AuthConfig = {
      * this window, counters reset. Default: 24.
      */
     failureWindowHours?: number;
+    /** Max cooldown duration for rate-limit/transient failures (minutes). Default: 5. */
+    maxCooldownMinutes?: number;
   };
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -260,6 +260,7 @@ export const OpenClawSchema = z
             billingBackoffHoursByProvider: z.record(z.string(), z.number().positive()).optional(),
             billingMaxHours: z.number().positive().optional(),
             failureWindowHours: z.number().positive().optional(),
+            maxCooldownMinutes: z.number().positive().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Fix

Auth profile cooldown backoff was too aggressive for transient rate limits — a single 429 could spiral into a 20+ minute lockout via exponential backoff (old cap: 1 hour).

**Root cause:** `calculateAuthProfileCooldownMs` used a 1-hour max cap with `5^n` exponential growth (`1min → 5min → 25min → 60min`). With multiple profiles failing in sequence, accumulated `errorCount` quickly pushed cooldown to the max.

## Changes

- `src/agents/auth-profiles/usage.ts`: Lower default max cooldown from 1h to **5 minutes**; accept optional `maxMs` parameter; pass config-resolved cap through `computeNextProfileUsageStats`
- `src/config/types.auth.ts`: Add `maxCooldownMinutes` to `AuthConfig.cooldowns`
- `src/config/zod-schema.ts`: Add `maxCooldownMinutes` to zod validation
- `src/config/schema.ts`: Add label + description for `auth.cooldowns.maxCooldownMinutes`
- `src/agents/auth-profiles.auth-profile-cooldowns.test.ts`: Update tests for new 5min cap + add test for custom `maxMs`
- `CHANGELOG.md`: Add entry

## New backoff sequence (default)

| errorCount | Before (1h cap) | After (5min cap) |
|---|---|---|
| 1 | 1 min | 1 min |
| 2 | 5 min | 5 min |
| 3 | 25 min | **5 min** |
| 4+ | 60 min | **5 min** |

Users can override via `auth.cooldowns.maxCooldownMinutes` in config.

## Verification

- `pnpm build` passes
- All 5 auth profile cooldown + failure tests pass
- Local reproduction confirms 15 errors → 5min max (was 60min)

Fixes #11352

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reduces auth profile rate-limit/transient failure cooldown backoff by capping the exponential cooldown at 5 minutes by default (previously effectively up to 1 hour), and introduces a new config knob `auth.cooldowns.maxCooldownMinutes` that is wired through types, zod validation, and config UI hints. The cooldown computation path in `src/agents/auth-profiles/usage.ts` now resolves the cap from config and passes it into `calculateAuthProfileCooldownMs`, and the associated cooldown unit tests and changelog entry were updated accordingly.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one exported-helper edge case that can break cooldown enforcement if misused.
- The functional change is small and well-covered by updated tests and config schema wiring; the only notable risk is that the newly-added optional `maxMs` parameter is not validated in the exported helper, so incorrect values from future call sites could silently disable cooldowns.
- src/agents/auth-profiles/usage.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->