### PR TITLE
feat(ui): add RTL support for Hebrew/Arabic text in webchat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,7 @@ Docs: https://docs.openclaw.ai
 - Providers: add xAI (Grok) support. (#9885) Thanks @grp06.
 - Providers: add Baidu Qianfan support. (#8868) Thanks @ide-rea.
 - Web UI: add token usage dashboard. (#10072) Thanks @Takhoffman.
+- Web UI: add RTL auto-direction support for Hebrew/Arabic text in chat composer and rendered messages. (#11498) Thanks @dirbalak.
 - Memory: native Voyage AI support. (#7078) Thanks @mcinteerj.
 - Sessions: cap sessions_history payloads to reduce context overflow. (#10000) Thanks @gut-puncture.
 - CLI: sort commands alphabetically in help output. (#8068) Thanks @deepsoumya617.

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -122,3 +122,23 @@
   border-top: 1px solid var(--border);
   margin: 1em 0;
 }
+
+/* =============================================
+   RTL (Right-to-Left) SUPPORT
+   ============================================= */
+
+.chat-text[dir="rtl"] {
+  text-align: right;
+}
+
+.chat-text[dir="rtl"] :where(ul, ol) {
+  padding-left: 0;
+  padding-right: 1.5em;
+}
+
+.chat-text[dir="rtl"] :where(blockquote) {
+  border-left: none;
+  border-right: 3px solid var(--border);
+  padding-left: 0;
+  padding-right: 1em;
+}

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -3,6 +3,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { AssistantIdentity } from "../assistant-identity.ts";
 import type { MessageGroup } from "../types/chat-types.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
+import { detectTextDirection } from "../text-direction.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import {
   extractTextCached,
@@ -272,7 +273,7 @@ function renderGroupedMessage(
       }
       ${
         markdown
-          ? html`<div class="chat-text">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+          ? html`<div class="chat-text" dir="${detectTextDirection(markdown, /[\s\p{P}\p{S}#*_`\[\]]/u)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
           : nothing
       }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -273,7 +273,7 @@ function renderGroupedMessage(
       }
       ${
         markdown
-          ? html`<div class="chat-text" dir="${detectTextDirection(markdown, /[\s\p{P}\p{S}#*_`\[\]]/u)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+          ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
           : nothing
       }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}

--- a/ui/src/ui/text-direction.test.ts
+++ b/ui/src/ui/text-direction.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { detectTextDirection } from "./text-direction.ts";
+
+describe("detectTextDirection", () => {
+  it("returns ltr for null and empty input", () => {
+    expect(detectTextDirection(null)).toBe("ltr");
+    expect(detectTextDirection("")).toBe("ltr");
+  });
+
+  it("detects rtl when first significant char is rtl script", () => {
+    expect(detectTextDirection("שלום עולם")).toBe("rtl");
+    expect(detectTextDirection("مرحبا")).toBe("rtl");
+  });
+
+  it("detects ltr when first significant char is ltr", () => {
+    expect(detectTextDirection("Hello world")).toBe("ltr");
+  });
+
+  it("skips punctuation and markdown prefix characters before detection", () => {
+    expect(detectTextDirection("**שלום")).toBe("rtl");
+    expect(detectTextDirection("# مرحبا")).toBe("rtl");
+    expect(detectTextDirection("- hello")).toBe("ltr");
+  });
+});

--- a/ui/src/ui/text-direction.ts
+++ b/ui/src/ui/text-direction.ts
@@ -1,0 +1,26 @@
+/**
+ * RTL (Right-to-Left) text direction detection.
+ * Detects Hebrew, Arabic, Syriac, Thaana, Nko, Samaritan, Mandaic, Adlam,
+ * Phoenician, and Lydian scripts using Unicode Script Properties.
+ */
+
+const RTL_CHAR_REGEX =
+  /\p{Script=Hebrew}|\p{Script=Arabic}|\p{Script=Syriac}|\p{Script=Thaana}|\p{Script=Nko}|\p{Script=Samaritan}|\p{Script=Mandaic}|\p{Script=Adlam}|\p{Script=Phoenician}|\p{Script=Lydian}/u;
+
+/**
+ * Detect text direction from the first significant character.
+ * @param text - The text to check
+ * @param skipPattern - Characters to skip when looking for the first significant char.
+ *   Defaults to whitespace and Unicode punctuation/symbols.
+ */
+export function detectTextDirection(
+  text: string | null,
+  skipPattern: RegExp = /[\s\p{P}\p{S}]/u,
+): "rtl" | "ltr" {
+  if (!text) return "ltr";
+  for (const char of text) {
+    if (skipPattern.test(char)) continue;
+    return RTL_CHAR_REGEX.test(char) ? "rtl" : "ltr";
+  }
+  return "ltr";
+}

--- a/ui/src/ui/text-direction.ts
+++ b/ui/src/ui/text-direction.ts
@@ -17,9 +17,13 @@ export function detectTextDirection(
   text: string | null,
   skipPattern: RegExp = /[\s\p{P}\p{S}]/u,
 ): "rtl" | "ltr" {
-  if (!text) return "ltr";
+  if (!text) {
+    return "ltr";
+  }
   for (const char of text) {
-    if (skipPattern.test(char)) continue;
+    if (skipPattern.test(char)) {
+      continue;
+    }
     return RTL_CHAR_REGEX.test(char) ? "rtl" : "ltr";
   }
   return "ltr";

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -11,6 +11,7 @@ import {
 } from "../chat/grouped-render.ts";
 import { normalizeMessage, normalizeRoleForGrouping } from "../chat/message-normalizer.ts";
 import { icons } from "../icons.ts";
+import { detectTextDirection } from "../text-direction.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
 import "../components/resizable-divider.ts";
 
@@ -375,6 +376,7 @@ export function renderChat(props: ChatProps) {
             <textarea
               ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
               .value=${props.draft}
+              dir=${detectTextDirection(props.draft)}
               ?disabled=${!props.connected}
               @keydown=${(e: KeyboardEvent) => {
                 if (e.key !== "Enter") {


### PR DESCRIPTION
## Summary

Adds automatic RTL (Right-to-Left) text direction detection for the webchat UI, supporting Hebrew, Arabic, and other RTL scripts.

## Changes

- **`ui/src/ui/text-direction.ts`** (new) — Shared `detectTextDirection()` utility using Unicode Script Properties
- **`ui/src/ui/views/chat.ts`** — Auto-detect direction on the input textarea
- **`ui/src/ui/chat/grouped-render.ts`** — Auto-detect direction on displayed messages
- **`ui/src/styles/chat/text.css`** — RTL styles for text-align, list padding, and blockquote borders

## How it works

Finds the first significant character in the text (skipping whitespace, punctuation, and markdown syntax) and checks if it belongs to an RTL script. Sets the `dir` attribute accordingly.

Supported scripts: Hebrew, Arabic, Syriac, Thaana, Nko, Samaritan, Mandaic, Adlam, Phoenician, Lydian.

## Testing

Tested manually in webchat with Hebrew, Arabic, mixed Hebrew/English, and pure English text. Input field and message display both switch direction correctly.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds automatic RTL/LTR direction detection for webchat by introducing a shared `detectTextDirection()` utility (based on the first significant character) and wiring it into both the draft textarea (`dir=…`) and rendered message containers (`dir="…"`). It also adds RTL-specific CSS for alignment and common markdown elements (lists and blockquotes) under `.chat-text[dir="rtl"]`.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but verify runtime/browser support for Unicode property escape regexes to avoid webchat load failures.
- The changes are localized and straightforward (dir attribute + CSS), but the new direction detector relies on Unicode property escapes, which can hard-crash at parse time in unsupported runtimes; this needs an explicit compatibility guarantee or a build-time/fallback mitigation.
- ui/src/ui/text-direction.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->