### PR TITLE
Gateway: fix multi-agent sessions.usage discovery

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/config.js", () => {
+  return {
+    loadConfig: vi.fn(() => ({
+      agents: {
+        list: [{ id: "main" }, { id: "opus" }],
+      },
+      session: {},
+    })),
+  };
+});
+
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    loadCombinedSessionStoreForGateway: vi.fn(() => ({ store: {} })),
+  };
+});
+
+vi.mock("../../infra/session-cost-usage.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/session-cost-usage.js")>(
+    "../../infra/session-cost-usage.js",
+  );
+  return {
+    ...actual,
+    discoverAllSessions: vi.fn(async (params?: { agentId?: string }) => {
+      if (params?.agentId === "main") {
+        return [
+          {
+            sessionId: "s-main",
+            sessionFile: "/tmp/agents/main/sessions/s-main.jsonl",
+            mtime: 100,
+            firstUserMessage: "hello",
+          },
+        ];
+      }
+      if (params?.agentId === "opus") {
+        return [
+          {
+            sessionId: "s-opus",
+            sessionFile: "/tmp/agents/opus/sessions/s-opus.jsonl",
+            mtime: 200,
+            firstUserMessage: "hi",
+          },
+        ];
+      }
+      return [];
+    }),
+    loadSessionCostSummary: vi.fn(async () => ({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    })),
+  };
+});
+
+import { discoverAllSessions } from "../../infra/session-cost-usage.js";
+import { usageHandlers } from "./usage.js";
+
+describe("sessions.usage", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("discovers sessions across configured agents and keeps agentId in key", async () => {
+    const respond = vi.fn();
+
+    await usageHandlers["sessions.usage"]({
+      respond,
+      params: {
+        startDate: "2026-02-01",
+        endDate: "2026-02-02",
+        limit: 10,
+      },
+    } as any);
+
+    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(discoverAllSessions).mock.calls[0]?.[0]?.agentId).toBe("main");
+    expect(vi.mocked(discoverAllSessions).mock.calls[1]?.[0]?.agentId).toBe("opus");
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    const result = respond.mock.calls[0]?.[1] as any;
+    expect(result.sessions).toHaveLength(2);
+
+    // Sorted by most recent first (mtime=200 -> opus first).
+    expect(result.sessions[0].key).toBe("agent:opus:s-opus");
+    expect(result.sessions[0].agentId).toBe("opus");
+    expect(result.sessions[1].key).toBe("agent:main:s-main");
+    expect(result.sessions[1].agentId).toBe("main");
+  });
+});

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -19,6 +19,7 @@ import {
   loadSessionCostSummary,
   loadSessionUsageTimeSeries,
   discoverAllSessions,
+  type DiscoveredSession,
 } from "../../infra/session-cost-usage.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import {
@@ -27,7 +28,11 @@ import {
   formatValidationErrors,
   validateSessionsUsageParams,
 } from "../protocol/index.js";
-import { loadCombinedSessionStoreForGateway, loadSessionEntry } from "../session-utils.js";
+import {
+  listAgentsForGateway,
+  loadCombinedSessionStoreForGateway,
+  loadSessionEntry,
+} from "../session-utils.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
 
