### PR TITLE
fix(webchat): filter HEARTBEAT_OK messages from chat.history response

### DIFF
--- a/src/gateway/chat-history-heartbeat.test.ts
+++ b/src/gateway/chat-history-heartbeat.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "vitest";
+import { filterHeartbeatMessages, isHeartbeatOkMessage } from "./chat-history-heartbeat.js";
+
+// ---------------------------------------------------------------------------
+// isHeartbeatOkMessage
+// ---------------------------------------------------------------------------
+
+describe("isHeartbeatOkMessage", () => {
+  test("detects plain HEARTBEAT_OK assistant message (content array)", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "HEARTBEAT_OK" }],
+      }),
+    ).toBe(true);
+  });
+
+  test("detects plain HEARTBEAT_OK assistant message (string content)", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "assistant",
+        content: "HEARTBEAT_OK",
+      }),
+    ).toBe(true);
+  });
+
+  test("detects HEARTBEAT_OK with surrounding whitespace", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "assistant",
+        content: "  HEARTBEAT_OK  ",
+      }),
+    ).toBe(true);
+  });
+
+  test("detects HEARTBEAT_OK wrapped in markdown bold", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "assistant",
+        content: "**HEARTBEAT_OK**",
+      }),
+    ).toBe(true);
+  });
+
+  test("detects HEARTBEAT_OK wrapped in HTML bold", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "assistant",
+        content: "<b>HEARTBEAT_OK</b>",
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects user messages", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "user",
+        content: "HEARTBEAT_OK",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects system messages", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "system",
+        content: "HEARTBEAT_OK",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects assistant messages with real content", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "assistant",
+        content: "Nothing to report. HEARTBEAT_OK",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects empty assistant messages", () => {
+    expect(
+      isHeartbeatOkMessage({
+        role: "assistant",
+        content: "",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects null/undefined", () => {
+    expect(isHeartbeatOkMessage(null)).toBe(false);
+    expect(isHeartbeatOkMessage(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterHeartbeatMessages
+// ---------------------------------------------------------------------------
+
+describe("filterHeartbeatMessages", () => {
+  const heartbeatPrompt = {
+    role: "user",
+    content:
+      "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
+  };
+
+  const heartbeatReply = {
+    role: "assistant",
+    content: [{ type: "text", text: "HEARTBEAT_OK" }],
+  };
+
+  const normalUser = {
+    role: "user",
+    content: "Hello, how are you?",
+  };
+
+  const normalAssistant = {
+    role: "assistant",
+    content: [{ type: "text", text: "I'm doing great!" }],
+  };
+
+  test("removes heartbeat prompt+reply pair", () => {
+    const messages = [normalUser, normalAssistant, heartbeatPrompt, heartbeatReply];
+    const filtered = filterHeartbeatMessages(messages);
+    expect(filtered).toEqual([normalUser, normalAssistant]);
+  });
+
+  test("removes only heartbeat reply when prompt does not contain HEARTBEAT_OK", () => {
+    const customPrompt = {
+      role: "user",
+      content: "Check if everything is okay",
+    };
+    const messages = [normalUser, normalAssistant, customPrompt, heartbeatReply];
+    const filtered = filterHeartbeatMessages(messages);
+    // Custom prompt is kept because it doesn't contain HEARTBEAT_OK
+    expect(filtered).toEqual([normalUser, normalAssistant, customPrompt]);
+  });
+
+  test("handles multiple heartbeat exchanges interspersed with real messages", () => {
+    const messages = [
+      heartbeatPrompt,
+      heartbeatReply,
+      normalUser,
+      normalAssistant,
+      heartbeatPrompt,
+      heartbeatReply,
+    ];
+    const filtered = filterHeartbeatMessages(messages);
+    expect(filtered).toEqual([normalUser, normalAssistant]);
+  });
+
+  test("returns same reference when no heartbeats found", () => {
+    const messages = [normalUser, normalAssistant];
+    const filtered = filterHeartbeatMessages(messages);
+    expect(filtered).toBe(messages); // same reference = no copy
+  });
+
+  test("handles empty array", () => {
+    expect(filterHeartbeatMessages([])).toEqual([]);
+  });
+
+  test("handles heartbeat reply at index 0 (no preceding prompt)", () => {
+    const messages = [heartbeatReply, normalUser, normalAssistant];
+    const filtered = filterHeartbeatMessages(messages);
+    expect(filtered).toEqual([normalUser, normalAssistant]);
+  });
+
+  test("does not remove alert messages that contain real content", () => {
+    const alertReply = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "You have 3 unread emails. HEARTBEAT_OK",
+        },
+      ],
+    };
+    const messages = [heartbeatPrompt, alertReply];
+    const filtered = filterHeartbeatMessages(messages);
+    // Alert reply is kept because it has real content beyond HEARTBEAT_OK
+    expect(filtered).toEqual([heartbeatPrompt, alertReply]);
+  });
+
+  test("handles consecutive heartbeat replies without prompts", () => {
+    const messages = [heartbeatReply, heartbeatReply, normalUser];
+    const filtered = filterHeartbeatMessages(messages);
+    expect(filtered).toEqual([normalUser]);
+  });
+});

--- a/src/gateway/chat-history-heartbeat.ts
+++ b/src/gateway/chat-history-heartbeat.ts
@@ -1,0 +1,79 @@
+import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
+
+type HistoryMessage = {
+  role?: string;
+  content?: string | Array<{ type?: string; text?: string }>;
+};
+
+/**
+ * Extract the plain-text body from a transcript message (string or content array).
+ */
+function extractMessageText(msg: HistoryMessage): string {
+  if (typeof msg.content === "string") {
+    return msg.content;
+  }
+  if (Array.isArray(msg.content)) {
+    return msg.content
+      .filter((p) => p?.type === "text" && typeof p.text === "string")
+      .map((p) => p.text!)
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * Returns true when the message is an assistant reply whose text is effectively
+ * just the HEARTBEAT_OK token (with optional surrounding whitespace / markup).
+ */
+export function isHeartbeatOkMessage(msg: unknown): boolean {
+  const m = msg as HistoryMessage;
+  if (m?.role !== "assistant") {
+    return false;
+  }
+  const text = extractMessageText(m).trim();
+  if (!text) {
+    return false;
+  }
+  // Strip lightweight markup wrappers (bold, code, etc.) that some models add.
+  const stripped = text
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/^[*`~_]+/, "")
+    .replace(/[*`~_]+$/, "")
+    .trim();
+  return stripped === HEARTBEAT_TOKEN;
+}
+
+/**
+ * Filter heartbeat exchanges from chat history messages.
+ *
+ * When `showOk` is false (the default for webchat), removes:
+ *   1. Assistant messages that are just "HEARTBEAT_OK"
+ *   2. The immediately preceding user message if it looks like a heartbeat prompt
+ *      (contains "HEARTBEAT_OK" — the standard prompt asks the agent to
+ *       "reply HEARTBEAT_OK")
+ */
+export function filterHeartbeatMessages(messages: unknown[]): unknown[] {
+  // Walk backwards so we can pair assistant HEARTBEAT_OK with its prompt.
+  const excluded = new Set<number>();
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (!isHeartbeatOkMessage(messages[i])) {
+      continue;
+    }
+    excluded.add(i);
+    // Check if the previous message is the heartbeat prompt.
+    if (i > 0) {
+      const prev = messages[i - 1] as HistoryMessage;
+      if (prev?.role === "user") {
+        const text = extractMessageText(prev);
+        if (text.includes(HEARTBEAT_TOKEN)) {
+          excluded.add(i - 1);
+        }
+      }
+    }
+  }
+  if (excluded.size === 0) {
+    return messages;
+  }
+  return messages.filter((_, idx) => !excluded.has(idx));
+}


### PR DESCRIPTION
## Summary

Fixes #11630 — `chat.history` returns raw transcript data without heartbeat filtering, causing `HEARTBEAT_OK` messages to reappear in the webchat UI after every page refresh or tab switch.

The **live broadcast** path already correctly suppresses heartbeat messages via `shouldSuppressHeartbeatBroadcast()` in `server-chat.ts`, but the **`chat.history`** handler had no equivalent filter.

## Root Cause

`chat.history` reads messages from the session transcript and returns them directly. The live broadcast path checks `resolveHeartbeatVisibility({ cfg, channel: "webchat" })` and suppresses broadcasts when `showOk` is `false` (the default). But `chat.history` skipped this check entirely, creating an inconsistency: heartbeat messages vanish during live sessions but reappear on every page load.

## Fix

Added `filterHeartbeatMessages()` in a new module `src/gateway/chat-history-heartbeat.ts` that removes:

1. **Assistant messages** whose text is solely `HEARTBEAT_OK` (including markup-wrapped variants like `**HEARTBEAT_OK**`, `<b>HEARTBEAT_OK</b>`)
2. **The immediately preceding user message** when it contains `HEARTBEAT_OK` (the standard heartbeat prompt asks the agent to "reply HEARTBEAT_OK")

The filter is applied in the `chat.history` handler **only when** `resolveHeartbeatVisibility` returns `showOk: false` (the webchat default), matching the existing live broadcast behavior. When `showOk` is explicitly set to `true`, heartbeat messages are preserved as before.

## Changes

| File | Change |
|------|--------|
| `src/gateway/chat-history-heartbeat.ts` | New module: `isHeartbeatOkMessage()` + `filterHeartbeatMessages()` |
| `src/gateway/chat-history-heartbeat.test.ts` | 18 unit tests |
| `src/gateway/server-methods/chat.ts` | Wire filter into `chat.history` handler (4 lines) |

## Tests

18 unit tests covering:
- Plain / whitespace / markdown-bold / HTML-bold wrapped tokens
- Content arrays vs string content format
- Prompt+reply pair removal (heartbeat prompt preceding HEARTBEAT_OK)
- Custom prompts without HEARTBEAT_OK token (kept, not removed)
- Multiple heartbeat exchanges interleaved with real messages
- Edge cases: empty arrays, reply at index 0, alert messages with real content beyond token, consecutive replies without prompts
- Reference identity (returns same array reference when no filtering needed)

```
✓ src/gateway/chat-history-heartbeat.test.ts (18 tests) 15ms
Test Files  1 passed (1)
     Tests  18 passed (18)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `chat.history` consistent with the live webchat broadcast path by filtering out heartbeat exchanges (assistant `HEARTBEAT_OK` acknowledgements and their paired prompt) when `resolveHeartbeatVisibility({ channel: "webchat" }).showOk` is `false`.

It does this by introducing `src/gateway/chat-history-heartbeat.ts` with helpers to recognize markup-wrapped `HEARTBEAT_OK` responses and then wiring that filter into the `chat.history` handler in `src/gateway/server-methods/chat.ts`. Unit tests were added to cover the detection and filtering behavior across string/array content formats and several edge cases.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, with one behavior bug around `chat.history` limits when heartbeats are present.
- The change is localized and covered by unit tests, and it reuses existing heartbeat visibility config. The main concern is that filtering happens after slicing to `limit`, so sessions with many heartbeat exchanges can return fewer messages than requested even though more non-heartbeat history exists earlier.
- src/gateway/server-methods/chat.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->