### PR TITLE
memory: index symlinked dirs/files (PARA notes symlink)

### DIFF
--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -74,7 +74,7 @@ describe("listMemoryFiles", () => {
     expect(files).toHaveLength(1);
   });
 
-  it("ignores symlinked files and directories", async () => {
+  it("follows symlinked files and directories", async () => {
     await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Default memory");
     const extraDir = path.join(tmpDir, "extra");
     await fs.mkdir(extraDir, { recursive: true });
@@ -105,8 +105,8 @@ describe("listMemoryFiles", () => {
     const files = await listMemoryFiles(tmpDir, [extraDir, linkDir]);
     expect(files.some((file) => file.endsWith("note.md"))).toBe(true);
     if (symlinksOk) {
-      expect(files.some((file) => file.endsWith("linked.md"))).toBe(false);
-      expect(files.some((file) => file.endsWith("nested.md"))).toBe(false);
+      expect(files.some((file) => file.endsWith("linked.md"))).toBe(true);
+      expect(files.some((file) => file.endsWith("nested.md"))).toBe(true);
     }
   });
 });


### PR DESCRIPTION
### Problem
`memory_search` indexes `MEMORY.md` + `memory/**/*.md` but the file walker skips symlinks. This breaks the PARA Second Brain “symlink trick” (`memory/notes -> notes`), so `notes/**` never gets indexed.

### Change
- Follow symlink targets during the directory walk:
  - if a symlink resolves to a directory, recurse into it
  - if a symlink resolves to a `.md` file, include it
- Also follow symlinked `extraPaths` entries (dir or single `.md`).
- Add a realpath-based visited set to prevent symlink cycles.
- Update unit test accordingly.

### Why safe
- Only follows symlinks that resolve; broken symlinks are ignored.
- Cycle protection prevents infinite recursion.

### Repro
1) `ln -s $(pwd)/notes $(pwd)/memory/notes`
2) create `notes/resources/foo.md`
3) `openclaw memory index`
4) search for content from `foo.md` — it should now be indexed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `listMemoryFiles`/`walkDir` to follow symlink targets when indexing markdown memory notes (including symlinked extra paths), and adjusts the unit test to assert that linked `.md` files and linked directories are included.

The change fits into the memory indexing pipeline by expanding the set of markdown files discovered under `MEMORY.md`, `memory/`, and configured `extraPaths`, while attempting to prevent infinite recursion via a realpath-based visited set.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but symlink cycle protection has gaps that can still lead to infinite recursion in some setups.
- Core behavior change (following symlinks) is reasonable and tests were updated, but the new cycle guard can be bypassed when `realpath` fails and it is not consistently shared across all `walkDir` entry points (notably symlinked `extraPaths`). Those are correctness issues that can cause hangs during indexing.
- src/memory/internal.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->