### PR TITLE
Tests: add unit tests for utils/provider-utils.ts

### DIFF
--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { isReasoningTagProvider } from "./provider-utils.js";
+
+describe("isReasoningTagProvider", () => {
+  // --- Exact matches ---
+
+  it("returns true for ollama", () => {
+    expect(isReasoningTagProvider("ollama")).toBe(true);
+  });
+
+  it("returns true for google-gemini-cli", () => {
+    expect(isReasoningTagProvider("google-gemini-cli")).toBe(true);
+  });
+
+  it("returns true for google-generative-ai", () => {
+    expect(isReasoningTagProvider("google-generative-ai")).toBe(true);
+  });
+
+  // --- Substring matches ---
+
+  it("returns true for google-antigravity", () => {
+    expect(isReasoningTagProvider("google-antigravity")).toBe(true);
+  });
+
+  it("returns true for google-antigravity/gemini-3", () => {
+    expect(isReasoningTagProvider("google-antigravity/gemini-3")).toBe(true);
+  });
+
+  it("returns true for minimax", () => {
+    expect(isReasoningTagProvider("minimax")).toBe(true);
+  });
+
+  it("returns true for minimax/M2.1", () => {
+    expect(isReasoningTagProvider("minimax/M2.1")).toBe(true);
+  });
+
+  // --- Case insensitivity ---
+
+  it("matches case-insensitively", () => {
+    expect(isReasoningTagProvider("OLLAMA")).toBe(true);
+    expect(isReasoningTagProvider("Google-Antigravity")).toBe(true);
+    expect(isReasoningTagProvider("MiniMax")).toBe(true);
+  });
+
+  // --- Whitespace trimming ---
+
+  it("trims leading and trailing whitespace", () => {
+    expect(isReasoningTagProvider("  ollama  ")).toBe(true);
+  });
+
+  // --- Negative cases ---
+
+  it("returns false for openai", () => {
+    expect(isReasoningTagProvider("openai")).toBe(false);
+  });
+
+  it("returns false for anthropic", () => {
+    expect(isReasoningTagProvider("anthropic")).toBe(false);
+  });
+
+  it("returns false for an unrelated provider", () => {
+    expect(isReasoningTagProvider("my-custom-provider")).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isReasoningTagProvider("")).toBe(false);
+  });
+
+  // --- Null / undefined ---
+
+  it("returns false for undefined", () => {
+    expect(isReasoningTagProvider(undefined)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isReasoningTagProvider(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add 15 tests for the reasoning-tag provider detection utility:

- **Exact matches**: ollama, google-gemini-cli, google-generative-ai
- **Substring matches**: google-antigravity (with model suffix), minimax (with model suffix)
- **Case insensitivity**: OLLAMA, Google-Antigravity, MiniMax
- **Whitespace trimming**
- **Negative cases**: openai, anthropic, custom providers, empty string
- **Null/undefined handling**

## Testing

- [x] All 15 tests pass via `pnpm vitest run src/utils/provider-utils.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Vitest unit test file (`src/utils/provider-utils.test.ts`) that exercises `isReasoningTagProvider` across exact matches, substring matches (provider/model variants), case-insensitivity, whitespace trimming, and null/undefined/negative inputs. The tests are colocated next to the utility and follow the repo’s existing ESM import convention for local modules (importing `./*.js`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to adding a new unit test file. Assertions align with the current `isReasoningTagProvider` implementation (trim/lowercase + exact/substring checks), and the import style matches other tests in `src/utils` (explicit `.js` extension for ESM).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->