### PR TITLE
fix: add firecrawl field to ToolsWebFetchSchema Zod validation

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -197,6 +197,17 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: z.string().optional(),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().int().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- The Zod schema `ToolsWebFetchSchema` uses `.strict()` but was missing the `firecrawl` field, causing config validation to reject `tools.web.fetch.firecrawl` as an unrecognized key
- Added the `firecrawl` nested object to match the existing TypeScript type at `src/config/types.tools.ts:376-389`
- All 4 schema tests pass

## Test plan

- [x] `pnpm exec vitest run src/config/schema.test.ts` — 4/4 passing
- [x] Verified Zod schema fields match the TypeScript type definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `ToolsWebFetchSchema` Zod schema in `src/config/zod-schema.agent-runtime.ts` to include the nested `tools.web.fetch.firecrawl` object. This aligns runtime config validation (which uses `.strict()`) with the existing TypeScript config type (`ToolsConfig.web.fetch.firecrawl`) so valid configs are no longer rejected as having an unrecognized key.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow schema alignment: it adds a previously missing `firecrawl` key to a `.strict()` Zod object, matching the existing TypeScript config shape. No behavior changes beyond accepting an already-supported config field, and there are no new side effects or complex logic paths introduced in the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->