### PR TITLE
fix(control-ui): hide tool-only assistant messages when thinking is off

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -506,6 +506,28 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       continue;
     }
 
+    // Hide assistant messages that contain only tool calls/thinking when thinking is off
+    if (
+      !props.showThinking &&
+      normalized.role === "assistant" &&
+      Array.isArray(raw.content) &&
+      raw.content.length > 0 &&
+      (raw.content as Array<Record<string, unknown>>).every((block) => {
+        const ct = (
+          typeof block.type === "string" ? block.type : ""
+        ).toLowerCase();
+        return (
+          ct === "toolcall" ||
+          ct === "tool_call" ||
+          ct === "tooluse" ||
+          ct === "tool_use" ||
+          ct === "thinking"
+        );
+      })
+    ) {
+      continue;
+    }
+
     items.push({
       kind: "message",
       key: messageKey(msg, i),


### PR DESCRIPTION
## Bug

When the thinking toggle is off, messages with role `toolresult` are correctly hidden. However, assistant messages that contain **only** tool calls (`toolcall`/`tool_call`/`tooluse`/`tool_use`) or `thinking` blocks are still displayed as empty bubbles in the chat.

## Fix

Add a check to also skip assistant messages where every content block is a tool call or thinking block, matching the existing behavior for toolresult messages.

## Changes

- `ui/src/ui/views/chat.ts`: Added filtering for tool-only assistant messages when `showThinking` is false

Small, surgical fix — one file, no new dependencies.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `buildChatItems` in `ui/src/ui/views/chat.ts` to additionally skip assistant messages when `showThinking` is false and the message’s `content` blocks are all tool-call or `thinking` blocks, preventing empty-looking chat bubbles.

The approach matches the existing behavior that already hides `toolresult` messages when thinking is off, but it currently relies on `raw.content` being a non-empty array, which may not cover all “empty bubble” shapes (e.g., assistant messages with missing/empty `content`).

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge, but verify it covers all empty assistant-message shapes.
- The change is localized and low-impact, but the new filter only triggers when `raw.content` is a non-empty array; if the empty-bubble messages in practice have empty/missing content, the bug can persist and should be addressed before merge.
- ui/src/ui/views/chat.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->