### PR TITLE
feat: add LINQ channel plugin for iMessage/RCS/SMS

### DIFF
--- a/extensions/linq/index.ts
+++ b/extensions/linq/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { linqPlugin } from "./src/channel.js";
+import { setLinqRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "linq",
+  name: "LINQ",
+  description: "LINQ channel plugin — iMessage/RCS/SMS via LINQ Partner API",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setLinqRuntime(api.runtime);
+    api.registerChannel({ plugin: linqPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/linq/openclaw.plugin.json
+++ b/extensions/linq/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "linq",
+  "channels": ["linq"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/linq/package.json
+++ b/extensions/linq/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/linq",
+  "version": "2026.2.6-3",
+  "description": "OpenClaw LINQ channel plugin — iMessage/RCS/SMS via LINQ Partner API",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/linq/src/channel.ts
+++ b/extensions/linq/src/channel.ts
@@ -1,0 +1,303 @@
+import {
+  applyAccountNameToChannelSection,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  normalizeAccountId,
+  setAccountEnabledInConfigSection,
+  collectLinqStatusIssues,
+  linqOnboardingAdapter,
+  linqOutbound,
+  linqMessageActions,
+  listLinqAccountIds,
+  looksLikeLinqTargetId,
+  normalizeLinqMessagingTarget,
+  resolveDefaultLinqAccountId,
+  resolveLinqAccount,
+  resolveLinqGroupRequireMention,
+  resolveLinqGroupToolPolicy,
+  monitorLinqProvider,
+  LinqClient,
+  type ChannelMessageActionAdapter,
+  type ChannelPlugin,
+  type OpenClawConfig,
+  type ResolvedLinqAccount,
+  type LinqAccountConfig,
+} from "openclaw/plugin-sdk";
+import { getLinqRuntime } from "./runtime.js";
+
+export const linqPlugin: ChannelPlugin<ResolvedLinqAccount> = {
+  id: "linq",
+  meta: {
+    id: "linq",
+    label: "LINQ",
+    selectionLabel: "LINQ (iMessage/RCS/SMS API)",
+    detailLabel: "LINQ Partner API",
+    docsPath: "/channels/linq",
+    docsLabel: "linq",
+    blurb: "send iMessage, RCS, and SMS via the LINQ Partner API.",
+    systemImage: "message",
+    showConfigured: false,
+    order: 8,
+  },
+  onboarding: linqOnboardingAdapter,
+  pairing: {
+    idLabel: "linqSenderId",
+  },
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    reactions: true,
+    media: true,
+    effects: true,
+  },
+  reload: { configPrefixes: ["channels.linq"] },
+  config: {
+    listAccountIds: (cfg) => listLinqAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveLinqAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultLinqAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "linq",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "linq",
+        accountId,
+        clearBaseFields: ["apiToken", "tokenFile", "fromNumber", "preferredService", "name"],
+      }),
+    isConfigured: (account) => account.configured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      fromNumber: account.config.fromNumber ?? null,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveLinqAccount({ cfg, accountId }).config.allowFrom ?? []).map((entry) =>
+        String(entry),
+      ),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry).trim())
+        .filter(Boolean)
+        .map((entry) => entry.replace(/^linq:/i, ""))
+        .map((entry) => entry.toLowerCase()),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const linq = cfg.channels?.linq as LinqAccountConfig & { accounts?: Record<string, LinqAccountConfig> } | undefined;
+      const useAccountPath = Boolean(linq?.accounts?.[resolvedAccountId]);
+      const basePath = useAccountPath
+        ? `channels.linq.accounts.${resolvedAccountId}.`
+        : "channels.linq.";
+      return {
+        policy: account.config.dmPolicy ?? "pairing",
+        allowFrom: account.config.allowFrom ?? [],
+        policyPath: `${basePath}dmPolicy`,
+        allowFromPath: basePath,
+        approveHint: formatPairingApproveHint("linq"),
+      };
+    },
+    collectWarnings: ({ account, cfg }) => {
+      const defaultGroupPolicy = (cfg.channels?.defaults as { groupPolicy?: string } | undefined)?.groupPolicy;
+      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      if (groupPolicy !== "open") {
+        return [];
+      }
+      return [
+        `- LINQ groups: groupPolicy="open" allows any member to trigger the bot. Set channels.linq.groupPolicy="allowlist" + channels.linq.groupAllowFrom to restrict senders.`,
+      ];
+    },
+  },
+  groups: {
+    resolveRequireMention: resolveLinqGroupRequireMention,
+    resolveToolPolicy: resolveLinqGroupToolPolicy,
+  },
+  messaging: {
+    normalizeTarget: normalizeLinqMessagingTarget,
+    targetResolver: {
+      looksLikeId: looksLikeLinqTargetId,
+      hint: "<phone_e164|email>",
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "linq",
+        accountId,
+        name,
+      }),
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "linq",
+        accountId,
+        name: input.name,
+      });
+      const linq = (namedConfig.channels?.linq ?? {}) as Record<string, unknown>;
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...namedConfig,
+          channels: {
+            ...namedConfig.channels,
+            linq: {
+              ...linq,
+              enabled: true,
+              ...(input.apiToken ? { apiToken: input.apiToken } : {}),
+              ...(input.fromNumber ? { fromNumber: input.fromNumber } : {}),
+              ...(input.preferredService ? { preferredService: input.preferredService } : {}),
+            },
+          },
+        };
+      }
+      const accounts = (linq.accounts ?? {}) as Record<string, unknown>;
+      return {
+        ...namedConfig,
+        channels: {
+          ...namedConfig.channels,
+          linq: {
+            ...linq,
+            enabled: true,
+            accounts: {
+              ...accounts,
+              [accountId]: {
+                ...(accounts[accountId] as Record<string, unknown> | undefined),
+                enabled: true,
+                ...(input.apiToken ? { apiToken: input.apiToken } : {}),
+                ...(input.fromNumber ? { fromNumber: input.fromNumber } : {}),
+                ...(input.preferredService ? { preferredService: input.preferredService } : {}),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  outbound: linqOutbound,
+  actions: linqMessageActions,
+  directory: {
+    self: async ({ cfg, accountId }) => {
+      const account = resolveLinqAccount({ cfg, accountId });
+      const fromNumber = account.config.fromNumber;
+      if (!fromNumber) return null;
+      return { id: fromNumber, name: account.name ?? fromNumber };
+    },
+    listPeers: async ({ cfg, accountId }) => {
+      const account = resolveLinqAccount({ cfg, accountId });
+      const token = account.config.apiToken;
+      const fromNumber = account.config.fromNumber;
+      if (!token || !fromNumber) return [];
+      try {
+        const client = new LinqClient(token);
+        const result = await client.listChats({ from: fromNumber, limit: 100 });
+        return result.chats
+          .filter((chat) => !chat.is_group)
+          .map((chat) => ({
+            id: chat.id,
+            name: chat.display_name || chat.handles.find((h) => !h.is_me)?.handle || chat.id,
+            kind: "user" as const,
+          }));
+      } catch {
+        return [];
+      }
+    },
+    listGroups: async ({ cfg, accountId }) => {
+      const account = resolveLinqAccount({ cfg, accountId });
+      const token = account.config.apiToken;
+      const fromNumber = account.config.fromNumber;
+      if (!token || !fromNumber) return [];
+      try {
+        const client = new LinqClient(token);
+        const result = await client.listChats({ from: fromNumber, limit: 100 });
+        return result.chats
+          .filter((chat) => chat.is_group)
+          .map((chat) => ({
+            id: chat.id,
+            name: chat.display_name || chat.id,
+            kind: "group" as const,
+          }));
+      } catch {
+        return [];
+      }
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: collectLinqStatusIssues,
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      running: snapshot.running ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt ?? null,
+    }),
+    probeAccount: async ({ account }) => {
+      const token = account.config.apiToken;
+      if (!token) {
+        return { ok: false, error: "API token not configured" };
+      }
+      try {
+        const client = new LinqClient(token);
+        const numbers = await client.listPhoneNumbers();
+        return { ok: true, phoneNumbers: numbers.map((n) => n.phone_number) };
+      } catch (error) {
+        return { ok: false, error: String(error) };
+      }
+    },
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      fromNumber: account.config.fromNumber ?? null,
+      probe,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+    }),
+    resolveAccountState: ({ enabled, configured }) => {
+      if (!configured) return "not configured";
+      return enabled ? "enabled" : "disabled";
+    },
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      const fromNumber = account.config.fromNumber;
+      ctx.setStatus({
+        accountId: account.accountId,
+      });
+      ctx.log?.info(
+        `[${account.accountId}] LINQ provider started (from=${fromNumber ?? "unset"})`,
+      );
+      // Poll LINQ API for inbound messages since webhooks require a public URL.
+      return monitorLinqProvider({
+        cfg: ctx.cfg,
+        accountId: account.accountId,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        pollIntervalMs: 2000,
+      });
+    },
+  },
+};

