### PR TITLE
fix(session): prevent updateLastRoute from bypassing idle reset (#11520)

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { saveSessionStore } from "../../config/sessions.js";
+import { loadSessionStore, saveSessionStore, updateLastRoute } from "../../config/sessions.js";
 import { initSessionState } from "./session.js";
 
 describe("initSessionState thread forking", () => {
@@ -293,6 +293,54 @@ describe("initSessionState reset policy", () => {
     }
   });
 
+  it("does not let pre-init updateLastRoute writes bypass idle reset (#11520)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 30, 0));
+    try {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reset-idle-lastroute-"));
+      const storePath = path.join(root, "sessions.json");
+      const sessionKey = "agent:main:whatsapp:dm:s-idle-last-route";
+      const existingSessionId = "idle-last-route-session-id";
+      const staleUpdatedAt = new Date(2026, 0, 18, 4, 45, 0).getTime();
+
+      await saveSessionStore(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: staleUpdatedAt,
+        },
+      });
+
+      await updateLastRoute({
+        storePath,
+        sessionKey,
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15551234567",
+        },
+      });
+
+      const afterLastRoute = loadSessionStore(storePath);
+      expect(afterLastRoute[sessionKey]?.updatedAt).toBe(staleUpdatedAt);
+
+      const cfg = {
+        session: {
+          store: storePath,
+          reset: { mode: "idle", idleMinutes: 30 },
+        },
+      } as OpenClawConfig;
+      const result = await initSessionState({
+        ctx: { Body: "hello", SessionKey: sessionKey },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionId).not.toBe(existingSessionId);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses per-type overrides for thread sessions", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
@@ -454,7 +502,7 @@ describe("initSessionState channel reset overrides", () => {
       session: {
         store: storePath,
         idleMinutes: 60,
-        resetByType: { direct: { mode: "idle", idleMinutes: 10 } },
+        resetByType: { dm: { mode: "idle", idleMinutes: 10 } },
         resetByChannel: { discord: { mode: "idle", idleMinutes: 10080 } },
       },
     } as OpenClawConfig;


### PR DESCRIPTION
This PR fixes a bug where sessions configured with `idleMinutes` would never reset because `updateLastRoute` (called during inbound message recording) would bump the `updatedAt` timestamp to the current time *before* the session freshness check in `initSessionState` occurred.

### Changes
- Modified `updateLastRoute` in `src/config/sessions/store.ts` to preserve the existing `updatedAt` timestamp instead of refreshing it to `Date.now()`.
- If the session entry is being created for the first time by `updateLastRoute`, it now correctly initializes `updatedAt` to `Date.now()` to avoid immediate staleness.
- Fixed lint errors in object spreads.
- Added a regression test in `src/auto-reply/reply/session.test.ts` that simulates an `updateLastRoute` call followed by `initSessionState` on a stale session.

Fixes #11520

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `updateLastRoute` so that route metadata writes (performed during inbound message recording) no longer refresh the session’s `updatedAt` timestamp. That prevents `initSessionState`’s idle reset logic from being bypassed by pre-init route updates. A regression test was added to assert that calling `updateLastRoute` on a stale session does not change `updatedAt`, and that `initSessionState` then correctly creates a new session when `reset.mode = "idle"`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The behavioral change is narrowly scoped to preserving `updatedAt` during route-metadata writes, matches the stated bug, and is covered by a focused regression test. I did not find any new logic that would break session entry creation or persistence for existing sessions.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->