### PR TITLE
fix: Clarify session.dmScope is global in security audit warning

### DIFF
--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -125,6 +125,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
     if (dmScope === "main" && isMultiUserDm) {
       warnings.push(
         `- ${params.label} DMs: multiple senders share the main session; set session.dmScope="per-channel-peer" (or "per-account-channel-peer" for multi-account channels) to isolate sessions.`,
+        `  Note: session.dmScope is a global setting, not per-channel. Use: ${formatCliCommand("openclaw config set session.dmScope per-channel-peer")}`,
       );
     }
   };


### PR DESCRIPTION
## Problem

The security audit warning for multi-user DM sessions suggested setting `session.dmScope` but didn't clarify it's a **global config**, not per-channel. This caused confusion when users tried invalid paths like:

```bash
openclaw config set channels.imessage.session '"dmScope": "per-channel-peer"'
# Error: Unrecognized key: "session"

openclaw config set channels.imessage.dmScope "per-channel-peer"
# Error: Unrecognized key: "dmScope"
```

## Solution

Added an explicit note in the audit warning that `session.dmScope` is a **global setting**, along with the correct CLI command example:

```
  Note: session.dmScope is a global setting, not per-channel. Use: openclaw config set session.dmScope per-channel-peer
```

## Changes

- Added clarification note to `doctor-security.ts` audit warning
- Included formatted CLI command for clarity
- No behavior changes, only improved UX

## Testing

- [x] Code follows project style (auto-formatted via git hook)
- [ ] Tested locally with `openclaw security audit`

## References

Fixes #11642

---

**Before:**
```
- iMessage DMs: multiple senders share the main session; set session.dmScope="per-channel-peer" ...
```

**After:**
```
- iMessage DMs: multiple senders share the main session; set session.dmScope="per-channel-peer" ...
  Note: session.dmScope is a global setting, not per-channel. Use: openclaw config set session.dmScope per-channel-peer
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the security-audit output in `src/commands/doctor-security.ts` to explicitly state that `session.dmScope` is a global configuration (not a per-channel setting) and provides the correct `openclaw config set session.dmScope per-channel-peer` CLI example. This improves UX for users running `openclaw security audit` by preventing confusion around invalid `channels.<provider>.*` config paths; it does not change runtime behavior or security logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to user-facing audit messaging in a single file and does not alter configuration parsing, security checks, or runtime behavior. No functional regressions are expected.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->