### PR TITLE
fix(cron): preserve schedule grid on force-run

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -353,11 +353,15 @@ export async function executeJob(
       if (job.schedule.kind === "at" && status === "ok") {
         job.enabled = false;
         job.state.nextRunAtMs = undefined;
-      } else if (job.enabled) {
+      } else if (job.enabled && !opts.forced) {
         job.state.nextRunAtMs = computeJobNextRunAtMs(job, endedAt);
-      } else {
+      } else if (!job.enabled) {
         job.state.nextRunAtMs = undefined;
       }
+      // When opts.forced is true and job is enabled, preserve the existing
+      // nextRunAtMs so the cron grid stays aligned.  The finally block also
+      // guards against recomputation for forced runs, but finish() executes
+      // first — without this check we'd overwrite the grid-aligned value.
     }
 
     emit(state, {


### PR DESCRIPTION
## Summary

Fix `executeJob()` to preserve the cron schedule grid when a job is force-run via `openclaw cron run <id> --force`.

## Problem

The `finish()` callback in `executeJob()` unconditionally recomputes `nextRunAtMs` from `endedAt`:

```typescript
} else if (job.enabled) {
  job.state.nextRunAtMs = computeJobNextRunAtMs(job, endedAt);
}
```

The `finally` block correctly guards with `!opts.forced`, but `finish()` runs first and already overwrites the grid-aligned value.

This causes force-running a `0 */3 * * *` job at 3:34 PM to set `nextRunAtMs` to 9:00 PM, skipping 6:00 PM.

## Fix

Check `opts.forced` in `finish()` so forced runs preserve the existing `nextRunAtMs`:

```typescript
} else if (job.enabled && !opts.forced) {
  job.state.nextRunAtMs = computeJobNextRunAtMs(job, endedAt);
} else if (!job.enabled) {
  job.state.nextRunAtMs = undefined;
}
```

When `opts.forced` is true and the job is enabled, the existing grid-aligned `nextRunAtMs` is preserved.

## Testing

Manual reproduction on OpenClaw 2026.2.6:
1. `0 */3 * * *` job (fires at 0,3,6,9,12,15,18,21)
2. Force-run at 12:25 PM → nextRunAtMs skipped to after 3:00 PM  
3. Force-run at 3:34 PM → nextRunAtMs jumped to 9:00 PM, skipping 6:00 PM

After fix: force-runs should not affect `nextRunAtMs` for enabled cron jobs.

Fixes #11609

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `executeJob()`'s `finish()` callback in `src/cron/service/timer.ts` so that when a cron job is run with `opts.forced` (e.g., via `openclaw cron run <id> --force`), it **does not recompute** `job.state.nextRunAtMs` from the run’s `endedAt` timestamp. This preserves the existing grid-aligned next-run time for enabled cron schedules, matching the guard already present in the `finally` block.

The change is localized to the cron timer/service execution path and only affects the forced-run flow; normal scheduled runs still recompute `nextRunAtMs` as before.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, well-scoped, and aligns `finish()` behavior with the existing `finally` guard to prevent forced runs from shifting cron grid scheduling; no other execution paths are altered.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->