### PR TITLE
fix(plugins): remove workspace:* from extension dependencies

### DIFF
--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -8,7 +8,6 @@
     "@microsoft/agents-hosting-express": "^1.2.3",
     "@microsoft/agents-hosting-extensions-teams": "^1.2.3",
     "express": "^5.2.1",
-    "openclaw": "workspace:*",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "dependencies": {
     "nostr-tools": "^2.23.0",
-    "openclaw": "workspace:*",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -4,7 +4,6 @@
   "description": "OpenClaw Zalo channel plugin",
   "type": "module",
   "dependencies": {
-    "openclaw": "workspace:*",
     "undici": "7.21.0"
   },
   "devDependencies": {

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -4,8 +4,7 @@
   "description": "OpenClaw Zalo Personal Account plugin via zca-cli",
   "type": "module",
   "dependencies": {
-    "@sinclair/typebox": "0.34.48",
-    "openclaw": "workspace:*"
+    "@sinclair/typebox": "0.34.48"
   },
   "devDependencies": {
     "openclaw": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,12 +435,13 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/nextcloud-talk:
     devDependencies:
@@ -453,12 +454,13 @@ importers:
       nostr-tools:
         specifier: ^2.23.0
         version: 2.23.0(typescript@5.9.3)
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/open-prose:
     devDependencies:
@@ -540,18 +542,20 @@ importers:
 
   extensions/zalo:
     dependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
       undici:
         specifier: 7.21.0
         version: 7.21.0
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/zalouser:
     dependencies:
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
+    devDependencies:
       openclaw:
         specifier: workspace:*
         version: link:../..


### PR DESCRIPTION
#### Summary

Fixes #10941, Fixes #11245

Four extensions had `"openclaw": "workspace:*"` in `dependencies` (not just `devDependencies`). When plugins are installed outside the pnpm workspace (e.g., `openclaw plugins install ./extensions/feishu`), npm cannot resolve the `workspace:` protocol and fails with `EUNSUPPORTEDPROTOCOL`.

lobster-biscuit

#### Repro Steps

1. `openclaw plugins install ./extensions/zalo` (or nostr, msteams, zalouser)
2. Plugin is copied to `~/.openclaw/extensions/`
3. `npm install --omit=dev` runs in the plugin dir
4. Fails: `Error: Unsupported URL Type "workspace:": workspace:*`

#### Root Cause

These 4 extensions had `"openclaw": "workspace:*"` in `dependencies`:
- `extensions/zalo/package.json`
- `extensions/zalouser/package.json`
- `extensions/nostr/package.json`
- `extensions/msteams/package.json`

The `workspace:*` protocol is a pnpm workspace feature. When the plugin is copied outside the workspace for installation, npm doesn't understand `workspace:*` and errors out. Per CLAUDE.md: _"Avoid `workspace:*` in `dependencies` (npm install breaks); put `openclaw` in `devDependencies` or `peerDependencies` instead (runtime resolves `openclaw/plugin-sdk` via jiti alias)."_

Most other extensions (telegram, discord, slack, matrix, etc.) already follow this pattern correctly — only these 4 had the bug.

#### Behavior Changes

- Removed `"openclaw": "workspace:*"` from `dependencies` in 4 extensions
- The `devDependencies` entry remains (for workspace-local development)
- Runtime plugin-sdk resolution is unaffected (uses jiti alias)
- No functional changes to plugin behavior

#### Codebase and GitHub Search

- Searched `workspace:*` across all `extensions/*/package.json` — found 4 with it in `dependencies`
- Verified `extensions/memory-core` uses the correct pattern (`devDependencies` + `peerDependencies`)
- Verified CLAUDE.md explicitly prohibits `workspace:*` in `dependencies`
- Confirmed #10941 (feishu/zalo) and #11245 (matrix) describe the same root cause

#### Tests

- `pnpm build` ✓
- `pnpm check` ✓
- No runtime test changes needed (this is a packaging/metadata fix)

**Sign-Off**

- AI-assisted: Yes (Cursor + Claude). All changes reviewed and understood.
- Degree of testing: Build + lint verified; packaging fix (no runtime logic changed)
- Models used: Claude claude-4.6-opus
- Submitter effort: Issue triage, codebase-wide search, pattern verification

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates four extension `package.json` files (`msteams`, `nostr`, `zalo`, `zalouser`) to remove `"openclaw": "workspace:*"` from `dependencies` while keeping it in `devDependencies`.

This aligns these extensions with the existing plugin packaging pattern in the repo: extensions are installed outside the pnpm workspace (via `openclaw plugins install ...`) and therefore must not rely on the pnpm-only `workspace:` protocol at runtime install time. Keeping `openclaw` only as a dev dependency preserves local workspace development while allowing `npm install --omit=dev` to succeed when extensions are copied to `~/.openclaw/extensions/`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to removing a pnpm-only `workspace:*` dependency specifier from runtime `dependencies` in four extensions; this directly fixes `npm install --omit=dev` outside the workspace and does not affect runtime code paths. The remaining `devDependencies` entry preserves local development behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->