### PR TITLE
feat: separate group-level allowlist from sender-level command authorization

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -131,6 +131,8 @@ Related:
 
 ## Group policy
 
+> ⚠️ **Common mistake:** `groupAllowFrom` expects **phone numbers** (e.g., `"+15551234567"`), not group JIDs. To allowlist specific groups, use the `groups` config with group JIDs as keys (e.g., `"my-group@g.us": {}`). Putting a group JID in `groupAllowFrom` will silently fail to match anything.
+
 Control how group/room messages are handled per channel:
 
 ```json5

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -31,8 +31,12 @@ Quick flow (what happens to a group message):
 
 ```
 groupPolicy? disabled -> drop
-groupPolicy? allowlist -> group allowed? no -> drop
+groupPolicy? allowlist ->
+  groups config has entries? ->
+    yes -> group JID in groups? no -> drop
+    no  -> sender in groupAllowFrom? no -> drop
 requireMention? yes -> mentioned? no -> store for context only
+is slash command? -> sender in groupAllowFrom? no -> reject command
 otherwise -> reply
 ```
 
@@ -345,6 +349,29 @@ Common intents (copy/paste):
   },
 }
 ```
+
+5. Approved groups + anyone chats + only owner runs slash commands
+
+When `groupPolicy: "allowlist"` and `groups` has specific group JID entries (not just `"*"`), the group JIDs act as a **group allowlist**: only those groups are allowed, but **anyone** in an approved group can chat. `groupAllowFrom` then only controls who can run **slash commands** (like `/activation`, `/config`, etc.) — it no longer gates regular messages.
+
+When no `groups` entries exist (or only `"*"` is present), it falls back to the old behavior where `groupAllowFrom` gates all message access.
+
+```json5
+{
+  channels: {
+    whatsapp: {
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["+16164259884"],
+      groups: {
+        "group1@g.us": { requireMention: false },
+        "group2@g.us": { requireMention: true },
+      },
+    },
+  },
+}
+```
+
+In this example: only `group1@g.us` and `group2@g.us` are allowed. Anyone in those groups can chat with the bot (subject to mention gating). Only `+16164259884` can use slash commands like `/activation`.
 
 ## Activation (owner-only)
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -349,6 +349,25 @@ OpenClaw has two separate “who can trigger me?” layers:
     - `channels.whatsapp.groups`, `channels.telegram.groups`, `channels.imessage.groups`: per-group defaults like `requireMention`; when set, it also acts as a group allowlist (include `"*"` to keep allow-all behavior).
     - `groupPolicy="allowlist"` + `groupAllowFrom`: restrict who can trigger the bot _inside_ a group session (WhatsApp/Telegram/Signal/iMessage/Microsoft Teams).
     - `channels.discord.guilds` / `channels.slack.channels`: per-surface allowlists + mention defaults.
+  - **Dual behavior of `groups` config (when `groupPolicy: "allowlist"`):**
+    - **With specific group JID entries:** the `groups` keys act as a **group JID allowlist** — only those groups are allowed, but **anyone** in an approved group can chat. `groupAllowFrom` then only controls **slash command authorization** (e.g., `/activation`, `/config`), not regular message access.
+    - **Without group entries (or only `"*"`):** falls back to the legacy behavior where `groupAllowFrom` gates all message access (sender-based filtering).
+    - Example — approved groups, open chat, owner-only commands:
+      ```json
+      {
+        "channels": {
+          "whatsapp": {
+            "groupPolicy": "allowlist",
+            "groupAllowFrom": ["+16164259884"],
+            "groups": {
+              "group1@g.us": { "requireMention": false },
+              "group2@g.us": { "requireMention": true }
+            }
+          }
+        }
+      }
+      ```
+      Only `group1@g.us` and `group2@g.us` are allowed. Anyone in those groups can chat. Only `+16164259884` can use slash commands.
   - Group checks run in this order: `groupPolicy`/group allowlists first, mention/reply activation second.
   - Replying to a bot message (implicit mention) does **not** bypass sender allowlists like `groupAllowFrom`.
   - **Security note:** treat `dmPolicy="open"` and `groupPolicy="open"` as last-resort settings. They should be barely used; prefer pairing + allowlists unless you fully trust every member of the room.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -353,6 +353,7 @@ OpenClaw has two separate “who can trigger me?” layers:
     - **With specific group JID entries:** the `groups` keys act as a **group JID allowlist** — only those groups are allowed, but **anyone** in an approved group can chat. `groupAllowFrom` then only controls **slash command authorization** (e.g., `/activation`, `/config`), not regular message access.
     - **Without group entries (or only `"*"`):** falls back to the legacy behavior where `groupAllowFrom` gates all message access (sender-based filtering).
     - Example — approved groups, open chat, owner-only commands:
+
       ```json
       {
         "channels": {
@@ -367,7 +368,9 @@ OpenClaw has two separate “who can trigger me?” layers:
         }
       }
       ```
+
       Only `group1@g.us` and `group2@g.us` are allowed. Anyone in those groups can chat. Only `+16164259884` can use slash commands.
+
   - Group checks run in this order: `groupPolicy`/group allowlists first, mention/reply activation second.
   - Replying to a bot message (implicit mention) does **not** bypass sender allowlists like `groupAllowFrom`.
   - **Security note:** treat `dmPolicy="open"` and `groupPolicy="open"` as last-resort settings. They should be barely used; prefer pairing + allowlists unless you fully trust every member of the room.

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -340,8 +340,11 @@ export function resolveChannelGroupPolicy(params: {
   const { cfg, channel } = params;
   const groups = resolveChannelGroups(cfg, channel, params.accountId);
   const groupPolicy = resolveChannelGroupPolicyMode(cfg, channel, params.accountId);
-  const hasGroups = Boolean(groups && Object.keys(groups).length > 0);
-  const allowlistEnabled = groupPolicy === "allowlist" || hasGroups;
+  // Only enable allowlist when groupPolicy is explicitly "allowlist".
+  // This allows explicit group configs (e.g., requireMention) to coexist
+  // with groupPolicy: "open" without creating an implicit allowlist.
+  const allowlistEnabled =
+    groupPolicy === "allowlist" && Boolean(groups && Object.keys(groups).length > 0);
   const normalizedId = params.groupId?.trim();
   const groupConfig = normalizedId
     ? resolveChannelGroupConfig(groups, normalizedId, params.groupIdCaseInsensitive)

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -343,8 +343,7 @@ export function resolveChannelGroupPolicy(params: {
   // Only enable allowlist when groupPolicy is explicitly "allowlist".
   // This allows explicit group configs (e.g., requireMention) to coexist
   // with groupPolicy: "open" without creating an implicit allowlist.
-  const allowlistEnabled =
-    groupPolicy === "allowlist" && Boolean(groups && Object.keys(groups).length > 0);
+  const allowlistEnabled = groupPolicy === "allowlist";
   const normalizedId = params.groupId?.trim();
   const groupConfig = normalizedId
     ? resolveChannelGroupConfig(groups, normalizedId, params.groupIdCaseInsensitive)

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1225,6 +1225,7 @@ describe("createTelegramBot", () => {
         config: {
           channels: {
             telegram: {
+              groupPolicy: "allowlist",
               groups: {
                 "123": { requireMention: false },
               },

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -72,7 +72,9 @@ describe("createTelegramBot", () => {
       description: string;
     }>;
     const skillCommands = resolveSkillCommands(config);
-    const native = listNativeCommandSpecsForConfig(config, { skillCommands }).map((command) => ({
+    const native = listNativeCommandSpecsForConfig(config, {
+      skillCommands,
+    }).map((command) => ({
       command: normalizeTelegramCommandName(command.name),
       description: command.description,
     }));
@@ -113,14 +115,22 @@ describe("createTelegramBot", () => {
       description: string;
     }>;
     const skillCommands = resolveSkillCommands(config);
-    const native = listNativeCommandSpecsForConfig(config, { skillCommands }).map((command) => ({
+    const native = listNativeCommandSpecsForConfig(config, {
+      skillCommands,
+    }).map((command) => ({
       command: normalizeTelegramCommandName(command.name),
       description: command.description,
     }));
     const nativeStatus = native.find((command) => command.command === "status");
     expect(nativeStatus).toBeDefined();
-    expect(registered).toContainEqual({ command: "custom_backup", description: "Git backup" });
-    expect(registered).not.toContainEqual({ command: "status", description: "Custom status" });
+    expect(registered).toContainEqual({
+      command: "custom_backup",
+      description: "Git backup",
+    });
+    expect(registered).not.toContainEqual({
+      command: "status",
+      description: "Custom status",
+    });
     expect(registered.filter((command) => command.command === "status")).toEqual([nativeStatus]);
     expect(errorSpy).toHaveBeenCalled();
   });
@@ -409,7 +419,6 @@ describe("createTelegramBot", () => {
           from: { first_name: "Ada" },
           quote: {
             text: "summarize this",
-
           },
         },
       },

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -409,6 +409,7 @@ describe("createTelegramBot", () => {
           from: { first_name: "Ada" },
           quote: {
             text: "summarize this",
+
           },
         },
       },

--- a/src/web/auto-reply/web-auto-reply-monitor.test.ts
+++ b/src/web/auto-reply/web-auto-reply-monitor.test.ts
@@ -252,6 +252,7 @@ describe("applyGroupGating", () => {
       channels: {
         whatsapp: {
           allowFrom: ["*"],
+          groupPolicy: "allowlist",
           groups: {
             "999@g.us": { requireMention: false },
           },

--- a/src/web/inbound/access-control.group-allowlist.test.ts
+++ b/src/web/inbound/access-control.group-allowlist.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { checkInboundAccessControl } from "./access-control.js";
+
+const sendMessageMock = vi.fn();
+const readAllowFromStoreMock = vi.fn();
+
+let config: Record<string, unknown> = {};
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => config,
+  };
+});
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+  upsertChannelPairingRequest: vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true }),
+}));
+
+const baseSock = { sendMessage: sendMessageMock };
+
+beforeEach(() => {
+  config = {};
+  sendMessageMock.mockReset().mockResolvedValue(undefined);
+  readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+});
+
+describe("group allowlist via groups config", () => {
+  it("allows group message when group JID is in groups config", async () => {
+    config = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groups: {
+            "approved-group@g.us": {},
+          },
+        },
+      },
+    };
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+1234567890",
+      selfE164: "+10000000000",
+      senderE164: "+9999999999", // random sender, not in any allowFrom
+      group: true,
+      isFromMe: false,
+      remoteJid: "approved-group@g.us",
+      sock: baseSock,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks group message when group JID is NOT in groups config", async () => {
+    config = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groups: {
+            "approved-group@g.us": {},
+          },
+        },
+      },
+    };
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+1234567890",
+      selfE164: "+10000000000",
+      senderE164: "+9999999999",
+      group: true,
+      isFromMe: false,
+      remoteJid: "spam-group@g.us",
+      sock: baseSock,
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it("falls back to sender-based filtering when no groups config", async () => {
+    config = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+1111111111"],
+        },
+      },
+    };
+    // Sender not in groupAllowFrom → blocked
+    const blocked = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+1234567890",
+      selfE164: "+10000000000",
+      senderE164: "+9999999999",
+      group: true,
+      isFromMe: false,
+      remoteJid: "some-group@g.us",
+      sock: baseSock,
+    });
+    expect(blocked.allowed).toBe(false);
+
+    // Sender in groupAllowFrom → allowed
+    const allowed = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+1234567890",
+      selfE164: "+10000000000",
+      senderE164: "+1111111111",
+      group: true,
+      isFromMe: false,
+      remoteJid: "some-group@g.us",
+      sock: baseSock,
+    });
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it("allows any sender in an approved group (chat open, commands gated separately)", async () => {
+    config = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+1111111111"], // only owner for commands
+          groups: {
+            "my-group@g.us": {},
+          },
+        },
+      },
+    };
+    // Random participant — should be allowed to chat
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+5555555555",
+      selfE164: "+10000000000",
+      senderE164: "+5555555555",
+      group: true,
+      isFromMe: false,
+      remoteJid: "my-group@g.us",
+      sock: baseSock,
+    });
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -101,7 +101,10 @@ export async function checkInboundAccessControl(params: {
   // Group policy filtering:
   // - "open": groups bypass allowFrom, only mention-gating applies
   // - "disabled": block all group messages entirely
-  // - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+  // - "allowlist": when a `groups` config maps group JIDs, only those groups are
+  //   accepted (any participant can chat); otherwise falls back to sender-based
+  //   filtering via groupAllowFrom/allowFrom. Command authorization still uses
+  //   groupAllowFrom regardless.
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const { groupPolicy, providerMissingFallbackApplied } = resolveWhatsAppRuntimeGroupPolicy({
     providerConfigPresent: cfg.channels?.whatsapp !== undefined,

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "../../config/config.js";
+import { resolveChannelGroupPolicy } from "../../config/group-policy.js";
 import {
   resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
@@ -123,28 +124,55 @@ export async function checkInboundAccessControl(params: {
     };
   }
   if (params.group && groupPolicy === "allowlist") {
-    if (!groupAllowFrom || groupAllowFrom.length === 0) {
-      logVerbose("Blocked group message (groupPolicy: allowlist, no groupAllowFrom)");
-      return {
-        allowed: false,
-        shouldMarkRead: false,
-        isSelfChat,
-        resolvedAccountId: account.accountId,
-      };
-    }
-    const senderAllowed =
-      groupHasWildcard ||
-      (params.senderE164 != null && normalizedGroupAllowFrom.includes(params.senderE164));
-    if (!senderAllowed) {
-      logVerbose(
-        `Blocked group message from ${params.senderE164 ?? "unknown sender"} (groupPolicy: allowlist)`,
-      );
-      return {
-        allowed: false,
-        shouldMarkRead: false,
-        isSelfChat,
-        resolvedAccountId: account.accountId,
-      };
+    // When a `groups` config is present (group JID allowlist), use it to gate
+    // group access instead of filtering by sender.  This lets any participant in
+    // an approved group chat while keeping unapproved groups blocked.
+    // `groupAllowFrom` is still used downstream for command authorization.
+    const groupJidPolicy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      groupId: params.remoteJid,
+      accountId: params.accountId,
+    });
+    if (groupJidPolicy.allowlistEnabled) {
+      if (!groupJidPolicy.allowed) {
+        logVerbose(
+          `Blocked group message from ${params.remoteJid} (groupPolicy: allowlist, group not in groups allowlist)`,
+        );
+        return {
+          allowed: false,
+          shouldMarkRead: false,
+          isSelfChat,
+          resolvedAccountId: account.accountId,
+        };
+      }
+      // Group is in the allowlist — allow the message through regardless of sender.
+      // Command authorization is handled separately by resolveWhatsAppCommandAuthorized.
+    } else {
+      // No `groups` config — fall back to legacy sender-based filtering.
+      if (!groupAllowFrom || groupAllowFrom.length === 0) {
+        logVerbose("Blocked group message (groupPolicy: allowlist, no groupAllowFrom)");
+        return {
+          allowed: false,
+          shouldMarkRead: false,
+          isSelfChat,
+          resolvedAccountId: account.accountId,
+        };
+      }
+      const senderAllowed =
+        groupHasWildcard ||
+        (params.senderE164 != null && normalizedGroupAllowFrom.includes(params.senderE164));
+      if (!senderAllowed) {
+        logVerbose(
+          `Blocked group message from ${params.senderE164 ?? "unknown sender"} (groupPolicy: allowlist)`,
+        );
+        return {
+          allowed: false,
+          shouldMarkRead: false,
+          isSelfChat,
+          resolvedAccountId: account.accountId,
+        };
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Currently `groupPolicy: "allowlist"` + `groupAllowFrom` gates **all** group interaction (both chat and commands) by sender phone number. There is no way to:

1. Allowlist specific groups by JID while letting anyone in those groups chat
2. Restrict slash commands (`/new`, `/reset`, etc.) to the owner only
3. Prevent the bot from being pulled into spam groups while keeping approved groups open to all participants

## Solution

When `groupPolicy: "allowlist"` is set **and** a `groups` config is present (mapping group JIDs), the access control layer now uses the `groups` config as the group-level gate instead of filtering by sender via `groupAllowFrom`.

This means:
- **Group-level filtering:** Only groups listed in `groups` config are accepted (spam groups blocked)
- **Open chat in approved groups:** Anyone in an approved group can chat (mention or always-on)
- **Command authorization unchanged:** `groupAllowFrom` continues to gate slash command access, so only the owner (or specified senders) can run `/new`, `/reset`, etc.

### Example config

```yaml
channels:
  whatsapp:
    groupPolicy: allowlist
    groupAllowFrom: ["+1234567890"]  # only owner can run slash commands
    groups:
      "my-group-123@g.us":
        requireMention: true
      "another-group@g.us": {}
```

### Backward compatibility

When no `groups` config is present, the existing sender-based `groupAllowFrom` filtering is preserved exactly as before.

## Changes

- **`src/web/inbound/access-control.ts`** — Integrate `resolveChannelGroupPolicy` to check group JID allowlist when `groups` config is present
- **`src/config/types.whatsapp.ts`** — Updated JSDoc for `groupPolicy` to document the new behavior
- **`src/web/inbound/access-control.group-allowlist.test.ts`** — 4 new tests covering the group allowlist behavior

## Dependencies

- Depends on #3326 — this PR incorporates their fix (only enable group allowlist when `groupPolicy` is explicitly `"allowlist"`, preventing implicit allowlist when `groups` config coexists with `groupPolicy: "open"`)

## Manual Testing

1. Set `groupPolicy: "allowlist"` with specific `groups` entries and `groupAllowFrom` with just your number
2. Send a message from a **non-allowlisted sender** in an approved group → ✅ should be received
3. Send `/new` from a **non-allowlisted sender** → ✅ should be silently ignored (only `groupAllowFrom` numbers can run slash commands)
4. Send a message from any **group not in `groups` config** → ❌ should be blocked
5. Remove `groups` entries → falls back to old sender-based filtering via `groupAllowFrom` (backward compat)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes WhatsApp `groupPolicy: "allowlist"` handling so that when a `channels.whatsapp.groups` mapping is present, inbound group access is gated by group JID membership in that mapping (via `resolveChannelGroupPolicy`), rather than by sender phone number. When no `groups` config is present, the prior sender-based behavior (using `groupAllowFrom`/`allowFrom`) remains.

It also updates the WhatsApp config type docs to describe the new behavior and adds a dedicated Vitest suite covering: (1) allowing messages from an approved group JID, (2) blocking unapproved group JIDs, (3) legacy sender-based fallback when no `groups` config exists, and (4) confirming that approved groups allow any sender to chat while command authorization remains separate.

<h3>Confidence Score: 4/5</h3>

- This PR appears safe to merge, with one small documentation inconsistency to fix.
- Core logic change is localized to `checkInboundAccessControl` and delegates group-JID gating to `resolveChannelGroupPolicy`, preserving the legacy sender-based path when no groups mapping exists. Added tests cover the new branches. Only issue found is an outdated inline comment that no longer matches behavior; runtime logic impact is unlikely beyond intended policy change.
- src/web/inbound/access-control.ts (update the stale allowlist comment)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->