--- a/extensions/linq/src/runtime.ts
+++ b/extensions/linq/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setLinqRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getLinqRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("LINQ runtime not initialized");
+  }
+  return runtime;
+}

--- a/src/channels/plugins/actions/linq.ts
+++ b/src/channels/plugins/actions/linq.ts
@@ -1,0 +1,57 @@
+import type { ChannelMessageActionAdapter } from "../types.js";
+import { LinqClient } from "../../../linq/client.js";
+import { resolveLinqAccount } from "../../../linq/accounts.js";
+import type { OpenClawConfig } from "../../../config/config.js";
+import { jsonResult } from "../../../agents/tools/common.js";
+
+const LINQ_REACTION_MAP: Record<string, string> = {
+  love: "love",
+  like: "like",
+  dislike: "dislike",
+  laugh: "laugh",
+  emphasize: "emphasize",
+  question: "question",
+};
+
+export const linqMessageActions: ChannelMessageActionAdapter = {
+  listActions: () => ["send", "react"],
+  supportsAction: ({ action }) => action !== "send",
+  handleAction: async ({ action, params, cfg, accountId }) => {
+    if (action === "send") {
+      throw new Error("Send should be handled by outbound, not actions handler.");
+    }
+    if (action !== "react") {
+      return jsonResult({ ok: false, error: `Unsupported action: ${action}` });
+    }
+    const messageId = params.messageId as string | undefined;
+    if (!messageId) {
+      return jsonResult({ ok: false, error: "messageId is required for react action" });
+    }
+    const emoji = params.emoji as string | undefined;
+    if (!emoji) {
+      return jsonResult({ ok: false, error: "emoji is required for react action" });
+    }
+    const operation = (params.operation as string | undefined) ?? "add";
+    const account = resolveLinqAccount({ cfg: cfg as OpenClawConfig, accountId });
+    const token = account.config.apiToken;
+    if (!token) {
+      return jsonResult({ ok: false, error: "LINQ API token not configured" });
+    }
+    const client = new LinqClient(token);
+
+    const reactionType = LINQ_REACTION_MAP[emoji.toLowerCase()] ?? "custom";
+    const customEmoji = reactionType === "custom" ? emoji : undefined;
+
+    try {
+      await client.addReaction(messageId, {
+        operation: operation === "remove" ? "remove" : "add",
+        type: reactionType as "love" | "like" | "dislike" | "laugh" | "emphasize" | "question" | "custom",
+        custom_emoji: customEmoji,
+        part_index: params.partIndex as number | undefined,
+      });
+      return jsonResult({ ok: true });
+    } catch (error) {
+      return jsonResult({ ok: false, error: String(error) });
+    }
+  },
+};

--- a/src/channels/plugins/group-mentions.ts
+++ b/src/channels/plugins/group-mentions.ts
@@ -406,3 +406,27 @@ export function resolveBlueBubblesGroupToolPolicy(
     senderE164: params.senderE164,
   });
 }
+
+export function resolveLinqGroupRequireMention(params: GroupMentionParams): boolean {
+  return resolveChannelGroupRequireMention({
+    cfg: params.cfg,
+    channel: "linq",
+    groupId: params.groupId,
+    accountId: params.accountId,
+  });
+}
+
+export function resolveLinqGroupToolPolicy(
+  params: GroupMentionParams,
+): GroupToolPolicyConfig | undefined {
+  return resolveChannelGroupToolsPolicy({
+    cfg: params.cfg,
+    channel: "linq",
+    groupId: params.groupId,
+    accountId: params.accountId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+}

--- a/src/channels/plugins/normalize/linq.ts
+++ b/src/channels/plugins/normalize/linq.ts
@@ -1,0 +1,34 @@
+import { normalizeLinqHandle } from "../../../linq/targets.js";
+
+export function normalizeLinqMessagingTarget(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  // Strip linq: prefix if present
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("linq:")) {
+    const remainder = trimmed.slice(5).trim();
+    const normalized = normalizeLinqHandle(remainder);
+    return normalized ? `linq:${normalized}` : undefined;
+  }
+
+  const normalized = normalizeLinqHandle(trimmed);
+  return normalized || undefined;
+}
+
+export function looksLikeLinqTargetId(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (/^linq:/i.test(trimmed)) {
+    return true;
+  }
+  if (trimmed.includes("@")) {
+    return true;
+  }
+  // E.164 phone number
+  return /^\+?\d{3,}$/.test(trimmed);
+}

--- a/src/channels/plugins/onboarding/linq.ts
+++ b/src/channels/plugins/onboarding/linq.ts
@@ -1,0 +1,274 @@
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { DmPolicy } from "../../../config/types.js";
+import type { WizardPrompter } from "../../../wizard/prompts.js";
+import type { ChannelOnboardingAdapter, ChannelOnboardingDmPolicy } from "../onboarding-types.js";
+import {
+  listLinqAccountIds,
+  resolveDefaultLinqAccountId,
+  resolveLinqAccount,
+} from "../../../linq/accounts.js";
+import { normalizeLinqHandle } from "../../../linq/targets.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../routing/session-key.js";
+import { formatDocsLink } from "../../../terminal/links.js";
+import { addWildcardAllowFrom, promptAccountId } from "./helpers.js";
+
+const channel = "linq" as const;
+
+function setLinqDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy) {
+  const linq = (cfg.channels?.linq ?? {}) as Record<string, unknown>;
+  const allowFrom =
+    dmPolicy === "open"
+      ? addWildcardAllowFrom(
+          (linq.allowFrom as Array<string | number> | undefined),
+        )
+      : undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      linq: {
+        ...linq,
+        dmPolicy,
+        ...(allowFrom ? { allowFrom } : {}),
+      },
+    },
+  };
+}
+
+function setLinqAllowFrom(
+  cfg: OpenClawConfig,
+  accountId: string,
+  allowFrom: string[],
+): OpenClawConfig {
+  const linq = (cfg.channels?.linq ?? {}) as Record<string, unknown>;
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        linq: {
+          ...linq,
+          allowFrom,
+        },
+      },
+    };
+  }
+  const accounts = (linq.accounts ?? {}) as Record<string, unknown>;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      linq: {
+        ...linq,
+        accounts: {
+          ...accounts,
+          [accountId]: {
+            ...(accounts[accountId] as Record<string, unknown> | undefined),
+            allowFrom,
+          },
+        },
+      },
+    },
+  };
+}
+
+function parseLinqAllowFromInput(raw: string): string[] {
+  return raw
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+async function promptLinqAllowFrom(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  accountId?: string;
+}): Promise<OpenClawConfig> {
+  const accountId =
+    params.accountId && normalizeAccountId(params.accountId)
+      ? (normalizeAccountId(params.accountId) ?? DEFAULT_ACCOUNT_ID)
+      : resolveDefaultLinqAccountId(params.cfg);
+  const resolved = resolveLinqAccount({ cfg: params.cfg, accountId });
+  const existing = resolved.config.allowFrom ?? [];
+  await params.prompter.note(
+    [
+      "Allowlist LINQ DMs by phone number or email handle.",
+      "Examples:",
+      "- +15555550123",
+      "- user@example.com",
+      "Multiple entries: comma-separated.",
+    ].join("\n"),
+    "LINQ allowlist",
+  );
+  const entry = await params.prompter.text({
+    message: "LINQ allowFrom (phone or email)",
+    placeholder: "+15555550123, user@example.com",
+    initialValue: existing[0] ? String(existing[0]) : undefined,
+    validate: (value) => {
+      const raw = String(value ?? "").trim();
+      if (!raw) {
+        return "Required";
+      }
+      const parts = parseLinqAllowFromInput(raw);
+      for (const part of parts) {
+        if (part === "*") {
+          continue;
+        }
+        if (!normalizeLinqHandle(part)) {
+          return `Invalid handle: ${part}`;
+        }
+      }
+      return undefined;
+    },
+  });
+  const parts = parseLinqAllowFromInput(String(entry));
+  const unique = [...new Set(parts)];
+  return setLinqAllowFrom(params.cfg, accountId, unique);
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "LINQ",
+  channel,
+  policyKey: "channels.linq.dmPolicy",
+  allowFromKey: "channels.linq.allowFrom",
+  getCurrent: (cfg) => {
+    const linq = cfg.channels?.linq as Record<string, unknown> | undefined;
+    return (linq?.dmPolicy as DmPolicy | undefined) ?? "pairing";
+  },
+  setPolicy: (cfg, policy) => setLinqDmPolicy(cfg, policy),
+  promptAllowFrom: promptLinqAllowFrom,
+};
+
+export const linqOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  getStatus: async ({ cfg }) => {
+    const configured = listLinqAccountIds(cfg).some((accountId) => {
+      const account = resolveLinqAccount({ cfg, accountId });
+      return Boolean(
+        account.config.apiToken ||
+        account.config.tokenFile ||
+        account.config.fromNumber,
+      );
+    });
+    return {
+      channel,
+      configured,
+      statusLines: [
+        `LINQ: ${configured ? "configured" : "needs setup"}`,
+      ],
+      selectionHint: configured ? "token set" : "needs API token",
+      quickstartScore: configured ? 1 : 0,
+    };
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const linqOverride = accountOverrides.linq?.trim();
+    const defaultLinqAccountId = resolveDefaultLinqAccountId(cfg);
+    let linqAccountId = linqOverride
+      ? normalizeAccountId(linqOverride)
+      : defaultLinqAccountId;
+    if (shouldPromptAccountIds && !linqOverride) {
+      linqAccountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "LINQ",
+        currentId: linqAccountId,
+        listAccountIds: listLinqAccountIds,
+        defaultAccountId: defaultLinqAccountId,
+      });
+    }
+
+    let next = cfg;
+    const resolvedAccount = resolveLinqAccount({
+      cfg: next,
+      accountId: linqAccountId,
+    });
+
+    // Prompt for API token if not set
+    let apiToken = resolvedAccount.config.apiToken ?? "";
+    if (!apiToken) {
+      const tokenEnv = process.env.LINQ_API_TOKEN?.trim();
+      if (tokenEnv) {
+        apiToken = tokenEnv;
+      } else {
+        const entered = await prompter.text({
+          message: "LINQ API bearer token",
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        });
+        apiToken = String(entered).trim();
+      }
+    }
+
+    // Prompt for from number if not set
+    let fromNumber = resolvedAccount.config.fromNumber ?? "";
+    if (!fromNumber) {
+      const entered = await prompter.text({
+        message: "Sender phone number (E.164, e.g. +14155551234)",
+        validate: (value) => {
+          const v = String(value ?? "").trim();
+          return v && /^\+\d{3,}$/.test(v) ? undefined : "Must be E.164 (e.g. +14155551234)";
+        },
+      });
+      fromNumber = String(entered).trim();
+    }
+
+    const linq = (next.channels?.linq ?? {}) as Record<string, unknown>;
+    if (linqAccountId === DEFAULT_ACCOUNT_ID) {
+      next = {
+        ...next,
+        channels: {
+          ...next.channels,
+          linq: {
+            ...linq,
+            enabled: true,
+            apiToken,
+            fromNumber,
+          },
+        },
+      };
+    } else {
+      const accounts = (linq.accounts ?? {}) as Record<string, unknown>;
+      next = {
+        ...next,
+        channels: {
+          ...next.channels,
+          linq: {
+            ...linq,
+            enabled: true,
+            accounts: {
+              ...accounts,
+              [linqAccountId]: {
+                ...(accounts[linqAccountId] as Record<string, unknown> | undefined),
+                enabled: true,
+                apiToken,
+                fromNumber,
+              },
+            },
+          },
+        },
+      };
+    }
+
+    await prompter.note(
+      [
+        "LINQ integration configured.",
+        "Send iMessage/RCS/SMS via the LINQ Partner API.",
+        "Webhook setup needed for inbound messages.",
+        `Docs: ${formatDocsLink("/channels/linq", "linq")}`,
+      ].join("\n"),
+      "LINQ next steps",
+    );
+
+    return { cfg: next, accountId: linqAccountId };
+  },
+  dmPolicy,
+  disable: (cfg) => {
+    const linq = (cfg.channels?.linq ?? {}) as Record<string, unknown>;
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        linq: { ...linq, enabled: false },
+      },
+    };
+  },
+};

