### PR TITLE
feat(webui): add terminal-style input history navigation

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1046,6 +1046,11 @@ export function renderApp(state: AppViewState) {
                 onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
                 assistantName: state.assistantName,
                 assistantAvatar: state.assistantAvatar,
+                // Input history (terminal-style)
+                inputHistory: state.chatInputHistory,
+                inputHistoryIndex: state.chatInputHistoryIndex,
+                onHistoryNavigate: (direction: "up" | "down") =>
+                  state.handleInputHistoryNavigate(direction),
               })
             : nothing
         }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -66,6 +66,8 @@ export type AppViewState = {
   chatMessage: string;
   chatAttachments: ChatAttachment[];
   chatMessages: unknown[];
+  chatInputHistory: string[];
+  chatInputHistoryIndex: number;
   chatToolMessages: unknown[];
   chatStream: string | null;
   chatStreamStartedAt: number | null;
@@ -313,6 +315,7 @@ export type AppViewState = {
   setChatMessage: (next: string) => void;
   handleSendChat: (messageOverride?: string, opts?: { restoreDraft?: boolean }) => Promise<void>;
   handleAbortChat: () => Promise<void>;
+  handleInputHistoryNavigate: (direction: "up" | "down") => void;
   removeQueuedMessage: (id: string) => void;
   handleChatScroll: (event: Event) => void;
   resetToolStream: () => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -491,10 +491,11 @@ export class OpenClawApp extends LitElement {
     messageOverride?: string,
     opts?: Parameters<typeof handleSendChatInternal>[2],
   ) {
-    // Add to input history before sending (includes slash commands)
+    // Add to input history before sending (excluding slash commands)
     const messageToSend = messageOverride ?? this.chatMessage;
-    if (messageToSend.trim()) {
-      this.addToInputHistory(messageToSend.trim());
+    const trimmedMessage = messageToSend.trim();
+    if (trimmedMessage && !trimmedMessage.startsWith("/")) {
+      this.addToInputHistory(trimmedMessage);
     }
     this.chatInputHistoryIndex = -1;
 

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -491,10 +491,10 @@ export class OpenClawApp extends LitElement {
     messageOverride?: string,
     opts?: Parameters<typeof handleSendChatInternal>[2],
   ) {
-    // Add to input history before sending (excluding slash commands)
+    // Add to input history before sending (including slash commands - they're often repeated)
     const messageToSend = messageOverride ?? this.chatMessage;
     const trimmedMessage = messageToSend.trim();
-    if (trimmedMessage && !trimmedMessage.startsWith("/")) {
+    if (trimmedMessage) {
       this.addToInputHistory(trimmedMessage);
     }
     this.chatInputHistoryIndex = -1;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -530,7 +530,14 @@ export class OpenClawApp extends LitElement {
   private loadInputHistory(): string[] {
     try {
       const stored = localStorage.getItem("openclaw:inputHistory");
-      return stored ? JSON.parse(stored) : [];
+      if (!stored) {
+        return [];
+      }
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.filter((item): item is string => typeof item === "string");
     } catch {
       return [];
     }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -151,6 +151,8 @@ export class OpenClawApp extends LitElement {
   @state() chatThinkingLevel: string | null = null;
   @state() chatQueue: ChatQueueItem[] = [];
   @state() chatAttachments: ChatAttachment[] = [];
+  @state() chatInputHistory: string[] = this.loadInputHistory();
+  @state() chatInputHistoryIndex = -1;
   @state() chatManualRefreshInFlight = false;
   // Sidebar state for tool output viewing
   @state() sidebarOpen = false;
@@ -489,11 +491,65 @@ export class OpenClawApp extends LitElement {
     messageOverride?: string,
     opts?: Parameters<typeof handleSendChatInternal>[2],
   ) {
+    // Add to input history before sending (includes slash commands)
+    const messageToSend = messageOverride ?? this.chatMessage;
+    if (messageToSend.trim()) {
+      this.addToInputHistory(messageToSend.trim());
+    }
+    this.chatInputHistoryIndex = -1;
+
     await handleSendChatInternal(
       this as unknown as Parameters<typeof handleSendChatInternal>[0],
       messageOverride,
       opts,
     );
+  }
+
+  handleInputHistoryNavigate(direction: "up" | "down") {
+    const history = this.chatInputHistory;
+    if (history.length === 0) {
+      return;
+    }
+
+    if (direction === "up") {
+      if (this.chatInputHistoryIndex < history.length - 1) {
+        this.chatInputHistoryIndex++;
+        this.chatMessage = history[history.length - 1 - this.chatInputHistoryIndex];
+      }
+    } else {
+      if (this.chatInputHistoryIndex > 0) {
+        this.chatInputHistoryIndex--;
+        this.chatMessage = history[history.length - 1 - this.chatInputHistoryIndex];
+      } else if (this.chatInputHistoryIndex === 0) {
+        this.chatInputHistoryIndex = -1;
+        this.chatMessage = "";
+      }
+    }
+  }
+
+  private loadInputHistory(): string[] {
+    try {
+      const stored = localStorage.getItem("openclaw:inputHistory");
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private addToInputHistory(message: string) {
+    // Don't add duplicates of the last entry
+    if (
+      this.chatInputHistory.length > 0 &&
+      this.chatInputHistory[this.chatInputHistory.length - 1] === message
+    ) {
+      return;
+    }
+    this.chatInputHistory = [...this.chatInputHistory, message].slice(-100);
+    try {
+      localStorage.setItem("openclaw:inputHistory", JSON.stringify(this.chatInputHistory));
+    } catch {
+      // Ignore storage errors
+    }
   }
 
   async handleWhatsAppStart(force: boolean) {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -153,6 +153,7 @@ export class OpenClawApp extends LitElement {
   @state() chatAttachments: ChatAttachment[] = [];
   @state() chatInputHistory: string[] = this.loadInputHistory();
   @state() chatInputHistoryIndex = -1;
+  chatInputDraft: string | null = null;
   @state() chatManualRefreshInFlight = false;
   // Sidebar state for tool output viewing
   @state() sidebarOpen = false;
@@ -514,6 +515,9 @@ export class OpenClawApp extends LitElement {
 
     if (direction === "up") {
       if (this.chatInputHistoryIndex < history.length - 1) {
+        if (this.chatInputHistoryIndex === -1) {
+          this.chatInputDraft = this.chatMessage;
+        }
         this.chatInputHistoryIndex++;
         this.chatMessage = history[history.length - 1 - this.chatInputHistoryIndex];
       }
@@ -523,7 +527,8 @@ export class OpenClawApp extends LitElement {
         this.chatMessage = history[history.length - 1 - this.chatInputHistoryIndex];
       } else if (this.chatInputHistoryIndex === 0) {
         this.chatInputHistoryIndex = -1;
-        this.chatMessage = "";
+        this.chatMessage = this.chatInputDraft ?? "";
+        this.chatInputDraft = null;
       }
     }
   }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -80,6 +80,10 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  // Input history (terminal-style)
+  inputHistory?: string[];
+  inputHistoryIndex?: number;
+  onHistoryNavigate?: (direction: "up" | "down") => void;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
@@ -431,6 +435,28 @@ export function renderChat(props: ChatProps) {
               dir=${detectTextDirection(props.draft)}
               ?disabled=${!props.connected}
               @keydown=${(e: KeyboardEvent) => {
+                // Handle input history navigation (terminal-style)
+                if (e.key === "ArrowUp" && !e.shiftKey && props.onHistoryNavigate) {
+                  const textarea = e.target as HTMLTextAreaElement;
+                  const cursorAtStart =
+                    textarea.selectionStart === 0 && textarea.selectionEnd === 0;
+                  const isSingleLine = !props.draft.includes("\n");
+                  if (cursorAtStart || isSingleLine) {
+                    e.preventDefault();
+                    props.onHistoryNavigate("up");
+                    return;
+                  }
+                }
+                if (e.key === "ArrowDown" && !e.shiftKey && props.onHistoryNavigate) {
+                  const textarea = e.target as HTMLTextAreaElement;
+                  const cursorAtEnd = textarea.selectionStart === props.draft.length;
+                  const isSingleLine = !props.draft.includes("\n");
+                  if (cursorAtEnd || isSingleLine) {
+                    e.preventDefault();
+                    props.onHistoryNavigate("down");
+                    return;
+                  }
+                }
                 if (e.key !== "Enter") {
                   return;
                 }


### PR DESCRIPTION
## Summary
Press ArrowUp/ArrowDown in the chat input to cycle through previously sent messages, like a terminal.

## Changes
- Added history state tracking to app view state
- Modified chat textarea keydown handler for ArrowUp/ArrowDown
- History persisted to localStorage (max 100 entries)
- **Includes slash commands** in history (useful for re-running commands)
- Skips duplicate consecutive entries
- Works on single-line input or when cursor at start/end for multiline

## Testing
1. Send a few messages in the web UI chat
2. Press ↑ to cycle back through history
3. Press ↓ to cycle forward or clear

Tested locally on OpenClaw 2026.2.6.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds terminal-style chat input history navigation in the web UI (ArrowUp/ArrowDown), with history stored in app state and persisted to `localStorage` (bounded to 100 entries and skipping consecutive duplicates). Rendering wires new state (`chatInputHistory`, `chatInputHistoryIndex`) and a navigate handler through `renderApp` into the chat textarea keydown handler so history traversal only triggers on single-line drafts or when the cursor is at the start/end of a multiline draft.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing two user-visible behavior issues in chat input history handling.
- Core changes are localized to chat input handling and state wiring, but there are two definite functional mismatches: slash commands are excluded from history despite the stated requirement, and navigating back to the end of history clears any pre-existing draft text.
- ui/src/ui/app.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->