### PR TITLE
feat(control-ui): configurable page title with hostname default

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -202,6 +202,7 @@ const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
   "gateway.controlUi.basePath": "Control UI Base Path",
   "gateway.controlUi.root": "Control UI Assets Root",
+  "gateway.controlUi.pageTitle": "Control UI Page Title",
   "gateway.controlUi.allowedOrigins": "Control UI Allowed Origins",
   "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
   "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
@@ -418,6 +419,8 @@ const FIELD_HELP: Record<string, string> = {
     "Optional URL prefix where the Control UI is served (e.g. /openclaw).",
   "gateway.controlUi.root":
     "Optional filesystem root for Control UI assets (defaults to dist/control-ui).",
+  "gateway.controlUi.pageTitle":
+    "Custom browser tab title for the Control UI. Defaults to '<hostname> - OpenClaw Control'. Useful when running multiple instances.",
   "gateway.controlUi.allowedOrigins":
     "Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com).",
   "gateway.controlUi.allowInsecureAuth":
@@ -760,6 +763,7 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.remote.sshTarget": "user@host",
   "gateway.controlUi.basePath": "/openclaw",
   "gateway.controlUi.root": "dist/control-ui",
+  "gateway.controlUi.pageTitle": "My Server - OpenClaw Control",
   "gateway.controlUi.allowedOrigins": "https://control.example.com",
   "channels.mattermost.baseUrl": "https://chat.example.com",
   "agents.list[].identity.avatar": "avatars/openclaw.png",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -68,6 +68,8 @@ export type GatewayControlUiConfig = {
   basePath?: string;
   /** Optional filesystem root for Control UI assets (defaults to dist/control-ui). */
   root?: string;
+  /** Custom page title for the Control UI tab. Defaults to "<hostname> - OpenClaw Control". */
+  pageTitle?: string;
   /** Allowed browser origins for Control UI/WebChat websocket connections. */
   allowedOrigins?: string[];
   /** Allow token-only auth over insecure HTTP (default: false). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -378,6 +378,7 @@ export const OpenClawSchema = z
             enabled: z.boolean().optional(),
             basePath: z.string().optional(),
             root: z.string().optional(),
+            pageTitle: z.string().optional(),
             allowedOrigins: z.array(z.string()).optional(),
             allowInsecureAuth: z.boolean().optional(),
             dangerouslyDisableDeviceAuth: z.boolean().optional(),


### PR DESCRIPTION
## Problem

When running multiple OpenClaw instances (laptop, server, VM, etc.), all browser tabs show the same title "OpenClaw Control". The only way to distinguish them is by URL, which is not practical.

## Solution

Add a `gateway.controlUi.pageTitle` config option that:
- Defaults to `<hostname> - OpenClaw Control` using `os.hostname()` (so it works out of the box)
- Can be overridden in config to any custom string
- Is injected server-side when serving `index.html` (no client-side changes needed)
- Is HTML-escaped to prevent injection

## Config example

```json
{
  "gateway": {
    "controlUi": {
      "pageTitle": "My Server - OpenClaw Control"
    }
  }
}
```

If not set, a machine named `MateBook` would show: **MateBook - OpenClaw Control**

## Changes

- `src/config/types.gateway.ts`: Add `pageTitle` to `GatewayControlUiConfig`
- `src/config/zod-schema.ts`: Add to validation schema
- `src/config/schema.ts`: Add labels, descriptions, examples
- `src/gateway/control-ui.ts`: Inject title in `injectControlUiConfig()`, add `os.hostname()` default

## Use case

Running OpenClaw on a MateBook (WSL) and a MacOS VM — need to tell the tabs apart. Currently requires post-install `sed` patching that breaks on every update. This makes it a first-class config option.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `gateway.controlUi.pageTitle` configuration option (with UI schema metadata + zod validation) and wires it into the Control UI index.html server-side injection.

On the gateway side, `injectControlUiConfig()` now computes a default title from `os.hostname()` and attempts to replace the static `<title>` in the served HTML, while still injecting the existing `window.__OPENCLAW_*` globals.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is one functional issue where title injection can be skipped in some scenarios.
- Changes are small and localized, with config/schema updates consistent across types + zod + UI hints. The main concern is the early-return in `injectControlUiConfig()` which can prevent applying the page title when the HTML already contains the injected globals or the function is invoked more than once.
- src/gateway/control-ui.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->