### PR TITLE
fix(session): prevent updateLastRoute from bypassing idle reset (#11520)

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -421,7 +421,6 @@ export async function updateLastRoute(params: {
   return await withSessionStoreLock(storePath, async () => {
     const store = loadSessionStore(storePath);
     const existing = store[sessionKey];
-    const now = Date.now();
     const explicitContext = normalizeDeliveryContext(params.deliveryContext);
     const inlineContext = normalizeDeliveryContext({
       channel,
@@ -448,17 +447,20 @@ export async function updateLastRoute(params: {
         })
       : null;
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
-      existing,
-      metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
-    );
+    const next: SessionEntry = {
+      ...(existing ?? {}),
+      ...(metaPatch ?? {}),
+      ...basePatch,
+      sessionId: existing?.sessionId ?? crypto.randomUUID(),
+      // Route metadata writes must not refresh session freshness timestamps.
+      updatedAt: existing?.updatedAt ?? 0,
+    };
     store[sessionKey] = next;
     await saveSessionStoreUnlocked(storePath, store);
     return next;


### PR DESCRIPTION
This PR fixes a bug where sessions configured with `idleMinutes` would never reset because `updateLastRoute` (called during inbound message recording) would bump the `updatedAt` timestamp to the current time *before* the session freshness check in `initSessionState` occurred.\n\n### Changes\n- Modified `updateLastRoute` in `src/config/sessions/store.ts` to preserve the existing `updatedAt` timestamp instead of refreshing it to `Date.now()`. This ensures that route metadata updates (which are purely administrative) do not affect the idle timeout logic.\n- Added a regression test in `src/auto-reply/reply/session.test.ts` that simulates an `updateLastRoute` call followed by `initSessionState` on a stale session.\n\nFixes #11520

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `updateLastRoute` so that route/delivery metadata writes no longer refresh the session’s `updatedAt`, preventing idle-based reset logic in `initSessionState` from being bypassed. It also adds a regression test that writes a stale session entry, calls `updateLastRoute`, and asserts the session still resets under `reset: { mode: "idle" }`.

Key interaction: `updatedAt` is used by session freshness checks to decide whether to reuse an existing session or start a new one; `updateLastRoute` is invoked during inbound message recording, so its timestamp behavior directly affects idle reset behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but a timestamp edge case in `updateLastRoute` can cause incorrect idle resets for newly-created session keys.
- The main fix (not bumping `updatedAt` during route metadata writes) matches the intended behavior and has a targeted regression test. However, the new logic sets `updatedAt` to `0` when `existing` is missing, which can make newly-created entries appear immediately stale and trigger unwanted session churn when `updateLastRoute` runs before session initialization.
- src/config/sessions/store.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->