### PR TITLE
diagnostics-otel: fix OpenTelemetry v2 resource/logs API compatibility

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -30,6 +30,7 @@ const sdkStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const sdkShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const logEmit = vi.hoisted(() => vi.fn());
 const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const loggerProviderConfigs = vi.hoisted(() => [] as Array<{ processors?: unknown[] }>);
 
 vi.mock("@opentelemetry/api", () => ({
   metrics: {
@@ -65,7 +66,9 @@ vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
 vi.mock("@opentelemetry/sdk-logs", () => ({
   BatchLogRecordProcessor: class {},
   LoggerProvider: class {
-    addLogRecordProcessor = vi.fn();
+    constructor(config?: { processors?: unknown[] }) {
+      loggerProviderConfigs.push(config ?? {});
+    }
     getLogger = vi.fn(() => ({
       emit: logEmit,
     }));
@@ -114,6 +117,7 @@ describe("diagnostics-otel service", () => {
     sdkShutdown.mockClear();
     logEmit.mockClear();
     logShutdown.mockClear();
+    loggerProviderConfigs.length = 0;
     registerLogTransportMock.mockReset();
   });
 
@@ -147,6 +151,8 @@ describe("diagnostics-otel service", () => {
         debug: vi.fn(),
       },
     });
+    expect(loggerProviderConfigs).toHaveLength(1);
+    expect(loggerProviderConfigs[0]?.processors).toHaveLength(1);
 
     emitDiagnosticEvent({
       type: "webhook.received",

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -83,10 +83,7 @@ vi.mock("@opentelemetry/sdk-trace-base", () => ({
 }));
 
 vi.mock("@opentelemetry/resources", () => ({
-  Resource: class {
-    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-    constructor(_value?: unknown) {}
-  },
+  resourceFromAttributes: vi.fn(() => ({})),
 }));
 
 vi.mock("@opentelemetry/semantic-conventions", () => ({

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -4,7 +4,7 @@ import { metrics, trace, SpanStatusCode } from "@opentelemetry/api";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
@@ -73,7 +73,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
-      const resource = new Resource({
+      const resource = resourceFromAttributes({
         [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
       });
 
@@ -210,15 +210,17 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           ...(logUrl ? { url: logUrl } : {}),
           ...(headers ? { headers } : {}),
         });
-        logProvider = new LoggerProvider({ resource });
-        logProvider.addLogRecordProcessor(
-          new BatchLogRecordProcessor(
-            logExporter,
-            typeof otel.flushIntervalMs === "number"
-              ? { scheduledDelayMillis: Math.max(1000, otel.flushIntervalMs) }
-              : {},
-          ),
-        );
+        logProvider = new LoggerProvider({
+          resource,
+          processors: [
+            new BatchLogRecordProcessor(
+              logExporter,
+              typeof otel.flushIntervalMs === "number"
+                ? { scheduledDelayMillis: Math.max(1000, otel.flushIntervalMs) }
+                : {},
+            ),
+          ],
+        });
         const otelLogger = logProvider.getLogger("openclaw");
 
         stopLogTransport = registerLogTransport((logObj) => {


### PR DESCRIPTION
## Summary

Fixes `diagnostics-otel` startup failures after upgrading OpenTelemetry dependencies.

Root cause was API drift in OTel v2:
- `@opentelemetry/resources`: `new Resource(...)` is no longer the supported constructor path.
- `@opentelemetry/sdk-logs`: `LoggerProvider#addLogRecordProcessor` is no longer available.

## Changes

- Switch resource creation to `resourceFromAttributes(...)`.
- Initialize `LoggerProvider` with `processors: [...]` instead of calling `addLogRecordProcessor(...)`.
- Update the extension unit test mock from `Resource` to `resourceFromAttributes`.

## Why this matters

Without this patch, `diagnostics-otel` fails during plugin startup and telemetry export is disabled at runtime.

## Validation

- `pnpm vitest run extensions/diagnostics-otel/src/service.test.ts`
- Manual runtime verification on a live gateway:
  - plugin starts successfully
  - `diagnostics-otel: logs exporter enabled (OTLP/HTTP)` appears in logs
  - no further plugin startup TypeErrors for diagnostics-otel

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `diagnostics-otel` plugin to match OpenTelemetry v2 API changes by switching resource creation to `resourceFromAttributes(...)` and constructing `LoggerProvider` with `processors: [...]` instead of calling `addLogRecordProcessor`.

The runtime changes in `extensions/diagnostics-otel/src/service.ts` align with the described OTel API drift, and the unit test updates the resources mock accordingly. One issue remains in the test harness: the `@opentelemetry/sdk-logs` mock `LoggerProvider` still models the removed `addLogRecordProcessor` API and does not capture/validate the new `processors` constructor option, so the test can pass without actually asserting that processors are wired.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix the unit test mock to reflect the new LoggerProvider initialization semantics.
- The production change is small and directly addresses known OTel v2 API incompatibilities. The main risk is around test coverage correctness: the current sdk-logs mock can mask regressions because it doesn’t model the new `processors` option and retains an unused API.
- extensions/diagnostics-otel/src/service.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->