### PR TITLE
fix(security): add --ignore-scripts to npm install in hook and plugin installers

### DIFF
--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -234,7 +234,7 @@ async function installHookPackageFromDir(params: {
   const hasDeps = Object.keys(deps).length > 0;
   if (hasDeps) {
     logger.info?.("Installing hook pack dependencies…");
-    const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent"], {
+    const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"], {
       timeoutMs: Math.max(timeoutMs, 300_000),
       cwd: targetDir,
     });

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -278,7 +278,7 @@ async function installPluginFromPackageDir(params: {
   const hasDeps = Object.keys(deps).length > 0;
   if (hasDeps) {
     logger.info?.("Installing plugin dependencies…");
-    const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent"], {
+    const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"], {
       timeoutMs: Math.max(timeoutMs, 300_000),
       cwd: targetDir,
     });


### PR DESCRIPTION
## Fix Summary

Add `--ignore-scripts` to all `npm install` invocations in hook and plugin install flows to prevent execution of untrusted lifecycle scripts (`preinstall`, `install`, `postinstall`) from packages and their transitive dependencies.

**Files changed:**
- `src/hooks/install.ts` — added `--ignore-scripts` to npm install args
- `src/plugins/install.ts` — added `--ignore-scripts` to npm install args

## Issue Linkage

Fixes #11431

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 9.6 / 10.0 |
| **Severity** | Critical |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H |

## Implementation Details

### Files Changed
- `src/hooks/install.ts` (+1/-1)
- `src/plugins/install.ts` (+1/-1)

### Technical Analysis
Add `--ignore-scripts` to all `npm install` invocations in hook and plugin install flows to prevent execution of untrusted lifecycle scripts (`preinstall`, `install`, `postinstall`) from packages and their transitive dependencies.

## Validation Evidence

- Command: `--ignore-scripts`
- Status: failed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `--ignore-scripts` to the `npm install` commands used during hook-pack and plugin dependency installation (`src/hooks/install.ts` and `src/plugins/install.ts`). This prevents untrusted lifecycle scripts (e.g., `preinstall`/`postinstall`) from executing when installing third-party hook/plugin dependencies, reducing RCE risk during these install flows.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to appending `--ignore-scripts` to existing `npm install` invocations in two installer flows. It does not alter control flow or data handling beyond disabling lifecycle scripts, and there are no other `npm install` call sites in `src/` using the same helper that appear to be missed.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
