### PR TITLE
fix(types): replace any with explicit DiscordMemberLike in sender-identity

### DIFF
--- a/src/discord/monitor/sender-identity.ts
+++ b/src/discord/monitor/sender-identity.ts
@@ -26,10 +26,13 @@ export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): str
   return typeof candidate === "string" && candidate.trim() ? candidate.trim() : null;
 }
 
+export type DiscordMemberLike = {
+  nickname?: string | null;
+};
+
 export function resolveDiscordSenderIdentity(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): DiscordSenderIdentity {
   const pkInfo = params.pluralkitInfo ?? null;
@@ -74,8 +77,7 @@ export function resolveDiscordSenderIdentity(params: {
 
 export function resolveDiscordSenderLabel(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): string {
   return resolveDiscordSenderIdentity(params).label;

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -827,9 +827,9 @@ async function collectChannelSecurityFindings(params: {
       }
 
       if (!hasAnySenderAllowlist) {
-        const providerSetting = (telegramCfg.commands as { nativeSkills?: unknown } | undefined)
-          // oxlint-disable-next-line typescript/no-explicit-any
-          ?.nativeSkills as any;
+        const providerSetting = coerceNativeSetting(
+          (telegramCfg.commands as { nativeSkills?: unknown } | undefined)?.nativeSkills,
+        );
         const skillsEnabled = resolveNativeSkillsEnabled({
           providerId: "telegram",
           providerSetting,


### PR DESCRIPTION
## Summary
Removes `any` usage in `resolveDiscordSenderIdentity` by introducing a structural `DiscordMemberLike` type.

## Changes
- Replaced `member?: any` with `member?: DiscordMemberLike | null`
- Added `DiscordMemberLike` type definition

## Testing
- `pnpm check` passed locally

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens typing in `resolveDiscordSenderIdentity` by removing an `any`-typed `member` value and introducing a structural `DiscordMemberLike` type, so call sites can pass the Discord member shape without losing type safety. The change is localized to the Discord monitor sender-identity logic and should improve compile-time guarantees without altering runtime behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a narrow type-safety improvement (replacing `any` with an explicit structural type) in a single file, and it should not affect runtime behavior; no functional logic changes were identified that would break execution.
- src/discord/monitor/sender-identity.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->