### PR TITLE
fix(gateway): use LAN IP for WebSocket/probe URLs when bind=lan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
+- Gateway/CLI: when `gateway.bind=lan`, use a LAN IP for probe URLs and Control UI links. (#11448) Thanks @AnonO6.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
 - Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.
 - Telegram: auto-inject DM topic threadId in message tool + subagent announce. (#7235) Thanks @Lukavyi.

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -4,6 +4,7 @@ import {
   resolveGatewayWindowsTaskName,
 } from "../../daemon/constants.js";
 import { resolveGatewayLogPaths } from "../../daemon/launchd.js";
+import { pickPrimaryLanIPv4 } from "../../gateway/net.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
 import { formatCliCommand } from "../command-format.js";
 
@@ -60,6 +61,9 @@ export function pickProbeHostForBind(
   }
   if (bindMode === "tailnet") {
     return tailnetIPv4 ?? "127.0.0.1";
+  }
+  if (bindMode === "lan") {
+    return pickPrimaryLanIPv4() ?? "127.0.0.1";
   }
   return "127.0.0.1";
 }

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -185,7 +185,7 @@ export async function gatherDaemonStatus(
   const probeUrl = probeUrlOverride ?? `ws://${probeHost}:${daemonPort}`;
   const probeNote =
     !probeUrlOverride && bindMode === "lan"
-      ? "Local probe uses loopback (127.0.0.1). bind=lan listens on 0.0.0.0 (all interfaces); use a LAN IP for remote clients."
+      ? `bind=lan listens on 0.0.0.0 (all interfaces); probing via ${probeHost}.`
       : !probeUrlOverride && bindMode === "loopback"
         ? "Loopback-only gateway; only local clients can connect."
         : undefined;

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -11,6 +11,7 @@ import { CONFIG_PATH } from "../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
+import { pickPrimaryLanIPv4 } from "../gateway/net.js";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
@@ -449,6 +450,9 @@ export function resolveControlUiLinks(params: {
     }
     if (bind === "tailnet" && tailnetIPv4) {
       return tailnetIPv4 ?? "127.0.0.1";
+    }
+    if (bind === "lan") {
+      return pickPrimaryLanIPv4() ?? "127.0.0.1";
     }
     return "127.0.0.1";
   })();

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const loadConfig = vi.fn();
 const resolveGatewayPort = vi.fn();
 const pickPrimaryTailnetIPv4 = vi.fn();
+const pickPrimaryLanIPv4 = vi.fn();
 
 let lastClientOptions: {
   url?: string;
@@ -27,6 +28,10 @@ vi.mock("../config/config.js", async (importOriginal) => {
 
 vi.mock("../infra/tailnet.js", () => ({
   pickPrimaryTailnetIPv4,
+}));
+
+vi.mock("./net.js", () => ({
+  pickPrimaryLanIPv4,
 }));
 
 vi.mock("./client.js", () => ({
@@ -70,6 +75,7 @@ describe("callGateway url resolution", () => {
     loadConfig.mockReset();
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
+    pickPrimaryLanIPv4.mockReset();
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -106,6 +112,28 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.url).toBe("ws://100.64.0.1:18800");
   });
 
+  it("uses LAN IP when bind is lan and LAN IP is available", async () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue("192.168.1.42");
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://192.168.1.42:18800");
+  });
+
+  it("falls back to loopback when bind is lan but no LAN IP found", async () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local", bind: "lan" } });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue(undefined);
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
+  });
+
   it("uses url override in remote mode even when remote url is missing", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },
@@ -129,6 +157,7 @@ describe("buildGatewayConnectionDetails", () => {
     loadConfig.mockReset();
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
+    pickPrimaryLanIPv4.mockReset();
   });
 
   it("uses explicit url overrides and omits bind details", () => {
@@ -168,6 +197,21 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.message).toContain("Gateway target: ws://127.0.0.1:18789");
   });
 
+  it("uses LAN IP and reports lan source when bind is lan", () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "lan" },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    pickPrimaryLanIPv4.mockReturnValue("10.0.0.5");
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://10.0.0.5:18800");
+    expect(details.urlSource).toBe("local lan 10.0.0.5");
+    expect(details.bindDetail).toBe("Bind: lan");
+  });
+
   it("prefers remote url when configured", () => {
     loadConfig.mockReturnValue({
       gateway: {
@@ -193,6 +237,7 @@ describe("callGateway error details", () => {
     loadConfig.mockReset();
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
+    pickPrimaryLanIPv4.mockReset();
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -267,6 +312,7 @@ describe("callGateway url override auth requirements", () => {
     loadConfig.mockReset();
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
+    pickPrimaryLanIPv4.mockReset();
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -303,6 +349,7 @@ describe("callGateway password resolution", () => {
     loadConfig.mockReset();
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
+    pickPrimaryLanIPv4.mockReset();
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;
@@ -404,6 +451,7 @@ describe("callGateway token resolution", () => {
     loadConfig.mockReset();
     resolveGatewayPort.mockReset();
     pickPrimaryTailnetIPv4.mockReset();
+    pickPrimaryLanIPv4.mockReset();
     lastClientOptions = null;
     startMode = "hello";
     closeCode = 1006;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -16,6 +16,7 @@ import {
   type GatewayClientName,
 } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
+import { pickPrimaryLanIPv4 } from "./net.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
 
 export type CallGatewayOptions = {
@@ -101,11 +102,15 @@ export function buildGatewayConnectionDetails(
   const tailnetIPv4 = pickPrimaryTailnetIPv4();
   const bindMode = config.gateway?.bind ?? "loopback";
   const preferTailnet = bindMode === "tailnet" && !!tailnetIPv4;
+  const preferLan = bindMode === "lan";
+  const lanIPv4 = preferLan ? pickPrimaryLanIPv4() : undefined;
   const scheme = tlsEnabled ? "wss" : "ws";
   const localUrl =
     preferTailnet && tailnetIPv4
       ? `${scheme}://${tailnetIPv4}:${localPort}`
-      : `${scheme}://127.0.0.1:${localPort}`;
+      : preferLan && lanIPv4
+        ? `${scheme}://${lanIPv4}:${localPort}`
+        : `${scheme}://127.0.0.1:${localPort}`;
   const urlOverride =
     typeof options.url === "string" && options.url.trim().length > 0
       ? options.url.trim()
@@ -122,7 +127,9 @@ export function buildGatewayConnectionDetails(
         ? "missing gateway.remote.url (fallback local)"
         : preferTailnet && tailnetIPv4
           ? `local tailnet ${tailnetIPv4}`
-          : "local loopback";
+          : preferLan && lanIPv4
+            ? `local lan ${lanIPv4}`
+            : "local loopback";
   const remoteFallbackNote = remoteMisconfigured
     ? "Warn: gateway.mode=remote but gateway.remote.url is missing; set gateway.remote.url or switch gateway.mode=local."
     : undefined;

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,5 +1,5 @@
 import os from "node:os";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickPrimaryLanIPv4, resolveGatewayListenHosts } from "./net.js";
 
 describe("resolveGatewayListenHosts", () => {
@@ -28,6 +28,10 @@ describe("resolveGatewayListenHosts", () => {
 });
 
 describe("pickPrimaryLanIPv4", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("returns en0 IPv4 address when available", () => {
     vi.spyOn(os, "networkInterfaces").mockReturnValue({
       lo0: [
@@ -38,7 +42,6 @@ describe("pickPrimaryLanIPv4", () => {
       ] as unknown as os.NetworkInterfaceInfo[],
     });
     expect(pickPrimaryLanIPv4()).toBe("192.168.1.42");
-    vi.restoreAllMocks();
   });
 
   it("returns eth0 IPv4 address when en0 is absent", () => {
@@ -51,7 +54,6 @@ describe("pickPrimaryLanIPv4", () => {
       ] as unknown as os.NetworkInterfaceInfo[],
     });
     expect(pickPrimaryLanIPv4()).toBe("10.0.0.5");
-    vi.restoreAllMocks();
   });
 
   it("falls back to any non-internal IPv4 interface", () => {
@@ -64,7 +66,6 @@ describe("pickPrimaryLanIPv4", () => {
       ] as unknown as os.NetworkInterfaceInfo[],
     });
     expect(pickPrimaryLanIPv4()).toBe("172.16.0.99");
-    vi.restoreAllMocks();
   });
 
   it("returns undefined when only internal interfaces exist", () => {
@@ -74,6 +75,5 @@ describe("pickPrimaryLanIPv4", () => {
       ] as unknown as os.NetworkInterfaceInfo[],
     });
     expect(pickPrimaryLanIPv4()).toBeUndefined();
-    vi.restoreAllMocks();
   });
 });

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { resolveGatewayListenHosts } from "./net.js";
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import { pickPrimaryLanIPv4, resolveGatewayListenHosts } from "./net.js";
 
 describe("resolveGatewayListenHosts", () => {
   it("returns the input host when not loopback", async () => {
@@ -23,5 +24,56 @@ describe("resolveGatewayListenHosts", () => {
       canBindToHost: async () => false,
     });
     expect(hosts).toEqual(["127.0.0.1"]);
+  });
+});
+
+describe("pickPrimaryLanIPv4", () => {
+  it("returns en0 IPv4 address when available", () => {
+    vi.spyOn(os, "networkInterfaces").mockReturnValue({
+      lo0: [
+        { address: "127.0.0.1", family: "IPv4", internal: true, netmask: "" },
+      ] as unknown as os.NetworkInterfaceInfo[],
+      en0: [
+        { address: "192.168.1.42", family: "IPv4", internal: false, netmask: "" },
+      ] as unknown as os.NetworkInterfaceInfo[],
+    });
+    expect(pickPrimaryLanIPv4()).toBe("192.168.1.42");
+    vi.restoreAllMocks();
+  });
+
+  it("returns eth0 IPv4 address when en0 is absent", () => {
+    vi.spyOn(os, "networkInterfaces").mockReturnValue({
+      lo: [
+        { address: "127.0.0.1", family: "IPv4", internal: true, netmask: "" },
+      ] as unknown as os.NetworkInterfaceInfo[],
+      eth0: [
+        { address: "10.0.0.5", family: "IPv4", internal: false, netmask: "" },
+      ] as unknown as os.NetworkInterfaceInfo[],
+    });
+    expect(pickPrimaryLanIPv4()).toBe("10.0.0.5");
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to any non-internal IPv4 interface", () => {
+    vi.spyOn(os, "networkInterfaces").mockReturnValue({
+      lo: [
+        { address: "127.0.0.1", family: "IPv4", internal: true, netmask: "" },
+      ] as unknown as os.NetworkInterfaceInfo[],
+      wlan0: [
+        { address: "172.16.0.99", family: "IPv4", internal: false, netmask: "" },
+      ] as unknown as os.NetworkInterfaceInfo[],
+    });
+    expect(pickPrimaryLanIPv4()).toBe("172.16.0.99");
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined when only internal interfaces exist", () => {
+    vi.spyOn(os, "networkInterfaces").mockReturnValue({
+      lo: [
+        { address: "127.0.0.1", family: "IPv4", internal: true, netmask: "" },
+      ] as unknown as os.NetworkInterfaceInfo[],
+    });
+    expect(pickPrimaryLanIPv4()).toBeUndefined();
+    vi.restoreAllMocks();
   });
 });

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -1,5 +1,29 @@
 import net from "node:net";
+import os from "node:os";
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
+
+/**
+ * Pick the primary non-internal IPv4 address (LAN IP).
+ * Prefers common interface names (en0, eth0) then falls back to any external IPv4.
+ */
+export function pickPrimaryLanIPv4(): string | undefined {
+  const nets = os.networkInterfaces();
+  const preferredNames = ["en0", "eth0"];
+  for (const name of preferredNames) {
+    const list = nets[name];
+    const entry = list?.find((n) => n.family === "IPv4" && !n.internal);
+    if (entry?.address) {
+      return entry.address;
+    }
+  }
+  for (const list of Object.values(nets)) {
+    const entry = list?.find((n) => n.family === "IPv4" && !n.internal);
+    if (entry?.address) {
+      return entry.address;
+    }
+  }
+  return undefined;
+}
 
 export function isLoopbackAddress(ip: string | undefined): boolean {
   if (!ip) {


### PR DESCRIPTION
#### Summary

Fixes #11329 — When `gateway.bind=lan`, WebSocket connection URLs, probe targets, and Control UI links were hardcoded to `127.0.0.1`, even though the HTTP server correctly binds to `0.0.0.0` (all interfaces). This caused `openclaw status` to show misleading probe URLs, CLI commands to target localhost instead of a LAN-reachable address, and onboarding to display wrong connection info for LAN users.

lobster-biscuit

#### Repro Steps

1. Set `gateway.bind = "lan"` in `openclaw.json`
2. Restart gateway
3. Run `openclaw status` — observe probe URL is `ws://127.0.0.1:18789`
4. Access `http://192.168.x.x:18789` from another LAN device — dashboard HTML loads but shows "disconnected from gateway"
5. CLI commands from LAN machines fail to connect (target `ws://127.0.0.1:...`)

#### Root Cause

Three functions hardcode `127.0.0.1` when constructing WebSocket/probe/UI URLs, with no branch for `bind === "lan"`:

- `pickProbeHostForBind()` in `src/cli/daemon-cli/shared.ts` — falls through to `return "127.0.0.1"`
- `buildGatewayConnectionDetails()` in `src/gateway/call.ts` — only checks tailnet, defaults to `127.0.0.1`
- `resolveControlUiLinks()` in `src/commands/onboard-helpers.ts` — only checks custom/tailnet, defaults to `127.0.0.1`

The HTTP server binds correctly (via `resolveGatewayBindHost()` which returns `"0.0.0.0"` for `lan`), but the URL-building functions never learned about LAN mode.

#### Behavior Changes

- When `gateway.bind=lan`, probe/connection/UI URLs now use the machine's primary LAN IPv4 (e.g., `192.168.1.42`) instead of `127.0.0.1`
- `openclaw status` reports `"local lan 192.168.x.x"` as the URL source instead of `"local loopback"`
- Falls back to `127.0.0.1` gracefully if no external network interface is detected
- No change for `bind=loopback`, `bind=tailnet`, `bind=custom`, or `bind=auto`

#### Codebase and GitHub Search

- Searched for all usages of `127.0.0.1` in gateway URL construction: `pickProbeHostForBind`, `buildGatewayConnectionDetails`, `resolveControlUiLinks`
- Verified `resolveGatewayBindHost()` in `net.ts` already correctly returns `"0.0.0.0"` for `bind=lan`
- Verified the Control UI frontend already uses `location.host` (not hardcoded) — so browser-side is fine
- Confirmed existing `resolvePrimaryIPv4()` pattern in `system-presence.ts` for LAN IP detection
- Confirmed issue #11329 had zero existing PRs at time of submission

#### Tests

- Added 4 unit tests for `pickPrimaryLanIPv4()` in `net.test.ts`:
  - Returns en0 IPv4 when available
  - Returns eth0 when en0 absent
  - Falls back to any non-internal interface
  - Returns undefined when only internal interfaces exist
- Added 3 tests for `bind=lan` in `call.test.ts`:
  - `callGateway` uses LAN IP when bind=lan
  - `callGateway` falls back to loopback when no LAN IP found
  - `buildGatewayConnectionDetails` returns correct URL and `"local lan <ip>"` source
- All existing tests continue to pass (228 tests, 36 files)

```
pnpm build   ✓
pnpm check   ✓
pnpm test    ✓ (228 passed, 0 failed)
```

#### Manual Testing

N/A — verified via unit tests with mocked `os.networkInterfaces()`; the LAN IP resolution follows the same proven pattern used by `resolvePrimaryIPv4()` in `system-presence.ts`.

**Sign-Off**

- AI-assisted: Yes (Cursor + Claude). All code reviewed and understood by submitter.
- Degree of testing: Fully tested (7 new unit tests + full suite pass)
- Models used: Claude claude-4.6-opus
- Submitter effort: Code review, issue triage, root cause analysis, test verification