### PR TITLE
fix: preserve multi-line input for skill commands

### DIFF
--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -48,6 +48,26 @@ describe("resolveSkillCommandInvocation", () => {
     expect(invocation?.args).toBeUndefined();
   });
 
+  it("preserves multi-line args", () => {
+    const invocation = resolveSkillCommandInvocation({
+      commandBodyNormalized: "/my_skill FEEDBACK BELOW:\nSecond line of feedback\nThird line of feedback",
+      skillCommands: [{ name: "my_skill", skillName: "my-skill", description: "My Skill" }],
+    });
+    expect(invocation?.command.skillName).toBe("my-skill");
+    expect(invocation?.args).toBe(
+      "FEEDBACK BELOW:\nSecond line of feedback\nThird line of feedback",
+    );
+  });
+
+  it("preserves multi-line args with /skill syntax", () => {
+    const invocation = resolveSkillCommandInvocation({
+      commandBodyNormalized: "/skill my_skill FEEDBACK:\nLine 2\nLine 3",
+      skillCommands: [{ name: "my_skill", skillName: "my-skill", description: "My Skill" }],
+    });
+    expect(invocation?.command.name).toBe("my_skill");
+    expect(invocation?.args).toBe("FEEDBACK:\nLine 2\nLine 3");
+  });
+
   it("returns null for unknown commands", () => {
     const invocation = resolveSkillCommandInvocation({
       commandBodyNormalized: "/unknown arg",


### PR DESCRIPTION
## Bug

Skill commands with multi-line input lose everything after the first newline.

**Steps to reproduce:**
1. Configure a skill command (e.g. `/my_skill`)
2. Send a message with the command and multi-line content:
```
/my_skill FEEDBACK BELOW:
First item to review
Second item to review
```
3. The agent only receives `"FEEDBACK BELOW:"` as user input. All subsequent lines are dropped.

**Expected:** Full multi-line content is preserved as skill command args.

## Root Cause

`normalizeCommandBody()` in `commands-registry.ts` truncates at the first newline:

```typescript
const newline = trimmed.indexOf("\n");
const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
```

This is correct for built-in commands (`/status`, `/reset`, etc.) but breaks skill commands that accept rich multi-line input. The downstream `resolveSkillCommandInvocation()` regex already uses `[\s\S]+` to handle newlines, but the input is truncated before it reaches that function.

## Fix

Rather than modifying `normalizeCommandBody()` (which would risk breaking built-in commands), the fix reconstructs the skill command body in `get-reply-inline-actions.ts` by:

1. Taking the normalised first line from `commandBodyNormalized` (with bot mentions stripped for groups)
2. Grafting the remaining lines from `rawBodyNormalized` back onto it

This preserves both normalisation (bot mention removal in groups) and multi-line content. Zero changes to `normalizeCommandBody` means zero risk to existing built-in command handling.

**Files changed:** 2 (`get-reply-inline-actions.ts` + `skill-commands.test.ts`)

## Tests Added

- Multi-line args with direct command syntax
- Multi-line args with `/skill` syntax
- Existing single-line tests unaffected

---

## Prompt Request

If you prefer to implement this differently:

```
Fix a bug where skill commands with multi-line input lose everything after the first newline.

normalizeCommandBody() in src/auto-reply/commands-registry.ts truncates at the
first \n. This is correct for built-in commands but breaks skill commands.

Key files:
- src/auto-reply/commands-registry.ts - normalizeCommandBody() truncates at \n (~line 375)
- src/auto-reply/reply/get-reply-inline-actions.ts - calls resolveSkillCommandInvocation (~line 153)
- src/auto-reply/skill-commands.ts - resolveSkillCommandInvocation() already handles \n via [\s\S]+
- src/auto-reply/reply/commands-context.ts - buildCommandContext() sets rawBodyNormalized (full) and commandBodyNormalized (truncated)
- src/auto-reply/reply/commands-types.ts - CommandContext type

Fix: in get-reply-inline-actions.ts, reconstruct a skill-specific body combining the
normalised first line (bot mentions stripped) with remaining lines from rawBodyNormalized.
Avoids changing normalizeCommandBody() (zero risk to built-in commands).

Add tests in src/auto-reply/skill-commands.test.ts for multi-line args.

Reproduce: /some_skill first line\nsecond line\nthird line
Expected args: "first line\nsecond line\nthird line"
Actual (before fix): "first line" (rest dropped)
```