### PR TITLE
Cron: disable one-shot at jobs after any terminal status to prevent retry storms (#11438, #11452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: disable one-shot `at` jobs on failure to prevent infinite retry storms. (#11438)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Cron: disable one-shot `at` jobs on failure to prevent infinite retry storms. (#11438)
+- Cron: disable one-shot `at` jobs after any terminal status to prevent infinite retry storms. (#11438, #11452)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -119,12 +119,10 @@ export async function onTimer(state: CronServiceState) {
             job.schedule.kind === "at" && result.status === "ok" && job.deleteAfterRun === true;
 
           if (!shouldDelete) {
-            if (job.schedule.kind === "at" && result.status === "ok") {
-              job.enabled = false;
-              job.state.nextRunAtMs = undefined;
-            } else if (job.schedule.kind === "at" && result.status === "error") {
-              // One-shot jobs should not retry indefinitely on failure.
-              // Disable to prevent retry storms (e.g. "model not allowed").
+            if (job.schedule.kind === "at") {
+              // One-shot jobs run once regardless of outcome. Disable after
+              // any terminal status (ok, error, skipped) to prevent retry
+              // storms when the scheduled time is in the past.
               job.enabled = false;
               job.state.nextRunAtMs = undefined;
             } else if (job.enabled) {
@@ -355,12 +353,10 @@ export async function executeJob(
       job.schedule.kind === "at" && status === "ok" && job.deleteAfterRun === true;
 
     if (!shouldDelete) {
-      if (job.schedule.kind === "at" && status === "ok") {
-        job.enabled = false;
-        job.state.nextRunAtMs = undefined;
-      } else if (job.schedule.kind === "at" && status === "error") {
-        // One-shot jobs should not retry indefinitely on failure.
-        // Disable to prevent retry storms (e.g. "model not allowed").
+      if (job.schedule.kind === "at") {
+        // One-shot jobs run once regardless of outcome. Disable after
+        // any terminal status (ok, error, skipped) to prevent retry
+        // storms when the scheduled time is in the past.
         job.enabled = false;
         job.state.nextRunAtMs = undefined;
       } else if (job.enabled) {


### PR DESCRIPTION
## Summary
Fixes #11438
Fixes #11452

One-shot `at` cron jobs that complete with a non-`"ok"` status (e.g. `"error"`, `"skipped"`) enter an infinite retry loop because `computeJobNextRunAtMs` returns the original (past) `atMs`, causing `findDueJobs` to immediately re-trigger the job. This generates 1,900+ failed attempts in 5 seconds and pegs the gateway at 100% CPU.

## Problem
When an `at` job finishes with any non-`"ok"` status:
1. `onTimer` calls `computeJobNextRunAtMs(job, result.endedAt)`
2. For `at` jobs, this returns the original `atMs` (already in the past)
3. `armTimer` fires immediately, `findDueJobs` picks up the job again
4. Repeat → infinite retry storm with ~2-3ms between attempts

## Solution
Disable one-shot `at` jobs after **any** terminal status (`ok`, `error`, `skipped`), not just `ok`. One-shot jobs are inherently run-once — if the job fails or is skipped, the user can manually re-enable or re-create it.

This applies to both `onTimer` (timer-triggered) and `executeJob` (`cron run` command) code paths.

## Changes
- `src/cron/service/timer.ts`: Simplify `at` job post-execution to disable on any terminal status
- `src/cron/service.runs-one-shot-main-job-disables-it.test.ts`: Add regression test
- `CHANGELOG.md`: Add entry referencing both issues

## Testing
- New unit test: "disables a one-shot at job after failure to prevent retry storm"
- All 87 cron tests pass (`pnpm vitest run src/cron/`)
- **Real-environment verification** with standalone script:

| Branch | Run attempts (5s) | Job enabled | Job status |
|--------|-------------------|-------------|------------|
| `main` (before fix) | **1,933** | `true` (still retrying) | error |
| `fix/cron-at-retry-storm-11438` | **1** | `false` (disabled) | error |