### PR TITLE
fix: add defense against consecutive tool misuse loops

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -56,9 +56,28 @@ export async function handleToolExecutionStart(
     const filePath = typeof record.path === "string" ? record.path.trim() : "";
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
+
+      // Track consecutive misuse
+      const currentCount = (ctx.state.toolMisuseCount?.get("read") ?? 0) + 1;
+      ctx.state.toolMisuseCount?.set("read", currentCount);
+
       ctx.log.warn(
-        `read tool called without path: toolCallId=${toolCallId} argsType=${typeof args}${argsPreview ? ` argsPreview=${argsPreview}` : ""}`,
+        `read tool called without path (${currentCount}x): toolCallId=${toolCallId} argsType=${typeof args}${argsPreview ? ` argsPreview=${argsPreview}` : ""}`,
       );
+
+      // After 3 consecutive failures, emit a stronger warning
+      if (currentCount >= 3 && ctx.state.lastToolMisuseWarned !== "read") {
+        ctx.state.lastToolMisuseWarned = "read";
+        ctx.log.warn(
+          `[DEFENSE] read tool misused ${currentCount} times consecutively. ` +
+            `The 'path' parameter is REQUIRED. Example: Read({ path: "/path/to/file" }). ` +
+            `Consider using a different approach or checking the file path.`,
+        );
+      }
+    } else {
+      // Reset counter on successful call
+      ctx.state.toolMisuseCount?.set("read", 0);
+      ctx.state.lastToolMisuseWarned = undefined;
     }
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -27,6 +27,10 @@ export type EmbeddedPiSubscribeState = {
   toolSummaryById: Set<string>;
   lastToolError?: ToolErrorSummary;
 
+  // Defense: track consecutive tool misuse to prevent infinite loops
+  toolMisuseCount: Map<string, number>; // toolName -> consecutive misuse count
+  lastToolMisuseWarned?: string; // toolName that was last warned
+
   blockReplyBreak: "text_end" | "message_end";
   reasoningMode: ReasoningLevel;
   includeReasoning: boolean;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -37,6 +37,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     toolMetaById: new Map(),
     toolSummaryById: new Set(),
     lastToolError: undefined,
+    toolMisuseCount: new Map(),
+    lastToolMisuseWarned: undefined,
     blockReplyBreak: params.blockReplyBreak ?? "text_end",
     reasoningMode,
     includeReasoning: reasoningMode === "on",


### PR DESCRIPTION
Adds toolMisuseCount tracking with [DEFENSE] warning after 3+ consecutive failures. Fixes #11228.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a small defense mechanism in the embedded Pi session subscription pipeline to detect repeated misuse of the `read` tool (calls without a `path`). It introduces new state (`toolMisuseCount`, `lastToolMisuseWarned`) initialized in `subscribeEmbeddedPiSession`, and updates `handleToolExecutionStart` to increment/reset the counter and emit an additional `[DEFENSE]` warning after 3 consecutive failures.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are localized to tool execution start handling and state initialization, and do not affect core tool execution or message emission flows beyond adding warnings and updating new state fields. No behavioral regressions were found in the reviewed paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->