### PR TITLE
feat(ui): add Delete Session button to /chat page

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -372,6 +372,12 @@
   border-color: rgba(255, 255, 255, 0.2);
 }
 
+.btn--danger-icon:not(:disabled):hover {
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.1);
+}
+
 /* Light theme icon button overrides */
 :root[data-theme="light"] .btn--icon {
   background: #ffffff;
@@ -384,6 +390,12 @@
   background: #ffffff;
   border-color: var(--border-strong);
   color: var(--text);
+}
+
+:root[data-theme="light"] .btn--danger-icon:not(:disabled):hover {
+  color: #dc2626;
+  border-color: rgba(220, 38, 38, 0.4);
+  background: rgba(220, 38, 38, 0.08);
 }
 
 .btn--icon svg {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -51,7 +51,8 @@ export function renderChatControls(state: AppViewState) {
   const disableFocusToggle = state.onboarding;
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
   const focusActive = state.onboarding ? true : state.settings.chatFocusMode;
-  const isMainSession = mainSessionKey != null && state.sessionKey === mainSessionKey;
+  const isMainSession =
+    state.sessionKey === "main" || (mainSessionKey != null && state.sessionKey === mainSessionKey);
   // Refresh icon
   const refreshIcon = html`
     <svg
@@ -170,13 +171,14 @@ export function renderChatControls(state: AppViewState) {
         class="btn btn--sm btn--icon btn--danger-icon"
         ?disabled=${!state.connected || isMainSession || state.chatLoading}
         @click=${async () => {
+          if (!state.client) return;
           const key = state.sessionKey;
           const confirmed = window.confirm(
             `Delete session "${key}"?\n\nThis will delete the session and archive its transcript.`,
           );
           if (!confirmed) return;
           try {
-            await state.client!.request("sessions.delete", { key, deleteTranscript: true });
+            await state.client.request("sessions.delete", { key, deleteTranscript: true });
             const fallback = mainSessionKey || "main";
             state.sessionKey = fallback;
             state.chatMessage = "";

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -8,6 +8,7 @@ import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import { OpenClawApp } from "./app.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
+import { loadSessions, type SessionsState } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 
@@ -50,6 +51,7 @@ export function renderChatControls(state: AppViewState) {
   const disableFocusToggle = state.onboarding;
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
   const focusActive = state.onboarding ? true : state.settings.chatFocusMode;
+  const isMainSession = mainSessionKey != null && state.sessionKey === mainSessionKey;
   // Refresh icon
   const refreshIcon = html`
     <svg
@@ -82,6 +84,22 @@ export function renderChatControls(state: AppViewState) {
       <path d="M4 17v3h3"></path>
       <path d="M20 17v3h-3"></path>
       <circle cx="12" cy="12" r="3"></circle>
+    </svg>
+  `;
+  const trashIcon = html`
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M3 6h18"></path>
+      <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path>
+      <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
     </svg>
   `;
   return html`
@@ -147,6 +165,46 @@ export function renderChatControls(state: AppViewState) {
         title="Refresh chat data"
       >
         ${refreshIcon}
+      </button>
+      <button
+        class="btn btn--sm btn--icon btn--danger-icon"
+        ?disabled=${!state.connected || isMainSession || state.chatLoading}
+        @click=${async () => {
+          const key = state.sessionKey;
+          const confirmed = window.confirm(
+            `Delete session "${key}"?\n\nThis will delete the session and archive its transcript.`,
+          );
+          if (!confirmed) return;
+          try {
+            await state.client!.request("sessions.delete", { key, deleteTranscript: true });
+            const fallback = mainSessionKey || "main";
+            state.sessionKey = fallback;
+            state.chatMessage = "";
+            state.chatStream = null;
+            (state as unknown as OpenClawApp).chatStreamStartedAt = null;
+            state.chatRunId = null;
+            (state as unknown as OpenClawApp).resetToolStream();
+            (state as unknown as OpenClawApp).resetChatScroll();
+            state.applySettings({
+              ...state.settings,
+              sessionKey: fallback,
+              lastActiveSessionKey: fallback,
+            });
+            void state.loadAssistantIdentity();
+            syncUrlWithSessionKey(
+              state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
+              fallback,
+              true,
+            );
+            void loadChatHistory(state as unknown as ChatState);
+            void loadSessions(state as unknown as SessionsState);
+          } catch (err) {
+            state.lastError = `Failed to delete session: ${String(err)}`;
+          }
+        }}
+        title=${isMainSession ? "Cannot delete the main session" : "Delete current session"}
+      >
+        ${trashIcon}
       </button>
       <span class="chat-controls__separator">|</span>
       <button


### PR DESCRIPTION
## Summary
Adds a Delete Session button to the `/chat` page, allowing users to delete sessions directly from the chat view without navigating to `/sessions`.

## Changes
- Add trash icon button to chat controls (right side, next to refresh)
- Disabled for main session (cannot be deleted)
- Shows confirmation dialog before deletion
- Falls back to main session after deletion
- Adds `btn--danger-icon` hover style (red tint)
- Supports both dark and light themes

## Screenshots
The button appears in the chat controls bar, grayed out for main session, with a red hover state for deletable sessions.

## Testing
- [x] Build passes (`pnpm build` in `ui/`)
- [x] Manual testing: button appears, confirmation works, session deletes correctly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new trash-icon button to the `/chat` page controls that deletes the currently-selected session (with a confirmation prompt), then switches the UI back to the main session and refreshes chat + sessions. It also introduces `btn--danger-icon` hover styling for a red “danger” affordance in both dark and light themes.

The main integration point is `renderChatControls` in `ui/src/ui/app-render.helpers.ts`, which wires the new button into the existing chat header control bar and uses the gateway RPC `sessions.delete` plus state resets similar to the existing session-switch logic. Styling changes live in `ui/src/styles/chat/layout.css` alongside other chat control button styles.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of edge cases that can break the intended “cannot delete main session” guarantee and can crash the click handler under certain state combinations.
- The feature is localized and follows existing UI patterns, but the main-session guard depends on `mainSessionKey` being resolved, and the delete action uses a non-null assertion on `state.client` while the button enablement only checks `connected`. Both are user-facing and should be fixed before merging.
- ui/src/ui/app-render.helpers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->