### PR TITLE
fix: clear stale model metadata on /new and /reset

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.runtime-model.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.runtime-model.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemPromptParams } from "../../system-prompt-params.js";
+import { buildRuntimeLine } from "../../system-prompt.js";
+
+/**
+ * Test for issue #10404: Runtime metadata shows stale model
+ *
+ * This test verifies that the Runtime line in the system prompt
+ * correctly shows the current turn's model, not a stale value
+ * from session state.
+ */
+describe("runtime model in system prompt", () => {
+  describe("buildSystemPromptParams", () => {
+    it("uses the model passed in runtime params, not any cached value", () => {
+      // Scenario: Primary model was changed from Sonnet to Codex in config.
+      // The current turn should use Codex, regardless of what was persisted
+      // in session state from a previous turn.
+      const result = buildSystemPromptParams({
+        runtime: {
+          host: "test-host",
+          os: "test-os",
+          arch: "x64",
+          node: "v22",
+          // This is the model for the CURRENT turn - should be used as-is
+          model: "openai-codex/gpt-5.3-codex",
+          defaultModel: "openai-codex/gpt-5.3-codex",
+        },
+      });
+
+      expect(result.runtimeInfo.model).toBe("openai-codex/gpt-5.3-codex");
+      expect(result.runtimeInfo.defaultModel).toBe("openai-codex/gpt-5.3-codex");
+    });
+
+    it("model and defaultModel can differ when fallback is used", () => {
+      // Scenario: Primary model (Codex) is in cooldown, falling back to Sonnet
+      // for this turn. Model should show the fallback, defaultModel shows config.
+      const result = buildSystemPromptParams({
+        runtime: {
+          host: "test-host",
+          os: "test-os",
+          arch: "x64",
+          node: "v22",
+          model: "anthropic/claude-sonnet-4-5", // Fallback model for this turn
+          defaultModel: "openai-codex/gpt-5.3-codex", // Config default
+        },
+      });
+
+      expect(result.runtimeInfo.model).toBe("anthropic/claude-sonnet-4-5");
+      expect(result.runtimeInfo.defaultModel).toBe("openai-codex/gpt-5.3-codex");
+    });
+  });
+
+  describe("buildRuntimeLine", () => {
+    it("includes the model passed to it in the output", () => {
+      const line = buildRuntimeLine(
+        {
+          agentId: "main",
+          host: "test-host",
+          model: "openai-codex/gpt-5.3-codex",
+          defaultModel: "openai-codex/gpt-5.3-codex",
+        },
+        "whatsapp",
+        [],
+        "off",
+      );
+
+      expect(line).toContain("model=openai-codex/gpt-5.3-codex");
+      expect(line).toContain("default_model=openai-codex/gpt-5.3-codex");
+    });
+
+    it("shows different model vs defaultModel when fallback is active", () => {
+      // Verify the Runtime line correctly shows when model differs from default
+      const line = buildRuntimeLine(
+        {
+          agentId: "main",
+          host: "test-host",
+          model: "anthropic/claude-sonnet-4-5", // Currently using fallback
+          defaultModel: "openai-codex/gpt-5.3-codex", // Config default
+        },
+        "whatsapp",
+        [],
+        "off",
+      );
+
+      expect(line).toContain("model=anthropic/claude-sonnet-4-5");
+      expect(line).toContain("default_model=openai-codex/gpt-5.3-codex");
+      // The agent greeting prompt checks if model != defaultModel
+      // This verifies both values are preserved
+    });
+  });
+});

