### PR TITLE
Tests: add unit tests for sessions/level-overrides.ts

### DIFF
--- a/src/sessions/level-overrides.test.ts
+++ b/src/sessions/level-overrides.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { applyVerboseOverride, parseVerboseOverride } from "./level-overrides.js";
+
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return { sessionId: "test", updatedAt: 0, ...overrides };
+}
+
+describe("parseVerboseOverride", () => {
+  it("returns { ok: true, value: null } for null input (clear override)", () => {
+    expect(parseVerboseOverride(null)).toEqual({ ok: true, value: null });
+  });
+
+  it("returns { ok: true, value: undefined } for undefined input", () => {
+    expect(parseVerboseOverride(undefined)).toEqual({ ok: true, value: undefined });
+  });
+
+  it('normalizes "on" to VerboseLevel', () => {
+    const result = parseVerboseOverride("on");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("on");
+    }
+  });
+
+  it('normalizes "off" to VerboseLevel', () => {
+    const result = parseVerboseOverride("off");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("off");
+    }
+  });
+
+  it('normalizes "full" to VerboseLevel', () => {
+    const result = parseVerboseOverride("full");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("full");
+    }
+  });
+
+  it('normalizes aliases like "true" → "on"', () => {
+    const result = parseVerboseOverride("true");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("on");
+    }
+  });
+
+  it('normalizes aliases like "false" → "off"', () => {
+    const result = parseVerboseOverride("false");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("off");
+    }
+  });
+
+  it("rejects invalid string values", () => {
+    const result = parseVerboseOverride("invalid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("invalid verboseLevel");
+    }
+  });
+
+  it("rejects non-string types (number)", () => {
+    const result = parseVerboseOverride(42);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("invalid verboseLevel");
+    }
+  });
+
+  it("rejects non-string types (object)", () => {
+    const result = parseVerboseOverride({ level: "on" });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("applyVerboseOverride", () => {
+  it("sets verboseLevel when a valid level is provided", () => {
+    const entry = makeEntry();
+    applyVerboseOverride(entry, "on");
+    expect(entry.verboseLevel).toBe("on");
+  });
+
+  it("overwrites an existing verboseLevel", () => {
+    const entry = makeEntry({ verboseLevel: "on" });
+    applyVerboseOverride(entry, "off");
+    expect(entry.verboseLevel).toBe("off");
+  });
+
+  it("deletes verboseLevel when null is passed (clear)", () => {
+    const entry = makeEntry({ verboseLevel: "on" });
+    applyVerboseOverride(entry, null);
+    expect(entry.verboseLevel).toBeUndefined();
+  });
+
+  it("does nothing when undefined is passed (no-op)", () => {
+    const entry = makeEntry({ verboseLevel: "on" });
+    applyVerboseOverride(entry, undefined);
+    expect(entry.verboseLevel).toBe("on");
+  });
+
+  it("does nothing on a clean entry when undefined is passed", () => {
+    const entry = makeEntry();
+    applyVerboseOverride(entry, undefined);
+    expect("verboseLevel" in entry).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the previously untested `src/sessions/level-overrides.ts` module, which handles verbose level parsing and session entry override application.

## Tests Added (15 tests)

**parseVerboseOverride** (10 tests):
- `null` → clear (returns `{ ok: true, value: null }`)
- `undefined` → no-op (returns `{ ok: true, value: undefined }`)
- Valid levels: `"on"`, `"off"`, `"full"` correctly normalized
- Aliases: `"true"` → `"on"`, `"false"` → `"off"`
- Rejection: invalid strings, non-string types (number, object)

**applyVerboseOverride** (5 tests):
- Set level on clean entry, overwrite existing level
- `null` clears (deletes) `verboseLevel` property
- `undefined` is a no-op (preserves existing or absent value)

## Testing

- [x] All 15 tests passing
- [x] `pnpm build` — successful
- [x] No mocks needed — uses actual `normalizeVerboseLevel` from auto-reply/thinking.ts

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest suite covering `src/sessions/level-overrides.ts` behavior for parsing and applying `verboseLevel` overrides. The tests exercise the three-state override semantics (`undefined` = no-op, `null` = clear, string = set) and verify normalization/alias handling via `normalizeVerboseLevel` (from `auto-reply/thinking.ts`) as well as mutation behavior in `applyVerboseOverride` against a minimal `SessionEntry` object shape.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge and limited to new unit tests.
- Only a new Vitest test file is added; it targets existing behavior in `level-overrides.ts` without modifying runtime code paths. No compatibility, security, or performance impacts were found.
- src/sessions/level-overrides.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->