### PR TITLE
feat: enable block streaming by default

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -367,9 +367,9 @@ export async function resolveReplyDirectives(params: {
       ? "off"
       : opts?.disableBlockStreaming === false
         ? "on"
-        : agentCfg?.blockStreamingDefault === "on"
-          ? "on"
-          : "off";
+        : agentCfg?.blockStreamingDefault === "off"
+          ? "off"
+          : "on";
   const resolvedBlockStreamingBreak: "text_end" | "message_end" =
     agentCfg?.blockStreamingBreak === "message_end" ? "message_end" : "text_end";
   const blockStreamingEnabled =

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -140,7 +140,7 @@ export type AgentDefaultsConfig = {
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
-  /** Default block streaming level when no override is present. */
+  /** Default block streaming level when no override is present. Defaults to "on". */
   blockStreamingDefault?: "off" | "on";
   /**
    * Block streaming boundary:


### PR DESCRIPTION
## What

Changes the default value of `blockStreamingDefault` from `"off"` to `"on"`.

## Why

When block streaming is off (current default), users on messaging channels (Telegram, Discord, etc.) see **no output** during long multi-step agent tasks until the entire turn completes. This can mean minutes of silence while the agent runs build/test/fix cycles or other iterative work.

With block streaming on, text blocks are sent progressively as the assistant produces them, giving users real-time visibility into what the agent is doing. This dramatically improves the user experience for any non-trivial task.

## Changes

- `src/auto-reply/reply/get-reply-directives.ts`: Flip the default resolution so unset `blockStreamingDefault` resolves to `"on"` instead of `"off"`
- `src/config/types.agent-defaults.ts`: Update JSDoc to reflect new default

## Backward compatibility

Users who prefer the old behavior can explicitly set `blockStreamingDefault: "off"` in their config. No breaking changes -- existing configs with an explicit value are unaffected.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR flips the default resolution of `blockStreamingDefault` so that when the config does not set an explicit value, block streaming resolves to `"on"` instead of `"off"`. It also updates the `AgentDefaultsConfig` JSDoc to reflect the new default.

The change is localized to reply-directive resolution (`src/auto-reply/reply/get-reply-directives.ts`), which determines whether the reply runner will use the block-reply pipeline (via `opts.onBlockReply`) to progressively emit assistant text blocks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are narrowly scoped to default resolution logic and a matching type/JSDoc update. The new default still respects explicit per-channel `disableBlockStreaming` settings, so external channel behavior remains controlled by existing configuration and call sites.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->