### PR TITLE
feat: Add GitHub Copilot gpt-5.2 models to XHIGH_MODEL_REFS

### DIFF
--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -26,6 +26,8 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
+  "github-copilot/gpt-5.2-codex",
+  "github-copilot/gpt-5.2",
 ] as const;
 
 const XHIGH_MODEL_SET = new Set(XHIGH_MODEL_REFS.map((entry) => entry.toLowerCase()));


### PR DESCRIPTION
## Description

Adds GitHub Copilot `gpt-5.2-codex` and `gpt-5.2` models to the `XHIGH_MODEL_REFS` list to enable xhigh reasoning mode support.

## Changes

- Added `github-copilot/gpt-5.2-codex` to `XHIGH_MODEL_REFS`
- Added `github-copilot/gpt-5.2` to `XHIGH_MODEL_REFS`

## References

- Fixes #11626
- Evidence of xhigh mode support: https://github.com/anomalyco/opencode/issues/9818

## Testing

- [x] Code follows project style (auto-formatted via git hook)
- [ ] Will run full test suite after PR creation

## Notes

This is a simple addition to enable xhigh thinking mode for GitHub Copilot models, consistent with existing OpenAI Codex entries in the same array.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `src/auto-reply/thinking.ts` by extending `XHIGH_MODEL_REFS` so `supportsXHighThinking()` recognizes GitHub Copilot models `github-copilot/gpt-5.2-codex` and `github-copilot/gpt-5.2` as supporting the `xhigh` thinking level. This feeds into `listThinkingLevels()` / `formatThinkingLevels()` so the UI/CLI can offer `xhigh` when those provider+model combinations are selected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a simple extension of a constant allowlist (`XHIGH_MODEL_REFS`) used for feature gating; it doesn’t alter control flow, parsing, or security-sensitive logic, and follows the existing provider/model naming pattern used elsewhere in the file.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->