--- a/src/channels/plugins/outbound/linq.ts
+++ b/src/channels/plugins/outbound/linq.ts
@@ -1,0 +1,108 @@
+import type { ChannelOutboundAdapter } from "../types.js";
+import { chunkText } from "../../../auto-reply/chunk.js";
+import { LinqClient } from "../../../linq/client.js";
+import type { LinqAccountConfig } from "../../../config/types.linq.js";
+import { resolveLinqAccount } from "../../../linq/accounts.js";
+
+function getLinqClient(cfg: unknown, accountId?: string | null): { client: LinqClient; fromNumber: string } {
+  const account = resolveLinqAccount({ cfg: cfg as import("../../../config/config.js").OpenClawConfig, accountId });
+  const token = account.config.apiToken;
+  if (!token) {
+    throw new Error("LINQ API token not configured");
+  }
+  const fromNumber = account.config.fromNumber;
+  if (!fromNumber) {
+    throw new Error("LINQ sender phone number (fromNumber) not configured");
+  }
+  return { client: new LinqClient(token), fromNumber };
+}
+
+export const linqOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  chunker: chunkText,
+  chunkerMode: "text",
+  textChunkLimit: 4000,
+  sendText: async ({ cfg, to, text, accountId, replyToId }) => {
+    const { client, fromNumber } = getLinqClient(cfg, accountId);
+    const account = resolveLinqAccount({ cfg: cfg as import("../../../config/config.js").OpenClawConfig, accountId });
+    const preferredService = account.config.preferredService;
+
+    // Resolve the target: could be a chat ID (UUID) or a phone number/email
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(to);
+
+    if (isUuid) {
+      // Send to existing chat by ID
+      const result = await client.sendMessage(to, {
+        parts: [{ type: "text", value: text }],
+        ...(replyToId ? { reply_to: { message_id: replyToId } } : {}),
+        ...(preferredService ? { preferred_service: preferredService } : {}),
+      });
+      return {
+        channel: "linq",
+        ok: true,
+        messageId: result.message.id,
+      };
+    }
+
+    // Create new chat and send initial message
+    const target = to.replace(/^linq:/, "");
+    const result = await client.createChat({
+      from: fromNumber,
+      to: [target],
+      message: {
+        parts: [{ type: "text", value: text }],
+        ...(preferredService ? { preferred_service: preferredService } : {}),
+      },
+    });
+    return {
+      channel: "linq",
+      ok: true,
+      messageId: result.message.id,
+      chatId: result.chat.id,
+    };
+  },
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId }) => {
+    const { client, fromNumber } = getLinqClient(cfg, accountId);
+    const account = resolveLinqAccount({ cfg: cfg as import("../../../config/config.js").OpenClawConfig, accountId });
+    const preferredService = account.config.preferredService;
+
+    const parts: import("../../../linq/client.js").LinqMessagePart[] = [];
+    if (mediaUrl) {
+      parts.push({ type: "media", url: mediaUrl });
+    }
+    if (text) {
+      parts.push({ type: "text", value: text });
+    }
+
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(to);
+
+    if (isUuid) {
+      const result = await client.sendMessage(to, {
+        parts,
+        ...(replyToId ? { reply_to: { message_id: replyToId } } : {}),
+        ...(preferredService ? { preferred_service: preferredService } : {}),
+      });
+      return {
+        channel: "linq",
+        ok: true,
+        messageId: result.message.id,
+      };
+    }
+
+    const target = to.replace(/^linq:/, "");
+    const result = await client.createChat({
+      from: fromNumber,
+      to: [target],
+      message: {
+        parts,
+        ...(preferredService ? { preferred_service: preferredService } : {}),
+      },
+    });
+    return {
+      channel: "linq",
+      ok: true,
+      messageId: result.message.id,
+      chatId: result.chat.id,
+    };
+  },
+};

