### PR TITLE
Security: resolve symlink target permissions in safeStat; skip doctor config warning for symlinks (#11307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security: resolve symlink target permissions in `safeStat` and skip config permission warning in `doctor` for symlinks (nix-managed configs). (#11307)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -226,17 +226,31 @@ export async function noteStateIntegrity(
       const isSymlink = lst.isSymbolicLink();
       // Use stat (follow symlink) for permission bits; lstat always returns 0o777 for symlinks.
       const stat = isSymlink ? fs.statSync(configPath) : lst;
-      if ((stat.mode & 0o077) !== 0 && !isSymlink) {
-        warnings.push(
-          `- Config file is group/world readable (${displayConfigPath ?? configPath}). Recommend chmod 600.`,
-        );
-        const tighten = await prompter.confirmSkipInNonInteractive({
-          message: `Tighten permissions on ${displayConfigPath ?? configPath} to 600?`,
-          initialValue: true,
-        });
-        if (tighten) {
-          fs.chmodSync(configPath, 0o600);
-          changes.push(`- Tightened permissions on ${displayConfigPath ?? configPath} to 600`);
+      if ((stat.mode & 0o077) !== 0) {
+        // For symlinks to read-only targets (e.g. /nix/store), chmod would
+        // fail and the containing directory (typically mode 700) already
+        // protects access.  Skip the warning in that case.  #11307
+        let skipWarning = false;
+        if (isSymlink) {
+          try {
+            const resolved = fs.realpathSync(configPath);
+            fs.accessSync(resolved, fs.constants.W_OK);
+          } catch {
+            skipWarning = true;
+          }
+        }
+        if (!skipWarning) {
+          warnings.push(
+            `- Config file is group/world readable (${displayConfigPath ?? configPath}). Recommend chmod 600.`,
+          );
+          const tighten = await prompter.confirmSkipInNonInteractive({
+            message: `Tighten permissions on ${displayConfigPath ?? configPath} to 600?`,
+            initialValue: true,
+          });
+          if (tighten) {
+            fs.chmodSync(configPath, 0o600);
+            changes.push(`- Tightened permissions on ${displayConfigPath ?? configPath} to 600`);
+          }
         }
       }
     } catch (err) {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -222,8 +222,11 @@ export async function noteStateIntegrity(
 
   if (configPath && existsFile(configPath) && process.platform !== "win32") {
     try {
-      const stat = fs.statSync(configPath);
-      if ((stat.mode & 0o077) !== 0) {
+      const lst = fs.lstatSync(configPath);
+      const isSymlink = lst.isSymbolicLink();
+      // Use stat (follow symlink) for permission bits; lstat always returns 0o777 for symlinks.
+      const stat = isSymlink ? fs.statSync(configPath) : lst;
+      if ((stat.mode & 0o077) !== 0 && !isSymlink) {
         warnings.push(
           `- Config file is group/world readable (${displayConfigPath ?? configPath}). Recommend chmod 600.`,
         );

--- a/src/security/audit-fs.symlink.test.ts
+++ b/src/security/audit-fs.symlink.test.ts
@@ -35,6 +35,20 @@ describe("safeStat symlink handling", () => {
     expect(st.mode! & 0o777).toBe(0o600);
   });
 
+  it.skipIf(isWin)("preserves isSymlink for broken symlinks", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-test-"));
+    dirs.push(tmp);
+
+    const missingTarget = path.join(tmp, "gone.json");
+    const link = path.join(tmp, "broken-link.json");
+    fs.symlinkSync(missingTarget, link);
+
+    const st = await safeStat(link);
+    expect(st.ok).toBe(false);
+    expect(st.isSymlink).toBe(true);
+    expect(st.error).toBeDefined();
+  });
+
   it.skipIf(isWin)("returns real file permissions for non-symlinks", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-test-"));
     dirs.push(tmp);

--- a/src/security/audit-fs.symlink.test.ts
+++ b/src/security/audit-fs.symlink.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { safeStat, inspectPathPermissions } from "./audit-fs.js";
+
+const isWin = process.platform === "win32";
+
+describe("safeStat symlink handling", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of dirs) {
+      await fsp.rm(d, { recursive: true, force: true }).catch(() => {});
+    }
+    dirs.length = 0;
+  });
+
+  it.skipIf(isWin)("returns target permissions for symlinks, not 0o777", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-test-"));
+    dirs.push(tmp);
+
+    const realFile = path.join(tmp, "real.json");
+    fs.writeFileSync(realFile, "{}", "utf-8");
+    fs.chmodSync(realFile, 0o600);
+
+    const link = path.join(tmp, "link.json");
+    fs.symlinkSync(realFile, link);
+
+    const st = await safeStat(link);
+    expect(st.ok).toBe(true);
+    expect(st.isSymlink).toBe(true);
+    // mode should reflect the target file (0o600), not the symlink (0o777)
+    expect(st.mode! & 0o777).toBe(0o600);
+  });
+
+  it.skipIf(isWin)("returns real file permissions for non-symlinks", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-test-"));
+    dirs.push(tmp);
+
+    const realFile = path.join(tmp, "real.json");
+    fs.writeFileSync(realFile, "{}", "utf-8");
+    fs.chmodSync(realFile, 0o644);
+
+    const st = await safeStat(realFile);
+    expect(st.ok).toBe(true);
+    expect(st.isSymlink).toBe(false);
+    expect(st.mode! & 0o777).toBe(0o644);
+  });
+});
+
+describe("inspectPathPermissions symlink handling", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of dirs) {
+      await fsp.rm(d, { recursive: true, force: true }).catch(() => {});
+    }
+    dirs.length = 0;
+  });
+
+  it.skipIf(isWin)("does not flag symlink to 0o600 file as world/group readable", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-test-"));
+    dirs.push(tmp);
+
+    const realFile = path.join(tmp, "config.json");
+    fs.writeFileSync(realFile, "{}", "utf-8");
+    fs.chmodSync(realFile, 0o600);
+
+    const link = path.join(tmp, "config-link.json");
+    fs.symlinkSync(realFile, link);
+
+    const perms = await inspectPathPermissions(link);
+    expect(perms.ok).toBe(true);
+    expect(perms.isSymlink).toBe(true);
+    expect(perms.worldReadable).toBe(false);
+    expect(perms.groupReadable).toBe(false);
+    expect(perms.worldWritable).toBe(false);
+    expect(perms.groupWritable).toBe(false);
+  });
+
+  it.skipIf(isWin)("flags symlink to 0o644 file as world/group readable", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-test-"));
+    dirs.push(tmp);
+
+    const realFile = path.join(tmp, "config.json");
+    fs.writeFileSync(realFile, "{}", "utf-8");
+    fs.chmodSync(realFile, 0o644);
+
+    const link = path.join(tmp, "config-link.json");
+    fs.symlinkSync(realFile, link);
+
+    const perms = await inspectPathPermissions(link);
+    expect(perms.ok).toBe(true);
+    expect(perms.isSymlink).toBe(true);
+    // Target is 0o644, so world-readable and group-readable
+    expect(perms.worldReadable).toBe(true);
+    expect(perms.groupReadable).toBe(true);
+  });
+});

