### PR TITLE
fix(cron): respect subagents.model in isolated cron sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -6,8 +6,9 @@ import {
   inferUniqueProviderFromConfiguredModels,
   parseModelRef,
   buildModelAliasIndex,
-  modelKey,
+  normalizeModelSelection,
   normalizeProviderId,
+  modelKey,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveModelRefFromString,
@@ -468,5 +469,33 @@ describe("model-selection", () => {
       });
       expect(result).toEqual({ provider: "openai", model: "gpt-4" });
     });
+  });
+});
+
+describe("normalizeModelSelection", () => {
+  it("returns trimmed string for string input", () => {
+    expect(normalizeModelSelection("ollama/llama3.2:3b")).toBe("ollama/llama3.2:3b");
+  });
+
+  it("returns undefined for empty/whitespace string", () => {
+    expect(normalizeModelSelection("")).toBeUndefined();
+    expect(normalizeModelSelection("   ")).toBeUndefined();
+  });
+
+  it("extracts primary from object", () => {
+    expect(normalizeModelSelection({ primary: "google/gemini-2.5-flash" })).toBe(
+      "google/gemini-2.5-flash",
+    );
+  });
+
+  it("returns undefined for object without primary", () => {
+    expect(normalizeModelSelection({ fallbacks: ["a"] })).toBeUndefined();
+    expect(normalizeModelSelection({})).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined/number", () => {
+    expect(normalizeModelSelection(undefined)).toBeUndefined();
+    expect(normalizeModelSelection(null)).toBeUndefined();
+    expect(normalizeModelSelection(42)).toBeUndefined();
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -612,3 +612,23 @@ export function resolveHooksGmailModel(params: {
 
   return resolved?.ref ?? null;
 }
+
+/**
+ * Normalize a model selection value (string or `{primary?: string}`) to a
+ * plain trimmed string.  Returns `undefined` when the input is empty/missing.
+ * Shared by sessions-spawn and cron isolated-agent model resolution.
+ */
+export function normalizeModelSelection(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const primary = (value as { primary?: unknown }).primary;
+  if (typeof primary === "string" && primary.trim()) {
+    return primary.trim();
+  }
+  return undefined;
+}

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -208,22 +208,6 @@ export function inferUniqueProviderFromConfiguredModels(params: {
   return providers.values().next().value;
 }
 
-export function normalizeModelSelection(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    return trimmed || undefined;
-  }
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const primary = (value as { primary?: unknown }).primary;
-  if (typeof primary === "string") {
-    const trimmed = primary.trim();
-    return trimmed || undefined;
-  }
-  return undefined;
-}
-
 export function resolveAllowlistModelKey(raw: string, defaultProvider: string): string | null {
   const parsed = parseModelRef(raw, defaultProvider);
   if (!parsed) {

--- a/src/cron/isolated-agent.subagent-model.test.ts
+++ b/src/cron/isolated-agent.subagent-model.test.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { CronJob } from "./types.js";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-cron-submodel-" });
+}
+
+async function writeSessionStore(home: string) {
+  const dir = path.join(home, ".openclaw", "sessions");
+  await fs.mkdir(dir, { recursive: true });
+  const storePath = path.join(dir, "sessions.json");
+  await fs.writeFile(
+    storePath,
+    JSON.stringify(
+      {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "webchat",
+          lastTo: "",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  return storePath;
+}
+
+function makeCfg(
+  home: string,
+  storePath: string,
+  overrides: Partial<OpenClawConfig> = {},
+): OpenClawConfig {
+  const base: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-sonnet-4-5",
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+  } as OpenClawConfig;
+  return { ...base, ...overrides };
+}
+
+function makeDeps(): CliDeps {
+  return {
+    sendMessageWhatsApp: vi.fn(),
+    sendMessageTelegram: vi.fn(),
+    sendMessageDiscord: vi.fn(),
+    sendMessageSignal: vi.fn(),
+    sendMessageIMessage: vi.fn(),
+  };
+}
+
+function makeJob(): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-sub",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "do work" },
+    state: {},
+  };
+}
+
+function mockEmbeddedAgent() {
+  vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+    payloads: [{ text: "ok" }],
+    meta: {
+      durationMs: 5,
+      agentMeta: { sessionId: "s", provider: "p", model: "m" },
+    },
+  });
+}
+
+describe("runCronIsolatedAgentTurn: subagent model resolution (#11461)", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+  });
+
+  it("uses agents.defaults.subagents.model when set", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      mockEmbeddedAgent();
+
+      await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-sonnet-4-5",
+              workspace: path.join(home, "openclaw"),
+              subagents: { model: "ollama/llama3.2:3b" },
+            },
+          },
+        }),
+        deps: makeDeps(),
+        job: makeJob(),
+        message: "do work",
+        sessionKey: "cron:job-sub",
+        lane: "cron",
+      });
+
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.provider).toBe("ollama");
+      expect(call?.model).toBe("llama3.2:3b");
+    });
+  });
+
+  it("explicit job model override takes precedence over subagents.model", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      mockEmbeddedAgent();
+
+      const job = makeJob();
+      job.payload = { kind: "agentTurn", message: "do work", model: "openai/gpt-4o" };
+
+      await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-sonnet-4-5",
+              workspace: path.join(home, "openclaw"),
+              subagents: { model: "ollama/llama3.2:3b" },
+            },
+          },
+        }),
+        deps: makeDeps(),
+        job,
+        message: "do work",
+        sessionKey: "cron:job-sub",
+        lane: "cron",
+      });
+
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.provider).toBe("openai");
+      expect(call?.model).toBe("gpt-4o");
+    });
+  });
+
+  it("falls back to main model when subagents.model is unset", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      mockEmbeddedAgent();
+
+      await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps: makeDeps(),
+        job: makeJob(),
+        message: "do work",
+        sessionKey: "cron:job-sub",
+        lane: "cron",
+      });
+
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.provider).toBe("anthropic");
+      expect(call?.model).toBe("claude-sonnet-4-5");
+    });
+  });
+
+  it("supports subagents.model with {primary} object format", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      mockEmbeddedAgent();
+
+      await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-sonnet-4-5",
+              workspace: path.join(home, "openclaw"),
+              subagents: { model: { primary: "google/gemini-2.5-flash" } },
+            },
+          },
+        }),
+        deps: makeDeps(),
+        job: makeJob(),
+        message: "do work",
+        sessionKey: "cron:job-sub",
+        lane: "cron",
+      });
+
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.provider).toBe("google");
+      expect(call?.model).toBe("gemini-2.5-flash");
+    });
+  });
+});