--- a/src/auto-reply/reply/session-model-reset.test.ts
+++ b/src/auto-reply/reply/session-model-reset.test.ts
@@ -1,0 +1,134 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionStore, updateSessionStore } from "../../config/sessions.js";
+
+/**
+ * Test for issue #10404: Runtime metadata shows stale model after /new or /reset
+ *
+ * This test verifies that when a new session is created via /new or /reset,
+ * stale model-related fields from the previous session are cleared.
+ *
+ * Key fields that must be cleared on session reset:
+ * - model: The model used in the LAST turn (persisted by persistSessionUsageUpdate)
+ * - modelProvider: The provider used in the LAST turn
+ * - systemPromptReport: Report from the LAST turn (includes provider/model)
+ *
+ * These fields should NOT persist after /new or /reset because they reflect
+ * the previous session's state, not the new session's.
+ */
+describe("session model reset on /new", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-model-reset-"));
+    storePath = path.join(tmpDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("clears stale model/modelProvider/systemPromptReport fields when session is reset", async () => {
+    // Setup: Create a session with model A
+    const sessionKey = "agent:main:test-session";
+    const initialEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now() - 60000, // 1 minute ago
+      systemSent: true,
+      // These are the "persisted" values from a previous turn
+      model: "claude-sonnet-4-5",
+      modelProvider: "anthropic",
+      systemPromptReport: {
+        source: "run",
+        generatedAt: Date.now() - 60000,
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+      } as SessionEntry["systemPromptReport"],
+    };
+
+    await updateSessionStore(storePath, (store) => {
+      store[sessionKey] = initialEntry;
+    });
+
+    // Simulate /new: Create a new session entry with model fields explicitly cleared
+    // This matches the behavior in session.ts when isNewSession is true
+    const newSessionId = crypto.randomUUID();
+    const newEntry: Partial<SessionEntry> = {
+      sessionId: newSessionId,
+      updatedAt: Date.now(),
+      systemSent: false,
+      compactionCount: 0,
+      // FIX for #10404: Explicitly clear stale model fields
+      model: undefined,
+      modelProvider: undefined,
+      systemPromptReport: undefined,
+    };
+
+    // Merge with existing entry (mimics session.ts behavior at line 349)
+    await updateSessionStore(storePath, (store) => {
+      store[sessionKey] = { ...store[sessionKey], ...newEntry };
+    });
+
+    // Verify: Stale fields are cleared
+    const store = loadSessionStore(storePath);
+    const entry = store[sessionKey];
+
+    expect(entry?.sessionId).toBe(newSessionId); // New session ID
+    expect(entry?.model).toBeUndefined(); // Cleared
+    expect(entry?.modelProvider).toBeUndefined(); // Cleared
+    expect(entry?.systemPromptReport).toBeUndefined(); // Cleared
+  });
+
+  it("preserves modelOverride/providerOverride when session is reset", async () => {
+    // modelOverride and providerOverride are sticky user preferences set via /model command.
+    // They should NOT be cleared on /new because the user explicitly chose them.
+    const sessionKey = "agent:main:test-session";
+    const initialEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now() - 60000,
+      systemSent: true,
+      // Sticky user preference (set via /model command)
+      modelOverride: "gpt-5.3-codex",
+      providerOverride: "openai-codex",
+      // Stale turn metadata (should be cleared)
+      model: "claude-sonnet-4-5",
+      modelProvider: "anthropic",
+    };
+
+    await updateSessionStore(storePath, (store) => {
+      store[sessionKey] = initialEntry;
+    });
+
+    // Simulate /new with model fields cleared but overrides preserved
+    const newSessionId = crypto.randomUUID();
+    const newEntry: Partial<SessionEntry> = {
+      sessionId: newSessionId,
+      updatedAt: Date.now(),
+      systemSent: false,
+      compactionCount: 0,
+      model: undefined,
+      modelProvider: undefined,
+      systemPromptReport: undefined,
+      // Note: NOT touching modelOverride/providerOverride - they should persist
+    };
+
+    await updateSessionStore(storePath, (store) => {
+      store[sessionKey] = { ...store[sessionKey], ...newEntry };
+    });
+
+    const store = loadSessionStore(storePath);
+    const entry = store[sessionKey];
+
+    // Sticky overrides are preserved
+    expect(entry?.modelOverride).toBe("gpt-5.3-codex");
+    expect(entry?.providerOverride).toBe("openai-codex");
+    // Stale turn metadata is cleared
+    expect(entry?.model).toBeUndefined();
+    expect(entry?.modelProvider).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/session-model-reset.test.ts
+++ b/src/auto-reply/reply/session-model-reset.test.ts
@@ -79,7 +79,8 @@ describe("session model reset on /new", () => {
     expect(result.resetTriggered).toBe(true);
 
     // Verify stale model fields are cleared
-    const store = loadSessionStore(storePath);
+    // Use skipCache to avoid reading stale cached values from prior saveSessionStore calls
+    const store = loadSessionStore(storePath, { skipCache: true });
     const entry = store[sessionKey];
 
     expect(entry?.sessionId).not.toBe("session-1"); // New session ID
@@ -130,7 +131,8 @@ describe("session model reset on /new", () => {
     expect(result.isNewSession).toBe(true);
     expect(result.resetTriggered).toBe(true);
 
-    const store = loadSessionStore(storePath);
+    // Use skipCache to avoid reading stale cached values
+    const store = loadSessionStore(storePath, { skipCache: true });
     const entry = store[sessionKey];
 
     expect(entry?.model).toBeUndefined();

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -369,6 +369,12 @@ export async function initSessionState(params: {
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
     sessionEntry.contextTokens = undefined;
+    // Clear stale model metadata from previous session. These fields reflect
+    // what was used in the LAST turn and shouldn't persist after /new or /reset.
+    // Fixes #10404: Runtime metadata shows stale model after session reset.
+    sessionEntry.model = undefined;
+    sessionEntry.modelProvider = undefined;
+    sessionEntry.systemPromptReport = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };


### PR DESCRIPTION
## Summary
- Clears `model`, `modelProvider`, and `systemPromptReport` fields when session is reset via `/new` or `/reset`
- These fields reflect the LAST turn's state and shouldn't persist after reset
- Follows the same pattern as #8929 which cleared token metrics on reset

Fixes #10404
Fixes #10834

## Test plan
- [x] Write failing test that reproduces stale model metadata bug
- [x] Implement fix in `session.ts` to clear fields on `isNewSession`
- [x] Verify all 6 new tests pass
- [x] Full CI gate: `pnpm build && pnpm check && pnpm test` (5611 tests pass)
- [x] Codex review loop completed

## Testing performed
1. Created session with model metadata from previous turn
2. Triggered `/new` command
3. Verified `model`, `modelProvider`, `systemPromptReport` are cleared
4. Verified token metrics are also cleared (existing behavior)
5. Verified sticky overrides (`modelOverride`, `providerOverride`) are preserved

## Changes
- `src/auto-reply/reply/session.ts`: Clear stale model fields in `isNewSession` block
- `src/auto-reply/reply/session-model-reset.test.ts`: New test file with 2 tests

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates session initialization so that when a reset is triggered via `/new` or `/reset`, the session entry also clears turn-specific model metadata (`model`, `modelProvider`, `systemPromptReport`) alongside the already-cleared token metrics. It also adds regression tests that construct a session store with persisted model fields, trigger `initSessionState()` via a reset command, and assert that the resulting persisted entry no longer contains the stale fields.

The change is localized to `src/auto-reply/reply/session.ts`’s `isNewSession` handling, which is where other “reset should wipe last-turn state” fields are already cleared. Two new Vitest suites cover both session reset behavior and the system-prompt runtime model line behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, scoped to the session reset path, and add targeted regression tests. The previous review concerns called out in the PR (session store cache and import paths) are already addressed/validated by the updated code and existing resolution notes. No additional correctness or safety issues were found in the modified logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->