### PR TITLE
feat: add groupHistoryLimit config to limit persistent group session history

### DIFF
--- a/src/agents/pi-embedded-runner.get-dm-history-limit-from-session-key.group-sessions.test.ts
+++ b/src/agents/pi-embedded-runner.get-dm-history-limit-from-session-key.group-sessions.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { getDmHistoryLimitFromSessionKey } from "./pi-embedded-runner.js";
+
+describe("getDmHistoryLimitFromSessionKey - group sessions", () => {
+  it("returns groupHistoryLimit for group sessions", () => {
+    const config = {
+      channels: {
+        whatsapp: {
+          groupHistoryLimit: 10,
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:group:120363419710760769@g.us", config)).toBe(
+      10,
+    );
+  });
+
+  it("returns groupHistoryLimit for agent-prefixed group sessions", () => {
+    const config = {
+      channels: {
+        telegram: {
+          groupHistoryLimit: 15,
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:group:123456", config)).toBe(15);
+  });
+
+  it("returns per-group override when configured", () => {
+    const config = {
+      channels: {
+        whatsapp: {
+          groupHistoryLimit: 10,
+          groups: {
+            "120363419710760769@g.us": {
+              historyLimit: 5,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:group:120363419710760769@g.us", config)).toBe(
+      5,
+    );
+  });
+
+  it("returns per-group override for agent-prefixed keys", () => {
+    const config = {
+      channels: {
+        telegram: {
+          groupHistoryLimit: 20,
+          groups: {
+            "789": {
+              historyLimit: 3,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:group:789", config)).toBe(3);
+  });
+
+  it("falls back to provider default when per-group not set", () => {
+    const config = {
+      channels: {
+        whatsapp: {
+          groupHistoryLimit: 12,
+          groups: {
+            "other-group": {
+              historyLimit: 5,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:group:120363419710760769@g.us", config)).toBe(
+      12,
+    );
+  });
+
+  it("returns undefined when groupHistoryLimit is not set", () => {
+    const config = {
+      channels: {
+        whatsapp: {
+          groups: {
+            "123": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:group:123", config)).toBeUndefined();
+  });
+
+  it("returns 0 when per-group historyLimit is explicitly 0 (unlimited)", () => {
+    const config = {
+      channels: {
+        telegram: {
+          groupHistoryLimit: 15,
+          groups: {
+            "123": {
+              historyLimit: 0,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("telegram:group:123", config)).toBe(0);
+  });
+
+  it("returns undefined for non-dm and non-group session kinds", () => {
+    const config = {
+      channels: {
+        whatsapp: {
+          dmHistoryLimit: 10,
+          groupHistoryLimit: 20,
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:channel:123", config)).toBeUndefined();
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:unknown:456", config)).toBeUndefined();
+  });
+
+  it("handles group IDs with colons (e.g., email-like formats)", () => {
+    const config = {
+      channels: {
+        msteams: {
+          groupHistoryLimit: 10,
+          groups: {
+            "group:with:colons": {
+              historyLimit: 7,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("msteams:group:group:with:colons", config)).toBe(7);
+  });
+
+  it("DM and group limits are independent", () => {
+    const config = {
+      channels: {
+        whatsapp: {
+          dmHistoryLimit: 50,
+          groupHistoryLimit: 10,
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:dm:123", config)).toBe(50);
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:group:456", config)).toBe(10);
+  });
+});

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -55,10 +55,12 @@ export type WhatsAppConfig = {
    * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
    */
   groupPolicy?: GroupPolicy;
-  /** Max group messages to keep as history context (0 disables). */
+  /** Max group messages to keep as in-memory history context (0 disables). */
   historyLimit?: number;
-  /** Max DM turns to keep as history context. */
+  /** Max DM turns to keep in persistent session history. */
   dmHistoryLimit?: number;
+  /** Max group turns to keep in persistent session history. */
+  groupHistoryLimit?: number;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
@@ -77,6 +79,7 @@ export type WhatsAppConfig = {
     string,
     {
       requireMention?: boolean;
+      historyLimit?: number;
       tools?: GroupToolPolicyConfig;
       toolsBySender?: GroupToolPolicyBySenderConfig;
     }
@@ -128,10 +131,12 @@ export type WhatsAppAccountConfig = {
   allowFrom?: string[];
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
-  /** Max group messages to keep as history context (0 disables). */
+  /** Max group messages to keep as in-memory history context (0 disables). */
   historyLimit?: number;
-  /** Max DM turns to keep as history context. */
+  /** Max DM turns to keep in persistent session history. */
   dmHistoryLimit?: number;
+  /** Max group turns to keep in persistent session history. */
+  groupHistoryLimit?: number;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   textChunkLimit?: number;
@@ -145,6 +150,7 @@ export type WhatsAppAccountConfig = {
     string,
     {
       requireMention?: boolean;
+      historyLimit?: number;
       tools?: GroupToolPolicyConfig;
       toolsBySender?: GroupToolPolicyBySenderConfig;
     }

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -30,6 +30,7 @@ export const WhatsAppAccountSchema = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
+    groupHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
@@ -42,6 +43,7 @@ export const WhatsAppAccountSchema = z
         z
           .object({
             requireMention: z.boolean().optional(),
+            historyLimit: z.number().int().min(0).optional(),
             tools: ToolPolicySchema,
             toolsBySender: ToolPolicyBySenderSchema,
           })
@@ -92,6 +94,7 @@ export const WhatsAppConfigSchema = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
+    groupHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
@@ -112,6 +115,7 @@ export const WhatsAppConfigSchema = z
         z
           .object({
             requireMention: z.boolean().optional(),
+            historyLimit: z.number().int().min(0).optional(),
             tools: ToolPolicySchema,
             toolsBySender: ToolPolicyBySenderSchema,
           })

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -20,6 +20,8 @@ export type ResolvedWhatsAppAccount = {
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
+  dmHistoryLimit?: number;
+  groupHistoryLimit?: number;
   textChunkLimit?: number;
   chunkMode?: "length" | "newline";
   mediaMaxMb?: number;
@@ -159,6 +161,8 @@ export function resolveWhatsAppAccount(params: {
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,
+    dmHistoryLimit: accountCfg?.dmHistoryLimit ?? rootCfg?.dmHistoryLimit,
+    groupHistoryLimit: accountCfg?.groupHistoryLimit ?? rootCfg?.groupHistoryLimit,
     textChunkLimit: accountCfg?.textChunkLimit ?? rootCfg?.textChunkLimit,
     chunkMode: accountCfg?.chunkMode ?? rootCfg?.chunkMode,
     mediaMaxMb: accountCfg?.mediaMaxMb ?? rootCfg?.mediaMaxMb,

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -78,6 +78,8 @@ export async function monitorWebChannel(
         allowFrom: account.allowFrom,
         groupAllowFrom: account.groupAllowFrom,
         groupPolicy: account.groupPolicy,
+        dmHistoryLimit: account.dmHistoryLimit,
+        groupHistoryLimit: account.groupHistoryLimit,
         textChunkLimit: account.textChunkLimit,
         chunkMode: account.chunkMode,
         mediaMaxMb: account.mediaMaxMb,


### PR DESCRIPTION
## Summary

  Fixes #11396

  Adds `groupHistoryLimit` configuration to limit persistent session history for WhatsApp groups (and other messaging
  channel groups), preventing context overflow in long-running group conversations.

  ## Problem

  WhatsApp groups create persistent agent sessions that accumulate unlimited conversation history. While `historyLimit`
  controls in-memory group messages, persistent sessions (`.jsonl` files) grew unbounded, causing context overflow after
   many conversation turns.

  ## Changes

  ### Core Changes
  - **Extended `getDmHistoryLimitFromSessionKey()`** to handle both `kind="dm"` and `kind="group"`
  - **Added `groupHistoryLimit` config** for channels (e.g., `channels.whatsapp.groupHistoryLimit`)
  - **Added per-group override support** via `channels.whatsapp.groups["groupId"].historyLimit`

  ### Type & Schema Updates
  - Updated `WhatsAppConfig` and `WhatsAppAccountConfig` types
  - Added Zod schema validation for `groupHistoryLimit`
  - Updated comments to clarify `historyLimit` (in-memory) vs `groupHistoryLimit` (persistent)

  ### Files Modified
  - `src/agents/pi-embedded-runner/history.ts`
  - `src/config/types.whatsapp.ts`
  - `src/config/zod-schema.providers-whatsapp.ts`

  ## How It Works

  The config works the same as `dmHistoryLimit`:
  - Limits the number of **user turns** (not individual messages) in persistent sessions
  - Each turn = user message + assistant response + tool calls
  - `groupHistoryLimit: 10` keeps last 10 turns (~30-50 total messages)

  ## Testing

  Tested with a WhatsApp group that had 74 accumulated messages causing context overflow:
  1. Added `groupHistoryLimit: 10` to config
  2. Deleted bloated session
  3. Sent multiple messages
  4. Verified no context overflow
  5. Confirmed session stays limited

  ## Configuration Example

  ```json
  {
    "channels": {
      "whatsapp": {
        "historyLimit": 20,           // In-memory group messages
        "groupHistoryLimit": 10,      // Persistent session turns
        "groups": {
          "120363419710760769@g.us": {
            "historyLimit": 5         // Per-group override
          }
        }
      }
    }
  }

  Checklist

  - Code follows project conventions
  - Types and schemas updated
  - Tested locally with real WhatsApp group
  - No breaking changes
  - Commit message follows conventional commits

  ---
  Note: This is my first contribution to OpenClaw! Feedback welcome. 🎉

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends persistent-session history limiting beyond DMs by teaching `getDmHistoryLimitFromSessionKey()` to also handle `kind="group"`, and adds a new WhatsApp config knob (`groupHistoryLimit`) plus schema/type updates to validate it. The change plugs into the existing `limitHistoryTurns()` flow that trims sanitized session transcripts before running/compacting.

Main issue to address before merge: WhatsApp’s web monitor path constructs a derived `cfg.channels.whatsapp` from the resolved account config but currently drops the new (and existing) persistent history limit fields, so account-level `dmHistoryLimit`/`groupHistoryLimit` won’t actually take effect for WhatsApp web sessions. Also, the new `group` session-key behavior is not covered by tests, leaving the added parsing/lookup logic unverified.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has a functional wiring gap for WhatsApp account-level limits and lacks tests for the new group behavior.
- Core logic changes are small and localized, but the missing propagation of dmHistoryLimit/groupHistoryLimit into the derived WhatsApp config in the web monitor path means the advertised per-account behavior won’t work there. Test coverage also doesn’t yet exercise the new group session-key path, increasing regression risk.
- src/web/auto-reply/monitor.ts; src/agents/pi-embedded-runner/history.ts; related session-key limit tests

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->