### PR TITLE
Tests: add unit tests for sessions/session-key-utils.ts

### DIFF
--- a/src/sessions/session-key-utils.test.ts
+++ b/src/sessions/session-key-utils.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAcpSessionKey,
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+  resolveThreadParentSessionKey,
+} from "./session-key-utils.js";
+
+describe("parseAgentSessionKey", () => {
+  it("parses a valid agent session key", () => {
+    const result = parseAgentSessionKey("agent:mybot:main");
+    expect(result).toEqual({ agentId: "mybot", rest: "main" });
+  });
+
+  it("preserves colons in the rest segment", () => {
+    const result = parseAgentSessionKey("agent:mybot:telegram:12345");
+    expect(result).toEqual({ agentId: "mybot", rest: "telegram:12345" });
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseAgentSessionKey(undefined)).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(parseAgentSessionKey(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseAgentSessionKey("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(parseAgentSessionKey("   ")).toBeNull();
+  });
+
+  it("returns null when prefix is not 'agent'", () => {
+    expect(parseAgentSessionKey("session:mybot:main")).toBeNull();
+  });
+
+  it("returns null when there are fewer than 3 parts", () => {
+    expect(parseAgentSessionKey("agent:mybot")).toBeNull();
+  });
+
+  it("returns null for a single word", () => {
+    expect(parseAgentSessionKey("agent")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    const result = parseAgentSessionKey("  agent:mybot:main  ");
+    expect(result).toEqual({ agentId: "mybot", rest: "main" });
+  });
+});
+
+describe("isSubagentSessionKey", () => {
+  it("returns true for bare subagent prefix", () => {
+    expect(isSubagentSessionKey("subagent:task-123")).toBe(true);
+  });
+
+  it("returns true for agent-scoped subagent key", () => {
+    expect(isSubagentSessionKey("agent:mybot:subagent:task-123")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isSubagentSessionKey("Subagent:task-123")).toBe(true);
+    expect(isSubagentSessionKey("agent:mybot:SUBAGENT:task-123")).toBe(true);
+  });
+
+  it("returns false for a regular session key", () => {
+    expect(isSubagentSessionKey("agent:mybot:main")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSubagentSessionKey(undefined)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isSubagentSessionKey(null)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isSubagentSessionKey("")).toBe(false);
+  });
+});
+
+describe("isAcpSessionKey", () => {
+  it("returns true for bare acp prefix", () => {
+    expect(isAcpSessionKey("acp:session-1")).toBe(true);
+  });
+
+  it("returns true for agent-scoped acp key", () => {
+    expect(isAcpSessionKey("agent:mybot:acp:session-1")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isAcpSessionKey("ACP:session-1")).toBe(true);
+    expect(isAcpSessionKey("agent:mybot:ACP:session-1")).toBe(true);
+  });
+
+  it("returns false for a regular session key", () => {
+    expect(isAcpSessionKey("agent:mybot:main")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isAcpSessionKey(undefined)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isAcpSessionKey(null)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isAcpSessionKey("")).toBe(false);
+  });
+});
+
+describe("resolveThreadParentSessionKey", () => {
+  it("extracts parent from a :thread: session key", () => {
+    expect(resolveThreadParentSessionKey("telegram:12345:thread:99")).toBe("telegram:12345");
+  });
+
+  it("extracts parent from a :topic: session key", () => {
+    expect(resolveThreadParentSessionKey("telegram:12345:topic:99")).toBe("telegram:12345");
+  });
+
+  it("uses the last marker when multiple exist", () => {
+    expect(resolveThreadParentSessionKey("a:thread:b:topic:c")).toBe("a:thread:b");
+  });
+
+  it("is case-insensitive for markers", () => {
+    expect(resolveThreadParentSessionKey("telegram:12345:THREAD:99")).toBe("telegram:12345");
+    expect(resolveThreadParentSessionKey("telegram:12345:Topic:99")).toBe("telegram:12345");
+  });
+
+  it("returns null when no thread/topic marker is found", () => {
+    expect(resolveThreadParentSessionKey("telegram:12345")).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(resolveThreadParentSessionKey(undefined)).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(resolveThreadParentSessionKey(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(resolveThreadParentSessionKey("")).toBeNull();
+  });
+
+  it("returns null when marker is at position 0", () => {
+    expect(resolveThreadParentSessionKey(":thread:something")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for the previously untested `session-key-utils` module (33 tests):

- `parseAgentSessionKey`: valid keys, colon preservation, null/empty/whitespace handling, wrong prefix, insufficient parts
- `isSubagentSessionKey`: bare prefix, agent-scoped, case insensitivity, negative cases
- `isAcpSessionKey`: bare prefix, agent-scoped, case insensitivity, negative cases
- `resolveThreadParentSessionKey`: `:thread:` and `:topic:` markers, last-marker precedence, case insensitivity, edge cases

## Testing

- [x] All 33 tests pass via `pnpm vitest run src/sessions/session-key-utils.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Vitest unit test suite for `src/sessions/session-key-utils.ts`, covering `parseAgentSessionKey`, `isSubagentSessionKey`, `isAcpSessionKey`, and `resolveThreadParentSessionKey` across valid inputs, whitespace/null handling, prefix/marker matching, and several edge cases.

The tests align with the current implementation (e.g., `parseAgentSessionKey` trimming and `split(":").filter(Boolean)` behavior, case-insensitive prefix checks in `isSubagentSessionKey`/`isAcpSessionKey`, and last-marker precedence in `resolveThreadParentSessionKey`). No production code paths are changed by this PR; it only increases confidence in the existing session key parsing utilities.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Only a new test file is added, and the assertions match the current behavior of `session-key-utils` without altering runtime logic. I did not find any failing or incorrect test expectations relative to the implementation.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->