### PR TITLE
Tests: add unit tests for sessions/session-label.ts

### DIFF
--- a/src/sessions/session-label.test.ts
+++ b/src/sessions/session-label.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { parseSessionLabel, SESSION_LABEL_MAX_LENGTH } from "./session-label.js";
+
+describe("parseSessionLabel", () => {
+  it("accepts a valid label", () => {
+    const result = parseSessionLabel("my-session");
+    expect(result).toEqual({ ok: true, label: "my-session" });
+  });
+
+  it("trims surrounding whitespace", () => {
+    const result = parseSessionLabel("  hello  ");
+    expect(result).toEqual({ ok: true, label: "hello" });
+  });
+
+  it("accepts a label at exactly the max length", () => {
+    const label = "a".repeat(SESSION_LABEL_MAX_LENGTH);
+    const result = parseSessionLabel(label);
+    expect(result).toEqual({ ok: true, label });
+  });
+
+  it("rejects a label exceeding the max length", () => {
+    const label = "a".repeat(SESSION_LABEL_MAX_LENGTH + 1);
+    const result = parseSessionLabel(label);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("too long");
+    }
+  });
+
+  it("rejects an empty string", () => {
+    const result = parseSessionLabel("");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("empty");
+    }
+  });
+
+  it("rejects a whitespace-only string", () => {
+    const result = parseSessionLabel("   ");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("empty");
+    }
+  });
+
+  it("rejects non-string input (number)", () => {
+    const result = parseSessionLabel(42);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+
+  it("rejects non-string input (null)", () => {
+    const result = parseSessionLabel(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+
+  it("rejects non-string input (undefined)", () => {
+    const result = parseSessionLabel(undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+
+  it("rejects non-string input (object)", () => {
+    const result = parseSessionLabel({ label: "test" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+
+  it("accepts labels with special characters", () => {
+    const result = parseSessionLabel("my-session_2026.02.07");
+    expect(result).toEqual({ ok: true, label: "my-session_2026.02.07" });
+  });
+
+  it("accepts labels with unicode characters", () => {
+    const result = parseSessionLabel("会话-テスト");
+    expect(result).toEqual({ ok: true, label: "会话-テスト" });
+  });
+
+  it("exports SESSION_LABEL_MAX_LENGTH as 64", () => {
+    expect(SESSION_LABEL_MAX_LENGTH).toBe(64);
+  });
+});


### PR DESCRIPTION
## Summary

Add 13 tests for the session label parsing module:

- Valid labels, whitespace trimming, special and unicode characters
- Max length boundary (exact limit and exceeding)
- Rejection of empty, whitespace-only, and non-string inputs (number, null, undefined, object)
- Constant export verification

## Testing

- [x] All 13 tests pass via `pnpm vitest run src/sessions/session-label.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Vitest unit test file for `src/sessions/session-label.ts`, covering success cases (valid labels, trimming, unicode/special characters), boundary behavior at `SESSION_LABEL_MAX_LENGTH`, and failure cases for empty/whitespace-only and non-string inputs. The tests align with the current `parseSessionLabel` contract (returning `{ ok: true, label }` or `{ ok: false, error }`) and don’t introduce changes to production logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is limited to a new unit test file exercising existing behavior in `parseSessionLabel`; the assertions match the current function outputs and don’t affect runtime code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->