### PR TITLE
fix(memory/qmd): handle plain-text no-results output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Docs: https://docs.openclaw.ai
 - Memory/QMD: run boot refresh in background by default, add configurable QMD maintenance timeouts, retry QMD after fallback failures, and scope QMD queries to OpenClaw-managed collections. (#9690, #9705, #10042) Thanks @vignesh07.
 - Memory/QMD: initialize QMD backend on gateway startup so background update timers restart after process reloads. (#10797) Thanks @vignesh07.
 - Config/Memory: auto-migrate legacy top-level `memorySearch` settings into `agents.defaults.memorySearch`. (#11278, #9143) Thanks @vignesh07.
+- Memory/QMD: treat plain-text `No results found` output from QMD as an empty result instead of throwing invalid JSON errors. (#9824)
 - Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.
 - State dir: honor `OPENCLAW_STATE_DIR` for default device identity and canvas storage paths. (#4824) Thanks @kossoy.
 

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -733,7 +733,6 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-
   it("treats plain-text no-results stdout as an empty result set", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
@@ -838,7 +837,6 @@ describe("QmdMemoryManager", () => {
     ).rejects.toThrow(/qmd query returned invalid JSON/);
     await manager.close();
   });
-
   describe("model cache symlink", () => {
     let defaultModelsDir: string;
     let customModelsDir: string;
@@ -920,7 +918,6 @@ describe("QmdMemoryManager", () => {
 
       await manager!.close();
     });
-  });
   });
 });
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -269,21 +269,16 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const args = ["query", trimmed, "--json", "-n", String(limit), ...collectionFilterArgs];
     let stdout: string;
+    let stderr: string;
     try {
       const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
       stdout = result.stdout;
+      stderr = result.stderr;
     } catch (err) {
       log.warn(`qmd query failed: ${String(err)}`);
       throw err instanceof Error ? err : new Error(String(err));
     }
-    let parsed: QmdQueryResult[] = [];
-    try {
-      parsed = JSON.parse(stdout);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(`qmd query returned invalid JSON: ${message}`);
-      throw new Error(`qmd query returned invalid JSON: ${message}`, { cause: err });
-    }
+    const parsed = this.parseQmdQueryJson(stdout, stderr);
     const results: MemorySearchResult[] = [];
     for (const entry of parsed) {
       const doc = await this.resolveDocLocation(entry.docid);
@@ -979,6 +974,42 @@ export class QmdMemoryManager implements MemorySearchManager {
       pending.catch(() => undefined),
       new Promise<void>((resolve) => setTimeout(resolve, SEARCH_PENDING_UPDATE_WAIT_MS)),
     ]);
+  }
+
+  private parseQmdQueryJson(stdout: string, stderr: string): QmdQueryResult[] {
+    const trimmedStdout = stdout.trim();
+    const trimmedStderr = stderr.trim();
+    const stdoutIsMarker = Boolean(trimmedStdout) && this.isQmdNoResultsOutput(trimmedStdout);
+    const stderrIsMarker = Boolean(trimmedStderr) && this.isQmdNoResultsOutput(trimmedStderr);
+    if (stdoutIsMarker || (!trimmedStdout && stderrIsMarker)) {
+      return [];
+    }
+    if (!trimmedStdout) {
+      const context = trimmedStderr ? ` (stderr: ${this.summarizeQmdStderr(trimmedStderr)})` : "";
+      const message = `stdout empty${context}`;
+      log.warn(`qmd query returned invalid JSON: ${message}`);
+      throw new Error(`qmd query returned invalid JSON: ${message}`);
+    }
+    try {
+      const parsed = JSON.parse(trimmedStdout) as unknown;
+      if (!Array.isArray(parsed)) {
+        throw new Error("qmd query JSON response was not an array");
+      }
+      return parsed as QmdQueryResult[];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`qmd query returned invalid JSON: ${message}`);
+      throw new Error(`qmd query returned invalid JSON: ${message}`, { cause: err });
+    }
+  }
+
+  private isQmdNoResultsOutput(raw: string): boolean {
+    const normalized = raw.trim().toLowerCase().replace(/\s+/g, " ");
+    return normalized === "no results found" || normalized === "no results found.";
+  }
+
+  private summarizeQmdStderr(raw: string): string {
+    return raw.length <= 120 ? raw : `${raw.slice(0, 117)}...`;
   }
 
   private buildCollectionFilterArgs(): string[] {

--- a/src/memory/qmd-query-parser.ts
+++ b/src/memory/qmd-query-parser.ts
@@ -1,0 +1,47 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("memory");
+
+export type QmdQueryResult = {
+  docid?: string;
+  score?: number;
+  file?: string;
+  snippet?: string;
+  body?: string;
+};
+
+export function parseQmdQueryJson(stdout: string, stderr: string): QmdQueryResult[] {
+  const trimmedStdout = stdout.trim();
+  const trimmedStderr = stderr.trim();
+  const stdoutIsMarker = trimmedStdout.length > 0 && isQmdNoResultsOutput(trimmedStdout);
+  const stderrIsMarker = trimmedStderr.length > 0 && isQmdNoResultsOutput(trimmedStderr);
+  if (stdoutIsMarker || (!trimmedStdout && stderrIsMarker)) {
+    return [];
+  }
+  if (!trimmedStdout) {
+    const context = trimmedStderr ? ` (stderr: ${summarizeQmdStderr(trimmedStderr)})` : "";
+    const message = `stdout empty${context}`;
+    log.warn(`qmd query returned invalid JSON: ${message}`);
+    throw new Error(`qmd query returned invalid JSON: ${message}`);
+  }
+  try {
+    const parsed = JSON.parse(trimmedStdout) as unknown;
+    if (!Array.isArray(parsed)) {
+      throw new Error("qmd query JSON response was not an array");
+    }
+    return parsed as QmdQueryResult[];
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`qmd query returned invalid JSON: ${message}`);
+    throw new Error(`qmd query returned invalid JSON: ${message}`, { cause: err });
+  }
+}
+
+function isQmdNoResultsOutput(raw: string): boolean {
+  const normalized = raw.trim().toLowerCase().replace(/\s+/g, " ");
+  return normalized === "no results found" || normalized === "no results found.";
+}
+
+function summarizeQmdStderr(raw: string): string {
+  return raw.length <= 120 ? raw : `${raw.slice(0, 117)}...`;
+}


