### PR TITLE
Tests: add unit tests for config/merge-patch.ts

### DIFF
--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { applyMergePatch } from "./merge-patch.js";
+
+describe("applyMergePatch", () => {
+  it("sets a new key on an empty base", () => {
+    expect(applyMergePatch({}, { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("overwrites an existing key", () => {
+    expect(applyMergePatch({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+
+  it("preserves keys not in the patch", () => {
+    expect(applyMergePatch({ a: 1, b: 2 }, { b: 3 })).toEqual({ a: 1, b: 3 });
+  });
+
+  it("removes a key when patch value is null", () => {
+    expect(applyMergePatch({ a: 1, b: 2 }, { b: null })).toEqual({ a: 1 });
+  });
+
+  it("recursively merges nested objects", () => {
+    const base = { nested: { x: 1, y: 2 } };
+    const patch = { nested: { y: 3, z: 4 } };
+    expect(applyMergePatch(base, patch)).toEqual({ nested: { x: 1, y: 3, z: 4 } });
+  });
+
+  it("removes a nested key when patch value is null", () => {
+    const base = { nested: { x: 1, y: 2 } };
+    const patch = { nested: { y: null } };
+    expect(applyMergePatch(base, patch)).toEqual({ nested: { x: 1 } });
+  });
+
+  it("replaces a primitive base value with an object patch", () => {
+    expect(applyMergePatch("string", { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("replaces an object base with a primitive patch", () => {
+    expect(applyMergePatch({ a: 1 }, "replaced" as unknown)).toBe("replaced");
+  });
+
+  it("replaces an object base with a number patch", () => {
+    expect(applyMergePatch({ a: 1 }, 42 as unknown)).toBe(42);
+  });
+
+  it("replaces base with null patch", () => {
+    expect(applyMergePatch({ a: 1 }, null as unknown)).toBeNull();
+  });
+
+  it("creates a new object when base is not a plain object", () => {
+    expect(applyMergePatch(null, { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("handles array base replaced by object patch", () => {
+    expect(applyMergePatch([1, 2, 3], { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("replaces arrays in patch (no array merge)", () => {
+    const base = { list: [1, 2, 3] };
+    const patch = { list: [4, 5] };
+    expect(applyMergePatch(base, patch)).toEqual({ list: [4, 5] });
+  });
+
+  it("does not mutate the original base object", () => {
+    const base = { a: 1, b: 2 };
+    const copy = { ...base };
+    applyMergePatch(base, { b: 3, c: 4 });
+    expect(base).toEqual(copy);
+  });
+
+  it("handles deeply nested merges", () => {
+    const base = { a: { b: { c: { d: 1, e: 2 } } } };
+    const patch = { a: { b: { c: { e: 3, f: 4 } } } };
+    expect(applyMergePatch(base, patch)).toEqual({
+      a: { b: { c: { d: 1, e: 3, f: 4 } } },
+    });
+  });
+
+  it("handles an empty patch (no changes)", () => {
+    const base = { a: 1, b: 2 };
+    expect(applyMergePatch(base, {})).toEqual({ a: 1, b: 2 });
+  });
+
+  it("creates nested structure from non-object base", () => {
+    expect(applyMergePatch(undefined, { a: { b: 1 } })).toEqual({ a: { b: 1 } });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the previously untested `src/config/merge-patch.ts` module, which implements JSON Merge Patch (RFC 7396) used for configuration updates.

## Tests Added (17 tests)

- **Basic operations**: set new key, overwrite existing, preserve untouched keys
- **Null deletion**: remove key via `null` value, remove nested key
- **Recursive merge**: nested objects, deeply nested (4 levels)
- **Type coercion**: primitive base → object patch, object base → primitive patch, null/undefined/array base handling
- **Array behavior**: arrays are replaced wholesale (no element-wise merge, per RFC 7396)
- **Immutability**: original base object is not mutated
- **Edge cases**: empty patch (no-op), nested structure creation from undefined base

## Testing

- [x] All 17 tests passing
- [x] `pnpm build` — successful
- [x] Pure function testing, no mocks needed

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest suite for `src/config/merge-patch.ts` covering key JSON Merge Patch behaviors: key set/overwrite, null deletion (including nested), recursive merge, array replacement, type replacement for non-object patches, and a basic immutability/no-op check.

The tests exercise the public `applyMergePatch` helper used for config updates, improving confidence that patch application matches the module’s semantics.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; it adds tests only, but one key test is currently too weak to guard against common nested-mutation regressions.
- Changes are isolated to a new unit test file and do not affect runtime code paths. However, the immutability assertion is shallow and could let a nested-mutation bug slip through unnoticed, reducing the test suite’s effectiveness for the recursive merge behavior being exercised.
- src/config/merge-patch.test.ts (immutability coverage)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->