### PR TITLE
fix: prevent config page header overlap with settings form

### DIFF
--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -8,7 +8,7 @@
   grid-template-columns: 260px minmax(0, 1fr);
   gap: 0;
   height: calc(100vh - 160px);
-  margin: -16px;
+  margin: 0 -16px -16px -16px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: var(--panel);


### PR DESCRIPTION
## Summary

- The `.config-layout` in the config page had `margin: -16px` on all sides, causing the settings form to overlap the page title ("Config") and subtitle ("Edit ~/.openclaw/openclaw.json safely.") rendered by `.content-header`
- Changed to `margin: 0 -16px -16px -16px` to preserve the edge-to-edge bleed on sides and bottom while removing the upward overlap

## AI-Assisted PR

- [x] AI-assisted (Claude)
- [x] Lightly tested — verified visually against a running gateway instance
- [x] I understand what the code does

## Test plan

- [ ] Open the gateway dashboard at `/config`
- [ ] Verify the "Config" title and "Edit ~/.openclaw/openclaw.json safely." subtitle are fully visible and not overlapped by the settings form below

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the config page layout container styling in `ui/src/styles/config.css` by changing `.config-layout` from `margin: -16px` to `margin: 0 -16px -16px -16px`. The intent is to preserve the side/bottom “bleed” while removing the negative top margin that caused the settings form to overlap the config page header (`.content-header`).

The change is narrowly scoped to the config page CSS and does not alter any runtime logic—only layout/spacing behavior of the main grid container on `/config`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, targeted CSS margin adjustment confined to the config page layout container; it resolves an overlap bug without affecting application logic or introducing complex interactions.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->