### PR TITLE
Fix GitHub Copilot Business 421 error with IDE headers and correct API base URL

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -6,10 +6,15 @@ import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
 import { installProcessWarningFilter } from "./infra/warnings.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
+import { patchFetchForGitHubCopilot } from "./providers/github-copilot-fetch-patch.js";
 
 process.title = "openclaw";
 installProcessWarningFilter();
 normalizeEnv();
+
+// Patch global fetch to inject GitHub Copilot IDE headers
+// This must happen early, before any API calls are made
+patchFetchForGitHubCopilot();
 
 if (process.argv.includes("--no-color")) {
   process.env.NO_COLOR = "1";

--- a/src/providers/github-copilot-fetch-patch.ts
+++ b/src/providers/github-copilot-fetch-patch.ts
@@ -1,0 +1,85 @@
+/**
+ * Monkey-patch global fetch to inject required GitHub Copilot IDE headers.
+ * 
+ * GitHub Copilot API requires specific IDE headers for authentication to work properly.
+ * Without these headers, requests return 421 Misdirected Request errors.
+ * 
+ * Required headers:
+ * - Editor-Version: Identifies the IDE version
+ * - Editor-Plugin-Version: Identifies the Copilot plugin version
+ * - Openai-Organization: Must be "github-copilot"
+ * - Openai-Intent: Identifies the request type (e.g., "conversation-panel")
+ * - User-Agent: Identifies the client as GitHub Copilot
+ */
+
+const COPILOT_IDE_HEADERS = {
+  "Editor-Version": "vscode/1.95.0",
+  "Editor-Plugin-Version": "copilot-chat/0.22.4",
+  "Openai-Organization": "github-copilot",
+  "Openai-Intent": "conversation-panel",
+  "User-Agent": "GithubCopilot/0.22.4",
+} as const;
+
+const originalFetch = globalThis.fetch;
+let patched = false;
+
+/**
+ * Check if a URL is a GitHub Copilot API endpoint
+ */
+function isGitHubCopilotUrl(url: string | URL): boolean {
+  const urlString = typeof url === "string" ? url : url.toString();
+  return (
+    urlString.includes("api.githubcopilot.com") ||
+    urlString.includes("api.individual.githubcopilot.com") ||
+    urlString.includes("api.business.githubcopilot.com")
+  );
+}
+
+/**
+ * Patch global fetch to inject GitHub Copilot headers when making requests
+ * to GitHub Copilot API endpoints.
+ */
+export function patchFetchForGitHubCopilot(): void {
+  if (patched) {
+    return;
+  }
+
+  globalThis.fetch = async function patchedFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url = typeof input === "string" ? input : input instanceof URL ? input : input.url;
+
+    // Only inject headers for GitHub Copilot API requests
+    if (isGitHubCopilotUrl(url)) {
+      const headers = new Headers(init?.headers);
+
+      // Only add headers if they don't already exist
+      for (const [key, value] of Object.entries(COPILOT_IDE_HEADERS)) {
+        if (!headers.has(key)) {
+          headers.set(key, value);
+        }
+      }
+
+      return originalFetch(input, {
+        ...init,
+        headers,
+      });
+    }
+
+    // For non-Copilot requests, use original fetch unchanged
+    return originalFetch(input, init);
+  };
+
+  patched = true;
+}
+
+/**
+ * Restore the original fetch implementation (primarily for testing)
+ */
+export function unpatchFetch(): void {
+  if (patched) {
+    globalThis.fetch = originalFetch;
+    patched = false;
+  }
+}

--- a/src/providers/github-copilot-token.ts
+++ b/src/providers/github-copilot-token.ts
@@ -70,7 +70,12 @@ export function deriveCopilotApiBaseUrlFromToken(token: string): string | null {
 
   // pi-ai expects converting proxy.* -> api.*
   // (see upstream getGitHubCopilotBaseUrl).
-  const host = proxyEp.replace(/^https?:\/\//, "").replace(/^proxy\./i, "api.");
+  // For Business accounts (proxy.business.githubcopilot.com), we need to use
+  // api.githubcopilot.com, not api.business.githubcopilot.com
+  const host = proxyEp
+    .replace(/^https?:\/\//, "")
+    .replace(/^proxy\.business\.githubcopilot\.com$/i, "api.githubcopilot.com")
+    .replace(/^proxy\./i, "api.");
   if (!host) {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes two critical bugs preventing GitHub Copilot Business accounts from working with OpenClaw:

### Bug 1: Incorrect API Base URL for Business Accounts
Business tokens contain `proxy.business.githubcopilot.com` which was incorrectly converted to `api.business.githubcopilot.com`. The correct endpoint is `api.githubcopilot.com` (without the `business` subdomain).

### Bug 2: Missing Required IDE Headers
GitHub Copilot API requires specific IDE headers for authentication:
- `Editor-Version: vscode/1.95.0`
- `Editor-Plugin-Version: copilot-chat/0.22.4`
- `Openai-Organization: github-copilot`
- `Openai-Intent: conversation-panel`
- `User-Agent: GithubCopilot/0.22.4`

Without these headers, the API returns `421 Misdirected Request` errors.

## Changes

1. **Fixed URL conversion logic** in `deriveCopilotApiBaseUrlFromToken()` to handle Business accounts correctly
2. **Created `github-copilot-fetch-patch.ts`** to monkey-patch global fetch with IDE headers
3. **Applied patch early** in `entry.ts` before any API calls are made

## Testing

- Tested with GitHub Copilot Business account
- Verified API calls now succeed with proper headers
- Confirmed both Individual and Business account token formats work

Closes #8366

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Copilot Business support by (1) adjusting `deriveCopilotApiBaseUrlFromToken()` so `proxy.business.githubcopilot.com` maps to `api.githubcopilot.com`, and (2) introducing a global `fetch` monkey-patch that injects required GitHub Copilot IDE/auth headers, applied early from `src/entry.ts`.

The main functional concerns are in the new fetch patch: URL detection is currently substring-based (can inject headers to non-Copilot endpoints), and the patch assumes `globalThis.fetch` exists in the runtime (can break the CLI in Node environments without built-in fetch).

<h3>Confidence Score: 3/5</h3>

- This PR is close, but the global fetch patch introduces two concrete failure/leakage modes that should be fixed before merge.
- The Copilot base-URL fix is small and targeted, but the new global fetch monkey-patch (applied for all CLI runs) (a) can leak Copilot headers to non-Copilot hosts due to substring URL matching, and (b) can throw in runtimes where `globalThis.fetch` is not available. Both issues are deterministic and stem directly from the new code.
- src/providers/github-copilot-fetch-patch.ts; src/entry.ts (because it applies the patch unconditionally)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->