### PR TITLE
fix(security): warn on relative OPENCLAW_CONFIG_PATH and disable config-origin plugin auto-enable

### DIFF
--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -192,6 +192,14 @@ export function resolveEnableState(
   if (origin === "bundled") {
     return { enabled: false, reason: "bundled (disabled by default)" };
   }
+  if (origin === "config") {
+    return {
+      enabled: false,
+      reason:
+        "config-origin plugins require explicit enablement " +
+        '(set enabled: true in plugins.entries["<plugin-id>"])',
+    };
+  }
   return { enabled: true };
 }
 


### PR DESCRIPTION
## Fix Summary

- Emit a `[security]` warning when `OPENCLAW_CONFIG_PATH` is a relative path, which may indicate a malicious `.env` file planted in a repository's working directory
- Change config-origin plugins (discovered via `plugins.load.paths`) to require explicit enablement rather than auto-enabling, breaking the untrusted code execution chain

## Issue Linkage

Fixes #11437

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 9.6 / 10.0 |
| **Severity** | Critical |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H |

## Implementation Details

### Files Changed
- `src/config/paths.ts` (+17/-0)
- `src/plugins/config-state.ts` (+8/-0)

### Technical Analysis
- Emit a `[security]` warning when `OPENCLAW_CONFIG_PATH` is a relative path, which may indicate a malicious `.env` file planted in a repository's working directory

## Validation Evidence

- Command: `OPENCLAW_CONFIG_PATH`
- Status: failed

## Risk and Compatibility

breaking change noted in original PR body; review downstream compatibility.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a security warning when `OPENCLAW_CONFIG_PATH` is set to a relative path, and changes plugin enablement so plugins discovered from `plugins.load.paths` (origin: `config`) are disabled by default unless explicitly enabled via `plugins.entries["<id>"].enabled: true`.

The config-path change affects `src/config/paths.ts` resolution helpers, while the plugin change is enforced centrally in `src/plugins/config-state.ts` via `resolveEnableState()`, which is consumed by the plugin loader when constructing plugin records.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one user-facing warning message bug to fix.
- The functional changes are localized and flow through existing central resolution points (`resolveConfigPath*` and `resolveEnableState`). The main correctness issue found is the warning text hardcoding `OPENCLAW_CONFIG_PATH` even when the legacy `CLAWDBOT_CONFIG_PATH` is the actual source, which will mislead users; otherwise the changes appear consistent with the stated security intent.
- src/config/paths.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
