### PR TITLE
fix: bypass bot filter and mention gate for sibling Discord bots

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -48,6 +48,7 @@ import {
 } from "./format.js";
 import { resolveDiscordChannelInfo, resolveDiscordMessageText } from "./message-utils.js";
 import { resolveDiscordSenderIdentity, resolveDiscordWebhookId } from "./sender-identity.js";
+import { isSiblingBot as isSiblingBotCheck } from "./sibling-bots.js";
 import { resolveDiscordSystemEvent } from "./system-events.js";
 import { resolveDiscordThreadChannel, resolveDiscordThreadParentInfo } from "./threading.js";
 
@@ -72,6 +73,11 @@ export async function preflightDiscordMessage(
     return null;
   }
 
+  // Check if the author is a sibling bot (a different Discord account in the
+  // same OpenClaw instance).  Sibling bots bypass bot filtering and mention
+  // gating so multi-agent setups work correctly.
+  const isSibling = Boolean(author.bot && isSiblingBotCheck(params.accountId, author.id));
+
   const pluralkitConfig = params.discordConfig?.pluralkit;
   const webhookId = resolveDiscordWebhookId(message);
   const shouldCheckPluralKit = Boolean(pluralkitConfig?.enabled) && !webhookId;
@@ -93,7 +99,7 @@ export async function preflightDiscordMessage(
   });
 
   if (author.bot) {
-    if (!allowBots && !sender.isPluralKit) {
+    if (!isSibling && !allowBots && !sender.isPluralKit) {
       logVerbose("discord: drop bot message (allowBots=false)");
       return null;
     }
@@ -464,7 +470,7 @@ export async function preflightDiscordMessage(
     commandAuthorized,
   });
   const effectiveWasMentioned = mentionGate.effectiveWasMentioned;
-  if (isGuildMessage && shouldRequireMention) {
+  if (isGuildMessage && shouldRequireMention && !isSibling) {
     if (botId && mentionGate.shouldSkip) {
       logVerbose(`discord: drop guild message (mention required, botId=${botId})`);
       logger.info(
@@ -527,6 +533,7 @@ export async function preflightDiscordMessage(
     token: params.token,
     runtime: params.runtime,
     botUserId: params.botUserId,
+    isSiblingBot: isSibling,
     guildHistories: params.guildHistories,
     historyLimit: params.historyLimit,
     mediaMaxBytes: params.mediaMaxBytes,

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -23,6 +23,7 @@ export type DiscordMessagePreflightContext = {
   token: string;
   runtime: RuntimeEnv;
   botUserId?: string;
+  isSiblingBot?: boolean;
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -40,6 +40,7 @@ import {
   createDiscordCommandArgFallbackButton,
   createDiscordNativeCommand,
 } from "./native-command.js";
+import { registerSiblingBot, unregisterSiblingBot } from "./sibling-bots.js";
 
 export type MonitorDiscordOpts = {
   token?: string;
@@ -529,6 +530,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   try {
     const botUser = await client.fetchUser("@me");
     botUserId = botUser?.id;
+    if (botUserId) {
+      registerSiblingBot(account.accountId, botUserId);
+    }
   } catch (err) {
     runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
   }
@@ -662,6 +666,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     });
   } finally {
     unregisterGateway(account.accountId);
+    unregisterSiblingBot(account.accountId);
     stopGatewayLogging();
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);

--- a/src/discord/monitor/sibling-bots.test.ts
+++ b/src/discord/monitor/sibling-bots.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearSiblingBots,
+  isSiblingBot,
+  registerSiblingBot,
+  unregisterSiblingBot,
+} from "./sibling-bots.js";
+
+describe("sibling-bots", () => {
+  beforeEach(() => {
+    clearSiblingBots();
+  });
+
+  it("identifies a sibling bot from a different account", () => {
+    registerSiblingBot("account-a", "bot-user-a");
+    registerSiblingBot("account-b", "bot-user-b");
+    expect(isSiblingBot("account-a", "bot-user-b")).toBe(true);
+    expect(isSiblingBot("account-b", "bot-user-a")).toBe(true);
+  });
+
+  it("returns false for own bot user ID", () => {
+    registerSiblingBot("account-a", "bot-user-a");
+    expect(isSiblingBot("account-a", "bot-user-a")).toBe(false);
+  });
+
+  it("returns false for unknown user IDs", () => {
+    registerSiblingBot("account-a", "bot-user-a");
+    expect(isSiblingBot("account-a", "unknown-user")).toBe(false);
+  });
+
+  it("unregisters a sibling bot", () => {
+    registerSiblingBot("account-a", "bot-user-a");
+    registerSiblingBot("account-b", "bot-user-b");
+    unregisterSiblingBot("account-b");
+    expect(isSiblingBot("account-a", "bot-user-b")).toBe(false);
+  });
+
+  it("clears all sibling bots", () => {
+    registerSiblingBot("account-a", "bot-user-a");
+    registerSiblingBot("account-b", "bot-user-b");
+    clearSiblingBots();
+    expect(isSiblingBot("account-a", "bot-user-b")).toBe(false);
+    expect(isSiblingBot("account-b", "bot-user-a")).toBe(false);
+  });
+
+  it("overwrites existing entry for same account", () => {
+    registerSiblingBot("account-a", "bot-user-old");
+    registerSiblingBot("account-a", "bot-user-new");
+    registerSiblingBot("account-b", "bot-user-b");
+    expect(isSiblingBot("account-b", "bot-user-old")).toBe(false);
+    expect(isSiblingBot("account-b", "bot-user-new")).toBe(true);
+  });
+
+  it("returns false when registry is empty", () => {
+    expect(isSiblingBot("account-a", "any-user")).toBe(false);
+  });
+
+  it("returns false with only one account registered", () => {
+    registerSiblingBot("account-a", "bot-user-a");
+    // Only one account -- no siblings exist
+    expect(isSiblingBot("account-a", "bot-user-a")).toBe(false);
+  });
+});

--- a/src/discord/monitor/sibling-bots.ts
+++ b/src/discord/monitor/sibling-bots.ts
@@ -1,0 +1,44 @@
+/**
+ * Module-level registry of Discord bot user IDs for all configured accounts.
+ * Used to identify "sibling bots" -- bots belonging to the same OpenClaw
+ * instance but running under a different Discord account.  Messages from
+ * sibling bots should bypass bot filtering and mention gating so multi-agent
+ * setups work correctly.
+ *
+ * Follows the same pattern as gateway-registry.ts.
+ */
+const siblingBotRegistry = new Map<string, string>();
+
+/** Register a bot user ID for a Discord account. */
+export function registerSiblingBot(accountId: string, botUserId: string): void {
+  siblingBotRegistry.set(accountId, botUserId);
+}
+
+/** Unregister a bot user ID when a Discord account shuts down. */
+export function unregisterSiblingBot(accountId: string): void {
+  siblingBotRegistry.delete(accountId);
+}
+
+/**
+ * Check whether `userId` belongs to a sibling bot -- i.e. a *different*
+ * configured Discord account in the same OpenClaw instance.
+ *
+ * Returns `false` for the caller's own bot user ID (that case is already
+ * handled by the self-message check) and for unknown user IDs.
+ */
+export function isSiblingBot(currentAccountId: string, userId: string): boolean {
+  for (const [accountId, botUserId] of siblingBotRegistry) {
+    if (accountId === currentAccountId) {
+      continue;
+    }
+    if (botUserId === userId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Clear all registered sibling bots (for testing). */
+export function clearSiblingBots(): void {
+  siblingBotRegistry.clear();
+}


### PR DESCRIPTION
#### Summary

Fixes #11199. In a multi-agent setup with multiple Discord bot accounts (one per agent),
messages between bots are silently dropped because:

1. The `author.bot` check drops ALL bot messages when `allowBots` defaults to `false` --
   including messages from sibling bots in the same OpenClaw instance.
2. Even with `allowBots: true`, the default `requireMention: true` blocks guild messages
   where the sibling bot wasn't explicitly @-mentioned.

This PR adds a sibling bot registry so multi-agent Discord setups can distinguish
messages from other bots in the same OpenClaw instance. Sibling bot
messages now bypass the allowBots filter and mention gate while
own-message filtering and external-bot filtering remain unchanged.

#### Repro Steps

1. Configure two Discord bot accounts (agent A and agent B) in the same OpenClaw instance.
2. Have agent A send a message in a guild channel.
3. Agent B never receives the message -- it is dropped at preflight.

#### Root Cause

The preflight pipeline has no concept of "sibling bots." All bot-authored messages are
treated identically -- filtered by the `allowBots` flag and gated by `requireMention`.

#### Behavior Changes

- Messages from sibling bots (other Discord accounts in the same OpenClaw instance) now
  bypass the bot filter (`allowBots=false` check) and the mention gate (`requireMention`).
- Own-message self-filtering: unchanged.
- External bot filtering: unchanged (still filtered when `allowBots=false`).
- PluralKit bypass: unchanged.
- User allowlists: NOT bypassed for sibling bots (intentional).
- DM policy: NOT bypassed for sibling bots (out of scope).
- Single-account setups: no behavioral change (`isSiblingBot` always returns `false`).

#### Codebase and GitHub Search

- Searched for existing sibling/multi-bot handling: none found.
- Reviewed `gateway-registry.ts` pattern for module-level Map registry approach.
- Checked `allow-list.ts` mention resolution and `sender-identity.ts` PluralKit handling
  to ensure no conflicts.

#### Tests

- `pnpm build` -- pass
- `pnpm check` -- pass (format issues only in pre-existing `.claude/rules/` files)
- `pnpm test` -- 962 test files, 6517 tests, all pass

New tests in `sibling-bots.test.ts` (8 tests):
- Identifies sibling bot from a different account
- Returns false for own bot user ID
- Returns false for unknown user IDs
- Unregister removes sibling
- Clear removes all siblings
- Overwrite replaces existing entry
- Returns false when registry is empty
- Returns false with only one account registered

#### Files

**New:**
- `src/discord/monitor/sibling-bots.ts` -- registry (register/unregister/isSiblingBot/clear)
- `src/discord/monitor/sibling-bots.test.ts` -- 8 unit tests

**Modified:**
- `src/discord/monitor/provider.ts` -- register on startup, unregister in finally
- `src/discord/monitor/message-handler.preflight.ts` -- compute `isSibling`, skip bot filter + mention gate
- `src/discord/monitor/message-handler.preflight.types.ts` -- add `isSiblingBot` to context type

**Sign-Off**

- Models used: Claude Opus 4.6 (AI-assisted)
- Testing degree: fully tested -- `pnpm build && pnpm check && pnpm test` all pass (962 files, 6517 tests); 8 new unit tests added
- I confirm I understand what this code does
- Submitter effort: planned approach, reviewed all relevant source files, implemented and verified
- Agent notes: startup race (account A starts before B registers) is transient and matches
  current behavior for unregistered bots -- acceptable tradeoff

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a module-level “sibling bot” registry (`src/discord/monitor/sibling-bots.ts`) and wires it into the Discord monitor startup/shutdown (`provider.ts`) and the message preflight pipeline (`message-handler.preflight.ts`). The goal is to allow multi-agent / multi-bot OpenClaw instances to treat messages from other configured bot accounts as “internal” and bypass the existing `allowBots=false` filter and the guild mention gate.

In preflight, a new `isSibling` flag is computed (only for `author.bot` authors) and used to skip the bot filter and skip the guild mention-required drop. The preflight context type gains `isSiblingBot?: boolean`, and unit tests are added to validate the registry behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe, but has a couple of correctness edge cases that should be addressed before merging.
- Core change is small and tests cover the new registry, but the registry lifecycle in `provider.ts` can become stale in long-lived/reconnecting scenarios, and the mention-gating bypass is only partially applied (drop condition) while gating state is still computed as if mention-required, which can cause inconsistent downstream behavior.
- src/discord/monitor/provider.ts, src/discord/monitor/message-handler.preflight.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->