### PR TITLE
feat(providers): add Claude models to GitHub Copilot provider

### DIFF
--- a/apps/macos/Sources/OpenClawIPC/IPC.swift
+++ b/apps/macos/Sources/OpenClawIPC/IPC.swift
@@ -407,11 +407,10 @@ extension Request: Codable {
     }
 }
 
-// Shared transport settings
+/// Shared transport settings
 public let controlSocketPath: String = {
     let home = FileManager().homeDirectoryForCurrentUser
-    let preferred = home
+    return home
         .appendingPathComponent("Library/Application Support/OpenClaw/control.sock")
         .path
-    return preferred
 }()

--- a/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
@@ -1,6 +1,6 @@
+import Foundation
 import OpenClawKit
 import OpenClawProtocol
-import Foundation
 #if canImport(Darwin)
 import Darwin
 #endif

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -63,6 +63,32 @@ openclaw models set github-copilot/gpt-4o
 }
 ```
 
+## Available models
+
+The following models are available through GitHub Copilot:
+
+### OpenAI models
+
+- `gpt-4o`
+- `gpt-4.1`
+- `gpt-4.1-mini`
+- `gpt-4.1-nano`
+- `o1`
+- `o1-mini`
+- `o3-mini`
+
+### Claude models (Pro+ subscription required)
+
+- `claude-opus-4.5`
+- `claude-sonnet-4.5`
+- `claude-sonnet-4`
+
+To use Claude Opus 4.5:
+
+```bash
+openclaw models set github-copilot/claude-opus-4.5
+```
+
 ## Notes
 
 - Requires an interactive TTY; run it directly in a terminal.

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -79,14 +79,14 @@ The following models are available through GitHub Copilot:
 
 ### Claude models (Pro+ subscription required)
 
-- `claude-opus-4.5`
-- `claude-sonnet-4.5`
+- `claude-opus-4-5`
+- `claude-sonnet-4-5`
 - `claude-sonnet-4`
 
 To use Claude Opus 4.5:
 
 ```bash
-openclaw models set github-copilot/claude-opus-4.5
+openclaw models set github-copilot/claude-opus-4-5
 ```
 
 ## Notes

--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.e2e.test.ts
@@ -24,6 +24,7 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("invalid request format")).toBe("format");
     expect(classifyFailoverReason("credit balance too low")).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
+    expect(classifyFailoverReason("fetch failed")).toBe("timeout");
     expect(
       classifyFailoverReason(
         "521 <!DOCTYPE html><html><head><title>Web server is down</title></head><body>Cloudflare</body></html>",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -549,7 +549,13 @@ const ERROR_PATTERNS = {
     "usage limit",
   ],
   overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
-  timeout: ["timeout", "timed out", "deadline exceeded", "context deadline exceeded"],
+  timeout: [
+    "timeout",
+    "timed out",
+    "deadline exceeded",
+    "context deadline exceeded",
+    "fetch failed",
+  ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
     "payment required",

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -3,6 +3,10 @@ import type { ModelDefinitionConfig } from "../config/types.js";
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 8192;
 
+// Claude models have larger context windows
+const CLAUDE_CONTEXT_WINDOW = 200_000;
+const CLAUDE_MAX_TOKENS = 8192;
+
 // Copilot model ids vary by plan/org and can change.
 // We keep this list intentionally broad; if a model isn't available Copilot will
 // return an error and users can remove it from their config.
@@ -14,7 +18,19 @@ const DEFAULT_MODEL_IDS = [
   "o1",
   "o1-mini",
   "o3-mini",
+  // Claude models (requires GitHub Copilot Pro+ subscription)
+  "claude-opus-4.5",
+  "claude-sonnet-4.5",
+  "claude-sonnet-4",
 ] as const;
+
+// Models that are known to be Claude models
+const CLAUDE_MODEL_PREFIXES = ["claude-"] as const;
+
+function isClaudeModel(modelId: string): boolean {
+  const lower = modelId.toLowerCase();
+  return CLAUDE_MODEL_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
 
 export function getDefaultCopilotModelIds(): string[] {
   return [...DEFAULT_MODEL_IDS];
@@ -25,6 +41,9 @@ export function buildCopilotModelDefinition(modelId: string): ModelDefinitionCon
   if (!id) {
     throw new Error("Model id required");
   }
+
+  const isClaude = isClaudeModel(id);
+
   return {
     id,
     name: id,
@@ -35,7 +54,7 @@ export function buildCopilotModelDefinition(modelId: string): ModelDefinitionCon
     reasoning: false,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
+    contextWindow: isClaude ? CLAUDE_CONTEXT_WINDOW : DEFAULT_CONTEXT_WINDOW,
+    maxTokens: isClaude ? CLAUDE_MAX_TOKENS : DEFAULT_MAX_TOKENS,
   };
 }

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -19,8 +19,8 @@ const DEFAULT_MODEL_IDS = [
   "o1-mini",
   "o3-mini",
   // Claude models (requires GitHub Copilot Pro+ subscription)
-  "claude-opus-4.5",
-  "claude-sonnet-4.5",
+  "claude-opus-4-5",
+  "claude-sonnet-4-5",
   "claude-sonnet-4",
 ] as const;
 


### PR DESCRIPTION
Add Claude model support (claude-sonnet-4, claude-opus-4.5) to the GitHub Copilot provider, enabling users to access Anthropic models through their Copilot subscription.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the built-in `github-copilot` provider by adding Claude model IDs to the default Copilot model list and documenting the available Copilot models. It also tweaks failover classification to treat the string `fetch failed` as a timeout.

The main issues are around model-id correctness/consistency: the PR introduces `claude-sonnet-4.5` (dot) but the rest of the repository uses the dash form `claude-sonnet-4-5`; if Copilot expects the dash form, the new default will fail and the docs will cause users to copy an invalid ID. Additionally, treating generic `fetch failed` network errors as timeouts can trigger failover for non-timeout failures, altering behavior in cases like DNS/TLS/connection failures.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but likely needs fixes to model IDs and error classification behavior.
- Core changes are small, but the introduced `claude-sonnet-4.5` identifier appears inconsistent with established model-id conventions in this repo and may cause immediate runtime model-selection failures if Copilot expects `claude-sonnet-4-5`. Separately, classifying the generic undici `fetch failed` error as a timeout can change failover routing for non-timeout network failures.
- docs/providers/github-copilot.md, src/providers/github-copilot-models.ts, src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->