### PR TITLE
fix(routing): make bindings dynamic by calling loadConfig() per-message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.
+- Routing: refresh bindings per message by loading config at route resolution so binding changes apply without restart. (#11372) Thanks @juanpablodlc.
 - TUI/Gateway: handle non-streaming finals, refresh history for non-local chat runs, and avoid event gap warnings for targeted tool streams. (#8432) Thanks @gumadeiras.
 - Shell completion: auto-detect and migrate slow dynamic patterns to cached files for faster terminal startup; add completion health checks to doctor/update/onboard.
 - Telegram: honor session model overrides in inline model selection. (#8193) Thanks @gildo.

--- a/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts
+++ b/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts
@@ -10,6 +10,7 @@ const updateLastRouteMock = vi.fn();
 const dispatchMock = vi.fn();
 const readAllowFromStoreMock = vi.fn();
 const upsertPairingRequestMock = vi.fn();
+const loadConfigMock = vi.fn();
 
 vi.mock("./send.js", () => ({
   sendMessageDiscord: (...args: unknown[]) => sendMock(...args),
@@ -30,6 +31,13 @@ vi.mock("../pairing/pairing-store.js", () => ({
   readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
   upsertChannelPairingRequest: (...args: unknown[]) => upsertPairingRequestMock(...args),
 }));
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+  };
+});
 vi.mock("../config/sessions.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/sessions.js")>();
   return {
@@ -50,6 +58,7 @@ beforeEach(() => {
   });
   readAllowFromStoreMock.mockReset().mockResolvedValue([]);
   upsertPairingRequestMock.mockReset().mockResolvedValue({ code: "PAIRCODE", created: true });
+  loadConfigMock.mockReset().mockReturnValue({});
   __resetDiscordChannelInfoCacheForTest();
 });
 
@@ -685,6 +694,7 @@ describe("discord tool result dispatch", () => {
       },
       bindings: [{ agentId: "support", match: { channel: "discord", guildId: "g1" } }],
     } as ReturnType<typeof import("../config/config.js").loadConfig>;
+    loadConfigMock.mockReturnValue(cfg);
 
     const handler = createDiscordMessageHandler({
       cfg,

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -219,6 +219,7 @@ export async function preflightDiscordMessage(
     earlyThreadParentType = parentInfo.type;
   }
 
+  // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const route = resolveAgentRoute({
     cfg: loadConfig(),
     channel: "discord",

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -17,6 +17,7 @@ import { formatAllowlistMatchMeta } from "../../channels/allowlist-match.js";
 import { resolveControlCommandGate } from "../../channels/command-gating.js";
 import { logInboundDrop } from "../../channels/logging.js";
 import { resolveMentionGatingWithBypass } from "../../channels/mention-gating.js";
+import { loadConfig } from "../../config/config.js";
 import { logVerbose, shouldLogVerbose } from "../../globals.js";
 import { recordChannelActivity } from "../../infra/channel-activity.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -219,7 +220,7 @@ export async function preflightDiscordMessage(
   }
 
   const route = resolveAgentRoute({
-    cfg: params.cfg,
+    cfg: loadConfig(),
     channel: "discord",
     accountId: params.accountId,
     guildId: params.data.guild_id ?? undefined,

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -164,6 +164,7 @@ export const buildTelegramMessageContext = async ({
   const { groupConfig, topicConfig } = resolveTelegramGroupConfig(chatId, resolvedThreadId);
   const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
   const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
+  // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const route = resolveAgentRoute({
     cfg: loadConfig(),
     channel: "telegram",

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -26,6 +26,7 @@ import { logInboundDrop } from "../channels/logging.js";
 import { resolveMentionGatingWithBypass } from "../channels/mention-gating.js";
 import { recordInboundSession } from "../channels/session.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { loadConfig } from "../config/config.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
@@ -164,7 +165,7 @@ export const buildTelegramMessageContext = async ({
   const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
   const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
   const route = resolveAgentRoute({
-    cfg,
+    cfg: loadConfig(),
     channel: "telegram",
     accountId: account.accountId,
     peer: {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -449,6 +449,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         : undefined;
       const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
       const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
+      // Fresh config for bindings lookup; other routing inputs are payload-derived.
       const route = resolveAgentRoute({
         cfg: loadConfig(),
         channel: "telegram",

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -450,7 +450,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
       const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
       const route = resolveAgentRoute({
-        cfg,
+        cfg: loadConfig(),
         channel: "telegram",
         accountId: account.accountId,
         peer: { kind: isGroup ? "group" : "dm", id: peerId },

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -63,6 +63,7 @@ export function createWebOnMessageHandler(params: {
   return async (msg: WebInboundMsg) => {
     const conversationId = msg.conversationId ?? msg.from;
     const peerId = resolvePeerId(msg);
+    // Fresh config for bindings lookup; other routing inputs are payload-derived.
     const route = resolveAgentRoute({
       cfg: loadConfig(),
       channel: "whatsapp",

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -1,10 +1,10 @@
 import type { getReplyFromConfig } from "../../../auto-reply/reply.js";
 import type { MsgContext } from "../../../auto-reply/templating.js";
-import type { loadConfig } from "../../../config/config.js";
 import type { MentionConfig } from "../mentions.js";
 import type { WebInboundMsg } from "../types.js";
 import type { EchoTracker } from "./echo.js";
 import type { GroupHistoryEntry } from "./group-gating.js";
+import { loadConfig } from "../../../config/config.js";
 import { logVerbose } from "../../../globals.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { buildGroupHistoryKey } from "../../../routing/session-key.js";
@@ -64,7 +64,7 @@ export function createWebOnMessageHandler(params: {
     const conversationId = msg.conversationId ?? msg.from;
     const peerId = resolvePeerId(msg);
     const route = resolveAgentRoute({
-      cfg: params.cfg,
+      cfg: loadConfig(),
       channel: "whatsapp",
       accountId: msg.accountId,
       peer: {


### PR DESCRIPTION
Fixes #6602

## Problem

When `bindings` are added or changed in `openclaw.json` while the gateway is running, the config watcher detects the change and logs `"config change applied (dynamic reads: bindings)"` — but **messages continue routing to the old/default agent** until the gateway is fully restarted.

This affects **all channels** (WhatsApp, Telegram, Discord) that use multi-agent routing via bindings.

**Related issues:** #9351 (Telegram accountId routing — different root cause but same file touched), #9198 (Google Chat DM routing — likely same stale-config pattern but extension channel not covered here)

## Root Cause (3 layers)

`config-reload.ts` classifies `bindings` as `kind: "none"`, meaning "this section is dynamically read per-request, no reload action needed." That assumption would be correct **if** channel monitors re-read config per-message — but they don't. They call `loadConfig()` once at startup and capture it in a closure.

**Layer 1 — Incorrect assumption:** `config-reload.ts:72` — `{ prefix: "bindings", kind: "none" }` assumes bindings are read dynamically. They aren't.

**Layer 2 — Config captured once at startup:**

| Channel | File | Line | Pattern |
|---------|------|------|---------|
| WhatsApp | `web/auto-reply/monitor.ts` | 65 | `const baseCfg = loadConfig()` passed to `createWebOnMessageHandler` |
| Telegram | `telegram/bot.ts` | 117 | `const cfg = loadConfig()` used in reaction handler |
| Discord | `discord/monitor/provider.ts` | 133 | `const cfg = loadConfig()` passed to `createDiscordMessageHandler` |

**Layer 3 — Routing uses stale snapshot:** `resolveAgentRoute({ cfg: params.cfg, ... })` in each channel's message handler uses the startup-time config, never seeing new bindings.

## Fix

`loadConfig()` in `config/io.ts` already has a **200ms TTL cache** (`DEFAULT_CONFIG_CACHE_MS = 200`). It was designed for per-request dynamic reads with minimal disk I/O.

This PR changes the `resolveAgentRoute()` call in each channel to use `loadConfig()` instead of the captured startup config:

```typescript
// Before:
const route = resolveAgentRoute({ cfg: params.cfg, channel: "whatsapp", ... });

// After:
// Fresh config for bindings lookup; other routing inputs are payload-derived.
const route = resolveAgentRoute({ cfg: loadConfig(), channel: "whatsapp", ... });
```

After this change, the `kind: "none"` classification for bindings **becomes correct** — routing truly reads config dynamically now.

## Files Changed

| File | Change |
|------|--------|
| `src/web/auto-reply/monitor/on-message.ts` | `import type` → value import; `params.cfg` → `loadConfig()` at routing call |
| `src/telegram/bot-message-context.ts` | Add `loadConfig` import; `cfg` → `loadConfig()` at routing call |
| `src/telegram/bot.ts` | `cfg` → `loadConfig()` in reaction handler routing call |
| `src/discord/monitor/message-handler.preflight.ts` | Add `loadConfig` import; `params.cfg` → `loadConfig()` at routing call |
| `...mentionpatterns-match.test.ts` | Mock `loadConfig()` so bindings test passes fresh config to routing |

## Mixed-config-source tradeoff

After this change, handler functions still receive `cfg` via params for non-routing purposes (channel config, media limits, mention patterns). Only `resolveAgentRoute()` reads fresh config. Each call site is annotated with an inline comment explaining this is intentional:

```typescript
// Fresh config for bindings lookup; other routing inputs are payload-derived.
const route = resolveAgentRoute({ cfg: loadConfig(), ... });
```

The other routing inputs (account ID, chat type, peer ID) come from the message payload, not config. A broader "fresh config everywhere" refactor could follow separately if runtime changes to non-binding config become a real requirement.

## Why this is safe

- **Performance:** 200ms cache means at most 5 disk reads/second. JSON5 parse is <1ms for typical configs.
- **Thread safety:** Node.js is single-threaded; `loadConfig()` reads synchronously.
- **Corrupted config:** `loadConfig()` returns last cached valid config on parse failure.
- **200ms staleness:** After writing a new binding, routing may use old bindings for up to 200ms. This is acceptable — the alternative (gateway restart) causes 2-5s of downtime.
- **Backward compatible:** No new APIs, no config changes required.

## Test plan

- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm build` — clean
- [x] `pnpm test` — 961 test files, 6510 tests passed, 0 failures
- [ ] Manual: start gateway, add binding at runtime, verify routing picks it up without restart

## AI Disclosure

This PR was prepared with assistance from Claude Opus 4.6. The bug analysis, code tracing, and fix were developed collaboratively. I understand the code and the fix. Lightly tested (automated tests pass; manual runtime testing not yet performed).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes stale multi-agent routing by switching channel message handlers (web/WhatsApp, Telegram, Discord) to call `loadConfig()` at the `resolveAgentRoute()` call site instead of using the startup-time config snapshot. The change leverages the existing TTL cache in `loadConfig()` so updated `bindings` in `openclaw.json` take effect without restarting the gateway, while leaving other handler logic on the originally provided `cfg`.

It also updates a Discord monitor test to mock `loadConfig()` so binding-based routing can be exercised under the new behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing one test robustness issue around the new `loadConfig()` behavior.
- The production changes are narrowly scoped (only routing config source changes, leveraging existing cached `loadConfig()`), but the updated Discord test introduces a default `loadConfigMock` value of `{}` that can make config-dependent behavior inconsistent unless each test explicitly sets the mock return to the intended config.
- src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->