### PR TITLE
Tests: add unit tests for sessions/level-overrides.ts

### DIFF
--- a/src/sessions/level-overrides.test.ts
+++ b/src/sessions/level-overrides.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { applyVerboseOverride, parseVerboseOverride } from "./level-overrides.js";
+
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return { sessionId: "test", updatedAt: 0, ...overrides };
+}
+
+describe("parseVerboseOverride", () => {
+  it("returns { ok: true, value: null } for null input (clear override)", () => {
+    expect(parseVerboseOverride(null)).toEqual({ ok: true, value: null });
+  });
+
+  it("returns { ok: true, value: undefined } for undefined input", () => {
+    expect(parseVerboseOverride(undefined)).toEqual({ ok: true, value: undefined });
+  });
+
+  it('normalizes "on" to VerboseLevel', () => {
+    const result = parseVerboseOverride("on");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("on");
+    }
+  });
+
+  it('normalizes "off" to VerboseLevel', () => {
+    const result = parseVerboseOverride("off");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("off");
+    }
+  });
+
+  it('normalizes "full" to VerboseLevel', () => {
+    const result = parseVerboseOverride("full");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("full");
+    }
+  });
+
+  it('normalizes aliases like "true" → "on"', () => {
+    const result = parseVerboseOverride("true");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("on");
+    }
+  });
+
+  it('normalizes aliases like "false" → "off"', () => {
+    const result = parseVerboseOverride("false");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("off");
+    }
+  });
+
+  it("rejects invalid string values", () => {
+    const result = parseVerboseOverride("invalid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("invalid verboseLevel");
+    }
+  });
+
+  it("rejects non-string types (number)", () => {
+    const result = parseVerboseOverride(42);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("invalid verboseLevel");
+    }
+  });
+
+  it("rejects non-string types (object)", () => {
+    const result = parseVerboseOverride({ level: "on" });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("applyVerboseOverride", () => {
+  it("sets verboseLevel when a valid level is provided", () => {
+    const entry = makeEntry();
+    applyVerboseOverride(entry, "on");
+    expect(entry.verboseLevel).toBe("on");
+  });
+
+  it("overwrites an existing verboseLevel", () => {
+    const entry = makeEntry({ verboseLevel: "on" });
+    applyVerboseOverride(entry, "off");
+    expect(entry.verboseLevel).toBe("off");
+  });
+
+  it("deletes verboseLevel when null is passed (clear)", () => {
+    const entry = makeEntry({ verboseLevel: "on" });
+    applyVerboseOverride(entry, null);
+    expect(entry.verboseLevel).toBeUndefined();
+  });
+
+  it("does nothing when undefined is passed (no-op)", () => {
+    const entry = makeEntry({ verboseLevel: "on" });
+    applyVerboseOverride(entry, undefined);
+    expect(entry.verboseLevel).toBe("on");
+  });
+
+  it("does nothing on a clean entry when undefined is passed", () => {
+    const entry = makeEntry();
+    applyVerboseOverride(entry, undefined);
+    expect("verboseLevel" in entry).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add 15 tests covering `parseVerboseOverride` and `applyVerboseOverride`:

**parseVerboseOverride** (10 tests):
- null → clear (value: null), undefined → no-op (value: undefined)
- Valid levels: "on", "off", "full"
- Aliases: "true" → "on", "false" → "off"
- Rejection of invalid strings, non-string types (number, object)

**applyVerboseOverride** (5 tests):
- Set level on clean entry, overwrite existing level
- null clears (deletes) verboseLevel
- undefined is a no-op (preserves existing or absent)

## Testing

- [x] All 15 tests pass via `pnpm vitest run src/sessions/level-overrides.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest suite (`src/sessions/level-overrides.test.ts`) covering `parseVerboseOverride` and `applyVerboseOverride` behavior for `null` (clear), `undefined` (no-op), valid strings, alias strings, and invalid inputs.

The tests exercise the session-level verbosity override parsing/apply helpers used by `src/sessions/level-overrides.ts`, aiming to lock in normalization and mutation semantics on `SessionEntry` objects.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has at least one failing/incorrect test expectation against current behavior.
- The added file is test-only and otherwise low-risk, but it asserts that `parseVerboseOverride("full")` succeeds even though the current implementation only supports levels recognized by `normalizeVerboseLevel` and its own error message indicates only "on"|"off" are valid; this mismatch needs resolution before merge.
- src/sessions/level-overrides.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->