### PR TITLE
Agents: guard billing error detection with length check (#11649)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: prevent `sanitizeUserFacingText` from replacing normal assistant replies that mention billing keywords. (#11649)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Telegram: auto-inject DM topic threadId in message tool + subagent announce. (#7235) Thanks @Lukavyi.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -51,6 +51,22 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(raw)).toBe("LLM error server_error: Something exploded");
   });
 
+  it("sanitizes short billing error messages", () => {
+    expect(sanitizeUserFacingText("402 Payment Required")).toContain("billing error");
+    expect(sanitizeUserFacingText("insufficient credits")).toContain("billing error");
+  });
+
+  it("does not replace long assistant replies discussing billing topics", () => {
+    const text =
+      "Sure, I can help you understand your billing situation. Your API credits are managed through the billing dashboard. " +
+      "To check your current balance, go to Settings > Billing > Credits. If you need to upgrade your plan, " +
+      "you can do so from the same page. The payment method on file will be charged automatically when your " +
+      "credits run low. Let me know if you have any other questions about billing, credits, or payment options. " +
+      "Here are some tips for managing your API usage efficiently and keeping costs under control. " +
+      "You can set up usage alerts, configure spending limits, and review your consumption patterns over time.";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
   it("collapses consecutive duplicate paragraphs", () => {
     const text = "Hello there!\n\nHello there!";
     expect(sanitizeUserFacingText(text)).toBe("Hello there!");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -424,7 +424,7 @@ export function sanitizeUserFacingText(text: string): string {
     );
   }
 
-  if (isBillingErrorMessage(trimmed)) {
+  if (trimmed.length < 500 && isBillingErrorMessage(trimmed)) {
     return BILLING_ERROR_USER_MESSAGE;
   }
 


### PR DESCRIPTION
## Summary
Fixes #11649

`sanitizeUserFacingText()` runs `isBillingErrorMessage()` against **all** assistant reply text, not just error payloads. When the assistant naturally discusses billing, credits, or payment topics, the sanitizer false-positives and replaces the entire reply with the canned billing error message.

## Root Cause
`isBillingErrorMessage()` matches broadly on keyword combinations (e.g. "billing" + "credits"/"payment"/"plan"). This is correct for short API error messages, but false-positives on normal assistant replies that happen to discuss those topics.

## Fix
Add a length guard (`trimmed.length < 500`) before the `isBillingErrorMessage` check in `sanitizeUserFacingText`. Real API billing errors are short error strings (<500 chars). Normal assistant replies discussing billing topics are longer and should pass through unchanged.

This is the same pattern already used for context overflow detection (`shouldRewriteContextOverflowText` has conversational-length guards).

## Changes
- `src/agents/pi-embedded-helpers/errors.ts`: Add `trimmed.length < 500` guard (1 line)
- Test: Add 2 test cases — short billing errors still caught, long billing discussions pass through
- `CHANGELOG.md`: Add entry

## Verification

### Bug reproduced on `main` branch ❌

```
Case 1: Short API error "402 Payment Required" (20 chars)
  Caught as billing error: true ✅

Case 2: Short billing combo (58 chars)
  Caught as billing error: true ✅

Case 3: Long assistant reply discussing billing (618 chars)
  Result preserved: false
  False-positive (replaced with billing error): true ❌ BUG

❌ BUG REPRODUCED: Long assistant reply was replaced with billing error message.
```

A 618-char assistant reply discussing billing/credits/payment was entirely replaced with the canned billing error string.

### Fix verified on feature branch ✅

```
Case 1: Short API error "402 Payment Required" (20 chars)
  Caught as billing error: true ✅

Case 2: Short billing combo (58 chars)
  Caught as billing error: true ✅

Case 3: Long assistant reply discussing billing (618 chars)
  Result preserved: true
  False-positive: false ✅ CORRECT

✅ FIX VERIFIED: Short billing errors caught, long replies pass through.
```

### Unit tests ✅

```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

### Lint ✅

```
Found 0 warnings and 0 errors.
```