### PR TITLE
fix(doctor): suppress repeated legacy state migration warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Memory/QMD: run boot refresh in background by default, add configurable QMD maintenance timeouts, and retry QMD after fallback failures. (#9690, #9705)
 - Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.
 - State dir: honor `OPENCLAW_STATE_DIR` for default device identity and canvas storage paths. (#4824) Thanks @kossoy.
+- Doctor/State dir: suppress repeated legacy migration warnings only for valid symlink mirrors, while keeping warnings for empty or invalid legacy trees. (#11709) Thanks @gumadeiras.
 - Tests: harden flaky hotspots by removing timer sleeps, consolidating onboarding provider-auth coverage, and improving memory test realism. (#11598) Thanks @gumadeiras.
 
 ## 2026.2.6

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -374,6 +374,24 @@ describe("doctor legacy state migrations", () => {
     expect(result.warnings).toEqual([]);
   });
 
+  it("warns when legacy state dir is empty and target already exists", async () => {
+    const root = await makeTempRoot();
+    const targetDir = path.join(root, ".openclaw");
+    const legacyDir = path.join(root, ".moltbot");
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.mkdirSync(legacyDir, { recursive: true });
+
+    const result = await autoMigrateLegacyStateDir({
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => root,
+    });
+
+    expect(result.migrated).toBe(false);
+    expect(result.warnings).toEqual([
+      `State dir migration skipped: target already exists (${targetDir}). Remove or merge manually.`,
+    ]);
+  });
+
   it("warns when legacy state dir contains non-symlink entries and target already exists", async () => {
     const root = await makeTempRoot();
     const targetDir = path.join(root, ".openclaw");

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -352,4 +352,91 @@ describe("doctor legacy state migrations", () => {
     expect(result.skipped).toBe(true);
     expect(result.migrated).toBe(false);
   });
+
+  it("does not warn when legacy state dir is an already-migrated symlink mirror", async () => {
+    const root = await makeTempRoot();
+    const targetDir = path.join(root, ".openclaw");
+    const legacyDir = path.join(root, ".moltbot");
+    fs.mkdirSync(path.join(targetDir, "sessions"), { recursive: true });
+    fs.mkdirSync(path.join(targetDir, "agent"), { recursive: true });
+    fs.mkdirSync(legacyDir, { recursive: true });
+
+    const dirLinkType = process.platform === "win32" ? "junction" : "dir";
+    fs.symlinkSync(path.join(targetDir, "sessions"), path.join(legacyDir, "sessions"), dirLinkType);
+    fs.symlinkSync(path.join(targetDir, "agent"), path.join(legacyDir, "agent"), dirLinkType);
+
+    const result = await autoMigrateLegacyStateDir({
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => root,
+    });
+
+    expect(result.migrated).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns when legacy state dir contains non-symlink entries and target already exists", async () => {
+    const root = await makeTempRoot();
+    const targetDir = path.join(root, ".openclaw");
+    const legacyDir = path.join(root, ".moltbot");
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, "sessions.json"), "{}", "utf-8");
+
+    const result = await autoMigrateLegacyStateDir({
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => root,
+    });
+
+    expect(result.migrated).toBe(false);
+    expect(result.warnings).toEqual([
+      `State dir migration skipped: target already exists (${targetDir}). Remove or merge manually.`,
+    ]);
+  });
+
+  it("does not warn when legacy state dir contains nested symlink mirrors", async () => {
+    const root = await makeTempRoot();
+    const targetDir = path.join(root, ".openclaw");
+    const legacyDir = path.join(root, ".moltbot");
+    fs.mkdirSync(path.join(targetDir, "agents", "main"), { recursive: true });
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.mkdirSync(path.join(legacyDir, "agents"), { recursive: true });
+
+    const dirLinkType = process.platform === "win32" ? "junction" : "dir";
+    fs.symlinkSync(
+      path.join(targetDir, "agents", "main"),
+      path.join(legacyDir, "agents", "main"),
+      dirLinkType,
+    );
+
+    const result = await autoMigrateLegacyStateDir({
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => root,
+    });
+
+    expect(result.migrated).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns when legacy state dir symlink points outside the target tree", async () => {
+    const root = await makeTempRoot();
+    const targetDir = path.join(root, ".openclaw");
+    const legacyDir = path.join(root, ".moltbot");
+    const outsideDir = path.join(root, ".outside-state");
+    fs.mkdirSync(path.join(targetDir, "sessions"), { recursive: true });
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+
+    const dirLinkType = process.platform === "win32" ? "junction" : "dir";
+    fs.symlinkSync(path.join(outsideDir), path.join(legacyDir, "sessions"), dirLinkType);
+
+    const result = await autoMigrateLegacyStateDir({
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => root,
+    });
+
+    expect(result.migrated).toBe(false);
+    expect(result.warnings).toEqual([
+      `State dir migration skipped: target already exists (${targetDir}). Remove or merge manually.`,
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- suppress repeated `State dir migration skipped: target already exists` warnings when the legacy state directory is already a symlink mirror of the new `~/.openclaw` tree
- keep the warning for real conflicts (non-symlink legacy entries or symlinks escaping the target tree)
- harden mirror detection to fail closed on filesystem/readlink errors and support nested mirrored layouts

## Testing
- `pnpm test src/commands/doctor-state-migrations.test.ts`
- `pnpm check`

## Notes
- this addresses repeated warning noise seen on `openclaw update` and `openclaw doctor` after successful one-time migration

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds logic to detect when a legacy state directory is already a symlink “mirror” of the new `~/.openclaw` tree and, in that case, suppresses the repeated `State dir migration skipped: target already exists` warning. It also extends the doctor migration tests to cover mirrored layouts (including nested mirrors) and to keep warnings for real conflicts such as non-symlink entries or symlinks that escape the target tree.

The changes are localized to the state-dir auto-migration path in `src/infra/state-migrations.ts` and its unit tests in `src/commands/doctor-state-migrations.test.ts`.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but the mirror detection currently suppresses warnings for an empty legacy directory, which changes user-visible behavior incorrectly.
- Core approach (fail-closed on FS errors, reject escaping symlinks, support nested layouts) is sound and tests cover several key scenarios. However, `isLegacyTreeSymlinkMirror()` returning true on an empty directory will definitely silence the `target already exists` warning for a non-mirrored legacy dir, which is a regression in the doctor output and could hide a manual migration requirement.
- src/infra/state-migrations.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->