### PR TITLE
feat(hooks): implement message:received hook

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -240,6 +240,15 @@ Triggered when the gateway starts:
 
 - **`gateway:startup`**: After channels start and hooks are loaded
 
+### Message Events
+
+Triggered when messages are sent or received:
+
+- **`message:received`**: When a message is received (before agent processing)
+  - Fires for all non-command messages
+  - Context includes: `body`, `rawBody`, `senderId`, `channel`, `chatType`, `messageId`, `replyToId`, `wasMentioned`, `workspaceDir`
+  - Runs asynchronously (doesn't block message processing)
+
 ### Tool Result Hooks (Plugin API)
 
 These hooks are not event-stream listeners; they let plugins synchronously adjust tool results before OpenClaw persists them.
@@ -254,7 +263,6 @@ Planned event types:
 - **`session:end`**: When a session ends
 - **`agent:error`**: When an agent encounters an error
 - **`message:sent`**: When a message is sent
-- **`message:received`**: When a message is received
 
 ## Creating Custom Hooks
 

--- a/src/auto-reply/dispatch-hooks.test.ts
+++ b/src/auto-reply/dispatch-hooks.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { dispatchInboundMessage } from "./dispatch.js";
+import * as internalHooks from "../hooks/internal-hooks.js";
+import type { MsgContext } from "./templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+
+describe("dispatchInboundMessage hooks", () => {
+  let triggerSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    triggerSpy = vi.spyOn(internalHooks, "triggerInternalHook").mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("triggers message:received hook for regular messages", async () => {
+    const ctx: MsgContext = {
+      Body: "Hello, this is a test message",
+      From: "user123",
+      SessionKey: "test-session",
+      Channel: "telegram",
+      ChatType: "direct",
+      MessageSid: "msg-123",
+    };
+
+    const cfg = { workspace: { dir: "/test/workspace" } } as OpenClawConfig;
+    const dispatcher = {
+      dispatch: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // We're testing the hook trigger, not the full dispatch
+    // So we mock dispatchReplyFromConfig
+    vi.mock("./reply/dispatch-from-config.js", () => ({
+      dispatchReplyFromConfig: vi.fn().mockResolvedValue({ kind: "ok" }),
+    }));
+
+    await dispatchInboundMessage({
+      ctx,
+      cfg,
+      dispatcher: dispatcher as any,
+    });
+
+    expect(triggerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message",
+        action: "received",
+        sessionKey: "test-session",
+        context: expect.objectContaining({
+          body: "Hello, this is a test message",
+          senderId: "user123",
+          channel: "telegram",
+        }),
+      }),
+    );
+  });
+
+  it("does not trigger message:received hook for commands", async () => {
+    const ctx: MsgContext = {
+      Body: "/new",
+      From: "user123",
+      SessionKey: "test-session",
+    };
+
+    const cfg = {} as OpenClawConfig;
+    const dispatcher = {
+      dispatch: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    vi.mock("./reply/dispatch-from-config.js", () => ({
+      dispatchReplyFromConfig: vi.fn().mockResolvedValue({ kind: "ok" }),
+    }));
+
+    await dispatchInboundMessage({
+      ctx,
+      cfg,
+      dispatcher: dispatcher as any,
+    });
+
+    expect(triggerSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger for empty messages", async () => {
+    const ctx: MsgContext = {
+      Body: "",
+      From: "user123",
+      SessionKey: "test-session",
+    };
+
+    const cfg = {} as OpenClawConfig;
+    const dispatcher = {
+      dispatch: vi.fn(),
+      waitForIdle: vi.fn().mockResolvedValue(undefined),
+    };
+
+    vi.mock("./reply/dispatch-from-config.js", () => ({
+      dispatchReplyFromConfig: vi.fn().mockResolvedValue({ kind: "ok" }),
+    }));
+
+    await dispatchInboundMessage({
+      ctx,
+      cfg,
+      dispatcher: dispatcher as any,
+    });
+
+    expect(triggerSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/dispatch-hooks.test.ts
+++ b/src/auto-reply/dispatch-hooks.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { dispatchInboundMessage } from "./dispatch.js";
-import * as internalHooks from "../hooks/internal-hooks.js";
-import type { MsgContext } from "./templating.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
+import type { MsgContext } from "./templating.js";
+import * as internalHooks from "../hooks/internal-hooks.js";
+import { dispatchInboundMessage } from "./dispatch.js";
 
 describe("dispatchInboundMessage hooks", () => {
   let triggerSpy: ReturnType<typeof vi.spyOn>;
@@ -40,7 +41,7 @@ describe("dispatchInboundMessage hooks", () => {
     await dispatchInboundMessage({
       ctx,
       cfg,
-      dispatcher: dispatcher as any,
+      dispatcher: dispatcher as unknown as ReplyDispatcher,
     });
 
     expect(triggerSpy).toHaveBeenCalledWith(
@@ -77,7 +78,7 @@ describe("dispatchInboundMessage hooks", () => {
     await dispatchInboundMessage({
       ctx,
       cfg,
-      dispatcher: dispatcher as any,
+      dispatcher: dispatcher as unknown as ReplyDispatcher,
     });
 
     expect(triggerSpy).not.toHaveBeenCalled();
@@ -103,7 +104,7 @@ describe("dispatchInboundMessage hooks", () => {
     await dispatchInboundMessage({
       ctx,
       cfg,
-      dispatcher: dispatcher as any,
+      dispatcher: dispatcher as unknown as ReplyDispatcher,
     });
 
     expect(triggerSpy).not.toHaveBeenCalled();

--- a/src/auto-reply/dispatch-hooks.test.ts
+++ b/src/auto-reply/dispatch-hooks.test.ts
@@ -21,12 +21,12 @@ describe("dispatchInboundMessage hooks", () => {
       Body: "Hello, this is a test message",
       From: "user123",
       SessionKey: "test-session",
-      Channel: "telegram",
+      Surface: "telegram",
       ChatType: "direct",
       MessageSid: "msg-123",
     };
 
-    const cfg = { workspace: { dir: "/test/workspace" } } as OpenClawConfig;
+    const cfg = {} as OpenClawConfig;
     const dispatcher = {
       dispatch: vi.fn(),
       waitForIdle: vi.fn().mockResolvedValue(undefined),

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions } from "./types.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
@@ -22,6 +23,26 @@ export async function dispatchInboundMessage(params: {
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
+
+  // Trigger message:received hook before processing
+  const messageBody = finalized.Body ?? finalized.RawBody ?? "";
+  if (messageBody && !messageBody.startsWith("/")) {
+    // Don't trigger for commands (they have their own hooks)
+    const hookEvent = createInternalHookEvent("message", "received", finalized.SessionKey ?? "", {
+      body: messageBody,
+      rawBody: finalized.RawBody,
+      senderId: finalized.From,
+      channel: finalized.Channel,
+      chatType: finalized.ChatType,
+      messageId: finalized.MessageSid,
+      replyToId: finalized.ReplyToId,
+      wasMentioned: finalized.WasMentioned,
+      workspaceDir: params.cfg.workspace?.dir,
+    });
+    // Fire and forget - don't block message processing
+    void triggerInternalHook(hookEvent);
+  }
+
   return await dispatchReplyFromConfig({
     ctx: finalized,
     cfg: params.cfg,

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -26,7 +26,10 @@ export async function dispatchInboundMessage(params: {
 
   // Trigger message:received hook before processing
   const messageBody = finalized.Body ?? finalized.RawBody ?? "";
-  if (messageBody && !messageBody.startsWith("/")) {
+  // Use same command detection field as command pipeline (BodyForCommands preferred)
+  const commandBody =
+    finalized.BodyForCommands ?? finalized.CommandBody ?? finalized.RawBody ?? finalized.Body ?? "";
+  if (messageBody && !commandBody.startsWith("/")) {
     // Don't trigger for commands (they have their own hooks)
     const hookEvent = createInternalHookEvent("message", "received", finalized.SessionKey ?? "", {
       body: messageBody,

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -32,12 +32,11 @@ export async function dispatchInboundMessage(params: {
       body: messageBody,
       rawBody: finalized.RawBody,
       senderId: finalized.From,
-      channel: finalized.Channel,
+      channel: finalized.Surface ?? finalized.Provider,
       chatType: finalized.ChatType,
       messageId: finalized.MessageSid,
       replyToId: finalized.ReplyToId,
       wasMentioned: finalized.WasMentioned,
-      workspaceDir: params.cfg.workspace?.dir,
     });
     // Fire and forget - don't block message processing
     void triggerInternalHook(hookEvent);

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,7 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -24,6 +24,44 @@ export type AgentBootstrapHookEvent = InternalHookEvent & {
   action: "bootstrap";
   context: AgentBootstrapHookContext;
 };
+
+export type MessageReceivedHookContext = {
+  /** The message body text */
+  body: string;
+  /** Raw message body without structural context */
+  rawBody?: string;
+  /** Sender identifier */
+  senderId?: string;
+  /** Originating channel (telegram, whatsapp, etc.) */
+  channel?: string;
+  /** Chat type (direct, group, etc.) */
+  chatType?: string;
+  /** Message ID from the provider */
+  messageId?: string;
+  /** Reply-to message ID if this is a reply */
+  replyToId?: string;
+  /** Whether the bot was mentioned */
+  wasMentioned?: boolean;
+  /** Workspace directory for the agent */
+  workspaceDir?: string;
+};
+
+export type MessageReceivedHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "received";
+  context: MessageReceivedHookContext;
+};
+
+export function isMessageReceivedEvent(event: InternalHookEvent): event is MessageReceivedHookEvent {
+  if (event.type !== "message" || event.action !== "received") {
+    return false;
+  }
+  const context = event.context as Partial<MessageReceivedHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.body === "string";
+}
 
 export interface InternalHookEvent {
   /** The type of event (command, session, agent, gateway, etc.) */

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -52,7 +52,9 @@ export type MessageReceivedHookEvent = InternalHookEvent & {
   context: MessageReceivedHookContext;
 };
 
-export function isMessageReceivedEvent(event: InternalHookEvent): event is MessageReceivedHookEvent {
+export function isMessageReceivedEvent(
+  event: InternalHookEvent,
+): event is MessageReceivedHookEvent {
   if (event.type !== "message" || event.action !== "received") {
     return false;
   }


### PR DESCRIPTION
## Summary

Implements the `message:received` hook that was listed under "Future Events" in the docs. This hook triggers when a message is received before agent processing.

## Motivation

This enables custom hooks to:
- Log/analyze incoming messages in real-time
- Build experiential memory systems that score message importance
- Implement custom message filtering or tagging
- Track conversation patterns

## Implementation

- Added `message` to `InternalHookEventType`
- Added `MessageReceivedHookContext` and `MessageReceivedHookEvent` types
- Modified `dispatchInboundMessage` to trigger the hook
- Hook fires asynchronously (fire-and-forget) to avoid blocking message processing
- Commands (starting with `/`) do not trigger this hook (they have their own hooks)

## Context Fields

| Field | Type | Description |
|-------|------|-------------|
| `body` | string | Message text |
| `rawBody` | string? | Raw message without structural context |
| `senderId` | string? | Sender identifier |
| `channel` | string? | Originating channel (telegram, whatsapp, etc.) |
| `chatType` | string? | direct/group |
| `messageId` | string? | Provider message ID |
| `replyToId` | string? | Reply-to ID if applicable |
| `wasMentioned` | boolean? | Whether bot was mentioned |
| `workspaceDir` | string? | Agent workspace directory |

## Example Usage

```typescript
// In a custom hook handler.ts
const handler: HookHandler = async (event) => {
  if (event.type !== "message" || event.action !== "received") {
    return;
  }
  
  const { body, senderId, channel } = event.context;
  console.log(`Message from ${senderId} on ${channel}: ${body}`);
  
  // Score importance, save to memory, etc.
};

export default handler;
```

## Testing

- Added unit tests for the hook trigger
- Verified commands do not trigger the hook
- Verified empty messages do not trigger the hook

## Documentation

- Updated `docs/automation/hooks.md` to move `message:received` from Future Events to implemented
- Documented context fields

Co-authored-by: Tony Xia <xia.tony@gmail.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Implements a new internal hook event `message:received` and wires it into the inbound message dispatch path so custom hooks can observe non-command messages before agent processing. Adds the corresponding internal hook event types/guards, updates hook documentation, and adds unit tests intended to verify the hook fires for normal messages and not for commands/empty bodies.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has test reliability issues and a likely mismatch between documented and actual command suppression behavior.
- Core hook wiring is straightforward, but the added Vitest tests use `vi.mock()` inside `it()` blocks (non-deterministic due to hoisting/module cache) and the command-skip logic in `dispatchInboundMessage` only checks `Body/RawBody`, which may not cover all command inputs used elsewhere in the pipeline.
- src/auto-reply/dispatch-hooks.test.ts, src/auto-reply/dispatch.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->