### PR TITLE
fix: clamp timeout values to avoid 32-bit overflow warning

### DIFF
--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+// Maximum safe value for setTimeout (32-bit signed integer max, ~24.8 days).
+// Values larger than this cause Node.js TimeoutOverflowWarning.
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
 
 const normalizeNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;
@@ -19,18 +22,19 @@ export function resolveAgentTimeoutMs(opts: {
 }): number {
   const minMs = Math.max(normalizeNumber(opts.minMs) ?? 1, 1);
   const defaultMs = resolveAgentTimeoutSeconds(opts.cfg) * 1000;
-  // Use a very large timeout value (30 days) to represent "no timeout"
-  // when explicitly set to 0. This avoids setTimeout issues with Infinity.
-  const NO_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
+  // Use the maximum safe setTimeout value (~24.8 days) to represent "no timeout"
+  // when explicitly set to 0. This avoids TimeoutOverflowWarning from Node.js
+  // which occurs when the value exceeds 32-bit signed integer max (2147483647).
+  const NO_TIMEOUT_MS = MAX_SAFE_TIMEOUT_MS;
   const overrideMs = normalizeNumber(opts.overrideMs);
   if (overrideMs !== undefined) {
     if (overrideMs === 0) {
       return NO_TIMEOUT_MS;
     }
     if (overrideMs < 0) {
-      return defaultMs;
+      return clampTimeout(defaultMs);
     }
-    return Math.max(overrideMs, minMs);
+    return clampTimeout(Math.max(overrideMs, minMs));
   }
   const overrideSeconds = normalizeNumber(opts.overrideSeconds);
   if (overrideSeconds !== undefined) {
@@ -38,9 +42,14 @@ export function resolveAgentTimeoutMs(opts: {
       return NO_TIMEOUT_MS;
     }
     if (overrideSeconds < 0) {
-      return defaultMs;
+      return clampTimeout(defaultMs);
     }
-    return Math.max(overrideSeconds * 1000, minMs);
+    return clampTimeout(Math.max(overrideSeconds * 1000, minMs));
   }
-  return Math.max(defaultMs, minMs);
+  return clampTimeout(Math.max(defaultMs, minMs));
+}
+
+/** Clamp timeout to maximum safe value for setTimeout (32-bit signed int). */
+function clampTimeout(ms: number): number {
+  return Math.min(ms, MAX_SAFE_TIMEOUT_MS);
 }


### PR DESCRIPTION
Fixes TimeoutOverflowWarning by clamping timeout values to MAX_SAFE_TIMEOUT_MS (2147483647).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates agent timeout normalization to avoid Node.js `TimeoutOverflowWarning` by clamping all computed timeout values to the maximum safe `setTimeout` duration (2,147,483,647 ms). It replaces the previous “no timeout” sentinel (30 days) with that maximum-safe value and ensures negative overrides (meaning “use default”) also get clamped.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to timeout value normalization and consistently clamps all timeout paths to Node’s maximum safe `setTimeout` value, eliminating the overflow warning without altering behavior for typical (small) timeouts.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->