### PR TITLE
feat(telegram): add health check watchdog for long-polling connections

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -22,6 +22,12 @@ const api = {
   sendDocument: vi.fn(),
   setWebhook: vi.fn(),
   deleteWebhook: vi.fn(),
+  getMe: vi.fn(async () => ({
+    id: 1,
+    is_bot: true,
+    username: "mybot",
+    first_name: "MyBot",
+  })),
 };
 const { initSpy, runSpy, loadConfig } = vi.hoisted(() => ({
   initSpy: vi.fn(async () => undefined),
@@ -211,6 +217,8 @@ describe("monitorTelegramProvider (grammY)", () => {
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
     createdBotStops.length = 0;
+    api.getMe.mockClear();
+    api.getMe.mockResolvedValue({ id: 1, is_bot: true, username: "mybot", first_name: "MyBot" });
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -489,5 +497,102 @@ describe("monitorTelegramProvider (grammY)", () => {
       }),
     );
     expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  describe("health check watchdog", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("restarts polling immediately without backoff on health check failure", async () => {
+      const abort = new AbortController();
+
+      // First runner is held open; health check failure triggers stop and restart.
+      let releaseTask: (() => void) | undefined;
+      runSpy
+        .mockImplementationOnce(() =>
+          makeRunnerStub({
+            task: () =>
+              new Promise<void>((resolve) => {
+                releaseTask = resolve;
+              }),
+            stop: vi.fn(() => {
+              releaseTask?.();
+            }),
+          }),
+        )
+        .mockImplementationOnce(() =>
+          makeRunnerStub({
+            task: async () => {
+              abort.abort();
+            },
+          }),
+        );
+
+      api.getMe.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+      const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+      await vi.waitFor(() => expect(runSpy).toHaveBeenCalledTimes(1));
+
+      // Advance timers to fire the health check, then let the second runner finish.
+      await vi.runAllTimersAsync();
+      await monitor;
+
+      // Stale-connection restart must skip backoff entirely.
+      expect(computeBackoff).not.toHaveBeenCalled();
+      expect(sleepWithAbort).not.toHaveBeenCalled();
+      expect(runSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("exits cleanly when abort fires concurrently with stale connection detection", async () => {
+      const abort = new AbortController();
+
+      let releaseTask: (() => void) | undefined;
+      runSpy.mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () =>
+            new Promise<void>((resolve) => {
+              releaseTask = resolve;
+            }),
+          stop: vi.fn(() => {
+            // Abort fires at same time as health-check-triggered stop.
+            abort.abort();
+            releaseTask?.();
+          }),
+        }),
+      );
+
+      api.getMe.mockRejectedValueOnce(new Error("timeout"));
+
+      const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+      await vi.waitFor(() => expect(runSpy).toHaveBeenCalledTimes(1));
+
+      await vi.runAllTimersAsync();
+      await monitor;
+
+      // Abort wins — must exit cleanly with no second runner.
+      expect(runSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops the health check timer when the runner exits before the interval elapses", async () => {
+      const abort = new AbortController();
+      runSpy.mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: async () => {
+            abort.abort();
+          },
+        }),
+      );
+
+      // Runner aborts; do not advance the fake clock.
+      await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+      // Timer was cancelled — getMe must never be called.
+      expect(api.getMe).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -271,7 +271,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       const runner = run(bot, runnerOptions);
       activeRunner = runner;
       let stopPromise: Promise<void> | undefined;
-      let healthCheckTimer: ReturnType<typeof setInterval> | undefined;
+      let healthCheckTimer: ReturnType<typeof setTimeout> | undefined;
       let staleConnectionDetected = false;
       const stopRunner = () => {
         stopPromise ??= Promise.resolve(runner.stop())
@@ -297,34 +297,51 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       // Health check watchdog: periodically ping Telegram API to detect stale connections.
       // If the connection is dead (NAT timeout, firewall drop), the health check will fail
       // and we'll restart the runner.
+      // Uses a self-scheduling loop instead of setInterval to prevent overlapping checks
+      // when a health check takes longer than the interval period.
       const startHealthCheck = () => {
-        healthCheckTimer = setInterval(async () => {
-          if (opts.abortSignal?.aborted) {
-            return;
-          }
-          try {
-            const timeoutPromise = new Promise<never>((_, reject) => {
-              setTimeout(() => reject(new Error("Health check timeout")), HEALTH_CHECK_TIMEOUT_MS);
-            });
-            await Promise.race([bot.api.getMe(), timeoutPromise]);
-            logVerbose("[telegram] Health check passed");
-          } catch (err) {
+        const scheduleNext = () => {
+          healthCheckTimer = setTimeout(async () => {
             if (opts.abortSignal?.aborted) {
               return;
             }
-            // Health check failed - connection is likely stale
-            staleConnectionDetected = true;
-            (opts.runtime?.error ?? console.error)(
-              `[telegram] Health check failed (stale connection detected): ${formatErrorMessage(err)}; restarting polling...`,
-            );
-            void stopRunner();
-          }
-        }, HEALTH_CHECK_INTERVAL_MS);
+            try {
+              let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+              const timeoutPromise = new Promise<never>((_, reject) => {
+                timeoutHandle = setTimeout(
+                  () => reject(new Error("Health check timeout")),
+                  HEALTH_CHECK_TIMEOUT_MS,
+                );
+              });
+              try {
+                await Promise.race([bot.api.getMe(), timeoutPromise]);
+              } finally {
+                if (timeoutHandle) {
+                  clearTimeout(timeoutHandle);
+                }
+              }
+              logVerbose("[telegram] Health check passed");
+            } catch (err) {
+              if (opts.abortSignal?.aborted) {
+                return;
+              }
+              // Health check failed - connection is likely stale
+              staleConnectionDetected = true;
+              (opts.runtime?.error ?? console.error)(
+                `[telegram] Health check failed (stale connection detected): ${formatErrorMessage(err)}; restarting polling...`,
+              );
+              void stopRunner();
+              return; // Don't schedule next check; runner restart will create a new watchdog
+            }
+            scheduleNext();
+          }, HEALTH_CHECK_INTERVAL_MS);
+        };
+        scheduleNext();
       };
 
       const stopHealthCheck = () => {
         if (healthCheckTimer) {
-          clearInterval(healthCheckTimer);
+          clearTimeout(healthCheckTimer);
           healthCheckTimer = undefined;
         }
       };

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -299,10 +299,13 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       // and we'll restart the runner.
       // Uses a self-scheduling loop instead of setInterval to prevent overlapping checks
       // when a health check takes longer than the interval period.
+      // healthCheckStopped guards against a concurrent in-flight check scheduling a new
+      // timer after stopHealthCheck() has been called (e.g., during runner teardown).
+      let healthCheckStopped = false;
       const startHealthCheck = () => {
         const scheduleNext = () => {
           healthCheckTimer = setTimeout(async () => {
-            if (opts.abortSignal?.aborted) {
+            if (healthCheckStopped || opts.abortSignal?.aborted) {
               return;
             }
             try {
@@ -322,7 +325,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
               }
               logVerbose("[telegram] Health check passed");
             } catch (err) {
-              if (opts.abortSignal?.aborted) {
+              if (healthCheckStopped || opts.abortSignal?.aborted) {
                 return;
               }
               // Health check failed - connection is likely stale
@@ -333,13 +336,17 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
               void stopRunner();
               return; // Don't schedule next check; runner restart will create a new watchdog
             }
-            scheduleNext();
+            // Only reschedule if watchdog is still active (not torn down mid-check).
+            if (!healthCheckStopped) {
+              scheduleNext();
+            }
           }, HEALTH_CHECK_INTERVAL_MS);
         };
         scheduleNext();
       };
 
       const stopHealthCheck = () => {
+        healthCheckStopped = true;
         if (healthCheckTimer) {
           clearTimeout(healthCheckTimer);
           healthCheckTimer = undefined;
@@ -352,13 +359,16 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       try {
         // runner.task() returns a promise that resolves when the runner stops
         await runner.task();
-        if (staleConnectionDetected) {
-          // Runner was stopped due to health check failure; continue to restart
-          restartAttempts = 0; // Reset backoff since this is a controlled restart
-          return "continue";
-        }
+        // Abort takes highest priority — always exit cleanly when signaled.
         if (opts.abortSignal?.aborted) {
           return "exit";
+        }
+        if (staleConnectionDetected) {
+          // Runner was stopped due to health check failure; continue to restart
+          // without backoff since this is a controlled recovery restart.
+          forceRestarted = false;
+          restartAttempts = 0;
+          return "continue";
         }
         const reason = forceRestarted
           ? "unhandled network error"

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -2,6 +2,7 @@ import { type RunOptions, run } from "@grammyjs/runner";
 import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
+import { logVerbose } from "../globals.js";
 import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -62,6 +63,14 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 };
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
+
+/**
+ * Health check interval: how often to ping Telegram API to detect stale connections.
+ * After inactivity, NAT/firewalls may silently drop TCP connections, causing the
+ * long-polling socket to hang indefinitely. This watchdog detects and recovers from that.
+ */
+const HEALTH_CHECK_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
+const HEALTH_CHECK_TIMEOUT_MS = 10 * 1000; // 10 seconds
 
 const isGetUpdatesConflict = (err: unknown) => {
   if (!err || typeof err !== "object") {
@@ -262,6 +271,8 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       const runner = run(bot, runnerOptions);
       activeRunner = runner;
       let stopPromise: Promise<void> | undefined;
+      let healthCheckTimer: ReturnType<typeof setInterval> | undefined;
+      let staleConnectionDetected = false;
       const stopRunner = () => {
         stopPromise ??= Promise.resolve(runner.stop())
           .then(() => undefined)
@@ -282,10 +293,53 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           void stopRunner();
         }
       };
+
+      // Health check watchdog: periodically ping Telegram API to detect stale connections.
+      // If the connection is dead (NAT timeout, firewall drop), the health check will fail
+      // and we'll restart the runner.
+      const startHealthCheck = () => {
+        healthCheckTimer = setInterval(async () => {
+          if (opts.abortSignal?.aborted) {
+            return;
+          }
+          try {
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              setTimeout(() => reject(new Error("Health check timeout")), HEALTH_CHECK_TIMEOUT_MS);
+            });
+            await Promise.race([bot.api.getMe(), timeoutPromise]);
+            logVerbose("[telegram] Health check passed");
+          } catch (err) {
+            if (opts.abortSignal?.aborted) {
+              return;
+            }
+            // Health check failed - connection is likely stale
+            staleConnectionDetected = true;
+            (opts.runtime?.error ?? console.error)(
+              `[telegram] Health check failed (stale connection detected): ${formatErrorMessage(err)}; restarting polling...`,
+            );
+            void stopRunner();
+          }
+        }, HEALTH_CHECK_INTERVAL_MS);
+      };
+
+      const stopHealthCheck = () => {
+        if (healthCheckTimer) {
+          clearInterval(healthCheckTimer);
+          healthCheckTimer = undefined;
+        }
+      };
+
       opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+      startHealthCheck();
+
       try {
         // runner.task() returns a promise that resolves when the runner stops
         await runner.task();
+        if (staleConnectionDetected) {
+          // Runner was stopped due to health check failure; continue to restart
+          restartAttempts = 0; // Reset backoff since this is a controlled restart
+          return "continue";
+        }
         if (opts.abortSignal?.aborted) {
           return "exit";
         }
@@ -314,6 +368,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         );
         return shouldRestart ? "continue" : "exit";
       } finally {
+        stopHealthCheck();
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
         await stopRunner();
         await stopBot();


### PR DESCRIPTION
## Problem

Telegram long-polling relies on a persistent TCP connection to Telegram's servers. After a period of inactivity, NAT devices and firewalls silently drop that TCP connection without sending a RST or FIN packet. The grammY runner's polling loop continues awaiting a response that will never arrive — the connection is zombie-hung indefinitely, with no timeout triggered and no error surfaced. Users experience the bot simply stopping to respond with no log output and no restart.

This failure mode is especially common on residential networks, cloud VMs behind NAT gateways (AWS, GCP, etc.), and any host that goes idle for more than a minute or two.

## Solution

A self-scheduling health check watchdog is added inside each polling cycle. Every 2 minutes it issues a `getMe` API call with a 10-second timeout. If the call fails (connection error, timeout, or any API error), the runner is stopped immediately and the outer loop restarts without backoff, allowing polling to recover within seconds.

## Implementation Details

**Watchdog lifecycle:**  
The watchdog is started with `startHealthCheck()` immediately after the runner is created and is torn down in the `finally` block of `runPollingCycle` via `stopHealthCheck()`. This guarantees it is always cleaned up regardless of how the cycle exits (abort, error, or normal stop).

**Self-scheduling `setTimeout` over `setInterval`:**  
`setInterval` would fire the next check even if the previous one is still in flight (e.g., the `getMe` call is hanging during a slow but not-yet-timed-out connection). The self-scheduling pattern — `setTimeout` at the end of each successful check — means the next check only starts after the previous one completes, preventing overlapping health checks.

**`healthCheckStopped` guard:**  
An in-flight health check (awaiting `getMe`) could complete *after* `stopHealthCheck()` has been called (e.g., during runner teardown in `finally`). Without a guard, the callback's success path would call `scheduleNext()`, leaking a timer into the next polling cycle. The `healthCheckStopped` boolean is set by `stopHealthCheck()` and checked at every re-entry point in the async callback, preventing any post-teardown rescheduling.

**Timeout cleanup:**  
The `getMe` timeout uses a nested `try/finally` to ensure `clearTimeout(timeoutHandle)` is called even if `getMe` resolves (preventing the timeout promise from hanging in memory after a successful check).

**Abort priority:**  
After `runner.task()` resolves, `opts.abortSignal?.aborted` is checked *before* `staleConnectionDetected`. If both are true simultaneously (e.g., the service is shutting down at the same moment the health check detects a stale connection), the function returns `"exit"` cleanly rather than kicking off a pointless restart.

**`forceRestarted` reset:**  
`forceRestarted` (used by the existing unhandled-rejection recovery path) is explicitly reset to `false` in the `staleConnectionDetected` early-return path. Without this, a race where an unhandled rejection sets `forceRestarted = true` and the health check simultaneously detects a stale connection would cause the next cycle's log message to incorrectly report "unhandled network error" instead of the actual stale-connection recovery.

**Backoff reset on stale restart:**  
When the health check triggers a restart, `restartAttempts` is reset to `0` so the next cycle's initial backoff is not penalized by previous failures.

## Configuration

| Constant | Value | Rationale |
|---|---|---|
| `HEALTH_CHECK_INTERVAL_MS` | 2 minutes | NAT timeouts on common networks occur after 1–5 minutes of inactivity. 2 minutes is aggressive enough to detect most stale connections promptly while generating negligible API traffic (one `getMe` per 2 minutes per bot). |
| `HEALTH_CHECK_TIMEOUT_MS` | 10 seconds | Generous enough to allow for slow but live connections; short enough to not stall the health check loop when the TCP path is dead. |

## Test Plan

- `pnpm build` — clean
- `pnpm check` — clean
- `pnpm test` — all tests pass; 3 new health check watchdog tests added to `src/telegram/monitor.test.ts`:
  - **`restarts polling immediately without backoff on health check failure`** — verifies a `getMe` failure stops the first runner, skips `computeBackoff`/`sleepWithAbort`, and starts a second runner
  - **`exits cleanly when abort fires concurrently with stale connection detection`** — verifies abort wins over stale detection, no second runner is started
  - **`stops the health check timer when the runner exits before the interval elapses`** — verifies `getMe` is never called when the runner exits before the 2-minute interval fires