--- a/src/channels/plugins/status-issues/linq.ts
+++ b/src/channels/plugins/status-issues/linq.ts
@@ -1,0 +1,30 @@
+import type { ChannelAccountSnapshot, ChannelStatusIssue } from "../types.js";
+
+export function collectLinqStatusIssues(
+  accounts: ChannelAccountSnapshot[],
+): ChannelStatusIssue[] {
+  return accounts.flatMap((account) => {
+    const issues: ChannelStatusIssue[] = [];
+
+    const lastError = typeof account.lastError === "string" ? account.lastError.trim() : "";
+    if (lastError) {
+      issues.push({
+        channel: "linq",
+        accountId: account.accountId,
+        kind: "runtime",
+        message: `Channel error: ${lastError}`,
+      });
+    }
+
+    if (!account.configured) {
+      issues.push({
+        channel: "linq",
+        accountId: account.accountId,
+        kind: "config",
+        message: "LINQ account not configured. Run `openclaw setup` or set channels.linq.apiToken and channels.linq.fromNumber.",
+      });
+    }
+
+    return issues;
+  });
+}

--- a/src/config/types.linq.ts
+++ b/src/config/types.linq.ts
@@ -1,0 +1,79 @@
+import type {
+  BlockStreamingCoalesceConfig,
+  DmPolicy,
+  GroupPolicy,
+  MarkdownConfig,
+} from "./types.base.js";
+import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type { DmConfig } from "./types.messages.js";
+import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
+
+export type LinqAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** Markdown formatting overrides (tables). */
+  markdown?: MarkdownConfig;
+  /** Allow channel-initiated config writes (default: true). */
+  configWrites?: boolean;
+  /** If false, do not start this LINQ account. Default: true. */
+  enabled?: boolean;
+  /** LINQ Partner API bearer token. */
+  apiToken?: string;
+  /** Path to file containing the API token (alternative to inline apiToken). */
+  tokenFile?: string;
+  /** Sender phone number in E.164 format (the LINQ-assigned number to send from). */
+  fromNumber?: string;
+  /** Preferred message service: iMessage, RCS, or SMS. */
+  preferredService?: "iMessage" | "RCS" | "SMS";
+  /** Direct message access policy (default: pairing). */
+  dmPolicy?: DmPolicy;
+  /** Optional allowlist for inbound handles (E.164 phone numbers or email handles). */
+  allowFrom?: Array<string | number>;
+  /** Optional allowlist for group senders. */
+  groupAllowFrom?: Array<string | number>;
+  /**
+   * Controls how group messages are handled:
+   * - "open": groups bypass allowFrom; mention-gating applies
+   * - "disabled": block all group messages entirely
+   * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+   */
+  groupPolicy?: GroupPolicy;
+  /** Max group messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  /** Max outbound media size in MB (LINQ supports up to 10MB via URL, 100MB via pre-upload). */
+  mediaMaxMb?: number;
+  /** Outbound text chunk size (chars). Default: 4000. */
+  textChunkLimit?: number;
+  /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
+  chunkMode?: "length" | "newline";
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  groups?: Record<
+    string,
+    {
+      requireMention?: boolean;
+      tools?: GroupToolPolicyConfig;
+      toolsBySender?: GroupToolPolicyBySenderConfig;
+    }
+  >;
+  /** Heartbeat visibility settings for this channel. */
+  heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Outbound response prefix override for this channel/account. */
+  responsePrefix?: string;
+  /** Webhook URL for receiving inbound messages (set during onboarding). */
+  webhookUrl?: string;
+  /** Webhook signing secret (set during subscription creation). */
+  webhookSecret?: string;
+};
+
+export type LinqConfig = {
+  /** Optional per-account LINQ configuration (multi-account). */
+  accounts?: Record<string, LinqAccountConfig>;
+} & LinqAccountConfig;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -14,6 +14,7 @@ export * from "./types.googlechat.js";
 export * from "./types.gateway.js";
 export * from "./types.hooks.js";
 export * from "./types.imessage.js";
+export * from "./types.linq.js";
 export * from "./types.messages.js";
 export * from "./types.models.js";
 export * from "./types.node-host.js";

