### PR TITLE
feat(slack): Add Home Tab support

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -537,7 +537,7 @@ When a user opens the bot's **Home** tab in Slack, OpenClaw automatically publis
 - Getting started guide and slash command reference
 - Links to docs, GitHub, and community
 
-The view is cached per user and only re-published when the version changes (e.g., after an update or restart). No additional configuration is required — the Home Tab works out of the box as long as the Slack app manifest includes `app_home.messages_tab_enabled: true` (which is the default).
+The view is cached per user and only re-published when the version changes (e.g., after an update or restart). No additional configuration is required — the Home Tab works out of the box as long as the Slack app manifest includes `app_home.home_tab_enabled: true` and subscribes to the `app_home_opened` event (both are set by the default OpenClaw manifest).
 
 ### Configuration
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -530,9 +530,11 @@ Slack tool actions can be gated with `channels.slack.actions.*`:
 
 When a user opens the bot's **Home** tab in Slack, OpenClaw automatically publishes a Block Kit view showing:
 
-- Agent version
-- Bot identity
-- Slash command quick reference (uses your configured slash command)
+- Agent name and online status
+- Version and current model
+- Uptime
+- Configured Slack channels
+- Getting started guide and slash command reference
 - Links to docs, GitHub, and community
 
 The view is cached per user and only re-published when the version changes (e.g., after an update or restart). No additional configuration is required — the Home Tab works out of the box as long as the Slack app manifest includes `app_home.messages_tab_enabled: true` (which is the default).

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -524,6 +524,7 @@ Slack tool actions can be gated with `channels.slack.actions.*`:
 | pins         | enabled | Pin/unpin/list         |
 | memberInfo   | enabled | Member info            |
 | emojiList    | enabled | Custom emoji list      |
+| homeTab      | enabled | Home Tab updates       |
 
 ## Home Tab
 
@@ -535,6 +536,29 @@ When a user opens the bot's **Home** tab in Slack, OpenClaw automatically publis
 - Links to docs, GitHub, and community
 
 The view is cached per user and only re-published when the version changes (e.g., after an update or restart). No additional configuration is required — the Home Tab works out of the box as long as the Slack app manifest includes `app_home.messages_tab_enabled: true` (which is the default).
+
+### Custom Home Tab via `updateHomeTab`
+
+Agents can dynamically customize a user's Home Tab using the `updateHomeTab` action:
+
+| Parameter | Type       | Required | Description                            |
+| --------- | ---------- | -------- | -------------------------------------- |
+| `userId`  | `string`   | yes      | Slack user ID whose Home tab to update |
+| `blocks`  | `object[]` | yes      | Block Kit blocks array for the view    |
+
+Example:
+
+```json
+{
+  "action": "updateHomeTab",
+  "userId": "U12345",
+  "blocks": [{ "type": "section", "text": { "type": "mrkdwn", "text": "Hello from your agent!" } }]
+}
+```
+
+Once an agent publishes a custom view, the default Home Tab view will **not** overwrite it on subsequent tab opens. The default view resumes after a process restart.
+
+This action is gated by the `homeTab` key in the actions config (enabled by default).
 
 ## Security notes
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -537,6 +537,24 @@ When a user opens the bot's **Home** tab in Slack, OpenClaw automatically publis
 
 The view is cached per user and only re-published when the version changes (e.g., after an update or restart). No additional configuration is required — the Home Tab works out of the box as long as the Slack app manifest includes `app_home.messages_tab_enabled: true` (which is the default).
 
+### Configuration
+
+The Home Tab can be toggled via config:
+
+```json5
+{
+  channels: {
+    slack: {
+      homeTab: {
+        enabled: false, // Disable the Home Tab entirely (default: true)
+      },
+    },
+  },
+}
+```
+
+When `enabled` is `false`, the `app_home_opened` event handler is not registered.
+
 ### Custom Home Tab via `updateHomeTab`
 
 Agents can dynamically customize a user's Home Tab using the `updateHomeTab` action:
@@ -556,9 +574,17 @@ Example:
 }
 ```
 
-Once an agent publishes a custom view, the default Home Tab view will **not** overwrite it on subsequent tab opens. The default view resumes after a process restart.
+Once an agent publishes a custom view, the default Home Tab view will **not** overwrite it on subsequent tab opens.
 
-This action is gated by the `homeTab` key in the actions config (enabled by default).
+To restore the default view, use the `resetHomeTab` action:
+
+| Parameter | Type     | Required | Description                                      |
+| --------- | -------- | -------- | ------------------------------------------------ |
+| `userId`  | `string` | yes      | Slack user ID whose Home tab to reset to default |
+
+The default view also resumes automatically after a process restart.
+
+Both actions are gated by the `homeTab` key in the actions config (enabled by default).
 
 ## Security notes
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -525,6 +525,17 @@ Slack tool actions can be gated with `channels.slack.actions.*`:
 | memberInfo   | enabled | Member info            |
 | emojiList    | enabled | Custom emoji list      |
 
+## Home Tab
+
+When a user opens the bot's **Home** tab in Slack, OpenClaw automatically publishes a Block Kit view showing:
+
+- Agent version
+- Bot identity
+- Slash command quick reference (uses your configured slash command)
+- Links to docs, GitHub, and community
+
+The view is cached per user and only re-published when the version changes (e.g., after an update or restart). No additional configuration is required — the Home Tab works out of the box as long as the Slack app manifest includes `app_home.messages_tab_enabled: true` (which is the default).
+
 ## Security notes
 
 - Writes default to the bot token so state-changing actions stay scoped to the

--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -474,7 +474,7 @@ describe("handleSlackAction", () => {
     const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
     resetSlackHomeTab.mockClear();
     const result = await handleSlackAction({ action: "resetHomeTab", userId: "U123" }, cfg);
-    expect(resetSlackHomeTab).toHaveBeenCalledWith("U123");
+    expect(resetSlackHomeTab).toHaveBeenCalledWith("U123", expect.any(Object));
     expect(result.details).toMatchObject({ ok: true });
   });
 

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -11,6 +11,7 @@ import {
   pinSlackMessage,
   publishSlackHomeTab,
   reactSlackMessage,
+  resetSlackHomeTab,
   readSlackMessages,
   removeOwnSlackReactions,
   removeSlackReaction,
@@ -325,6 +326,18 @@ export async function handleSlackAction(
       await publishSlackHomeTab(userId, blocks as Record<string, unknown>[]);
     }
     return jsonResult({ ok: true });
+  }
+
+  if (action === "resetHomeTab") {
+    if (!isActionEnabled("homeTab")) {
+      throw new Error("Slack Home Tab updates are disabled.");
+    }
+    const userId = readStringParam(params, "userId", { required: true });
+    resetSlackHomeTab(userId);
+    return jsonResult({
+      ok: true,
+      message: "Custom Home Tab cleared; default will restore on next visit.",
+    });
   }
 
   throw new Error(`Unknown action: ${action}`);

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -333,7 +333,7 @@ export async function handleSlackAction(
       throw new Error("Slack Home Tab updates are disabled.");
     }
     const userId = readStringParam(params, "userId", { required: true });
-    resetSlackHomeTab(userId);
+    resetSlackHomeTab(userId, writeOpts ?? {});
     return jsonResult({
       ok: true,
       message: "Custom Home Tab cleared; default will restore on next visit.",

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -9,6 +9,7 @@ import {
   listSlackPins,
   listSlackReactions,
   pinSlackMessage,
+  publishSlackHomeTab,
   reactSlackMessage,
   readSlackMessages,
   removeOwnSlackReactions,
@@ -307,6 +308,23 @@ export async function handleSlackAction(
     }
     const emojis = readOpts ? await listSlackEmojis(readOpts) : await listSlackEmojis();
     return jsonResult({ ok: true, emojis });
+  }
+
+  if (action === "updateHomeTab") {
+    if (!isActionEnabled("homeTab")) {
+      throw new Error("Slack Home Tab updates are disabled.");
+    }
+    const userId = readStringParam(params, "userId", { required: true });
+    const blocks = params.blocks;
+    if (!Array.isArray(blocks)) {
+      throw new Error("blocks (array) is required for updateHomeTab.");
+    }
+    if (writeOpts) {
+      await publishSlackHomeTab(userId, blocks as Record<string, unknown>[], writeOpts);
+    } else {
+      await publishSlackHomeTab(userId, blocks as Record<string, unknown>[]);
+    }
+    return jsonResult({ ok: true });
   }
 
   throw new Error(`Unknown action: ${action}`);

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -49,6 +49,7 @@ function buildSlackManifest(botName: string) {
         always_online: false,
       },
       app_home: {
+        home_tab_enabled: true,
         messages_tab_enabled: true,
         messages_tab_read_only_enabled: false,
       },
@@ -86,6 +87,7 @@ function buildSlackManifest(botName: string) {
       socket_mode_enabled: true,
       event_subscriptions: {
         bot_events: [
+          "app_home_opened",
           "app_mention",
           "message.channels",
           "message.groups",

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -11,22 +11,11 @@ import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./typ
 
 /**
  * Configuration for the Slack App Home Tab.
- *
- * When `blocks` is provided, they are used as the Home Tab content (Block Kit JSON).
- * Template variables are substituted before rendering:
- *   {{agent_name}}, {{version}}, {{model}}, {{uptime}}, {{channels}}, {{slash_command}}
- *
- * When `blocks` is omitted, a sensible default view is rendered.
+ * Custom content can be pushed dynamically via the `updateHomeTab` tool action.
  */
 export type SlackHomeTabConfig = {
   /** Enable the Home Tab (default: true). */
   enabled?: boolean;
-  /**
-   * Custom Block Kit blocks for the Home Tab.
-   * Supports template variable substitution (e.g. `{{agent_name}}`).
-   * When omitted, the default built-in view is used.
-   */
-  blocks?: Record<string, unknown>[];
 };
 
 export type SlackDmConfig = {

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -9,6 +9,26 @@ import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
+/**
+ * Configuration for the Slack App Home Tab.
+ *
+ * When `blocks` is provided, they are used as the Home Tab content (Block Kit JSON).
+ * Template variables are substituted before rendering:
+ *   {{agent_name}}, {{version}}, {{model}}, {{uptime}}, {{channels}}, {{slash_command}}
+ *
+ * When `blocks` is omitted, a sensible default view is rendered.
+ */
+export type SlackHomeTabConfig = {
+  /** Enable the Home Tab (default: true). */
+  enabled?: boolean;
+  /**
+   * Custom Block Kit blocks for the Home Tab.
+   * Supports template variable substitution (e.g. `{{agent_name}}`).
+   * When omitted, the default built-in view is used.
+   */
+  blocks?: Record<string, unknown>[];
+};
+
 export type SlackDmConfig = {
   /** If false, ignore all incoming Slack DMs. Default: true. */
   enabled?: boolean;
@@ -139,6 +159,8 @@ export type SlackAccountConfig = {
   /** Thread session behavior. */
   thread?: SlackThreadConfig;
   actions?: SlackActionConfig;
+  /** Home Tab configuration. */
+  homeTab?: SlackHomeTabConfig;
   slashCommand?: SlackSlashCommandConfig;
   dm?: SlackDmConfig;
   channels?: Record<string, SlackChannelConfig>;

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -55,6 +55,8 @@ export type SlackActionConfig = {
   memberInfo?: boolean;
   channelInfo?: boolean;
   emojiList?: boolean;
+  /** Enable the `updateHomeTab` action (default: true). */
+  homeTab?: boolean;
 };
 
 export type SlackSlashCommandConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -496,6 +496,13 @@ export const SlackAccountSchema = z
         memberInfo: z.boolean().optional(),
         channelInfo: z.boolean().optional(),
         emojiList: z.boolean().optional(),
+        homeTab: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    homeTab: z
+      .object({
+        enabled: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -3,7 +3,7 @@ import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
 import { resolveSlackAccount } from "./accounts.js";
 import { createSlackWebClient } from "./client.js";
-import { markHomeTabCustom } from "./home-tab-state.js";
+import { clearHomeTabCustom, markHomeTabCustom } from "./home-tab-state.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
@@ -281,4 +281,12 @@ export async function publishSlackHomeTab(
     view: { type: "home", blocks: blocks as any },
   });
   markHomeTabCustom(userId);
+}
+
+/**
+ * Clear a user's custom Home Tab view, allowing the default view to be
+ * published again on the next `app_home_opened` event.
+ */
+export function resetSlackHomeTab(userId: string): void {
+  clearHomeTabCustom(userId);
 }

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -268,25 +268,31 @@ export async function listSlackPins(
  *
  * After a successful publish the user is marked as having a custom view so the
  * default `app_home_opened` handler will not overwrite it.
+ *
+ * Note: Agents are trusted with workspace-level access. The userId parameter
+ * is not restricted to the invoking user — agents can update any user's Home
+ * tab, consistent with other Slack tool actions (send, react, pin).
  */
 export async function publishSlackHomeTab(
   userId: string,
   blocks: Record<string, unknown>[],
   opts: SlackActionClientOpts = {},
 ): Promise<void> {
+  const accountId = opts.accountId ?? "default";
   const client = await getClient(opts);
   await client.views.publish({
     user_id: userId,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Block Kit JSON built dynamically
     view: { type: "home", blocks: blocks as any },
   });
-  markHomeTabCustom(userId);
+  markHomeTabCustom(accountId, userId);
 }
 
 /**
  * Clear a user's custom Home Tab view, allowing the default view to be
  * published again on the next `app_home_opened` event.
  */
-export function resetSlackHomeTab(userId: string): void {
-  clearHomeTabCustom(userId);
+export function resetSlackHomeTab(userId: string, opts: SlackActionClientOpts = {}): void {
+  const accountId = opts.accountId ?? "default";
+  clearHomeTabCustom(accountId, userId);
 }

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
 import { resolveSlackAccount } from "./accounts.js";
 import { createSlackWebClient } from "./client.js";
+import { markHomeTabCustom } from "./home-tab-state.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
@@ -260,4 +261,23 @@ export async function listSlackPins(
   const client = await getClient(opts);
   const result = await client.pins.list({ channel: channelId });
   return (result.items ?? []) as SlackPin[];
+}
+
+/**
+ * Publish a custom Block Kit view to a user's Slack App Home tab.
+ *
+ * After a successful publish the user is marked as having a custom view so the
+ * default `app_home_opened` handler will not overwrite it.
+ */
+export async function publishSlackHomeTab(
+  userId: string,
+  blocks: Record<string, unknown>[],
+  opts: SlackActionClientOpts = {},
+): Promise<void> {
+  const client = await getClient(opts);
+  await client.views.publish({
+    user_id: userId,
+    view: { type: "home", blocks },
+  });
+  markHomeTabCustom(userId);
 }

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -277,7 +277,8 @@ export async function publishSlackHomeTab(
   const client = await getClient(opts);
   await client.views.publish({
     user_id: userId,
-    view: { type: "home", blocks },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Block Kit JSON built dynamically
+    view: { type: "home", blocks: blocks as any },
   });
   markHomeTabCustom(userId);
 }

--- a/src/slack/home-tab-state.test.ts
+++ b/src/slack/home-tab-state.test.ts
@@ -1,38 +1,72 @@
-import { describe, expect, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
-  clearHomeTabCustom,
-  hasCurrentHomeTab,
-  hasCustomHomeTab,
   markHomeTabCustom,
+  clearHomeTabCustom,
+  hasCustomHomeTab,
   markHomeTabPublished,
+  hasCurrentHomeTab,
+  isPublishInFlight,
+  markPublishInFlight,
+  clearPublishInFlight,
 } from "./home-tab-state.js";
 
+const ACCOUNT = "default";
+
 describe("home-tab-state", () => {
-  it("markHomeTabCustom → hasCustomHomeTab returns true", () => {
-    markHomeTabCustom("U_CUSTOM_1");
-    expect(hasCustomHomeTab("U_CUSTOM_1")).toBe(true);
+  it("tracks custom view per account+user", () => {
+    markHomeTabCustom(ACCOUNT, "U1");
+    expect(hasCustomHomeTab(ACCOUNT, "U1")).toBe(true);
+    expect(hasCustomHomeTab(ACCOUNT, "U2")).toBe(false);
+    clearHomeTabCustom(ACCOUNT, "U1");
+    expect(hasCustomHomeTab(ACCOUNT, "U1")).toBe(false);
   });
 
-  it("clearHomeTabCustom removes custom flag", () => {
-    markHomeTabCustom("U_CUSTOM_2");
-    clearHomeTabCustom("U_CUSTOM_2");
-    expect(hasCustomHomeTab("U_CUSTOM_2")).toBe(false);
+  it("tracks published version per account+user", () => {
+    markHomeTabPublished(ACCOUNT, "U1", "1.0.0");
+    expect(hasCurrentHomeTab(ACCOUNT, "U1", "1.0.0")).toBe(true);
+    expect(hasCurrentHomeTab(ACCOUNT, "U1", "2.0.0")).toBe(false);
+    expect(hasCurrentHomeTab(ACCOUNT, "U2", "1.0.0")).toBe(false);
   });
 
-  it("markHomeTabCustom clears published version cache", () => {
-    markHomeTabPublished("U_CUSTOM_3", "1.0.0");
-    expect(hasCurrentHomeTab("U_CUSTOM_3", "1.0.0")).toBe(true);
-    markHomeTabCustom("U_CUSTOM_3");
-    expect(hasCurrentHomeTab("U_CUSTOM_3", "1.0.0")).toBe(false);
+  it("markHomeTabCustom clears published version", () => {
+    markHomeTabPublished(ACCOUNT, "U3", "1.0.0");
+    expect(hasCurrentHomeTab(ACCOUNT, "U3", "1.0.0")).toBe(true);
+    markHomeTabCustom(ACCOUNT, "U3");
+    expect(hasCurrentHomeTab(ACCOUNT, "U3", "1.0.0")).toBe(false);
   });
 
-  it("markHomeTabPublished / hasCurrentHomeTab roundtrip", () => {
-    markHomeTabPublished("U_PUB_1", "2.0.0");
-    expect(hasCurrentHomeTab("U_PUB_1", "2.0.0")).toBe(true);
-    expect(hasCurrentHomeTab("U_PUB_1", "3.0.0")).toBe(false);
+  it("clearHomeTabCustom does not restore published version", () => {
+    markHomeTabPublished(ACCOUNT, "U4", "1.0.0");
+    markHomeTabCustom(ACCOUNT, "U4");
+    clearHomeTabCustom(ACCOUNT, "U4");
+    expect(hasCurrentHomeTab(ACCOUNT, "U4", "1.0.0")).toBe(false);
   });
 
-  it("hasCustomHomeTab returns false for unknown users", () => {
-    expect(hasCustomHomeTab("U_UNKNOWN")).toBe(false);
+  it("clears custom independently per user", () => {
+    markHomeTabCustom(ACCOUNT, "U5");
+    markHomeTabCustom(ACCOUNT, "U6");
+    clearHomeTabCustom(ACCOUNT, "U5");
+    expect(hasCustomHomeTab(ACCOUNT, "U5")).toBe(false);
+    expect(hasCustomHomeTab(ACCOUNT, "U6")).toBe(true);
+    clearHomeTabCustom(ACCOUNT, "U6");
+  });
+
+  it("isolates state across different accounts", () => {
+    markHomeTabCustom("account-a", "U1");
+    markHomeTabPublished("account-b", "U1", "1.0.0");
+    expect(hasCustomHomeTab("account-a", "U1")).toBe(true);
+    expect(hasCustomHomeTab("account-b", "U1")).toBe(false);
+    expect(hasCurrentHomeTab("account-a", "U1", "1.0.0")).toBe(false);
+    expect(hasCurrentHomeTab("account-b", "U1", "1.0.0")).toBe(true);
+    clearHomeTabCustom("account-a", "U1");
+  });
+
+  it("tracks in-flight publish state", () => {
+    expect(isPublishInFlight(ACCOUNT, "U1")).toBe(false);
+    markPublishInFlight(ACCOUNT, "U1");
+    expect(isPublishInFlight(ACCOUNT, "U1")).toBe(true);
+    expect(isPublishInFlight(ACCOUNT, "U2")).toBe(false);
+    clearPublishInFlight(ACCOUNT, "U1");
+    expect(isPublishInFlight(ACCOUNT, "U1")).toBe(false);
   });
 });

--- a/src/slack/home-tab-state.test.ts
+++ b/src/slack/home-tab-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearHomeTabCustom,
+  hasCurrentHomeTab,
+  hasCustomHomeTab,
+  markHomeTabCustom,
+  markHomeTabPublished,
+} from "./home-tab-state.js";
+
+describe("home-tab-state", () => {
+  it("markHomeTabCustom → hasCustomHomeTab returns true", () => {
+    markHomeTabCustom("U_CUSTOM_1");
+    expect(hasCustomHomeTab("U_CUSTOM_1")).toBe(true);
+  });
+
+  it("clearHomeTabCustom removes custom flag", () => {
+    markHomeTabCustom("U_CUSTOM_2");
+    clearHomeTabCustom("U_CUSTOM_2");
+    expect(hasCustomHomeTab("U_CUSTOM_2")).toBe(false);
+  });
+
+  it("markHomeTabCustom clears published version cache", () => {
+    markHomeTabPublished("U_CUSTOM_3", "1.0.0");
+    expect(hasCurrentHomeTab("U_CUSTOM_3", "1.0.0")).toBe(true);
+    markHomeTabCustom("U_CUSTOM_3");
+    expect(hasCurrentHomeTab("U_CUSTOM_3", "1.0.0")).toBe(false);
+  });
+
+  it("markHomeTabPublished / hasCurrentHomeTab roundtrip", () => {
+    markHomeTabPublished("U_PUB_1", "2.0.0");
+    expect(hasCurrentHomeTab("U_PUB_1", "2.0.0")).toBe(true);
+    expect(hasCurrentHomeTab("U_PUB_1", "3.0.0")).toBe(false);
+  });
+
+  it("hasCustomHomeTab returns false for unknown users", () => {
+    expect(hasCustomHomeTab("U_UNKNOWN")).toBe(false);
+  });
+});

--- a/src/slack/home-tab-state.ts
+++ b/src/slack/home-tab-state.ts
@@ -3,7 +3,14 @@
  * handler and the `publishSlackHomeTab` action.
  *
  * Both modules import from here so they share the same in-memory caches.
+ *
+ * State is keyed by `accountId:userId` to prevent cross-contamination in
+ * multi-account setups (Slack user IDs are workspace-local and can collide).
  */
+
+function stateKey(accountId: string, userId: string): string {
+  return `${accountId}:${userId}`;
+}
 
 /**
  * Per-user cache of the VERSION string at the time the default Home Tab view
@@ -13,34 +20,56 @@
 const publishedVersionByUser = new Map<string, string>();
 
 /**
- * Set of user IDs whose Home Tab is currently showing a custom (agent-pushed)
- * view. While a user is in this set the default `app_home_opened` handler
- * will skip publishing the default view.
+ * Set of (accountId:userId) keys whose Home Tab is currently showing a custom
+ * (agent-pushed) view. While a key is in this set the default `app_home_opened`
+ * handler will skip publishing the default view.
  */
 const customViewUsers = new Set<string>();
 
+/**
+ * Set of (accountId:userId) keys that currently have an in-flight publish.
+ * Used to deduplicate concurrent `app_home_opened` events for the same user.
+ */
+const publishingInFlight = new Set<string>();
+
 /** Mark a user as having a custom (agent-pushed) Home Tab view. */
-export function markHomeTabCustom(userId: string): void {
-  customViewUsers.add(userId);
-  publishedVersionByUser.delete(userId);
+export function markHomeTabCustom(accountId: string, userId: string): void {
+  const key = stateKey(accountId, userId);
+  customViewUsers.add(key);
+  publishedVersionByUser.delete(key);
 }
 
 /** Clear the custom-view flag so the default view can be published again. */
-export function clearHomeTabCustom(userId: string): void {
-  customViewUsers.delete(userId);
+export function clearHomeTabCustom(accountId: string, userId: string): void {
+  customViewUsers.delete(stateKey(accountId, userId));
 }
 
 /** Returns `true` if the user currently has a custom Home Tab view. */
-export function hasCustomHomeTab(userId: string): boolean {
-  return customViewUsers.has(userId);
+export function hasCustomHomeTab(accountId: string, userId: string): boolean {
+  return customViewUsers.has(stateKey(accountId, userId));
 }
 
 /** Record that the default Home Tab was published for `userId` at `version`. */
-export function markHomeTabPublished(userId: string, version: string): void {
-  publishedVersionByUser.set(userId, version);
+export function markHomeTabPublished(accountId: string, userId: string, version: string): void {
+  publishedVersionByUser.set(stateKey(accountId, userId), version);
 }
 
 /** Returns `true` if the user already has the default view at `version`. */
-export function hasCurrentHomeTab(userId: string, version: string): boolean {
-  return publishedVersionByUser.get(userId) === version;
+export function hasCurrentHomeTab(accountId: string, userId: string, version: string): boolean {
+  return publishedVersionByUser.get(stateKey(accountId, userId)) === version;
+}
+
+/** Returns `true` if a publish is currently in-flight for this user. */
+export function isPublishInFlight(accountId: string, userId: string): boolean {
+  return publishingInFlight.has(stateKey(accountId, userId));
+}
+
+/** Mark a publish as in-flight. */
+export function markPublishInFlight(accountId: string, userId: string): void {
+  publishingInFlight.add(stateKey(accountId, userId));
+}
+
+/** Clear the in-flight flag. */
+export function clearPublishInFlight(accountId: string, userId: string): void {
+  publishingInFlight.delete(stateKey(accountId, userId));
 }

--- a/src/slack/home-tab-state.ts
+++ b/src/slack/home-tab-state.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared Home Tab state for coordinating between the `app_home_opened` event
+ * handler and the `publishSlackHomeTab` action.
+ *
+ * Both modules import from here so they share the same in-memory caches.
+ */
+
+/**
+ * Per-user cache of the VERSION string at the time the default Home Tab view
+ * was last published. Cleared on process restart (a fresh publish after
+ * restart is desirable).
+ */
+const publishedVersionByUser = new Map<string, string>();
+
+/**
+ * Set of user IDs whose Home Tab is currently showing a custom (agent-pushed)
+ * view. While a user is in this set the default `app_home_opened` handler
+ * will skip publishing the default view.
+ */
+const customViewUsers = new Set<string>();
+
+/** Mark a user as having a custom (agent-pushed) Home Tab view. */
+export function markHomeTabCustom(userId: string): void {
+  customViewUsers.add(userId);
+  publishedVersionByUser.delete(userId);
+}
+
+/** Clear the custom-view flag so the default view can be published again. */
+export function clearHomeTabCustom(userId: string): void {
+  customViewUsers.delete(userId);
+}
+
+/** Returns `true` if the user currently has a custom Home Tab view. */
+export function hasCustomHomeTab(userId: string): boolean {
+  return customViewUsers.has(userId);
+}
+
+/** Record that the default Home Tab was published for `userId` at `version`. */
+export function markHomeTabPublished(userId: string, version: string): void {
+  publishedVersionByUser.set(userId, version);
+}
+
+/** Returns `true` if the user already has the default view at `version`. */
+export function hasCurrentHomeTab(userId: string, version: string): boolean {
+  return publishedVersionByUser.get(userId) === version;
+}

--- a/src/slack/monitor/events.ts
+++ b/src/slack/monitor/events.ts
@@ -2,6 +2,7 @@ import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMonitorContext } from "./context.js";
 import type { SlackMessageHandler } from "./message-handler.js";
 import { registerSlackChannelEvents } from "./events/channels.js";
+import { registerSlackHomeTabEvents } from "./events/home.js";
 import { registerSlackMemberEvents } from "./events/members.js";
 import { registerSlackMessageEvents } from "./events/messages.js";
 import { registerSlackPinEvents } from "./events/pins.js";
@@ -20,4 +21,5 @@ export function registerSlackMonitorEvents(params: {
   registerSlackMemberEvents({ ctx: params.ctx });
   registerSlackChannelEvents({ ctx: params.ctx });
   registerSlackPinEvents({ ctx: params.ctx });
+  registerSlackHomeTabEvents({ ctx: params.ctx });
 }

--- a/src/slack/monitor/events/home.test.ts
+++ b/src/slack/monitor/events/home.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import {
-  buildHomeTabBlocks,
-  formatUptime,
-  resolveAgentModelDisplay,
-  resolveTemplateVars,
-  substituteTemplateVars,
-} from "./home.js";
+import { buildHomeTabBlocks, formatUptime, resolveAgentModelDisplay } from "./home.js";
 
 describe("formatUptime", () => {
   it("formats minutes only", () => {
@@ -190,112 +184,5 @@ describe("buildHomeTabBlocks", () => {
     expect(fullText).not.toContain("token");
     expect(fullText).not.toContain("Dashboard");
     expect(fullText).not.toContain("127.0.0.1");
-  });
-
-  it("uses custom blocks from homeTabConfig when provided", () => {
-    const customBlocks = [
-      { type: "header", text: { type: "plain_text", text: "Hello {{agent_name}}!" } },
-      { type: "section", text: { type: "mrkdwn", text: "Running {{version}} on {{model}}" } },
-    ];
-    const cfg: OpenClawConfig = {
-      agents: { list: [{ id: "main", default: true, name: "MyBot", model: "gpt-5" }] },
-    };
-    const blocks = buildHomeTabBlocks({
-      botUserId: "U99",
-      cfg,
-      homeTabConfig: { blocks: customBlocks },
-    });
-    expect(blocks[0]).toMatchObject({
-      type: "header",
-      text: { type: "plain_text", text: "Hello MyBot!" },
-    });
-    expect(blocks[1]).toMatchObject({
-      type: "section",
-      text: { type: "mrkdwn", text: expect.stringContaining("gpt-5") },
-    });
-  });
-
-  it("falls back to default blocks when homeTabConfig has no blocks", () => {
-    const blocks = buildHomeTabBlocks({
-      botUserId: "U99",
-      homeTabConfig: { enabled: true },
-    });
-    // Should still render default view
-    expect(blocks[0]).toMatchObject({ type: "header" });
-    expect(blocks.length).toBeGreaterThan(3);
-  });
-
-  it("falls back to default blocks when homeTabConfig.blocks is empty", () => {
-    const blocks = buildHomeTabBlocks({
-      botUserId: "U99",
-      homeTabConfig: { blocks: [] },
-    });
-    expect(blocks[0]).toMatchObject({ type: "header" });
-    expect(blocks.length).toBeGreaterThan(3);
-  });
-});
-
-describe("substituteTemplateVars", () => {
-  const vars = {
-    agent_name: "TestBot",
-    version: "1.0.0",
-    model: "gpt-5",
-    uptime: "2h 30m",
-    channels: "<#C123>",
-    slash_command: "/test",
-  };
-
-  it("substitutes string variables", () => {
-    expect(substituteTemplateVars("Hello {{agent_name}}!", vars)).toBe("Hello TestBot!");
-  });
-
-  it("substitutes multiple variables in one string", () => {
-    expect(substituteTemplateVars("{{agent_name}} v{{version}}", vars)).toBe("TestBot v1.0.0");
-  });
-
-  it("leaves unknown variables unchanged", () => {
-    expect(substituteTemplateVars("{{unknown_var}}", vars)).toBe("{{unknown_var}}");
-  });
-
-  it("handles nested objects", () => {
-    const obj = { text: { type: "mrkdwn", text: "Model: {{model}}" } };
-    expect(substituteTemplateVars(obj, vars)).toEqual({
-      text: { type: "mrkdwn", text: "Model: gpt-5" },
-    });
-  });
-
-  it("handles arrays", () => {
-    const arr = ["{{agent_name}}", "{{version}}"];
-    expect(substituteTemplateVars(arr, vars)).toEqual(["TestBot", "1.0.0"]);
-  });
-
-  it("passes through non-string primitives", () => {
-    expect(substituteTemplateVars(42, vars)).toBe(42);
-    expect(substituteTemplateVars(true, vars)).toBe(true);
-    expect(substituteTemplateVars(null, vars)).toBe(null);
-  });
-});
-
-describe("resolveTemplateVars", () => {
-  it("resolves agent name from config", () => {
-    const cfg: OpenClawConfig = {
-      agents: { list: [{ id: "main", default: true, name: "MyAgent" }] },
-    };
-    const vars = resolveTemplateVars({ cfg });
-    expect(vars.agent_name).toBe("MyAgent");
-  });
-
-  it("resolves channels from config", () => {
-    const cfg: OpenClawConfig = {
-      channels: { slack: { channels: { C111: {}, C222: {} } } },
-    };
-    const vars = resolveTemplateVars({ cfg });
-    expect(vars.channels).toContain("<#C111>");
-    expect(vars.channels).toContain("<#C222>");
-  });
-
-  it("returns 'None configured' when no channels", () => {
-    const vars = resolveTemplateVars({});
-    expect(vars.channels).toBe("None configured");
   });
 });

--- a/src/slack/monitor/events/home.test.ts
+++ b/src/slack/monitor/events/home.test.ts
@@ -51,7 +51,7 @@ describe("buildHomeTabBlocks", () => {
     const cfg: OpenClawConfig = {
       agents: { list: [{ id: "main", default: true, name: "TestBot" }] },
     };
-    const blocks = buildHomeTabBlocks({ botUserId: "U12345", cfg });
+    const blocks = buildHomeTabBlocks({ cfg });
 
     expect(blocks[0]).toMatchObject({
       type: "header",
@@ -61,7 +61,7 @@ describe("buildHomeTabBlocks", () => {
 
   it("falls back to ui.assistant.name when no agent name", () => {
     const cfg: OpenClawConfig = { ui: { assistant: { name: "MyAssistant" } } };
-    const blocks = buildHomeTabBlocks({ botUserId: "U12345", cfg });
+    const blocks = buildHomeTabBlocks({ cfg });
 
     expect(blocks[0]).toMatchObject({
       type: "header",
@@ -89,7 +89,7 @@ describe("buildHomeTabBlocks", () => {
     const cfg: OpenClawConfig = {
       agents: { list: [{ id: "main", model: "anthropic/opus-4" }] },
     };
-    const blocks = buildHomeTabBlocks({ botUserId: "U12345", cfg, uptimeMs: 7200_000 });
+    const blocks = buildHomeTabBlocks({ cfg, uptimeMs: 7200_000 });
     const infoSection = blocks[2];
     const text = JSON.stringify(infoSection);
     expect(text).toContain("anthropic/opus-4");
@@ -97,7 +97,7 @@ describe("buildHomeTabBlocks", () => {
   });
 
   it("uses default /openclaw slash command when none provided", () => {
-    const blocks = buildHomeTabBlocks({ botUserId: "U99" });
+    const blocks = buildHomeTabBlocks({});
     const slashBlock = blocks.find(
       (b) =>
         b.type === "section" &&
@@ -113,7 +113,7 @@ describe("buildHomeTabBlocks", () => {
   });
 
   it("uses custom slash command when provided", () => {
-    const blocks = buildHomeTabBlocks({ botUserId: "U99", slashCommand: "/mybot" });
+    const blocks = buildHomeTabBlocks({ slashCommand: "/mybot" });
     const slashBlock = blocks.find(
       (b) =>
         b.type === "section" &&
@@ -130,7 +130,7 @@ describe("buildHomeTabBlocks", () => {
   });
 
   it("includes docs/github/community links in context block", () => {
-    const blocks = buildHomeTabBlocks({ botUserId: "U99" });
+    const blocks = buildHomeTabBlocks({});
     const contextBlock = blocks.find((b) => b.type === "context");
     expect(contextBlock).toBeDefined();
     const contextText = JSON.stringify(contextBlock);
@@ -150,7 +150,7 @@ describe("buildHomeTabBlocks", () => {
         },
       },
     };
-    const blocks = buildHomeTabBlocks({ botUserId: "U99", cfg });
+    const blocks = buildHomeTabBlocks({ cfg });
     const channelBlock = blocks.find(
       (b) =>
         b.type === "section" &&
@@ -172,7 +172,7 @@ describe("buildHomeTabBlocks", () => {
         ],
       },
     };
-    const blocks = buildHomeTabBlocks({ botUserId: "U99", cfg });
+    const blocks = buildHomeTabBlocks({ cfg });
     expect(blocks[0]).toMatchObject({
       type: "header",
       text: { type: "plain_text", text: "Alpha" },
@@ -180,7 +180,7 @@ describe("buildHomeTabBlocks", () => {
   });
 
   it("does not include any auth tokens or dashboard links", () => {
-    const blocks = buildHomeTabBlocks({ botUserId: "U99" });
+    const blocks = buildHomeTabBlocks({});
     const fullText = JSON.stringify(blocks);
     expect(fullText).not.toContain("token");
     expect(fullText).not.toContain("Dashboard");

--- a/src/slack/monitor/events/home.test.ts
+++ b/src/slack/monitor/events/home.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildHomeTabBlocks } from "./home.js";
+
+describe("buildHomeTabBlocks", () => {
+  it("returns blocks with header, version, and bot mention", () => {
+    const blocks = buildHomeTabBlocks({ botUserId: "U12345" });
+
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks[0]).toMatchObject({ type: "header" });
+
+    // Section with fields containing bot user and version
+    const section = blocks[1];
+    expect(section).toMatchObject({ type: "section" });
+    expect("fields" in section && section.fields).toBeTruthy();
+    const fieldsText = JSON.stringify(section);
+    expect(fieldsText).toContain("U12345");
+    expect(fieldsText).toContain("Version");
+  });
+
+  it("uses default /openclaw slash command when none provided", () => {
+    const blocks = buildHomeTabBlocks({ botUserId: "U99" });
+    const slashBlock = blocks.find(
+      (b) => b.type === "section" && "text" in b && b.text?.text?.includes("Slash Commands"),
+    );
+    expect(slashBlock).toBeDefined();
+    const text = slashBlock && "text" in slashBlock ? (slashBlock.text?.text ?? "") : "";
+    expect(text).toContain("`/openclaw`");
+  });
+
+  it("uses custom slash command when provided", () => {
+    const blocks = buildHomeTabBlocks({ botUserId: "U99", slashCommand: "/mybot" });
+    const slashBlock = blocks.find(
+      (b) => b.type === "section" && "text" in b && b.text?.text?.includes("Slash Commands"),
+    );
+    expect(slashBlock).toBeDefined();
+    const text = slashBlock && "text" in slashBlock ? (slashBlock.text?.text ?? "") : "";
+    expect(text).toContain("`/mybot`");
+    expect(text).not.toContain("/openclaw");
+  });
+
+  it("includes docs/github/community links in context block", () => {
+    const blocks = buildHomeTabBlocks({ botUserId: "U99" });
+    const contextBlock = blocks.find((b) => b.type === "context");
+    expect(contextBlock).toBeDefined();
+    const contextText = JSON.stringify(contextBlock);
+    expect(contextText).toContain("docs.openclaw.ai");
+    expect(contextText).toContain("github.com");
+    expect(contextText).toContain("discord.com");
+  });
+});

--- a/src/slack/monitor/events/home.test.ts
+++ b/src/slack/monitor/events/home.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { SlackAccountSchema } from "../../../config/zod-schema.providers-core.js";
 import { buildHomeTabBlocks, formatUptime, resolveAgentModelDisplay } from "./home.js";
 
 describe("formatUptime", () => {
@@ -184,5 +185,28 @@ describe("buildHomeTabBlocks", () => {
     expect(fullText).not.toContain("token");
     expect(fullText).not.toContain("Dashboard");
     expect(fullText).not.toContain("127.0.0.1");
+  });
+});
+
+describe("Zod schema validation", () => {
+  it("accepts homeTab config in SlackAccountSchema", () => {
+    const result = SlackAccountSchema.safeParse({
+      homeTab: { enabled: true },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts homeTab: false in actions config", () => {
+    const result = SlackAccountSchema.safeParse({
+      actions: { homeTab: false },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown keys in homeTab config", () => {
+    const result = SlackAccountSchema.safeParse({
+      homeTab: { enabled: true, unknownKey: "bad" },
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/src/slack/monitor/events/home.ts
+++ b/src/slack/monitor/events/home.ts
@@ -6,8 +6,10 @@ import { danger, logVerbose } from "../../../globals.js";
 import { VERSION } from "../../../version.js";
 import { hasCurrentHomeTab, hasCustomHomeTab, markHomeTabPublished } from "../../home-tab-state.js";
 
-/** Gateway process start time — used for uptime display. */
-const GATEWAY_START_MS = Date.now();
+/** Returns process uptime in milliseconds, consistent with gateway health state. */
+function processUptimeMs(): number {
+  return Math.round(process.uptime() * 1000);
+}
 
 /**
  * Format a millisecond duration as a human-readable uptime string.
@@ -86,7 +88,7 @@ export function buildHomeTabBlocks(params: {
     { type: "mrkdwn", text: `*Model:*\n\`${model}\`` },
   ];
 
