### PR TITLE
Tests: add unit tests for sessions/session-label.ts

### DIFF
--- a/src/sessions/session-label.test.ts
+++ b/src/sessions/session-label.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { parseSessionLabel, SESSION_LABEL_MAX_LENGTH } from "./session-label.js";
+
+describe("parseSessionLabel", () => {
+  it("accepts a valid label", () => {
+    const result = parseSessionLabel("my-session");
+    expect(result).toEqual({ ok: true, label: "my-session" });
+  });
+
+  it("trims surrounding whitespace", () => {
+    const result = parseSessionLabel("  hello  ");
+    expect(result).toEqual({ ok: true, label: "hello" });
+  });
+
+  it("accepts a label at exactly the max length", () => {
+    const label = "a".repeat(SESSION_LABEL_MAX_LENGTH);
+    const result = parseSessionLabel(label);
+    expect(result).toEqual({ ok: true, label });
+  });
+
+  it("rejects a label exceeding the max length", () => {
+    const label = "a".repeat(SESSION_LABEL_MAX_LENGTH + 1);
+    const result = parseSessionLabel(label);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("too long");
+    }
+  });
+
+  it("rejects an empty string", () => {
+    const result = parseSessionLabel("");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("empty");
+    }
+  });
+
+  it("rejects a whitespace-only string", () => {
+    const result = parseSessionLabel("   ");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("empty");
+    }
+  });
+
+  it("rejects non-string input (number)", () => {
+    const result = parseSessionLabel(42);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+
+  it("rejects non-string input (null)", () => {
+    const result = parseSessionLabel(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+
+  it("rejects non-string input (undefined)", () => {
+    const result = parseSessionLabel(undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+
+  it("rejects non-string input (object)", () => {
+    const result = parseSessionLabel({ label: "test" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+
+  it("accepts labels with special characters", () => {
+    const result = parseSessionLabel("my-session_2026.02.07");
+    expect(result).toEqual({ ok: true, label: "my-session_2026.02.07" });
+  });
+
+  it("accepts labels with unicode characters", () => {
+    const result = parseSessionLabel("会话-テスト");
+    expect(result).toEqual({ ok: true, label: "会话-テスト" });
+  });
+
+  it("exports SESSION_LABEL_MAX_LENGTH as 64", () => {
+    expect(SESSION_LABEL_MAX_LENGTH).toBe(64);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the previously untested `src/sessions/session-label.ts` module, which handles session label parsing and validation.

## Tests Added (13 tests)

- **Valid inputs**: normal labels, whitespace trimming, special characters (`-`, `_`, `.`), unicode
- **Boundary**: label at exactly max length (64) accepted, label exceeding max length rejected
- **Invalid inputs**: empty string, whitespace-only, non-string types (number, null, undefined, object)
- **Constants**: `SESSION_LABEL_MAX_LENGTH` export value verified

## Testing

- [x] All 13 tests passing
- [x] `pnpm build` — successful
- [x] Pure function testing, no mocks needed

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest unit test suite for `src/sessions/session-label.ts` covering trimming, max-length boundary behavior, accepted characters (including Unicode), rejection of empty/whitespace-only labels, and rejection of non-string inputs. The tests also assert the exported `SESSION_LABEL_MAX_LENGTH` constant value.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it only adds unit tests and does not change production behavior.
- Reviewed the new test file against `src/sessions/session-label.ts`; assertions align with current behavior (trimming, empty/non-string rejection, max length). No code changes outside tests. Only caveat is some assertions depend on exact error message substrings, which can make tests brittle to future wording changes.
- src/sessions/session-label.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->