### PR TITLE
docs(security): Add API key hardening guide

### DIFF
--- a/docs/security/api-key-hardening.md
+++ b/docs/security/api-key-hardening.md
@@ -100,6 +100,11 @@ Add a line for each script (replace `youruser` with your actual username):
 youruser ALL=(secretsuser) NOPASSWD: /home/secretsuser/scripts/myapi.sh
 ```
 
+**Important security notes:**
+- Only whitelist the exact script paths — never add `/bin/bash`, `/bin/sh`, or other interpreters
+- The whitelist is strict: `sudo -u secretsuser /bin/bash /path/to/script` will be denied because `/bin/bash` isn't whitelisted
+- Each script must be listed separately; wildcards like `/home/secretsuser/scripts/*` would allow creating new scripts to bypass security
+
 ### Step 6: Test It
 
 As your normal user:
@@ -133,6 +138,7 @@ cat /home/secretsuser/.env
 | Agent reads script source | Directory permissions (700) |
 | Prompt injection to leak keys | Cannot read what it cannot access |
 | Agent runs arbitrary sudo | Whitelist only allows specific scripts |
+| Interpreter bypass (`sudo -u secretsuser /bin/bash script`) | Only exact paths are whitelisted; `/bin/bash` not allowed |
 | Argument injection | Proper quoting in scripts (see below) |
 
 ## Writing Secure Scripts

--- a/docs/security/api-key-hardening.md
+++ b/docs/security/api-key-hardening.md
@@ -1,0 +1,216 @@
+# Securing API Keys from Agent Access
+
+This guide shows how to protect your API credentials from being exposed by your OpenClaw agent, even under prompt injection attacks.
+
+## The Problem
+
+OpenClaw agents have filesystem access to read configuration files, including `.env` files containing API keys. While you can instruct the agent not to display these values, this relies on "discipline" — the agent choosing to follow rules.
+
+**This is not secure because:**
+1. Agents may accidentally display keys while debugging
+2. Prompt injection attacks could trick the agent into revealing secrets
+3. Rules can be bypassed; permissions cannot
+
+## The Solution: User Isolation
+
+Create a separate Linux user that:
+- Owns your secrets (`.env` file)
+- Owns wrapper scripts that use those secrets
+- Cannot be accessed by your main user (or the agent)
+
+Your agent gets **limited sudo access** to run specific scripts as this user, but cannot read the secrets themselves.
+
+## Setup Guide
+
+### Step 1: Create the Secrets User
+
+```bash
+# Create user with home directory
+sudo useradd -m -s /bin/bash secretsuser
+
+# Lock down their home directory
+sudo chmod 700 /home/secretsuser
+```
+
+### Step 2: Create Scripts Directory
+
+```bash
+sudo -u secretsuser mkdir -p /home/secretsuser/scripts
+```
+
+### Step 3: Create the Secrets File
+
+```bash
+sudo -u secretsuser nano /home/secretsuser/.env
+```
+
+Add your API keys:
+```
+MY_API_KEY=your_key_here
+MY_API_SECRET=your_secret_here
+```
+
+Lock it down:
+```bash
+sudo -u secretsuser chmod 600 /home/secretsuser/.env
+```
+
+### Step 4: Create Wrapper Scripts
+
+Example: Generic API script that accepts method, endpoint, and data:
+
+```bash
+sudo -u secretsuser tee /home/secretsuser/scripts/myapi.sh << 'ENDSCRIPT'
+#!/bin/bash
+set -euo pipefail
+source /home/secretsuser/.env
+
+METHOD="${1:-GET}"
+ENDPOINT="${2:-}"
+DATA="${3:-}"
+
+if [ -n "$DATA" ]; then
+  curl -s -X "$METHOD" \
+    -H "Authorization: Bearer ${MY_API_KEY}" \
+    -H "Content-Type: application/json" \
+    "https://api.example.com/${ENDPOINT}" \
+    -d "$DATA"
+else
+  curl -s -X "$METHOD" \
+    -H "Authorization: Bearer ${MY_API_KEY}" \
+    -H "Accept: application/json" \
+    "https://api.example.com/${ENDPOINT}"
+fi
+ENDSCRIPT
+```
+
+Make it executable:
+```bash
+sudo -u secretsuser chmod 700 /home/secretsuser/scripts/myapi.sh
+```
+
+### Step 5: Configure Sudo Access
+
+```bash
+sudo visudo -f /etc/sudoers.d/openclaw-secrets
+```
+
+Add a line for each script (replace `youruser` with your actual username):
+```
+youruser ALL=(secretsuser) NOPASSWD: /home/secretsuser/scripts/myapi.sh
+```
+
+### Step 6: Test It
+
+As your normal user:
+```bash
+# This should work:
+sudo -u secretsuser /home/secretsuser/scripts/myapi.sh GET "users/me"
+
+# This should fail:
+cat /home/secretsuser/.env
+# Permission denied
+```
+
+## Security Analysis
+
+### What the agent CAN do:
+- Run whitelisted scripts via sudo
+- Pass arguments to those scripts
+- See the output (API responses)
+
+### What the agent CANNOT do:
+- Read `/home/secretsuser/.env` — Permission denied
+- Read `/home/secretsuser/scripts/*` — Permission denied
+- Run arbitrary commands as secretsuser — Not in sudoers whitelist
+- Modify the scripts — Permission denied
+
+### Attack Vectors Addressed:
+
+| Attack | Mitigated By |
+|--------|--------------|
+| Agent reads .env directly | File permissions (600, wrong user) |
+| Agent reads script source | Directory permissions (700) |
+| Prompt injection to leak keys | Cannot read what it cannot access |
+| Agent runs arbitrary sudo | Whitelist only allows specific scripts |
+| Argument injection | Proper quoting in scripts (see below) |
+
+## Writing Secure Scripts
+
+### DO: Quote all variables
+```bash
+# Good
+curl -d "text=${TEXT}" ...
+```
+
+### DON'T: Use eval or unquoted expansion
+```bash
+# Bad - allows injection
+eval "$1"
+curl -d text=$TEXT ...
+```
+
+### DO: Validate inputs
+```bash
+# Good
+if [[ ! "$1" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "Invalid input"
+  exit 1
+fi
+```
+
+### DON'T: Echo raw API responses with potential secrets
+```bash
+# Bad - might leak tokens in error messages
+curl ... 2>&1
+
+# Good - only show what you intend
+RESPONSE=$(curl -s ...)
+echo "$RESPONSE" | jq '.data'
+```
+
+## Common API Patterns
+
+### Basic Auth (e.g., Follow Up Boss)
+```bash
+curl -s -u "${API_KEY}:" "https://api.example.com/endpoint"
+```
+
+### Bearer Token
+```bash
+curl -s -H "Authorization: Bearer ${API_KEY}" "https://api.example.com/endpoint"
+```
+
+### OAuth 1.0 (e.g., Twitter/X)
+Use a library like `twurl` or Python's `tweepy` inside the script.
+
+## Removing Old Keys
+
+After setting this up, remove keys from locations the agent can access:
+
+```bash
+# Remove from old .env
+rm ~/.openclaw/.env
+# Or edit to remove sensitive values
+nano ~/.openclaw/.env
+```
+
+## Troubleshooting
+
+**"Permission denied" when agent runs script:**
+- Check sudoers config: `sudo cat /etc/sudoers.d/openclaw-secrets`
+- Ensure exact path matches
+
+**"unbound variable" error:**
+- Key not in `.env` or misspelled
+- Check with: `sudo -u secretsuser cat /home/secretsuser/.env | sed 's/=.*/=***/'`
+
+**Script works manually but not via sudo:**
+- Check script permissions: `sudo -u secretsuser ls -la /home/secretsuser/scripts/`
+- Should be `-rwx------` (700)
+
+## Conclusion
+
+This approach provides real security through Linux permissions — not just rules the agent might break. Until OpenClaw implements native secret masking, this is the most robust protection available.
+
+See also: [OpenClaw Feature Request #10659](https://github.com/openclaw/openclaw/issues/10659)


### PR DESCRIPTION
## Summary

Adds a guide to `docs/security/` explaining how to protect API keys from agent access using Linux user isolation.

## The Problem

Agents have filesystem access and can accidentally (or be tricked into) exposing API keys stored in `.env` files. Rules-based protection ('please don't read this') is not sufficient — agents can forget, make mistakes while debugging, or be manipulated via prompt injection.

## The Solution

This guide shows how to:
1. Create a separate Linux user that owns secrets
2. Write wrapper scripts that use those secrets internally
3. Configure limited sudo access for the agent
4. Result: Agent can USE APIs but cannot SEE credentials

This is a hard technical block enforced by the kernel, not agent discipline.

## Context

- Feature request for native support: #10659
- Standalone repo with templates: https://github.com/jmkritt/openclaw-secrets-hardening

This guide provides a working solution today while native masked secrets support is being considered.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new security doc at `docs/security/api-key-hardening.md` describing a Linux user-isolation pattern for keeping API keys out of an agent’s readable filesystem while still allowing API usage via whitelisted `sudo`-run wrapper scripts. The guide walks through creating a dedicated “secrets” user, placing secrets in a root-owned home directory, creating wrapper scripts that source the secrets, and configuring a sudoers allowlist so the agent can execute only those scripts.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing sudoers-related correctness/security guidance in the new doc.
- Only documentation changes, but the doc currently contains sudoers guidance that can be misapplied (whitelist/test mismatch) and may give a false sense of safety if the allowlist can be bypassed via alternate invocation paths; these should be corrected to avoid teaching an insecure or non-working setup.
- docs/security/api-key-hardening.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->