### PR TITLE
fix: compile bundled hook handlers during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "android:install": "cd apps/android && ./gradlew :app:installDebug",
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n ai.openclaw.android/.MainActivity",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
-    "build": "pnpm canvas:a2ui:bundle && tsdown && node --import tsx scripts/build-hooks.ts && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",    
+    "build": "pnpm canvas:a2ui:bundle && tsdown && node --import tsx scripts/build-hooks.ts && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
     "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
     "check": "pnpm tsgo && pnpm lint && pnpm format",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "android:install": "cd apps/android && ./gradlew :app:installDebug",
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n ai.openclaw.android/.MainActivity",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
-    "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
+    "build": "pnpm canvas:a2ui:bundle && tsdown && node --import tsx scripts/build-hooks.ts && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",    
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
     "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
     "check": "pnpm tsgo && pnpm lint && pnpm format",

--- a/scripts/build-hooks.ts
+++ b/scripts/build-hooks.ts
@@ -7,7 +7,7 @@
  */
 
 import { build } from "esbuild";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -45,6 +45,7 @@ async function buildHooks() {
     if (!existsSync(entry)) continue;
 
     try {
+      mkdirSync(join(HOOKS_DIST, hook), { recursive: true });
       await build({
         entryPoints: [entry],
         bundle: true,

--- a/scripts/build-hooks.ts
+++ b/scripts/build-hooks.ts
@@ -1,0 +1,62 @@
+/**
+ * Compile bundled hook handlers from TypeScript to JavaScript.
+ *
+ * The main tsdown build doesn't include hook handlers, so this script
+ * compiles them separately with esbuild. Heavy/native dependencies are
+ * marked external since they're already available in the main bundle.
+ */
+
+import { build } from "esbuild";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const HOOKS_SRC = "src/hooks/bundled";
+const HOOKS_DIST = "dist/hooks/bundled";
+
+const EXTERNAL_DEPS = [
+  "@anthropic-ai/*",
+  "openai",
+  "grammy",
+  "discord.js",
+  "@slack/*",
+  "playwright*",
+  "@napi-rs/*",
+  "node-llama-cpp",
+];
+
+async function buildHooks() {
+  const hooks = readdirSync(HOOKS_SRC, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  let built = 0;
+  let failed = 0;
+
+  for (const hook of hooks) {
+    const entry = join(HOOKS_SRC, hook, "handler.ts");
+    if (!existsSync(entry)) continue;
+
+    try {
+      await build({
+        entryPoints: [entry],
+        bundle: true,
+        platform: "node",
+        format: "esm",
+        target: "node22",
+        outfile: join(HOOKS_DIST, hook, "handler.js"),
+        external: EXTERNAL_DEPS,
+        logLevel: "warning",
+      });
+      console.log(`✓ ${hook}`);
+      built++;
+    } catch (err) {
+      console.error(`✗ ${hook}:`, err instanceof Error ? err.message : err);
+      failed++;
+    }
+  }
+
+  console.log(`\nHooks: ${built} built, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+buildHooks();

--- a/scripts/build-hooks.ts
+++ b/scripts/build-hooks.ts
@@ -8,10 +8,13 @@
 
 import { build } from "esbuild";
 import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const HOOKS_SRC = "src/hooks/bundled";
-const HOOKS_DIST = "dist/hooks/bundled";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const HOOKS_SRC = join(ROOT, "src/hooks/bundled");
+const HOOKS_DIST = join(ROOT, "dist/hooks/bundled");
 
 const EXTERNAL_DEPS = [
   "@anthropic-ai/*",
@@ -25,6 +28,11 @@ const EXTERNAL_DEPS = [
 ];
 
 async function buildHooks() {
+  if (!existsSync(HOOKS_SRC)) {
+    console.log("No bundled hooks directory found, skipping");
+    return;
+  }
+
   const hooks = readdirSync(HOOKS_SRC, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name);


### PR DESCRIPTION
#### Summary

Fixes #11348. Bundled hook `handler.ts` files are not compiled to `handler.js` during build, causing all hooks to fail on npm/git installs.

lobster-biscuit

#### Repro Steps

1. `npm install -g openclaw@latest` (or clone + `pnpm build`)
2. `ls dist/hooks/bundled/session-memory/` → only `HOOK.md`, no `handler.js`
3. `openclaw hooks list --verbose` → "No hooks found"

#### Root Cause

`tsdown.config.ts` only compiles main entry points. `scripts/copy-hook-metadata.ts` copies `HOOK.md` but never compiles `handler.ts` → `handler.js`. Hook discovery requires `handler.js` to exist.

#### Behavior Changes

- New build step: `scripts/build-hooks.ts` runs after `tsdown`
- Compiles `src/hooks/bundled/*/handler.ts` → `dist/hooks/bundled/*/handler.js`
- Hooks now discoverable on npm/git installs

#### Codebase and GitHub Search

- Found #11331 and #11348 reporting same issue
- Reviewed `copy-hook-metadata.ts` for patterns (existence check, path anchoring)
- Checked `tsdown.config.ts` — hooks not included as entry points

#### Tests

- No new tests added (build script)
- Existing hook tests pass

#### Manual Testing

##### Prerequisites
- Clean clone of repo

##### Steps
1. `pnpm install && pnpm build`
2. `ls dist/hooks/bundled/*/handler.js` — should list handler files
3. `openclaw hooks list --verbose` — should show hooks as "ready"

#### Evidence

Verified on VPS with npm global install — hooks now load correctly.

**Sign-Off**

- Models used: Claude Opus 4.5
- Submitter effort: Discovered issue independently while debugging hooks on VPS, diagnosed root cause, implemented fix
- Agent notes: Claude assisted with esbuild configuration, PR formatting, and addressing Greptile review comments.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the build pipeline to ensure bundled hook handlers are included in published artifacts. It adds a new `scripts/build-hooks.ts` step (run after `tsdown`) that scans `src/hooks/bundled/*/handler.ts` and uses esbuild to emit `dist/hooks/bundled/*/handler.js`, so hook discovery works on npm/git installs where only `dist/**` is present.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are isolated to the build pipeline and a new script that compiles bundled hook handlers; the script includes existence checks and creates output directories before invoking esbuild, and the Node target aligns with the repo’s Node engine baseline (>=22).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->