### PR TITLE
Tests: add unit tests for utils/shell-argv.ts

### DIFF
--- a/src/utils/shell-argv.test.ts
+++ b/src/utils/shell-argv.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { splitShellArgs } from "./shell-argv.js";
+
+describe("splitShellArgs", () => {
+  it("splits simple space-separated args", () => {
+    expect(splitShellArgs("a b c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles multiple spaces between args", () => {
+    expect(splitShellArgs("a   b   c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles tabs and mixed whitespace", () => {
+    expect(splitShellArgs("a\tb\t c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(splitShellArgs("")).toEqual([]);
+  });
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(splitShellArgs("   ")).toEqual([]);
+  });
+
+  // Double quotes
+  it("handles double-quoted strings", () => {
+    expect(splitShellArgs('a "hello world" b')).toEqual(["a", "hello world", "b"]);
+  });
+
+  it("handles double-quoted string with spaces", () => {
+    expect(splitShellArgs('"foo bar"')).toEqual(["foo bar"]);
+  });
+
+  it("skips empty double-quoted string (no token produced)", () => {
+    expect(splitShellArgs('a "" b')).toEqual(["a", "b"]);
+  });
+
+  // Single quotes
+  it("handles single-quoted strings", () => {
+    expect(splitShellArgs("a 'hello world' b")).toEqual(["a", "hello world", "b"]);
+  });
+
+  it("handles single-quoted string preserving double quotes inside", () => {
+    expect(splitShellArgs(`'say "hi"'`)).toEqual(['say "hi"']);
+  });
+
+  // Backslash escaping
+  it("handles backslash-escaped spaces", () => {
+    expect(splitShellArgs("hello\\ world")).toEqual(["hello world"]);
+  });
+
+  it("handles backslash-escaped backslash", () => {
+    expect(splitShellArgs("a\\\\b")).toEqual(["a\\b"]);
+  });
+
+  // Error cases (unclosed quotes / trailing backslash)
+  it("returns null for unclosed double quote", () => {
+    expect(splitShellArgs('"unclosed')).toBeNull();
+  });
+
+  it("returns null for unclosed single quote", () => {
+    expect(splitShellArgs("'unclosed")).toBeNull();
+  });
+
+  it("returns null for trailing backslash", () => {
+    expect(splitShellArgs("trailing\\")).toBeNull();
+  });
+
+  // Mixed quoting
+  it("handles adjacent quoted and unquoted segments", () => {
+    expect(splitShellArgs('pre"mid"post')).toEqual(["premidpost"]);
+  });
+
+  it("handles complex mixed quoting", () => {
+    expect(splitShellArgs(`echo "hello" 'world' foo`)).toEqual(["echo", "hello", "world", "foo"]);
+  });
+
+  // Real-world patterns
+  it("parses a typical command line", () => {
+    expect(splitShellArgs("git commit -m 'initial commit'")).toEqual([
+      "git",
+      "commit",
+      "-m",
+      "initial commit",
+    ]);
+  });
+
+  it("parses a command with key=value pairs", () => {
+    expect(splitShellArgs('ENV_VAR="some value" ./run.sh')).toEqual([
+      "ENV_VAR=some value",
+      "./run.sh",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the previously untested `src/utils/shell-argv.ts` module, which provides shell-style argument splitting with quote and escape handling.

## Tests Added (19 tests)

- **Basic splitting**: simple spaces, multiple spaces, tabs, mixed whitespace
- **Empty input**: empty string and whitespace-only produce empty arrays
- **Quoting**: double-quoted strings, single-quoted strings, empty quotes, adjacent quoted/unquoted segments, mixed quoting styles
- **Escaping**: backslash-escaped spaces, backslash-escaped backslash
- **Error handling**: unclosed double quote returns null, unclosed single quote returns null, trailing backslash returns null
- **Real-world patterns**: `git commit -m 'initial commit'`, `ENV_VAR="some value" ./run.sh`

## Testing

- [x] All 19 tests passing
- [x] `pnpm build` — successful
- [x] Pure function testing, no mocks needed

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest unit test suite for `src/utils/shell-argv.ts` covering whitespace splitting, quoting (single/double), escaping, and several error cases, plus a couple of realistic command-line examples. The tests exercise the parser’s current contract of returning `null` on unclosed quotes/trailing backslash and producing tokens by concatenating adjacent quoted/unquoted segments.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but one test encodes behavior that may contradict intended shell semantics.
- Only adds tests and doesn’t modify runtime code. The suite broadly matches the current implementation, but the empty-quoted-argument expectation (`""` producing no token) bakes in a non-shell-compatible behavior and could cause confusion or block future correctness fixes if the goal is true shell argv semantics.
- src/utils/shell-argv.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->