### PR TITLE
Fix grammar: "a OpenClaw" → "an OpenClaw"

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -228,7 +228,7 @@ Triggered by a roof camera: ask OpenClaw to snap a sky photo whenever it looks p
 <Card title="Visual Morning Briefing Scene" icon="robot" href="https://x.com/buddyhadry/status/2010005331925954739">
   **@buddyhadry** • `automation` `briefing` `images` `telegram`
 
-A scheduled prompt generates a single "scene" image each morning (weather, tasks, date, favorite post/quote) via a OpenClaw persona.
+A scheduled prompt generates a single "scene" image each morning (weather, tasks, date, favorite post/quote) via an OpenClaw persona.
 </Card>
 
 <Card title="Padel Court Booking" icon="calendar-check" href="https://github.com/joshp123/padel-cli">


### PR DESCRIPTION
## Summary
- Fix article usage in `docs/start/showcase.md`: "via a OpenClaw" → "via an OpenClaw"

## Test plan
- [x] Docs-only change, no code affected


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes a docs-only copy edit in `docs/start/showcase.md`, correcting the article in the phrase “via a OpenClaw persona” to “via an OpenClaw persona”. No code paths or configuration are affected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-word documentation grammar fix with a clean diff and no behavioral impact; no additional related files or build/test changes required.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->