### PR TITLE
fix(bluebubbles): skip typing indicator for tapback messages

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1016,6 +1016,11 @@ export async function processMessage(
           if (!baseUrl || !password) {
             return;
           }
+          // Skip typing indicator for tapback/reaction messages to avoid lingering
+          // indicator when agent returns NO_REPLY (fixes #11189)
+          if (isTapbackMessage) {
+            return;
+          }
           streamingActive = true;
           clearTypingRestartTimer();
           try {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2420,6 +2420,57 @@ describe("BlueBubbles webhook monitor", () => {
         expect.any(Object),
       );
     });
+
+    it("does not start typing indicator for tapback/reaction messages", async () => {
+      const { sendBlueBubblesTyping } = await import("./chat.js");
+      vi.mocked(sendBlueBubblesTyping).mockClear();
+
+      const account = createMockAccount();
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      // Tapback message with standard iMessage reaction text pattern
+      const payload = {
+        type: "new-message",
+        data: {
+          text: 'Loved "hello world"',
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-tapback-1",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+        },
+      };
+
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+        // Simulate what happens when onReplyStart is called for tapback messages
+        await params.dispatcherOptions.onReplyStart?.();
+        // Agent returns NO_REPLY for tapback messages, so no deliver() call
+      });
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      // Typing indicator should NOT be started for tapback messages
+      // because they typically result in NO_REPLY and the indicator would linger
+      const typingStartCalls = vi
+        .mocked(sendBlueBubblesTyping)
+        .mock.calls.filter(([, isTyping]) => isTyping === true);
+      expect(typingStartCalls).toHaveLength(0);
+    });
   });
 
   describe("outbound message ids", () => {


### PR DESCRIPTION
## Summary

Fixes #11189

When a tapback/reaction message is received, the typing indicator was being started in `onReplyStart` but would linger indefinitely because the agent typically returns `NO_REPLY` for these messages.

This PR adds an early return check for `isTapbackMessage` in the `onReplyStart` callback to skip starting the typing indicator for tapback/reaction messages.

## Changes

- `extensions/bluebubbles/src/monitor.ts`: Added check for `isTapbackMessage` before starting typing indicator
- `extensions/bluebubbles/src/monitor.test.ts`: Added test to verify typing indicator is NOT started for tapback messages

## Test plan

- [x] New test fails before fix, passes after (TDD)
- [x] All 52 existing monitor tests pass
- [x] Full CI gate passes (`pnpm build && pnpm check && pnpm test`)
- [x] Codex review passes with no regressions identified

### Manual verification scenarios:
- [ ] Receive a tapback → Verify no typing indicator appears
- [ ] Receive a regular message → Verify typing indicator still works normally
- [ ] Receive a tapback in a group → Verify no typing indicator

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the BlueBubbles webhook monitor to avoid starting a typing indicator for tapback/reaction (“tapback”) messages. Specifically, `onReplyStart` now returns early when `isTapbackMessage` is true, preventing a typing “start” call that would otherwise linger when the agent returns `NO_REPLY`.

A new test in `extensions/bluebubbles/src/monitor.test.ts` asserts that for a tapback-pattern payload, invoking the reply start hook does not result in any `sendBlueBubblesTyping(..., true, ...)` calls, while existing typing indicator behavior remains covered by adjacent tests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (an early return in `onReplyStart` guarded by an existing `isTapbackMessage` flag) and is covered by a targeted unit test. No other behavior is modified, and the new logic is consistent with the reported issue (typing indicator lingering when no reply is produced).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->