### PR TITLE
fix(agents): support file_path alias in read tool monitoring

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -53,7 +53,13 @@ export async function handleToolExecutionStart(
 
   if (toolName === "read") {
     const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-    const filePath = typeof record.path === "string" ? record.path.trim() : "";
+    const rawPath =
+      typeof record.path === "string"
+        ? record.path
+        : typeof record.file_path === "string"
+          ? (record.file_path as string)
+          : "";
+    const filePath = rawPath.trim();
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
       ctx.log.warn(


### PR DESCRIPTION
## Summary

Fixed false-positive warnings in the embedded agent monitoring layer when the read tool is called with `file_path` parameter instead of `path`.

## Problem

The monitoring layer (`handleToolExecutionStart`) only checked for `args.path`, causing warnings like:
```
warn agent/embedded read tool called without path: toolCallId=read-... argsType=object
```

when models used the `file_path` parameter, which is a valid Claude Code alias.

## Solution

Updated the monitoring check to accept both `path` and `file_path` parameters, aligning with the execution layer's `normalizeToolParams()` behavior.

## Changes

- **File**: `src/agents/pi-embedded-subscribe.handlers.tools.ts` (lines 56-58)
- Added fallback to `record.file_path` when `record.path` is not available

## Testing

- ✅ Build passes: `bun run build`
- No existing unit tests for this monitoring function

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the embedded agent monitoring hook (`handleToolExecutionStart`) to treat `read` tool calls using Claude Code’s `file_path` argument as valid, rather than warning that `path` is missing. The change mirrors the execution layer’s `normalizeToolParams()` aliasing behavior (which maps `file_path → path`), reducing false-positive warnings while keeping the existing warning when neither key is present or the value is empty.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is tightly scoped to monitoring/logging, matches the existing execution-layer aliasing (`file_path → path`), and preserves the existing warning behavior when the path is absent/empty. No functional tool execution paths are altered.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->