### PR TITLE
fix: quote description values in SKILL.md frontmatter to prevent YAML misparse

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discord
-description: Use when you need to control Discord from OpenClaw via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, set bot presence/activity, or handle moderation actions in Discord DMs or channels.
+description: "Use when you need to control Discord from OpenClaw via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, set bot presence/activity, or handle moderation actions in Discord DMs or channels."
 metadata: {"openclaw":{"emoji":"🎮","requires":{"config":["channels.discord"]}}}
 ---
 

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: discord
 description: "Use when you need to control Discord from OpenClaw via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, set bot presence/activity, or handle moderation actions in Discord DMs or channels."
-metadata: {"openclaw":{"emoji":"🎮","requires":{"config":["channels.discord"]}}}
+metadata: { "openclaw": { "emoji": "🎮", "requires": { "config": ["channels.discord"] } } }
 ---
 
 # Discord Actions

--- a/skills/food-order/SKILL.md
+++ b/skills/food-order/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: food-order
-description: Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA.
+description: "Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA."
 homepage: https://ordercli.sh
 metadata: {"openclaw":{"emoji":"🥡","requires":{"bins":["ordercli"]},"install":[{"id":"go","kind":"go","module":"github.com/steipete/ordercli/cmd/ordercli@latest","bins":["ordercli"],"label":"Install ordercli (go)"}]}}
 ---

--- a/skills/food-order/SKILL.md
+++ b/skills/food-order/SKILL.md
@@ -2,7 +2,24 @@
 name: food-order
 description: "Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA."
 homepage: https://ordercli.sh
-metadata: {"openclaw":{"emoji":"🥡","requires":{"bins":["ordercli"]},"install":[{"id":"go","kind":"go","module":"github.com/steipete/ordercli/cmd/ordercli@latest","bins":["ordercli"],"label":"Install ordercli (go)"}]}}
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🥡",
+        "requires": { "bins": ["ordercli"] },
+        "install":
+          [
+            {
+              "id": "go",
+              "kind": "go",
+              "module": "github.com/steipete/ordercli/cmd/ordercli@latest",
+              "bins": ["ordercli"],
+              "label": "Install ordercli (go)",
+            },
+          ],
+      },
+  }
 ---
 
 # Food order (Foodora via ordercli)


### PR DESCRIPTION
## Problem

The \description\ fields in \skills/discord/SKILL.md\ and \skills/food-order/SKILL.md\ contain colon-space patterns (\	ool: ...\ and \Triggers: ...\) that the YAML parser interprets as separate mapping keys, silently truncating the description value.

## Fix

Wrap the description values in double quotes so the YAML parser treats each as a single scalar string. This is consistent with other skills that already quote their descriptions (e.g. \skills/github/SKILL.md\).

## Changes

- \skills/discord/SKILL.md\: quoted \description\ value
- \skills/food-order/SKILL.md\: quoted \description\ value

Co-Authored-By: Warp <agent@warp.dev>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the YAML frontmatter in two skill docs (`skills/discord/SKILL.md` and `skills/food-order/SKILL.md`) by wrapping the `description` value in double quotes. This prevents YAML from interpreting colon-space sequences inside the description text as new mapping keys, which can otherwise truncate the parsed description silently.

The rest of each skill document (frontmatter keys like `metadata`/`homepage` and the markdown content) is unchanged, so the fix is narrowly scoped to frontmatter parsing behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff is narrowly scoped to quoting two YAML frontmatter string values. The new values contain no embedded double quotes and preserve existing content, so the change should only affect YAML parsing correctness without altering other behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->