### PR TITLE
Tests: add unit tests for infra/format-duration

### DIFF
--- a/src/infra/format-duration.test.ts
+++ b/src/infra/format-duration.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { formatDurationSeconds, formatDurationMs } from "./format-duration.js";
+
+describe("formatDurationSeconds", () => {
+  it("converts milliseconds to seconds with default options", () => {
+    expect(formatDurationSeconds(1500)).toBe("1.5s");
+    expect(formatDurationSeconds(3000)).toBe("3s");
+  });
+
+  it("trims trailing zeros", () => {
+    expect(formatDurationSeconds(2000)).toBe("2s");
+    expect(formatDurationSeconds(1100)).toBe("1.1s");
+    expect(formatDurationSeconds(1010)).toBe("1s");
+  });
+
+  it("respects decimals option", () => {
+    expect(formatDurationSeconds(1234, { decimals: 0 })).toBe("1s");
+    expect(formatDurationSeconds(1234, { decimals: 2 })).toBe("1.23s");
+    expect(formatDurationSeconds(1234, { decimals: 3 })).toBe("1.234s");
+  });
+
+  it("supports 'seconds' unit", () => {
+    expect(formatDurationSeconds(2500, { unit: "seconds" })).toBe("2.5 seconds");
+    expect(formatDurationSeconds(3000, { unit: "seconds" })).toBe("3 seconds");
+  });
+
+  it("clamps negative values to zero", () => {
+    expect(formatDurationSeconds(-500)).toBe("0s");
+    expect(formatDurationSeconds(-1)).toBe("0s");
+  });
+
+  it("handles zero", () => {
+    expect(formatDurationSeconds(0)).toBe("0s");
+  });
+
+  it("returns 'unknown' for non-finite values", () => {
+    expect(formatDurationSeconds(NaN)).toBe("unknown");
+    expect(formatDurationSeconds(Infinity)).toBe("unknown");
+    expect(formatDurationSeconds(-Infinity)).toBe("unknown");
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("returns milliseconds for values under 1000ms", () => {
+    expect(formatDurationMs(0)).toBe("0ms");
+    expect(formatDurationMs(1)).toBe("1ms");
+    expect(formatDurationMs(500)).toBe("500ms");
+    expect(formatDurationMs(999)).toBe("999ms");
+  });
+
+  it("converts to seconds at 1000ms and above", () => {
+    expect(formatDurationMs(1000)).toBe("1s");
+    expect(formatDurationMs(1500)).toBe("1.5s");
+    expect(formatDurationMs(2345)).toBe("2.35s");
+  });
+
+  it("trims trailing zeros in seconds", () => {
+    expect(formatDurationMs(5000)).toBe("5s");
+    expect(formatDurationMs(10_000)).toBe("10s");
+  });
+
+  it("defaults to 2 decimals for seconds", () => {
+    expect(formatDurationMs(1234)).toBe("1.23s");
+    expect(formatDurationMs(1050)).toBe("1.05s");
+  });
+
+  it("respects decimals option", () => {
+    expect(formatDurationMs(1234, { decimals: 0 })).toBe("1s");
+    expect(formatDurationMs(1234, { decimals: 3 })).toBe("1.234s");
+  });
+
+  it("supports 'seconds' unit", () => {
+    expect(formatDurationMs(2500, { unit: "seconds" })).toBe("2.5 seconds");
+  });
+
+  it("returns 'unknown' for non-finite values", () => {
+    expect(formatDurationMs(NaN)).toBe("unknown");
+    expect(formatDurationMs(Infinity)).toBe("unknown");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/infra/format-duration.test.ts` with 14 tests covering both `formatDurationSeconds()` and `formatDurationMs()`
- Covers: non-finite values (NaN, Infinity), negative inputs, zero, trailing zero trimming, decimal precision options, unit labels (`s` vs `seconds`), and the ms-to-seconds threshold at 1000ms

## Test plan
- [x] All 14 tests pass locally via `vitest run src/infra/format-duration.test.ts`
- [x] AI-assisted (Claude Code), tested, and verified against source implementation


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Vitest unit test file (`src/infra/format-duration.test.ts`) covering `formatDurationSeconds()` and `formatDurationMs()` across typical values and edge cases (non-finite numbers, negatives, zero, trailing-zero trimming, decimals option, unit label options, and the 1000ms threshold behavior). The tests align with the current implementation in `src/infra/format-duration.ts` (e.g., `formatDurationMs` returning raw `ms` strings for values `< 1000`, and delegating to `formatDurationSeconds` with a default of 2 decimals).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to adding a new unit test file, and the assertions match the current `format-duration` implementation (including edge-case handling and default options). No production code paths are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->