### PR TITLE
Add extensible search providers for web_search

### DIFF
--- a/extensions/kagi-search/README.md
+++ b/extensions/kagi-search/README.md
@@ -1,0 +1,137 @@
+# Kagi Search Provider Plugin
+
+Example plugin demonstrating how to add custom search providers to Clawdbot's `web_search` tool.
+
+## Installation
+
+1. Copy this directory to your Clawdbot extensions folder
+2. Add to your config:
+
+```yaml
+plugins:
+  load:
+    paths:
+      - "./extensions/kagi-search"
+  entries:
+    kagi-search:
+      enabled: true
+      config:
+        apiKey: "your-kagi-api-key"
+```
+
+Or set the `KAGI_API_KEY` environment variable.
+
+## Usage
+
+Once installed, set your web search provider to `kagi`:
+
+```yaml
+tools:
+  web:
+    search:
+      provider: kagi
+```
+
+Now `web_search` will use Kagi instead of Brave or Perplexity.
+
+## Creating Your Own Provider
+
+This example shows the minimal implementation of a search provider:
+
+```typescript
+api.registerSearchProvider({
+  id: "my-provider",
+  label: "My Search Provider",
+  description: "Optional description",
+
+  async search(params, ctx) {
+    // params: { query, count, country?, search_lang?, ui_lang?, freshness?, providerConfig? }
+    // ctx: { config, timeoutSeconds, cacheTtlMs }
+
+    // Implement your search logic here
+    const results = await fetchFromYourAPI(params.query);
+
+    return {
+      query: params.query,
+      provider: "my-provider",
+      results: [
+        {
+          title: "Result title",
+          url: "https://example.com",
+          description: "Result description",
+          published: "2024-01-15", // optional
+        },
+      ],
+      // OR for AI-synthesized answers (like Perplexity):
+      // content: "AI-generated answer text",
+      // citations: ["https://source1.com", "https://source2.com"],
+      tookMs: 123, // optional
+    };
+  },
+});
+```
+
+## Provider Types
+
+Two result formats are supported:
+
+### 1. Link Results (like Brave)
+
+```typescript
+return {
+  query: params.query,
+  provider: "my-provider",
+  results: [{ title: "...", url: "...", description: "..." }],
+};
+```
+
+### 2. AI-Synthesized (like Perplexity)
+
+```typescript
+return {
+  query: params.query,
+  provider: "my-provider",
+  content: "AI-generated answer",
+  citations: ["https://source1.com"],
+};
+```
+
+## API Key Management
+
+Best practices for API keys:
+
+1. **Environment variable** (simplest):
+
+   ```bash
+   export MY_PROVIDER_API_KEY="..."
+   ```
+
+2. **Plugin config** (more flexible):
+
+   ```yaml
+   plugins:
+     entries:
+       my-provider:
+         config:
+           apiKey: "..."
+   ```
+
+3. **Access in plugin**:
+   ```typescript
+   const apiKey =
+     ctx.config.plugins?.entries?.["my-provider"]?.config?.apiKey ||
+     process.env.MY_PROVIDER_API_KEY;
+   ```
+
+## Testing
+
+To test your provider without changing the default:
+
+```yaml
+tools:
+  web:
+    search:
+      provider: my-provider
+```
+
+Then use the `web_search` tool normally.

