### PR TITLE
Docs: fix cron.update param name id → jobId (#11365)

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -406,7 +406,7 @@ Core actions:
 Notes:
 
 - `add` expects a full cron job object (same schema as `cron.add` RPC).
-- `update` uses `{ id, patch }`.
+- `update` uses `{ jobId, patch }` (`id` accepted for compatibility).
 
 ### `gateway`
 

--- a/docs/zh-CN/tools/index.md
+++ b/docs/zh-CN/tools/index.md
@@ -412,7 +412,7 @@ OpenClaw 为 browser、canvas、nodes 和 cron 暴露**一流的智能体工具*
 注意：
 
 - `add` 期望完整的定时任务对象（与 `cron.add` RPC 相同的 schema）。
-- `update` 使用 `{ id, patch }`。
+- `update` 使用 `{ jobId, patch }`（`id` 可作为兼容别名）。
 
 ### `gateway`
 

--- a/docs/zh-CN/tools/index.md
+++ b/docs/zh-CN/tools/index.md
@@ -412,7 +412,7 @@ OpenClaw 为 browser、canvas、nodes 和 cron 暴露**一流的智能体工具*
 注意：
 
 - `add` 期望完整的定时任务对象（与 `cron.add` RPC 相同的 schema）。
-- `update` 使用 `{ jobId, patch }`（`id` 可作为兼容别名）。
+- `update` 使用 `{ id, patch }`。
 
 ### `gateway`
 


### PR DESCRIPTION
## Summary
Fixes #11365

The runtime bug described in #11365 (using `id` causes schema validation error) was already fixed in commit `4dac298ae` (2026-01-08) which added `jobId` as the canonical agent tool parameter, and `871c9e528` which added backward compatibility for `id`.

However, the **documentation inconsistency** remains:
- `docs/tools/index.md` says `update` uses `{ id, patch }`
- `docs/automation/cron-jobs.md` says `update` uses `{ jobId, patch }`
- The agent tool system prompt (`cron-tool.ts:236`) says `jobId`

Since the agent tool schema uses `jobId` as the canonical name (with `id` as a compat fallback), the docs should match.

## Changes
- `docs/tools/index.md`: `{ id, patch }` → `{ jobId, patch }` with compat note
- `docs/zh-CN/tools/index.md`: sync the same fix to Chinese translation

https://docs.openclaw.ai/tools