### PR TITLE
fix: dynamically include bundled hooks in tsdown build

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,10 +1,14 @@
+import fs from "node:fs";
+import path from "node:path";
 import { defineConfig } from "tsdown";
 
 const env = {
   NODE_ENV: "production",
 };
 
-export default defineConfig([
+type Entry = Parameters<typeof defineConfig>[0][number];
+
+const baseEntries: Entry[] = [
   {
     entry: "src/index.ts",
     env,
@@ -36,10 +40,40 @@ export default defineConfig([
     fixedExtension: false,
     platform: "node",
   },
-  {
-    entry: ["src/hooks/bundled/*/handler.ts", "src/hooks/llm-slug-generator.ts"],
-    env,
-    fixedExtension: false,
-    platform: "node",
-  },
-]);
+];
+
+const bundledHookEntries = createBundledHookEntries();
+
+export default defineConfig([...baseEntries, ...bundledHookEntries]);
+
+function createBundledHookEntries(): Entry[] {
+  const entries: Entry[] = [];
+  const bundledDir = path.join(process.cwd(), "src", "hooks", "bundled");
+
+  if (!fs.existsSync(bundledDir)) {
+    return entries;
+  }
+
+  for (const dirent of fs.readdirSync(bundledDir, { withFileTypes: true })) {
+    if (!dirent.isDirectory()) {
+      continue;
+    }
+
+    const handlerRelative = path.join("src", "hooks", "bundled", dirent.name, "handler.ts");
+    const handlerAbsolute = path.join(process.cwd(), handlerRelative);
+
+    if (!fs.existsSync(handlerAbsolute)) {
+      continue;
+    }
+
+    entries.push({
+      entry: handlerRelative,
+      outDir: path.join("dist", "hooks", "bundled", dirent.name),
+      env,
+      fixedExtension: false,
+      platform: "node",
+    });
+  }
+
+  return entries;
+}


### PR DESCRIPTION
# Problem
Starting from v2026.2.6-3, the bundled hooks (like `soul-evil`, `session-memory`, etc.) are missing their compiled `handler.js` files in the `dist` directory. The current build process only copies the `HOOK.md` metadata but doesn't include the hook logic as entry points for the bundler. This renders all built-in hooks non-functional in distribution builds.

# Changes
- Modified `tsdown.config.ts` to dynamically scan the `src/hooks/bundled` directory.
- For each directory containing a `handler.ts`, a new entry point is added to the `tsdown` configuration.
- The compiled output is directed to `dist/hooks/bundled/<hook-name>/handler.js`, mirroring the source structure.
- This ensures that every bundled hook is automatically compiled and included in the final package without manual configuration updates when new hooks are added.

# Validation
- Ran `pnpm build` and confirmed that `dist/hooks/bundled/soul-evil/handler.js` (and others) are correctly generated.
- Ran `pnpm lint` to ensure configuration changes adhere to standards.
- Verified directory structure alignment between `src` and `dist`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `tsdown.config.ts` to automatically discover bundled hook implementations under `src/hooks/bundled/*/handler.ts` and add each as an additional `tsdown` entry point. Each discovered hook is built to `dist/hooks/bundled/<hook-name>/handler.js`, ensuring built-in hooks ship with compiled handlers without needing manual config updates when new hooks are added.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is localized to build configuration, adds deterministic entry generation for bundled hooks, and does not alter runtime logic outside packaging. The implementation only includes directories with an actual `handler.ts`, so it should not introduce build-time failures in normal repo layouts.
- tsdown.config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->