### PR TITLE
Model Provider Failover for Default and Session Model When Rate Limiting or Other Errors Occur

### DIFF
--- a/update/README.md
+++ b/update/README.md
@@ -1,0 +1,67 @@
+Failover utilities
+
+This folder contains two small Node.js utilities that help with model failover when the configured provider/model becomes unavailable:
+
+- `update/session-failover.js` — per-session failover. Probes a list of candidate provider/model pairs and writes a per-session override into a sessions store (JSON file). It mirrors the minimal behavior of OpenClaw's `applyModelOverrideToSessionEntry`.
+- `update/default-model-failover.js` — default/global failover. Probes candidates and, on success, updates `agents.defaults.model.primary` in the global OpenClaw config file (by default `%USERPROFILE%/.openclaw/openclaw.json`) while preserving other keys (e.g. `fallbacks`). A backup of the config is created before modification.
+
+Why two scripts?
+
+- Session failover targets a single session entry in a sessions store (e.g. `sessions.json`) and is useful when a specific channel/agent needs a working model quickly.
+- Default failover changes the application-wide default model used when sessions do not have overrides.
+
+Quick examples
+
+Session failover (updates the session store):
+
+```bash
+node update/session-failover.js \
+	--sessionKey agent:main:default \
+	--models openai/gpt-4o,anthropic/claude-opus-4-6 \
+	--store ./path/to/sessions.json \
+	--timeout 5000
+```
+
+Default failover (updates global config, backups created):
+
+```bash
+node update/default-model-failover.js \
+	--models openai/gpt-4o,anthropic/claude-opus-4-6 \
+	--config "%USERPROFILE%/.openclaw/openclaw.json" \
+	--timeout 5000
+```
+
+Behavior and safety
+
+- Both scripts probe candidate models in the order provided and apply the first model that responds within the provided timeout (milliseconds). If none respond, `session-failover` resets session overrides to default; `default-model-failover` leaves the config unchanged and writes a backup before modifying the file if the target config already exists.
+- `default-model-failover.js` creates a timestamped backup of the existing target config (same directory by default, or use `--backup-dir` to override); if the config file does not yet exist, no backup file is created.
+
+Probing caveats and environment variables
+
+- The `probeModel` implementation is intentionally lightweight and currently performs provider-specific HTTP checks for known providers (OpenAI, Anthropic) and simple heuristics for others:
+  - For `openai`, the script attempts a GET to `https://api.openai.com/v1/models/<model>` using `OPENAI_API_KEY`.
+  - For `anthropic`, it attempts `https://api.anthropic.com/v1/models/<model>` using `ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY_0`.
+  - For CLI-style backends (provider ids ending with `-cli`), it assumes availability.
+  - For other providers it falls back to checking for an environment variable named `<PROVIDER>_API_KEY` (provider uppercased, non-alphanumeric replaced with `_`).
+
+Important: some providers use non-standard env var names in your environment (for example you may have `GEMINI_API_KEY` or `NVIDIA_API_KEY`). If the script expects `GOOGLE_API_KEY` or `MOONSHOTAI_API_KEY` it will not detect the key unless you export the expected name as well. You can either:
+
+```powershell
+$env:GOOGLE_API_KEY = $env:GEMINI_API_KEY
+$env:MOONSHOTAI_API_KEY = $env:NVIDIA_API_KEY
+node update/default-model-failover.js --models google/gemini-2.5-flash,moonshotai/kimi-k2.5
+```
+
+or extend `probeModel` in the scripts to check additional environment variable names or perform provider-specific health checks.
+
+Customization
+
+- You can extend `probeModel` with provider-specific endpoints and richer checks (model-listing, small completion / ping endpoints) for higher confidence before switching.
+- Run the default failover as a periodic job (cron / Task Scheduler) or invoke it from a monitoring script when you detect repeated failures.
+
+Safety checklist before running
+
+- Ensure you have backups of `%USERPROFILE%/.openclaw/openclaw.json` and your session store files.
+- Stop any running OpenClaw processes before running these scripts to avoid clobbering concurrent writes to config or session store files.
+- Export any provider API keys the script expects, or modify `probeModel` to accept your existing env var names.
+- Test with a short candidate list and a small timeout to verify behavior before automating.

