### PR TITLE
fix(doctor): skip config permission warning for symlinks

### DIFF
--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -222,8 +222,11 @@ export async function noteStateIntegrity(
 
   if (configPath && existsFile(configPath) && process.platform !== "win32") {
     try {
-      const stat = fs.statSync(configPath);
-      if ((stat.mode & 0o077) !== 0) {
+      const lstat = fs.lstatSync(configPath);
+      if (lstat.isSymbolicLink()) {
+        // Symlinks (e.g. Nix store) are intentionally world-readable;
+        // the containing directory provides access control.
+      } else if ((lstat.mode & 0o077) !== 0) {
         warnings.push(
           `- Config file is group/world readable (${displayConfigPath ?? configPath}). Recommend chmod 600.`,
         );


### PR DESCRIPTION
## Summary

On Nix-managed systems the config file (`~/.openclaw/openclaw.json`) is a symlink into the Nix store, which is intentionally world-readable (content-addressed, immutable). The containing `~/.openclaw/` directory (mode 700) provides the actual access control. `openclaw doctor` currently warns about group/world-readable permissions on these symlinks, which is a false positive.

## Changes

- Use `lstatSync` instead of `statSync` to detect symlinks before checking permissions
- Skip the permission warning when the config path is a symbolic link

## Testing

- [x] `pnpm build` — successful
- [x] Verified symlink detection logic matches Node.js `lstatSync` behavior
- [x] Non-symlink config files still get the permission warning as before

Fixes #11307

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

PR updates `openclaw doctor`’s config permission check to use `lstatSync` so it can detect when the config file path is a symbolic link (common on Nix-managed installs). When the config path is a symlink, the doctor command skips the group/world-readable warning that would otherwise be triggered by Nix store permissions; non-symlink config files continue to be checked as before. This change is localized to the doctor “state integrity” command logic and primarily affects the permission-warning behavior for the config file path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to the doctor config permission warning logic, aligns with intended behavior on Nix systems, and does not alter non-symlink permission checks. No functional regressions were identified in the modified control flow.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->