### PR TITLE
fix(doctor): skip config permission check on symlinks

### DIFF
--- a/src/commands/doctor-state-integrity.symlink-perms.test.ts
+++ b/src/commands/doctor-state-integrity.symlink-perms.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Skip on Windows — symlinks work differently and the issue is Linux/macOS only
 const isWindows = process.platform === "win32";
@@ -18,8 +18,6 @@ vi.mock("../terminal/note.js", () => ({
 describe("noteStateIntegrity: symlink config permissions (#11307)", () => {
   let tempDir: string;
   let stateDir: string;
-  let configTarget: string;
-  let configSymlink: string;
   const prevEnv: Record<string, string | undefined> = {};
 
   beforeAll(async () => {
@@ -30,15 +28,6 @@ describe("noteStateIntegrity: symlink config permissions (#11307)", () => {
     stateDir = path.join(tempDir, ".openclaw");
     await fsp.mkdir(stateDir, { recursive: true, mode: 0o700 });
 
-    // Create target file with world-readable perms (like nix store)
-    configTarget = path.join(tempDir, "openclaw-target.json");
-    await fsp.writeFile(configTarget, '{"gateway":{"mode":"local"}}\n', "utf-8");
-    await fsp.chmod(configTarget, 0o644);
-
-    // Create symlink to it (simulates nix-managed config)
-    configSymlink = path.join(stateDir, "openclaw.json");
-    await fsp.symlink(configTarget, configSymlink);
-
     // Create required subdirectories so the function doesn't warn about missing dirs
     for (const sub of ["sessions", "store", "oauth", "agents"]) {
       await fsp.mkdir(path.join(stateDir, sub), { recursive: true, mode: 0o700 });
@@ -48,6 +37,10 @@ describe("noteStateIntegrity: symlink config permissions (#11307)", () => {
     prevEnv.HOME = process.env.HOME;
     process.env.OPENCLAW_STATE_DIR = stateDir;
     process.env.HOME = tempDir;
+  });
+
+  beforeEach(() => {
+    noteCalls.length = 0;
   });
 
   afterAll(async () => {
@@ -69,29 +62,68 @@ describe("noteStateIntegrity: symlink config permissions (#11307)", () => {
     }
   });
 
-  it("does not warn about world-readable permissions on symlinked config", async () => {
+  it("skips warning when symlink target is read-only (nix store scenario)", async () => {
     if (isWindows) {
       return;
     }
-    // Verify the symlink exists and target is world-readable (the #11307 scenario)
-    const lstat = fs.lstatSync(configSymlink);
-    expect(lstat.isSymbolicLink()).toBe(true);
-    const stat = fs.statSync(configSymlink);
-    expect((stat.mode & 0o044) !== 0).toBe(true);
+    // Simulate a nix store file: world-readable AND read-only
+    const readOnlyTarget = path.join(tempDir, "nix-store-config.json");
+    await fsp.writeFile(readOnlyTarget, '{"gateway":{"mode":"local"}}\n', "utf-8");
+    await fsp.chmod(readOnlyTarget, 0o444);
 
-    noteCalls.length = 0;
+    const symlink = path.join(stateDir, "openclaw.json");
+    try {
+      await fsp.unlink(symlink);
+    } catch {
+      /* may not exist */
+    }
+    await fsp.symlink(readOnlyTarget, symlink);
+
+    // Verify setup: symlink exists, target is world-readable, target is NOT writable
+    expect(fs.lstatSync(symlink).isSymbolicLink()).toBe(true);
+    expect((fs.statSync(symlink).mode & 0o044) !== 0).toBe(true);
+
     const { noteStateIntegrity } = await import("./doctor-state-integrity.js");
+    const prompter = { confirmSkipInNonInteractive: async () => false };
 
-    const prompter = {
-      confirmSkipInNonInteractive: async () => false,
-    };
+    await noteStateIntegrity({ gateway: { mode: "local" } }, prompter, symlink);
 
-    await noteStateIntegrity({ gateway: { mode: "local" } }, prompter, configSymlink);
-
-    // No note() call should contain the chmod 600 warning for a symlinked config
     const permWarning = noteCalls.find(
       (msg) => msg.includes("group/world readable") || msg.includes("Recommend chmod 600"),
     );
     expect(permWarning).toBeUndefined();
+
+    // Restore writable so cleanup can delete it
+    await fsp.chmod(readOnlyTarget, 0o644);
+  });
+
+  it("still warns when symlink target is writable and world-readable", async () => {
+    if (isWindows) {
+      return;
+    }
+    // Simulate a regular symlink to a writable world-readable file
+    const writableTarget = path.join(tempDir, "writable-config.json");
+    await fsp.writeFile(writableTarget, '{"gateway":{"mode":"local"}}\n', "utf-8");
+    await fsp.chmod(writableTarget, 0o644);
+
+    const symlink = path.join(stateDir, "openclaw.json");
+    try {
+      await fsp.unlink(symlink);
+    } catch {
+      /* may not exist */
+    }
+    await fsp.symlink(writableTarget, symlink);
+
+    expect(fs.lstatSync(symlink).isSymbolicLink()).toBe(true);
+
+    const { noteStateIntegrity } = await import("./doctor-state-integrity.js");
+    const prompter = { confirmSkipInNonInteractive: async () => false };
+
+    await noteStateIntegrity({ gateway: { mode: "local" } }, prompter, symlink);
+
+    const permWarning = noteCalls.find(
+      (msg) => msg.includes("group/world readable") || msg.includes("Recommend chmod 600"),
+    );
+    expect(permWarning).toBeDefined();
   });
 });

--- a/src/commands/doctor-state-integrity.symlink-perms.test.ts
+++ b/src/commands/doctor-state-integrity.symlink-perms.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Skip on Windows — symlinks work differently and the issue is Linux/macOS only
+const isWindows = process.platform === "win32";
+
+// Capture note() calls
+const noteCalls: string[] = [];
+vi.mock("../terminal/note.js", () => ({
+  note: (msg: string) => {
+    noteCalls.push(msg);
+  },
+}));
+
+describe("noteStateIntegrity: symlink config permissions (#11307)", () => {
+  let tempDir: string;
+  let stateDir: string;
+  let configTarget: string;
+  let configSymlink: string;
+  const prevEnv: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    if (isWindows) {
+      return;
+    }
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-symlink-"));
+    stateDir = path.join(tempDir, ".openclaw");
+    await fsp.mkdir(stateDir, { recursive: true, mode: 0o700 });
+
+    // Create target file with world-readable perms (like nix store)
+    configTarget = path.join(tempDir, "openclaw-target.json");
+    await fsp.writeFile(configTarget, '{"gateway":{"mode":"local"}}\n', "utf-8");
+    await fsp.chmod(configTarget, 0o644);
+
+    // Create symlink to it (simulates nix-managed config)
+    configSymlink = path.join(stateDir, "openclaw.json");
+    await fsp.symlink(configTarget, configSymlink);
+
+    // Create required subdirectories so the function doesn't warn about missing dirs
+    for (const sub of ["sessions", "store", "oauth", "agents"]) {
+      await fsp.mkdir(path.join(stateDir, sub), { recursive: true, mode: 0o700 });
+    }
+
+    prevEnv.OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+    prevEnv.HOME = process.env.HOME;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.HOME = tempDir;
+  });
+
+  afterAll(async () => {
+    if (isWindows) {
+      return;
+    }
+    if (prevEnv.OPENCLAW_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = prevEnv.OPENCLAW_STATE_DIR;
+    }
+    if (prevEnv.HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevEnv.HOME;
+    }
+    if (tempDir) {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not warn about world-readable permissions on symlinked config", async () => {
+    if (isWindows) {
+      return;
+    }
+    // Verify the symlink exists and target is world-readable (the #11307 scenario)
+    const lstat = fs.lstatSync(configSymlink);
+    expect(lstat.isSymbolicLink()).toBe(true);
+    const stat = fs.statSync(configSymlink);
+    expect((stat.mode & 0o044) !== 0).toBe(true);
+
+    noteCalls.length = 0;
+    const { noteStateIntegrity } = await import("./doctor-state-integrity.js");
+
+    const prompter = {
+      confirmSkipInNonInteractive: async () => false,
+    };
+
+    await noteStateIntegrity({ gateway: { mode: "local" } }, prompter, configSymlink);
+
+    // No note() call should contain the chmod 600 warning for a symlinked config
+    const permWarning = noteCalls.find(
+      (msg) => msg.includes("group/world readable") || msg.includes("Recommend chmod 600"),
+    );
+    expect(permWarning).toBeUndefined();
+  });
+});


### PR DESCRIPTION
#### Summary

Fixes #11307

`openclaw doctor` warns "Config file is group/world readable" for Nix-managed configs that are symlinks to the nix store. This is a false positive: symlinks always report mode `777`, and nix store files are world-readable by design. The containing `~/.openclaw` directory (mode `700`) provides actual access control.

lobster-biscuit

#### Root Cause

`fs.statSync` follows symlinks and returns the target file's permissions. For a nix store symlink:
- Symlink: `~/.openclaw/openclaw.json` -> `/nix/store/xxx-openclaw-default.json`
- Target permissions: `644` (world-readable, by nix design)
- `statSync` returns `644` -> `(mode & 0o077) !== 0` -> warning fires
- Attempting `chmod 600` on the target would fail (nix store is read-only) or break the store

#### Fix

Use `lstatSync` first to detect if the config path is a symbolic link. When it is, skip the permission check entirely. The containing directory's permissions (typically `700`) protect access.

```typescript
const lstat = fs.lstatSync(configPath);
if (!lstat.isSymbolicLink()) {
  // Only check permissions on regular files
  const stat = fs.statSync(configPath);
  if ((stat.mode & 0o077) !== 0) { ... }
}
```

#### Codebase and GitHub Search

- Searched all `mode & 0o077` / `chmod 600` checks in the codebase
- Found the same check exists in `security/audit.ts` but it already uses `lstat` via `safeStat` and separately reports symlinks — different code path, not affected by this fix
- Verified `existsFile()` in the same file uses `statSync` (follows symlinks), so the `configPath` check already handles symlinks pointing to real files
- Confirmed the fix doesn't affect non-symlink configs (same behavior as before)

#### Tests

- `pnpm build` ✓
- `pnpm check` ✓
- Added 1 focused test: creates a symlinked config with world-readable target, runs `noteStateIntegrity`, verifies no "chmod 600" warning is emitted
- Test skips on Windows (symlinks work differently there)

**Sign-Off**

- AI-assisted: Yes (Cursor + Claude). All changes reviewed and understood.
- Degree of testing: Build + lint + 1 integration test with real symlink
- Models used: Claude claude-4.6-opus
- Submitter effort: Root cause analysis, codebase-wide search for similar patterns

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `noteStateIntegrity`’s config permission check to `lstatSync` the config path and skip the group/world-readable warning (and `chmod 600` prompt) when the config path is a symlink, aiming to avoid false positives for Nix-managed configs. It also adds a Vitest that creates a symlinked config whose target is world-readable and asserts the permission warning is not emitted.

The change is localized to the `doctor` state-integrity checks and affects only the config file permissions diagnostic on non-Windows platforms.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but current symlink handling can hide real insecure config permissions.
- The implementation avoids the reported Nix false positive, but it now suppresses permission warnings for any symlinked config, including cases where the symlink points to a genuinely world-readable target outside the protected state directory. That’s a functional regression in the security diagnostic and should be narrowed before merge.
- src/commands/doctor-state-integrity.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->