--- a/src/cron/isolated-agent.subagent-model.test.ts
+++ b/src/cron/isolated-agent.subagent-model.test.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { CronJob } from "./types.js";
-import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 
 vi.mock("../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
@@ -68,6 +68,7 @@ function makeDeps(): CliDeps {
     sendMessageWhatsApp: vi.fn(),
     sendMessageTelegram: vi.fn(),
     sendMessageDiscord: vi.fn(),
+    sendMessageSlack: vi.fn(),
     sendMessageSignal: vi.fn(),
     sendMessageIMessage: vi.fn(),
   };
@@ -77,6 +78,7 @@ function makeJob(): CronJob {
   const now = Date.now();
   return {
     id: "job-sub",
+    name: "subagent-model-job",
     enabled: true,
     createdAtMs: now,
     updatedAtMs: now,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -16,9 +16,11 @@ import { runWithModelFallback } from "../../agents/model-fallback.js";
 import {
   getModelRefStatus,
   isCliProvider,
+  normalizeModelSelection,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveModelRefFromString,
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -160,6 +162,22 @@ export async function runCronIsolatedAgentTurn(params: {
   });
   let provider = resolvedDefault.provider;
   let model = resolvedDefault.model;
+
+  // Isolated cron sessions are subagents — prefer subagents.model when set.
+  // Precedence: per-agent subagents.model > global subagents.model.  #11461
+  const subagentModelRaw =
+    normalizeModelSelection(agentConfigOverride?.subagents?.model) ??
+    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model);
+  if (subagentModelRaw) {
+    const resolved = resolveModelRefFromString({
+      raw: subagentModelRaw,
+      defaultProvider: resolvedDefault.provider,
+    });
+    if (resolved) {
+      provider = resolved.ref.provider;
+      model = resolved.ref.model;
+    }
+  }
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
   const loadCatalog = async () => {
     if (!catalog) {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -20,7 +20,6 @@ import {
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
-  resolveModelRefFromString,
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -163,21 +162,6 @@ export async function runCronIsolatedAgentTurn(params: {
   let provider = resolvedDefault.provider;
   let model = resolvedDefault.model;
 
-  // Isolated cron sessions are subagents — prefer subagents.model when set.
-  // Precedence: per-agent subagents.model > global subagents.model.  #11461
-  const subagentModelRaw =
-    normalizeModelSelection(agentConfigOverride?.subagents?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model);
-  if (subagentModelRaw) {
-    const resolved = resolveModelRefFromString({
-      raw: subagentModelRaw,
-      defaultProvider: resolvedDefault.provider,
-    });
-    if (resolved) {
-      provider = resolved.ref.provider;
-      model = resolved.ref.model;
-    }
-  }
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
   const loadCatalog = async () => {
     if (!catalog) {
@@ -185,6 +169,24 @@ export async function runCronIsolatedAgentTurn(params: {
     }
     return catalog;
   };
+  // Isolated cron sessions are subagents — prefer subagents.model when set,
+  // but only if it passes the model allowlist.  #11461
+  const subagentModelRaw =
+    normalizeModelSelection(agentConfigOverride?.subagents?.model) ??
+    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model);
+  if (subagentModelRaw) {
+    const resolvedSubagent = resolveAllowedModelRef({
+      cfg: cfgWithAgentDefaults,
+      catalog: await loadCatalog(),
+      raw: subagentModelRaw,
+      defaultProvider: resolvedDefault.provider,
+      defaultModel: resolvedDefault.model,
+    });
+    if (!("error" in resolvedSubagent)) {
+      provider = resolvedSubagent.ref.provider;
+      model = resolvedSubagent.ref.model;
+    }
+  }
   // Resolve model - prefer hooks.gmail.model for Gmail hooks.
   const isGmailHook = baseSessionKey.startsWith("hook:gmail:");
   let hooksGmailModelApplied = false;


### PR DESCRIPTION
#### Summary

Fixes #11461

`agents.defaults.subagents.model` is ignored when spawning isolated cron sessions. All isolated sessions fall back to `agents.defaults.model.primary`, regardless of the subagents config. This means users can't use cheaper local models (e.g. Ollama) for background cron work while keeping premium models for interactive sessions.

lobster-biscuit

#### Repro Steps

1. Configure `agents.defaults.subagents.model` to a different model than the main agent model:
   ```json
   {
     "agents": {
       "defaults": {
         "model": { "primary": "anthropic/claude-sonnet-4-5" },
         "subagents": { "model": "ollama/llama3.2:3b" }
       }
     }
   }
   ```
2. Create a cron job with `sessionTarget: "isolated"` (no explicit `--model`)
3. Run the job
4. Observe the session uses `anthropic/claude-sonnet-4-5` instead of `ollama/llama3.2:3b`

#### Root Cause

In `src/cron/isolated-agent/run.ts`, `resolveConfiguredModelRef()` only checks `cfg.agents.defaults.model.primary` and never checks `cfg.agents.defaults.subagents.model`. The correct pattern already exists in `sessions-spawn-tool.ts` which properly resolves subagent models.

#### Behavior Changes

- Isolated cron sessions now respect `agents.defaults.subagents.model` (and per-agent `subagents.model`) when selecting the default model.
- Precedence chain: explicit job model > gmail hook model > subagents.model > main model.
- No change when `subagents.model` is not configured (falls back to main model as before).
- Extracted `normalizeModelSelection` from `sessions-spawn-tool.ts` into shared `model-selection.ts` to avoid duplication.

#### Codebase and GitHub Search

- Searched `sessions-spawn-tool.ts` for reference implementation of subagent model resolution.
- Verified `resolveConfiguredModelRef` only checks `agents.defaults.model`, confirmed the gap.
- Confirmed no existing PRs targeting #11461.

#### Tests

- **4 new integration tests** (`isolated-agent.subagent-model.test.ts`):
  - Uses `subagents.model` when set (string format)
  - Explicit job model override takes precedence over `subagents.model`
  - Falls back to main model when `subagents.model` is unset
  - Supports `{primary}` object format for `subagents.model`
- **5 new unit tests** (`model-selection.test.ts`): `normalizeModelSelection` utility coverage
- All 963 test files / 6523 tests pass

#### Manual Testing

N/A — fully covered by automated tests.

**Sign-Off**

- Models used: Claude (AI-assisted)
- Submitter effort: read issue, traced code, implemented fix + tests, ran full gate
- Agent notes: The fix mirrors the existing `sessions-spawn-tool.ts` pattern. `normalizeModelSelection` was extracted to a shared module to avoid duplication.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes isolated cron sessions to respect `agents.defaults.subagents.model` (and per-agent `subagents.model`) when choosing the default model, matching the existing behavior in `sessions-spawn-tool.ts`. To avoid duplication, it extracts `normalizeModelSelection` into `src/agents/model-selection.ts` and adds unit + integration coverage for the new resolution behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a model-allowlist enforcement gap in cron isolated sessions.
- Core change is small and well-tested, but the new `subagents.model` resolution path in `runCronIsolatedAgentTurn` does not enforce the model allowlist in the way the explicit job override does, which can lead to running disallowed models in allowlist configurations.
- src/cron/isolated-agent/run.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->