### PR TITLE
feat: add standalone browser CLI for Linux users

### DIFF
--- a/packages/browser-cli/README.md
+++ b/packages/browser-cli/README.md
@@ -1,0 +1,123 @@
+# @openclaw/browser-cli
+
+Standalone browser control CLI for OpenClaw using playwright-core via Chrome DevTools Protocol (CDP).
+
+## Why?
+
+On Linux systems (tested on Ubuntu 22.04/24.04), OpenClaw's built-in browser tool `act` actions (click, type, fill) can timeout due to pointer event interception issues. This CLI bypasses those issues by connecting directly to Chrome via CDP. May also help on other systems experiencing similar timeouts.
+
+## Prerequisites
+
+Start Chrome with remote debugging enabled:
+
+```bash
+google-chrome --remote-debugging-port=18800 --user-data-dir=/tmp/chrome-debug
+```
+
+## Installation
+
+```bash
+# Global install
+npm install -g @openclaw/browser-cli
+
+# Or use npx
+npx @openclaw/browser-cli navigate "https://example.com"
+```
+
+## Usage
+
+```bash
+# Navigation
+browser navigate "https://google.com"
+
+# Click elements (supports text=, css selectors, xpath)
+browser click "text=Sign In"
+browser click "button[type=submit]"
+browser click "#login-btn"
+
+# Type into fields
+browser type "input[name=email]" "user@example.com"
+browser type "#password" "secret123"
+
+# Press keyboard keys
+browser press Enter
+browser press Tab
+browser press Escape
+
+# Get page content
+browser snapshot           # First 2000 chars
+browser snapshot 5000      # First 5000 chars
+
+# Take screenshot
+browser screenshot                    # Saves to /tmp/screenshot.png
+browser screenshot ./my-screenshot.png
+
+# Execute JavaScript
+browser eval "document.title"
+browser eval "document.querySelector('h1').innerText"
+
+# Fill multiple fields at once
+browser fill "input[name=user]=john,input[name=pass]=secret"
+
+# Wait for element
+browser wait "text=Loading complete"
+browser wait "#results" 30000
+
+# Get current page info
+browser info
+```
+
+## Environment Variables
+
+| Variable  | Default                  | Description                  |
+| --------- | ------------------------ | ---------------------------- |
+| `CDP_URL` | `http://127.0.0.1:18800` | Chrome DevTools Protocol URL |
+
+## Selectors
+
+The CLI supports Playwright's selector syntax:
+
+- `text=Submit` - Match by text content
+- `text="Exact Match"` - Exact text match
+- `#id` - CSS ID selector
+- `.class` - CSS class selector
+- `button[type=submit]` - CSS attribute selector
+- `xpath=//button` - XPath selector
+
+## Output
+
+All commands output JSON for easy parsing:
+
+```json
+{ "ok": true, "url": "https://example.com", "title": "Example" }
+```
+
+On error:
+
+```json
+{ "ok": false, "error": "Cannot connect to Chrome..." }
+```
+
+## Troubleshooting
+
+### "Cannot connect to Chrome"
+
+Make sure Chrome is running with remote debugging:
+
+```bash
+google-chrome --remote-debugging-port=18800 --user-data-dir=/tmp/chrome-debug
+```
+
+### "No page found"
+
+Open at least one tab in Chrome before running commands.
+
+### Custom CDP port
+
+```bash
+CDP_URL=http://127.0.0.1:9222 browser navigate "https://example.com"
+```
+
+## License
+
+MIT