--- a/src/security/audit-fs.ts
+++ b/src/security/audit-fs.ts
@@ -41,14 +41,38 @@ export async function safeStat(targetPath: string): Promise<{
     const isSymlink = lst.isSymbolicLink();
     // For symlinks, use fs.stat to get the target's real permissions;
     // lstat returns the symlink's own mode (always 0o777 on POSIX).
-    const resolved = isSymlink ? await fs.stat(targetPath) : lst;
+    if (isSymlink) {
+      try {
+        const resolved = await fs.stat(targetPath);
+        return {
+          ok: true,
+          isSymlink: true,
+          isDir: resolved.isDirectory(),
+          mode: typeof resolved.mode === "number" ? resolved.mode : null,
+          uid: typeof resolved.uid === "number" ? resolved.uid : null,
+          gid: typeof resolved.gid === "number" ? resolved.gid : null,
+        };
+      } catch (statErr) {
+        // Broken symlink or inaccessible target — preserve isSymlink so
+        // callers can distinguish broken symlinks from missing paths.
+        return {
+          ok: false,
+          isSymlink: true,
+          isDir: false,
+          mode: null,
+          uid: null,
+          gid: null,
+          error: String(statErr),
+        };
+      }
+    }
     return {
       ok: true,
-      isSymlink,
-      isDir: resolved.isDirectory(),
-      mode: typeof resolved.mode === "number" ? resolved.mode : null,
-      uid: typeof resolved.uid === "number" ? resolved.uid : null,
-      gid: typeof resolved.gid === "number" ? resolved.gid : null,
+      isSymlink: false,
+      isDir: lst.isDirectory(),
+      mode: typeof lst.mode === "number" ? lst.mode : null,
+      uid: typeof lst.uid === "number" ? lst.uid : null,
+      gid: typeof lst.gid === "number" ? lst.gid : null,
     };
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary
Fixes #11307

Also addresses the `openclaw status` false positive reported in the [issue comment](https://github.com/openclaw/openclaw/issues/11307#issuecomment-2841078291) by @fredcy.

## Problem

`openclaw doctor` and `openclaw status` warn that config file is group/world readable when using nix-openclaw (home-manager). This is a false positive because:

1. The config is a nix-managed **symlink**, and symlinks always show permissions as `0o777` regardless of target permissions
2. The target file lives in `/nix/store` which is **read-only** — `chmod` would fail
3. The containing `~/.openclaw` directory is mode `700`, protecting all files within

## Root Cause

- `safeStat()` in `audit-fs.ts` uses `lstat()` which returns the symlink's own mode (`0o777`), not the target's real permissions\n- `doctor-state-integrity.ts` checks `stat.mode & 0o077` against the symlink mode, triggering a false warning\n\n## Fix (two layers)\n\n### 1. `safeStat()` — resolve symlink target permissions\n\nWhen the path is a symlink, follow it with `fs.stat()` to get the **target's real permissions**. This fixes all callers (doctor, status, security audit) at once. Broken symlinks are handled gracefully with `isSymlink: true` preserved in the error path.\n\n### 2. `doctor-state-integrity.ts` — skip warning for read-only symlink targets\n\nFor symlinks whose target is **not writable** (e.g. `/nix/store`), skip the permission warning entirely — `chmod` would fail and the directory-level protection is sufficient.\n\nFor symlinks to **writable** world-readable targets, the warning is **still shown** — this is a real security concern.\n\n## Model resolution priority\n\n| Scenario | Warning? | Action |\n|---|---|---|\n| Regular file, mode 644 | ✅ Yes | Offer chmod 600 |\n| Symlink → read-only target (nix store) | ❌ No | Skip (chmod would fail, dir protects) |\n| Symlink → writable 644 target | ✅ Yes | Offer chmod 600 |\n| Broken symlink | ❌ No | Error logged |\n\n## Changes\n- `src/security/audit-fs.ts`: `safeStat()` follows symlinks to get target permissions (+28 lines)\n- `src/commands/doctor-state-integrity.ts`: Skip warning for read-only symlink targets (+14 lines)\n- `src/security/audit-fs.symlink.test.ts`: 5 tests covering symlink resolution, broken symlinks, and `inspectPathPermissions`\n- `CHANGELOG.md`: Add entry\n\n## Testing\n\n- 5 symlink-specific tests pass (`audit-fs.symlink.test.ts`)\n- 43 doctor tests pass (`pnpm vitest run src/commands/doctor`)\n- `pnpm lint` passes with 0 errors\n\n## vs PR #11458\n\nBoth PRs fix the same issue. Key differences:\n- This PR fixes **both** `safeStat` (affects all callers including `openclaw status`) **and** `doctor`\n- This PR distinguishes read-only vs writable symlink targets (same approach as #11458)\n- #11458 only fixes `doctor`, not `safeStat`/`status`