### PR TITLE
Tests: add unit tests for cli/parse-timeout.ts

### DIFF
--- a/src/cli/parse-timeout.test.ts
+++ b/src/cli/parse-timeout.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { parseTimeoutMs } from "./parse-timeout.js";
+
+describe("parseTimeoutMs", () => {
+  // --- Number inputs ---
+
+  it("returns a finite number unchanged", () => {
+    expect(parseTimeoutMs(5000)).toBe(5000);
+  });
+
+  it("returns zero for number 0", () => {
+    expect(parseTimeoutMs(0)).toBe(0);
+  });
+
+  it("returns negative numbers as-is", () => {
+    expect(parseTimeoutMs(-100)).toBe(-100);
+  });
+
+  it("returns undefined for NaN", () => {
+    expect(parseTimeoutMs(Number.NaN)).toBeUndefined();
+  });
+
+  it("returns undefined for Infinity", () => {
+    expect(parseTimeoutMs(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it("returns undefined for -Infinity", () => {
+    expect(parseTimeoutMs(Number.NEGATIVE_INFINITY)).toBeUndefined();
+  });
+
+  // --- String inputs ---
+
+  it("parses an integer string", () => {
+    expect(parseTimeoutMs("3000")).toBe(3000);
+  });
+
+  it("trims whitespace from string input", () => {
+    expect(parseTimeoutMs("  4000  ")).toBe(4000);
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(parseTimeoutMs("")).toBeUndefined();
+  });
+
+  it("returns undefined for a whitespace-only string", () => {
+    expect(parseTimeoutMs("   ")).toBeUndefined();
+  });
+
+  it("returns undefined for a non-numeric string", () => {
+    expect(parseTimeoutMs("abc")).toBeUndefined();
+  });
+
+  it("parses integer prefix of a mixed string (parseInt behavior)", () => {
+    // parseInt("123abc") === 123
+    expect(parseTimeoutMs("123abc")).toBe(123);
+  });
+
+  // --- BigInt inputs ---
+
+  it("converts bigint to number", () => {
+    expect(parseTimeoutMs(BigInt(9000))).toBe(9000);
+  });
+
+  // --- Null / undefined ---
+
+  it("returns undefined for undefined", () => {
+    expect(parseTimeoutMs(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(parseTimeoutMs(null)).toBeUndefined();
+  });
+
+  // --- Other types ---
+
+  it("returns undefined for a boolean", () => {
+    expect(parseTimeoutMs(true)).toBeUndefined();
+  });
+
+  it("returns undefined for an object", () => {
+    expect(parseTimeoutMs({})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add 17 tests for the timeout parsing utility:

- **Number inputs**: finite values, zero, negative, NaN, ±Infinity
- **String inputs**: integer parsing, whitespace trimming, empty/whitespace-only, non-numeric strings, parseInt prefix behavior
- **BigInt**: conversion to number
- **Null/undefined**: returns undefined
- **Other types**: boolean, object rejected

## Testing

- [x] All 17 tests pass via `pnpm vitest run src/cli/parse-timeout.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest unit test suite for `src/cli/parse-timeout.ts` covering number, string, bigint, null/undefined, and other-type inputs, including edge cases like NaN/±Infinity and `parseInt` prefix behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is isolated to a new unit test file that matches the current `parseTimeoutMs` behavior (Number.isFinite checks, string trim + parseInt base 10, bigint conversion). No production code paths are modified and no failing/flake-inducing patterns (timers, environment dependencies) are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->