### PR TITLE
Update Dockerfile, change file ownership during copy to prevent long …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,13 @@ COPY scripts ./scripts
 
 RUN pnpm install --frozen-lockfile
 
-COPY . .
+COPY --chown=node:node . .
 RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build
 
 ENV NODE_ENV=production
-
-# Allow non-root user to write temp files during runtime/tests.
-RUN chown -R node:node /app
 
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)


### PR DESCRIPTION
…build time.

The build time of the image was taking a very longtime on "chown" of "app" folder. applying this during copy phase saves a lot of time.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `Dockerfile` to apply `--chown=node:node` during the full source `COPY`, and removes the subsequent `RUN chown -R node:node /app` step. Functionally, it keeps the image running as the non-root `node` user while avoiding an expensive recursive `chown` layer that was slowing builds.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to the Docker build (replacing a post-copy recursive chown with `COPY --chown`), which should preserve the intended non-root runtime while reducing build overhead; no application logic is affected.
- Dockerfile

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->