### PR TITLE
Tests: add unit tests for config/merge-patch.ts

### DIFF
--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -60,11 +60,18 @@ describe("applyMergePatch", () => {
     expect(applyMergePatch(base, patch)).toEqual({ list: [4, 5] });
   });
 
-  it("does not mutate the original base object", () => {
+  it("does not mutate the original base object (shallow)", () => {
     const base = { a: 1, b: 2 };
     const copy = { ...base };
     applyMergePatch(base, { b: 3, c: 4 });
     expect(base).toEqual(copy);
+  });
+
+  it("does not mutate nested objects in the base", () => {
+    const nested = { x: 1, y: 2 };
+    const base = { a: nested };
+    applyMergePatch(base, { a: { y: 99, z: 3 } });
+    expect(nested).toEqual({ x: 1, y: 2 });
   });
 
   it("handles deeply nested merges", () => {

--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { applyMergePatch } from "./merge-patch.js";
+
+describe("applyMergePatch", () => {
+  it("sets a new key on an empty base", () => {
+    expect(applyMergePatch({}, { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("overwrites an existing key", () => {
+    expect(applyMergePatch({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+
+  it("preserves keys not in the patch", () => {
+    expect(applyMergePatch({ a: 1, b: 2 }, { b: 3 })).toEqual({ a: 1, b: 3 });
+  });
+
+  it("removes a key when patch value is null", () => {
+    expect(applyMergePatch({ a: 1, b: 2 }, { b: null })).toEqual({ a: 1 });
+  });
+
+  it("recursively merges nested objects", () => {
+    const base = { nested: { x: 1, y: 2 } };
+    const patch = { nested: { y: 3, z: 4 } };
+    expect(applyMergePatch(base, patch)).toEqual({ nested: { x: 1, y: 3, z: 4 } });
+  });
+
+  it("removes a nested key when patch value is null", () => {
+    const base = { nested: { x: 1, y: 2 } };
+    const patch = { nested: { y: null } };
+    expect(applyMergePatch(base, patch)).toEqual({ nested: { x: 1 } });
+  });
+
+  it("replaces a primitive base value with an object patch", () => {
+    expect(applyMergePatch("string", { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("replaces an object base with a primitive patch", () => {
+    expect(applyMergePatch({ a: 1 }, "replaced" as unknown)).toBe("replaced");
+  });
+
+  it("replaces an object base with a number patch", () => {
+    expect(applyMergePatch({ a: 1 }, 42 as unknown)).toBe(42);
+  });
+
+  it("replaces base with null patch", () => {
+    expect(applyMergePatch({ a: 1 }, null as unknown)).toBeNull();
+  });
+
+  it("creates a new object when base is not a plain object", () => {
+    expect(applyMergePatch(null, { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("handles array base replaced by object patch", () => {
+    expect(applyMergePatch([1, 2, 3], { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("replaces arrays in patch (no array merge)", () => {
+    const base = { list: [1, 2, 3] };
+    const patch = { list: [4, 5] };
+    expect(applyMergePatch(base, patch)).toEqual({ list: [4, 5] });
+  });
+
+  it("does not mutate the original base object", () => {
+    const base = { a: 1, b: 2 };
+    const copy = { ...base };
+    applyMergePatch(base, { b: 3, c: 4 });
+    expect(base).toEqual(copy);
+  });
+
+  it("handles deeply nested merges", () => {
+    const base = { a: { b: { c: { d: 1, e: 2 } } } };
+    const patch = { a: { b: { c: { e: 3, f: 4 } } } };
+    expect(applyMergePatch(base, patch)).toEqual({
+      a: { b: { c: { d: 1, e: 3, f: 4 } } },
+    });
+  });
+
+  it("handles an empty patch (no changes)", () => {
+    const base = { a: 1, b: 2 };
+    expect(applyMergePatch(base, {})).toEqual({ a: 1, b: 2 });
+  });
+
+  it("creates nested structure from non-object base", () => {
+    expect(applyMergePatch(undefined, { a: { b: 1 } })).toEqual({ a: { b: 1 } });
+  });
+});


### PR DESCRIPTION
## Summary

Add 17 tests for the JSON merge-patch implementation (RFC 7396):

- Set/overwrite/preserve keys, null-deletion
- Recursive nested object merging, deep nesting
- Primitive-to-object and object-to-primitive replacement
- Array replacement (no array merge per RFC 7396)
- Immutability (base object not mutated)
- Edge cases: null/undefined/array base, empty patch

## Testing

- [x] All 17 tests pass via `pnpm vitest run src/config/merge-patch.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest suite (`src/config/merge-patch.test.ts`) that exercises `applyMergePatch`’s RFC 7396 JSON Merge Patch semantics: setting/overwriting keys, null-deletion, recursive object merging, primitive/object replacement, and array replacement. The tests also include a basic immutability check to ensure the input base object isn’t modified during patch application.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; it only adds tests, with one gap in the immutability coverage.
- The change is isolated to a new unit test file and aligns with the current `applyMergePatch` implementation behavior. The main concern is that the immutability test is shallow and can miss nested mutations, reducing its value for catching regressions in the recursive merge behavior.
- src/config/merge-patch.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->