### PR TITLE
feat: pluggable secrets manager integration ($secret{NAME} syntax)

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -471,6 +471,33 @@ Rules:
 
 </Accordion>
 
+<Accordion title="External secrets resolution ($secret{NAME})">
+  Configure external secret resolution for config values using `$secret{NAME}`.
+  This helps keep API keys and tokens out of plaintext `openclaw.json`.
+
+  ```json5
+  {
+    secrets: {
+      provider: "gcp", // gcp | env | keyring | aws | 1password | doppler | bitwarden | vault
+      gcp: { project: "my-project" },
+    },
+    gateway: {
+      auth: {
+        token: "$secret{OPENCLAW_GATEWAY_TOKEN}",
+      },
+    },
+  }
+  ```
+
+  Notes:
+
+  - `$secret{...}` resolves after `${ENV_VAR}` substitution.
+  - `$$secret{...}` escapes to a literal string.
+  - Without a `secrets` block, behavior is unchanged.
+
+  See [Secrets Manager](/gateway/secrets/) for provider setup, syntax details, and troubleshooting.
+</Accordion>
+
 See [Environment](/help/environment) for full precedence and sources.
 
 ## Full reference

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -475,27 +475,27 @@ Rules:
   Configure external secret resolution for config values using `$secret{NAME}`.
   This helps keep API keys and tokens out of plaintext `openclaw.json`.
 
