### PR TITLE
feat(telegram): add spoiler tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Cron: route text-only isolated agent announces through the shared subagent announce flow; add exponential backoff for repeated errors; preserve future `nextRunAtMs` on restart; include current-boundary schedule matches; prevent stale threadId reuse across targets; and add per-job execution timeout. (#11641) Thanks @tyler6204.
 - Subagents: stabilize announce timing, preserve compaction metrics across retries, clamp overflow-prone long timeouts, and cap impossible context usage token totals. (#11551) Thanks @tyler6204.
 - Agents: recover from context overflow caused by oversized tool results (pre-emptive capping + fallback truncation). (#11579) Thanks @tyler6204.
+- Telegram: render markdown spoilers with `<tg-spoiler>` HTML tags. (#11543) Thanks @ezhikkk.
 - Gateway/CLI: when `gateway.bind=lan`, use a LAN IP for probe URLs and Control UI links. (#11448) Thanks @AnonO6.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
 - Memory/QMD: run boot refresh in background by default, add configurable QMD maintenance timeouts, and retry QMD after fallback failures. (#9690, #9705)

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -68,4 +68,14 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("[**bold**](https://example.com)");
     expect(res).toBe('<a href="https://example.com"><b>bold</b></a>');
   });
+
+  it("renders spoiler tags", () => {
+    const res = markdownToTelegramHtml("the answer is ||42||");
+    expect(res).toBe("the answer is <tg-spoiler>42</tg-spoiler>");
+  });
+
+  it("renders spoiler with nested formatting", () => {
+    const res = markdownToTelegramHtml("||**secret** text||");
+    expect(res).toBe("<tg-spoiler><b>secret</b> text</tg-spoiler>");
+  });
 });

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -58,6 +58,7 @@ export function markdownToTelegramHtml(
 ): string {
   const ir = markdownToIR(markdown ?? "", {
     linkify: true,
+    enableSpoilers: true,
     headingStyle: "none",
     blockquotePrefix: "",
     tableMode: options.tableMode,
@@ -83,6 +84,7 @@ export function markdownToTelegramChunks(
 ): TelegramFormattedChunk[] {
   const ir = markdownToIR(markdown ?? "", {
     linkify: true,
+    enableSpoilers: true,
     headingStyle: "none",
     blockquotePrefix: "",
     tableMode: options.tableMode,

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -45,6 +45,7 @@ function renderTelegramHtml(ir: MarkdownIR): string {
       strikethrough: { open: "<s>", close: "</s>" },
       code: { open: "<code>", close: "</code>" },
       code_block: { open: "<pre><code>", close: "</code></pre>" },
+      spoiler: { open: "<tg-spoiler>", close: "</tg-spoiler>" },
     },
     escapeText: escapeHtml,
     buildLink: buildTelegramLink,


### PR DESCRIPTION
## Summary

Render markdown `||spoiler||` syntax as `<tg-spoiler>` tags in Telegram HTML output.

## Problem

The markdown IR already parses spoiler syntax, but the Telegram renderer was missing the style marker. This caused spoiler text to appear as raw `||text||` instead of hidden/blurred text.

## Solution

Add the `spoiler` style marker to `renderTelegramHtml()` in `src/telegram/format.ts`.

## Testing

Added two test cases:
- Basic spoiler rendering
- Spoiler with nested formatting (bold inside spoiler)

---

*PR created by Параша 🧹*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Telegram HTML support for markdown spoiler spans by mapping the existing markdown IR `spoiler` style to Telegram’s `<tg-spoiler>` tag in `src/telegram/format.ts`. It also extends `src/telegram/format.test.ts` with two unit tests that validate basic spoiler rendering and correct nesting when spoiler spans contain nested formatting (e.g., bold).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized mapping of an already-supported IR style (`spoiler`) to Telegram HTML output, plus focused unit tests. It doesn’t alter parsing behavior or shared rendering logic, and the tag used matches Telegram’s supported HTML markup.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->