### PR TITLE
Tests: add unit tests for utils/account-id.ts

### DIFF
--- a/src/utils/account-id.test.ts
+++ b/src/utils/account-id.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAccountId } from "./account-id.js";
+
+describe("normalizeAccountId", () => {
+  it("returns trimmed string for a valid account id", () => {
+    expect(normalizeAccountId("user-123")).toBe("user-123");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(normalizeAccountId("  user-123  ")).toBe("user-123");
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(normalizeAccountId("")).toBeUndefined();
+  });
+
+  it("returns undefined for a whitespace-only string", () => {
+    expect(normalizeAccountId("   ")).toBeUndefined();
+  });
+
+  it("returns undefined when called with undefined", () => {
+    expect(normalizeAccountId(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when called with no arguments", () => {
+    expect(normalizeAccountId()).toBeUndefined();
+  });
+
+  it("returns undefined for non-string types", () => {
+    // @ts-expect-error -- testing runtime behavior with wrong type
+    expect(normalizeAccountId(123)).toBeUndefined();
+    // @ts-expect-error -- testing runtime behavior with wrong type
+    expect(normalizeAccountId(null)).toBeUndefined();
+    // @ts-expect-error -- testing runtime behavior with wrong type
+    expect(normalizeAccountId({})).toBeUndefined();
+  });
+
+  it("preserves internal whitespace", () => {
+    expect(normalizeAccountId("user 123")).toBe("user 123");
+  });
+
+  it("handles single-character ids", () => {
+    expect(normalizeAccountId("a")).toBe("a");
+  });
+});


### PR DESCRIPTION
## Summary

Add 9 tests for the account ID normalization utility:

- Valid IDs: returns trimmed string
- Whitespace: trims leading/trailing, preserves internal
- Empty/undefined: returns undefined for empty, whitespace-only, undefined, and missing argument
- Type safety: returns undefined for non-string types (number, null, object)
- Edge case: single-character IDs

## Testing

- [x] All 9 tests pass via `pnpm vitest run src/utils/account-id.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest suite (`src/utils/account-id.test.ts`) covering `normalizeAccountId`’s trimming and undefined-return behavior for empty/whitespace/non-string inputs, plus a couple edge cases. The tests import the utility using the repo’s existing NodeNext/ESM `.js`-extension convention and match the current implementation in `src/utils/account-id.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Only adds a new unit test file; imports and expectations align with the existing ESM/NodeNext setup and the current normalizeAccountId implementation.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->