-  ```json5
-  {
-    secrets: {
-      provider: "gcp", // gcp | env | keyring | aws | 1password | doppler | bitwarden | vault
-      gcp: { project: "my-project" },
+```json5
+{
+  secrets: {
+    provider: "gcp", // gcp | env | keyring | aws | 1password | doppler | bitwarden | vault
+    gcp: { project: "my-project" },
+  },
+  gateway: {
+    auth: {
+      token: "$secret{OPENCLAW_GATEWAY_TOKEN}",
     },
-    gateway: {
-      auth: {
-        token: "$secret{OPENCLAW_GATEWAY_TOKEN}",
-      },
-    },
-  }
-  ```
+  },
+}
+```
 
-  Notes:
+Notes:
 
-  - `$secret{...}` resolves after `${ENV_VAR}` substitution.
-  - `$$secret{...}` escapes to a literal string.
-  - Without a `secrets` block, behavior is unchanged.
+- `$secret{...}` resolves after `${ENV_VAR}` substitution.
+- `$$secret{...}` escapes to a literal string.
+- Without a `secrets` block, behavior is unchanged.
 
-  See [Secrets Manager](/gateway/secrets/) for provider setup, syntax details, and troubleshooting.
+See [Secrets Manager](/gateway/secrets/) for provider setup, syntax details, and troubleshooting.
 </Accordion>
 
 See [Environment](/help/environment) for full precedence and sources.

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -224,17 +224,22 @@ Example config:
 
 Not yet supported.
 
-### Stub Providers
+### Not Yet Implemented
 
-The following providers are recognized in config, but not yet implemented:
+The following providers are recognized in config but **will fail at runtime** if you try to
+resolve secrets through them. They exist as placeholders for future implementation:
 
-- AWS
-- 1Password
-- Doppler
-- Bitwarden
-- Vault
+- AWS Secrets Manager (`aws`)
+- 1Password (`1password`)
+- Doppler (`doppler`)
+- Bitwarden (`bitwarden`)
+- HashiCorp Vault (`vault`)
 
-Contributions are welcome.
+Setting `secrets.provider` to one of these values will pass config validation, but any
+`$secret{...}` reference will throw an error during resolution. **Do not use these in
+production configs until they are implemented.**
+
+Contributions are welcome — see the stub files in `src/config/secrets/`.
 
 ## Sync vs Async
 

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -224,10 +224,9 @@ Example config:
 
 Not yet supported.
 
-### Not Yet Implemented
+### Coming Soon
 
-The following providers are recognized in config but **will fail at runtime** if you try to
-resolve secrets through them. They exist as placeholders for future implementation:
+The following providers are recognized in config but **not yet implemented**:
 
 - AWS Secrets Manager (`aws`)
 - 1Password (`1password`)
@@ -235,9 +234,15 @@ resolve secrets through them. They exist as placeholders for future implementati
 - Bitwarden (`bitwarden`)
 - HashiCorp Vault (`vault`)
 
-Setting `secrets.provider` to one of these values will pass config validation, but any
-`$secret{...}` reference will throw an error during resolution. **Do not use these in
-production configs until they are implemented.**
+**Behavior when configured:**
+
+- If your config has `$secret{...}` references → startup **fails immediately** with a clear
+  error telling you the provider isn't available yet and listing supported alternatives.
+- If your config has **no** `$secret{...}` references → startup **succeeds with a warning**
+  in the logs, so you're aware the provider won't work when you add secret references later.
+
+This means you can safely prepare your config for a future provider switch without breaking
+your current setup — just don't add `$secret{...}` references until the provider is implemented.
 
 Contributions are welcome — see the stub files in `src/config/secrets/`.
 

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -1,0 +1,254 @@
+---
+summary: "Configure external secrets managers to keep API keys out of openclaw.json"
+read_when:
+  - Setting up secrets management
+  - Moving secrets out of plaintext config
+title: "Secrets Manager"
+---
+
+# Secrets Manager
+
+Keep API keys and tokens out of plaintext config whenever possible.
+
+## Overview
+
+By default, OpenClaw reads values directly from `openclaw.json`. That is simple, but storing
+credentials in plaintext config is a security risk (especially on shared machines or in backups).
+
+The secrets manager integration lets you reference external secrets with `$secret{NAME}`.
+At config load time, OpenClaw resolves those references using a configured provider.
+
+This is backward compatible: if you do **not** configure a `secrets` block, behavior is unchanged.
+
+## Quick Start
+
+### 1) Use `env` provider for local testing
+
+```json5
+{
+  secrets: { provider: "env" },
+  models: {
+    providers: {
+      openrouter: {
+        apiKey: "$secret{OPENROUTER_API_KEY}",
+      },
+    },
+  },
+}
+```
+
+Set the variable before starting OpenClaw:
+
+```bash
+export OPENROUTER_API_KEY="sk-or-..."
+openclaw gateway start
+```
+
+### 2) Switch to GCP Secret Manager for production
+
+```json5
+{
+  secrets: {
+    provider: "gcp",
+    gcp: { project: "my-prod-project" },
+  },
+  gateway: {
+    auth: {
+      token: "$secret{OPENCLAW_GATEWAY_TOKEN}",
+    },
+  },
+}
+```
+
+## Configuration
+
+Full `secrets` config block:
+
+```json5
+{
+  secrets: {
+    provider: "gcp" | "env" | "keyring" | "aws" | "1password" | "doppler" | "bitwarden" | "vault",
+    gcp: { project: "..." },
+    aws: { region: "..." },
+    doppler: { project: "...", config: "..." },
+    vault: { address: "...", namespace: "...", mountPath: "..." },
+    keyring: { keychainPath: "...", keychainPassword: "...", account: "..." },
+  },
+}
+```
+
+Only configure the provider block you use.
+
+## Syntax
+
+- `$secret{NAME}`: resolves to the secret value
+- `$$secret{NAME}`: escapes to literal `$secret{NAME}`
+- **Valid secret names:** alphanumeric characters, hyphens, underscores, and dots (`[a-zA-Z0-9_.-]+`). Examples: `my-api-key`, `slack.bot.token`, `DB_PASSWORD_v2`
+- Works in any string value in config
+- Resolution happens **after** `${ENV_VAR}` substitution
+  - This means you can use env vars inside `secrets` provider settings
+- The `secrets` block itself is **not** secret-resolved (prevents circular dependencies)
+
+## Provider Guides
+
+### Environment Variables (`env`)
+
+Best for local testing, CI/CD, and Docker-based deployments.
+
+```json5
+{
+  secrets: { provider: "env" },
+  channels: {
+    telegram: {
+      botToken: "$secret{TELEGRAM_BOT_TOKEN}",
+    },
+  },
+}
+```
+
+Set environment variables:
+
+```bash
+export TELEGRAM_BOT_TOKEN="123456:ABC..."
+export OPENROUTER_API_KEY="sk-or-..."
+```
+
+In CI/Docker, set them using your platform’s secret/env settings.
+
+### GCP Secret Manager (`gcp`)
+
+Prerequisites:
+
+- Install dependency: `pnpm add @google-cloud/secret-manager`
+- Configure ADC (Application Default Credentials)
+
+Create a secret:
+
+```bash
+gcloud secrets create NAME --data-file=-
+```
+
+Then paste/pipe the secret value when prompted.
+
+Example config:
+
+```json5
+{
+  secrets: {
+    provider: "gcp",
+    gcp: { project: "my-project-id" },
+  },
+  models: {
+    providers: {
+      openai: {
+        apiKey: "$secret{OPENAI_API_KEY}",
+      },
+    },
+  },
+}
+```
+
+How ADC works:
+
+- Local development: typically uses your user credentials from `gcloud auth application-default login`
+- Containers/servers: typically uses attached service account credentials
+
+### OS Keyring (`keyring`)
+
+#### macOS
+
+Uses the `security` CLI with a dedicated OpenClaw keychain.
+
+Create keychain:
+
+```bash
+security create-keychain -p '' ~/Library/Keychains/openclaw.keychain-db
+```
+
+Add secret:
+
+```bash
+security add-generic-password -a openclaw -s NAME -w "VALUE" ~/Library/Keychains/openclaw.keychain-db
+```
+
+Example config:
+
+```json5
+{
+  secrets: {
+    provider: "keyring",
+    keyring: {
+      keychainPath: "~/Library/Keychains/openclaw.keychain-db",
+      keychainPassword: "",
+      account: "openclaw",
+    },
+  },
+}
+```
+
+#### Linux
+
+Uses `secret-tool` (libsecret / D-Bus Secret Service).
+
+Install libsecret tools:
+
+```bash
+# Arch
+sudo pacman -S libsecret
+
+# Debian/Ubuntu
+sudo apt install libsecret-tools
+
+# Fedora
+sudo dnf install libsecret
+```
+
+Add secret:
+
+```bash
+echo -n "VALUE" | secret-tool store --label="openclaw: NAME" service openclaw key NAME
+```
+
+Example config:
+
+```json5
+{
+  secrets: {
+    provider: "keyring",
+  },
+}
+```
+
+#### Windows
+
+Not yet supported.
+
+### Stub Providers
+
+The following providers are recognized in config, but not yet implemented:
+
+- AWS
+- 1Password
+- Doppler
+- Bitwarden
+- Vault
+
+Contributions are welcome.
+
+## Sync vs Async
+
+`$secret{...}` resolution requires async config loading.
+
+The Gateway handles this automatically during normal startup. If secret references are detected in a sync-only load path, OpenClaw throws a clear error instead of silently continuing.
+
+## Troubleshooting
+
+- `Failed to load @google-cloud/secret-manager`
+  - Install the dependency in your OpenClaw environment:
+    - `pnpm add @google-cloud/secret-manager`
+- `secret-tool not found`
+  - Install libsecret tools (`libsecret-tools` on Debian/Ubuntu)
+- `Secret not found in keychain`
+  - Add it with the keychain CLI commands above and verify `NAME` matches exactly
+- `Config contains $secret{...} references but secrets can only be resolved in async mode`
+  - Start the gateway normally (`openclaw gateway start`) so async config loading is used

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -121,6 +121,7 @@ Prerequisites:
 
 - Install dependency: `pnpm add @google-cloud/secret-manager`
 - Configure ADC (Application Default Credentials)
+- Set `project` in config (required — Secret Manager doesn't support automatic project discovery)
 
 Create a secret:
 

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -68,7 +68,7 @@ Full `secrets` config block:
 {
   secrets: {
     provider: "gcp" | "env" | "keyring" | "aws" | "1password" | "doppler" | "bitwarden" | "vault",
-    gcp: { project: "..." },
+    gcp: { project: "..." },          // required when provider is "gcp"
     aws: { region: "..." },
     doppler: { project: "...", config: "..." },
     vault: { address: "...", namespace: "...", mountPath: "..." },
@@ -242,8 +242,22 @@ Contributions are welcome.
 
 The Gateway handles this automatically during normal startup. If secret references are detected in a sync-only load path, OpenClaw throws a clear error instead of silently continuing.
 
+## Error Diagnostics
+
+When `$secret{...}` references remain unresolved (e.g. sync load path), error messages include
+the full config path where each reference was found:
+
+```
+Unresolved secret references: $secret{OPENAI_KEY} at models.providers.openai.apiKey
+```
+
+This helps you quickly locate which config field needs attention, especially in large configs
+with multiple secret references.
+
 ## Troubleshooting
 
+- `GCP secrets provider requires 'gcp.project' to be set`
+  - Add `gcp: { project: "your-project-id" }` to your `secrets` config block
 - `Failed to load @google-cloud/secret-manager`
   - Install the dependency in your OpenClaw environment:
     - `pnpm add @google-cloud/secret-manager`

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -67,6 +67,8 @@ Full `secrets` config block:
 ```json5
 {
   secrets: {
+    // Supported: gcp, env, keyring
+    // Planned (not yet implemented): aws, 1password, doppler, bitwarden, vault
     provider: "gcp" | "env" | "keyring" | "aws" | "1password" | "doppler" | "bitwarden" | "vault",
     gcp: { project: "..." },          // required when provider is "gcp"
     aws: { region: "..." },

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -58,6 +58,9 @@ Use this when auditing access or deciding what to back up:
 - **Telegram bot token**: config/env or `channels.telegram.tokenFile`
 - **Discord bot token**: config/env (token file not yet supported)
 - **Slack tokens**: config/env (`channels.slack.*`)
+- **Secrets manager**: When configured, API keys and tokens can be stored in external
+  secrets managers (GCP Secret Manager, OS Keyring, etc.) instead of plaintext in config.
+  See [Secrets Manager](/gateway/secrets/) for setup.
 - **Pairing allowlists**: `~/.openclaw/credentials/<channel>-allowFrom.json`
 - **Model auth profiles**: `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
 - **Legacy OAuth import**: `~/.openclaw/credentials/oauth.json`
@@ -70,8 +73,9 @@ When the audit prints findings, treat this as a priority order:
 2. **Public network exposure** (LAN bind, Funnel, missing auth): fix immediately.
 3. **Browser control remote exposure**: treat it like operator access (tailnet-only, pair nodes deliberately, avoid public exposure).
 4. **Permissions**: make sure state/config/credentials/auth are not group/world-readable.
-5. **Plugins/extensions**: only load what you explicitly trust.
-6. **Model choice**: prefer modern, instruction-hardened models for any bot with tools.
+5. **Secrets management**: consider storing sensitive credentials in an external secrets manager instead of plaintext config.
+6. **Plugins/extensions**: only load what you explicitly trust.
+7. **Model choice**: prefer modern, instruction-hardened models for any bot with tools.
 
 ## Control UI over HTTP
 

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
+    "@google-cloud/secret-manager": "^6.1.0",
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.15.1"
   },

--- a/package.json
+++ b/package.json
@@ -195,6 +195,17 @@
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.15.1"
   },
+  "peerDependenciesMeta": {
+    "@google-cloud/secret-manager": {
+      "optional": true
+    },
+    "@napi-rs/canvas": {
+      "optional": true
+    },
+    "node-llama-cpp": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=22.12.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,24 +642,12 @@ packages:
     resolution: {integrity: sha512-1/bog4fe1K8xie4JT9WGDIiNGAI6J/mDB6skOYayMzcSCbvsDU5TouEHweYzv53xkwsZaomNszNkTcXS6BFLmA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-sso@3.988.0':
-    resolution: {integrity: sha512-ThqQ7aF1k0Zz4yJRwegHw+T1rM3a7ZPvvEUSEdvn5Z8zTeWgJAbtqW/6ejPsMLmFOlHgNcwDQN/e69OvtEOoIQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/client-sso@3.990.0':
     resolution: {integrity: sha512-xTEaPjZwOqVjGbLOP7qzwbdOWJOo1ne2mUhTZwEBBkPvNk4aXB/vcYwWwrjoSWUqtit4+GDbO75ePc/S6TUJYQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.973.10':
     resolution: {integrity: sha512-4u/FbyyT3JqzfsESI70iFg6e2yp87MB5kS2qcxIA66m52VSTN1fvuvbCY1h/LKq1LvuxIrlJ1ItcyjvcKoaPLg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.973.8':
-    resolution: {integrity: sha512-WeYJ2sfvRLbbUIrjGMUXcEHGu5SJk53jz3K9F8vFP42zWyROzPJ2NB6lMu9vWl5hnMwzwabX7pJc9Euh3JyMGw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.6':
-    resolution: {integrity: sha512-+dYEBWgTqkQQHFUllvBL8SLyXyLKWdxLMD1LmKJRvmb0NMJuaJFG/qg78C+LE67eeGbipYcE+gJ48VlLBGHlMw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.8':
@@ -670,52 +658,24 @@ packages:
     resolution: {integrity: sha512-DTtuyXSWB+KetzLcWaSahLJCtTUe/3SXtlGp4ik9PCe9xD6swHEkG8n8/BNsQ9dsihb9nhFvuUB4DpdBGDcvVg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.8':
-    resolution: {integrity: sha512-z3QkozMV8kOFisN2pgRag/f0zPDrw96mY+ejAM0xssV/+YQ2kklbylRNI/TcTQUDnGg0yPxNjyV6F2EM2zPTwg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.6':
-    resolution: {integrity: sha512-6tkIYFv3sZH1XsjQq+veOmx8XWRnyqTZ5zx/sMtdu/xFRIzrJM1Y2wAXeCJL1rhYSB7uJSZ1PgALI2WVTj78ow==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-ini@3.972.8':
     resolution: {integrity: sha512-n2dMn21gvbBIEh00E8Nb+j01U/9rSqFIamWRdGm/mE5e+vHQ9g0cBNdrYFlM6AAiryKVHZmShWT9D1JAWJ3ISw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.6':
-    resolution: {integrity: sha512-LXsoBoaTSGHdRCQXlWSA0CHHh05KWncb592h9ElklnPus++8kYn1Ic6acBR4LKFQ0RjjMVgwe5ypUpmTSUOjPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.8':
     resolution: {integrity: sha512-rMFuVids8ICge/X9DF5pRdGMIvkVhDV9IQFQ8aTYk6iF0rl9jOUa1C3kjepxiXUlpgJQT++sLZkT9n0TMLHhQw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.7':
-    resolution: {integrity: sha512-PuJ1IkISG7ZDpBFYpGotaay6dYtmriBYuHJ/Oko4VHxh8YN5vfoWnMNYFEWuzOfyLmP7o9kDVW0BlYIpb3skvw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-node@3.972.9':
     resolution: {integrity: sha512-LfJfO0ClRAq2WsSnA9JuUsNyIicD2eyputxSlSL0EiMrtxOxELLRG6ZVYDf/a1HCepaYPXeakH4y8D5OLCauag==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.6':
-    resolution: {integrity: sha512-Yf34cjIZJHVnD92jnVYy3tNjM+Q4WJtffLK2Ehn0nKpZfqd1m7SI0ra22Lym4C53ED76oZENVSS2wimoXJtChQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.8':
     resolution: {integrity: sha512-6cg26ffFltxM51OOS8NH7oE41EccaYiNlbd5VgUYwhiGCySLfHoGuGrLm2rMB4zhy+IO5nWIIG0HiodX8zdvHA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.6':
-    resolution: {integrity: sha512-2+5UVwUYdD4BBOkLpKJ11MQ8wQeyJGDVMDRH5eWOULAh9d6HJq07R69M/mNNMC9NTjr3mB1T0KGDn4qyQh5jzg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-sso@3.972.8':
     resolution: {integrity: sha512-35kqmFOVU1n26SNv+U37sM8b2TzG8LyqAcd6iM9gprqxyHEh/8IM3gzN4Jzufs3qM6IrH8e43ryZWYdvfVzzKQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.6':
-    resolution: {integrity: sha512-pdJzwKtlDxBnvZ04pWMqttijmkUIlwOsS0GcxCjzEVyUMpARysl0S0ks74+gs2Pdev3Ujz+BTAjOc1tQgAxGqA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.8':
@@ -744,10 +704,6 @@ packages:
 
   '@aws-sdk/middleware-user-agent@3.972.10':
     resolution: {integrity: sha512-bBEL8CAqPQkI91ZM5a9xnFAzedpzH6NYCOtNyLarRAzTUTFN2DKqaC60ugBa7pnU1jSi4mA7WAXBsrod7nJltg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.972.8':
-    resolution: {integrity: sha512-3PGL+Kvh1PhB0EeJeqNqOWQgipdqFheO4OUKc6aYiFwEpM5t9AyE5hjjxZ5X6iSj8JiduWFZLPwASzF6wQRgFg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-websocket@3.972.6':
@@ -796,15 +752,6 @@ packages:
 
   '@aws-sdk/util-user-agent-browser@3.972.3':
     resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
-
-  '@aws-sdk/util-user-agent-node@3.972.6':
-    resolution: {integrity: sha512-966xH8TPqkqOXP7EwnEThcKKz0SNP9kVJBKd9M8bNXE4GSqVouMKKnFBwYnzbWVKuLXubzX5seokcX4a0JLJIA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
 
   '@aws-sdk/util-user-agent-node@3.972.8':
     resolution: {integrity: sha512-XJZuT0LWsFCW1C8dEpPAXSa7h6Pb3krr2y//1X0Zidpcl0vmgY5nL/X0JuBZlntpBzaN3+U4hvKjuijyiiR8zw==}
@@ -5927,21 +5874,21 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/credential-provider-node': 3.972.7
+      '@aws-sdk/core': 3.973.10
+      '@aws-sdk/credential-provider-node': 3.972.9
       '@aws-sdk/eventstream-handler-node': 3.972.5
       '@aws-sdk/middleware-eventstream': 3.972.3
       '@aws-sdk/middleware-host-header': 3.972.3
       '@aws-sdk/middleware-logger': 3.972.3
       '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.8
+      '@aws-sdk/middleware-user-agent': 3.972.10
       '@aws-sdk/middleware-websocket': 3.972.6
       '@aws-sdk/region-config-resolver': 3.972.3
       '@aws-sdk/token-providers': 3.988.0
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-endpoints': 3.988.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.6
+      '@aws-sdk/util-user-agent-node': 3.972.8
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.23.0
       '@smithy/eventstream-serde-browser': 4.2.8
@@ -5991,49 +5938,6 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.990.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
       '@aws-sdk/util-user-agent-node': 3.972.8
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sso@3.988.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.8
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.988.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.6
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.23.0
       '@smithy/fetch-http-handler': 5.3.9
@@ -6122,30 +6026,6 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.973.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/xml-builder': 3.972.4
-      '@smithy/core': 3.23.0
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/signature-v4': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.6':
-    dependencies:
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-env@3.972.8':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -6167,38 +6047,6 @@ snapshots:
       '@smithy/util-stream': 4.5.12
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.8':
-    dependencies:
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/types': 3.973.1
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/util-stream': 4.5.12
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.6':
-    dependencies:
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/credential-provider-env': 3.972.6
-      '@aws-sdk/credential-provider-http': 3.972.8
-      '@aws-sdk/credential-provider-login': 3.972.6
-      '@aws-sdk/credential-provider-process': 3.972.6
-      '@aws-sdk/credential-provider-sso': 3.972.6
-      '@aws-sdk/credential-provider-web-identity': 3.972.6
-      '@aws-sdk/nested-clients': 3.988.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-ini@3.972.8':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -6218,19 +6066,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.6':
-    dependencies:
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/nested-clients': 3.988.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-login@3.972.8':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -6238,23 +6073,6 @@ snapshots:
       '@aws-sdk/types': 3.973.1
       '@smithy/property-provider': 4.2.8
       '@smithy/protocol-http': 5.3.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.972.7':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.6
-      '@aws-sdk/credential-provider-http': 3.972.8
-      '@aws-sdk/credential-provider-ini': 3.972.6
-      '@aws-sdk/credential-provider-process': 3.972.6
-      '@aws-sdk/credential-provider-sso': 3.972.6
-      '@aws-sdk/credential-provider-web-identity': 3.972.6
-      '@aws-sdk/types': 3.973.1
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
       '@smithy/shared-ini-file-loader': 4.4.3
       '@smithy/types': 4.12.0
       tslib: 2.8.1
@@ -6278,15 +6096,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.6':
-    dependencies:
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-process@3.972.8':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -6296,36 +6105,11 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.6':
-    dependencies:
-      '@aws-sdk/client-sso': 3.988.0
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/token-providers': 3.988.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-sso@3.972.8':
     dependencies:
       '@aws-sdk/client-sso': 3.990.0
       '@aws-sdk/core': 3.973.10
       '@aws-sdk/token-providers': 3.990.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.972.6':
-    dependencies:
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/nested-clients': 3.988.0
       '@aws-sdk/types': 3.973.1
       '@smithy/property-provider': 4.2.8
       '@smithy/shared-ini-file-loader': 4.4.3
@@ -6391,16 +6175,6 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.8':
-    dependencies:
-      '@aws-sdk/core': 3.973.8
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.988.0
-      '@smithy/core': 3.23.0
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-websocket@3.972.6':
     dependencies:
       '@aws-sdk/types': 3.973.1
@@ -6420,16 +6194,16 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/core': 3.973.10
       '@aws-sdk/middleware-host-header': 3.972.3
       '@aws-sdk/middleware-logger': 3.972.3
       '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.8
+      '@aws-sdk/middleware-user-agent': 3.972.10
       '@aws-sdk/region-config-resolver': 3.972.3
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-endpoints': 3.988.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.6
+      '@aws-sdk/util-user-agent-node': 3.972.8
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.23.0
       '@smithy/fetch-http-handler': 5.3.9
@@ -6512,7 +6286,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.988.0':
     dependencies:
-      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/core': 3.973.10
       '@aws-sdk/nested-clients': 3.988.0
       '@aws-sdk/types': 3.973.1
       '@smithy/property-provider': 4.2.8
@@ -6571,14 +6345,6 @@ snapshots:
       '@aws-sdk/types': 3.973.1
       '@smithy/types': 4.12.0
       bowser: 2.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.972.6':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.8
-      '@aws-sdk/types': 3.973.1
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.972.8':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,10 +24,13 @@ importers:
         version: 3.990.0
       '@buape/carbon':
         specifier: 0.14.0
-        version: 0.14.0(hono@4.11.9)
+        version: 0.14.0(hono@4.11.8)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
+      '@google-cloud/secret-manager':
+        specifier: ^6.1.0
+        version: 6.1.1
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.40.0)
@@ -63,7 +66,7 @@ importers:
         version: 0.6.0
       '@napi-rs/canvas':
         specifier: ^0.1.89
-        version: 0.1.92
+        version: 0.1.91
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
@@ -631,12 +634,16 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-bedrock-runtime@3.990.0':
-    resolution: {integrity: sha512-8TtV9c0DWGxwYvlcED/NlhTM0aDHM9yb0Y3Q0b0NQwiyrahX+qlck/Wo8fJQ7GHAkFn8MtczvAQzbLszyo+w0Q==}
+  '@aws-sdk/client-bedrock-runtime@3.988.0':
+    resolution: {integrity: sha512-NZlsQ8rjmAG0zRteqEiRakV97/nToIwDqT0zbye+j+HN60wiRSESAFCEozdwiiuVr0xl69NcoTiMg64xbh2I9g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-bedrock@3.990.0':
     resolution: {integrity: sha512-1/bog4fe1K8xie4JT9WGDIiNGAI6J/mDB6skOYayMzcSCbvsDU5TouEHweYzv53xkwsZaomNszNkTcXS6BFLmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sso@3.988.0':
+    resolution: {integrity: sha512-ThqQ7aF1k0Zz4yJRwegHw+T1rM3a7ZPvvEUSEdvn5Z8zTeWgJAbtqW/6ejPsMLmFOlHgNcwDQN/e69OvtEOoIQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sso@3.990.0':
@@ -647,6 +654,14 @@ packages:
     resolution: {integrity: sha512-4u/FbyyT3JqzfsESI70iFg6e2yp87MB5kS2qcxIA66m52VSTN1fvuvbCY1h/LKq1LvuxIrlJ1ItcyjvcKoaPLg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.973.8':
+    resolution: {integrity: sha512-WeYJ2sfvRLbbUIrjGMUXcEHGu5SJk53jz3K9F8vFP42zWyROzPJ2NB6lMu9vWl5hnMwzwabX7pJc9Euh3JyMGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.6':
+    resolution: {integrity: sha512-+dYEBWgTqkQQHFUllvBL8SLyXyLKWdxLMD1LmKJRvmb0NMJuaJFG/qg78C+LE67eeGbipYcE+gJ48VlLBGHlMw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.8':
     resolution: {integrity: sha512-r91OOPAcHnLCSxaeu/lzZAVRCZ/CtTNuwmJkUwpwSDshUrP7bkX1OmFn2nUMWd9kN53Q4cEo8b7226G4olt2Mg==}
     engines: {node: '>=20.0.0'}
@@ -655,24 +670,52 @@ packages:
     resolution: {integrity: sha512-DTtuyXSWB+KetzLcWaSahLJCtTUe/3SXtlGp4ik9PCe9xD6swHEkG8n8/BNsQ9dsihb9nhFvuUB4DpdBGDcvVg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.8':
+    resolution: {integrity: sha512-z3QkozMV8kOFisN2pgRag/f0zPDrw96mY+ejAM0xssV/+YQ2kklbylRNI/TcTQUDnGg0yPxNjyV6F2EM2zPTwg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.6':
+    resolution: {integrity: sha512-6tkIYFv3sZH1XsjQq+veOmx8XWRnyqTZ5zx/sMtdu/xFRIzrJM1Y2wAXeCJL1rhYSB7uJSZ1PgALI2WVTj78ow==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.8':
     resolution: {integrity: sha512-n2dMn21gvbBIEh00E8Nb+j01U/9rSqFIamWRdGm/mE5e+vHQ9g0cBNdrYFlM6AAiryKVHZmShWT9D1JAWJ3ISw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.6':
+    resolution: {integrity: sha512-LXsoBoaTSGHdRCQXlWSA0CHHh05KWncb592h9ElklnPus++8kYn1Ic6acBR4LKFQ0RjjMVgwe5ypUpmTSUOjPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.8':
     resolution: {integrity: sha512-rMFuVids8ICge/X9DF5pRdGMIvkVhDV9IQFQ8aTYk6iF0rl9jOUa1C3kjepxiXUlpgJQT++sLZkT9n0TMLHhQw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.7':
+    resolution: {integrity: sha512-PuJ1IkISG7ZDpBFYpGotaay6dYtmriBYuHJ/Oko4VHxh8YN5vfoWnMNYFEWuzOfyLmP7o9kDVW0BlYIpb3skvw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.9':
     resolution: {integrity: sha512-LfJfO0ClRAq2WsSnA9JuUsNyIicD2eyputxSlSL0EiMrtxOxELLRG6ZVYDf/a1HCepaYPXeakH4y8D5OLCauag==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.6':
+    resolution: {integrity: sha512-Yf34cjIZJHVnD92jnVYy3tNjM+Q4WJtffLK2Ehn0nKpZfqd1m7SI0ra22Lym4C53ED76oZENVSS2wimoXJtChQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.8':
     resolution: {integrity: sha512-6cg26ffFltxM51OOS8NH7oE41EccaYiNlbd5VgUYwhiGCySLfHoGuGrLm2rMB4zhy+IO5nWIIG0HiodX8zdvHA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.6':
+    resolution: {integrity: sha512-2+5UVwUYdD4BBOkLpKJ11MQ8wQeyJGDVMDRH5eWOULAh9d6HJq07R69M/mNNMC9NTjr3mB1T0KGDn4qyQh5jzg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.8':
     resolution: {integrity: sha512-35kqmFOVU1n26SNv+U37sM8b2TzG8LyqAcd6iM9gprqxyHEh/8IM3gzN4Jzufs3qM6IrH8e43ryZWYdvfVzzKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.6':
+    resolution: {integrity: sha512-pdJzwKtlDxBnvZ04pWMqttijmkUIlwOsS0GcxCjzEVyUMpARysl0S0ks74+gs2Pdev3Ujz+BTAjOc1tQgAxGqA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.8':
@@ -703,9 +746,17 @@ packages:
     resolution: {integrity: sha512-bBEL8CAqPQkI91ZM5a9xnFAzedpzH6NYCOtNyLarRAzTUTFN2DKqaC60ugBa7pnU1jSi4mA7WAXBsrod7nJltg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.972.8':
+    resolution: {integrity: sha512-3PGL+Kvh1PhB0EeJeqNqOWQgipdqFheO4OUKc6aYiFwEpM5t9AyE5hjjxZ5X6iSj8JiduWFZLPwASzF6wQRgFg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-websocket@3.972.6':
     resolution: {integrity: sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==}
     engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.988.0':
+    resolution: {integrity: sha512-OgYV9k1oBCQ6dOM+wWAMNNehXA8L4iwr7ydFV+JDHyuuu0Ko7tDXnLEtEmeQGYRcAFU3MGasmlBkMB8vf4POrg==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.990.0':
     resolution: {integrity: sha512-3NA0s66vsy8g7hPh36ZsUgO4SiMyrhwcYvuuNK1PezO52vX3hXDW4pQrC6OQLGKGJV0o6tbEyQtXb/mPs8zg8w==}
@@ -715,12 +766,20 @@ packages:
     resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.988.0':
+    resolution: {integrity: sha512-xvXVlRVKHnF2h6fgWBm64aPP5J+58aJyGfRrQa/uFh8a9mcK68mLfJOYq+ZSxQy/UN3McafJ2ILAy7IWzT9kRw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.990.0':
     resolution: {integrity: sha512-L3BtUb2v9XmYgQdfGBzbBtKMXaP5fV973y3Qdxeevs6oUTVXFmi/mV1+LnScA/1wVPJC9/hlK+1o5vbt7cG7EQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.1':
     resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.988.0':
+    resolution: {integrity: sha512-HuXu4boeUWU0DQiLslbgdvuQ4ZMCo4Lsk97w8BIUokql2o9MvjE5dwqI5pzGt0K7afO1FybjidUQVTMLuZNTOA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.990.0':
@@ -737,6 +796,15 @@ packages:
 
   '@aws-sdk/util-user-agent-browser@3.972.3':
     resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
+
+  '@aws-sdk/util-user-agent-node@3.972.6':
+    resolution: {integrity: sha512-966xH8TPqkqOXP7EwnEThcKKz0SNP9kVJBKd9M8bNXE4GSqVouMKKnFBwYnzbWVKuLXubzX5seokcX4a0JLJIA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
 
   '@aws-sdk/util-user-agent-node@3.972.8':
     resolution: {integrity: sha512-XJZuT0LWsFCW1C8dEpPAXSa7h6Pb3krr2y//1X0Zidpcl0vmgY5nL/X0JuBZlntpBzaN3+U4hvKjuijyiiR8zw==}
@@ -1051,8 +1119,12 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
-  '@google/genai@1.41.0':
-    resolution: {integrity: sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ==}
+  '@google-cloud/secret-manager@6.1.1':
+    resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
+    engines: {node: '>=18'}
+
+  '@google/genai@1.40.0':
+    resolution: {integrity: sha512-fhIww8smT0QYRX78qWOiz/nIQhHMF5wXOrlXvj33HBrz3vKDBb+wibLcEmTA+L9dmPD4KmfNr7UF3LDQVTXNjA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -1100,8 +1172,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@huggingface/jinja@0.5.5':
-    resolution: {integrity: sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==}
+  '@huggingface/jinja@0.5.4':
+    resolution: {integrity: sha512-VoQJywjpjy2D88Oj0BTHRuS8JCbUgoOg5t1UGgbtGh2fRia9Dx/k6Wf8FqrEWIvWK9fAkfJeeLB9fcSpCNPCpw==}
     engines: {node: '>=18'}
 
   '@img/colour@1.0.0':
@@ -1241,13 +1313,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
+    engines: {node: 20 || >=22}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
-
-  '@isaacs/cliui@9.0.0':
-    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
-    engines: {node: '>=18'}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -1498,74 +1574,74 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
-  '@napi-rs/canvas-android-arm64@0.1.92':
-    resolution: {integrity: sha512-rDOtq53ujfOuevD5taxAuIFALuf1QsQWZe1yS/N4MtT+tNiDBEdjufvQRPWZ11FubL2uwgP8ApYU3YOaNu1ZsQ==}
+  '@napi-rs/canvas-android-arm64@0.1.91':
+    resolution: {integrity: sha512-SLLzXXgSnfct4zy/BVAfweZQkYkPJsNsJ2e5DOE8DFEHC6PufyUrwb12yqeu2So2IOIDpWJJaDAxKY/xpy6MYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-darwin-arm64@0.1.92':
-    resolution: {integrity: sha512-4PT6GRGCr7yMRehp42x0LJb1V0IEy1cDZDDayv7eKbFUIGbPFkV7CRC9Bee5MPkjg1EB4ZPXXUyy3gjQm7mR8Q==}
+  '@napi-rs/canvas-darwin-arm64@0.1.91':
+    resolution: {integrity: sha512-bzdbCjIjw3iRuVFL+uxdSoMra/l09ydGNX9gsBxO/zg+5nlppscIpj6gg+nL6VNG85zwUarDleIrUJ+FWHvmuA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-x64@0.1.92':
-    resolution: {integrity: sha512-5e/3ZapP7CqPtDcZPtmowCsjoyQwuNMMD7c0GKPtZQ8pgQhLkeq/3fmk0HqNSD1i227FyJN/9pDrhw/UMTkaWA==}
+  '@napi-rs/canvas-darwin-x64@0.1.91':
+    resolution: {integrity: sha512-q3qpkpw0IsG9fAS/dmcGIhCVoNxj8ojbexZKWwz3HwxlEWsLncEQRl4arnxrwbpLc2nTNTyj4WwDn7QR5NDAaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.92':
-    resolution: {integrity: sha512-j6KaLL9iir68lwpzzY+aBGag1PZp3+gJE2mQ3ar4VJVmyLRVOh+1qsdNK1gfWoAVy5w6U7OEYFrLzN2vOFUSng==}
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.91':
+    resolution: {integrity: sha512-Io3g8wJZVhK8G+Fpg1363BE90pIPqg+ZbeehYNxPWDSzbgwU3xV0l8r/JBzODwC7XHi1RpFEk+xyUTMa2POj6w==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.92':
-    resolution: {integrity: sha512-s3NlnJMHOSotUYVoTCoC1OcomaChFdKmZg0VsHFeIkeHbwX0uPHP4eCX1irjSfMykyvsGHTQDfBAtGYuqxCxhQ==}
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.91':
+    resolution: {integrity: sha512-HBnto+0rxx1bQSl8bCWA9PyBKtlk2z/AI32r3cu4kcNO+M/5SD4b0v1MWBWZyqMQyxFjWgy3ECyDjDKMC6tY1A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.92':
-    resolution: {integrity: sha512-xV0GQnukYq5qY+ebkAwHjnP2OrSGBxS3vSi1zQNQj0bkXU6Ou+Tw7JjCM7pZcQ28MUyEBS1yKfo7rc7ip2IPFQ==}
+  '@napi-rs/canvas-linux-arm64-musl@0.1.91':
+    resolution: {integrity: sha512-/eJtVe2Xw9A86I4kwXpxxoNagdGclu12/NSMsfoL8q05QmeRCbfjhg1PJS7ENAuAvaiUiALGrbVfeY1KU1gztQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.92':
-    resolution: {integrity: sha512-+GKvIFbQ74eB/TopEdH6XIXcvOGcuKvCITLGXy7WLJAyNp3Kdn1ncjxg91ihatBaPR+t63QOE99yHuIWn3UQ9w==}
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.91':
+    resolution: {integrity: sha512-floNK9wQuRWevUhhXRcuis7h0zirdytVxPgkonWO+kQlbvxV7gEUHGUFQyq4n55UHYFwgck1SAfJ1HuXv/+ppQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.92':
-    resolution: {integrity: sha512-tFd6MwbEhZ1g64iVY2asV+dOJC+GT3Yd6UH4G3Hp0/VHQ6qikB+nvXEULskFYZ0+wFqlGPtXjG1Jmv7sJy+3Ww==}
+  '@napi-rs/canvas-linux-x64-gnu@0.1.91':
+    resolution: {integrity: sha512-c3YDqBdf7KETuZy2AxsHFMsBBX1dWT43yFfWUq+j1IELdgesWtxf/6N7csi3VPf6VA3PmnT9EhMyb+M1wfGtqw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.92':
-    resolution: {integrity: sha512-uSuqeSveB/ZGd72VfNbHCSXO9sArpZTvznMVsb42nqPP7gBGEH6NJQ0+hmF+w24unEmxBhPYakP/Wiosm16KkA==}
+  '@napi-rs/canvas-linux-x64-musl@0.1.91':
+    resolution: {integrity: sha512-RpZ3RPIwgEcNBHSHSX98adm+4VP8SMT5FN6250s5jQbWpX/XNUX5aLMfAVJS/YnDjS1QlsCgQxFOPU0aCCWgag==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.92':
-    resolution: {integrity: sha512-20SK5AU/OUNz9ZuoAPj5ekWai45EIBDh/XsdrVZ8le/pJVlhjFU3olbumSQUXRFn7lBRS+qwM8kA//uLaDx6iQ==}
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.91':
+    resolution: {integrity: sha512-gF8MBp4X134AgVurxqlCdDA2qO0WaDdi9o6Sd5rWRVXRhWhYQ6wkdEzXNLIrmmros0Tsp2J0hQzx4ej/9O8trQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.92':
-    resolution: {integrity: sha512-KEhyZLzq1MXCNlXybz4k25MJmHFp+uK1SIb8yJB0xfrQjz5aogAMhyseSzewo+XxAq3OAOdyKvfHGNzT3w1RPg==}
+  '@napi-rs/canvas-win32-x64-msvc@0.1.91':
+    resolution: {integrity: sha512-++gtW9EV/neKI8TshD8WFxzBYALSPag2kFRahIJV+LYsyt5kBn21b1dBhEUDHf7O+wiZmuFCeUa7QKGHnYRZBA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/canvas@0.1.92':
-    resolution: {integrity: sha512-q7ZaUCJkEU5BeOdE7fBx1XWRd2T5Ady65nxq4brMf5L4cE1VV/ACq5w9Z5b/IVJs8CwSSIwc30nlthH0gFo4Ig==}
+  '@napi-rs/canvas@0.1.91':
+    resolution: {integrity: sha512-eeIe1GoB74P1B0Nkw6pV8BCQ3hfCfvyYr4BntzlCsnFXzVJiPMDnLeIx3gVB0xQMblHYnjK/0nCLvirEhOjr5g==}
     engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.1':
@@ -1668,8 +1744,8 @@ packages:
     resolution: {integrity: sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==}
     engines: {node: '>= 20'}
 
-  '@octokit/auth-app@8.2.0':
-    resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
+  '@octokit/auth-app@8.1.2':
+    resolution: {integrity: sha512-db8VO0PqXxfzI6GdjtgEFHY9tzqUql5xMFXYA12juq8TeTgPAuiiP3zid4h50lwlIP457p5+56PnJOgd2GGBuw==}
     engines: {node: '>= 20'}
 
   '@octokit/auth-oauth-app@9.0.3':
@@ -2825,16 +2901,16 @@ packages:
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
 
-  '@thi.ng/bitstream@2.4.41':
-    resolution: {integrity: sha512-treRzw3+7I1YCuilFtznwT3SGtceS9spUXhyBqeuKNTm4nIfMuvg4fNqx4GgpuS6cGPQNPMUJm0OyzKnSe2Emw==}
+  '@thi.ng/bitstream@2.4.40':
+    resolution: {integrity: sha512-zMQ3xbfxlMwfUjEjnTtXE3ism/CVrfKug/Yn8EeljEWqR/s69QY7Avr60limwA25808kBR/P7BW4tNIx6RKI6w==}
     engines: {node: '>=18'}
 
   '@thi.ng/errors@2.6.3':
     resolution: {integrity: sha512-owkOOKHf7MrAPN2jNpKWDdY/vjtPFiJf6oxZ3jkkhV6ICTu2iY1fXIR2wQ7kVEeybdtb0w24k2PtrU43OYCWdg==}
     engines: {node: '>=18'}
 
-  '@tinyhttp/content-disposition@2.2.4':
-    resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
+  '@tinyhttp/content-disposition@2.2.3':
+    resolution: {integrity: sha512-0nSvOgFHvq0a15+pZAdbAyHUk0+AGLX6oyo45b7fPdgWdPfHA19IfgUKRECYT0aw86ZP6ZDDLxGQ7FEA1fAVOg==}
     engines: {node: '>=12.17.0'}
 
   '@tokenizer/inflate@0.4.1':
@@ -2843,6 +2919,10 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -3149,6 +3229,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -3283,10 +3367,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  balanced-match@4.0.2:
-    resolution: {integrity: sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==}
-    engines: {node: 20 || >=22}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3332,10 +3412,6 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  brace-expansion@5.0.2:
-    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
-    engines: {node: 20 || >=22}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -3620,6 +3696,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -3648,6 +3727,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -3907,12 +3989,16 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@13.0.3:
-    resolution: {integrity: sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==}
+  glob@13.0.2:
+    resolution: {integrity: sha512-035InabNu/c1lW0tzPhAgapKctblppqsKKG9ZaNzbr+gXwWMjXoiyGSyB9sArzrjG7jY+zntRq5ZSUYemrnWVQ==}
     engines: {node: 20 || >=22}
 
   google-auth-library@10.5.0:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -3976,8 +4062,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.11.9:
-    resolution: {integrity: sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==}
+  hono@4.11.8:
+    resolution: {integrity: sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.0.1:
@@ -4013,6 +4099,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -4020,6 +4110,10 @@ packages:
   http-signature@1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4087,10 +4181,6 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
-  is-network-error@1.3.0:
-    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
-    engines: {node: '>=16'}
-
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
@@ -4122,9 +4212,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isexe@3.1.5:
-    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
-    engines: {node: '>=18'}
+  isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -4143,10 +4233,6 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
-  jackspeak@4.2.3:
-    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
-    engines: {node: 20 || >=22}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -4234,8 +4320,8 @@ packages:
   lifecycle-utils@2.1.0:
     resolution: {integrity: sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==}
 
-  lifecycle-utils@3.1.0:
-    resolution: {integrity: sha512-kVvegv+r/icjIo1dkHv1hznVQi4FzEVglJD2IU4w07HzevIyH3BAYsFZzEIbBk/nNZjXHGgclJ5g9rz9QdBCLw==}
+  lifecycle-utils@3.0.1:
+    resolution: {integrity: sha512-Qt/Jl5dsNIsyCAZsHB6x3mbwHFn0HJbdmvF49sVX/bHgX2cW7+G+U+I67Zw+TPM1Sr21Gb2nfJMd2g6iUcI1EQ==}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -4494,8 +4580,8 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@10.2.0:
-    resolution: {integrity: sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==}
+  minimatch@10.1.2:
+    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
 
   minimatch@9.0.5:
@@ -4644,6 +4730,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -4757,10 +4847,6 @@ packages:
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
-
-  p-retry@7.1.1:
-    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
-    engines: {node: '>=20'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -4930,6 +5016,10 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
   protobufjs@6.8.8:
     resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
     hasBin: true
@@ -5060,6 +5150,10 @@ packages:
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
 
   retry@0.12.0:
@@ -5207,8 +5301,8 @@ packages:
     peerDependencies:
       signal-polyfill: ^0.2.0
 
-  simple-git@3.31.1:
-    resolution: {integrity: sha512-oiWP4Q9+kO8q9hHqkX35uuHmxiEbZNTrZ5IPxgMGrJwN76pzjm/jabkZO0ItEcqxAincqGAzL3QHSaHt4+knBg==}
+  simple-git@3.30.0:
+    resolution: {integrity: sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==}
 
   simple-yenc@1.0.4:
     resolution: {integrity: sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==}
@@ -5319,6 +5413,12 @@ packages:
     resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
     engines: {node: '>=18'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -5356,6 +5456,9 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5366,6 +5469,10 @@ packages:
 
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+    engines: {node: '>=18'}
+
+  teeny-request@10.1.0:
+    resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
     engines: {node: '>=18'}
 
   thenify-all@1.6.0:
@@ -5505,8 +5612,8 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
-  unconfig-core@7.5.0:
-    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+  unconfig-core@7.4.2:
+    resolution: {integrity: sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5816,25 +5923,25 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-bedrock-runtime@3.990.0':
+  '@aws-sdk/client-bedrock-runtime@3.988.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/credential-provider-node': 3.972.9
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/credential-provider-node': 3.972.7
       '@aws-sdk/eventstream-handler-node': 3.972.5
       '@aws-sdk/middleware-eventstream': 3.972.3
       '@aws-sdk/middleware-host-header': 3.972.3
       '@aws-sdk/middleware-logger': 3.972.3
       '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.8
       '@aws-sdk/middleware-websocket': 3.972.6
       '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/token-providers': 3.990.0
+      '@aws-sdk/token-providers': 3.988.0
       '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.990.0
+      '@aws-sdk/util-endpoints': 3.988.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.972.6
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.23.0
       '@smithy/eventstream-serde-browser': 4.2.8
@@ -5884,6 +5991,49 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.990.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
       '@aws-sdk/util-user-agent-node': 3.972.8
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.988.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.8
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.988.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.6
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.23.0
       '@smithy/fetch-http-handler': 5.3.9
@@ -5972,6 +6122,30 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.973.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.4
+      '@smithy/core': 3.23.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.6':
+    dependencies:
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.8':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -5993,6 +6167,38 @@ snapshots:
       '@smithy/util-stream': 4.5.12
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-http@3.972.8':
+    dependencies:
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.6':
+    dependencies:
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/credential-provider-env': 3.972.6
+      '@aws-sdk/credential-provider-http': 3.972.8
+      '@aws-sdk/credential-provider-login': 3.972.6
+      '@aws-sdk/credential-provider-process': 3.972.6
+      '@aws-sdk/credential-provider-sso': 3.972.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.6
+      '@aws-sdk/nested-clients': 3.988.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-ini@3.972.8':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -6012,6 +6218,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-login@3.972.6':
+    dependencies:
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/nested-clients': 3.988.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.972.8':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -6019,6 +6238,23 @@ snapshots:
       '@aws-sdk/types': 3.973.1
       '@smithy/property-provider': 4.2.8
       '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.7':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.6
+      '@aws-sdk/credential-provider-http': 3.972.8
+      '@aws-sdk/credential-provider-ini': 3.972.6
+      '@aws-sdk/credential-provider-process': 3.972.6
+      '@aws-sdk/credential-provider-sso': 3.972.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.6
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
       '@smithy/shared-ini-file-loader': 4.4.3
       '@smithy/types': 4.12.0
       tslib: 2.8.1
@@ -6042,6 +6278,15 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-process@3.972.6':
+    dependencies:
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.8':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -6051,11 +6296,36 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.6':
+    dependencies:
+      '@aws-sdk/client-sso': 3.988.0
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/token-providers': 3.988.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-sso@3.972.8':
     dependencies:
       '@aws-sdk/client-sso': 3.990.0
       '@aws-sdk/core': 3.973.10
       '@aws-sdk/token-providers': 3.990.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.6':
+    dependencies:
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/nested-clients': 3.988.0
       '@aws-sdk/types': 3.973.1
       '@smithy/property-provider': 4.2.8
       '@smithy/shared-ini-file-loader': 4.4.3
@@ -6121,6 +6391,16 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-user-agent@3.972.8':
+    dependencies:
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.988.0
+      '@smithy/core': 3.23.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-websocket@3.972.6':
     dependencies:
       '@aws-sdk/types': 3.973.1
@@ -6135,6 +6415,49 @@ snapshots:
       '@smithy/util-hex-encoding': 4.2.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.988.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.8
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.988.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.6
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/nested-clients@3.990.0':
     dependencies:
@@ -6187,6 +6510,18 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.988.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.8
+      '@aws-sdk/nested-clients': 3.988.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/token-providers@3.990.0':
     dependencies:
       '@aws-sdk/core': 3.973.10
@@ -6202,6 +6537,14 @@ snapshots:
   '@aws-sdk/types@3.973.1':
     dependencies:
       '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.988.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.990.0':
@@ -6228,6 +6571,14 @@ snapshots:
       '@aws-sdk/types': 3.973.1
       '@smithy/types': 4.12.0
       bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.972.6':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.8
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.972.8':
@@ -6315,14 +6666,14 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.14.0(hono@4.11.9)':
+  '@buape/carbon@0.14.0(hono@4.11.8)':
     dependencies:
       '@types/node': 25.2.3
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
       '@discordjs/voice': 0.19.0
-      '@hono/node-server': 1.19.9(hono@4.11.9)
+      '@hono/node-server': 1.19.9(hono@4.11.8)
       '@types/bun': 1.3.6
       '@types/ws': 8.18.1
       ws: 8.19.0
@@ -6528,10 +6879,15 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google/genai@1.41.0':
+  '@google-cloud/secret-manager@6.1.1':
+    dependencies:
+      google-gax: 5.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@google/genai@1.40.0':
     dependencies:
       google-auth-library: 10.5.0
-      p-retry: 7.1.1
       protobufjs: 7.5.4
       ws: 8.19.0
     transitivePeerDependencies:
@@ -6578,12 +6934,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.9(hono@4.11.9)':
+  '@hono/node-server@1.19.9(hono@4.11.8)':
     dependencies:
-      hono: 4.11.9
+      hono: 4.11.8
     optional: true
 
-  '@huggingface/jinja@0.5.5': {}
+  '@huggingface/jinja@0.5.4': {}
 
   '@img/colour@1.0.0': {}
 
@@ -6681,6 +7037,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.1':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -6689,8 +7051,6 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  '@isaacs/cliui@9.0.0': {}
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -6890,8 +7250,8 @@ snapshots:
   '@mariozechner/pi-ai@0.52.12(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.990.0
-      '@google/genai': 1.41.0
+      '@aws-sdk/client-bedrock-runtime': 3.988.0
+      '@google/genai': 1.40.0
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -6922,11 +7282,11 @@ snapshots:
       cli-highlight: 2.1.11
       diff: 8.0.3
       file-type: 21.3.0
-      glob: 13.0.3
+      glob: 13.0.2
       hosted-git-info: 9.0.2
       ignore: 7.0.5
       marked: 15.0.12
-      minimatch: 10.2.0
+      minimatch: 10.1.2
       proper-lockfile: 4.1.2
       yaml: 2.8.2
     optionalDependencies:
@@ -6999,52 +7359,52 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@napi-rs/canvas-android-arm64@0.1.92':
+  '@napi-rs/canvas-android-arm64@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.92':
+  '@napi-rs/canvas-darwin-arm64@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.92':
+  '@napi-rs/canvas-darwin-x64@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.92':
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.92':
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.92':
+  '@napi-rs/canvas-linux-arm64-musl@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.92':
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.92':
+  '@napi-rs/canvas-linux-x64-gnu@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.92':
+  '@napi-rs/canvas-linux-x64-musl@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.92':
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.92':
+  '@napi-rs/canvas-win32-x64-msvc@0.1.91':
     optional: true
 
-  '@napi-rs/canvas@0.1.92':
+  '@napi-rs/canvas@0.1.91':
     optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.92
-      '@napi-rs/canvas-darwin-arm64': 0.1.92
-      '@napi-rs/canvas-darwin-x64': 0.1.92
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.92
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.92
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.92
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.92
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.92
-      '@napi-rs/canvas-linux-x64-musl': 0.1.92
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.92
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.92
+      '@napi-rs/canvas-android-arm64': 0.1.91
+      '@napi-rs/canvas-darwin-arm64': 0.1.91
+      '@napi-rs/canvas-darwin-x64': 0.1.91
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.91
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.91
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.91
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.91
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.91
+      '@napi-rs/canvas-linux-x64-musl': 0.1.91
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.91
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.91
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -7104,7 +7464,7 @@ snapshots:
 
   '@octokit/app@16.1.2':
     dependencies:
-      '@octokit/auth-app': 8.2.0
+      '@octokit/auth-app': 8.1.2
       '@octokit/auth-unauthenticated': 7.0.3
       '@octokit/core': 7.0.6
       '@octokit/oauth-app': 8.0.3
@@ -7112,7 +7472,7 @@ snapshots:
       '@octokit/types': 16.0.0
       '@octokit/webhooks': 14.2.0
 
-  '@octokit/auth-app@8.2.0':
+  '@octokit/auth-app@8.1.2':
     dependencies:
       '@octokit/auth-oauth-app': 9.0.3
       '@octokit/auth-oauth-user': 6.0.2
@@ -8249,7 +8609,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@thi.ng/bitstream@2.4.41':
+  '@thi.ng/bitstream@2.4.40':
     dependencies:
       '@thi.ng/errors': 2.6.3
     optional: true
@@ -8257,7 +8617,7 @@ snapshots:
   '@thi.ng/errors@2.6.3':
     optional: true
 
-  '@tinyhttp/content-disposition@2.2.4': {}
+  '@tinyhttp/content-disposition@2.2.3': {}
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -8267,6 +8627,8 @@ snapshots:
       - supports-color
 
   '@tokenizer/token@0.3.0': {}
+
+  '@tootallnate/once@2.0.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -8691,6 +9053,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
@@ -8826,10 +9194,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  balanced-match@4.0.2:
-    dependencies:
-      jackspeak: 4.2.3
-
   base64-js@1.5.1: {}
 
   basic-auth@2.0.1:
@@ -8890,10 +9254,6 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.2:
-    dependencies:
-      balanced-match: 4.0.2
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -9148,6 +9508,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   ecc-jsbn@0.1.2:
@@ -9170,6 +9537,10 @@ snapshots:
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@4.5.0: {}
 
@@ -9516,9 +9887,9 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@13.0.3:
+  glob@13.0.2:
     dependencies:
-      minimatch: 10.2.0
+      minimatch: 10.1.2
       minipass: 7.1.2
       path-scurry: 2.0.1
 
@@ -9531,6 +9902,22 @@ snapshots:
       google-logging-utils: 1.1.3
       gtoken: 8.0.0
       jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
     transitivePeerDependencies:
       - supports-color
 
@@ -9591,7 +9978,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.11.9:
+  hono@4.11.8:
     optional: true
 
   hookable@6.0.1: {}
@@ -9638,6 +10025,14 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -9650,6 +10045,13 @@ snapshots:
       assert-plus: 1.0.0
       jsprim: 1.4.2
       sshpk: 1.18.0
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -9691,7 +10093,7 @@ snapshots:
 
   ipull@3.9.3:
     dependencies:
-      '@tinyhttp/content-disposition': 2.2.4
+      '@tinyhttp/content-disposition': 2.2.3
       async-retry: 1.3.3
       chalk: 5.6.2
       ci-info: 4.4.0
@@ -9736,8 +10138,6 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
-  is-network-error@1.3.0: {}
-
   is-plain-object@5.0.0: {}
 
   is-promise@2.2.2: {}
@@ -9756,7 +10156,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isexe@3.1.5: {}
+  isexe@3.1.1: {}
 
   isstream@0.1.2: {}
 
@@ -9778,10 +10178,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jackspeak@4.2.3:
-    dependencies:
-      '@isaacs/cliui': 9.0.0
 
   jiti@2.6.1: {}
 
@@ -9882,7 +10278,7 @@ snapshots:
 
   lifecycle-utils@2.1.0: {}
 
-  lifecycle-utils@3.1.0: {}
+  lifecycle-utils@3.0.1: {}
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -10096,9 +10492,9 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@10.2.0:
+  minimatch@10.1.2:
     dependencies:
-      brace-expansion: 5.0.2
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@9.0.5:
     dependencies:
@@ -10198,7 +10594,7 @@ snapshots:
 
   node-llama-cpp@3.15.1(typescript@5.9.3):
     dependencies:
-      '@huggingface/jinja': 0.5.5
+      '@huggingface/jinja': 0.5.4
       async-retry: 1.3.3
       bytes: 3.1.2
       chalk: 5.6.2
@@ -10211,7 +10607,7 @@ snapshots:
       ignore: 7.0.5
       ipull: 3.9.3
       is-unicode-supported: 2.1.0
-      lifecycle-utils: 3.1.0
+      lifecycle-utils: 3.0.1
       log-symbols: 7.0.1
       nanoid: 5.1.6
       node-addon-api: 8.5.0
@@ -10220,7 +10616,7 @@ snapshots:
       pretty-ms: 9.3.0
       proper-lockfile: 4.1.2
       semver: 7.7.4
-      simple-git: 3.31.1
+      simple-git: 3.30.0
       slice-ansi: 7.1.2
       stdout-update: 4.0.1
       strip-ansi: 7.1.2
@@ -10279,6 +10675,8 @@ snapshots:
   oauth-sign@0.9.0: {}
 
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -10434,10 +10832,6 @@ snapshots:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
-  p-retry@7.1.1:
-    dependencies:
-      is-network-error: 1.3.0
-
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
@@ -10509,7 +10903,7 @@ snapshots:
 
   pdfjs-dist@5.4.624:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.92
+      '@napi-rs/canvas': 0.1.91
       node-readable-to-web-readable-stream: 0.4.2
 
   peberminta@0.9.0: {}
@@ -10586,6 +10980,10 @@ snapshots:
       graceful-fs: 4.2.11
       retry: 0.12.0
       signal-exit: 3.0.7
+
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.4
 
   protobufjs@6.8.8:
     dependencies:
@@ -10667,7 +11065,7 @@ snapshots:
 
   qoa-format@1.0.1:
     dependencies:
-      '@thi.ng/bitstream': 2.4.41
+      '@thi.ng/bitstream': 2.4.40
     optional: true
 
   qrcode-terminal@0.12.0: {}
@@ -10782,6 +11180,13 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   retry@0.12.0: {}
 
@@ -11046,7 +11451,7 @@ snapshots:
     dependencies:
       signal-polyfill: 0.2.2
 
-  simple-git@3.31.1:
+  simple-git@3.30.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
@@ -11160,6 +11565,12 @@ snapshots:
 
   steno@4.0.2: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -11202,6 +11613,8 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  stubs@3.0.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -11218,6 +11631,15 @@ snapshots:
       minipass: 7.1.2
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teeny-request@10.1.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   thenify-all@1.6.0:
     dependencies:
@@ -11285,7 +11707,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
-      unconfig-core: 7.5.0
+      unconfig-core: 7.4.2
       unrun: 0.2.27
     optionalDependencies:
       typescript: 5.9.3
@@ -11338,7 +11760,7 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
-  unconfig-core@7.5.0:
+  unconfig-core@7.4.2:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
@@ -11466,7 +11888,7 @@ snapshots:
 
   which@5.0.0:
     dependencies:
-      isexe: 3.1.5
+      isexe: 3.1.1
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -160,7 +160,12 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   const passwordRaw = toOptionString(opts.password);
   const tokenRaw = toOptionString(opts.token);
 
-  const snapshot = await readConfigFileSnapshot().catch(() => null);
+  const snapshot = await readConfigFileSnapshot().catch((err: unknown) => {
+    console.warn(
+      `[config] Failed to read config snapshot: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  });
   const configExists = snapshot?.exists ?? fs.existsSync(CONFIG_PATH);
   const configAuditPath = path.join(resolveStateDir(process.env), "logs", "config-audit.jsonl");
   const mode = cfg.gateway?.mode;

--- a/src/config/env-preserve-io.test.ts
+++ b/src/config/env-preserve-io.test.ts
@@ -111,6 +111,47 @@ describe("env snapshot TOCTOU via createConfigIO", () => {
       expect(parsed.gateway.remote.token).toBe("original-key-123");
     });
   });
+
+  it("env snapshot is reusable across multiple writes in the same read cycle", async () => {
+    const env: Record<string, string> = {
+      MY_TOKEN: "secret-abc",
+    };
+
+    const configJson = JSON.stringify({ gateway: { auth: { token: "${MY_TOKEN}" } } }, null, 2);
+
+    await withTempConfig(configJson, async (configPath) => {
+      // Read config — captures env snapshot
+      const ioRead = createConfigIO({ configPath, env: env as unknown as NodeJS.ProcessEnv });
+      const snapshot = await ioRead.readConfigFileSnapshot();
+      const envSnap = ioRead.getEnvSnapshot();
+
+      // Mutate env between read and writes
+      env.MY_TOKEN = "mutated-xyz";
+
+      // First write with snapshot bridging
+      const ioWrite1 = createConfigIO({ configPath, env: env as unknown as NodeJS.ProcessEnv });
+      if (envSnap) {
+        ioWrite1.setEnvSnapshot(envSnap);
+      }
+      await ioWrite1.writeConfigFile(snapshot.config);
+
+      const written1 = await fs.readFile(configPath, "utf-8");
+      const parsed1 = JSON.parse(written1);
+      expect(parsed1.gateway.auth.token).toBe("${MY_TOKEN}");
+
+      // Second write — reuse the SAME snapshot (simulates retained snapshot)
+      const ioWrite2 = createConfigIO({ configPath, env: env as unknown as NodeJS.ProcessEnv });
+      if (envSnap) {
+        ioWrite2.setEnvSnapshot(envSnap);
+      }
+      await ioWrite2.writeConfigFile(snapshot.config);
+
+      const written2 = await fs.readFile(configPath, "utf-8");
+      const parsed2 = JSON.parse(written2);
+      // Should still restore correctly — snapshot wasn't consumed/deleted
+      expect(parsed2.gateway.auth.token).toBe("${MY_TOKEN}");
+    });
+  });
 });
 
 describe("env snapshot TOCTOU via wrapper APIs", () => {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -680,6 +680,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           exists: true,
           raw,
           parsed: parsedRes.parsed,
+          resolved: coerceConfig(substituted),
           valid: false,
           config: coerceConfig(substituted),
           hash,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -38,6 +38,7 @@ import { applyMergePatch } from "./merge-patch.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
 import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
+import { GcpSecretsProviderError } from "./secrets/gcp.js";
 import { detectUnresolvedSecretRefs } from "./secrets/index.js";
 import {
   resolveConfigSecrets,
@@ -669,7 +670,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         secretsResolved = await resolveConfigSecrets(substituted, deps.env);
       } catch (err) {
         const message =
-          err instanceof MissingSecretError || err instanceof SecretsProviderError
+          err instanceof MissingSecretError ||
+          err instanceof SecretsProviderError ||
+          err instanceof GcpSecretsProviderError
             ? err.message
             : `Secret resolution failed: ${String(err)}`;
         return {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -469,7 +469,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       // $secret{} resolution is async-only. Detect any unresolved refs and throw a clear error.
       const unresolvedSecretRefs = detectUnresolvedSecretRefs(substituted);
       if (unresolvedSecretRefs.length > 0) {
-        throw new Error(
+        throw new SecretsProviderError(
           `Config contains ${unresolvedSecretRefs[0]} references but secrets can only be resolved in async mode. ` +
             `Use readConfigFileSnapshot() or ensure the gateway starts with async config loading.`,
         );

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -758,6 +758,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     // with a new snapshot based on the (possibly mutated) live env.
     const savedEnvSnapshot = envSnapshotForRestore;
     const snapshot = await readConfigFileSnapshot();
+    if (savedEnvSnapshot) {
+      envSnapshotForRestore = savedEnvSnapshot;
+    }
     let envRefMap: Map<string, string> | null = null;
     let changedPaths: Set<string> | null = null;
     if (savedEnvSnapshot) {

--- a/src/config/secrets/aws.ts
+++ b/src/config/secrets/aws.ts
@@ -7,6 +7,7 @@
  */
 
 import type { SecretsProvider } from "./provider.js";
+import { SecretsProviderError } from "./errors.js";
 
 /** Options for the AWS Secrets Manager provider. */
 export interface AwsSecretsProviderOptions {
@@ -24,7 +25,7 @@ export function createAwsSecretsProvider(
   return {
     name: "aws",
     async resolve(_secretName: string): Promise<string> {
-      throw new Error(
+      throw new SecretsProviderError(
         "AWS Secrets Manager provider is not yet implemented. " +
           "Contributions welcome — see src/config/secrets/aws.ts",
       );

--- a/src/config/secrets/aws.ts
+++ b/src/config/secrets/aws.ts
@@ -1,0 +1,33 @@
+/**
+ * AWS Secrets Manager provider (stub).
+ *
+ * TODO: Implement using @aws-sdk/client-secrets-manager
+ *
+ * @throws Always throws — not yet implemented.
+ */
+
+import type { SecretsProvider } from "./provider.js";
+
+/** Options for the AWS Secrets Manager provider. */
+export interface AwsSecretsProviderOptions {
+  /** AWS region. If omitted, uses the default region from AWS config. */
+  region?: string;
+}
+
+/**
+ * Creates an AWS Secrets Manager provider.
+ * Currently a stub that throws on any resolution attempt.
+ */
+export function createAwsSecretsProvider(
+  _options: AwsSecretsProviderOptions = {},
+): SecretsProvider {
+  return {
+    name: "aws",
+    async resolve(_secretName: string): Promise<string> {
+      throw new Error(
+        "AWS Secrets Manager provider is not yet implemented. " +
+          "Contributions welcome — see src/config/secrets/aws.ts",
+      );
+    },
+  };
+}

--- a/src/config/secrets/bitwarden.ts
+++ b/src/config/secrets/bitwarden.ts
@@ -13,6 +13,7 @@
  */
 
 import type { SecretsProvider } from "./provider.js";
+import { SecretsProviderError } from "./errors.js";
 
 /**
  * Creates a Bitwarden secrets provider.
@@ -22,7 +23,7 @@ export function createBitwardenSecretsProvider(): SecretsProvider {
   return {
     name: "bitwarden",
     async resolve(_secretName: string): Promise<string> {
-      throw new Error(
+      throw new SecretsProviderError(
         "Bitwarden secrets provider is not yet implemented — no access to a Bitwarden account. " +
           "Contributions welcome — see src/config/secrets/bitwarden.ts",
       );

--- a/src/config/secrets/bitwarden.ts
+++ b/src/config/secrets/bitwarden.ts
@@ -1,0 +1,31 @@
+/**
+ * Bitwarden Secrets Manager provider (stub).
+ *
+ * Bitwarden is a popular open-source password/secrets manager.
+ *
+ * TODO: Implement using Bitwarden CLI (`bw get`) or Bitwarden Secrets Manager SDK.
+ * Reference: https://bitwarden.com/help/secrets-manager-overview/
+ *
+ * Note: No implementation provided — we don't currently have access to a Bitwarden account.
+ * Contributions welcome!
+ *
+ * @throws Always throws — not yet implemented.
+ */
+
+import type { SecretsProvider } from "./provider.js";
+
+/**
+ * Creates a Bitwarden secrets provider.
+ * Currently a stub that throws on any resolution attempt.
+ */
+export function createBitwardenSecretsProvider(): SecretsProvider {
+  return {
+    name: "bitwarden",
+    async resolve(_secretName: string): Promise<string> {
+      throw new Error(
+        "Bitwarden secrets provider is not yet implemented — no access to a Bitwarden account. " +
+          "Contributions welcome — see src/config/secrets/bitwarden.ts",
+      );
+    },
+  };
+}

--- a/src/config/secrets/doppler.ts
+++ b/src/config/secrets/doppler.ts
@@ -13,6 +13,7 @@
  */
 
 import type { SecretsProvider } from "./provider.js";
+import { SecretsProviderError } from "./errors.js";
 
 /** Options for the Doppler secrets provider. */
 export interface DopplerSecretsProviderOptions {
@@ -32,7 +33,7 @@ export function createDopplerSecretsProvider(
   return {
     name: "doppler",
     async resolve(_secretName: string): Promise<string> {
-      throw new Error(
+      throw new SecretsProviderError(
         "Doppler secrets provider is not yet implemented — no access to a Doppler account. " +
           "Contributions welcome — see src/config/secrets/doppler.ts",
       );

--- a/src/config/secrets/doppler.ts
+++ b/src/config/secrets/doppler.ts
@@ -1,0 +1,41 @@
+/**
+ * Doppler secrets provider (stub).
+ *
+ * Doppler is popular for CLI/server environments with automatic secret syncing.
+ *
+ * TODO: Implement using Doppler CLI (`doppler secrets get`) or Doppler REST API.
+ * Reference: https://docs.doppler.com/docs/api
+ *
+ * Note: No implementation provided — we don't currently have access to a Doppler account.
+ * Contributions welcome!
+ *
+ * @throws Always throws — not yet implemented.
+ */
+
+import type { SecretsProvider } from "./provider.js";
+
+/** Options for the Doppler secrets provider. */
+export interface DopplerSecretsProviderOptions {
+  /** Doppler project name. */
+  project?: string;
+  /** Doppler config/environment (e.g. "dev", "staging", "prod"). */
+  config?: string;
+}
+
+/**
+ * Creates a Doppler secrets provider.
+ * Currently a stub that throws on any resolution attempt.
+ */
+export function createDopplerSecretsProvider(
+  _options: DopplerSecretsProviderOptions = {},
+): SecretsProvider {
+  return {
+    name: "doppler",
+    async resolve(_secretName: string): Promise<string> {
+      throw new Error(
+        "Doppler secrets provider is not yet implemented — no access to a Doppler account. " +
+          "Contributions welcome — see src/config/secrets/doppler.ts",
+      );
+    },
+  };
+}

--- a/src/config/secrets/env.ts
+++ b/src/config/secrets/env.ts
@@ -1,0 +1,25 @@
+/**
+ * Environment variable secrets provider.
+ *
+ * Resolves secret names by looking them up as environment variables.
+ * Useful as a simple local-dev fallback.
+ */
+
+import type { SecretsProvider } from "./provider.js";
+
+/**
+ * Creates an environment variable secrets provider.
+ * Secret names are used directly as env var names.
+ */
+export function createEnvSecretsProvider(env: NodeJS.ProcessEnv = process.env): SecretsProvider {
+  return {
+    name: "env",
+    async resolve(secretName: string): Promise<string> {
+      const value = env[secretName];
+      if (value === undefined || value === "") {
+        throw new Error(`Secret "${secretName}" not found in environment variables`);
+      }
+      return value;
+    },
+  };
+}

--- a/src/config/secrets/env.ts
+++ b/src/config/secrets/env.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SecretsProvider } from "./provider.js";
+import { MissingSecretError } from "./errors.js";
 
 /**
  * Creates an environment variable secrets provider.
@@ -17,7 +18,7 @@ export function createEnvSecretsProvider(env: NodeJS.ProcessEnv = process.env): 
     async resolve(secretName: string): Promise<string> {
       const value = env[secretName];
       if (value === undefined || value === "") {
-        throw new Error(`Secret "${secretName}" not found in environment variables`);
+        throw new MissingSecretError(secretName, "env");
       }
       return value;
     },

--- a/src/config/secrets/errors.ts
+++ b/src/config/secrets/errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Error types for secrets resolution.
+ */
+
+export class MissingSecretError extends Error {
+  constructor(
+    public readonly secretName: string,
+    public readonly configPath: string,
+  ) {
+    super(`Missing secret "${secretName}" referenced at config path: ${configPath}`);
+    this.name = "MissingSecretError";
+  }
+}
+
+export class SecretsProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SecretsProviderError";
+  }
+}

--- a/src/config/secrets/gcp.ts
+++ b/src/config/secrets/gcp.ts
@@ -13,8 +13,8 @@ import type { SecretsProvider } from "./provider.js";
 
 /** Options for the GCP Secret Manager provider. */
 export interface GcpSecretsProviderOptions {
-  /** GCP project ID. If omitted, uses the default project from ADC. */
-  project?: string;
+  /** GCP project ID. Required — Secret Manager does not support automatic project discovery. */
+  project: string;
 }
 
 export class GcpSecretsProviderError extends Error {

--- a/src/config/secrets/gcp.ts
+++ b/src/config/secrets/gcp.ts
@@ -38,7 +38,7 @@ interface SecretManagerClient {
  * @param options - Provider configuration
  * @returns A SecretsProvider backed by GCP Secret Manager
  */
-export function createGcpSecretsProvider(options: GcpSecretsProviderOptions = {}): SecretsProvider {
+export function createGcpSecretsProvider(options: GcpSecretsProviderOptions): SecretsProvider {
   const cache = new Map<string, string>();
   let client: SecretManagerClient | null = null;
 

--- a/src/config/secrets/gcp.ts
+++ b/src/config/secrets/gcp.ts
@@ -64,9 +64,11 @@ export function createGcpSecretsProvider(options: GcpSecretsProviderOptions): Se
       client = new SecretManagerServiceClient() as SecretManagerClient;
       return client;
     } catch (err) {
-      throw new GcpSecretsProviderError(
-        `Failed to load @google-cloud/secret-manager. Is it installed? ${String(err)}`,
+      const wrapped = new GcpSecretsProviderError(
+        `Failed to load @google-cloud/secret-manager. Is it installed? ${err instanceof Error ? err.message : String(err)}`,
       );
+      wrapped.cause = err;
+      throw wrapped;
     }
   }
 

--- a/src/config/secrets/gcp.ts
+++ b/src/config/secrets/gcp.ts
@@ -5,8 +5,9 @@
  * Application Default Credentials (ADC). Secrets are cached for the lifetime
  * of the provider instance.
  *
- * NOTE: The `@google-cloud/secret-manager` package is NOT yet installed.
- * This module will fail at runtime until the dependency is added.
+ * The `@google-cloud/secret-manager` package is an optional peer dependency
+ * loaded via dynamic `import()`. Users must install it separately:
+ *   pnpm add @google-cloud/secret-manager
  */
 
 import type { SecretsProvider } from "./provider.js";

--- a/src/config/secrets/gcp.ts
+++ b/src/config/secrets/gcp.ts
@@ -64,8 +64,7 @@ export function createGcpSecretsProvider(options: GcpSecretsProviderOptions = {}
   }
 
   function buildSecretPath(secretName: string): string {
-    const project = options.project ?? "-"; // "-" uses ADC default project
-    return `projects/${project}/secrets/${secretName}/versions/latest`;
+    return `projects/${options.project}/secrets/${secretName}/versions/latest`;
   }
 
   return {

--- a/src/config/secrets/gcp.ts
+++ b/src/config/secrets/gcp.ts
@@ -29,8 +29,9 @@ export class GcpSecretsProviderError extends Error {
   constructor(
     message: string,
     public readonly secretName?: string,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.name = "GcpSecretsProviderError";
   }
 }
@@ -64,11 +65,11 @@ export function createGcpSecretsProvider(options: GcpSecretsProviderOptions): Se
       client = new SecretManagerServiceClient() as SecretManagerClient;
       return client;
     } catch (err) {
-      const wrapped = new GcpSecretsProviderError(
+      throw new GcpSecretsProviderError(
         `Failed to load @google-cloud/secret-manager. Is it installed? ${err instanceof Error ? err.message : String(err)}`,
+        undefined,
+        { cause: err },
       );
-      wrapped.cause = err;
-      throw wrapped;
     }
   }
 

--- a/src/config/secrets/gcp.ts
+++ b/src/config/secrets/gcp.ts
@@ -1,0 +1,109 @@
+/**
+ * Google Cloud Secret Manager provider.
+ *
+ * Resolves secrets via the `@google-cloud/secret-manager` package using
+ * Application Default Credentials (ADC). Secrets are cached for the lifetime
+ * of the provider instance.
+ *
+ * NOTE: The `@google-cloud/secret-manager` package is NOT yet installed.
+ * This module will fail at runtime until the dependency is added.
+ */
+
+import type { SecretsProvider } from "./provider.js";
+
+/** Options for the GCP Secret Manager provider. */
+export interface GcpSecretsProviderOptions {
+  /** GCP project ID. If omitted, uses the default project from ADC. */
+  project?: string;
+}
+
+export class GcpSecretsProviderError extends Error {
+  constructor(
+    message: string,
+    public readonly secretName?: string,
+  ) {
+    super(message);
+    this.name = "GcpSecretsProviderError";
+  }
+}
+
+/** Shape of the GCP Secret Manager client we use. */
+interface SecretManagerClient {
+  accessSecretVersion(req: { name: string }): Promise<[{ payload?: { data?: unknown } }]>;
+}
+
+/**
+ * Creates a GCP Secret Manager secrets provider.
+ *
+ * @param options - Provider configuration
+ * @returns A SecretsProvider backed by GCP Secret Manager
+ */
+export function createGcpSecretsProvider(options: GcpSecretsProviderOptions = {}): SecretsProvider {
+  const cache = new Map<string, string>();
+  let client: SecretManagerClient | null = null;
+
+  async function getClient(): Promise<SecretManagerClient> {
+    if (client) {
+      return client;
+    }
+    try {
+      // Dynamic import — will fail until @google-cloud/secret-manager is installed
+      const mod = await import("@google-cloud/secret-manager" as string);
+      const SecretManagerServiceClient =
+        mod.SecretManagerServiceClient ?? mod.default?.SecretManagerServiceClient;
+      if (!SecretManagerServiceClient) {
+        throw new Error("SecretManagerServiceClient not found in module");
+      }
+      client = new SecretManagerServiceClient() as SecretManagerClient;
+      return client;
+    } catch (err) {
+      throw new GcpSecretsProviderError(
+        `Failed to load @google-cloud/secret-manager. Is it installed? ${String(err)}`,
+      );
+    }
+  }
+
+  function buildSecretPath(secretName: string): string {
+    const project = options.project ?? "-"; // "-" uses ADC default project
+    return `projects/${project}/secrets/${secretName}/versions/latest`;
+  }
+
+  return {
+    name: "gcp",
+
+    async resolve(secretName: string): Promise<string> {
+      const cached = cache.get(secretName);
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      const svc = await getClient();
+      const secretPath = buildSecretPath(secretName);
+
+      try {
+        const [response] = await svc.accessSecretVersion({ name: secretPath });
+        const payload = response.payload?.data;
+        if (payload === undefined || payload === null) {
+          throw new GcpSecretsProviderError(
+            `Secret "${secretName}" has no payload data`,
+            secretName,
+          );
+        }
+        const value =
+          typeof payload === "string"
+            ? payload
+            : Buffer.from(payload as Uint8Array).toString("utf-8");
+        cache.set(secretName, value);
+        return value;
+      } catch (err) {
+        if (err instanceof GcpSecretsProviderError) {
+          throw err;
+        }
+        throw new GcpSecretsProviderError(
+          `Failed to resolve secret "${secretName}": ${String(err)}`,
+          secretName,
+        );
+      }
+    },
+  };
+}

--- a/src/config/secrets/index.ts
+++ b/src/config/secrets/index.ts
@@ -6,6 +6,8 @@ export {
   MissingSecretError,
   SecretsProviderError,
 } from "./resolve.js";
+export { createGcpSecretsProvider } from "./gcp.js";
+export { createEnvSecretsProvider } from "./env.js";
 export { createAwsSecretsProvider } from "./aws.js";
 export { createOnePasswordSecretsProvider } from "./onepassword.js";
 export { createKeyringSecretsProvider } from "./keyring.js";

--- a/src/config/secrets/index.ts
+++ b/src/config/secrets/index.ts
@@ -1,0 +1,14 @@
+export type { SecretsProvider } from "./provider.js";
+export type { SecretsConfig, SecretsProviderType } from "./types.js";
+export {
+  resolveConfigSecrets,
+  detectUnresolvedSecretRefs,
+  MissingSecretError,
+  SecretsProviderError,
+} from "./resolve.js";
+export { createAwsSecretsProvider } from "./aws.js";
+export { createOnePasswordSecretsProvider } from "./onepassword.js";
+export { createKeyringSecretsProvider } from "./keyring.js";
+export { createDopplerSecretsProvider } from "./doppler.js";
+export { createBitwardenSecretsProvider } from "./bitwarden.js";
+export { createVaultSecretsProvider } from "./vault.js";

--- a/src/config/secrets/keyring.ts
+++ b/src/config/secrets/keyring.ts
@@ -14,6 +14,7 @@ import { homedir, platform } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { SecretsProvider } from "./provider.js";
+import { SecretsProviderError } from "./errors.js";
 import { MissingSecretError } from "./errors.js";
 
 const execFileAsync = promisify(execFile);
@@ -87,7 +88,7 @@ export function createKeyringSecretsProvider(
   return {
     name: "keyring",
     async resolve(_secretName: string): Promise<string> {
-      throw new Error(
+      throw new SecretsProviderError(
         `OS keyring secrets provider is not implemented for platform: ${os}. ` +
           `Supported: macOS (security CLI), Linux (secret-tool / libsecret). ` +
           `Contributions welcome for Windows (Credential Manager) — see src/config/secrets/keyring.ts`,

--- a/src/config/secrets/keyring.ts
+++ b/src/config/secrets/keyring.ts
@@ -119,13 +119,12 @@ function createMacOSProvider(
     try {
       // Pass password via stdin to avoid exposing it in process arguments (ps aux).
       // The `security unlock-keychain` command reads from stdin when no -p flag is given.
-      // Use stdio: ['pipe', 'pipe', 'pipe'] and a timeout to prevent hanging if the
-      // process prompts interactively or fills its output buffer.
+      // execFile without a callback returns a ChildProcess with piped stdio by default.
+      // Use a timeout to prevent hanging if the process prompts interactively.
       const UNLOCK_TIMEOUT_MS = 10_000;
       const child = execFile("security", ["unlock-keychain", keychainPath], {
-        stdio: ["pipe", "pipe", "pipe"],
         timeout: UNLOCK_TIMEOUT_MS,
-      } as Parameters<typeof execFile>[2]);
+      });
       if (child.stdin) {
         child.stdin.write(keychainPassword + "\n");
         child.stdin.end();

--- a/src/config/secrets/keyring.ts
+++ b/src/config/secrets/keyring.ts
@@ -1,34 +1,143 @@
 /**
- * OS Keyring / macOS Keychain provider (stub).
+ * OS Keyring / macOS Keychain provider.
  *
- * Covers platform-native credential stores:
- * - macOS Keychain (already on every Mac)
- * - Linux: libsecret / GNOME Keyring / KDE Wallet
- * - Windows: Credential Manager
+ * Uses the macOS `security` CLI to store and retrieve secrets from a dedicated
+ * OpenClaw keychain. On other platforms, falls back to a "not implemented" error
+ * with guidance on what's needed.
  *
- * TODO: Implement using the `keytar` npm package for cross-platform support,
- * or native `security` CLI on macOS.
+ * macOS implementation:
+ * - Uses a dedicated keychain file (`~/Library/Keychains/openclaw.keychain-db`)
+ * - Secrets stored as generic password items with account="openclaw"
+ * - Keychain must be unlocked before use (password defaults to empty string)
  *
- * Note: No implementation provided — we don't currently have access to test
- * across all platforms. Contributions welcome!
- *
- * @throws Always throws — not yet implemented.
+ * Linux/Windows: not yet implemented. Contributions welcome.
+ * Potential approaches: libsecret (Linux), Windows Credential Manager, or `keytar` npm package.
  */
 
+import { execFile } from "node:child_process";
+import { homedir, platform } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
 import type { SecretsProvider } from "./provider.js";
 
+const execFileAsync = promisify(execFile);
+
+/** Options for the keyring secrets provider. */
+export interface KeyringSecretsProviderOptions {
+  /**
+   * Path to the keychain file (macOS only).
+   * Defaults to `~/Library/Keychains/openclaw.keychain-db`.
+   */
+  keychainPath?: string;
+
+  /**
+   * Password to unlock the keychain (macOS only).
+   * Defaults to empty string (matching the default created by setup).
+   */
+  keychainPassword?: string;
+
+  /** Account name used for keychain items. Defaults to "openclaw". */
+  account?: string;
+}
+
 /**
- * Creates an OS keyring / macOS Keychain secrets provider.
- * Currently a stub that throws on any resolution attempt.
+ * Creates a macOS Keychain secrets provider.
+ *
+ * Resolves secrets by looking up generic password items in the OpenClaw keychain
+ * using the `security` CLI.
+ *
+ * @example
+ * ```json5
+ * {
+ *   "secrets": {
+ *     "provider": "keyring",
+ *     "keyring": { "keychainPath": "~/Library/Keychains/openclaw.keychain-db" }
+ *   },
+ *   "channels": {
+ *     "slack": { "botToken": "$secret{slack-bot-token}" }
+ *   }
+ * }
+ * ```
  */
-export function createKeyringSecretsProvider(): SecretsProvider {
+export function createKeyringSecretsProvider(
+  options: KeyringSecretsProviderOptions = {},
+): SecretsProvider {
+  const os = platform();
+
+  if (os !== "darwin") {
+    return {
+      name: "keyring",
+      async resolve(_secretName: string): Promise<string> {
+        throw new Error(
+          `OS keyring secrets provider is only implemented for macOS (darwin). ` +
+            `Current platform: ${os}. ` +
+            `Contributions welcome for Linux (libsecret) and Windows (Credential Manager) — ` +
+            `see src/config/secrets/keyring.ts`,
+        );
+      },
+    };
+  }
+
+  const account = options.account ?? "openclaw";
+  const keychainPath =
+    options.keychainPath ?? path.join(homedir(), "Library", "Keychains", "openclaw.keychain-db");
+  const keychainPassword = options.keychainPassword ?? "";
+
+  let unlocked = false;
+
+  async function ensureUnlocked(): Promise<void> {
+    if (unlocked) return;
+    try {
+      await execFileAsync("security", ["unlock-keychain", "-p", keychainPassword, keychainPath]);
+      unlocked = true;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Failed to unlock keychain at ${keychainPath}: ${msg}. ` +
+          `Make sure the keychain exists (security create-keychain -p '' ${keychainPath}) ` +
+          `and the password is correct.`,
+      );
+    }
+  }
+
   return {
     name: "keyring",
-    async resolve(_secretName: string): Promise<string> {
-      throw new Error(
-        "OS keyring / macOS Keychain secrets provider is not yet implemented. " +
-          "Contributions welcome — see src/config/secrets/keyring.ts",
-      );
+
+    async resolve(secretName: string): Promise<string> {
+      await ensureUnlocked();
+
+      try {
+        const { stdout } = await execFileAsync("security", [
+          "find-generic-password",
+          "-a",
+          account,
+          "-s",
+          secretName,
+          "-w",
+          keychainPath,
+        ]);
+        // stdout includes a trailing newline
+        return stdout.trimEnd();
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("could not be found") || msg.includes("SecKeychainSearchCopyNext")) {
+          throw new Error(
+            `Secret "${secretName}" not found in keychain at ${keychainPath}. ` +
+              `Add it with: security add-generic-password -a ${account} -s ${secretName} -w "VALUE" ${keychainPath}`,
+          );
+        }
+        throw new Error(`Failed to retrieve secret "${secretName}" from keychain: ${msg}`);
+      }
+    },
+
+    async dispose(): Promise<void> {
+      // Lock the keychain when done (security best practice)
+      try {
+        await execFileAsync("security", ["lock-keychain", keychainPath]);
+      } catch {
+        // Best effort — don't throw on cleanup
+      }
+      unlocked = false;
     },
   };
 }

--- a/src/config/secrets/keyring.ts
+++ b/src/config/secrets/keyring.ts
@@ -1,0 +1,34 @@
+/**
+ * OS Keyring / macOS Keychain provider (stub).
+ *
+ * Covers platform-native credential stores:
+ * - macOS Keychain (already on every Mac)
+ * - Linux: libsecret / GNOME Keyring / KDE Wallet
+ * - Windows: Credential Manager
+ *
+ * TODO: Implement using the `keytar` npm package for cross-platform support,
+ * or native `security` CLI on macOS.
+ *
+ * Note: No implementation provided — we don't currently have access to test
+ * across all platforms. Contributions welcome!
+ *
+ * @throws Always throws — not yet implemented.
+ */
+
+import type { SecretsProvider } from "./provider.js";
+
+/**
+ * Creates an OS keyring / macOS Keychain secrets provider.
+ * Currently a stub that throws on any resolution attempt.
+ */
+export function createKeyringSecretsProvider(): SecretsProvider {
+  return {
+    name: "keyring",
+    async resolve(_secretName: string): Promise<string> {
+      throw new Error(
+        "OS keyring / macOS Keychain secrets provider is not yet implemented. " +
+          "Contributions welcome — see src/config/secrets/keyring.ts",
+      );
+    },
+  };
+}

--- a/src/config/secrets/keyring.ts
+++ b/src/config/secrets/keyring.ts
@@ -119,11 +119,20 @@ function createMacOSProvider(
     try {
       // Pass password via stdin to avoid exposing it in process arguments (ps aux).
       // The `security unlock-keychain` command reads from stdin when no -p flag is given.
-      const child = execFile("security", ["unlock-keychain", keychainPath]);
+      // Use stdio: ['pipe', 'pipe', 'pipe'] and a timeout to prevent hanging if the
+      // process prompts interactively or fills its output buffer.
+      const UNLOCK_TIMEOUT_MS = 10_000;
+      const child = execFile("security", ["unlock-keychain", keychainPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: UNLOCK_TIMEOUT_MS,
+      } as Parameters<typeof execFile>[2]);
       if (child.stdin) {
         child.stdin.write(keychainPassword + "\n");
         child.stdin.end();
       }
+      // Consume stdout/stderr to prevent buffer blocking
+      child.stdout?.resume();
+      child.stderr?.resume();
       await new Promise<void>((resolve, reject) => {
         child.on("close", (code) => {
           if (code === 0) {

--- a/src/config/secrets/keyring.ts
+++ b/src/config/secrets/keyring.ts
@@ -236,7 +236,7 @@ function createLinuxProvider(account: string): SecretsProvider {
           throw new Error("empty");
         }
         return value;
-      } catch (err: unknown) {
+      } catch {
         // secret-tool exits non-zero when a key isn't found. execFileAsync wraps
         // this as an Error, but the message may just be stderr (often empty) rather
         // than including "exit code". Treat any execFile rejection after our own

--- a/src/config/secrets/onepassword.ts
+++ b/src/config/secrets/onepassword.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SecretsProvider } from "./provider.js";
+import { SecretsProviderError } from "./errors.js";
 
 /**
  * Creates a 1Password secrets provider.
@@ -17,7 +18,7 @@ export function createOnePasswordSecretsProvider(): SecretsProvider {
   return {
     name: "1password",
     async resolve(_secretName: string): Promise<string> {
-      throw new Error(
+      throw new SecretsProviderError(
         "1Password secrets provider is not yet implemented. " +
           "Contributions welcome — see src/config/secrets/onepassword.ts",
       );

--- a/src/config/secrets/onepassword.ts
+++ b/src/config/secrets/onepassword.ts
@@ -1,0 +1,26 @@
+/**
+ * 1Password Secrets Automation provider (stub).
+ *
+ * TODO: Implement using `op://` URI resolution via 1Password CLI or Connect API
+ * Reference: https://developer.1password.com/docs/connect/
+ *
+ * @throws Always throws — not yet implemented.
+ */
+
+import type { SecretsProvider } from "./provider.js";
+
+/**
+ * Creates a 1Password secrets provider.
+ * Currently a stub that throws on any resolution attempt.
+ */
+export function createOnePasswordSecretsProvider(): SecretsProvider {
+  return {
+    name: "1password",
+    async resolve(_secretName: string): Promise<string> {
+      throw new Error(
+        "1Password secrets provider is not yet implemented. " +
+          "Contributions welcome — see src/config/secrets/onepassword.ts",
+      );
+    },
+  };
+}

--- a/src/config/secrets/provider.ts
+++ b/src/config/secrets/provider.ts
@@ -1,0 +1,53 @@
+/**
+ * Secrets provider interface for pluggable secret resolution.
+ *
+ * Providers resolve secret names to their plaintext values at config load time.
+ * Each provider implements at minimum the `resolve` method; `resolveAll` is an
+ * optional batch optimization.
+ */
+
+/** A pluggable secrets provider that resolves secret names to values. */
+export interface SecretsProvider {
+  /** Human-readable provider name (e.g. "gcp", "aws"). */
+  readonly name: string;
+
+  /** Resolve a single secret by name. */
+  resolve(secretName: string): Promise<string>;
+
+  /**
+   * Batch-resolve multiple secrets. Optional optimization — the default
+   * implementation calls `resolve()` for each name in parallel via `Promise.all`.
+   *
+   * Providers with rate limits or concurrency constraints should override this
+   * method to control batching/throttling (e.g. limiting concurrent requests).
+   */
+  resolveAll?(secretNames: string[]): Promise<Map<string, string>>;
+
+  /**
+   * Optional cleanup hook for releasing resources (connections, caches, etc.).
+   * Called when the config loader is done with the provider.
+   */
+  dispose?(): Promise<void>;
+}
+
+/**
+ * Default batch resolver that calls `resolve()` for each name.
+ * Used when a provider does not implement `resolveAll`.
+ *
+ * **Note:** All names are resolved concurrently via `Promise.all`. Providers
+ * with rate limits should implement `resolveAll` directly to control concurrency.
+ */
+export async function defaultResolveAll(
+  provider: SecretsProvider,
+  secretNames: string[],
+): Promise<Map<string, string>> {
+  const results = new Map<string, string>();
+  // Resolve in parallel for better performance
+  const entries = await Promise.all(
+    secretNames.map(async (name) => [name, await provider.resolve(name)] as const),
+  );
+  for (const [name, value] of entries) {
+    results.set(name, value);
+  }
+  return results;
+}

--- a/src/config/secrets/resolve.test.ts
+++ b/src/config/secrets/resolve.test.ts
@@ -249,6 +249,20 @@ describe("resolveConfigSecrets", () => {
   });
 
   it("throws for keyring provider when secret not found", async () => {
+    const os = (await import("node:os")).platform();
+    // Skip on platforms where keyring isn't supported (e.g. Windows, CI containers)
+    if (os !== "darwin" && os !== "linux") {
+      return;
+    }
+    // On Linux, skip if secret-tool isn't installed
+    if (os === "linux") {
+      const { execSync } = await import("node:child_process");
+      try {
+        execSync("which secret-tool", { stdio: "ignore" });
+      } catch {
+        return; // secret-tool not available — skip test
+      }
+    }
     const config = {
       token: "$secret{nonexistent-test-secret-xyzzy}",
       secrets: { provider: "keyring" },

--- a/src/config/secrets/resolve.test.ts
+++ b/src/config/secrets/resolve.test.ts
@@ -269,8 +269,19 @@ describe("resolveConfigSecrets", () => {
       token: "$secret{nonexistent-test-secret-xyzzy}",
       secrets: { provider: "keyring" },
     };
-    // On both macOS and Linux, this should throw because the secret doesn't exist
-    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not found|keychain|keyring/i);
+    // On both macOS and Linux, this should throw MissingSecretError because the secret doesn't exist
+    const { MissingSecretError } = await import("./errors.js");
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(MissingSecretError);
+  });
+
+  it("stub provider error message uses relative docs path", async () => {
+    const config = {
+      token: "$secret{X}",
+      secrets: { provider: "aws" },
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/docs\/gateway\/secrets/);
+    // Should NOT contain an absolute URL
+    await expect(resolveConfigSecrets(config)).rejects.not.toThrow(/https?:\/\//);
   });
 
   it("throws SecretsProviderError for doppler provider with secret refs", async () => {

--- a/src/config/secrets/resolve.test.ts
+++ b/src/config/secrets/resolve.test.ts
@@ -249,14 +249,13 @@ describe("resolveConfigSecrets", () => {
     await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
   });
 
-  it("throws error for keyring provider on non-macOS", async () => {
+  it("throws for keyring provider when secret not found", async () => {
     const config = {
-      token: "$secret{X}",
+      token: "$secret{nonexistent-test-secret-xyzzy}",
       secrets: { provider: "keyring" },
     };
-    // On Linux (CI/test), this throws because macOS Keychain isn't available
-    // On macOS, it would attempt to unlock the keychain
-    await expect(resolveConfigSecrets(config)).rejects.toThrow(/keyring|keychain/i);
+    // On both macOS and Linux, this should throw because the secret doesn't exist
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not found|keychain|keyring/i);
   });
 
   it("throws coming-soon error for doppler provider", async () => {

--- a/src/config/secrets/resolve.test.ts
+++ b/src/config/secrets/resolve.test.ts
@@ -232,19 +232,21 @@ describe("resolveConfigSecrets", () => {
     expect(result.token).toBe("$secret{INNER}");
   });
 
-  it("throws coming-soon error for aws provider", async () => {
+  it("throws SecretsProviderError for aws provider with secret refs", async () => {
     const config = {
       token: "$secret{X}",
       secrets: { provider: "aws" },
     };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(SecretsProviderError);
     await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
   });
 
-  it("throws coming-soon error for 1password provider", async () => {
+  it("throws SecretsProviderError for 1password provider with secret refs", async () => {
     const config = {
       token: "$secret{X}",
       secrets: { provider: "1password" },
     };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(SecretsProviderError);
     await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
   });
 
@@ -271,28 +273,45 @@ describe("resolveConfigSecrets", () => {
     await expect(resolveConfigSecrets(config)).rejects.toThrow(/not found|keychain|keyring/i);
   });
 
-  it("throws coming-soon error for doppler provider", async () => {
+  it("throws SecretsProviderError for doppler provider with secret refs", async () => {
     const config = {
       token: "$secret{X}",
       secrets: { provider: "doppler" },
     };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(SecretsProviderError);
     await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
   });
 
-  it("throws coming-soon error for bitwarden provider", async () => {
+  it("throws SecretsProviderError for bitwarden provider with secret refs", async () => {
     const config = {
       token: "$secret{X}",
       secrets: { provider: "bitwarden" },
     };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(SecretsProviderError);
     await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
   });
 
-  it("throws coming-soon error for vault provider", async () => {
+  it("throws SecretsProviderError for vault provider with secret refs", async () => {
     const config = {
       token: "$secret{X}",
       secrets: { provider: "vault" },
     };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(SecretsProviderError);
     await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
+  });
+
+  it("warns but does not throw for stub provider with no secret refs", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const config = {
+      token: "plain-value",
+      secrets: { provider: "aws" },
+    };
+    // Should not throw — no $secret{} refs to resolve
+    const result = await resolveConfigSecrets(config);
+    expect(result).toEqual({ token: "plain-value", secrets: { provider: "aws" } });
+    // Should have warned about the unimplemented provider
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("not yet implemented"));
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/config/secrets/resolve.test.ts
+++ b/src/config/secrets/resolve.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { SecretsProvider } from "./provider.js";
 import {
   resolveConfigSecrets,

--- a/src/config/secrets/resolve.test.ts
+++ b/src/config/secrets/resolve.test.ts
@@ -249,12 +249,14 @@ describe("resolveConfigSecrets", () => {
     await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
   });
 
-  it("throws coming-soon error for keyring provider", async () => {
+  it("throws error for keyring provider on non-macOS", async () => {
     const config = {
       token: "$secret{X}",
       secrets: { provider: "keyring" },
     };
-    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
+    // On Linux (CI/test), this throws because macOS Keychain isn't available
+    // On macOS, it would attempt to unlock the keychain
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/keyring|keychain/i);
   });
 
   it("throws coming-soon error for doppler provider", async () => {

--- a/src/config/secrets/resolve.test.ts
+++ b/src/config/secrets/resolve.test.ts
@@ -322,6 +322,20 @@ describe("detectUnresolvedSecretRefs", () => {
   });
 });
 
+describe("sync loadConfig detection", () => {
+  it("detectUnresolvedSecretRefs finds refs for sync path error", () => {
+    // This is what the sync loadConfig() uses to detect unresolved $secret{} refs
+    // and throw SecretsProviderError before returning invalid config
+    const config = {
+      models: { providers: { openai: { apiKey: "$secret{KEY}" } } },
+      secrets: { provider: "env", prefix: "$secret{IGNORED}" },
+    };
+    const refs = detectUnresolvedSecretRefs(config);
+    // Should find the ref in models but NOT in the secrets block
+    expect(refs).toEqual(["$secret{KEY}"]);
+  });
+});
+
 describe("GCP provider", () => {
   it("creates a GCP provider with the correct name", async () => {
     const { createGcpSecretsProvider } = await import("./gcp.js");

--- a/src/config/secrets/resolve.test.ts
+++ b/src/config/secrets/resolve.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi } from "vitest";
+import type { SecretsProvider } from "./provider.js";
+import {
+  resolveConfigSecrets,
+  detectUnresolvedSecretRefs,
+  MissingSecretError,
+  SecretsProviderError,
+} from "./resolve.js";
+
+describe("resolveConfigSecrets", () => {
+  it("passes through config with no secrets provider", async () => {
+    const config = { channels: { slack: { botToken: "xoxb-123" } } };
+    const result = await resolveConfigSecrets(config);
+    expect(result).toEqual(config);
+  });
+
+  it("passes through non-object values", async () => {
+    expect(await resolveConfigSecrets(null)).toBeNull();
+    expect(await resolveConfigSecrets("hello")).toBe("hello");
+    expect(await resolveConfigSecrets(42)).toBe(42);
+  });
+
+  it("resolves $secret{NAME} references using env provider", async () => {
+    const config = {
+      channels: {
+        slack: {
+          botToken: "$secret{SLACK_BOT_TOKEN}",
+          appToken: "$secret{SLACK_APP_TOKEN}",
+        },
+      },
+      secrets: {
+        provider: "env",
+      },
+    };
+    const env = {
+      SLACK_BOT_TOKEN: "xoxb-secret-123",
+      SLACK_APP_TOKEN: "xapp-secret-456",
+    } as NodeJS.ProcessEnv;
+
+    const result = (await resolveConfigSecrets(config, env)) as typeof config;
+    expect(result.channels.slack.botToken).toBe("xoxb-secret-123");
+    expect(result.channels.slack.appToken).toBe("xapp-secret-456");
+  });
+
+  it("resolves secrets in arrays", async () => {
+    const config = {
+      items: ["$secret{SECRET_A}", "plain", "$secret{SECRET_B}"],
+      secrets: { provider: "env" },
+    };
+    const env = { SECRET_A: "aaa", SECRET_B: "bbb" } as NodeJS.ProcessEnv;
+    const result = (await resolveConfigSecrets(config, env)) as typeof config;
+    expect(result.items).toEqual(["aaa", "plain", "bbb"]);
+  });
+
+  it("handles mixed text with secret references", async () => {
+    const config = {
+      url: "https://api.example.com?key=$secret{API_KEY}&v=1",
+      secrets: { provider: "env" },
+    };
+    const env = { API_KEY: "my-key" } as NodeJS.ProcessEnv;
+    const result = (await resolveConfigSecrets(config, env)) as typeof config;
+    expect(result.url).toBe("https://api.example.com?key=my-key&v=1");
+  });
+
+  it("escapes $$secret{NAME} to literal $secret{NAME}", async () => {
+    const config = {
+      example: "$$secret{NOT_A_SECRET}",
+      secrets: { provider: "env" },
+    };
+    const result = (await resolveConfigSecrets(config, {} as NodeJS.ProcessEnv)) as typeof config;
+    expect(result.example).toBe("$secret{NOT_A_SECRET}");
+  });
+
+  it("does not resolve secrets inside the secrets config block", async () => {
+    const config = {
+      secrets: {
+        provider: "env",
+        gcp: {
+          project: "$secret{SHOULD_NOT_RESOLVE}",
+        },
+      },
+    };
+    const result = (await resolveConfigSecrets(config, {} as NodeJS.ProcessEnv)) as typeof config;
+    expect((result.secrets as Record<string, unknown>).gcp).toEqual({
+      project: "$secret{SHOULD_NOT_RESOLVE}",
+    });
+  });
+
+  it("throws MissingSecretError when env provider can't find secret", async () => {
+    const config = {
+      token: "$secret{MISSING_SECRET}",
+      secrets: { provider: "env" },
+    };
+    await expect(resolveConfigSecrets(config, {} as NodeJS.ProcessEnv)).rejects.toThrow(
+      /MISSING_SECRET/,
+    );
+  });
+
+  it("throws SecretsProviderError when no provider configured but refs exist", async () => {
+    const config = {
+      token: "$secret{SOME_SECRET}",
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(SecretsProviderError);
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(
+      /no secrets\.provider is configured/,
+    );
+  });
+
+  it("throws SecretsProviderError for unknown provider", async () => {
+    const config = {
+      token: "$secret{X}",
+      secrets: { provider: "nonexistent" },
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(SecretsProviderError);
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/Unknown secrets provider/);
+  });
+
+  it("leaves strings without $secret{ untouched", async () => {
+    const config = {
+      plain: "no secrets here",
+      dollar: "$not_a_secret",
+      secrets: { provider: "env" },
+    };
+    const result = (await resolveConfigSecrets(config, {} as NodeJS.ProcessEnv)) as typeof config;
+    expect(result.plain).toBe("no secrets here");
+    expect(result.dollar).toBe("$not_a_secret");
+  });
+
+  it("handles deeply nested config", async () => {
+    const config = {
+      a: {
+        b: {
+          c: {
+            d: "$secret{DEEP}",
+          },
+        },
+      },
+      secrets: { provider: "env" },
+    };
+    const env = { DEEP: "found-it" } as NodeJS.ProcessEnv;
+    const result = (await resolveConfigSecrets(config, env)) as typeof config;
+    expect(result.a.b.c.d).toBe("found-it");
+  });
+
+  it("resolves multiple references in same string", async () => {
+    const config = {
+      dsn: "$secret{DB_USER}:$secret{DB_PASS}@host",
+      secrets: { provider: "env" },
+    };
+    const env = { DB_USER: "admin", DB_PASS: "s3cret" } as NodeJS.ProcessEnv;
+    const result = (await resolveConfigSecrets(config, env)) as typeof config;
+    expect(result.dsn).toBe("admin:s3cret@host");
+  });
+
+  it("uses resolveAll when provider implements it", async () => {
+    const resolveAllMock = vi.fn(async (names: string[]) => {
+      const map = new Map<string, string>();
+      for (const name of names) {
+        map.set(name, `batch-${name}`);
+      }
+      return map;
+    });
+    const resolveMock = vi.fn(async () => "should-not-be-called");
+
+    // Inject a custom provider by mocking createProvider indirectly via the env approach
+    // We need to test via resolveConfigSecrets so we use the env provider path
+    // Instead, test that resolveAll is preferred by using a mock provider directly
+    // We can't easily inject a provider, so we test via the env provider
+    // Actually, let's test by creating a provider with resolveAll and using it
+    // through the public API. We'll use the "env" provider type but the test
+    // really needs a custom provider. Let's use a different approach:
+
+    // Use env provider and verify the result is correct (resolveAll is tested indirectly)
+    // For a direct test of resolveAll, we test the batch provider path:
+    const mockProvider: SecretsProvider = {
+      name: "mock",
+      resolve: resolveMock,
+      resolveAll: resolveAllMock,
+    };
+
+    // We can't inject the provider through resolveConfigSecrets easily,
+    // so let's test defaultResolveAll + the resolveAll contract directly
+    const { defaultResolveAll } = await import("./provider.js");
+    const result = await mockProvider.resolveAll!(["key1", "key2"]);
+    expect(result.get("key1")).toBe("batch-key1");
+    expect(result.get("key2")).toBe("batch-key2");
+    expect(resolveAllMock).toHaveBeenCalledWith(["key1", "key2"]);
+    expect(resolveMock).not.toHaveBeenCalled();
+
+    // Also test defaultResolveAll
+    const defaultResult = await defaultResolveAll(mockProvider, ["a", "b"]);
+    expect(resolveMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves secret names with dots and hyphens", async () => {
+    const config = {
+      token: "$secret{my-app.api-key}",
+      secrets: { provider: "env" },
+    };
+    const env = { "my-app.api-key": "dotted-value" } as unknown as NodeJS.ProcessEnv;
+    const result = (await resolveConfigSecrets(config, env)) as typeof config;
+    expect(result.token).toBe("dotted-value");
+  });
+
+  it("ignores empty secret name $secret{}", async () => {
+    const config = {
+      token: "$secret{}",
+      secrets: { provider: "env" },
+    };
+    // Empty name doesn't match SECRET_NAME_PATTERN, so it passes through as literal
+    const result = (await resolveConfigSecrets(config, {} as NodeJS.ProcessEnv)) as typeof config;
+    expect(result.token).toBe("$secret{}");
+  });
+
+  it("ignores invalid secret name with spaces", async () => {
+    const config = {
+      token: "$secret{foo bar}",
+      secrets: { provider: "env" },
+    };
+    // Spaces don't match SECRET_NAME_PATTERN, so it passes through as literal
+    const result = (await resolveConfigSecrets(config, {} as NodeJS.ProcessEnv)) as typeof config;
+    expect(result.token).toBe("$secret{foo bar}");
+  });
+
+  it("does not recursively resolve secret values containing $secret{...}", async () => {
+    const config = {
+      token: "$secret{OUTER}",
+      secrets: { provider: "env" },
+    };
+    // The resolved value itself contains a $secret{} reference — should NOT be resolved again
+    const env = { OUTER: "$secret{INNER}", INNER: "should-not-appear" } as NodeJS.ProcessEnv;
+    const result = (await resolveConfigSecrets(config, env)) as typeof config;
+    expect(result.token).toBe("$secret{INNER}");
+  });
+
+  it("throws coming-soon error for aws provider", async () => {
+    const config = {
+      token: "$secret{X}",
+      secrets: { provider: "aws" },
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
+  });
+
+  it("throws coming-soon error for 1password provider", async () => {
+    const config = {
+      token: "$secret{X}",
+      secrets: { provider: "1password" },
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
+  });
+
+  it("throws coming-soon error for keyring provider", async () => {
+    const config = {
+      token: "$secret{X}",
+      secrets: { provider: "keyring" },
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
+  });
+
+  it("throws coming-soon error for doppler provider", async () => {
+    const config = {
+      token: "$secret{X}",
+      secrets: { provider: "doppler" },
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
+  });
+
+  it("throws coming-soon error for bitwarden provider", async () => {
+    const config = {
+      token: "$secret{X}",
+      secrets: { provider: "bitwarden" },
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
+  });
+
+  it("throws coming-soon error for vault provider", async () => {
+    const config = {
+      token: "$secret{X}",
+      secrets: { provider: "vault" },
+    };
+    await expect(resolveConfigSecrets(config)).rejects.toThrow(/not yet implemented/);
+  });
+});
+
+describe("detectUnresolvedSecretRefs", () => {
+  it("returns empty array for config without secret refs", () => {
+    expect(detectUnresolvedSecretRefs({ foo: "bar" })).toEqual([]);
+  });
+
+  it("detects $secret{...} patterns in config", () => {
+    const config = { token: "$secret{MY_TOKEN}", nested: { key: "$secret{OTHER}" } };
+    const refs = detectUnresolvedSecretRefs(config);
+    expect(refs).toContain("$secret{MY_TOKEN}");
+    expect(refs).toContain("$secret{OTHER}");
+  });
+
+  it("ignores $$secret{...} escape sequences", () => {
+    expect(detectUnresolvedSecretRefs({ val: "$$secret{ESCAPED}" })).toEqual([]);
+  });
+
+  it("ignores invalid secret names", () => {
+    expect(detectUnresolvedSecretRefs({ val: "$secret{}" })).toEqual([]);
+    expect(detectUnresolvedSecretRefs({ val: "$secret{foo bar}" })).toEqual([]);
+  });
+});
+
+describe("GCP provider with mocked API", () => {
+  it("resolves secrets via mocked GCP client", async () => {
+    const { createGcpSecretsProvider } = await import("./gcp.js");
+    const provider = createGcpSecretsProvider({ project: "test-project" });
+    expect(provider.name).toBe("gcp");
+    await expect(provider.resolve("test")).rejects.toThrow(/@google-cloud\/secret-manager/);
+  });
+});

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -272,7 +272,7 @@ function createProvider(config: SecretsConfig, env?: NodeJS.ProcessEnv): Secrets
       return createVaultSecretsProvider(config.vault);
     default:
       throw new SecretsProviderError(
-        `Unknown secrets provider: "${config.provider}". Supported: gcp, env, keyring. Stubs available: aws, 1password, doppler, bitwarden, vault`,
+        `Unknown secrets provider: "${config.provider}". Supported: gcp, env, keyring. Not yet implemented: aws, 1password, doppler, bitwarden, vault`,
       );
   }
 }

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -252,6 +252,9 @@ function substituteSecrets(
 function createProvider(config: SecretsConfig, env?: NodeJS.ProcessEnv): SecretsProvider {
   switch (config.provider) {
     case "gcp":
+      if (!config.gcp?.project) {
+        throw new SecretsProviderError("GCP secrets provider requires 'gcp.project' to be set");
+      }
       return createGcpSecretsProvider(config.gcp);
     case "env":
       return createEnvSecretsProvider(env);

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -269,7 +269,7 @@ function createProvider(config: SecretsConfig, env?: NodeJS.ProcessEnv): Secrets
       return createVaultSecretsProvider(config.vault);
     default:
       throw new SecretsProviderError(
-        `Unknown secrets provider: "${config.provider}". Supported: gcp, env. Stubs available: aws, keyring, 1password, doppler, bitwarden, vault`,
+        `Unknown secrets provider: "${config.provider}". Supported: gcp, env, keyring. Stubs available: aws, 1password, doppler, bitwarden, vault`,
       );
   }
 }

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -249,7 +249,7 @@ function createProvider(config: SecretsConfig, env?: NodeJS.ProcessEnv): Secrets
       throw new SecretsProviderError(
         `Secrets provider "${config.provider}" is not yet implemented. ` +
           `Supported providers: gcp, env, keyring. ` +
-          `See https://docs.openclaw.ai/gateway/secrets for alternatives. ` +
+          `See docs/gateway/secrets for alternatives. ` +
           `Contributions welcome — see src/config/secrets/${config.provider === "1password" ? "onepassword" : config.provider}.ts`,
       );
     default:

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -247,7 +247,7 @@ function createProvider(config: SecretsConfig, env?: NodeJS.ProcessEnv): Secrets
     case "aws":
       return createAwsSecretsProvider(config.aws);
     case "keyring":
-      return createKeyringSecretsProvider();
+      return createKeyringSecretsProvider(config.keyring);
     case "1password":
       return createOnePasswordSecretsProvider();
     case "doppler":

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -25,15 +25,10 @@
 
 import type { SecretsProvider } from "./provider.js";
 import type { SecretsConfig } from "./types.js";
-import { createAwsSecretsProvider } from "./aws.js";
-import { createBitwardenSecretsProvider } from "./bitwarden.js";
-import { createDopplerSecretsProvider } from "./doppler.js";
 import { createEnvSecretsProvider } from "./env.js";
 import { createGcpSecretsProvider } from "./gcp.js";
 import { createKeyringSecretsProvider } from "./keyring.js";
-import { createOnePasswordSecretsProvider } from "./onepassword.js";
 import { defaultResolveAll } from "./provider.js";
-import { createVaultSecretsProvider } from "./vault.js";
 
 /** Pattern for valid secret names: alphanumeric, hyphens, underscores, dots. */
 const SECRET_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/;

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -1,0 +1,364 @@
+/**
+ * Secret reference resolution for config values.
+ *
+ * Supports `$secret{SECRET_NAME}` syntax in string values, resolved at config load time
+ * via the configured secrets provider.
+ * - Escape with `$$secret{...}` to output literal `$secret{...}`
+ * - Missing secrets throw `MissingSecretError` with context
+ * - The `secrets` config block itself is excluded from resolution (avoids circular deps)
+ *
+ * @example
+ * ```json5
+ * {
+ *   channels: {
+ *     slack: {
+ *       botToken: "$secret{openclaw-slack-bot-token}"
+ *     }
+ *   },
+ *   secrets: {
+ *     provider: "gcp",
+ *     gcp: { project: "my-project" }
+ *   }
+ * }
+ * ```
+ */
+
+import type { SecretsProvider } from "./provider.js";
+import type { SecretsConfig } from "./types.js";
+import { createAwsSecretsProvider } from "./aws.js";
+import { createBitwardenSecretsProvider } from "./bitwarden.js";
+import { createDopplerSecretsProvider } from "./doppler.js";
+import { createEnvSecretsProvider } from "./env.js";
+import { createGcpSecretsProvider } from "./gcp.js";
+import { createKeyringSecretsProvider } from "./keyring.js";
+import { createOnePasswordSecretsProvider } from "./onepassword.js";
+import { defaultResolveAll } from "./provider.js";
+import { createVaultSecretsProvider } from "./vault.js";
+
+/** Pattern for valid secret names: alphanumeric, hyphens, underscores, dots. */
+const SECRET_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/;
+
+export class MissingSecretError extends Error {
+  constructor(
+    public readonly secretName: string,
+    public readonly configPath: string,
+  ) {
+    super(`Missing secret "${secretName}" referenced at config path: ${configPath}`);
+    this.name = "MissingSecretError";
+  }
+}
+
+export class SecretsProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SecretsProviderError";
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.prototype.toString.call(value) === "[object Object]"
+  );
+}
+
+/**
+ * Parse a string into a sequence of tokens representing literal text,
+ * `$secret{NAME}` references, and `$$secret{NAME}` escape sequences.
+ *
+ * Shared between collect and substitute phases to ensure consistent handling.
+ */
+type SecretToken =
+  | { type: "literal"; text: string }
+  | { type: "ref"; name: string }
+  | { type: "escape"; name: string };
+
+function tokenizeSecretString(value: string): SecretToken[] {
+  const tokens: SecretToken[] = [];
+  let i = 0;
+
+  while (i < value.length) {
+    const char = value[i];
+    if (char !== "$") {
+      // Scan forward for the next '$' to batch literal chars
+      let j = i + 1;
+      while (j < value.length && value[j] !== "$") j++;
+      tokens.push({ type: "literal", text: value.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    // Check for $$secret{...} escape
+    if (value.startsWith("$$secret{", i)) {
+      const start = i + 9; // after "$$secret{"
+      const end = value.indexOf("}", start);
+      if (end !== -1) {
+        const name = value.slice(start, end);
+        if (SECRET_NAME_PATTERN.test(name)) {
+          tokens.push({ type: "escape", name });
+          i = end + 1;
+          continue;
+        }
+      }
+    }
+
+    // Check for $secret{...} substitution
+    if (value.startsWith("$secret{", i)) {
+      const start = i + 8; // after "$secret{"
+      const end = value.indexOf("}", start);
+      if (end !== -1) {
+        const name = value.slice(start, end);
+        if (SECRET_NAME_PATTERN.test(name)) {
+          tokens.push({ type: "ref", name });
+          i = end + 1;
+          continue;
+        }
+      }
+    }
+
+    tokens.push({ type: "literal", text: char });
+    i++;
+  }
+
+  return tokens;
+}
+
+/**
+ * Collect all `$secret{NAME}` references from a config tree.
+ * Skips the `secrets` key at the root level to avoid circular deps.
+ */
+function collectSecretRefs(
+  value: unknown,
+  path: string,
+  skipKeys: Set<string>,
+  refs: Map<string, string[]>,
+): void {
+  if (typeof value === "string") {
+    if (!value.includes("$secret{")) return;
+    for (const token of tokenizeSecretString(value)) {
+      if (token.type === "ref") {
+        const existing = refs.get(token.name);
+        if (existing) {
+          existing.push(path);
+        } else {
+          refs.set(token.name, [path]);
+        }
+      }
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      collectSecretRefs(value[i], `${path}[${i}]`, skipKeys, refs);
+    }
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    for (const [key, val] of Object.entries(value)) {
+      if (path === "" && skipKeys.has(key)) continue;
+      const childPath = path ? `${path}.${key}` : key;
+      collectSecretRefs(val, childPath, skipKeys, refs);
+    }
+  }
+}
+
+/**
+ * Replace `$secret{NAME}` references in a string with resolved values.
+ * Handles escaping: `$$secret{NAME}` -> `$secret{NAME}`.
+ */
+function substituteSecretString(
+  value: string,
+  resolved: Map<string, string>,
+  configPath: string,
+): string {
+  if (!value.includes("$secret{")) return value;
+
+  const chunks: string[] = [];
+  for (const token of tokenizeSecretString(value)) {
+    switch (token.type) {
+      case "literal":
+        chunks.push(token.text);
+        break;
+      case "escape":
+        chunks.push(`$secret{${token.name}}`);
+        break;
+      case "ref": {
+        const secretValue = resolved.get(token.name);
+        if (secretValue === undefined) {
+          throw new MissingSecretError(token.name, configPath);
+        }
+        chunks.push(secretValue);
+        break;
+      }
+    }
+  }
+  return chunks.join("");
+}
+
+/**
+ * Walk the config tree and substitute resolved secrets.
+ * Skips the `secrets` key at root level.
+ */
+function substituteSecrets(
+  value: unknown,
+  resolved: Map<string, string>,
+  path: string,
+  skipKeys: Set<string>,
+): unknown {
+  if (typeof value === "string") {
+    return substituteSecretString(value, resolved, path);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      substituteSecrets(item, resolved, `${path}[${index}]`, skipKeys),
+    );
+  }
+
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      if (path === "" && skipKeys.has(key)) {
+        result[key] = val;
+        continue;
+      }
+      const childPath = path ? `${path}.${key}` : key;
+      result[key] = substituteSecrets(val, resolved, childPath, skipKeys);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Create a secrets provider from the config.
+ */
+function createProvider(config: SecretsConfig, env?: NodeJS.ProcessEnv): SecretsProvider {
+  switch (config.provider) {
+    case "gcp":
+      return createGcpSecretsProvider(config.gcp);
+    case "env":
+      return createEnvSecretsProvider(env);
+    case "aws":
+      return createAwsSecretsProvider(config.aws);
+    case "keyring":
+      return createKeyringSecretsProvider();
+    case "1password":
+      return createOnePasswordSecretsProvider();
+    case "doppler":
+      return createDopplerSecretsProvider(config.doppler);
+    case "bitwarden":
+      return createBitwardenSecretsProvider();
+    case "vault":
+      return createVaultSecretsProvider(config.vault);
+    default:
+      throw new SecretsProviderError(
+        `Unknown secrets provider: "${config.provider}". Supported: gcp, env. Stubs available: aws, keyring, 1password, doppler, bitwarden, vault`,
+      );
+  }
+}
+
+/**
+ * Detect any unresolved `$secret{...}` references in a config tree.
+ * Returns the list of `$secret{...}` patterns found (e.g. `["$secret{MY_KEY}"]`).
+ * Useful for sync code paths that cannot resolve secrets.
+ */
+export function detectUnresolvedSecretRefs(config: unknown): string[] {
+  const refs: string[] = [];
+  walk(config);
+  return refs;
+
+  function walk(value: unknown): void {
+    if (typeof value === "string") {
+      if (!value.includes("$secret{")) return;
+      for (const token of tokenizeSecretString(value)) {
+        if (token.type === "ref") {
+          refs.push(`$secret{${token.name}}`);
+        }
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) walk(item);
+      return;
+    }
+    if (isPlainObject(value)) {
+      for (const val of Object.values(value)) walk(val);
+    }
+  }
+}
+
+/**
+ * Resolves `$secret{SECRET_NAME}` references in config values using the
+ * configured secrets provider.
+ *
+ * @param obj - The parsed config object (after env-var substitution)
+ * @param env - Environment variables (passed to env provider)
+ * @returns The config object with secrets substituted
+ * @throws {MissingSecretError} If a referenced secret cannot be resolved
+ * @throws {SecretsProviderError} If the provider is not configured or fails
+ */
+export async function resolveConfigSecrets(
+  obj: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<unknown> {
+  if (!isPlainObject(obj)) {
+    return obj;
+  }
+
+  // Extract secrets config
+  const secretsConfig = obj.secrets as SecretsConfig | undefined;
+  if (!secretsConfig?.provider) {
+    // No provider configured — check if there are any secret refs that would go unresolved
+    const refs = new Map<string, string[]>();
+    collectSecretRefs(obj, "", new Set(["secrets"]), refs);
+    if (refs.size > 0) {
+      const first = refs.entries().next().value;
+      if (first) {
+        throw new SecretsProviderError(
+          `Found $secret{${first[0]}} reference at "${first[1][0]}" but no secrets.provider is configured`,
+        );
+      }
+    }
+    // Still run substitution to handle $$secret{} escape sequences
+    return substituteSecrets(obj, new Map(), "", new Set(["secrets"]));
+  }
+
+  const skipKeys = new Set(["secrets"]);
+
+  // Collect all secret references
+  const refs = new Map<string, string[]>();
+  collectSecretRefs(obj, "", skipKeys, refs);
+
+  let resolved: Map<string, string>;
+
+  if (refs.size === 0) {
+    resolved = new Map();
+  } else {
+    // Create provider and resolve all secrets
+    const provider = createProvider(secretsConfig, env);
+    const secretNames = Array.from(refs.keys());
+
+    if (provider.resolveAll) {
+      resolved = await provider.resolveAll(secretNames);
+    } else {
+      resolved = await defaultResolveAll(provider, secretNames);
+    }
+
+    // Verify all secrets were resolved
+    for (const name of secretNames) {
+      if (!resolved.has(name)) {
+        const paths = refs.get(name)!;
+        throw new MissingSecretError(name, paths[0]);
+      }
+    }
+  }
+
+  // Substitute (also handles $$secret{} escaping)
+  return substituteSecrets(obj, resolved, "", skipKeys);
+}

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -26,18 +26,18 @@
 import type { SecretsProvider } from "./provider.js";
 import type { SecretsConfig } from "./types.js";
 import { createEnvSecretsProvider } from "./env.js";
+import { MissingSecretError, SecretsProviderError } from "./errors.js";
 import { createGcpSecretsProvider } from "./gcp.js";
 import { createKeyringSecretsProvider } from "./keyring.js";
 import { defaultResolveAll } from "./provider.js";
+
+export { MissingSecretError, SecretsProviderError } from "./errors.js";
 
 /** Pattern for valid secret names: alphanumeric, hyphens, underscores, dots. */
 const SECRET_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/;
 
 /** Config keys to skip during secret resolution (avoids circular deps). */
 const DEFAULT_SKIP_KEYS: ReadonlySet<string> = new Set(["secrets"]);
-
-import { MissingSecretError, SecretsProviderError } from "./errors.js";
-export { MissingSecretError, SecretsProviderError } from "./errors.js";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return (

--- a/src/config/secrets/resolve.ts
+++ b/src/config/secrets/resolve.ts
@@ -36,22 +36,8 @@ const SECRET_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/;
 /** Config keys to skip during secret resolution (avoids circular deps). */
 const DEFAULT_SKIP_KEYS: ReadonlySet<string> = new Set(["secrets"]);
 
-export class MissingSecretError extends Error {
-  constructor(
-    public readonly secretName: string,
-    public readonly configPath: string,
-  ) {
-    super(`Missing secret "${secretName}" referenced at config path: ${configPath}`);
-    this.name = "MissingSecretError";
-  }
-}
-
-export class SecretsProviderError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "SecretsProviderError";
-  }
-}
+import { MissingSecretError, SecretsProviderError } from "./errors.js";
+export { MissingSecretError, SecretsProviderError } from "./errors.js";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return (

--- a/src/config/secrets/types.ts
+++ b/src/config/secrets/types.ts
@@ -20,8 +20,8 @@ export interface SecretsConfig {
 
   /** GCP Secret Manager options. */
   gcp?: {
-    /** GCP project ID. Defaults to the gcloud default project. */
-    project?: string;
+    /** GCP project ID (required — Secret Manager doesn't support automatic project discovery). */
+    project: string;
   };
 
   /** AWS Secrets Manager options. */

--- a/src/config/secrets/types.ts
+++ b/src/config/secrets/types.ts
@@ -48,6 +48,16 @@ export interface SecretsConfig {
     mountPath?: string;
   };
 
+  /** OS Keyring / macOS Keychain options. */
+  keyring?: {
+    /** Path to the keychain file (macOS only). Defaults to ~/Library/Keychains/openclaw.keychain-db. */
+    keychainPath?: string;
+    /** Password to unlock the keychain. Defaults to empty string. */
+    keychainPassword?: string;
+    /** Account name for keychain items. Defaults to "openclaw". */
+    account?: string;
+  };
+
   /**
    * Optional mapping of secret names to config paths.
    * Reserved for future use (e.g. auto-mapping secrets to config locations).

--- a/src/config/secrets/types.ts
+++ b/src/config/secrets/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Type definitions for the secrets configuration block.
+ */
+
+/** Supported secrets provider identifiers. */
+export type SecretsProviderType =
+  | "gcp"
+  | "aws"
+  | "env"
+  | "keyring"
+  | "1password"
+  | "doppler"
+  | "bitwarden"
+  | "vault";
+
+/** Configuration for secrets resolution in openclaw.json. */
+export interface SecretsConfig {
+  /** The secrets provider to use for resolving `$secret{...}` references. */
+  provider?: SecretsProviderType;
+
+  /** GCP Secret Manager options. */
+  gcp?: {
+    /** GCP project ID. Defaults to the gcloud default project. */
+    project?: string;
+  };
+
+  /** AWS Secrets Manager options. */
+  aws?: {
+    /** AWS region. Defaults to the AWS SDK default region. */
+    region?: string;
+  };
+
+  /** Doppler options. */
+  doppler?: {
+    /** Doppler project name. */
+    project?: string;
+    /** Doppler config/environment (e.g. "dev", "staging", "prod"). */
+    config?: string;
+  };
+
+  /** HashiCorp Vault options. */
+  vault?: {
+    /** Vault server address (e.g. "https://vault.example.com:8200"). */
+    address?: string;
+    /** Vault namespace (enterprise feature). */
+    namespace?: string;
+    /** Secret engine mount path (default: "secret"). */
+    mountPath?: string;
+  };
+
+  /**
+   * Optional mapping of secret names to config paths.
+   * Reserved for future use (e.g. auto-mapping secrets to config locations).
+   */
+  mapping?: Record<string, string>;
+}

--- a/src/config/secrets/vault.ts
+++ b/src/config/secrets/vault.ts
@@ -13,6 +13,7 @@
  */
 
 import type { SecretsProvider } from "./provider.js";
+import { SecretsProviderError } from "./errors.js";
 
 /** Options for the HashiCorp Vault secrets provider. */
 export interface VaultSecretsProviderOptions {
@@ -34,7 +35,7 @@ export function createVaultSecretsProvider(
   return {
     name: "vault",
     async resolve(_secretName: string): Promise<string> {
-      throw new Error(
+      throw new SecretsProviderError(
         "HashiCorp Vault secrets provider is not yet implemented — no access to a Vault instance. " +
           "Contributions welcome — see src/config/secrets/vault.ts",
       );

--- a/src/config/secrets/vault.ts
+++ b/src/config/secrets/vault.ts
@@ -1,0 +1,43 @@
+/**
+ * HashiCorp Vault secrets provider (stub).
+ *
+ * HashiCorp Vault is the enterprise standard for secrets management.
+ *
+ * TODO: Implement using Vault HTTP API or node-vault package.
+ * Reference: https://developer.hashicorp.com/vault/api-docs
+ *
+ * Note: No implementation provided — we don't currently have access to a Vault instance.
+ * Contributions welcome!
+ *
+ * @throws Always throws — not yet implemented.
+ */
+
+import type { SecretsProvider } from "./provider.js";
+
+/** Options for the HashiCorp Vault secrets provider. */
+export interface VaultSecretsProviderOptions {
+  /** Vault server address (e.g. "https://vault.example.com:8200"). */
+  address?: string;
+  /** Vault namespace (enterprise feature). */
+  namespace?: string;
+  /** Secret engine mount path (default: "secret"). */
+  mountPath?: string;
+}
+
+/**
+ * Creates a HashiCorp Vault secrets provider.
+ * Currently a stub that throws on any resolution attempt.
+ */
+export function createVaultSecretsProvider(
+  _options: VaultSecretsProviderOptions = {},
+): SecretsProvider {
+  return {
+    name: "vault",
+    async resolve(_secretName: string): Promise<string> {
+      throw new Error(
+        "HashiCorp Vault secrets provider is not yet implemented — no access to a Vault instance. " +
+          "Contributions welcome — see src/config/secrets/vault.ts",
+      );
+    },
+  };
+}

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -1,3 +1,4 @@
+import type { SecretsConfig } from "./secrets/types.js";
 import type { AgentBinding, AgentsConfig } from "./types.agents.js";
 import type { ApprovalsConfig } from "./types.approvals.js";
 import type { AuthConfig } from "./types.auth.js";
@@ -97,6 +98,7 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  secrets?: SecretsConfig;
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -565,7 +565,7 @@ export const OpenClawSchema = z
           .optional(),
         gcp: z
           .object({
-            project: z.string().optional(),
+            project: z.string(),
           })
           .strict()
           .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -565,7 +565,7 @@ export const OpenClawSchema = z
           .optional(),
         gcp: z
           .object({
-            project: z.string(),
+            project: z.string().min(1, "GCP project ID cannot be empty"),
           })
           .strict()
           .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -590,6 +590,14 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        keyring: z
+          .object({
+            keychainPath: z.string().optional(),
+            keychainPassword: z.string().optional(),
+            account: z.string().optional(),
+          })
+          .strict()
+          .optional(),
         mapping: z.record(z.string(), z.string()).optional(),
       })
       .strict()

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -549,6 +549,51 @@ export const OpenClawSchema = z
       .strict()
       .optional(),
     memory: MemorySchema,
+    secrets: z
+      .object({
+        provider: z
+          .union([
+            z.literal("gcp"),
+            z.literal("aws"),
+            z.literal("env"),
+            z.literal("keyring"),
+            z.literal("1password"),
+            z.literal("doppler"),
+            z.literal("bitwarden"),
+            z.literal("vault"),
+          ])
+          .optional(),
+        gcp: z
+          .object({
+            project: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        aws: z
+          .object({
+            region: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        doppler: z
+          .object({
+            project: z.string().optional(),
+            config: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        vault: z
+          .object({
+            address: z.string().optional(),
+            namespace: z.string().optional(),
+            mountPath: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        mapping: z.record(z.string(), z.string()).optional(),
+      })
+      .strict()
+      .optional(),
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Adds a pluggable secrets manager that resolves `$secret{NAME}` references in config values at load time. This lets users keep API keys, tokens, and other credentials in external secret stores instead of plaintext in `openclaw.json`.

## Dependencies

> This PR is rebased on `feature/config-env-preserve` (#11560) and must merge **after** it. The config-env-preserve branch adds env-snapshot scoping in `io.ts` that this PR builds on for the sync ↔ async cache bridge (secrets resolution primes the same config cache that env-preserve scopes by path).

## What's included

- **Core engine**: tokenizer-based parser for `$secret{NAME}` syntax with `$$secret{NAME}` escape support
- **Provider interface**: `SecretsProvider` with `resolve()`, optional `resolveAll()`, and `dispose()`
- **Implemented providers**:
  - `env` — resolves from environment variables (with optional prefix)
  - `gcp` — Google Cloud Secret Manager (optional peer dep `@google-cloud/secret-manager`)
  - `keyring` — OS-native credential storage:
    - macOS: `security` CLI with dedicated OpenClaw keychain
    - Linux: `secret-tool` / libsecret (GNOME Keyring / KDE Wallet)
- **Provider stubs** (interface only, not yet implemented): AWS Secrets Manager, HashiCorp Vault, 1Password, Doppler, Bitwarden
- **Sync ↔ async cache bridge**: `readConfigFileSnapshot()` primes the module-level config cache with resolved secrets; subsequent sync `loadConfig()` calls return the cached config when `$secret{}` refs are detected, avoiding the need to convert every sync callsite to async
- **Gateway startup**: `run.ts` primes the async cache before the first sync `loadConfig()`; `context.ts` switched to async `readConfigFileSnapshot()` to avoid noisy errors at module init
- **Config integration**: resolves after `${ENV_VAR}` substitution, before Zod validation
- **Documentation**: `docs/gateway/secrets.md` + updates to `configuration.md` and `security/index.md`
- **51 tests** (49 provider/engine + 2 sync-cache-fallback), full suite passes

## Security

- Keychain password passed via stdin (not CLI args)
- Provider `dispose()` always called (best-effort, won't mask primary errors)
- 30s timeout + max-5 concurrency on secret resolution
- `SECRET_NAME_PATTERN` (`[a-zA-Z0-9_.-]+`) prevents injection
- `execFile` (not `exec`) — no shell invocation
- Secret values never logged or included in error messages
- No recursive resolution (secret values containing `$secret{}` are not re-expanded)

## Design discussion

RFC posted at #10033 (comment: https://github.com/openclaw/openclaw/issues/10033#issuecomment-3865603612)

## AI disclosure

- [x] AI-assisted (Claude via OpenClaw)
- [x] Fully tested (51 unit tests + full suite green)
- [x] I understand what all the code does

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds pluggable secrets manager integration with `$secret{NAME}` syntax for resolving credentials from external stores (GCP Secret Manager, environment variables, OS keyring) at config load time.

**Key changes:**
- Tokenizer-based parser handles `$secret{NAME}` refs and `$$secret{NAME}` escapes with validation (`[a-zA-Z0-9_.-]+` pattern)
- Three fully-implemented providers: `env` (environment variables), `gcp` (Google Cloud Secret Manager with optional peer dependency), `keyring` (macOS Keychain via `security` CLI, Linux libsecret via `secret-tool`)
- Five stub providers (aws, 1password, doppler, bitwarden, vault) with clear "not yet implemented" errors
- Sync/async cache bridge: `readConfigFileSnapshot()` primes module-level cache with resolved secrets; sync `loadConfig()` falls back to cached config when `$secret{}` refs detected
- Gateway startup (`run.ts`) primes async cache before first sync config access, with warnings logged on resolution failures
- Resolves after `${ENV_VAR}` substitution, before Zod validation
- 51 comprehensive tests (49 provider/engine + 2 sync-cache-fallback)

**Security measures:**
- Keychain passwords passed via stdin (not CLI args)
- Provider `dispose()` always called (best-effort cleanup)
- 30s timeout + max-5 concurrency on secret resolution
- `SECRET_NAME_PATTERN` prevents injection
- `execFile` (not `exec`) avoids shell invocation
- Secret values never logged
- No recursive resolution

**Documentation:**
- Comprehensive guide at `docs/gateway/secrets.md` with provider setup instructions
- Updates to `configuration.md` and `security/index.md`

The implementation is thorough, well-tested, and addresses all issues raised in previous review cycles. The sync/async bridge is a pragmatic solution that avoids converting hundreds of sync callsites to async.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects comprehensive testing (51 tests), thorough security design, extensive review iterations addressing all raised concerns, and backward-compatible implementation. All previous review comments have been addressed with fixes committed. The feature is opt-in (requires `secrets` config), preserves existing behavior when not configured, and includes detailed documentation. The sync/async bridge pattern is well-designed to avoid breaking existing callsites.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->