### PR TITLE
feat: enable block streaming by default, default break to message_end

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -371,7 +371,7 @@ export async function resolveReplyDirectives(params: {
           ? "off"
           : "on";
   const resolvedBlockStreamingBreak: "text_end" | "message_end" =
-    agentCfg?.blockStreamingBreak === "message_end" ? "message_end" : "text_end";
+    agentCfg?.blockStreamingBreak === "text_end" ? "text_end" : "message_end";
   const blockStreamingEnabled =
     resolvedBlockStreaming === "on" && opts?.disableBlockStreaming !== true;
   const blockReplyChunking = blockStreamingEnabled

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -367,9 +367,9 @@ export async function resolveReplyDirectives(params: {
       ? "off"
       : opts?.disableBlockStreaming === false
         ? "on"
-        : agentCfg?.blockStreamingDefault === "on"
-          ? "on"
-          : "off";
+        : agentCfg?.blockStreamingDefault === "off"
+          ? "off"
+          : "on";
   const resolvedBlockStreamingBreak: "text_end" | "message_end" =
     agentCfg?.blockStreamingBreak === "message_end" ? "message_end" : "text_end";
   const blockStreamingEnabled =

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -146,6 +146,7 @@ export type AgentDefaultsConfig = {
    * Block streaming boundary:
    * - "text_end": end of each assistant text content block (before tool calls)
    * - "message_end": end of the whole assistant message (may include tool blocks)
+   * Defaults to "message_end".
    */
   blockStreamingBreak?: "text_end" | "message_end";
   /** Soft block chunking for streamed replies (min/max chars, prefer paragraph/newline). */

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -140,7 +140,7 @@ export type AgentDefaultsConfig = {
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
-  /** Default block streaming level when no override is present. */
+  /** Default block streaming level when no override is present. Defaults to "on". */
   blockStreamingDefault?: "off" | "on";
   /**
    * Block streaming boundary:


### PR DESCRIPTION
## What

1. Changes the default value of `blockStreamingDefault` from `"off"` to `"on"`.
2. Changes the default value of `blockStreamingBreak` from `"text_end"` to `"message_end"`.

## Why

**Block streaming on by default:** When block streaming is off (current default), users on messaging channels (Telegram, Discord, etc.) see **no output** during long multi-step agent tasks until the entire turn completes. With block streaming on, text blocks are sent progressively, giving users real-time visibility.

**message_end as default break:** With `text_end`, messages split prematurely whenever tool calls happen mid-reply -- the text before a tool call gets flushed as a separate message, resulting in fragmented replies. `message_end` waits for the complete assistant turn, delivering clean single messages.

## Changes

- `src/auto-reply/reply/get-reply-directives.ts`: Flip defaults so unset `blockStreamingDefault` resolves to `"on"` and unset `blockStreamingBreak` resolves to `"message_end"`
- `src/config/types.agent-defaults.ts`: Update JSDoc to reflect new defaults

## Backward compatibility

Users who prefer the old behavior can explicitly set `blockStreamingDefault: "off"` and/or `blockStreamingBreak: "text_end"` in their config. No breaking changes -- existing configs with explicit values are unaffected.