@@ -109,6 +114,27 @@ const parseDateRange = (params: {
   return { startMs: defaultStartMs, endMs: todayEndMs };
 };
 
+type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
+
+async function discoverAllSessionsForUsage(params: {
+  config: ReturnType<typeof loadConfig>;
+  startMs: number;
+  endMs: number;
+}): Promise<DiscoveredSessionWithAgent[]> {
+  const agents = listAgentsForGateway(params.config).agents;
+  const results = await Promise.all(
+    agents.map(async (agent) => {
+      const sessions = await discoverAllSessions({
+        agentId: agent.id,
+        startMs: params.startMs,
+        endMs: params.endMs,
+      });
+      return sessions.map((session) => ({ ...session, agentId: agent.id }));
+    }),
+  );
+  return results.flat().toSorted((a, b) => b.mtime - a.mtime);
+}
+
 async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
@@ -166,6 +192,7 @@ export const __test = {
   parseDateToMs,
   parseDays,
   parseDateRange,
+  discoverAllSessionsForUsage,
   loadCostUsageSummaryCached,
   costUsageCache,
 };
@@ -282,12 +309,18 @@ export const usageHandlers: GatewayRequestHandlers = {
 
     // Optimization: If a specific key is requested, skip full directory scan
     if (specificKey) {
+      const parsed = parseAgentSessionKey(specificKey);
+      const agentIdFromKey = parsed?.agentId;
+      const keyRest = parsed?.rest ?? specificKey;
+
       // Check if it's a named session in the store
       const storeEntry = store[specificKey];
-      let sessionId = storeEntry?.sessionId ?? specificKey;
+      const sessionId = storeEntry?.sessionId ?? keyRest;
 
       // Resolve the session file path
-      const sessionFile = resolveSessionFilePath(sessionId, storeEntry);
+      const sessionFile = resolveSessionFilePath(sessionId, storeEntry, {
+        agentId: agentIdFromKey,
+      });
 
       try {
         const stats = fs.statSync(sessionFile);
@@ -306,7 +339,8 @@ export const usageHandlers: GatewayRequestHandlers = {
       }
     } else {
       // Full discovery for list view
-      const discoveredSessions = await discoverAllSessions({
+      const discoveredSessions = await discoverAllSessionsForUsage({
+        config,
         startMs,
         endMs,
       });
@@ -334,7 +368,8 @@ export const usageHandlers: GatewayRequestHandlers = {
         } else {
           // Unnamed session - use session ID as key, no label
           mergedEntries.push({
-            key: discovered.sessionId,
+            // Keep agentId in the key so the dashboard can attribute sessions and later fetch logs.
+            key: `agent:${discovered.agentId}:${discovered.sessionId}`,
             sessionId: discovered.sessionId,
             sessionFile: discovered.sessionFile,
             label: undefined, // No label for unnamed sessions
@@ -711,8 +746,12 @@ export const usageHandlers: GatewayRequestHandlers = {
     const { entry } = loadSessionEntry(key);
 
     // For discovered sessions (not in store), try using key as sessionId directly
-    const sessionId = entry?.sessionId ?? key;
-    const sessionFile = entry?.sessionFile ?? resolveSessionFilePath(key);
+    const parsed = parseAgentSessionKey(key);
+    const agentId = parsed?.agentId;
+    const rawSessionId = parsed?.rest ?? key;
+    const sessionId = entry?.sessionId ?? rawSessionId;
+    const sessionFile =
+      entry?.sessionFile ?? resolveSessionFilePath(rawSessionId, entry, { agentId });
 
     const timeseries = await loadSessionUsageTimeSeries({
       sessionId,
@@ -749,8 +788,12 @@ export const usageHandlers: GatewayRequestHandlers = {
     const { entry } = loadSessionEntry(key);
 
     // For discovered sessions (not in store), try using key as sessionId directly
-    const sessionId = entry?.sessionId ?? key;
-    const sessionFile = entry?.sessionFile ?? resolveSessionFilePath(key);
+    const parsed = parseAgentSessionKey(key);
+    const agentId = parsed?.agentId;
+    const rawSessionId = parsed?.rest ?? key;
+    const sessionId = entry?.sessionId ?? rawSessionId;
+    const sessionFile =
+      entry?.sessionFile ?? resolveSessionFilePath(rawSessionId, entry, { agentId });
 
     const { loadSessionLogs } = await import("../../infra/session-cost-usage.js");
     const logs = await loadSessionLogs({


### PR DESCRIPTION
Fixes #11275
Fixes #11422

### What changed
- `sessions.usage` now discovers transcript sessions across all configured agents (not just the default agent).
- For discovered (unnamed) sessions, the returned `key` is now `agent:<agentId>:<sessionId>` so the UI can attribute sessions and follow-up calls can resolve the correct transcript path.
- Follow-up handlers (`sessions.usage.timeseries` / `sessions.usage.logs`) now correctly parse `agent:<id>:...` keys for discovered sessions.

### Tests
- Added `src/gateway/server-methods/usage.sessions-usage.test.ts` covering multi-agent discovery + key shaping.
- `pnpm test` (full suite) locally.

### Manual testing
I (the committer) cannot do real multi-agent user testing here because the operator doesn't have a multi-agent setup; this is covered via unit tests instead.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Gateway usage endpoints to discover transcript sessions across all configured agents (instead of only the default), and introduces an agent-scoped key format for discovered/unnamed sessions so the UI can attribute sessions and fetch follow-up data.

Implementation-wise, `sessions.usage` now scans each agent via `discoverAllSessionsForUsage` (parallelized over `listAgentsForGateway(config).agents`), sorts results by mtime, merges with the combined session store, and emits discovered keys shaped like `agent:<agentId>:<sessionId>`. The `sessions.usage.timeseries` and `sessions.usage.logs` handlers now parse agent-prefixed keys so they resolve the correct transcript path for discovered sessions.

A unit test was added to validate multi-agent discovery and key shaping.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of correctness gaps around key handling and agent attribution.
- The multi-agent discovery and downstream parsing changes are coherent, but the `sessions.usage` specific-key fast path still looks up the store by the raw request key and the response derives `agentId` by parsing `merged.key`, which can be unprefixed for stored/named sessions. These issues can lead to incorrect results or missing agent attribution in realistic configurations.
- src/gateway/server-methods/usage.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->