### PR TITLE
fix: retry media fetch on transient network errors

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -77,8 +77,33 @@ async function readErrorBodySnippet(res: Response, maxChars = 200): Promise<stri
   }
 }
 
-const MEDIA_FETCH_MAX_RETRIES = 3;
+/** Maximum number of retry attempts for transient network errors. */
+const MEDIA_FETCH_MAX_ATTEMPTS = 3;
 const MEDIA_FETCH_BASE_DELAY_MS = 1000;
+
+/**
+ * Transient network error patterns worth retrying — these are fetch-level
+ * failures (Node undici / DNS), not application-level errors like SSRF
+ * blocks, invalid URLs, or redirect limits.
+ */
+const TRANSIENT_ERROR_PATTERNS = [
+  "fetch failed",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "UND_ERR_SOCKET",
+  "AbortError",
+] as const;
+
+function isTransientFetchError(err: unknown): boolean {
+  if (err instanceof TypeError && String(err.message).includes("fetch failed")) return true;
+  const msg = String(err);
+  return TRANSIENT_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -92,11 +117,11 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
   let release: (() => Promise<void>) | null = null;
   let lastErr: unknown;
 
-  for (let attempt = 0; attempt <= MEDIA_FETCH_MAX_RETRIES; attempt++) {
-    if (attempt > 0) {
-      const delay = MEDIA_FETCH_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+  for (let attempt = 1; attempt <= MEDIA_FETCH_MAX_ATTEMPTS; attempt++) {
+    if (attempt > 1) {
+      const delay = MEDIA_FETCH_BASE_DELAY_MS * Math.pow(2, attempt - 2);
       console.warn(
-        `[media-fetch] Retry ${attempt}/${MEDIA_FETCH_MAX_RETRIES} for ${url} after ${delay}ms`,
+        `[media-fetch] Retry ${attempt - 1}/${MEDIA_FETCH_MAX_ATTEMPTS - 1} for ${url} after ${delay}ms`,
       );
       await sleep(delay);
     }
@@ -122,6 +147,11 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
           /* ignore cleanup errors */
         }
         release = null;
+      }
+      // Only retry transient network errors; deterministic failures
+      // (SSRF blocks, invalid URLs, redirect limits) fail immediately.
+      if (!isTransientFetchError(err)) {
+        break;
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds exponential backoff retry to `fetchRemoteMedia()` in `src/media/fetch.ts` for transient network failures.

## Problem

When fetching media from provider APIs (Telegram, Discord, Slack, etc.), a single transient `TypeError: fetch failed` causes the entire inbound message to be dropped. The agent never sees the message, and there is no re-delivery mechanism.

This is especially common in VM/container environments where network connectivity to provider APIs can be intermittent.

## Fix

- Retry up to **3 times** with exponential backoff (**1s → 2s → 4s**)
- Only retries on network-level fetch failures (the `catch` block)
- **Does not retry** deterministic errors: HTTP status errors (`http_error`) or size limit violations (`max_bytes`)
- Logs each retry attempt for observability
- Properly cleans up `release` handle between retries

## Testing

Verified locally by:
1. Observing a `MediaFetchError: fetch_failed` dropping a Telegram photo message (see logs in #11471)
2. Applying the patch to `dist/deliver-BIDW_mg2.js`
3. Restarting the gateway
4. Successfully receiving the same photo on retry

Fixes #11471

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds retry-with-exponential-backoff around `fetchWithSsrFGuard()` in `src/media/fetch.ts` to reduce dropped inbound messages when media fetch fails due to transient network issues. The retry loop logs each backoff attempt and keeps existing behavior for HTTP status errors and max-bytes enforcement in the response handling path.

Key things to double-check before merge:
- The retry loop currently performs one more attempt than `MEDIA_FETCH_MAX_RETRIES` suggests (off-by-one).
- The retry is applied to any error thrown by `fetchWithSsrFGuard`, including deterministic SSRF/URL/redirect errors, which adds delay/noise and diverges from the stated goal of retrying only transient fetch failures.

<h3>Confidence Score: 3/5</h3>

- Mergeable after fixing retry semantics and error filtering
- Change is localized and the intent is clear, but current loop bounds add an extra attempt and the retry catches deterministic errors from fetchWithSsrFGuard (SSRF/URL/redirect validation), causing unnecessary delays and noisy logs in those scenarios.
- src/media/fetch.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->