### PR TITLE
fix: respect configured provider for compaction and session-memory hook

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -25,7 +25,7 @@ import {
   resolveAuthProfileOrder,
   type ResolvedProviderAuth,
 } from "../model-auth.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { normalizeProviderId, resolveConfiguredModelRef } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
@@ -109,8 +109,21 @@ export async function runEmbeddedPiAgent(
       }
       const prevCwd = process.cwd();
 
-      const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+      // Resolve provider and model from config, falling back to defaults if not specified
+      let provider: string;
+      let modelId: string;
+      if (params.provider && params.model) {
+        provider = params.provider.trim();
+        modelId = params.model.trim();
+      } else {
+        const configuredRef = resolveConfiguredModelRef({
+          cfg: params.config,
+          defaultProvider: DEFAULT_PROVIDER,
+          defaultModel: DEFAULT_MODEL,
+        });
+        provider = configuredRef.provider;
+        modelId = configuredRef.model;
+      }
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
       const fallbackConfigured =
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -11,7 +11,9 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -26,6 +28,13 @@ export async function generateSlugViaLLM(params: {
     const agentId = resolveDefaultAgentId(params.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
+
+    // Resolve provider and model from config
+    const configuredRef = resolveConfiguredModelRef({
+      cfg: params.cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
 
     // Create a temporary session file for this one-off LLM call
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
@@ -47,6 +56,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
+      provider: configuredRef.provider,
+      model: configuredRef.model,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
## Summary

Fixes #11550 - Internal operations (compaction, session-memory hook) were using hardcoded Anthropic defaults instead of respecting the user's configured provider.

## Changes

- **run.ts**: Modified to use `resolveConfiguredModelRef` instead of hardcoded `DEFAULT_PROVIDER`
- **compact.ts**: Modified to use `resolveConfiguredModelRef` instead of hardcoded `DEFAULT_PROVIDER`
- **llm-slug-generator.ts**: Modified to pass provider and model from config to `runEmbeddedPiAgent`

## Problem

When users configured OpenClaw with a non-Anthropic provider (e.g., MiniMax), internal operations would fail with:
- "No API key found for provider 'anthropic'"

This happened because these operations fell back to hardcoded `DEFAULT_PROVIDER = "anthropic"` instead of using the user's configured provider.

## Solution

The fix uses the existing `resolveConfiguredModelRef` function to read the provider and model from the user's configuration, falling back to defaults only when not explicitly specified.

## Testing

The changes follow the same pattern used elsewhere in the codebase for resolving provider/model from configuration. The `resolveConfiguredModelRef` function is already well-tested and used in multiple places.

Closes #11550

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes internal embedded Pi operations (session compaction and the session-memory slug hook) to respect the user’s configured model provider/model instead of always defaulting to the Anthropic constants.

It does so by switching provider/model selection in the embedded runner to use `resolveConfiguredModelRef(...)` when explicit params aren’t supplied, and by explicitly passing the configured provider/model into `runEmbeddedPiAgent` from the LLM slug generator.

Main correctness concern: the new selection logic in `pi-embedded-runner/run.ts` and `pi-embedded-runner/compact.ts` changes override semantics (only honoring overrides when *both* provider+model are provided, and losing the prior empty-string fallback), which can break callers relying on partial overrides or passing empty strings.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but has a couple of real behavioral regressions in provider/model override handling that should be fixed first.
- The change correctly threads configured provider/model into internal operations, but the new conditional logic only honors overrides when both fields are set and no longer falls back on defaults for empty-string overrides. Those regressions can cause wrong provider/model selection or hard failures in embedded runs/compaction.
- src/agents/pi-embedded-runner/run.ts, src/agents/pi-embedded-runner/compact.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->