### PR TITLE
fix(gateway): eager-init QMD backend on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 - Memory: disable async batch embeddings by default for memory indexing (opt-in via `agents.defaults.memorySearch.remote.batch.enabled`). (#13069) Thanks @mcinteerj.
 - Memory/QMD: reuse default model cache across agents instead of re-downloading per agent. (#12114) Thanks @tyler6204.
 - Memory/QMD: run boot refresh in background by default, add configurable QMD maintenance timeouts, retry QMD after fallback failures, and scope QMD queries to OpenClaw-managed collections. (#9690, #9705, #10042) Thanks @vignesh07.
+- Memory/QMD: initialize QMD backend on gateway startup so background update timers restart after process reloads. (#10797) Thanks @vignesh07.
 - Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.
 - State dir: honor `OPENCLAW_STATE_DIR` for default device identity and canvas storage paths. (#4824) Thanks @kossoy.
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -132,6 +132,8 @@ out to QMD for retrieval. Key points:
   (plus default workspace memory files), then `qmd update` + `qmd embed` run
   on boot and on a configurable interval (`memory.qmd.update.interval`,
   default 5 m).
+- The gateway now initializes the QMD manager on startup, so periodic update
+  timers are armed even before the first `memory_search` call.
 - Boot refresh now runs in the background by default so chat startup is not
   blocked; set `memory.qmd.update.waitForBootSync = true` to keep the previous
   blocking behavior.

--- a/src/gateway/server-startup-memory.test.ts
+++ b/src/gateway/server-startup-memory.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const { getMemorySearchManagerMock } = vi.hoisted(() => ({
+  getMemorySearchManagerMock: vi.fn(),
+}));
+
+vi.mock("../memory/index.js", () => ({
+  getMemorySearchManager: getMemorySearchManagerMock,
+}));
+
+import { startGatewayMemoryBackend } from "./server-startup-memory.js";
+
+describe("startGatewayMemoryBackend", () => {
+  beforeEach(() => {
+    getMemorySearchManagerMock.mockReset();
+  });
+
+  it("skips initialization when memory backend is not qmd", async () => {
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+      memory: { backend: "builtin" },
+    } as OpenClawConfig;
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    await startGatewayMemoryBackend({ cfg, log });
+
+    expect(getMemorySearchManagerMock).not.toHaveBeenCalled();
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("initializes qmd backend for the default agent", async () => {
+    const cfg = {
+      agents: { list: [{ id: "ops", default: true }, { id: "main" }] },
+      memory: { backend: "qmd", qmd: {} },
+    } as OpenClawConfig;
+    const log = { info: vi.fn(), warn: vi.fn() };
+    getMemorySearchManagerMock.mockResolvedValue({ manager: { search: vi.fn() } });
+
+    await startGatewayMemoryBackend({ cfg, log });
+
+    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({ cfg, agentId: "ops" });
+    expect(log.info).toHaveBeenCalledWith(
+      'qmd memory startup initialization armed for agent "ops"',
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning when qmd manager init fails", async () => {
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+      memory: { backend: "qmd", qmd: {} },
+    } as OpenClawConfig;
+    const log = { info: vi.fn(), warn: vi.fn() };
+    getMemorySearchManagerMock.mockResolvedValue({ manager: null, error: "qmd missing" });
+
+    await startGatewayMemoryBackend({ cfg, log });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'qmd memory startup initialization failed for agent "main": qmd missing',
+    );
+    expect(log.info).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
+import { getMemorySearchManager } from "../memory/index.js";
+
+export async function startGatewayMemoryBackend(params: {
+  cfg: OpenClawConfig;
+  log: { info?: (msg: string) => void; warn: (msg: string) => void };
+}): Promise<void> {
+  const agentId = resolveDefaultAgentId(params.cfg);
+  const resolved = resolveMemoryBackendConfig({ cfg: params.cfg, agentId });
+  if (resolved.backend !== "qmd" || !resolved.qmd) {
+    return;
+  }
+
+  const { manager, error } = await getMemorySearchManager({ cfg: params.cfg, agentId });
+  if (!manager) {
+    params.log.warn(
+      `qmd memory startup initialization failed for agent "${agentId}": ${error ?? "unknown error"}`,
+    );
+    return;
+  }
+  params.log.info?.(`qmd memory startup initialization armed for agent "${agentId}"`);
+}

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -22,6 +22,7 @@ import {
   scheduleRestartSentinelWake,
   shouldWakeFromRestartSentinel,
 } from "./server-restart-sentinel.js";
+import { startGatewayMemoryBackend } from "./server-startup-memory.js";
 
 export async function startGatewaySidecars(params: {
   cfg: ReturnType<typeof loadConfig>;
@@ -149,6 +150,10 @@ export async function startGatewaySidecars(params: {
   } catch (err) {
     params.log.warn(`plugin services failed to start: ${String(err)}`);
   }
+
+  void startGatewayMemoryBackend({ cfg: params.cfg, log: params.log }).catch((err) => {
+    params.log.warn(`qmd memory startup initialization failed: ${String(err)}`);
+  });
 
   if (shouldWakeFromRestartSentinel()) {
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- Eagerly initialize the QMD memory backend during gateway startup for the default agent.
- Keep startup non-blocking by running initialization in the background.
- Add dedicated tests for startup backend initialization behavior.

## Why
Fixes #10797. After gateway restart/config reload, QMD update/embed timers were not re-armed until the first memory tool call.

## Changes
- `src/gateway/server-startup-memory.ts` (new)
  - Added `startGatewayMemoryBackend()` helper.
  - Detects QMD backend for default agent and initializes the memory manager.
  - Emits startup warning when initialization fails.
- `src/gateway/server-startup.ts`
  - Invokes startup memory backend initialization in the background.
- `src/gateway/server-startup-memory.test.ts` (new)
  - Covers non-QMD no-op behavior.
  - Covers default-agent initialization behavior.
  - Covers warning path when manager init fails.
- `docs/concepts/memory.md`
  - Documented startup initialization behavior.
- `CHANGELOG.md`
  - Added `#10797` fix entry.

## Validation
- `pnpm test src/gateway/server-startup-memory.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces eager initialization of the QMD memory backend at gateway startup by adding a new `startGatewayMemoryBackend()` helper and invoking it in the background from gateway startup. It also adds unit tests for the no-op path (non-QMD backend), the default-agent QMD initialization path, and the warning path when manager initialization fails, plus accompanying docs/changelog updates.

The change fits into the gateway lifecycle by ensuring QMD’s timers are re-armed immediately after restart/config reload, rather than waiting until the first memory tool call triggers manager creation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The startup initialization is explicitly non-blocking, scoped to the default agent’s QMD backend, and has defensive error handling with warning logs; added tests cover the main control-flow paths (non-QMD no-op, successful init, and failure logging). No functional regressions were identified in the changed files.
- src/gateway/server-startup-memory.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->