--- a/extensions/kagi-search/index.ts
+++ b/extensions/kagi-search/index.ts
@@ -1,0 +1,102 @@
+/**
+ * Example Kagi Search Provider Plugin for Clawdbot
+ * Demonstrates how to register a custom search provider.
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+const plugin = {
+  id: "kagi-search",
+  name: "Kagi Search Provider",
+  description: "Add Kagi as a web_search provider",
+  version: "1.0.0",
+
+  register(api: OpenClawPluginApi) {
+    api.registerSearchProvider({
+      id: "kagi",
+      label: "Kagi Search",
+      description: "Privacy-focused search engine with high-quality results",
+
+      async search(params, ctx) {
+        // Get API key from plugin config or environment
+        const pluginConfig = ctx.pluginConfig as { apiKey?: string } | undefined;
+        const apiKey = pluginConfig?.apiKey || process.env.KAGI_API_KEY;
+
+        if (!apiKey) {
+          throw new Error(
+            "Kagi API key required. Set KAGI_API_KEY env var or configure plugins.entries.kagi-search.config.apiKey",
+          );
+        }
+
+        // Build Kagi Search API request
+        const url = "https://kagi.com/api/v0/search";
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bot ${apiKey}`,
+          },
+          body: JSON.stringify({
+            q: params.query,
+            limit: Math.min(params.count, 10),
+          }),
+          signal: AbortSignal.timeout(ctx.timeoutSeconds * 1000),
+        });
+
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(`Kagi API error (${response.status}): ${text || response.statusText}`);
+        }
+
+        const data = (await response.json()) as {
+          meta?: { id?: string; node?: string; ms?: number };
+          data?: Array<{
+            t?: number;
+            title?: string;
+            snippet?: string;
+            url?: string;
+            published?: string;
+          }>;
+        };
+
+        const results =
+          data.data
+            ?.filter((item) => item.t === 0) // Type 0 = search result
+            .map((item) => ({
+              title: item.title || "",
+              url: item.url || "",
+              description: item.snippet || "",
+              published: item.published,
+            })) || [];
+
+        return {
+          query: params.query,
+          provider: "kagi",
+          results,
+          tookMs: data.meta?.ms,
+        };
+      },
+    });
+  },
+
+  configSchema: {
+    jsonSchema: {
+      type: "object",
+      properties: {
+        apiKey: {
+          type: "string",
+          description: "Kagi API token",
+        },
+      },
+    },
+    uiHints: {
+      apiKey: {
+        label: "Kagi API Key",
+        help: "Get your API key from https://kagi.com/settings?p=api",
+        sensitive: true,
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/extensions/kagi-search/openclaw.plugin.json
+++ b/extensions/kagi-search/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "kagi-search",
+  "description": "Example Kagi search provider plugin for web_search",
+  "entry": "./index.ts",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/kagi-search/package.json
+++ b/extensions/kagi-search/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openclaw/plugin-kagi-search",
+  "version": "1.0.0",
+  "description": "Example Kagi search provider plugin for Clawdbot",
+  "keywords": [
+    "clawdbot",
+    "kagi",
+    "openclaw",
+    "plugin",
+    "search"
+  ],
+  "license": "MIT",
+  "author": "OpenClaw Contributors",
+  "type": "module",
+  "main": "index.ts"
+}

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -40,6 +40,7 @@ function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi 
     registerCli() {},
     registerService() {},
     registerProvider() {},
+    registerSearchProvider() {},
     registerHook() {},
     registerHttpRoute() {},
     registerCommand() {},

--- a/src/agents/tools/search-providers.ts
+++ b/src/agents/tools/search-providers.ts
@@ -1,0 +1,48 @@
+/**
+ * Global registry for web search providers.
+ * Allows plugins to register custom search providers for the web_search tool.
+ */
+
+import type { SearchProviderPlugin } from "../../plugins/types.js";
+
+const searchProviderRegistry = new Map<string, SearchProviderPlugin>();
+
+export function registerSearchProvider(provider: SearchProviderPlugin): void {
+  const id = provider.id.trim().toLowerCase();
+  if (!id) {
+    throw new Error("Search provider must have a non-empty id");
+  }
+  if (searchProviderRegistry.has(id)) {
+    throw new Error(`Search provider "${id}" is already registered`);
+  }
+  searchProviderRegistry.set(id, provider);
+}
+
+export function getSearchProvider(id: string): SearchProviderPlugin | undefined {
+  const normalized = id.trim().toLowerCase();
+  return searchProviderRegistry.get(normalized);
+}
+
+export function listSearchProviders(): string[] {
+  return Array.from(searchProviderRegistry.keys());
+}
+
+export function hasSearchProvider(id: string): boolean {
+  const normalized = id.trim().toLowerCase();
+  return searchProviderRegistry.has(normalized);
+}
+
+/**
+ * Unregister a search provider (primarily for testing).
+ */
+export function unregisterSearchProvider(id: string): boolean {
+  const normalized = id.trim().toLowerCase();
+  return searchProviderRegistry.delete(normalized);
+}
+
+/**
+ * Clear all registered providers (primarily for testing).
+ */
+export function clearSearchProviders(): void {
+  searchProviderRegistry.clear();
+}

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1,10 +1,16 @@
 import { Type } from "@sinclair/typebox";
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { SearchProviderPlugin } from "../../plugins/types.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+import {
+  registerSearchProvider,
+  getSearchProvider,
+  hasSearchProvider,
+} from "./search-providers.js";
 import {
   CacheEntry,
   DEFAULT_CACHE_TTL_MINUTES,
@@ -18,9 +24,9 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
+const DEFAULT_PROVIDER = "brave";
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
@@ -106,7 +112,7 @@ type GrokSearchResponse = {
   output?: Array<{
     type?: string;
     role?: string;
-    text?: string; // present when type === "output_text" (top-level output_text block)
+    text?: string;
     content?: Array<{
       type?: string;
       text?: string;
@@ -124,7 +130,7 @@ type GrokSearchResponse = {
       end_index?: number;
     }>;
   }>;
-  output_text?: string; // deprecated field - kept for backwards compatibility
+  output_text?: string;
   citations?: string[];
   inline_citations?: Array<{
     start_index: number;
@@ -210,12 +216,13 @@ function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
   return fromConfig || fromEnv || undefined;
 }
 
-function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
+function missingSearchKeyPayload(provider: string) {
   if (provider === "perplexity") {
     return {
       error: "missing_perplexity_api_key",
       message:
         "web_search (perplexity) needs an API key. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY in the Gateway environment, or configure tools.web.search.perplexity.apiKey.",
+      provider: "perplexity",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
@@ -224,31 +231,32 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       error: "missing_xai_api_key",
       message:
         "web_search (grok) needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure tools.web.search.grok.apiKey.",
+      provider: "grok",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
+  if (provider === "brave") {
+    return {
+      error: "missing_brave_api_key",
+      message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
+      provider: "brave",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
   return {
-    error: "missing_brave_api_key",
-    message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
+    error: "missing_api_key",
+    message: `web_search (${provider}) needs an API key. Check the provider's configuration.`,
+    provider,
     docs: "https://docs.openclaw.ai/tools/web",
   };
 }
 
-function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDERS)[number] {
+function resolveSearchProvider(search?: WebSearchConfig): string {
   const raw =
     search && "provider" in search && typeof search.provider === "string"
       ? search.provider.trim().toLowerCase()
       : "";
-  if (raw === "perplexity") {
-    return "perplexity";
-  }
-  if (raw === "grok") {
-    return "grok";
-  }
-  if (raw === "brave") {
-    return "brave";
-  }
-  return "brave";
+  return raw || DEFAULT_PROVIDER;
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -575,179 +583,280 @@ async function runGrokSearch(params: {
   return { content, citations, inlineCitations };
 }
 
-async function runWebSearch(params: {
-  query: string;
-  count: number;
-  apiKey: string;
-  timeoutSeconds: number;
-  cacheTtlMs: number;
-  provider: (typeof SEARCH_PROVIDERS)[number];
-  country?: string;
-  search_lang?: string;
-  ui_lang?: string;
-  freshness?: string;
-  perplexityBaseUrl?: string;
-  perplexityModel?: string;
-  grokModel?: string;
-  grokInlineCitations?: boolean;
-}): Promise<Record<string, unknown>> {
-  const cacheKey = normalizeCacheKey(
-    params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : params.provider === "perplexity"
-        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}:${params.freshness || "default"}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
-  );
-  const cached = readCache(SEARCH_CACHE, cacheKey);
-  if (cached) {
-    return { ...cached.value, cached: true };
-  }
+// =============================================================================
+// Built-in Search Providers
+// =============================================================================
 
-  const start = Date.now();
+let builtinProvidersInitialized = false;
 
-  if (params.provider === "perplexity") {
+const braveSearchProvider: SearchProviderPlugin = {
+  id: "brave",
+  label: "Brave Search",
+  description:
+    "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.",
+  async search(params, ctx) {
+    const search = resolveSearchConfig(ctx.config);
+    const apiKey = resolveSearchApiKey(search);
+    if (!apiKey) {
+      return missingSearchKeyPayload("brave");
+    }
+
+    const freshness = params.freshness ? normalizeFreshness(params.freshness) : undefined;
+    if (params.freshness && !freshness) {
+      return {
+        error: "invalid_freshness",
+        message: "freshness must be one of pd, pw, pm, py, or a range like YYYY-MM-DDtoYYYY-MM-DD.",
+        provider: "brave",
+      };
+    }
+
+    const cacheKey = normalizeCacheKey(
+      `brave:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${freshness || "default"}`,
+    );
+    const cached = readCache(SEARCH_CACHE, cacheKey);
+    if (cached) {
+      return { ...cached.value, cached: true, query: params.query, provider: "brave" };
+    }
+
+    const start = Date.now();
+    const url = new URL(BRAVE_SEARCH_ENDPOINT);
+    url.searchParams.set("q", params.query);
+    url.searchParams.set("count", String(params.count));
+    if (params.country) {
+      url.searchParams.set("country", params.country);
+    }
+    if (params.search_lang) {
+      url.searchParams.set("search_lang", params.search_lang);
+    }
+    if (params.ui_lang) {
+      url.searchParams.set("ui_lang", params.ui_lang);
+    }
+    if (freshness) {
+      url.searchParams.set("freshness", freshness);
+    }
+
+    const res = await fetch(url.toString(), {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        "X-Subscription-Token": apiKey,
+      },
+      signal: withTimeout(undefined, ctx.timeoutSeconds * 1000),
+    });
+
+    if (!res.ok) {
+      const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+      const detail = detailResult.text;
+      throw new Error(`Brave Search API error (${res.status}): ${detail || res.statusText}`);
+    }
+
+    const data = (await res.json()) as BraveSearchResponse;
+    const results = Array.isArray(data.web?.results) ? (data.web?.results ?? []) : [];
+    const mapped = results.map((entry) => {
+      const description = entry.description ?? "";
+      const title = entry.title ?? "";
+      const url = entry.url ?? "";
+      const rawSiteName = resolveSiteName(url);
+      return {
+        title: title ? wrapWebContent(title, "web_search") : "",
+        url,
+        description: description ? wrapWebContent(description, "web_search") : "",
+        published: entry.age || undefined,
+        siteName: rawSiteName || undefined,
+      };
+    });
+
+    const payload = {
+      query: params.query,
+      provider: "brave",
+      count: mapped.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: "brave",
+        wrapped: true,
+      },
+      results: mapped,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, ctx.cacheTtlMs);
+    return payload;
+  },
+};
+
+const perplexitySearchProvider: SearchProviderPlugin = {
+  id: "perplexity",
+  label: "Perplexity Sonar",
+  description:
+    "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search.",
+  async search(params, ctx) {
+    const search = resolveSearchConfig(ctx.config);
+    const perplexityConfig = resolvePerplexityConfig(search);
+    const perplexityAuth = resolvePerplexityApiKey(perplexityConfig);
+    const apiKey = perplexityAuth?.apiKey;
+
+    if (!apiKey) {
+      return missingSearchKeyPayload("perplexity");
+    }
+
+    const baseUrl = resolvePerplexityBaseUrl(perplexityConfig, perplexityAuth.source, apiKey);
+    const model = resolvePerplexityModel(perplexityConfig);
+
+    const cacheKey = normalizeCacheKey(
+      `perplexity:${params.query}:${baseUrl}:${model}:${params.freshness || "default"}`,
+    );
+    const cached = readCache(SEARCH_CACHE, cacheKey);
+    if (cached) {
+      return { ...cached.value, cached: true, query: params.query, provider: "perplexity" };
+    }
+
+    const start = Date.now();
     const { content, citations } = await runPerplexitySearch({
       query: params.query,
-      apiKey: params.apiKey,
-      baseUrl: params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL,
-      model: params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL,
-      timeoutSeconds: params.timeoutSeconds,
+      apiKey,
+      baseUrl,
+      model,
+      timeoutSeconds: ctx.timeoutSeconds,
       freshness: params.freshness,
     });
 
     const payload = {
       query: params.query,
-      provider: params.provider,
-      model: params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL,
+      provider: "perplexity",
+      model,
       tookMs: Date.now() - start,
       externalContent: {
         untrusted: true,
         source: "web_search",
-        provider: params.provider,
+        provider: "perplexity",
         wrapped: true,
       },
       content: wrapWebContent(content),
       citations,
     };
-    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    writeCache(SEARCH_CACHE, cacheKey, payload, ctx.cacheTtlMs);
     return payload;
-  }
+  },
+};
 
-  if (params.provider === "grok") {
-    const { content, citations, inlineCitations } = await runGrokSearch({
+const grokSearchProvider: SearchProviderPlugin = {
+  id: "grok",
+  label: "xAI Grok",
+  description:
+    "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search.",
+  async search(params, ctx) {
+    const search = resolveSearchConfig(ctx.config);
+    const grokConfig = resolveGrokConfig(search);
+    const apiKey = resolveGrokApiKey(grokConfig);
+
+    if (!apiKey) {
+      return missingSearchKeyPayload("grok");
+    }
+
+    if (params.freshness) {
+      return {
+        error: "unsupported_freshness",
+        message: "freshness is only supported by the Brave and Perplexity web_search providers.",
+        provider: "grok",
+        docs: "https://docs.openclaw.ai/tools/web",
+      };
+    }
+
+    const model = resolveGrokModel(grokConfig);
+    const inlineCitations = resolveGrokInlineCitations(grokConfig);
+
+    const cacheKey = normalizeCacheKey(`grok:${params.query}:${model}:${String(inlineCitations)}`);
+    const cached = readCache(SEARCH_CACHE, cacheKey);
+    if (cached) {
+      return { ...cached.value, cached: true, query: params.query, provider: "grok" };
+    }
+
+    const start = Date.now();
+    const {
+      content,
+      citations,
+      inlineCitations: inlineCites,
+    } = await runGrokSearch({
       query: params.query,
-      apiKey: params.apiKey,
-      model: params.grokModel ?? DEFAULT_GROK_MODEL,
-      timeoutSeconds: params.timeoutSeconds,
-      inlineCitations: params.grokInlineCitations ?? false,
+      apiKey,
+      model,
+      timeoutSeconds: ctx.timeoutSeconds,
+      inlineCitations,
     });
 
     const payload = {
       query: params.query,
-      provider: params.provider,
-      model: params.grokModel ?? DEFAULT_GROK_MODEL,
+      provider: "grok",
+      model,
       tookMs: Date.now() - start,
       externalContent: {
         untrusted: true,
         source: "web_search",
-        provider: params.provider,
+        provider: "grok",
         wrapped: true,
       },
       content: wrapWebContent(content),
       citations,
-      inlineCitations,
+      inlineCitations: inlineCites,
     };
-    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    writeCache(SEARCH_CACHE, cacheKey, payload, ctx.cacheTtlMs);
     return payload;
-  }
+  },
+};
 
-  if (params.provider !== "brave") {
-    throw new Error("Unsupported web search provider.");
+/**
+ * Initialize built-in search providers (brave, perplexity, grok).
+ * Safe to call multiple times — idempotent.
+ */
+export function initBuiltinProviders(): void {
+  if (builtinProvidersInitialized) {
+    return;
   }
+  builtinProvidersInitialized = true;
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
-  url.searchParams.set("q", params.query);
-  url.searchParams.set("count", String(params.count));
-  if (params.country) {
-    url.searchParams.set("country", params.country);
+  for (const provider of [braveSearchProvider, perplexitySearchProvider, grokSearchProvider]) {
+    if (!hasSearchProvider(provider.id)) {
+      registerSearchProvider(provider);
+    }
   }
-  if (params.search_lang) {
-    url.searchParams.set("search_lang", params.search_lang);
-  }
-  if (params.ui_lang) {
-    url.searchParams.set("ui_lang", params.ui_lang);
-  }
-  if (params.freshness) {
-    url.searchParams.set("freshness", params.freshness);
-  }
-
-  const res = await fetch(url.toString(), {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      "X-Subscription-Token": params.apiKey,
-    },
-    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
-  });
-
-  if (!res.ok) {
-    const detailResult = await readResponseText(res, { maxBytes: 64_000 });
-    const detail = detailResult.text;
-    throw new Error(`Brave Search API error (${res.status}): ${detail || res.statusText}`);
-  }
-
-  const data = (await res.json()) as BraveSearchResponse;
-  const results = Array.isArray(data.web?.results) ? (data.web?.results ?? []) : [];
-  const mapped = results.map((entry) => {
-    const description = entry.description ?? "";
-    const title = entry.title ?? "";
-    const url = entry.url ?? "";
-    const rawSiteName = resolveSiteName(url);
-    return {
-      title: title ? wrapWebContent(title, "web_search") : "",
-      url, // Keep raw for tool chaining
-      description: description ? wrapWebContent(description, "web_search") : "",
-      published: entry.age || undefined,
-      siteName: rawSiteName || undefined,
-    };
-  });
-
-  const payload = {
-    query: params.query,
-    provider: params.provider,
-    count: mapped.length,
-    tookMs: Date.now() - start,
-    externalContent: {
-      untrusted: true,
-      source: "web_search",
-      provider: params.provider,
-      wrapped: true,
-    },
-    results: mapped,
-  };
-  writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
-  return payload;
 }
+
+// =============================================================================
+// Web Search Tool
+// =============================================================================
 
 export function createWebSearchTool(options?: {
   config?: OpenClawConfig;
   sandboxed?: boolean;
 }): AnyAgentTool | null {
+  // Initialize built-in providers on first tool creation
+  initBuiltinProviders();
+
   const search = resolveSearchConfig(options?.config);
   if (!resolveSearchEnabled({ search, sandboxed: options?.sandboxed })) {
     return null;
   }
 
-  const provider = resolveSearchProvider(search);
-  const perplexityConfig = resolvePerplexityConfig(search);
-  const grokConfig = resolveGrokConfig(search);
+  const providerName = resolveSearchProvider(search);
+  let searchProvider = getSearchProvider(providerName);
+  let actualProviderName = providerName;
+
+  // If unknown provider, fall back to Brave
+  if (!searchProvider) {
+    searchProvider = getSearchProvider("brave");
+    actualProviderName = "brave";
+  }
+
+  if (!searchProvider) {
+    return null;
+  }
 
   const description =
-    provider === "perplexity"
-      ? "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search."
-      : provider === "grok"
-        ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
-        : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+    searchProvider.description ||
+    `Search the web using ${searchProvider.label || actualProviderName}.`;
+
+  // Look up plugin config using the provider's pluginId (not the provider id)
+  const pluginId = searchProvider.pluginId;
 
   return {
     label: "Web Search",
@@ -755,63 +864,49 @@ export function createWebSearchTool(options?: {
     description,
     parameters: WebSearchSchema,
     execute: async (_toolCallId, args) => {
-      const perplexityAuth =
-        provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
-      const apiKey =
-        provider === "perplexity"
-          ? perplexityAuth?.apiKey
-          : provider === "grok"
-            ? resolveGrokApiKey(grokConfig)
-            : resolveSearchApiKey(search);
-
-      if (!apiKey) {
-        return jsonResult(missingSearchKeyPayload(provider));
-      }
       const params = args as Record<string, unknown>;
       const query = readStringParam(params, "query", { required: true });
       const count =
-        readNumberParam(params, "count", { integer: true }) ?? search?.maxResults ?? undefined;
+        readNumberParam(params, "count", { integer: true }) ??
+        search?.maxResults ??
+        DEFAULT_SEARCH_COUNT;
       const country = readStringParam(params, "country");
       const search_lang = readStringParam(params, "search_lang");
       const ui_lang = readStringParam(params, "ui_lang");
-      const rawFreshness = readStringParam(params, "freshness");
-      if (rawFreshness && provider !== "brave" && provider !== "perplexity") {
+      const freshness = readStringParam(params, "freshness");
+
+      // Look up plugin entry config using pluginId (config.plugins.entries[pluginId].config)
+      const pluginConfig = pluginId
+        ? (options?.config?.plugins as { entries?: Record<string, { config?: unknown }> })
+            ?.entries?.[pluginId]?.config
+        : undefined;
+
+      try {
+        const result = await searchProvider.search(
+          {
+            query,
+            count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+            country,
+            search_lang,
+            ui_lang,
+            freshness,
+            providerConfig: search as Record<string, unknown>,
+          },
+          {
+            config: options?.config ?? ({} as OpenClawConfig),
+            timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
+            cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
+            pluginConfig,
+          },
+        );
+        return jsonResult(result);
+      } catch (error) {
         return jsonResult({
-          error: "unsupported_freshness",
-          message: "freshness is only supported by the Brave and Perplexity web_search providers.",
-          docs: "https://docs.openclaw.ai/tools/web",
+          error: "search_failed",
+          provider: actualProviderName,
+          message: error instanceof Error ? error.message : String(error),
         });
       }
-      const freshness = rawFreshness ? normalizeFreshness(rawFreshness) : undefined;
-      if (rawFreshness && !freshness) {
-        return jsonResult({
-          error: "invalid_freshness",
-          message:
-            "freshness must be one of pd, pw, pm, py, or a range like YYYY-MM-DDtoYYYY-MM-DD.",
-          docs: "https://docs.openclaw.ai/tools/web",
-        });
-      }
-      const result = await runWebSearch({
-        query,
-        count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-        apiKey,
-        timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
-        cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
-        provider,
-        country,
-        search_lang,
-        ui_lang,
-        freshness,
-        perplexityBaseUrl: resolvePerplexityBaseUrl(
-          perplexityConfig,
-          perplexityAuth?.source,
-          perplexityAuth?.apiKey,
-        ),
-        perplexityModel: resolvePerplexityModel(perplexityConfig),
-        grokModel: resolveGrokModel(grokConfig),
-        grokInlineCitations: resolveGrokInlineCitations(grokConfig),
-      });
-      return jsonResult(result);
     },
   };
 }

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -69,6 +69,7 @@ const createRegistry = (channels: PluginRegistry["channels"]): PluginRegistry =>
   commands: [],
   channels,
   providers: [],
+  searchProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -430,8 +430,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", or "grok"). */
-      provider?: "brave" | "perplexity" | "grok";
+      /** Search provider (e.g., "brave", "perplexity", "grok", or any plugin-registered provider). */
+      provider?: string;
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -239,7 +239,7 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
+    provider: z.string().optional(),
     apiKey: z.string().optional().register(sensitive),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -17,6 +17,7 @@ const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
   channels: [],
   commands: [],
   providers: [],
+  searchProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -145,6 +145,7 @@ const createStubPluginRegistry = (): PluginRegistry => ({
     },
   ],
   providers: [],
+  searchProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -163,6 +163,7 @@ function createPluginRecord(params: {
     hookNames: [],
     channelIds: [],
     providerIds: [],
+    searchProviderIds: [],
     gatewayMethods: [],
     cliCommands: [],
     services: [],

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import { registerSearchProvider as registerGlobalSearchProvider } from "../agents/tools/search-providers.js";
 import type { ChannelDock } from "../channels/dock.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type {
@@ -75,6 +76,12 @@ export type PluginProviderRegistration = {
   source: string;
 };
 
+export type PluginSearchProviderRegistration = {
+  pluginId: string;
+  provider: import("./types.js").SearchProviderPlugin;
+  source: string;
+};
+
 export type PluginHookRegistration = {
   pluginId: string;
   entry: HookEntry;
@@ -110,6 +117,7 @@ export type PluginRecord = {
   hookNames: string[];
   channelIds: string[];
   providerIds: string[];
+  searchProviderIds: string[];
   gatewayMethods: string[];
   cliCommands: string[];
   services: string[];
@@ -128,6 +136,7 @@ export type PluginRegistry = {
   typedHooks: TypedPluginHookRegistration[];
   channels: PluginChannelRegistration[];
   providers: PluginProviderRegistration[];
+  searchProviders: PluginSearchProviderRegistration[];
   gatewayHandlers: GatewayRequestHandlers;
   httpHandlers: PluginHttpRegistration[];
   httpRoutes: PluginHttpRouteRegistration[];
@@ -151,6 +160,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     typedHooks: [],
     channels: [],
     providers: [],
+    searchProviders: [],
     gatewayHandlers: {},
     httpHandlers: [],
     httpRoutes: [],
@@ -386,6 +396,58 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  const registerSearchProvider = (
+    record: PluginRecord,
+    provider: import("./types.js").SearchProviderPlugin,
+  ) => {
+    const id = typeof provider?.id === "string" ? provider.id.trim() : "";
+    if (!id) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "search provider registration missing id",
+      });
+      return;
+    }
+    const normalizedId = id.toLowerCase();
+    const existing = registry.searchProviders.find(
+      (entry) => entry.provider.id.trim().toLowerCase() === normalizedId,
+    );
+    if (existing) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `search provider already registered: ${id} (${existing.pluginId})`,
+      });
+      return;
+    }
+
+    // Attach the plugin entry id to the provider for config lookup
+    const providerWithPluginId = { ...provider, pluginId: record.id };
+
+    // Register in the global search provider registry
+    try {
+      registerGlobalSearchProvider(providerWithPluginId);
+    } catch (error) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `failed to register search provider: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      return;
+    }
+
+    record.searchProviderIds.push(id);
+    registry.searchProviders.push({
+      pluginId: record.id,
+      provider: providerWithPluginId,
+      source: record.source,
+    });
+  };
+
   const registerCli = (
     record: PluginRecord,
     registrar: OpenClawPluginCliRegistrar,
@@ -493,6 +555,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerHttpRoute: (params) => registerHttpRoute(record, params),
       registerChannel: (registration) => registerChannel(record, registration),
       registerProvider: (provider) => registerProvider(record, provider),
+      registerSearchProvider: (provider) => registerSearchProvider(record, provider),
       registerGatewayMethod: (method, handler) => registerGatewayMethod(record, method, handler),
       registerCli: (registrar, opts) => registerCli(record, registrar, opts),
       registerService: (service) => registerService(record, service),
@@ -509,6 +572,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     registerTool,
     registerChannel,
     registerProvider,
+    registerSearchProvider,
     registerGatewayMethod,
     registerCli,
     registerService,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -131,6 +131,63 @@ export type OpenClawPluginGatewayMethod = {
 };
 
 // =============================================================================
+// Search Provider Plugins
+// =============================================================================
+
+export type SearchProviderResult =
+  | {
+      query: string;
+      provider: string;
+      results?: Array<{
+        title: string;
+        url: string;
+        description?: string;
+        published?: string;
+      }>;
+      content?: string;
+      citations?: string[];
+      tookMs?: number;
+      cached?: boolean;
+    }
+  | {
+      error: string;
+      message: string;
+      provider: string;
+    };
+
+export type SearchProviderContext = {
+  config: OpenClawConfig;
+  timeoutSeconds: number;
+  cacheTtlMs: number;
+  pluginConfig?: unknown;
+};
+
+export type SearchProviderPlugin = {
+  id: string;
+  label: string;
+  description?: string;
+  configSchema?: Record<string, unknown>;
+  /**
+   * The plugin entry id that registered this provider.
+   * Set automatically during registration; used to look up plugin config.
+   * For built-in providers, this is undefined and falls back to provider id.
+   */
+  pluginId?: string;
+  search: (
+    params: {
+      query: string;
+      count: number;
+      country?: string;
+      search_lang?: string;
+      ui_lang?: string;
+      freshness?: string;
+      providerConfig?: Record<string, unknown>;
+    },
+    ctx: SearchProviderContext,
+  ) => Promise<SearchProviderResult>;
+};
+
+// =============================================================================
 // Plugin Commands
 // =============================================================================
 
@@ -268,6 +325,7 @@ export type OpenClawPluginApi = {
   registerCli: (registrar: OpenClawPluginCliRegistrar, opts?: { commands?: string[] }) => void;
   registerService: (service: OpenClawPluginService) => void;
   registerProvider: (provider: ProviderPlugin) => void;
+  registerSearchProvider: (provider: SearchProviderPlugin) => void;
   /**
    * Register a custom command that bypasses the LLM agent.
    * Plugin commands are processed before built-in commands and before agent invocation.

--- a/src/test-utils/channel-plugins.ts
+++ b/src/test-utils/channel-plugins.ts
@@ -19,6 +19,7 @@ export const createTestRegistry = (channels: TestChannelRegistration[] = []): Pl
   typedHooks: [],
   channels: channels as unknown as PluginRegistry["channels"],
   providers: [],
+  searchProviders: [],
   gatewayHandlers: {},
   httpHandlers: [],
   httpRoutes: [],


### PR DESCRIPTION
## Summary

Makes web_search providers extensible via the plugin system, allowing custom search providers (Kagi, SerpAPI, Tavily, etc.) without modifying core code.

Closes #11399

## Changes

- **New provider registry** (`src/agents/tools/search-providers.ts`) - global registry for search providers
- **Refactored web-search.ts** - uses registry instead of hardcoded switch statement
- **New plugin type** (`SearchProviderPlugin`) - plugins can now register custom search providers
- **Updated schema** - provider field accepts any string (validated at runtime against registered providers)
- **Example plugin** (`extensions/kagi-search/`) - demonstrates how to build a custom provider

## Plugin API

```typescript
import type { SearchProviderPlugin } from 'clawdbot';

const plugin: SearchProviderPlugin = {
  name: 'kagi-search',
  type: 'search-provider',
  providerName: 'kagi',
  
  async search(query, options) {
    // Implementation
    return { results: [...], provider: 'kagi' };
  }
};

export default plugin;
```

## Backward Compatibility

- Built-in providers (brave, perplexity) work exactly as before
- Existing configs with `provider: brave` or `provider: perplexity` unchanged
- No breaking changes

## Testing

All 12 existing web-search tests pass locally.

**Note:** 3 tests in `web-tools.enabled-defaults.test.ts` fail on this PR, but they also fail on `main` — these are pre-existing test issues (caching/isolation bugs), not regressions from this PR.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `web_search` provider-extensible by introducing a global search-provider registry and wiring the tool to dispatch searches through registered providers (built-in Brave/Perplexity plus plugin-registered providers). It also loosens the config schema so `tools.web.search.provider` can be any string and adds an example Kagi provider plugin.

Main issues to address before merge:
- Provider plugins don’t reliably receive their per-plugin `plugins.entries.<pluginId>.config` because `web-search.ts` indexes config by provider id, not plugin id.
- When falling back from an unknown provider to Brave, error payloads can incorrectly report the configured provider name instead of the effective provider used.

Otherwise the architecture fits the existing plugin registry/runtime patterns (new `registerSearchProvider` API and registry bookkeeping), and built-in providers are moved behind the same interface.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has two correctness issues affecting plugin provider config and error reporting.
- Core refactor to a provider registry is coherent and built-in providers remain functional, but provider plugins currently won’t receive their per-plugin config due to an ID mismatch, and fallback-to-Brave can emit misleading error payloads when the effective provider differs from the configured name.
- src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->