### PR TITLE
Tests: add unit tests for auto-reply/tokens.ts

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN, isSilentReplyText } from "./tokens.js";
+
+describe("token constants", () => {
+  it("exports HEARTBEAT_TOKEN as HEARTBEAT_OK", () => {
+    expect(HEARTBEAT_TOKEN).toBe("HEARTBEAT_OK");
+  });
+
+  it("exports SILENT_REPLY_TOKEN as NO_REPLY", () => {
+    expect(SILENT_REPLY_TOKEN).toBe("NO_REPLY");
+  });
+});
+
+describe("isSilentReplyText", () => {
+  // --- Exact match ---
+
+  it("returns true for exact NO_REPLY token", () => {
+    expect(isSilentReplyText("NO_REPLY")).toBe(true);
+  });
+
+  // --- Prefix match (token at the start) ---
+
+  it("returns true when token is at the start followed by non-word char", () => {
+    expect(isSilentReplyText("NO_REPLY - nothing to say")).toBe(true);
+  });
+
+  it("returns true when token is at the start followed by newline", () => {
+    expect(isSilentReplyText("NO_REPLY\nsome explanation")).toBe(true);
+  });
+
+  // --- Suffix match (token at the end) ---
+
+  it("returns true when token is at the end of text", () => {
+    expect(isSilentReplyText("Some reasoning... NO_REPLY")).toBe(true);
+  });
+
+  it("returns true when token is at end with trailing whitespace", () => {
+    expect(isSilentReplyText("explanation NO_REPLY  ")).toBe(true);
+  });
+
+  // --- Leading whitespace ---
+
+  it("returns true with leading whitespace before token", () => {
+    expect(isSilentReplyText("   NO_REPLY")).toBe(true);
+  });
+
+  // --- Negative cases ---
+
+  it("returns false for empty string", () => {
+    expect(isSilentReplyText("")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSilentReplyText(undefined)).toBe(false);
+  });
+
+  it("returns false for text without the token", () => {
+    expect(isSilentReplyText("Hello, this is a normal reply")).toBe(false);
+  });
+
+  it("returns false when token is embedded in a word", () => {
+    // "NOTNO_REPLYHERE" — token is not at a word boundary at the end
+    expect(isSilentReplyText("XYZNO_REPLYXYZ")).toBe(false);
+  });
+
+  // --- Custom token ---
+
+  it("uses a custom token when provided", () => {
+    expect(isSilentReplyText("SKIP_ME", "SKIP_ME")).toBe(true);
+  });
+
+  it("returns false for default token when custom token is specified", () => {
+    expect(isSilentReplyText("NO_REPLY", "CUSTOM")).toBe(false);
+  });
+
+  // --- Special regex characters in token ---
+
+  it("handles tokens containing regex special characters", () => {
+    expect(isSilentReplyText("[DONE]", "[DONE]")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Add 15 tests for the reply token detection module:

- **Constants**: `HEARTBEAT_TOKEN` and `SILENT_REPLY_TOKEN` export verification
- **isSilentReplyText**: exact match, prefix match (non-word char, newline), suffix match (end of text, trailing whitespace), leading whitespace
- **Negative cases**: empty string, undefined, text without token, token embedded in a word
- **Custom token**: custom token detection, regex-special characters in token (e.g. `[DONE]`)

## Testing

- [x] All 15 tests pass via `pnpm vitest run src/auto-reply/tokens.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Vitest unit test suite for `src/auto-reply/tokens.ts`, covering exported constants and `isSilentReplyText()` behavior across exact matches, prefix/suffix matches, whitespace handling, negative cases (empty/undefined/no token/embedded token), and custom tokens including regex-special characters (e.g. `[DONE]`).

Changes are isolated to `src/auto-reply/tokens.test.ts` and improve confidence in the reply token detection logic without modifying production code.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change only adds a new unit test file; tests are self-contained, use existing public exports, and do not alter runtime behavior. No logical issues were identified in the test expectations relative to the token-detection semantics described.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->