### PR TITLE
fix: apply normalizeToolName() at all tool lookup points

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/src/agents/tool-policy.normalize-tool-name.test.ts
+++ b/src/agents/tool-policy.normalize-tool-name.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolName } from "./tool-policy.js";
+
+describe("normalizeToolName", () => {
+  it("trims leading and trailing whitespace", () => {
+    expect(normalizeToolName(" exec")).toBe("exec");
+    expect(normalizeToolName("exec ")).toBe("exec");
+    expect(normalizeToolName("  exec  ")).toBe("exec");
+    expect(normalizeToolName("\texec\n")).toBe("exec");
+  });
+
+  it("lowercases tool names", () => {
+    expect(normalizeToolName("Exec")).toBe("exec");
+    expect(normalizeToolName("BROWSER")).toBe("browser");
+    expect(normalizeToolName(" Read ")).toBe("read");
+  });
+
+  it("resolves known aliases", () => {
+    expect(normalizeToolName("bash")).toBe("exec");
+    expect(normalizeToolName("BASH")).toBe("exec");
+    expect(normalizeToolName(" bash ")).toBe("exec");
+    expect(normalizeToolName("apply-patch")).toBe("apply_patch");
+    expect(normalizeToolName(" Apply-Patch ")).toBe("apply_patch");
+  });
+
+  it("preserves valid tool names", () => {
+    expect(normalizeToolName("exec")).toBe("exec");
+    expect(normalizeToolName("read")).toBe("read");
+    expect(normalizeToolName("web_search")).toBe("web_search");
+    expect(normalizeToolName("memory_get")).toBe("memory_get");
+  });
+
+  it("handles empty and whitespace-only input", () => {
+    expect(normalizeToolName("")).toBe("");
+    expect(normalizeToolName("   ")).toBe("");
+  });
+});

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -1,7 +1,7 @@
 import { collectTextContentBlocks } from "../../agents/content-blocks.js";
 import { createOpenClawTools } from "../../agents/openclaw-tools.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
-import { applyOwnerOnlyToolPolicy } from "../../agents/tool-policy.js";
+import { applyOwnerOnlyToolPolicy, normalizeToolName } from "../../agents/tool-policy.js";
 import { getChannelDock } from "../../channels/dock.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -205,7 +205,8 @@ export async function handleInlineActions(params: {
       });
       const authorizedTools = applyOwnerOnlyToolPolicy(tools, command.senderIsOwner);
 
-      const tool = authorizedTools.find((candidate) => candidate.name === dispatch.toolName);
+      const normalizedDispatchName = normalizeToolName(dispatch.toolName);
+      const tool = authorizedTools.find((candidate) => candidate.name === normalizedDispatchName);
       if (!tool) {
         typing.cleanup();
         return { kind: "reply", reply: { text: `❌ Tool not available: ${dispatch.toolName}` } };

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -272,6 +272,22 @@ describe("POST /tools/invoke", () => {
     expect(body).toHaveProperty("result");
   });
 
+  it("normalizes tool name with whitespace and casing", async () => {
+    allowAgentsListForMain();
+
+    const res = await invokeTool({
+      port: sharedPort,
+      tool: " Agents_List ",
+      action: "json",
+      headers: gatewayAuthHeaders(),
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
   it("supports tools.alsoAllow in profile and implicit modes", async () => {
     cfg = {
       ...cfg,

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -12,6 +12,7 @@ import {
 import {
   collectExplicitAllowlist,
   mergeAlsoAllowPolicy,
+  normalizeToolName,
   resolveToolProfilePolicy,
 } from "../agents/tool-policy.js";
 import { ToolInputError } from "../agents/tools/common.js";
@@ -173,7 +174,7 @@ export async function handleToolsInvokeHttpRequest(
   }
   const body = (bodyUnknown ?? {}) as ToolsInvokeBody;
 
-  const toolName = typeof body.tool === "string" ? body.tool.trim() : "";
+  const toolName = typeof body.tool === "string" ? normalizeToolName(body.tool) : "";
   if (!toolName) {
     sendInvalidRequest(res, "tools.invoke requires body.tool");
     return true;


### PR DESCRIPTION
## Summary

Apply `normalizeToolName()` consistently at tool dispatch entry points to handle model-generated tool names with leading/trailing whitespace or unexpected casing. Fixes #11441.

## Problem

When a model outputs a tool call with leading/trailing whitespace in the tool name (e.g., `" exec"` instead of `"exec"`), OpenClaw fails to find the tool and returns "Tool not found". The existing `normalizeToolName()` function already handles `.trim()` + `.toLowerCase()` + alias resolution, but was not applied at all lookup points.

## Changes

- **`src/gateway/tools-invoke-http.ts`**: Replace bare `.trim()` with `normalizeToolName()` for the HTTP tools/invoke endpoint — this also adds alias resolution (`bash` → `exec`) and case normalization that `.trim()` alone misses.
- **`src/auto-reply/reply/get-reply-inline-actions.ts`**: Normalize `dispatch.toolName` before tool lookup in skill command dispatch.
- **`src/agents/tool-policy.normalize-tool-name.test.ts`**: Add test coverage for `normalizeToolName()` edge cases — whitespace trimming, case normalization, alias resolution, and empty input handling.

## Upstream note

The core model→tool dispatch in `@mariozechner/pi-agent-core` (`agent-loop.js` `executeToolCalls`) also uses strict `===` equality without trimming:

```js
const tool = tools?.find((t) => t.name === toolCall.name);
```

Fixing that lookup upstream would fully resolve the issue for all model-generated tool calls. This PR addresses the OpenClaw-controlled dispatch points.

## Testing

- [x] New unit tests for `normalizeToolName()` covering whitespace, casing, aliases, empty input
- [x] AI-assisted (OpenClaw agent + Claude Opus 4.6); changes reviewed and understood
- [x] CI: `pnpm build && pnpm check && pnpm test`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes tool dispatch more tolerant of model-generated tool names by applying `normalizeToolName()` (trim + lowercase + alias resolution) at additional entry points:

- `/tools/invoke` HTTP handler now normalizes `body.tool` before policy checks and lookup.
- Inline skill command tool dispatch now normalizes `dispatch.toolName` before searching the available tool list.
- Adds Vitest coverage for `normalizeToolName()` behavior around whitespace, casing, aliases, and empty input.

Overall this improves resilience to minor formatting differences in tool call names, but care is needed to ensure alias normalization doesn’t break lookups when any tools are registered under an aliased (non-canonical) name.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one correctness check needed around alias vs canonical tool names in HTTP tool invocation.
- Changes are small and targeted (normalizing tool names at dispatch boundaries plus unit tests). The main remaining risk is behavior change when callers send an alias (e.g. "bash") but the actual registered tool name is the alias rather than the canonical name, which would cause a new 404 until lookup/registration is made consistent.
- src/gateway/tools-invoke-http.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->