### PR TITLE
fix(wizard): strip shell-style backslash escapes from workspace paths

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -290,15 +290,19 @@ export function resolveUserPath(input: string): string {
   if (!trimmed) {
     return trimmed;
   }
-  if (trimmed.startsWith("~")) {
-    const expanded = expandHomePrefix(trimmed, {
+  // Strip shell-style backslash escapes (e.g., "Mobile\ Documents" → "Mobile Documents")
+  // This is common when users copy paths from terminal autocomplete on macOS.
+  // Only unescape backslash followed by space - preserve other backslash usage.
+  const unescaped = trimmed.replace(/\\ /g, " ");
+  if (unescaped.startsWith("~")) {
+    const expanded = expandHomePrefix(unescaped, {
       home: resolveRequiredHomeDir(process.env, os.homedir),
       env: process.env,
       homedir: os.homedir,
     });
     return path.resolve(expanded);
   }
-  return path.resolve(trimmed);
+  return path.resolve(unescaped);
 }
 
 export function resolveConfigDir(


### PR DESCRIPTION
## Summary
- Strip shell-style backslash-space escapes from paths in `resolveUserPath()`
- Fixes issue where terminal autocomplete on macOS produces paths like `~/Library/Mobile\ Documents/...` that get stored literally in `openclaw.json`

## Problem
When users enter workspace paths via `openclaw configure`, terminal autocomplete often shell-escapes spaces (e.g., `Mobile\ Documents`). This backslash-space sequence was stored literally in JSON, producing an invalid path that silently fails at startup.

## Solution
`resolveUserPath()` now strips `\ ` → ` ` before resolving, so shell-escaped paths work correctly.

## Test plan
- [x] Added 3 new tests for shell-escaped path handling
- [x] All 3 tests fail before fix, pass after
- [x] Full CI gate passes (`pnpm build && pnpm check && pnpm test`)

Fixes #10939

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveUserPath()` to normalize shell-escaped spaces (`\ `) commonly produced by terminal autocomplete (notably on macOS) before `~` expansion and `path.resolve()`. It also adds unit tests covering `~` + escaped-space paths, absolute paths with escaped spaces, and ensuring Windows-style backslashes are preserved.

The change is localized to the shared path resolution utility used by config/workspace path handling, preventing incorrectly persisted `openclaw.json` workspace paths like `Mobile\ Documents` from failing at startup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to `resolveUserPath()` and are covered by new tests that demonstrate the previously failing behavior and the intended normalization. The unescaping is limited to the exact `\ ` sequence, reducing risk of corrupting legitimate backslash usage, and existing `~` handling remains intact.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->