--- a/update/default-model-failover.js
+++ b/update/default-model-failover.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Default-model failover utility for OpenClaw.
+// Probes a list of candidate models and updates the global config's
+// `agents.defaults.model.primary` to the first responsive model.
+// Usage:
+// node update/default-model-failover.js --models openai/gpt-4o,anthropic/claude-opus-4-6 --config "C:\Users\you\.openclaw\openclaw.json" --timeout 5000
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--models" || a === "-m") {
+      out.models = args[++i];
+    } else if (a === "--config" || a === "-c") {
+      out.config = args[++i];
+    } else if (a === "--timeout" || a === "-t") {
+      out.timeout = Number(args[++i]) || 5000;
+    } else if (a === "--backup-dir" || a === "-b") {
+      out.backupDir = args[++i];
+    }
+  }
+  return out;
+}
+
+function defaultConfigPath() {
+  const home = process.env.USERPROFILE || process.env.HOME || ".";
+  return path.join(home, ".openclaw", "openclaw.json");
+}
+
+function backupFile(filePath, backupDir) {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const base = path.basename(filePath);
+  const dir = backupDir || path.dirname(filePath);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {}
+  const dest = path.join(dir, `${base}.backup-${ts}`);
+  fs.copyFileSync(filePath, dest);
+  return dest;
+}
+
+function loadJson(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const raw = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+function atomicWriteFileSync(targetPath, data) {
+  const dir = path.dirname(targetPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const base = path.basename(targetPath);
+  const tmpPath = path.join(dir, `${base}.tmp-${process.pid}-${Date.now()}`);
+  try {
+    fs.writeFileSync(tmpPath, data, { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmpPath, targetPath);
+    try {
+      fs.chmodSync(targetPath, 0o600);
+    } catch {}
+  } catch (err) {
+    try {
+      if (fs.existsSync(tmpPath)) {
+        fs.unlinkSync(tmpPath);
+      }
+    } catch {}
+    throw err;
+  }
+}
+
+function saveJson(filePath, obj) {
+  atomicWriteFileSync(filePath, JSON.stringify(obj, null, 2));
+}
+
+function splitModelRef(raw) {
+  const trimmed = String(raw ?? "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  const slash = trimmed.indexOf("/");
+  if (slash === -1) {
+    return null;
+  }
+  return { provider: trimmed.slice(0, slash), model: trimmed.slice(slash + 1) };
+}
+
+async function probeModel(provider, model, timeoutMs) {
+  const ac = new AbortController();
+  const to = setTimeout(() => ac.abort(), timeoutMs ?? 5000);
+  try {
+    const p = String(provider || "").toLowerCase();
+    if (p === "openai") {
+      const key = process.env.OPENAI_API_KEY;
+      if (!key) {
+        return false;
+      }
+      const res = await fetch(`https://api.openai.com/v1/models/${encodeURIComponent(model)}`, {
+        signal: ac.signal,
+        headers: { Authorization: `Bearer ${key}` },
+      });
+      return res.ok;
+    }
+    if (p === "anthropic") {
+      const key = process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY_0;
+      if (!key) {
+        return false;
+      }
+      const res = await fetch(`https://api.anthropic.com/v1/models/${encodeURIComponent(model)}`, {
+        signal: ac.signal,
+        headers: { "x-api-key": key, "anthropic-version": "2023-06-01" },
+      });
+      return res.ok;
+    }
+    if (p.endsWith("-cli") || p === "claude-cli" || p === "codex-cli") {
+      clearTimeout(to);
+      return true;
+    }
+    const envKey = process.env[`${p.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`];
+    clearTimeout(to);
+    return Boolean(envKey);
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(to);
+  }
+}
+
+function applyDefaultModel(cfg, provider, model) {
+  if (!cfg.agents) {
+    cfg.agents = {};
+  }
+  if (!cfg.agents.defaults) {
+    cfg.agents.defaults = {};
+  }
+  // merge into existing object to preserve keys like fallbacks
+  cfg.agents.defaults.model = {
+    ...cfg.agents.defaults.model,
+    primary: `${provider}/${model}`,
+  };
+}
+
+async function main() {
+  const args = parseArgs();
+  if (!args.models) {
+    console.error("--models required (comma-separated provider/model list)");
+    process.exit(2);
+  }
+  const timeoutMs = args.timeout ?? 5000;
+  const configPath = args.config ? path.resolve(args.config) : defaultConfigPath();
+
+  const candidates = String(args.models)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(splitModelRef)
+    .filter(Boolean);
+
+  if (candidates.length === 0) {
+    console.error("No valid model candidates provided");
+    process.exit(3);
+  }
+
+  const cfg = loadJson(configPath) ?? {};
+  const bak = backupFile(configPath, args.backupDir);
+  if (bak) {
+    console.log(`Backed up ${configPath} -> ${bak}`);
+  }
+
+  console.log(`Probing ${candidates.length} candidate default models with ${timeoutMs}ms timeout`);
+  for (const c of candidates) {
+    process.stdout.write(`Checking ${c.provider}/${c.model} ... `);
+    const ok = await probeModel(c.provider, c.model, timeoutMs);
+    if (ok) {
+      console.log("ok");
+      applyDefaultModel(cfg, c.provider, c.model);
+      saveJson(configPath, cfg);
+      console.log(`Updated default model in ${configPath} -> ${c.provider}/${c.model}`);
+      process.exit(0);
+    }
+    console.log("failed");
+  }
+
+  console.log(`No candidates succeeded; leaving config unchanged${bak ? " (backup created)" : ""}`);
+  process.exit(1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(10);
+  });
+}

--- a/update/session-failover.js
+++ b/update/session-failover.js
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Simple model failover utility for OpenClaw sessions.
+// Usage: node update/session-failover.js --sessionKey <sessionKey> --models provider1/model1,provider2/model2 --store <path/to/sessions.json> --timeout 5000
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--sessionKey" || a === "-s") {
+      out.sessionKey = args[++i];
+    } else if (a === "--models" || a === "-m") {
+      out.models = args[++i];
+    } else if (a === "--store" || a === "-f") {
+      out.store = args[++i];
+    } else if (a === "--timeout" || a === "-t") {
+      out.timeout = Number(args[++i]) || 5000;
+    }
+  }
+  return out;
+}
+
+function defaultStorePath() {
+  // Try to find a sessions store under the repo. Fall back to ./sessions.json
+  return path.resolve(process.cwd(), "sessions.json");
+}
+
+function loadStore(storePath) {
+  if (!fs.existsSync(storePath)) {
+    throw new Error(`Session store not found: ${storePath}`);
+  }
+  const raw = fs.readFileSync(storePath, "utf8");
+  return JSON.parse(raw);
+}
+
+function atomicWriteFileSync(targetPath, data) {
+  const dir = path.dirname(targetPath);
+  const base = path.basename(targetPath);
+  const tmpPath = path.join(dir, `${base}.tmp-${process.pid}-${Date.now()}`);
+  try {
+    fs.writeFileSync(tmpPath, data, { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmpPath, targetPath);
+    try {
+      fs.chmodSync(targetPath, 0o600);
+    } catch {}
+  } catch (err) {
+    try {
+      if (fs.existsSync(tmpPath)) {
+        fs.unlinkSync(tmpPath);
+      }
+    } catch {}
+    throw err;
+  }
+}
+
+function saveStore(storePath, store) {
+  atomicWriteFileSync(storePath, JSON.stringify(store, null, 2));
+}
+
+function splitModelRef(raw) {
+  const trimmed = String(raw ?? "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  const slash = trimmed.indexOf("/");
+  if (slash === -1) {
+    return null;
+  }
+  return { provider: trimmed.slice(0, slash), model: trimmed.slice(slash + 1) };
+}
+
+function clearAuthProfileOverrides(entry) {
+  // Mirrors the cleanup in src/sessions/model-overrides.ts:52-65
+  let updated = false;
+  if (entry.authProfileOverride) {
+    delete entry.authProfileOverride;
+    updated = true;
+  }
+  if (entry.authProfileOverrideSource) {
+    delete entry.authProfileOverrideSource;
+    updated = true;
+  }
+  if (entry.authProfileOverrideCompactionCount !== undefined) {
+    delete entry.authProfileOverrideCompactionCount;
+    updated = true;
+  }
+  return updated;
+}
+
+function clearStaleRuntimeFields(entry) {
+  // Mirrors src/sessions/model-overrides.ts:53-61 — clear cached
+  // model/modelProvider so status surfaces reflect the new override immediately.
+  let cleared = false;
+  if (entry.model !== undefined) {
+    delete entry.model;
+    cleared = true;
+  }
+  if (entry.modelProvider !== undefined) {
+    delete entry.modelProvider;
+    cleared = true;
+  }
+  return cleared;
+}
+
+function clearFallbackNotice(entry) {
+  // Mirrors src/sessions/model-overrides.ts:93-96
+  delete entry.fallbackNoticeSelectedModel;
+  delete entry.fallbackNoticeActiveModel;
+  delete entry.fallbackNoticeReason;
+}
+
+function applyModelOverrideToEntry(entry, selection) {
+  // Mirrors OpenClaw's applyModelOverrideToSessionEntry behaviour
+  let updated = false;
+  if (selection.isDefault) {
+    if (entry.providerOverride) {
+      delete entry.providerOverride;
+      updated = true;
+    }
+    if (entry.modelOverride) {
+      delete entry.modelOverride;
+      updated = true;
+    }
+    if (clearAuthProfileOverrides(entry)) {
+      updated = true;
+    }
+  } else {
+    if (entry.providerOverride !== selection.provider) {
+      entry.providerOverride = selection.provider;
+      updated = true;
+    }
+    if (entry.modelOverride !== selection.model) {
+      entry.modelOverride = selection.model;
+      updated = true;
+    }
+    if (clearAuthProfileOverrides(entry)) {
+      updated = true;
+    }
+  }
+  if (updated) {
+    if (clearStaleRuntimeFields(entry)) {
+      // already counted via updated
+    }
+    clearFallbackNotice(entry);
+    entry.updatedAt = Date.now();
+  }
+  return { updated };
+}
+
+async function probeModel(provider, model, timeoutMs) {
+  // Basic provider probes. Uses environment API keys where appropriate.
+  const ac = new AbortController();
+  const to = setTimeout(() => ac.abort(), timeoutMs ?? 5000);
+  try {
+    if (!provider) {
+      return false;
+    }
+    const p = provider.toLowerCase();
+    if (p === "openai") {
+      const key = process.env.OPENAI_API_KEY;
+      if (!key) {
+        return false;
+      }
+      const res = await fetch(`https://api.openai.com/v1/models/${encodeURIComponent(model)}`, {
+        signal: ac.signal,
+        headers: { Authorization: `Bearer ${key}` },
+      });
+      return res.ok;
+    }
+    if (p === "anthropic") {
+      const key = process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY_0;
+      if (!key) {
+        return false;
+      }
+      const res = await fetch(`https://api.anthropic.com/v1/models/${encodeURIComponent(model)}`, {
+        signal: ac.signal,
+        headers: { "x-api-key": key, "anthropic-version": "2023-06-01" },
+      });
+      return res.ok;
+    }
+    if (p.endsWith("-cli") || p === "claude-cli" || p === "codex-cli") {
+      // Local CLI backends - assume available (they are handled outside HTTP)
+      clearTimeout(to);
+      return true;
+    }
+    if (p === "minimax" || p === "minimax-portal" || p.includes("minimax")) {
+      const key = process.env.MINIMAX_API_KEY || process.env.MINIMAX_KEY;
+      if (!key) {
+        return false;
+      }
+      // Attempt a generic models endpoint if present
+      const endpoint = process.env.MINIMAX_API_BASE || "https://api.minimax.ai/v1";
+      try {
+        const res = await fetch(`${endpoint}/models/${encodeURIComponent(model)}`, {
+          signal: ac.signal,
+          headers: { Authorization: `Bearer ${key}` },
+        });
+        return res.ok;
+      } catch {
+        return false;
+      }
+    }
+
+    // Fallback: check for an env var for the provider's API key and assume ok if present
+    const envKey = process.env[`${p.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`];
+    clearTimeout(to);
+    return Boolean(envKey);
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(to);
+  }
+}
+
+async function main() {
+  const args = parseArgs();
+  if (!args.sessionKey) {
+    console.error("--sessionKey is required");
+    process.exit(2);
+  }
+  if (!args.models) {
+    console.error("--models is required (comma-separated provider/model list)");
+    process.exit(2);
+  }
+  const timeoutMs = args.timeout ?? 5000;
+  const storePath = args.store ? path.resolve(args.store) : defaultStorePath();
+
+  const store = loadStore(storePath);
+  const entry = store[args.sessionKey];
+  if (!entry) {
+    console.error(`Session key not found in store: ${args.sessionKey}`);
+    process.exit(3);
+  }
+
+  const candidates = String(args.models)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(splitModelRef)
+    .filter(Boolean);
+
+  if (candidates.length === 0) {
+    console.error("No valid model candidates provided");
+    process.exit(4);
+  }
+
+  console.log(
+    `Probing ${candidates.length} model(s) for session ${args.sessionKey} with ${timeoutMs}ms timeout`,
+  );
+
+  for (const cand of candidates) {
+    const provider = cand.provider;
+    const model = cand.model;
+    process.stdout.write(`Checking ${provider}/${model} ... `);
+    /* eslint-disable no-await-in-loop */
+    const ok = await probeModel(provider, model, timeoutMs);
+    if (ok) {
+      console.log("ok");
+      const applied = applyModelOverrideToEntry(entry, { provider, model, isDefault: false });
+      if (applied.updated) {
+        store[args.sessionKey] = entry;
+        saveStore(storePath, store);
+        console.log(`Applied override ${provider}/${model} to ${args.sessionKey} in ${storePath}`);
+      } else {
+        console.log(`No change required for ${args.sessionKey}`);
+      }
+      process.exit(0);
+    }
+    console.log("failed");
+  }
+
+  // None succeeded — reset to default by removing overrides
+  const applied = applyModelOverrideToEntry(entry, { provider: "", model: "", isDefault: true });
+  if (applied.updated) {
+    store[args.sessionKey] = entry;
+    saveStore(storePath, store);
+    console.log(`No candidate succeeded — reset overrides for ${args.sessionKey}`);
+    process.exit(1);
+  }
+  console.log(
+    "No changes made (none of the candidates were available and overrides were already default)",
+  );
+  process.exit(1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(10);
+  });
+}


### PR DESCRIPTION
The README documents two new Node.js failover utilities added under update/. default-model-failover.js probes a prioritized list of candidate models and updates the global OpenClaw config's agents.defaults.model.primary (preserving existing keys like fallbacks), with automatic timestamped backups before any modification. session-failover.js performs the same probe-and-switch logic for individual session entries in a sessions JSON store, mirroring OpenClaw's applyModelOverrideToSessionEntry behavior including auth profile cleanup. The README covers usage examples for both scripts, explains the lightweight provider-specific probing strategy (HTTP checks for OpenAI/Anthropic, env var heuristics for others), documents environment variable caveats for non-standard provider key names, and includes a safety checklist for operators before running or automating the utilities.

[README.md](https://github.com/user-attachments/files/25159062/README.md)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two Node.js utilities under `update/` for operational model failover:

- `update/default-model-failover.js` probes a prioritized list of provider/model pairs and updates the global OpenClaw config’s `agents.defaults.model.primary`, creating a timestamped backup before writing.
- `update/session-failover.js` probes candidates and writes per-session `providerOverride`/`modelOverride` into a sessions JSON store, attempting to mirror core session override behavior.

The implementation follows existing config/session key conventions in the repo (e.g., `agents.defaults.model.primary`, session override fields), but there are a couple of correctness mismatches vs documented/core behavior that should be addressed before merging.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix session override cleanup parity and correct the README claim about backups.
- Changes are isolated to new `update/` utilities and documentation, with no runtime impact on the main app. Main remaining risk is that `session-failover.js` claims to mirror core behavior but currently leaves stale auth override metadata, which can alter effective auth/profile selection after failover; and README contains a concrete behavior guarantee that isn’t true when the config file doesn’t exist.
- update/session-failover.js, update/README.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->