### PR TITLE
fix(inbound): preserve literal backslash-n sequences in Windows paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.
+- Inbound/Web UI: preserve literal `\n` sequences when normalizing inbound text so Windows paths like `C:\\Work\\nxxx\\README.md` are not corrupted. (#11547) Thanks @mcaxtr.
 - Security/Canvas: serve A2UI assets via the shared safe-open path (`openFileWithinRoot`) to close traversal/TOCTOU gaps, with traversal and symlink regression coverage. (#10525) Thanks @abdelsfane.
 - Security/Gateway: breaking default-behavior change - canvas IP-based auth fallback now only accepts machine-scoped addresses (RFC1918, link-local, ULA IPv6, CGNAT); public-source IP matches now require bearer token auth. (#14661) Thanks @sumleo.
 - Security/Gateway: sanitize and truncate untrusted WebSocket header values in pre-handshake close logs to reduce log-poisoning risk. Thanks @thewilloftheshadow.

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -61,16 +61,19 @@ describe("normalizeInboundTextNewlines", () => {
     expect(normalizeInboundTextNewlines("a\rb")).toBe("a\nb");
   });
 
-  it("decodes literal \\n to newlines when no real newlines exist", () => {
-    expect(normalizeInboundTextNewlines("a\\nb")).toBe("a\nb");
+  it("preserves literal backslash-n sequences (Windows paths)", () => {
+    // Windows paths like C:\Work\nxxx should NOT have \n converted to newlines
+    expect(normalizeInboundTextNewlines("a\\nb")).toBe("a\\nb");
+    expect(normalizeInboundTextNewlines("C:\\Work\\nxxx")).toBe("C:\\Work\\nxxx");
   });
 });
 
 describe("finalizeInboundContext", () => {
   it("fills BodyForAgent/BodyForCommands and normalizes newlines", () => {
     const ctx: MsgContext = {
-      Body: "a\\nb\r\nc",
-      RawBody: "raw\\nline",
+      // Use actual CRLF for newline normalization test, not literal \n sequences
+      Body: "a\r\nb\r\nc",
+      RawBody: "raw\r\nline",
       ChatType: "channel",
       From: "whatsapp:group:123@g.us",
       GroupSubject: "Test",
@@ -85,6 +88,19 @@ describe("finalizeInboundContext", () => {
     expect(out.CommandAuthorized).toBe(false);
     expect(out.ChatType).toBe("channel");
     expect(out.ConversationLabel).toContain("Test");
+  });
+
+  it("preserves literal backslash-n in Windows paths", () => {
+    const ctx: MsgContext = {
+      Body: "C:\\Work\\nxxx\\README.md",
+      RawBody: "raw",
+      ChatType: "direct",
+      From: "web:user",
+    };
+
+    const out = finalizeInboundContext(ctx);
+    expect(out.Body).toBe("C:\\Work\\nxxx\\README.md");
+    expect(out.BodyForAgent).toBe("C:\\Work\\nxxx\\README.md");
   });
 
   it("can force BodyForCommands to follow updated CommandBody", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -101,6 +101,7 @@ describe("finalizeInboundContext", () => {
     const out = finalizeInboundContext(ctx);
     expect(out.Body).toBe("C:\\Work\\nxxx\\README.md");
     expect(out.BodyForAgent).toBe("C:\\Work\\nxxx\\README.md");
+    expect(out.BodyForCommands).toBe("C:\\Work\\nxxx\\README.md");
   });
 
   it("can force BodyForCommands to follow updated CommandBody", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -93,7 +93,7 @@ describe("finalizeInboundContext", () => {
   it("preserves literal backslash-n in Windows paths", () => {
     const ctx: MsgContext = {
       Body: "C:\\Work\\nxxx\\README.md",
-      RawBody: "raw",
+      RawBody: "C:\\Work\\nxxx\\README.md",
       ChatType: "direct",
       From: "web:user",
     };

--- a/src/auto-reply/reply/inbound-text.test.ts
+++ b/src/auto-reply/reply/inbound-text.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { normalizeInboundTextNewlines } from "./inbound-text.js";
+
+describe("normalizeInboundTextNewlines", () => {
+  it("converts CRLF to LF", () => {
+    expect(normalizeInboundTextNewlines("hello\r\nworld")).toBe("hello\nworld");
+  });
+
+  it("converts CR to LF", () => {
+    expect(normalizeInboundTextNewlines("hello\rworld")).toBe("hello\nworld");
+  });
+
+  it("preserves literal backslash-n sequences in Windows paths", () => {
+    // Windows paths like C:\Work\nxxx should NOT have \n converted to newlines
+    const windowsPath = "C:\\Work\\nxxx\\README.md";
+    expect(normalizeInboundTextNewlines(windowsPath)).toBe("C:\\Work\\nxxx\\README.md");
+  });
+
+  it("preserves backslash-n in messages containing Windows paths", () => {
+    const message = "Please read the file at C:\\Work\\nxxx\\README.md";
+    expect(normalizeInboundTextNewlines(message)).toBe(
+      "Please read the file at C:\\Work\\nxxx\\README.md",
+    );
+  });
+
+  it("preserves multiple backslash-n sequences", () => {
+    const message = "C:\\new\\notes\\nested";
+    expect(normalizeInboundTextNewlines(message)).toBe("C:\\new\\notes\\nested");
+  });
+
+  it("still normalizes actual CRLF while preserving backslash-n", () => {
+    const message = "Line 1\r\nC:\\Work\\nxxx";
+    expect(normalizeInboundTextNewlines(message)).toBe("Line 1\nC:\\Work\\nxxx");
+  });
+});

--- a/src/auto-reply/reply/inbound-text.ts
+++ b/src/auto-reply/reply/inbound-text.ts
@@ -1,3 +1,6 @@
 export function normalizeInboundTextNewlines(input: string): string {
-  return input.replaceAll("\r\n", "\n").replaceAll("\r", "\n").replaceAll("\\n", "\n");
+  // Normalize actual newline characters (CR+LF and CR to LF).
+  // Do NOT replace literal backslash-n sequences (\\n) as they may be part of
+  // Windows paths like C:\Work\nxxx\README.md or user-intended escape sequences.
+  return input.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
 }


### PR DESCRIPTION
## Summary
- Fixes Windows paths containing `\n` sequences (like `C:\Work\nxxx\README.md`) being corrupted when sent through WebUI
- The `normalizeInboundTextNewlines()` function was converting literal backslash-n (`\n`) to actual newlines, breaking paths

## Root Cause
The function had `.replaceAll("\\n", "\n")` which converted literal backslash-n sequences to newlines. While the intent was to normalize escaped newlines, this also corrupted:
- Windows paths: `C:\Work\nxxx` → `C:\Work<newline>xxx`
- Any user input containing literal `\n` sequences

## Fix
Removed the `.replaceAll("\\n", "\n")` operation. The function now only normalizes actual newline characters (CRLF and CR to LF), preserving literal backslash-n sequences.

## Test Plan
- [x] Added 6 new tests in `inbound-text.test.ts` covering Windows path preservation
- [x] Added test case in `inbound.test.ts` for `finalizeInboundContext` with Windows paths
- [x] Updated existing tests to reflect correct behavior
- [x] All 5391 tests pass (TDD: 4 tests failed before fix, pass after)
- [x] Full CI gate passes (`pnpm build && pnpm check && pnpm test`)

Fixes #7968

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `normalizeInboundTextNewlines()` to only normalize *actual* newline characters (CRLF/CR → LF) and stop converting literal `\\n` sequences into real newlines. This prevents Windows paths like `C:\\Work\\nxxx\\README.md` from being corrupted when sent through the WebUI.

Tests were updated/added to cover both direct calls to `normalizeInboundTextNewlines()` and the `finalizeInboundContext()` flow, ensuring CRLF normalization still works while preserving literal backslash-n sequences in paths and messages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (removes a single problematic replacement), matches the stated root cause, and is backed by targeted unit tests covering both normalization and context finalization. No call sites appear to rely on converting literal `\\n` into newlines, and the remaining CRLF/CR normalization behavior is preserved.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->