--- a/packages/browser-cli/index.js
+++ b/packages/browser-cli/index.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * OpenClaw Browser CLI
+ *
+ * Standalone browser control tool using playwright-core via CDP.
+ * Workaround for Ubuntu/Linux systems where OpenClaw's browser tool
+ * `act` actions timeout.
+ *
+ * Usage:
+ *   browser navigate "https://example.com"
+ *   browser click "text=Submit"
+ *   browser type "input[name=email]" "user@example.com"
+ *   browser snapshot
+ *
+ * Environment:
+ *   CDP_URL - Chrome DevTools Protocol URL (default: http://127.0.0.1:18800)
+ */
+
+const { chromium } = require("playwright-core");
+
+const CDP_URL = process.env.CDP_URL || "http://127.0.0.1:18800";
+
+async function connect() {
+  try {
+    const browser = await chromium.connectOverCDP(CDP_URL);
+    const context = browser.contexts()[0];
+    if (!context) {
+      throw new Error("No browser context found. Is Chrome running with --remote-debugging-port?");
+    }
+    const page = context.pages()[0];
+    if (!page) {
+      throw new Error("No page found. Open a tab in Chrome first.");
+    }
+    return { browser, context, page };
+  } catch (e) {
+    if (e.message.includes("ECONNREFUSED")) {
+      throw new Error(
+        `Cannot connect to Chrome at ${CDP_URL}. Start Chrome with: google-chrome --remote-debugging-port=18800`,
+      );
+    }
+    throw e;
+  }
+}
+
+async function navigate(url) {
+  const { browser, page } = await connect();
+  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+  console.log(JSON.stringify({ ok: true, url: page.url(), title: await page.title() }));
+  await browser.close();
+}
+
+async function click(selector) {
+  const { browser, page } = await connect();
+  await page.locator(selector).first().click({ timeout: 10000 });
+  console.log(JSON.stringify({ ok: true, clicked: selector, url: page.url() }));
+  await browser.close();
+}
+
+async function type(selector, text) {
+  const { browser, page } = await connect();
+  await page.locator(selector).first().fill(text);
+  console.log(JSON.stringify({ ok: true, typed: text, selector }));
+  await browser.close();
+}
+
+async function press(key) {
+  const { browser, page } = await connect();
+  await page.keyboard.press(key);
+  console.log(JSON.stringify({ ok: true, pressed: key }));
+  await browser.close();
+}
+
+async function snapshot(maxLen = 2000) {
+  const { browser, page } = await connect();
+  const url = page.url();
+  const title = await page.title();
+  const text = await page.evaluate(() => document.body.innerText);
+  console.log(
+    JSON.stringify({
+      ok: true,
+      url,
+      title,
+      text: text.slice(0, parseInt(maxLen)),
+    }),
+  );
+  await browser.close();
+}
+
+async function screenshot(path = "/tmp/screenshot.png") {
+  const { browser, page } = await connect();
+  await page.screenshot({ path, fullPage: false });
+  console.log(JSON.stringify({ ok: true, path }));
+  await browser.close();
+}
+
+async function evaluate(code) {
+  const { browser, page } = await connect();
+  const result = await page.evaluate(code);
+  console.log(JSON.stringify({ ok: true, result }));
+  await browser.close();
+}
+
+async function fill(fields) {
+  // fields = "selector1=value1,selector2=value2"
+  const { browser, page } = await connect();
+  const pairs = fields.split(",").map((p) => {
+    const idx = p.indexOf("=");
+    return [p.slice(0, idx), p.slice(idx + 1)];
+  });
+  for (const [sel, val] of pairs) {
+    if (sel && val !== undefined) {
+      await page.locator(sel.trim()).first().fill(val.trim());
+    }
+  }
+  console.log(JSON.stringify({ ok: true, filled: pairs.length }));
+  await browser.close();
+}
+
+async function waitFor(selector, timeout = 10000) {
+  const { browser, page } = await connect();
+  await page
+    .locator(selector)
+    .first()
+    .waitFor({ timeout: parseInt(timeout) });
+  console.log(JSON.stringify({ ok: true, found: selector }));
+  await browser.close();
+}
+
+async function info() {
+  const { browser, page } = await connect();
+  console.log(
+    JSON.stringify({
+      ok: true,
+      url: page.url(),
+      title: await page.title(),
+    }),
+  );
+  await browser.close();
+}
+
+// Help text
+const HELP = `
+OpenClaw Browser CLI - Direct CDP browser control
+
+Usage: browser <command> [args]
+
+Commands:
+  navigate <url>              Navigate to URL
+  click <selector>            Click element (supports text=, css, xpath)
+  type <selector> <text>      Type text into element
+  press <key>                 Press keyboard key (Enter, Tab, Escape, etc.)
+  snapshot [maxLen]           Get page text content (default: 2000 chars)
+  screenshot [path]           Save screenshot (default: /tmp/screenshot.png)
+  eval <code>                 Execute JavaScript in page context
+  fill <sel=val,sel=val>      Fill multiple form fields
+  wait <selector> [timeout]   Wait for element (default: 10000ms)
+  info                        Get current URL and title
+
+Environment:
+  CDP_URL                     Chrome DevTools URL (default: http://127.0.0.1:18800)
+
+Examples:
+  browser navigate "https://google.com"
+  browser type "input[name=q]" "hello world"
+  browser click "text=Google Search"
+  browser press Enter
+  browser snapshot 5000
+  browser screenshot ./page.png
+
+Prerequisites:
+  Start Chrome with remote debugging:
+  google-chrome --remote-debugging-port=18800 --user-data-dir=/tmp/chrome-debug
+`.trim();
+
+// Main
+const [, , cmd, ...args] = process.argv;
+
+const commands = {
+  navigate: () => navigate(args[0]),
+  click: () => click(args[0]),
+  type: () => type(args[0], args.slice(1).join(" ")),
+  press: () => press(args[0]),
+  snapshot: () => snapshot(args[0] || 2000),
+  screenshot: () => screenshot(args[0]),
+  eval: () => evaluate(args.join(" ")),
+  fill: () => fill(args[0]),
+  wait: () => waitFor(args[0], args[1]),
+  info: () => info(),
+  help: () => {
+    console.log(HELP);
+    process.exit(0);
+  },
+  "--help": () => {
+    console.log(HELP);
+    process.exit(0);
+  },
+  "-h": () => {
+    console.log(HELP);
+    process.exit(0);
+  },
+};
+
+if (!cmd || !commands[cmd]) {
+  console.log(HELP);
+  process.exit(cmd ? 1 : 0);
+}
+
+commands[cmd]().catch((e) => {
+  console.log(JSON.stringify({ ok: false, error: e.message }));
+  process.exit(1);
+});

--- a/packages/browser-cli/package.json
+++ b/packages/browser-cli/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@openclaw/browser-cli",
+  "version": "1.0.0",
+  "description": "Standalone browser control CLI for OpenClaw - Linux workaround for browser action timeouts",
+  "keywords": [
+    "automation",
+    "browser",
+    "cdp",
+    "chrome",
+    "openclaw",
+    "playwright"
+  ],
+  "bugs": {
+    "url": "https://github.com/openclaw/openclaw/issues"
+  },
+  "license": "MIT",
+  "author": "OpenClaw Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw.git",
+    "directory": "packages/browser-cli"
+  },
+  "bin": {
+    "browser": "./index.js",
+    "openclaw-browser": "./index.js"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "node index.js help"
+  },
+  "dependencies": {
+    "playwright-core": "^1.40.0"
+  },
+  "peerDependencies": {
+    "playwright-core": ">=1.40.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
# PR: Add standalone browser CLI for Linux users

## Related Issue
Fixes #11691 (Browser `act` actions timeout on Linux)

## Summary
Adds a standalone browser CLI tool that uses playwright-core directly via CDP, bypassing the action handler timeout issues on Linux systems (tested on Ubuntu 22.04/24.04).

## Changes
- Added `packages/browser-cli/` with standalone browser control tool
- Direct CDP connection to Chrome (no relay dependency for basic operations)
- Commands: navigate, click, type, press, snapshot, screenshot, eval, fill, wait, info

## Usage

```bash
# Install globally (optional)
npm install -g @openclaw/browser-cli

# Or use directly
npx @openclaw/browser-cli navigate "https://example.com"
npx @openclaw/browser-cli click "text=Submit"
npx @openclaw/browser-cli type "input[name=email]" "user@example.com"
npx @openclaw/browser-cli snapshot
```

## Why This Approach

The existing browser tool's `act` actions timeout on Ubuntu due to pointer event interception detection issues. Rather than deep-diving into the complex action handler, this CLI:

1. Uses playwright-core directly (same underlying library)
2. Connects via CDP to user's Chrome instance
3. Executes actions without the problematic wrapper layer
4. Provides same functionality agents need

## Testing

Tested on:
- [x] Ubuntu 24.04 + Chrome 133
- [x] Ubuntu 22.04 + Chrome 131
- [ ] macOS (should work, needs verification)
- [ ] Windows (should work, needs verification)

## Example Session

```bash
# Start Chrome with debugging
google-chrome --remote-debugging-port=18800 --user-data-dir=/tmp/chrome-debug

# Navigate and interact
browser navigate "https://zapier.com"
browser snapshot
browser click "text=Sign In"
browser type "input[type=email]" "user@example.com"
browser press Enter
```

## Backwards Compatibility
- Non-breaking addition
- Existing browser tool unchanged
- Users can choose which tool to use

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new standalone package (`packages/browser-cli/`) that provides a `browser`/`openclaw-browser` CLI for driving an existing Chrome instance via Playwright CDP, intended as a workaround for Linux `act` action timeouts. The tool exposes commands like `navigate`, `click`, `type`, `press`, `snapshot`, `screenshot`, `eval`, `fill`, `wait`, and `info`, and prints JSON responses for scripting.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge once the CLI correctness issues are fixed.
- New package is isolated and doesn’t modify existing browser tooling, but there are a couple of definite runtime/behavior issues (`eval` implementation and `fill` argument handling) plus a packaging concern (`playwright-core` declared as both dependency and peerDependency) that should be resolved to avoid broken CLI behavior and dependency conflicts.
- packages/browser-cli/index.js, packages/browser-cli/package.json

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->