### PR TITLE
Memory: harden QMD startup, timeouts, and fallback recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Gateway/CLI: when `gateway.bind=lan`, use a LAN IP for probe URLs and Control UI links. (#11448) Thanks @AnonO6.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
+- Memory/QMD: run boot refresh in background by default, add configurable QMD maintenance timeouts, and retry QMD after fallback failures. (#9690, #9705)
 - Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.
 - Telegram: auto-inject DM topic threadId in message tool + subagent announce. (#7235) Thanks @Lukavyi.
 - Security: require auth for Gateway canvas host and A2UI assets. (#9518) Thanks @coygeek.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -127,12 +127,18 @@ out to QMD for retrieval. Key points:
 
 - The gateway writes a self-contained QMD home under
   `~/.openclaw/agents/<agentId>/qmd/` (config + cache + sqlite DB).
-- Collections are rewritten from `memory.qmd.paths` (plus default workspace
-  memory files) into `index.yml`, then `qmd update` + `qmd embed` run on boot and
-  on a configurable interval (`memory.qmd.update.interval`, default 5 m).
+- Collections are created via `qmd collection add` from `memory.qmd.paths`
+  (plus default workspace memory files), then `qmd update` + `qmd embed` run
+  on boot and on a configurable interval (`memory.qmd.update.interval`,
+  default 5 m).
+- Boot refresh now runs in the background by default so chat startup is not
+  blocked; set `memory.qmd.update.waitForBootSync = true` to keep the previous
+  blocking behavior.
 - Searches run via `qmd query --json`. If QMD fails or the binary is missing,
   OpenClaw automatically falls back to the builtin SQLite manager so memory tools
   keep working.
+- OpenClaw does not expose QMD embed batch-size tuning today; batch behavior is
+  controlled by QMD itself.
 - **First search may be slow**: QMD may download local GGUF models (reranker/query
   expansion) on the first `qmd query` run.
   - OpenClaw sets `XDG_CONFIG_HOME`/`XDG_CACHE_HOME` automatically when it runs QMD.
@@ -170,7 +176,9 @@ out to QMD for retrieval. Key points:
   stable `name`).
 - `sessions`: opt into session JSONL indexing (`enabled`, `retentionDays`,
   `exportDir`).
-- `update`: controls refresh cadence (`interval`, `debounceMs`, `onBoot`, `embedInterval`).
+- `update`: controls refresh cadence and maintenance execution:
+  (`interval`, `debounceMs`, `onBoot`, `waitForBootSync`, `embedInterval`,
+  `commandTimeoutMs`, `updateTimeoutMs`, `embedTimeoutMs`).
 - `limits`: clamp recall payload (`maxResults`, `maxSnippetChars`,
   `maxInjectedChars`, `timeoutMs`).
 - `scope`: same schema as [`session.sendPolicy`](/gateway/configuration#session).

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -271,7 +271,11 @@ const FIELD_LABELS: Record<string, string> = {
   "memory.qmd.update.interval": "QMD Update Interval",
   "memory.qmd.update.debounceMs": "QMD Update Debounce (ms)",
   "memory.qmd.update.onBoot": "QMD Update on Startup",
+  "memory.qmd.update.waitForBootSync": "QMD Wait for Boot Sync",
   "memory.qmd.update.embedInterval": "QMD Embed Interval",
+  "memory.qmd.update.commandTimeoutMs": "QMD Command Timeout (ms)",
+  "memory.qmd.update.updateTimeoutMs": "QMD Update Timeout (ms)",
+  "memory.qmd.update.embedTimeoutMs": "QMD Embed Timeout (ms)",
   "memory.qmd.limits.maxResults": "QMD Max Results",
   "memory.qmd.limits.maxSnippetChars": "QMD Max Snippet Chars",
   "memory.qmd.limits.maxInjectedChars": "QMD Max Injected Chars",
@@ -602,8 +606,14 @@ const FIELD_HELP: Record<string, string> = {
   "memory.qmd.update.debounceMs":
     "Minimum delay between successive QMD refresh runs (default: 15000).",
   "memory.qmd.update.onBoot": "Run QMD update once on gateway startup (default: true).",
+  "memory.qmd.update.waitForBootSync":
+    "Block startup until the boot QMD refresh finishes (default: false).",
   "memory.qmd.update.embedInterval":
     "How often QMD embeddings are refreshed (duration string, default: 60m). Set to 0 to disable periodic embed.",
+  "memory.qmd.update.commandTimeoutMs":
+    "Timeout for QMD maintenance commands like collection list/add (default: 30000).",
+  "memory.qmd.update.updateTimeoutMs": "Timeout for `qmd update` runs (default: 120000).",
+  "memory.qmd.update.embedTimeoutMs": "Timeout for `qmd embed` runs (default: 120000).",
   "memory.qmd.limits.maxResults": "Max QMD results returned to the agent loop (default: 6).",
   "memory.qmd.limits.maxSnippetChars": "Max characters per snippet pulled from QMD (default: 700).",
   "memory.qmd.limits.maxInjectedChars": "Max total characters injected from QMD hits per turn.",

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -35,7 +35,11 @@ export type MemoryQmdUpdateConfig = {
   interval?: string;
   debounceMs?: number;
   onBoot?: boolean;
+  waitForBootSync?: boolean;
   embedInterval?: string;
+  commandTimeoutMs?: number;
+  updateTimeoutMs?: number;
+  embedTimeoutMs?: number;
 };
 
 export type MemoryQmdLimitsConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -53,7 +53,11 @@ const MemoryQmdUpdateSchema = z
     interval: z.string().optional(),
     debounceMs: z.number().int().nonnegative().optional(),
     onBoot: z.boolean().optional(),
+    waitForBootSync: z.boolean().optional(),
     embedInterval: z.string().optional(),
+    commandTimeoutMs: z.number().int().nonnegative().optional(),
+    updateTimeoutMs: z.number().int().nonnegative().optional(),
+    embedTimeoutMs: z.number().int().nonnegative().optional(),
   })
   .strict();
 

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -26,6 +26,10 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.qmd?.collections.length).toBeGreaterThanOrEqual(3);
     expect(resolved.qmd?.command).toBe("qmd");
     expect(resolved.qmd?.update.intervalMs).toBeGreaterThan(0);
+    expect(resolved.qmd?.update.waitForBootSync).toBe(false);
+    expect(resolved.qmd?.update.commandTimeoutMs).toBe(30_000);
+    expect(resolved.qmd?.update.updateTimeoutMs).toBe(120_000);
+    expect(resolved.qmd?.update.embedTimeoutMs).toBe(120_000);
   });
 
   it("parses quoted qmd command paths", () => {
@@ -66,5 +70,27 @@ describe("resolveMemoryBackendConfig", () => {
     expect(custom).toBeDefined();
     const workspaceRoot = resolveAgentWorkspaceDir(cfg, "main");
     expect(custom?.path).toBe(path.resolve(workspaceRoot, "notes"));
+  });
+
+  it("resolves qmd update timeout overrides", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          update: {
+            waitForBootSync: true,
+            commandTimeoutMs: 12_000,
+            updateTimeoutMs: 480_000,
+            embedTimeoutMs: 360_000,
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(resolved.qmd?.update.waitForBootSync).toBe(true);
+    expect(resolved.qmd?.update.commandTimeoutMs).toBe(12_000);
+    expect(resolved.qmd?.update.updateTimeoutMs).toBe(480_000);
+    expect(resolved.qmd?.update.embedTimeoutMs).toBe(360_000);
   });
 });

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -29,7 +29,11 @@ export type ResolvedQmdUpdateConfig = {
   intervalMs: number;
   debounceMs: number;
   onBoot: boolean;
+  waitForBootSync: boolean;
   embedIntervalMs: number;
+  commandTimeoutMs: number;
+  updateTimeoutMs: number;
+  embedTimeoutMs: number;
 };
 
 export type ResolvedQmdLimitsConfig = {
@@ -61,6 +65,9 @@ const DEFAULT_QMD_INTERVAL = "5m";
 const DEFAULT_QMD_DEBOUNCE_MS = 15_000;
 const DEFAULT_QMD_TIMEOUT_MS = 4_000;
 const DEFAULT_QMD_EMBED_INTERVAL = "60m";
+const DEFAULT_QMD_COMMAND_TIMEOUT_MS = 30_000;
+const DEFAULT_QMD_UPDATE_TIMEOUT_MS = 120_000;
+const DEFAULT_QMD_EMBED_TIMEOUT_MS = 120_000;
 const DEFAULT_QMD_LIMITS: ResolvedQmdLimitsConfig = {
   maxResults: 6,
   maxSnippetChars: 700,
@@ -138,6 +145,13 @@ function resolveDebounceMs(raw: number | undefined): number {
     return Math.floor(raw);
   }
   return DEFAULT_QMD_DEBOUNCE_MS;
+}
+
+function resolveTimeoutMs(raw: number | undefined, fallback: number): number {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw);
+  }
+  return fallback;
 }
 
 function resolveLimits(raw?: MemoryQmdConfig["limits"]): ResolvedQmdLimitsConfig {
@@ -258,7 +272,20 @@ export function resolveMemoryBackendConfig(params: {
       intervalMs: resolveIntervalMs(qmdCfg?.update?.interval),
       debounceMs: resolveDebounceMs(qmdCfg?.update?.debounceMs),
       onBoot: qmdCfg?.update?.onBoot !== false,
+      waitForBootSync: qmdCfg?.update?.waitForBootSync === true,
       embedIntervalMs: resolveEmbedIntervalMs(qmdCfg?.update?.embedInterval),
+      commandTimeoutMs: resolveTimeoutMs(
+        qmdCfg?.update?.commandTimeoutMs,
+        DEFAULT_QMD_COMMAND_TIMEOUT_MS,
+      ),
+      updateTimeoutMs: resolveTimeoutMs(
+        qmdCfg?.update?.updateTimeoutMs,
+        DEFAULT_QMD_UPDATE_TIMEOUT_MS,
+      ),
+      embedTimeoutMs: resolveTimeoutMs(
+        qmdCfg?.update?.embedTimeoutMs,
+        DEFAULT_QMD_EMBED_TIMEOUT_MS,
+      ),
     },
     limits: resolveLimits(qmdCfg?.limits),
     scope: qmdCfg?.scope ?? DEFAULT_QMD_SCOPE,

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -22,6 +22,37 @@ const mockPrimary = {
   close: vi.fn(async () => {}),
 };
 
+const fallbackSearch = vi.fn(async () => [
+  {
+    path: "MEMORY.md",
+    startLine: 1,
+    endLine: 1,
+    score: 1,
+    snippet: "fallback",
+    source: "memory" as const,
+  },
+]);
+
+const fallbackManager = {
+  search: fallbackSearch,
+  readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
+  status: vi.fn(() => ({
+    backend: "builtin" as const,
+    provider: "openai",
+    model: "text-embedding-3-small",
+    requestedProvider: "openai",
+    files: 0,
+    chunks: 0,
+    dirty: false,
+    workspaceDir: "/tmp",
+    dbPath: "/tmp/index.sqlite",
+  })),
+  sync: vi.fn(async () => {}),
+  probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
+  probeVectorAvailability: vi.fn(async () => true),
+  close: vi.fn(async () => {}),
+};
+
 vi.mock("./qmd-manager.js", () => ({
   QmdMemoryManager: {
     create: vi.fn(async () => mockPrimary),
@@ -30,34 +61,7 @@ vi.mock("./qmd-manager.js", () => ({
 
 vi.mock("./manager.js", () => ({
   MemoryIndexManager: {
-    get: vi.fn(async () => ({
-      search: vi.fn(async () => [
-        {
-          path: "MEMORY.md",
-          startLine: 1,
-          endLine: 1,
-          score: 1,
-          snippet: "fallback",
-          source: "memory",
-        },
-      ]),
-      readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
-      status: vi.fn(() => ({
-        backend: "builtin" as const,
-        provider: "openai",
-        model: "text-embedding-3-small",
-        requestedProvider: "openai",
-        files: 0,
-        chunks: 0,
-        dirty: false,
-        workspaceDir: "/tmp",
-        dbPath: "/tmp/index.sqlite",
-      })),
-      sync: vi.fn(async () => {}),
-      probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
-      probeVectorAvailability: vi.fn(async () => true),
-      close: vi.fn(async () => {}),
-    })),
+    get: vi.fn(async () => fallbackManager),
   },
 }));
 
@@ -72,6 +76,13 @@ beforeEach(() => {
   mockPrimary.probeEmbeddingAvailability.mockClear();
   mockPrimary.probeVectorAvailability.mockClear();
   mockPrimary.close.mockClear();
+  fallbackSearch.mockClear();
+  fallbackManager.readFile.mockClear();
+  fallbackManager.status.mockClear();
+  fallbackManager.sync.mockClear();
+  fallbackManager.probeEmbeddingAvailability.mockClear();
+  fallbackManager.probeVectorAvailability.mockClear();
+  fallbackManager.close.mockClear();
   QmdMemoryManager.create.mockClear();
 });
 
@@ -144,5 +155,28 @@ describe("getMemorySearchManager caching", () => {
     expect(third.manager).toBe(second.manager);
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(QmdMemoryManager.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to builtin search when qmd fails with sqlite busy", async () => {
+    const retryAgentId = "retry-agent-busy";
+    const cfg = {
+      memory: { backend: "qmd", qmd: {} },
+      agents: { list: [{ id: retryAgentId, default: true, workspace: "/tmp/workspace" }] },
+    } as const;
+
+    mockPrimary.search.mockRejectedValueOnce(
+      new Error("qmd index busy while reading results: SQLITE_BUSY: database is locked"),
+    );
+
+    const first = await getMemorySearchManager({ cfg, agentId: retryAgentId });
+    expect(first.manager).toBeTruthy();
+    if (!first.manager) {
+      throw new Error("manager missing");
+    }
+
+    const results = await first.manager.search("hello");
+    expect(results).toHaveLength(1);
+    expect(results[0]?.path).toBe("MEMORY.md");
+    expect(fallbackSearch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -68,6 +68,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   private fallback: MemorySearchManager | null = null;
   private primaryFailed = false;
   private lastError?: string;
+  private cacheEvicted = false;
 
   constructor(
     private readonly deps: {
@@ -90,7 +91,7 @@ class FallbackMemoryManager implements MemorySearchManager {
         log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);
         await this.deps.primary.close?.().catch(() => {});
         // Evict the failed wrapper so the next request can retry QMD with a fresh manager.
-        this.onClose?.();
+        this.evictCacheEntry();
       }
     }
     const fallback = await this.ensureFallback();
@@ -175,7 +176,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   async close() {
     await this.deps.primary.close?.();
     await this.fallback?.close?.();
-    this.onClose?.();
+    this.evictCacheEntry();
   }
 
   private async ensureFallback(): Promise<MemorySearchManager | null> {
@@ -189,6 +190,14 @@ class FallbackMemoryManager implements MemorySearchManager {
     }
     this.fallback = fallback;
     return this.fallback;
+  }
+
+  private evictCacheEntry(): void {
+    if (this.cacheEvicted) {
+      return;
+    }
+    this.cacheEvicted = true;
+    this.onClose?.();
   }
 }
 

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -89,6 +89,8 @@ class FallbackMemoryManager implements MemorySearchManager {
         this.lastError = err instanceof Error ? err.message : String(err);
         log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);
         await this.deps.primary.close?.().catch(() => {});
+        // Evict the failed wrapper so the next request can retry QMD with a fresh manager.
+        this.onClose?.();
       }
     }
     const fallback = await this.ensureFallback();


### PR DESCRIPTION
## Summary

Fixes several QMD reliability gaps reported in #9690 (and related #9705):

- Prevent startup/chat stalls from QMD boot refreshes.
- Add configurable timeout controls for QMD maintenance commands.
- Recover QMD usage after fallback failures by evicting failed cached wrappers.
- Improve QMD docs for current runtime behavior and config surface.

## What changed

- `QmdMemoryManager`
  - Run boot update in background by default (`onBoot` no longer blocks startup).
  - Add opt-in blocking mode: `memory.qmd.update.waitForBootSync = true`.
  - Apply timeouts to `qmd collection list/add` via `memory.qmd.update.commandTimeoutMs`.
  - Use configurable maintenance timeouts:
    - `memory.qmd.update.updateTimeoutMs`
    - `memory.qmd.update.embedTimeoutMs`
  - Bound search wait on pending updates to avoid long request stalls.
  - Avoid concurrent update runs even when `force` is set.

- `FallbackMemoryManager`
  - On primary QMD failure, evict the cached wrapper so next request can recreate/retry QMD.

- Config/schema/docs/changelog
  - Added new QMD update config fields in type + zod + schema labels/help.
  - Updated memory docs to reflect current QMD collection behavior and non-blocking boot refresh.
  - Added changelog entry referencing #9690 / #9705.

## Testing

- `pnpm test src/memory/backend-config.test.ts src/memory/qmd-manager.test.ts src/memory/search-manager.test.ts`
- `pnpm check`

## Notes

- This intentionally does not add an OpenClaw-level QMD embed batch-size setting; that behavior is controlled upstream by QMD.

Fixes #9690
Related #9705

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the QMD memory backend by moving the boot refresh off the critical startup path (with an opt-in blocking mode), adding configurable timeouts for QMD maintenance commands (`collection list/add`, `update`, `embed`), bounding search stalls while updates are in flight, and evicting cached QMD wrappers after primary failures so subsequent requests can recreate and retry QMD. It also updates config schema/types/zod validation, tests, docs, and changelog to reflect the new behavior and configuration surface.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with one small correctness concern around cache-eviction callback semantics.
- Core behavior changes are localized to QMD startup/update flow and are covered by new tests. The main issue found is `FallbackMemoryManager` invoking the same eviction callback both on primary failure and on explicit close, which is currently benign but can become a real bug if the callback gains side effects beyond `Map.delete()`.
- src/memory/search-manager.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->