### PR TITLE
 Chore: add Dockerfile HEALTHCHECK and debug-log silent catch blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker/Image health checks: add Dockerfile `HEALTHCHECK` that probes gateway `GET /healthz` so container runtimes can mark unhealthy instances without requiring auth credentials in the probe command. (#11478) Thanks @U-C4N and @vincentkoc.
 - Android/Nodes reliability: reject `facing=both` when `deviceId` is set to avoid mislabeled duplicate captures, allow notification `open`/`reply` on non-clearable entries while still gating dismiss, trigger listener rebind before notification actions, and scale invoke-result ack timeout to invoke budget for large clip payloads. (#28260) Thanks @obviyus.
 - Windows/Plugin install: avoid `spawn EINVAL` on Windows npm/npx invocations by resolving to `node` + npm CLI scripts instead of spawning `.cmd` directly. Landed from contributor PR #31147 by @codertony. Thanks @codertony.
 - LINE/Voice transcription: classify M4A voice media as `audio/mp4` (not `video/mp4`) by checking the MPEG-4 `ftyp` major brand (`M4A ` / `M4B `), restoring voice transcription for LINE voice messages. Landed from contributor PR #31151 by @scoootscooob. Thanks @scoootscooob.

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,6 @@ USER node
 #   - GET /healthz (liveness) and GET /readyz (readiness)
 #   - aliases: /health and /ready
 # For external access from host/ingress, override bind to "lan" and set auth.
-HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+HEALTHCHECK --interval=3m --timeout=10s --start-period=15s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,4 +96,6 @@ USER node
 #   - GET /healthz (liveness) and GET /readyz (readiness)
 #   - aliases: /health and /ready
 # For external access from host/ingress, override bind to "lan" and set auth.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -403,6 +403,13 @@ curl -fsS http://127.0.0.1:18789/readyz
 
 Aliases: `/health` and `/ready`.
 
+The Docker image also includes a `HEALTHCHECK` that probes `GET /healthz`:
+
+```bash
+docker inspect --format '{{json .Config.Healthcheck}}' openclaw:local
+docker ps --format 'table {{.Names}}\t{{.Status}}'
+```
+
 Authenticated deep health snapshot (gateway + channels):
 
 ```bash

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -403,12 +403,11 @@ curl -fsS http://127.0.0.1:18789/readyz
 
 Aliases: `/health` and `/ready`.
 
-The Docker image also includes a `HEALTHCHECK` that probes `GET /healthz`:
-
-```bash
-docker inspect --format '{{json .Config.Healthcheck}}' openclaw:local
-docker ps --format 'table {{.Names}}\t{{.Status}}'
-```
+The Docker image includes a built-in `HEALTHCHECK` that pings `/healthz` in the
+background. In plain terms: Docker keeps checking if OpenClaw is still
+responsive. If checks keep failing, Docker marks the container as `unhealthy`,
+and orchestration systems (Docker Compose restart policy, Swarm, Kubernetes,
+etc.) can automatically restart or replace it.
 
 Authenticated deep health snapshot (gateway + channels):
 


### PR DESCRIPTION
#### Summary

  Added HEALTHCHECK to the Dockerfile and added debug logging to silent catch blocks in 3 files. No behavior changes.

  lobster-biscuit

  #### Why This Matters

  HEALTHCHECK lets container orchestrators (Docker Compose, Swarm, K8s) detect an unresponsive gateway and restart it automatically. Uses Node 22 native
  `fetch()` against the `/health` endpoint every 30s.

  Silent catch blocks were making debugging harder. They now log via `getLogger().debug()` — crash behavior unchanged.

  #### Tests

  - `pnpm build` and `pnpm check` pass
  - No new tests — logging-only and Dockerfile changes

  #### Manual Testing

  1. `docker build -t openclaw-test .` then `docker inspect` shows HEALTHCHECK
  2. Debug logs only appear when actual errors occur during gateway operation

  #### Evidence

  - `Dockerfile` — added HEALTHCHECK
  - `src/infra/update-startup.ts` — log update check failures
  - `src/agents/model-auth.ts` — log auth profile resolution failures
  - `src/gateway/server-close.ts` — log shutdown cleanup failures (pluginServices, configReloader, browserControl)

  Telegram catch blocks (`withTelegramApiErrorLogging` already handles logging), media-understanding speculative JSON parse blocks, and cleanup/finally
  blocks were intentionally left unchanged.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a Dockerfile HEALTHCHECK that probes the gateway’s `/health` endpoint via Node’s built-in `fetch()`, and replaces a few silent `catch {}` blocks with `getLogger().debug(...)` calls in the auth profile resolver, gateway shutdown handler, and update check scheduler. The logging changes are localized and keep control flow the same; the main behavioral impact is the new container health probe, which will affect how orchestrators classify the service as healthy/unhealthy.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe, but the Docker HEALTHCHECK may mark containers unhealthy depending on gateway /health auth behavior.
- The code changes are small and limited to logging, but the Dockerfile HEALTHCHECK introduces a new runtime contract with orchestrators. If `/health` requires auth under the default container config, the container will flap unhealthy and be restarted despite the gateway running normally.
- Dockerfile

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->