### PR TITLE
feat(control-ui): UX improvements — Enter key, thinking icon, auto-chat

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -145,6 +145,14 @@ export function connectGateway(host: GatewayHost) {
       void loadNodes(host as unknown as OpenClawApp, { quiet: true });
       void loadDevices(host as unknown as OpenClawApp, { quiet: true });
       void refreshActiveTab(host as unknown as Parameters<typeof refreshActiveTab>[0]);
+
+      // Auto-switch to Chat tab when connecting from the Overview page
+      if ((host as unknown as { tab: string }).tab === "overview") {
+        const appHost = host as unknown as { setTab: (tab: string) => void };
+        if (typeof appHost.setTab === "function") {
+          appHost.setTab("chat");
+        }
+      }
     },
     onClose: ({ code, reason }) => {
       host.connected = false;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -154,7 +154,7 @@ export function renderChatControls(state: AppViewState) {
             : "Toggle assistant thinking/working output"
         }
       >
-        ${icons.brain}
+        ${showThinking ? icons.brain : icons.circle}
       </button>
       <button
         class="btn btn--sm btn--icon ${focusActive ? "active" : ""}"

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -156,6 +156,12 @@ export function renderOverview(props: OverviewProps) {
                 const v = (e.target as HTMLInputElement).value;
                 props.onPasswordChange(v);
               }}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  props.onConnect();
+                }
+              }}
               placeholder="system or shared password"
             />
           </label>


### PR DESCRIPTION
Three small UX enhancements for the Control UI:

### 1. Enter key on password field triggers Connect
Users expect to press Enter after typing a password. The password field (not stored, entered every session) now submits on Enter.

### 2. Thinking toggle icon reflects state
- **On**: Brain icon (🧠)
- **Off**: Circle icon (⭕)

Provides clear visual feedback beyond the CSS `active` class highlight.

### 3. Auto-switch to Chat tab after connection
When connecting from the Overview page, automatically switches to the Chat tab on successful `onHello`. Saves a click since most users connect to chat.

## Changes

- `ui/src/ui/views/overview.ts`: Add `@keydown` handler to password input
- `ui/src/ui/app-render.helpers.ts`: Conditional icon for thinking toggle
- `ui/src/ui/app-gateway.ts`: Switch to chat tab in `onHello` callback

All three are independent, small changes. Happy to split into separate PRs if preferred.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds three Control UI UX tweaks: submitting the password field with Enter on the Overview page, showing a different icon for the thinking toggle based on state, and auto-switching to the Chat tab after a successful gateway hello.

The main integration concern is in the new auto-switch logic in `app-gateway.ts`: it switches tabs by calling `host.setTab("chat")` directly from the gateway connect layer, which can bypass the existing tab-change machinery in `app-settings.ts` that synchronizes URL state and runs per-tab side effects (polling/refresh). The other changes look localized and consistent with existing patterns.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix the tab-switch implementation to use the standard tab-change path.
- Changes are small and localized. The thinking icon and Enter-to-connect behavior look correct, but the onHello auto-switch currently calls `host.setTab` directly, which can bypass required side effects handled in `app-settings.ts:setTab`/`setTabInternal`. Fixing that should make the PR low-risk.
- ui/src/ui/app-gateway.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->