### PR TITLE
fix(security): coerce nativeSkills type in audit.ts

### DIFF
--- a/src/discord/monitor/sender-identity.ts
+++ b/src/discord/monitor/sender-identity.ts
@@ -26,10 +26,13 @@ export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): str
   return typeof candidate === "string" && candidate.trim() ? candidate.trim() : null;
 }
 
+export type DiscordMemberLike = {
+  nickname?: string | null;
+};
+
 export function resolveDiscordSenderIdentity(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): DiscordSenderIdentity {
   const pkInfo = params.pluralkitInfo ?? null;
@@ -74,8 +77,7 @@ export function resolveDiscordSenderIdentity(params: {
 
 export function resolveDiscordSenderLabel(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): string {
   return resolveDiscordSenderIdentity(params).label;

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -827,9 +827,9 @@ async function collectChannelSecurityFindings(params: {
       }
 
       if (!hasAnySenderAllowlist) {
-        const providerSetting = (telegramCfg.commands as { nativeSkills?: unknown } | undefined)
-          // oxlint-disable-next-line typescript/no-explicit-any
-          ?.nativeSkills as any;
+        const providerSetting = coerceNativeSetting(
+          (telegramCfg.commands as { nativeSkills?: unknown } | undefined)?.nativeSkills,
+        );
         const skillsEnabled = resolveNativeSkillsEnabled({
           providerId: "telegram",
           providerSetting,


### PR DESCRIPTION
Replaces `as any` cast with safer `coerceNativeSetting` in `src/security/audit.ts` to improve type safety and maintainability. Part of security hardening efforts.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes a `as any` cast in `src/security/audit.ts` by introducing a small local `coerceNativeSetting()` helper and using it when reading `channels.telegram.config.commands.nativeSkills`. It also narrows the Discord `member` parameter type in `src/discord/monitor/sender-identity.ts` by replacing `any` with a `DiscordMemberLike` shape (nickname-only), which is sufficient for current usage.

The changes fit into the existing security audit flow by ensuring `resolveNativeSkillsEnabled()` always receives a well-typed provider override (`true | false | "auto" | undefined`) rather than an arbitrary unknown value, avoiding unsafe casts while keeping existing behavior the same for valid config values.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and replace unsafe casts with explicit coercion. The new types are consistent with actual usage (only `nickname` is accessed) and the audit logic continues to pass the expected union type into `resolveNativeSkillsEnabled()`.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->