### PR TITLE
Cron: respect subagents.model in isolated cron sessions (#11461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: respect `agents.defaults.subagents.model` in isolated cron sessions. (#11461)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -169,7 +169,7 @@ export async function runCronIsolatedAgentTurn(params: {
       ? agentConfigOverride.subagents.model.trim()
       : undefined) ||
     (typeof params.cfg.agents?.defaults?.subagents?.model === "string"
-      ? (params.cfg.agents.defaults.subagents.model as string).trim()
+      ? params.cfg.agents.defaults.subagents.model.trim()
       : undefined);
   if (subagentsModelRaw) {
     const subagentsResolved = resolveAllowedModelRef({


### PR DESCRIPTION
## Summary
Fixes #11461

Isolated cron sessions ignore `agents.defaults.subagents.model` and always use the primary model (`agents.defaults.model.primary`). This forces users to specify the model explicitly in every cron job payload to use cheaper/local models for background tasks.

## Root Cause
`runCronIsolatedAgentTurn` in `src/cron/isolated-agent/run.ts` calls `resolveConfiguredModelRef()` which only reads `agents.defaults.model.primary`. It never checks `subagents.model`, unlike `sessions_spawn` which correctly resolves per-agent then global `subagents.model` (`sessions-spawn-tool.ts:171-174`).

## Fix
After resolving the default model, check `subagents.model` (per-agent override first, then global default) and use it if configured and allowed. This matches the existing `sessions_spawn` behavior.

Model resolution priority (unchanged for non-subagent fields):
1. Job-level `payload.model` (highest)
2. Gmail hook model (`hooks.gmail.model`)
3. **`subagents.model` (per-agent → global)** ← NEW
4. `agents.defaults.model.primary` (lowest)

## Changes
- `src/cron/isolated-agent/run.ts`: Add subagents.model resolution after primary model, before job-level override
- Test: Add "uses subagents.model for isolated cron sessions" test case
- `CHANGELOG.md`: Add entry

## Verification

### Bug reproduced on `main` branch ❌

Copied the new test to `main` and ran it:

```
❯ pnpm vitest run ... -t "uses subagents.model"

Expected: "ollama"
Received: "anthropic"

Tests: 1 failed
```

With config `subagents.model: "ollama/llama3.2:3b"` and `model.primary: "anthropic/claude-sonnet-4-5"`, the isolated cron session used `anthropic` (primary) instead of `ollama` (subagents). **subagents.model was completely ignored.**

Also confirmed via `grep -n subagents src/cron/isolated-agent/run.ts` on `main` — zero matches. The code path simply did not exist.

### Fix verified on feature branch ✅

```
❯ pnpm vitest run ... -t "uses subagents.model"

✓ uses subagents.model for isolated cron sessions
Tests: 1 passed | 14 skipped (15)
```

The isolated cron session correctly resolved `ollama/llama3.2:3b` from `subagents.model`.

### Full cron test suite ✅

```
Test Files  20 passed (20)
     Tests  87 passed (87)
```

All 87 cron tests pass, including the new test.