### PR TITLE
Tests: add unit tests for config/agent-limits.ts

### DIFF
--- a/src/config/agent-limits.test.ts
+++ b/src/config/agent-limits.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+  resolveAgentMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "./agent-limits.js";
+import type { OpenClawConfig } from "./types.js";
+
+describe("DEFAULT constants", () => {
+  it("DEFAULT_AGENT_MAX_CONCURRENT is 4", () => {
+    expect(DEFAULT_AGENT_MAX_CONCURRENT).toBe(4);
+  });
+
+  it("DEFAULT_SUBAGENT_MAX_CONCURRENT is 8", () => {
+    expect(DEFAULT_SUBAGENT_MAX_CONCURRENT).toBe(8);
+  });
+});
+
+describe("resolveAgentMaxConcurrent", () => {
+  it("returns default when config is undefined", () => {
+    expect(resolveAgentMaxConcurrent()).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+  });
+
+  it("returns default when agents.defaults is missing", () => {
+    expect(resolveAgentMaxConcurrent({} as OpenClawConfig)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+  });
+
+  it("returns configured value", () => {
+    const cfg = { agents: { defaults: { maxConcurrent: 10 } } } as OpenClawConfig;
+    expect(resolveAgentMaxConcurrent(cfg)).toBe(10);
+  });
+
+  it("floors fractional values", () => {
+    const cfg = { agents: { defaults: { maxConcurrent: 3.9 } } } as OpenClawConfig;
+    expect(resolveAgentMaxConcurrent(cfg)).toBe(3);
+  });
+
+  it("clamps to minimum of 1", () => {
+    const cfg = { agents: { defaults: { maxConcurrent: 0 } } } as OpenClawConfig;
+    expect(resolveAgentMaxConcurrent(cfg)).toBe(1);
+  });
+
+  it("clamps negative values to 1", () => {
+    const cfg = { agents: { defaults: { maxConcurrent: -5 } } } as OpenClawConfig;
+    expect(resolveAgentMaxConcurrent(cfg)).toBe(1);
+  });
+
+  it("returns default for NaN", () => {
+    const cfg = { agents: { defaults: { maxConcurrent: Number.NaN } } } as OpenClawConfig;
+    expect(resolveAgentMaxConcurrent(cfg)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+  });
+
+  it("returns default for Infinity", () => {
+    const cfg = {
+      agents: { defaults: { maxConcurrent: Number.POSITIVE_INFINITY } },
+    } as OpenClawConfig;
+    expect(resolveAgentMaxConcurrent(cfg)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+  });
+});
+
+describe("resolveSubagentMaxConcurrent", () => {
+  it("returns default when config is undefined", () => {
+    expect(resolveSubagentMaxConcurrent()).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+  });
+
+  it("returns default when subagents config is missing", () => {
+    expect(resolveSubagentMaxConcurrent({} as OpenClawConfig)).toBe(
+      DEFAULT_SUBAGENT_MAX_CONCURRENT,
+    );
+  });
+
+  it("returns configured value", () => {
+    const cfg = {
+      agents: { defaults: { subagents: { maxConcurrent: 16 } } },
+    } as OpenClawConfig;
+    expect(resolveSubagentMaxConcurrent(cfg)).toBe(16);
+  });
+
+  it("floors fractional values", () => {
+    const cfg = {
+      agents: { defaults: { subagents: { maxConcurrent: 5.7 } } },
+    } as OpenClawConfig;
+    expect(resolveSubagentMaxConcurrent(cfg)).toBe(5);
+  });
+
+  it("clamps to minimum of 1", () => {
+    const cfg = {
+      agents: { defaults: { subagents: { maxConcurrent: 0 } } },
+    } as OpenClawConfig;
+    expect(resolveSubagentMaxConcurrent(cfg)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Add 15 tests for the agent concurrency limit resolution module:

- **DEFAULT constants**: `AGENT_MAX_CONCURRENT=4`, `SUBAGENT_MAX_CONCURRENT=8`
- **resolveAgentMaxConcurrent**: default fallback (undefined config, missing defaults), configured value, floor fractional, clamp to min 1, negative values, NaN/Infinity rejection
- **resolveSubagentMaxConcurrent**: default fallback, missing subagents config, configured value, floor fractional, clamp to min 1

## Testing

- [x] All 15 tests pass via `pnpm vitest run src/config/agent-limits.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Vitest unit test suite for `src/config/agent-limits.ts`, covering the exported default constants and the two resolver helpers (`resolveAgentMaxConcurrent` and `resolveSubagentMaxConcurrent`) across default fallbacks, configured values, fractional flooring, minimum clamping, and non-finite values (NaN/Infinity).

The tests align with the current implementation: both resolvers accept an optional `OpenClawConfig`, read a nested `maxConcurrent` value, require it to be a finite number, and otherwise fall back to the respective module defaults.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it only adds unit tests and matches the current implementation behavior.
- Only a new test file is added, and the assertions align with the current logic in `src/config/agent-limits.ts`. I could not execute the tests in this environment because Node/pnpm are unavailable, so the score is slightly reduced despite the change being low risk.
- src/config/agent-limits.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->