### PR TITLE
fix(memory/qmd): log when scope denies search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/CLI: when `gateway.bind=lan`, use a LAN IP for probe URLs and Control UI links. (#11448) Thanks @AnonO6.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
 - Memory/QMD: run boot refresh in background by default, add configurable QMD maintenance timeouts, and retry QMD after fallback failures. (#9690, #9705)
+- Memory/QMD: log explicit warnings when `memory.qmd.scope` blocks a search request. (#10191)
 - Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.
 - State dir: honor `OPENCLAW_STATE_DIR` for default device identity and canvas storage paths. (#4824) Thanks @kossoy.
 - Tests: harden flaky hotspots by removing timer sleeps, consolidating onboarding provider-auth coverage, and improving memory test realism. (#11598) Thanks @gumadeiras.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -184,6 +184,8 @@ out to QMD for retrieval. Key points:
 - `scope`: same schema as [`session.sendPolicy`](/gateway/configuration#session).
   Default is DM-only (`deny` all, `allow` direct chats); loosen it to surface QMD
   hits in groups/channels.
+- When `scope` denies a search, OpenClaw logs a warning with the derived
+  `channel`/`chatType` so empty results are easier to debug.
 - Snippets sourced outside the workspace show up as
   `qmd/<collection>/<relative-path>` in `memory_search` results; `memory_get`
   understands that prefix and reads from the configured QMD collection root.

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -242,6 +242,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
   ): Promise<MemorySearchResult[]> {
     if (!this.isScopeAllowed(opts?.sessionKey)) {
+      this.logScopeDenied(opts?.sessionKey);
       return [];
     }
     const trimmed = query.trim();
@@ -691,6 +692,15 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const fallback = scope.default ?? "allow";
     return fallback === "allow";
+  }
+
+  private logScopeDenied(sessionKey?: string): void {
+    const channel = this.deriveChannelFromKey(sessionKey) ?? "unknown";
+    const chatType = this.deriveChatTypeFromKey(sessionKey) ?? "unknown";
+    const key = sessionKey?.trim() || "<none>";
+    log.warn(
+      `qmd search denied by scope (channel=${channel}, chatType=${chatType}, session=${key})`,
+    );
   }
 
   private deriveChannelFromKey(key?: string) {


### PR DESCRIPTION
## Summary
- Log explicit warnings when `memory.qmd.scope` denies a `memory_search` request.
- Include derived channel/chatType/session in the warning payload for quick debugging.
- Add regression tests for the deny path.

## Why
Fixes #10191. Scope-denied searches were silently returning empty results, which looked like missing memory instead of policy gating.

## Changes
- `src/memory/qmd-manager.ts`
  - Added `logScopeDenied(sessionKey)` helper.
  - Emit warning when scope blocks a search.
- `src/memory/qmd-manager.test.ts`
  - Mocked logger and added `logs when qmd scope denies search` test.
  - Asserted no query subprocess is spawned in the deny path.
- `docs/concepts/memory.md`
  - Documented scope-deny warning behavior.
- `CHANGELOG.md`
  - Added `#10191` fix note.

## Validation
- `pnpm test src/memory/qmd-manager.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds explicit warning logs when `memory.qmd.scope` denies a `memory_search` request, including derived `channel`, `chatType`, and the session key in the log message to make scope-gated empty results easier to diagnose. It also adds a regression test that verifies the deny path returns `[]`, emits the warning, and does not spawn the QMD query subprocess.

The behavioral change is localized to `QmdMemoryManager.search()` and uses the existing session-key parsing helpers (`deriveChannelFromKey` / `deriveChatTypeFromKey`) to populate the warning payload. Documentation and changelog are updated to reflect the new warning behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and localized (adds a warning + test for an existing deny path) and does not alter allowed search behavior; the new test covers the main regression (deny returns empty and avoids spawning QMD).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->