-  const uptimeMs = params.uptimeMs ?? Date.now() - GATEWAY_START_MS;
+  const uptimeMs = params.uptimeMs ?? processUptimeMs();
   infoFields.push({ type: "mrkdwn", text: `*Uptime:*\n${formatUptime(uptimeMs)}` });
 
   blocks.push({ type: "section", fields: infoFields });

--- a/src/slack/monitor/events/home.ts
+++ b/src/slack/monitor/events/home.ts
@@ -1,7 +1,6 @@
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
 import type { AgentConfig } from "../../../config/types.agents.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import type { SlackHomeTabConfig } from "../../../config/types.slack.js";
 import type { SlackMonitorContext } from "../context.js";
 import { danger, logVerbose } from "../../../globals.js";
 import { VERSION } from "../../../version.js";
@@ -53,107 +52,14 @@ export function resolveAgentModelDisplay(
   return "—";
 }
 
-/**
- * Template variable context for Home Tab blocks.
- * Used to substitute `{{var_name}}` placeholders in custom block templates.
- */
-export interface HomeTabTemplateVars {
-  agent_name: string;
-  version: string;
-  model: string;
-  uptime: string;
-  channels: string;
-  slash_command: string;
-}
-
-/**
- * Recursively substitute `{{var_name}}` template variables in Block Kit JSON.
- * @internal Exported for testing only.
- */
-export function substituteTemplateVars(obj: unknown, vars: HomeTabTemplateVars): unknown {
-  if (typeof obj === "string") {
-    return obj.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
-      const val = vars[key as keyof HomeTabTemplateVars];
-      return val !== undefined ? val : match;
-    });
-  }
-  if (Array.isArray(obj)) {
-    return obj.map((item) => substituteTemplateVars(item, vars));
-  }
-  if (obj !== null && typeof obj === "object") {
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-      result[key] = substituteTemplateVars(value, vars);
-    }
-    return result;
-  }
-  return obj;
-}
-
-/**
- * Resolve template variables from the current config/runtime state.
- * @internal Exported for testing only.
- */
-export function resolveTemplateVars(params: {
-  cfg?: OpenClawConfig;
-  slashCommand?: string;
-  uptimeMs?: number;
-}): HomeTabTemplateVars {
-  const cfg = params.cfg;
-  const agents = cfg?.agents?.list ?? [];
-  const defaultAgent = agents.find((a) => a.default) ?? agents[0];
-  const agentName = defaultAgent?.name ?? cfg?.ui?.assistant?.name ?? "OpenClaw";
-  const model = resolveAgentModelDisplay(defaultAgent, cfg ?? {});
-  const uptimeMs = params.uptimeMs ?? Date.now() - GATEWAY_START_MS;
-  const cmd = params.slashCommand ?? "/openclaw";
-
-  const slackCfg = cfg?.channels?.slack;
-  const channelIds: string[] = [];
-  if (slackCfg) {
-    if (slackCfg.channels) {
-      channelIds.push(...Object.keys(slackCfg.channels));
-    }
-    if (slackCfg.accounts) {
-      for (const account of Object.values(slackCfg.accounts)) {
-        if (account?.channels) {
-          channelIds.push(...Object.keys(account.channels));
-        }
-      }
-    }
-  }
-
-  return {
-    agent_name: agentName,
-    version: VERSION,
-    model,
-    uptime: formatUptime(uptimeMs),
-    channels:
-      channelIds.length > 0 ? channelIds.map((id) => `<#${id}>`).join(", ") : "None configured",
-    slash_command: cmd,
-  };
-}
-
-/** @internal Exported for testing only. */
 export function buildHomeTabBlocks(params: {
   botUserId: string;
   slashCommand?: string;
   cfg?: OpenClawConfig;
   uptimeMs?: number;
-  homeTabConfig?: SlackHomeTabConfig;
 }): Record<string, unknown>[] {
   const cmd = params.slashCommand ?? "/openclaw";
   const cfg = params.cfg;
-
-  // If custom blocks are configured, substitute template variables and return.
-  if (params.homeTabConfig?.blocks && params.homeTabConfig.blocks.length > 0) {
-    const vars = resolveTemplateVars({
-      cfg,
-      slashCommand: cmd,
-      uptimeMs: params.uptimeMs,
-    });
-    return substituteTemplateVars(params.homeTabConfig.blocks, vars) as Record<string, unknown>[];
-  }
-
   const blocks: Record<string, unknown>[] = [];
 
   // --- Header: Agent name & status ---
@@ -300,7 +206,6 @@ export function registerSlackHomeTabEvents(params: { ctx: SlackMonitorContext })
           botUserId: ctx.botUserId,
           slashCommand: ctx.slashCommand.name ? `/${ctx.slashCommand.name}` : undefined,
           cfg: ctx.cfg,
-          homeTabConfig,
         });
 
         await ctx.app.client.views.publish({

--- a/src/slack/monitor/events/home.ts
+++ b/src/slack/monitor/events/home.ts
@@ -1,58 +1,158 @@
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
+import type { AgentConfig } from "../../../config/types.agents.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SlackMonitorContext } from "../context.js";
 import { danger, logVerbose } from "../../../globals.js";
 import { VERSION } from "../../../version.js";
 import { hasCurrentHomeTab, hasCustomHomeTab, markHomeTabPublished } from "../../home-tab-state.js";
 
+/** Gateway process start time — used for uptime display. */
+const GATEWAY_START_MS = Date.now();
+
+/**
+ * Format a millisecond duration as a human-readable uptime string.
+ * @internal Exported for testing only.
+ */
+export function formatUptime(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
+/**
+ * Resolve the primary model string for an agent, falling back to the
+ * agents.defaults or top-level model config.
+ * @internal Exported for testing only.
+ */
+export function resolveAgentModelDisplay(
+  agent: AgentConfig | undefined,
+  cfg: OpenClawConfig,
+): string {
+  // Per-agent model
+  const agentModel = agent?.model;
+  if (agentModel) {
+    return typeof agentModel === "string" ? agentModel : (agentModel.primary ?? "—");
+  }
+  // Agent defaults model (always AgentModelListConfig, not a plain string)
+  const defaultsModel = cfg.agents?.defaults?.model;
+  if (defaultsModel?.primary) {
+    return defaultsModel.primary;
+  }
+  return "—";
+}
+
 /** @internal Exported for testing only. */
 export function buildHomeTabBlocks(params: {
   botUserId: string;
   slashCommand?: string;
+  cfg?: OpenClawConfig;
+  uptimeMs?: number;
 }): Record<string, unknown>[] {
   const cmd = params.slashCommand ?? "/openclaw";
-  return [
-    {
-      type: "header",
-      text: { type: "plain_text", text: "OpenClaw", emoji: true },
-    },
-    {
-      type: "section",
-      fields: [
-        { type: "mrkdwn", text: `*Version:*\n\`${VERSION}\`` },
-        { type: "mrkdwn", text: `*Bot:*\n<@${params.botUserId}>` },
-      ],
-    },
-    { type: "divider" },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Getting Started*\nSend me a DM or mention me in a channel to start a conversation.",
-      },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: [
-          "*Slash Commands*",
-          `• \`${cmd}\` — Main command`,
-          `• \`${cmd} status\` — Check status`,
-          `• \`${cmd} help\` — Show help`,
-        ].join("\n"),
-      },
-    },
-    { type: "divider" },
-    {
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: "<https://docs.openclaw.ai|Docs> · <https://github.com/openclaw/openclaw|GitHub> · <https://discord.com/invite/clawd|Community>",
-        },
-      ],
-    },
+  const cfg = params.cfg;
+  const blocks: Record<string, unknown>[] = [];
+
+  // --- Header: Agent name & status ---
+  const agents = cfg?.agents?.list ?? [];
+  const defaultAgent = agents.find((a) => a.default) ?? agents[0];
+  const agentName = defaultAgent?.name ?? cfg?.ui?.assistant?.name ?? "OpenClaw";
+
+  blocks.push({
+    type: "header",
+    text: { type: "plain_text", text: agentName, emoji: true },
+  });
+
+  // --- Agent status + version ---
+  const model = resolveAgentModelDisplay(defaultAgent, cfg ?? {});
+  const statusFields: Record<string, unknown>[] = [
+    { type: "mrkdwn", text: `*Status:*\n:large_green_circle: Online` },
+    { type: "mrkdwn", text: `*Version:*\n\`${VERSION}\`` },
   ];