### PR DESCRIPTION
## Summary
- Treat plain-text `No results found` outputs from QMD as an empty result set.
- Handle this marker from both stdout and stderr.
- Keep strict JSON parsing for non-empty/non-marker outputs.

## Why
Fixes #9824. Some QMD runs can return plain-text "No results found." despite `--json`; previously this triggered invalid JSON errors and unnecessary fallback behavior.

## Changes
- `src/memory/qmd-manager.ts`
  - Added `parseQmdQueryJson(stdout, stderr)`.
  - Added `isQmdNoResultsOutput(...)` marker detection.
  - Search now uses robust parser instead of raw `JSON.parse(stdout)`.
- `src/memory/qmd-manager.test.ts`
  - Added regression tests for no-results marker in stdout and stderr.
- `CHANGELOG.md`
  - Added `#9824` fix note.

## Validation
- `pnpm test src/memory/qmd-manager.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens `QmdMemoryManager.search()` to treat QMD’s plain-text `No results found.` marker (seen despite `--json`) as an empty result set, whether emitted on stdout or stderr. It introduces a dedicated parser (`parseQmdQueryJson`) that preserves strict JSON parsing for any non-empty non-marker output, and adds regression tests covering both stdout/stderr cases. The changelog is updated to document the fix for #9824.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to QMD query output parsing, preserve strict JSON parsing for real results, and include targeted regression tests for the reported failure mode (plain-text no-results on stdout/stderr).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->