### PR TITLE
feat(plugins): add cancel support to message_received hook

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -166,8 +166,8 @@ export async function dispatchReplyFromConfig(params: {
     const channelId = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
     const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
 
-    void hookRunner
-      .runMessageReceived(
+    try {
+      const hookResult = await hookRunner.runMessageReceived(
         {
           from: ctx.From ?? "",
           content,
@@ -191,10 +191,18 @@ export async function dispatchReplyFromConfig(params: {
           accountId: ctx.AccountId,
           conversationId,
         },
-      )
-      .catch((err) => {
-        logVerbose(`dispatch-from-config: message_received hook failed: ${String(err)}`);
-      });
+      );
+
+      // If plugin marked message for cancel, stop processing
+      if (hookResult?.cancel) {
+        logVerbose(
+          `dispatch-from-config: message marked for cancel by plugin hook from ${ctx.From ?? "unknown"}`,
+        );
+        return;
+      }
+    } catch (err) {
+      logVerbose(`dispatch-from-config: message_received hook failed: ${String(err)}`);
+    }
   }
 
   // Check if we should route replies to originating channel instead of dispatcher.

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -198,6 +198,8 @@ export async function dispatchReplyFromConfig(params: {
         logVerbose(
           `dispatch-from-config: message marked for cancel by plugin hook from ${ctx.From ?? "unknown"}`,
         );
+        recordProcessed("skipped", { reason: "cancelled_by_plugin" });
+        markIdle("message_cancelled");
         return;
       }
     } catch (err) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -200,7 +200,7 @@ export async function dispatchReplyFromConfig(params: {
         );
         recordProcessed("skipped", { reason: "cancelled_by_plugin" });
         markIdle("message_cancelled");
-        return;
+        return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
       }
     } catch (err) {
       logVerbose(`dispatch-from-config: message_received hook failed: ${String(err)}`);

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -21,6 +21,7 @@ import type {
   PluginHookGatewayStopEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
+  PluginHookMessageReceivedResult,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
@@ -45,6 +46,7 @@ export type {
   PluginHookAfterCompactionEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
+  PluginHookMessageReceivedResult,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
@@ -236,13 +238,45 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
 
   /**
    * Run message_received hook.
-   * Runs in parallel (fire-and-forget).
+   * Plugins can block or audit inbound messages.
+   * Runs in parallel.
    */
   async function runMessageReceived(
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,
-  ): Promise<void> {
-    return runVoidHook("message_received", event, ctx);
+  ): Promise<PluginHookMessageReceivedResult | undefined> {
+    const hooks = getHooksForName(registry, "message_received");
+    if (hooks.length === 0) {
+      return undefined;
+    }
+
+    logger?.debug?.(`[hooks] running message_received (${hooks.length} handlers, parallel)`);
+
+    // Run all hooks in parallel (preserves existing behavior)
+    const promises = hooks.map(async (hook) => {
+      try {
+        return await (
+          hook.handler as (
+            event: PluginHookMessageReceivedEvent,
+            ctx: PluginHookMessageContext,
+          ) => Promise<PluginHookMessageReceivedResult>
+        )(event, ctx);
+      } catch (err) {
+        const msg = `[hooks] message_received handler from ${hook.pluginId} failed: ${String(err)}`;
+        if (catchErrors) {
+          logger?.error(msg);
+        } else {
+          throw new Error(msg, { cause: err });
+        }
+        return undefined;
+      }
+    });
+
+    const results = await Promise.all(promises);
+
+    // Merge results: if any hook cancelled, message is cancelled
+    const cancelled = results.some((r) => r?.cancel === true);
+    return cancelled ? { cancel: true } : undefined;
   }
 
   /**

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -238,8 +238,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
 
   /**
    * Run message_received hook.
+   * Runs in parallel and blocks until all hooks complete.
    * Plugins can block or audit inbound messages.
-   * Runs in parallel.
    */
   async function runMessageReceived(
     event: PluginHookMessageReceivedEvent,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -366,6 +366,11 @@ export type PluginHookMessageSendingResult = {
   cancel?: boolean;
 };
 
+// message_received result
+export type PluginHookMessageReceivedResult = {
+  cancel?: boolean;
+};
+
 // message_sent hook
 export type PluginHookMessageSentEvent = {
   to: string;
@@ -478,7 +483,7 @@ export type PluginHookHandlerMap = {
   message_received: (
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,
-  ) => Promise<void> | void;
+  ) => Promise<PluginHookMessageReceivedResult | void> | PluginHookMessageReceivedResult | void;
   message_sending: (
     event: PluginHookMessageSendingEvent,
     ctx: PluginHookMessageContext,


### PR DESCRIPTION
## Summary

Enables plugins to block inbound messages by returning `{ cancel: true }` from the `message_received` hook, matching the existing `message_sending` cancel behavior.

## Changes

**3 files changed:**
- `src/plugins/types.ts` - Add `PluginHookMessageReceivedResult` type with `cancel` field
- `src/plugins/hooks.ts` - Collect results from parallel hook execution, return `{ cancel: true }` if any hook cancelled
- `src/auto-reply/reply/dispatch-from-config.ts` - Await hook results and stop processing if message marked for cancel

## Usage

api.on('message_received', async (event, ctx) => {
  if (containsThreat(event.content)) {
    return { cancel: true };  // Block the message
  }
  // Allow through
}, { priority: 100 });

## Use Cases

- Security/DLP plugins blocking malicious content
- Content moderation (spam, abuse)
- Rate limiting excessive messages
- Access control

## Behavior

- Hooks run in **parallel** (preserves existing `Promise.all` behavior)
- If **any** hook returns `{ cancel: true }`, message is blocked
- Dispatcher now **awaits** hook results to check cancel flag (was fire-and-forget)

## Breaking Changes

**Latency impact:** Messages now wait for all `message_received` hooks to complete before processing (was fire-and-forget). Adds ~10ms latency per message if hooks are present.

Plugins should be optimized for fast execution (<10ms recommended).

## Backward Compatibility

Existing `message_received` hooks that return `void` continue to work unchanged.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a cancellable return type for the `message_received` plugin hook (`{ cancel?: boolean }`), updates the hook runner to execute all `message_received` handlers in parallel and aggregate their results, and changes the config-based dispatcher to await `message_received` hooks and stop further processing when any hook cancels.

This fits into the existing plugin hook system by extending the hook type map in `src/plugins/types.ts` and exposing the new result type via `src/plugins/hooks.ts`, then consuming the cancel result in the inbound message dispatch path.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a cancel-path lifecycle/diagnostics bug that should be fixed first.
- Core typing and hook aggregation look consistent, but early-return on cancel bypasses existing message processing/idle tracking in the dispatcher, which can break diagnostics/session state accounting. There’s also a behavior change (message_received now blocks) that should be made consistent with expectations across the codebase.
- src/auto-reply/reply/dispatch-from-config.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->