+
+  blocks.push({ type: "section", fields: statusFields });
+
+  // --- Model + Uptime ---
+  const infoFields: Record<string, unknown>[] = [
+    { type: "mrkdwn", text: `*Model:*\n\`${model}\`` },
+  ];
+
+  const uptimeMs = params.uptimeMs ?? Date.now() - GATEWAY_START_MS;
+  infoFields.push({ type: "mrkdwn", text: `*Uptime:*\n${formatUptime(uptimeMs)}` });
+
+  blocks.push({ type: "section", fields: infoFields });
+
+  // --- Configured channels ---
+  const slackCfg = cfg?.channels?.slack;
+  const channelIds: string[] = [];
+  if (slackCfg) {
+    // Top-level channels (single-account or default account)
+    if (slackCfg.channels) {
+      channelIds.push(...Object.keys(slackCfg.channels));
+    }
+    // Multi-account channels
+    if (slackCfg.accounts) {
+      for (const account of Object.values(slackCfg.accounts)) {
+        if (account?.channels) {
+          channelIds.push(...Object.keys(account.channels));
+        }
+      }
+    }
+  }
+
+  if (channelIds.length > 0) {
+    const channelList = channelIds.map((id) => `<#${id}>`).join(", ");
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*Channels:*\n${channelList}` },
+    });
+  }
+
+  blocks.push({ type: "divider" });
+
+  // --- Quick start ---
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Getting Started*\nSend me a DM or mention me in a channel to start a conversation.",
+    },
+  });
+
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: [
+        "*Slash Commands*",
+        `• \`${cmd}\` — Main command`,
+        `• \`${cmd} status\` — Check status`,
+        `• \`${cmd} help\` — Show help`,
+      ].join("\n"),
+    },
+  });
+
+  blocks.push({ type: "divider" });
+
+  // --- Footer: links ---
+  const footerParts = [
+    "<https://docs.openclaw.ai|Docs>",
+    "<https://github.com/openclaw/openclaw|GitHub>",
+    "<https://discord.com/invite/clawd|Community>",
+  ];
+
+  blocks.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: footerParts.join(" · ") }],
+  });
+
+  return blocks;
 }
 
 export function registerSlackHomeTabEvents(params: { ctx: SlackMonitorContext }) {
@@ -93,6 +193,7 @@ export function registerSlackHomeTabEvents(params: { ctx: SlackMonitorContext })
         const blocks = buildHomeTabBlocks({
           botUserId: ctx.botUserId,
           slashCommand: ctx.slashCommand.name ? `/${ctx.slashCommand.name}` : undefined,
+          cfg: ctx.cfg,
         });
 
         await ctx.app.client.views.publish({

--- a/src/slack/monitor/events/home.ts
+++ b/src/slack/monitor/events/home.ts
@@ -20,8 +20,12 @@ export function formatUptime(ms: number): string {
   const minutes = Math.floor((seconds % 3600) / 60);
 
   const parts: string[] = [];
-  if (days > 0) parts.push(`${days}d`);
-  if (hours > 0) parts.push(`${hours}h`);
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
   parts.push(`${minutes}m`);
   return parts.join(" ");
 }
@@ -201,7 +205,8 @@ export function registerSlackHomeTabEvents(params: { ctx: SlackMonitorContext })
           user_id: userId,
           view: {
             type: "home",
-            blocks,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Block Kit JSON built dynamically
+            blocks: blocks as any,
           },
         });
 

--- a/src/slack/monitor/events/home.ts
+++ b/src/slack/monitor/events/home.ts
@@ -1,0 +1,113 @@
+import type { SlackEventMiddlewareArgs } from "@slack/bolt";
+import type { SlackMonitorContext } from "../context.js";
+import { danger, logVerbose } from "../../../globals.js";
+import { VERSION } from "../../../version.js";
+
+/** @internal Exported for testing only. */
+export function buildHomeTabBlocks(params: {
+  botUserId: string;
+  slashCommand?: string;
+}): Record<string, unknown>[] {
+  const cmd = params.slashCommand ?? "/openclaw";
+  return [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "OpenClaw", emoji: true },
+    },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*Version:*\n\`${VERSION}\`` },
+        { type: "mrkdwn", text: `*Bot:*\n<@${params.botUserId}>` },
+      ],
+    },
+    { type: "divider" },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Getting Started*\nSend me a DM or mention me in a channel to start a conversation.",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: [
+          "*Slash Commands*",
+          `• \`${cmd}\` — Main command`,
+          `• \`${cmd} status\` — Check status`,
+          `• \`${cmd} help\` — Show help`,
+        ].join("\n"),
+      },
+    },
+    { type: "divider" },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "<https://docs.openclaw.ai|Docs> · <https://github.com/openclaw/openclaw|GitHub> · <https://discord.com/invite/clawd|Community>",
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Simple per-user publish cache to avoid redundant views.publish calls
+ * when the view hasn't changed. Keyed by userId, value is the VERSION
+ * string at publish time. Cleared on process restart (which is fine —
+ * a fresh publish after restart is desirable).
+ */
+const publishedVersionByUser = new Map<string, string>();
+
+export function registerSlackHomeTabEvents(params: { ctx: SlackMonitorContext }) {
+  const { ctx } = params;
+
+  ctx.app.event(
+    "app_home_opened",
+    async ({ event, body }: SlackEventMiddlewareArgs<"app_home_opened">) => {
+      try {
+        if (ctx.shouldDropMismatchedSlackEvent(body)) {
+          return;
+        }
+
+        // Only handle the "home" tab (not "messages")
+        if (event.tab !== "home") {
+          return;
+        }
+
+        if (!ctx.botUserId) {
+          logVerbose("slack: skipping home tab publish — botUserId not available");
+          return;
+        }
+
+        // Skip re-publish if this user already has the current version rendered
+        const userId = event.user;
+        if (publishedVersionByUser.get(userId) === VERSION) {
+          logVerbose(`slack: home tab already published for ${userId}, skipping`);
+          return;
+        }
+
+        const blocks = buildHomeTabBlocks({
+          botUserId: ctx.botUserId,
+          slashCommand: ctx.slashCommand.name ? `/${ctx.slashCommand.name}` : undefined,
+        });
+
+        await ctx.app.client.views.publish({
+          token: ctx.botToken,
+          user_id: userId,
+          view: {
+            type: "home",
+            blocks,
+          },
+        });
+
+        publishedVersionByUser.set(userId, VERSION);
+      } catch (err) {
+        ctx.runtime.error?.(danger(`slack app_home_opened handler failed: ${String(err)}`));
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Adds Slack Home Tab (App Home) support. When a user opens the app's Home tab, a Block Kit view is published showing:

- **Agent info** — version and bot identity
- **Getting started** — how to interact (DM or mention)
- **Slash commands** — quick reference
- **Links** — docs, GitHub, community

## Implementation
- New event handler: `src/slack/monitor/events/home.ts`
  - Registers `app_home_opened` event
  - Publishes Block Kit view via `views.publish()`
  - Only handles the `home` tab (ignores `messages` tab)
- Wired into `registerSlackMonitorEvents()`
- Unit tests for `buildHomeTabBlocks()`

## Notes
- No new scopes needed — manifest already declares `app_home.messages_tab_enabled`
- No config changes required — works out of the box
- The view is intentionally simple for now; can be extended with dynamic status, uptime, session info, etc.

Closes #11655

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Slack “App Home” support by registering an `app_home_opened` event handler and publishing a static Block Kit Home view containing agent/version info, basic usage instructions, slash command references, and a links footer. It wires the new handler into the existing Slack monitor event registration, and adds unit tests covering `buildHomeTabBlocks()` output shape/content.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but there is one correctness edge case worth addressing in the Home tab publish handler.
- The change set is small and isolated (new Slack event handler + wiring + unit tests). The main concern is publishing a malformed Home view if `ctx.botUserId` is unexpectedly empty, since the handler does not validate it before rendering `<@...>` and calling `views.publish`.
- src/slack/monitor/events/home.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->