--- a/src/linq/accounts.ts
+++ b/src/linq/accounts.ts
@@ -1,0 +1,91 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { LinqAccountConfig } from "../config/types.linq.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
+
+export type ResolvedLinqAccount = {
+  accountId: string;
+  enabled: boolean;
+  name?: string;
+  config: LinqAccountConfig;
+  configured: boolean;
+};
+
+function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
+  const linq = cfg.channels?.linq as LinqAccountConfig & { accounts?: Record<string, unknown> } | undefined;
+  const accounts = linq?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return [];
+  }
+  return Object.keys(accounts).filter(Boolean);
+}
+
+export function listLinqAccountIds(cfg: OpenClawConfig): string[] {
+  const ids = listConfiguredAccountIds(cfg);
+  if (ids.length === 0) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  return ids.toSorted((a, b) => a.localeCompare(b));
+}
+
+export function resolveDefaultLinqAccountId(cfg: OpenClawConfig): string {
+  const ids = listLinqAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): LinqAccountConfig | undefined {
+  const linq = cfg.channels?.linq as LinqAccountConfig & { accounts?: Record<string, LinqAccountConfig> } | undefined;
+  const accounts = linq?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return undefined;
+  }
+  return accounts[accountId] as LinqAccountConfig | undefined;
+}
+
+function mergeLinqAccountConfig(cfg: OpenClawConfig, accountId: string): LinqAccountConfig {
+  const linq = (cfg.channels?.linq ?? {}) as LinqAccountConfig & { accounts?: unknown };
+  const { accounts: _ignored, ...base } = linq;
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account };
+}
+
+export function resolveLinqAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedLinqAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const linq = params.cfg.channels?.linq as LinqAccountConfig | undefined;
+  const baseEnabled = linq?.enabled !== false;
+  const merged = mergeLinqAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const configured = Boolean(
+    merged.apiToken?.trim() ||
+    merged.tokenFile?.trim() ||
+    merged.fromNumber?.trim() ||
+    (merged.allowFrom && merged.allowFrom.length > 0) ||
+    (merged.groupAllowFrom && merged.groupAllowFrom.length > 0) ||
+    merged.dmPolicy ||
+    merged.groupPolicy ||
+    typeof merged.mediaMaxMb === "number" ||
+    typeof merged.textChunkLimit === "number" ||
+    (merged.groups && Object.keys(merged.groups).length > 0),
+  );
+  return {
+    accountId,
+    enabled: baseEnabled && accountEnabled,
+    name: merged.name?.trim() || undefined,
+    config: merged,
+    configured,
+  };
+}
+
+export function listEnabledLinqAccounts(cfg: OpenClawConfig): ResolvedLinqAccount[] {
+  return listLinqAccountIds(cfg)
+    .map((accountId) => resolveLinqAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}

--- a/src/linq/client.ts
+++ b/src/linq/client.ts
@@ -1,0 +1,431 @@
+/**
+ * LINQ Partner API v3 HTTP client.
+ *
+ * Docs: https://apidocs.linqapp.com
+ * Base URL: https://api.linqapp.com/api/partner/v3
+ */
+
+const BASE_URL = "https://api.linqapp.com/api/partner/v3";
+
+/** Parts as sent in requests. */
+export type LinqMessagePart =
+  | { type: "text"; value: string }
+  | { type: "media"; url: string }
+  | { type: "media"; attachment_id: string };
+
+/** Parts as returned from the API (messages endpoint). */
+export type LinqReceivedMessagePart =
+  | { type: "text"; value: string; reactions?: unknown }
+  | {
+      type: "media";
+      id: string;
+      url: string;
+      filename: string;
+      mime_type: string;
+      size_bytes: number;
+      reactions?: unknown;
+    };
+
+export type LinqMessageEffect = {
+  type: "screen" | "bubble";
+  name: string;
+};
+
+export type LinqReplyTo = {
+  message_id: string;
+  part_index?: number;
+};
+
+export type LinqMessageContent = {
+  parts: LinqMessagePart[];
+  effect?: LinqMessageEffect;
+  reply_to?: LinqReplyTo;
+  preferred_service?: "iMessage" | "RCS" | "SMS";
+};
+
+export type LinqChatHandle = {
+  id: string;
+  handle: string;
+  service: string;
+  status: "active" | "left" | "removed";
+  joined_at: string;
+  left_at: string | null;
+  is_me: boolean;
+};
+
+export type LinqChat = {
+  id: string;
+  display_name: string;
+  service: string;
+  handles: LinqChatHandle[];
+  is_archived: boolean;
+  is_group: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type LinqSentMessage = {
+  id: string;
+  parts: LinqMessagePart[];
+  sent_at: string | null;
+  delivered_at: string | null;
+  delivery_status: "pending" | "queued" | "sent" | "delivered" | "failed";
+  is_read: boolean;
+  effect?: LinqMessageEffect;
+  from_handle?: string;
+  reply_to?: LinqReplyTo;
+};
+
+export type LinqMessage = {
+  id: string;
+  chat_id: string;
+  parts: LinqReceivedMessagePart[];
+  from_handle: LinqChatHandle;
+  is_from_me: boolean;
+  is_delivered: boolean;
+  is_read: boolean;
+  sent_at: string | null;
+  delivered_at: string | null;
+  created_at: string;
+  updated_at: string;
+  read_at: string | null;
+  delivery_status: "pending" | "queued" | "sent" | "delivered" | "failed";
+  effect?: LinqMessageEffect | null;
+  reply_to?: LinqReplyTo | null;
+  reactions?: LinqReaction[];
+};
+
+export type LinqReaction = {
+  is_me: boolean;
+  handle: string;
+  type: "love" | "like" | "dislike" | "laugh" | "emphasize" | "question" | "custom";
+  custom_emoji?: string;
+};
+
+export type LinqPhoneNumber = {
+  id: string;
+  phone_number: string;
+  type: "TWILIO" | "APPLE_ID";
+  country_code: string;
+  capabilities: {
+    sms: boolean;
+    mms: boolean;
+    voice: boolean;
+  };
+};
+
+export type LinqAttachment = {
+  id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  status: "pending" | "complete" | "failed";
+  download_url: string;
+  created_at: string;
+};
+
+export type LinqWebhookSubscription = {
+  id: string;
+  url: string;
+  events: string[];
+  signing_secret?: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type LinqCreateChatResult = {
+  chat: LinqChat;
+  message: LinqSentMessage;
+};
+
+export type LinqSendMessageResponse = {
+  chat_id: string;
+  message: LinqSentMessage;
+};
+
+export type LinqListChatsResult = {
+  chats: LinqChat[];
+  next_cursor?: string;
+};
+
+export type LinqListMessagesResult = {
+  messages: LinqMessage[];
+  next_cursor?: string;
+};
+
+export type LinqRequestUploadResult = {
+  attachment_id: string;
+  upload_url: string;
+  download_url: string;
+  method: string;
+  headers: Record<string, string>;
+};
+
+export class LinqApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: number | undefined,
+    message: string,
+    public readonly traceId?: string,
+  ) {
+    super(message);
+    this.name = "LinqApiError";
+  }
+}
+
+export class LinqClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+
+  constructor(token: string, baseUrl?: string) {
+    this.token = token;
+    this.baseUrl = baseUrl?.replace(/\/+$/, "") ?? BASE_URL;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    query?: Record<string, string>,
+  ): Promise<T> {
+    const url = new URL(`${this.baseUrl}${path}`);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined && value !== null) {
+          url.searchParams.set(key, value);
+        }
+      }
+    }
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+      Accept: "application/json",
+    };
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+    const response = await fetch(url.toString(), {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    const text = await response.text();
+    if (!response.ok) {
+      let code: number | undefined;
+      let msg = text;
+      let traceId: string | undefined;
+      try {
+        const parsed = JSON.parse(text);
+        code = parsed.error?.code;
+        msg = parsed.error?.message ?? text;
+        traceId = parsed.trace_id;
+      } catch {
+        // use raw text
+      }
+      throw new LinqApiError(response.status, code, msg, traceId);
+    }
+    if (!text) {
+      return undefined as T;
+    }
+    return JSON.parse(text) as T;
+  }
+
+  // ── Phone Numbers ──
+
+  async listPhoneNumbers(): Promise<LinqPhoneNumber[]> {
+    const result = await this.request<{ phone_numbers: LinqPhoneNumber[] }>(
+      "GET",
+      "/phonenumbers",
+    );
+    return result.phone_numbers;
+  }
+
+  // ── Chats ──
+
+  async createChat(params: {
+    from: string;
+    to: string[];
+    message: LinqMessageContent;
+  }): Promise<LinqCreateChatResult> {
+    return this.request<LinqCreateChatResult>("POST", "/chats", params);
+  }
+
+  async listChats(params: {
+    from: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<LinqListChatsResult> {
+    const query: Record<string, string> = { from: params.from };
+    if (params.limit !== undefined) query.limit = String(params.limit);
+    if (params.cursor) query.cursor = params.cursor;
+    return this.request<LinqListChatsResult>("GET", "/chats", undefined, query);
+  }
+
+  async getChat(chatId: string): Promise<LinqChat> {
+    return this.request<LinqChat>("GET", `/chats/${chatId}`);
+  }
+
+  async updateChat(
+    chatId: string,
+    params: { display_name?: string; group_chat_icon?: string },
+  ): Promise<LinqChat> {
+    return this.request<LinqChat>("PUT", `/chats/${chatId}`, params);
+  }
+
+  async addParticipant(chatId: string, handle: string): Promise<void> {
+    return this.request<void>("POST", `/chats/${chatId}/participants`, { handle });
+  }
+
+  async removeParticipant(chatId: string, handle: string): Promise<void> {
+    return this.request<void>("DELETE", `/chats/${chatId}/participants`, { handle });
+  }
+
+  async startTyping(chatId: string): Promise<void> {
+    return this.request<void>("POST", `/chats/${chatId}/typing`);
+  }
+
+  async stopTyping(chatId: string): Promise<void> {
+    return this.request<void>("DELETE", `/chats/${chatId}/typing`);
+  }
+
+  async markRead(chatId: string): Promise<void> {
+    return this.request<void>("POST", `/chats/${chatId}/read`);
+  }
+
+  async shareContactCard(chatId: string): Promise<void> {
+    return this.request<void>("POST", `/chats/${chatId}/share_contact_card`);
+  }
+
+  // ── Messages ──
+
+  async sendMessage(
+    chatId: string,
+    message: LinqMessageContent,
+  ): Promise<LinqSendMessageResponse> {
+    return this.request<LinqSendMessageResponse>(
+      "POST",
+      `/chats/${chatId}/messages`,
+      { message },
+    );
+  }
+
+  async listMessages(
+    chatId: string,
+    params?: { limit?: number; cursor?: string },
+  ): Promise<LinqListMessagesResult> {
+    const query: Record<string, string> = {};
+    if (params?.limit !== undefined) query.limit = String(params.limit);
+    if (params?.cursor) query.cursor = params.cursor;
+    return this.request<LinqListMessagesResult>(
+      "GET",
+      `/chats/${chatId}/messages`,
+      undefined,
+      query,
+    );
+  }
+
+  async getMessage(messageId: string): Promise<LinqMessage> {
+    return this.request<LinqMessage>("GET", `/messages/${messageId}`);
+  }
+
+  async deleteMessage(messageId: string, chatId: string): Promise<void> {
+    return this.request<void>("DELETE", `/messages/${messageId}`, { chat_id: chatId });
+  }
+
+  async getThread(
+    messageId: string,
+    params?: { limit?: number; cursor?: string; order?: "asc" | "desc" },
+  ): Promise<LinqListMessagesResult> {
+    const query: Record<string, string> = {};
+    if (params?.limit !== undefined) query.limit = String(params.limit);
+    if (params?.cursor) query.cursor = params.cursor;
+    if (params?.order) query.order = params.order;
+    return this.request<LinqListMessagesResult>(
+      "GET",
+      `/messages/${messageId}/thread`,
+      undefined,
+      query,
+    );
+  }
+
+  async sendVoiceMemo(
+    chatId: string,
+    from: string,
+    voiceMemoUrl: string,
+  ): Promise<LinqSendMessageResponse> {
+    return this.request<LinqSendMessageResponse>("POST", `/chats/${chatId}/voicememo`, {
+      from,
+      voice_memo_url: voiceMemoUrl,
+    });
+  }
+
+  async addReaction(
+    messageId: string,
+    params: {
+      operation: "add" | "remove";
+      type: "love" | "like" | "dislike" | "laugh" | "emphasize" | "question" | "custom";
+      custom_emoji?: string;
+      part_index?: number;
+    },
+  ): Promise<LinqReaction> {
+    return this.request<LinqReaction>("POST", `/messages/${messageId}/reactions`, params);
+  }
+
+  // ── Attachments ──
+
+  async requestUpload(params: {
+    filename: string;
+    content_type: string;
+    size_bytes: number;
+  }): Promise<LinqRequestUploadResult> {
+    return this.request<LinqRequestUploadResult>("POST", "/attachments", params);
+  }
+
+  async getAttachment(attachmentId: string): Promise<LinqAttachment> {
+    return this.request<LinqAttachment>("GET", `/attachments/${attachmentId}`);
+  }
+
+  // ── Webhooks ──
+
+  async listWebhookEvents(): Promise<string[]> {
+    const result = await this.request<{ events: string[] }>("GET", "/webhook-events");
+    return result.events;
+  }
+
+  async createWebhookSubscription(params: {
+    url: string;
+    events: string[];
+  }): Promise<LinqWebhookSubscription> {
+    return this.request<LinqWebhookSubscription>("POST", "/webhook-subscriptions", params);
+  }
+
+  async listWebhookSubscriptions(): Promise<LinqWebhookSubscription[]> {
+    const result = await this.request<{ subscriptions: LinqWebhookSubscription[] }>(
+      "GET",
+      "/webhook-subscriptions",
+    );
+    return result.subscriptions;
+  }
+
+  async getWebhookSubscription(id: string): Promise<LinqWebhookSubscription> {
+    return this.request<LinqWebhookSubscription>("GET", `/webhook-subscriptions/${id}`);
+  }
+
+  async updateWebhookSubscription(
+    id: string,
+    params: { url?: string; events?: string[]; status?: string },
+  ): Promise<LinqWebhookSubscription> {
+    return this.request<LinqWebhookSubscription>(
+      "PUT",
+      `/webhook-subscriptions/${id}`,
+      params,
+    );
+  }
+
+  async deleteWebhookSubscription(id: string): Promise<void> {
+    return this.request<void>("DELETE", `/webhook-subscriptions/${id}`);
+  }
+}

--- a/src/linq/monitor.ts
+++ b/src/linq/monitor.ts
@@ -1,0 +1,400 @@
+/**
+ * LINQ polling monitor — fetches new inbound messages from the LINQ API
+ * and dispatches them to the agent system.
+ *
+ * Since LINQ uses webhooks for inbound in production, this polling fallback
+ * is useful when a public webhook URL is not available.
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+import type { LinqAccountConfig } from "../config/types.linq.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveHumanDelayConfig } from "../agents/identity.js";
+import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
+import { hasControlCommand } from "../auto-reply/command-detection.js";
+import { dispatchInboundMessage } from "../auto-reply/dispatch.js";
+import {
+  formatInboundEnvelope,
+  formatInboundFromLabel,
+  resolveEnvelopeFormatOptions,
+} from "../auto-reply/envelope.js";
+import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
+import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
+import { resolveControlCommandGate } from "../channels/command-gating.js";
+import { logInboundDrop } from "../channels/logging.js";
+import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+import { recordInboundSession } from "../channels/session.js";
+import { readSessionUpdatedAt, resolveStorePath } from "../config/sessions.js";
+import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
+import { buildPairingReply } from "../pairing/pairing-messages.js";
+import { upsertChannelPairingRequest } from "../pairing/pairing-store.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
+import { truncateUtf16Safe } from "../utils.js";
+import { LinqClient, type LinqMessage, type LinqChat } from "./client.js";
+import { resolveLinqAccount } from "./accounts.js";
+import { sendMessageLinq } from "./send.js";
+
+export type MonitorLinqOpts = {
+  cfg?: OpenClawConfig;
+  accountId?: string;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  pollIntervalMs?: number;
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+export async function monitorLinqProvider(opts: MonitorLinqOpts = {}): Promise<void> {
+  const { loadConfig } = await import("../config/config.js");
+  let cfg = opts.cfg ?? (await loadConfig());
+  const runtime = opts.runtime;
+  const account = resolveLinqAccount({ cfg, accountId: opts.accountId });
+  const token = account.config.apiToken;
+  const fromNumber = account.config.fromNumber;
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  if (!token || !fromNumber) {
+    runtime?.error?.("linq: API token and fromNumber are required for polling");
+    return;
+  }
+
+  const client = new LinqClient(token);
+  const processedMessageIds = new Set<string>();
+  // Track known chat IDs so we can poll them individually
+  const knownChatIds = new Set<string>();
+
+  // Seed processed messages: fetch existing messages so we don't replay history
+  try {
+    const chats = await client.listChats({ from: fromNumber, limit: 100 });
+    for (const chat of chats.chats) {
+      knownChatIds.add(chat.id);
+      try {
+        const msgs = await client.listMessages(chat.id, { limit: 20 });
+        for (const msg of msgs.messages) {
+          processedMessageIds.add(msg.id);
+        }
+      } catch {
+        // ignore per-chat fetch errors during seed
+      }
+    }
+    logVerbose(
+      `linq: seeded ${processedMessageIds.size} existing messages across ${knownChatIds.size} chats`,
+    );
+  } catch (err) {
+    runtime?.error?.(`linq: failed to seed message history: ${String(err)}`);
+  }
+
+  // Main polling loop
+  while (!opts.abortSignal?.aborted) {
+    try {
+      // Reload config periodically
+      cfg = await loadConfig();
+      const currentAccount = resolveLinqAccount({ cfg, accountId: opts.accountId });
+      if (!currentAccount.enabled) {
+        logVerbose("linq: account disabled, stopping poll");
+        break;
+      }
+
+      // Discover new chats
+      const chatResult = await client.listChats({ from: fromNumber, limit: 100 });
+      for (const chat of chatResult.chats) {
+        knownChatIds.add(chat.id);
+      }
+
+      // Poll each known chat for new messages
+      for (const chatId of knownChatIds) {
+        if (opts.abortSignal?.aborted) break;
+        try {
+          const msgResult = await client.listMessages(chatId, { limit: 20 });
+          const newMessages = msgResult.messages.filter(
+            (msg) => !processedMessageIds.has(msg.id) && !msg.is_from_me,
+          );
+
+          for (const msg of newMessages) {
+            processedMessageIds.add(msg.id);
+            // Find the chat object for context
+            const chat = chatResult.chats.find((c) => c.id === chatId);
+            try {
+              await handleInboundMessage({
+                cfg,
+                account: currentAccount,
+                client,
+                chat,
+                chatId,
+                message: msg,
+                fromNumber,
+                runtime,
+                token,
+              });
+            } catch (err) {
+              runtime?.error?.(
+                danger(`linq: failed to handle message ${msg.id}: ${String(err)}`),
+              );
+            }
+          }
+        } catch {
+          // Individual chat poll failure — continue with other chats
+        }
+      }
+
+      // Bound the processed set to avoid memory growth
+      if (processedMessageIds.size > 10000) {
+        const arr = [...processedMessageIds];
+        const excess = arr.slice(0, arr.length - 5000);
+        for (const id of excess) {
+          processedMessageIds.delete(id);
+        }
+      }
+    } catch (err) {
+      runtime?.error?.(`linq: poll cycle failed: ${String(err)}`);
+    }
+
+    await sleep(pollIntervalMs, opts.abortSignal);
+  }
+}
+
+// ── Inbound message handler ──
+
+async function handleInboundMessage(params: {
+  cfg: OpenClawConfig;
+  account: ReturnType<typeof resolveLinqAccount>;
+  client: LinqClient;
+  chat: LinqChat | undefined;
+  chatId: string;
+  message: LinqMessage;
+  fromNumber: string;
+  runtime?: RuntimeEnv;
+  token: string;
+}): Promise<void> {
+  const { cfg, account, client, chat, chatId, message, fromNumber, runtime, token } = params;
+
+  const isGroup = chat?.is_group ?? false;
+  const senderHandle =
+    message.from_handle?.handle ??
+    (typeof (message as Record<string, unknown>).from_handle === "string"
+      ? (message as Record<string, unknown>).from_handle as string
+      : "unknown");
+  const senderName = chat?.display_name || senderHandle;
+
+  // Extract text from message parts
+  const textParts = (message.parts ?? [])
+    .filter((p) => p.type === "text")
+    .map((p) => (p as { value: string }).value);
+  const bodyText = textParts.join("\n").trim();
+
+  // Extract media from received message parts (API returns id, url, filename, mime_type, size_bytes)
+  const mediaParts = (message.parts ?? []).filter((p) => p.type === "media");
+  const firstMedia = mediaParts[0] as { url?: string; mime_type?: string; filename?: string } | undefined;
+  const mediaUrl = firstMedia?.url;
+  const mediaType = firstMedia?.mime_type;
+  const allMediaUrls = mediaParts
+    .map((p) => (p as { url?: string }).url)
+    .filter((u): u is string => Boolean(u));
+  const allMediaTypes = mediaParts
+    .map((p) => (p as { mime_type?: string }).mime_type)
+    .filter((t): t is string => Boolean(t));
+
+  if (!bodyText && mediaParts.length === 0) {
+    return; // No content
+  }
+  const mediaKind = mediaType ? mediaType.split("/")[0] : undefined;
+  const mediaPlaceholder = mediaParts.length > 0
+    ? (mediaKind ? `<media:${mediaKind}>` : "<media:attachment>")
+    : "";
+  const displayBody = bodyText
+    ? (mediaParts.length > 0 ? `${bodyText}\n${mediaPlaceholder}` : bodyText)
+    : mediaPlaceholder;
+
+  // DM policy / allowFrom gating
+  const dmPolicy = account.config.dmPolicy ?? "pairing";
+  const allowFrom = (account.config.allowFrom ?? []).map((e) => String(e));
+  const isAllowed =
+    allowFrom.length === 0 ||
+    allowFrom.includes("*") ||
+    allowFrom.some((entry) => {
+      const normalized = entry.toLowerCase().replace(/^linq:/, "");
+      const senderNormalized = senderHandle.toLowerCase();
+      return normalized === senderNormalized;
+    });
+
+  if (!isGroup && !isAllowed) {
+    if (dmPolicy === "pairing") {
+      const { created, code } = await upsertChannelPairingRequest({
+        channel: "linq",
+        id: senderHandle,
+        meta: { sender: senderHandle, chatId },
+      });
+      if (created) {
+        logVerbose(`linq: pairing request sender=${senderHandle}`);
+        try {
+          await sendMessageLinq(chatId, buildPairingReply({
+            channel: "linq",
+            idLine: `Your LINQ sender id: ${senderHandle}`,
+            code,
+          }), {
+            apiToken: token,
+            fromNumber,
+          });
+        } catch (err) {
+          logVerbose(`linq: pairing reply failed for ${senderHandle}: ${String(err)}`);
+        }
+      }
+    } else {
+      logVerbose(`linq: blocked sender ${senderHandle} (dmPolicy=${dmPolicy})`);
+    }
+    return;
+  }
+
+  // Resolve agent route
+  const route = resolveAgentRoute({
+    cfg,
+    channel: "linq",
+    accountId: account.accountId,
+    peer: {
+      kind: isGroup ? "group" : "dm",
+      id: isGroup ? chatId : senderHandle,
+    },
+  });
+
+  const fromLabel = formatInboundFromLabel({
+    isGroup,
+    groupLabel: chat?.display_name ?? undefined,
+    groupId: chatId,
+    groupFallback: "Group",
+    directLabel: senderName,
+    directId: senderHandle,
+  });
+
+  const storePath = resolveStorePath(cfg.session?.store, {
+    agentId: route.agentId,
+  });
+  const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
+  const previousTimestamp = readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+
+  const body = formatInboundEnvelope({
+    channel: "LINQ",
+    from: fromLabel,
+    timestamp: message.sent_at ? Date.parse(message.sent_at) : undefined,
+    body: displayBody,
+    chatType: isGroup ? "group" : "direct",
+    sender: { name: senderName, id: senderHandle },
+    previousTimestamp,
+    envelope: envelopeOptions,
+  });
+
+  const linqTo = isGroup ? `linq:group:${chatId}` : `linq:${senderHandle}`;
+  const ctxPayload = finalizeInboundContext({
+    Body: body,
+    RawBody: displayBody,
+    CommandBody: displayBody,
+    From: isGroup ? `linq:group:${chatId}` : `linq:${senderHandle}`,
+    To: linqTo,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: isGroup ? "group" : "direct",
+    ConversationLabel: fromLabel,
+    GroupSubject: isGroup ? (chat?.display_name ?? undefined) : undefined,
+    SenderName: senderName,
+    SenderId: senderHandle,
+    Provider: "linq",
+    Surface: "linq",
+    MessageSid: message.id,
+    MessageSidFull: message.id,
+    ReplyToId: message.reply_to?.message_id,
+    Timestamp: message.sent_at ? Date.parse(message.sent_at) : undefined,
+    MediaUrl: mediaUrl,
+    MediaType: mediaType,
+    MediaUrls: allMediaUrls.length > 0 ? allMediaUrls : undefined,
+    MediaTypes: allMediaTypes.length > 0 ? allMediaTypes : undefined,
+    WasMentioned: !isGroup,
+    CommandAuthorized: isAllowed,
+    OriginatingChannel: "linq" as const,
+    OriginatingTo: linqTo,
+  });
+
+  await recordInboundSession({
+    storePath,
+    sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+    ctx: ctxPayload,
+    updateLastRoute: !isGroup
+      ? {
+          sessionKey: route.mainSessionKey,
+          channel: "linq",
+          to: senderHandle,
+          accountId: route.accountId,
+        }
+      : undefined,
+    onRecordError: (err) => {
+      logVerbose(`linq: failed updating session meta: ${String(err)}`);
+    },
+  });
+
+  if (shouldLogVerbose()) {
+    const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
+    logVerbose(
+      `linq inbound: chatId=${chatId} from=${ctxPayload.From} len=${body.length} preview="${preview}"`,
+    );
+  }
+
+  const textLimit = resolveTextChunkLimit(
+    cfg,
+    "linq",
+    account.accountId,
+    { fallbackLimit: 4000 },
+  );
+
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg,
+    agentId: route.agentId,
+    channel: "linq",
+    accountId: route.accountId,
+  });
+
+  const dispatcher = createReplyDispatcher({
+    ...prefixOptions,
+    humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+    deliver: async (payload) => {
+      const replyText = typeof payload === "string" ? payload : payload.text ?? "";
+      const replyMediaUrl =
+        typeof payload === "string" ? undefined : payload.mediaUrl ?? undefined;
+
+      if (!replyText && !replyMediaUrl) return;
+
+      await sendMessageLinq(chatId, replyText, {
+        apiToken: token,
+        fromNumber,
+        mediaUrl: replyMediaUrl,
+        preferredService: account.config.preferredService,
+      });
+    },
+    onError: (err, info) => {
+      runtime?.error?.(danger(`linq ${info.kind} reply failed: ${String(err)}`));
+    },
+  });
+
+  await dispatchInboundMessage({
+    ctx: ctxPayload,
+    cfg,
+    dispatcher,
+    replyOptions: {
+      disableBlockStreaming:
+        typeof account.config.blockStreaming === "boolean"
+          ? !account.config.blockStreaming
+          : undefined,
+      onModelSelected,
+    },
+  });
+}

--- a/src/linq/send.ts
+++ b/src/linq/send.ts
@@ -1,0 +1,76 @@
+/**
+ * High-level send helper for LINQ outbound messages.
+ * Mirrors the pattern of src/imessage/send.ts.
+ */
+
+import { LinqClient, type LinqMessagePart } from "./client.js";
+
+export type LinqSendOptions = {
+  mediaUrl?: string;
+  maxBytes?: number;
+  accountId?: string;
+  apiToken: string;
+  fromNumber: string;
+  preferredService?: "iMessage" | "RCS" | "SMS";
+  replyToId?: string;
+  effect?: { type: "screen" | "bubble"; name: string };
+};
+
+export type LinqSendResult = {
+  ok: boolean;
+  messageId?: string;
+  chatId?: string;
+  error?: string;
+};
+
+/**
+ * Send a message to a LINQ target (phone number, email, or chat UUID).
+ */
+export async function sendMessageLinq(
+  to: string,
+  text: string,
+  options: LinqSendOptions,
+): Promise<LinqSendResult> {
+  const client = new LinqClient(options.apiToken);
+  const target = to.replace(/^linq:/, "");
+
+  const parts: LinqMessagePart[] = [];
+  if (options.mediaUrl) {
+    parts.push({ type: "media", url: options.mediaUrl });
+  }
+  if (text) {
+    parts.push({ type: "text", value: text });
+  }
+  if (parts.length === 0) {
+    return { ok: false, error: "No content to send" };
+  }
+
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(target);
+
+  try {
+    if (isUuid) {
+      // Send to existing chat
+      const result = await client.sendMessage(target, {
+        parts,
+        ...(options.replyToId ? { reply_to: { message_id: options.replyToId } } : {}),
+        ...(options.preferredService ? { preferred_service: options.preferredService } : {}),
+        ...(options.effect ? { effect: options.effect } : {}),
+      });
+      return { ok: true, messageId: result.message.id, chatId: result.chat_id };
+    }
+
+    // Create chat and send
+    const result = await client.createChat({
+      from: options.fromNumber,
+      to: [target],
+      message: {
+        parts,
+        ...(options.preferredService ? { preferred_service: options.preferredService } : {}),
+        ...(options.effect ? { effect: options.effect } : {}),
+      },
+    });
+    return { ok: true, messageId: result.message.id, chatId: result.chat.id };
+  } catch (error) {
+    return { ok: false, error: String(error) };
+  }
+}

--- a/src/linq/targets.ts
+++ b/src/linq/targets.ts
@@ -1,0 +1,32 @@
+import { normalizeE164 } from "../utils.js";
+
+/**
+ * Normalizes a LINQ messaging target handle.
+ * LINQ uses E.164 phone numbers and email addresses.
+ */
+export function normalizeLinqHandle(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const lowered = trimmed.toLowerCase();
+
+  // Strip linq: prefix
+  if (lowered.startsWith("linq:")) {
+    return normalizeLinqHandle(trimmed.slice(5));
+  }
+
+  // Email handle
+  if (trimmed.includes("@")) {
+    return trimmed.toLowerCase();
+  }
+
+  // E.164 phone number
+  const normalized = normalizeE164(trimmed);
+  if (normalized) {
+    return normalized;
+  }
+
+  // Return cleaned up
+  return trimmed.replace(/\s+/g, "");
+}

--- a/src/linq/webhook.ts
+++ b/src/linq/webhook.ts
@@ -1,0 +1,82 @@
+/**
+ * LINQ webhook signature verification and event processing.
+ *
+ * Webhook headers:
+ *   X-Webhook-Event       – event type (e.g. "message.received")
+ *   X-Webhook-Subscription-ID – subscription reference
+ *   X-Webhook-Timestamp   – unix timestamp (seconds)
+ *   X-Webhook-Signature   – HMAC-SHA256 hex digest
+ *
+ * Signature is computed over: "{timestamp}.{rawBody}"
+ * using the signing secret as the HMAC key.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export type LinqWebhookHeaders = {
+  event: string;
+  subscriptionId: string;
+  timestamp: string;
+  signature: string;
+};
+
+export function extractWebhookHeaders(
+  headers: Record<string, string | string[] | undefined>,
+): LinqWebhookHeaders | null {
+  const event = headerValue(headers, "x-webhook-event");
+  const subscriptionId = headerValue(headers, "x-webhook-subscription-id");
+  const timestamp = headerValue(headers, "x-webhook-timestamp");
+  const signature = headerValue(headers, "x-webhook-signature");
+  if (!event || !timestamp || !signature) {
+    return null;
+  }
+  return { event, subscriptionId: subscriptionId ?? "", timestamp, signature };
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined>,
+  key: string,
+): string | undefined {
+  const value = headers[key] ?? headers[key.toLowerCase()];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function verifyWebhookSignature(
+  signingSecret: string,
+  rawBody: string | Buffer,
+  timestamp: string,
+  signature: string,
+): boolean {
+  const payload = typeof rawBody === "string" ? rawBody : rawBody.toString("utf-8");
+  const message = `${timestamp}.${payload}`;
+  const expected = createHmac("sha256", signingSecret)
+    .update(message)
+    .digest("hex");
+  try {
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+// Webhook event types
+export const LINQ_WEBHOOK_EVENTS = [
+  "message.sent",
+  "message.received",
+  "message.read",
+  "message.delivered",
+  "message.failed",
+  "reaction.added",
+  "reaction.removed",
+  "participant.added",
+  "participant.removed",
+  "chat.created",
+  "chat.group_name_updated",
+  "chat.group_icon_updated",
+  "chat.group_name_update_failed",
+  "chat.group_icon_update_failed",
+  "chat.typing_indicator.started",
+  "chat.typing_indicator.stopped",
+] as const;
+
+export type LinqWebhookEvent = (typeof LINQ_WEBHOOK_EVENTS)[number];

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -337,6 +337,29 @@ export {
 } from "../channels/plugins/normalize/whatsapp.js";
 export { collectWhatsAppStatusIssues } from "../channels/plugins/status-issues/whatsapp.js";
 
+// Channel: LINQ
+export {
+  listLinqAccountIds,
+  resolveDefaultLinqAccountId,
+  resolveLinqAccount,
+  type ResolvedLinqAccount,
+} from "../linq/accounts.js";
+export { linqOnboardingAdapter } from "../channels/plugins/onboarding/linq.js";
+export {
+  looksLikeLinqTargetId,
+  normalizeLinqMessagingTarget,
+} from "../channels/plugins/normalize/linq.js";
+export { collectLinqStatusIssues } from "../channels/plugins/status-issues/linq.js";
+export {
+  resolveLinqGroupRequireMention,
+  resolveLinqGroupToolPolicy,
+} from "../channels/plugins/group-mentions.js";
+export { monitorLinqProvider } from "../linq/monitor.js";
+export { linqOutbound } from "../channels/plugins/outbound/linq.js";
+export { linqMessageActions } from "../channels/plugins/actions/linq.js";
+export { LinqClient } from "../linq/client.js";
+export type { LinqAccountConfig, LinqConfig } from "../config/types.linq.js";
+
 // Channel: BlueBubbles
 export { collectBlueBubblesStatusIssues } from "../channels/plugins/status-issues/bluebubbles.js";
 


### PR DESCRIPTION
## Summary

- Adds a new **LINQ** channel extension that integrates with the [LINQ Partner API v3](https://apidocs.linqapp.com) to send and receive iMessage, RCS, and SMS messages
- Full channel plugin implementation following the same architecture as existing channels (Telegram, WhatsApp, iMessage, Signal, etc.)
- Includes a polling-based inbound monitor for environments without a public webhook URL

## Capabilities

- **Outbound**: text + media messages via direct delivery mode
- **Inbound**: polling monitor (configurable interval, default 2s) with proper DM policy/allowlist gating and pairing support
- **Reactions**: love, like, dislike, laugh, emphasize, question, custom emoji
- **iMessage effects**: confetti, fireworks, slam, invisible ink, etc.
- **Group chats**: create, send, participant management
- **Directory**: list peers and groups via API
- **Multi-account**: full account resolution, enable/disable, config writes
- **Attachments**: direct URL (up to 10MB) and pre-upload (up to 100MB)
- **Webhook verification**: HMAC-SHA256 signature verification ready for webhook-based inbound
- **Typing indicators**, read receipts, voice memos via API client
- **Onboarding wizard**: interactive setup for API token and sender phone number

## Known limitations

- **Outbound image sending** only works with publicly accessible URLs — local file paths are not supported (the LINQ API requires an HTTPS URL or a pre-uploaded attachment ID)
- **Inbound image receiving** is still broken — media parts are extracted from the API response but not yet properly passed through to the agent as viewable images

## New files

| Path | Purpose |
|---|---|
| `extensions/linq/` | Plugin entry, manifest, package, channel impl, runtime |
| `src/linq/client.ts` | Full LINQ API v3 HTTP client (~430 lines) |
| `src/linq/accounts.ts` | Account resolution & multi-account support |
| `src/linq/targets.ts` | Target normalization (E.164, email) |
| `src/linq/send.ts` | High-level send helper |
| `src/linq/monitor.ts` | Polling-based inbound message monitor (~400 lines) |
| `src/linq/webhook.ts` | Webhook signature verification |
| `src/config/types.linq.ts` | Config type definitions |
| `src/channels/plugins/*/linq.ts` | Normalize, onboarding, outbound, status, actions adapters |

## Modified files

- `src/channels/plugins/group-mentions.ts` — added `resolveLinqGroupRequireMention` + `resolveLinqGroupToolPolicy`
- `src/config/types.ts` — added `types.linq.js` re-export
- `src/plugin-sdk/index.ts` — added LINQ exports (accounts, onboarding, normalize, status, group mentions, monitor, outbound, actions, client, config types)

## Configuration example

```json
{
  "channels": {
    "linq": {
      "enabled": true,
      "apiToken": "your-linq-api-token",
      "fromNumber": "+14155551234",
      "preferredService": "iMessage",
      "dmPolicy": "allowlist",
      "allowFrom": ["+15551234567"],
      "mediaMaxMb": 10
    }
  }
}
```

## Test plan

- [x] API connectivity verified (list phone numbers, create chat, send message)
- [x] Outbound text messages delivered via iMessage
- [x] Inbound polling monitor receives and dispatches messages to agent
- [x] DM policy gating (allowlist, pairing) working
- [x] Multi-channel operation (Telegram + LINQ running simultaneously)
- [ ] Inbound image receiving (media parts extracted but not yet viewable by agent)
- [ ] Outbound image sending with local files (requires public URL or pre-upload)
- [ ] Group chat creation and messaging
- [ ] Reaction send/receive
- [ ] Webhook-based inbound (when public URL available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)