### PR TITLE
feat(config): opt-in agent contextBudget caps (chars) + /context reporting

### DIFF
--- a/PR_CONTEXT_BUDGET.md
+++ b/PR_CONTEXT_BUDGET.md
@@ -1,0 +1,61 @@
+# PR: Opt-in agent contextBudget caps (chars)
+
+## Summary
+
+Add an **opt-in**, agent-level `agents.defaults.contextBudget` config block to cap the biggest context/token cost drivers:
+
+- bootstrap file injection (`bootstrapMaxChars`)
+- memory search snippet injection (`memoryMaxInjectedChars`)
+- `web_fetch` output size (`webFetchMaxChars`)
+
+Default behavior is unchanged unless `contextBudget.enabled=true`.
+
+## Motivation
+
+OpenClaw already has per-feature caps (`bootstrapMaxChars`, `memory.qmd.limits.maxInjectedChars`, `tools.web.fetch.maxChars`), but deployments often want a single, upstream-friendly switch to keep costs predictable without rewriting workflow/policy.
+
+This adds a small, backwards-compatible "budget override" layer.
+
+## Config
+
+```jsonc
+{
+  "agents": {
+    "defaults": {
+      "contextBudget": {
+        "enabled": true,
+        "bootstrapMaxChars": 8000,
+        "memoryMaxInjectedChars": 2500,
+        "webFetchMaxChars": 8000,
+      },
+    },
+  },
+}
+```
+
+## Behavior
+
+When enabled, the effective caps become:
+
+- bootstrap: `min(agents.defaults.bootstrapMaxChars, contextBudget.bootstrapMaxChars)`
+- memory_search (qmd backend): `min(memory.qmd.limits.maxInjectedChars, contextBudget.memoryMaxInjectedChars)`
+- web_fetch: `min(tools.web.fetch.maxChars, contextBudget.webFetchMaxChars)`
+
+If any `contextBudget.*` value is missing/invalid, it is ignored.
+
+## Tests
+
+- `src/agents/pi-embedded-helpers/bootstrap.context-budget.test.ts`
+- `src/agents/tools/web-fetch.context-budget.test.ts`
+
+Run (example):
+
+```bash
+pnpm vitest run --config vitest.unit.config.ts \
+  src/agents/pi-embedded-helpers/bootstrap.context-budget.test.ts \
+  src/agents/tools/web-fetch.context-budget.test.ts
+```
+
+## Notes / Future work
+
+- Phase 2 can add optional summarization/trimming hooks when a cap is hit, plus `/context` reporting of effective budgets.

--- a/docs/adr/0001-context-budget.md
+++ b/docs/adr/0001-context-budget.md
@@ -1,0 +1,77 @@
+# ADR 0001 — Context Budget (Chars) for Token Cost Control
+
+Status: Proposed
+
+## Context
+
+OpenClaw deployments often want lower token usage without degrading UX.
+The main cost drivers are _context construction_:
+
+- injected workspace files (bootstrap)
+- memory search snippets injected into the prompt
+- large tool outputs (especially `web_fetch`)
+
+Today, OpenClaw offers per-feature limits (e.g. `agents.defaults.bootstrapMaxChars`, `memory.qmd.limits.maxInjectedChars`, `tools.web.fetch.maxChars`), but there is no single, agent-level, opt-in “budget policy” that can:
+
+- be enabled/disabled with a flag
+- override limits consistently across features
+- remain upstream-friendly (small, optional, backwards compatible)
+
+## Decision
+
+Introduce an **opt-in** agent-level config block:
+
+```jsonc
+{
+  "agents": {
+    "defaults": {
+      "contextBudget": {
+        "enabled": false,
+        "bootstrapMaxChars": 8000,
+        "memoryMaxInjectedChars": 2500,
+        "webFetchMaxChars": 8000,
+      },
+    },
+  },
+}
+```
+
+When `enabled=true`, these values act as _global caps_ that override the existing per-feature defaults.
+When `enabled=false` (default), behavior is unchanged.
+
+### Scope (Phase 1)
+
+- **bootstrap injection**: `resolveBootstrapMaxChars()` uses `contextBudget.bootstrapMaxChars` if enabled.
+- **memory injection**: memory tool clamps results using `min(configuredMaxInjectedChars, contextBudget.memoryMaxInjectedChars)` if enabled.
+- **web_fetch output**: `web_fetch` resolves `maxChars` using `min(configuredMaxChars, contextBudget.webFetchMaxChars)` if enabled.
+
+This phase intentionally stays in **chars** (not exact tokens) because:
+
+- it is deterministic and cheap to compute
+- it maps well to existing controls (`maxChars`)
+
+### Non-goals (Phase 1)
+
+- token-precise accounting across full prompt
+- automatic summarization/trimming policies
+- per-session adaptive budgets
+
+Those can be layered later once the budget “hook points” exist.
+
+## Consequences
+
+Pros:
+
+- upstream-friendly: additive + behind a flag
+- consistent caps across the biggest cost drivers
+- easy to reason about and tune
+
+Cons:
+
+- chars are only an approximation of tokens
+- does not by itself guarantee quality (still needs good prompting/usage)
+
+## Follow-ups
+
+- Phase 2: add optional summarization hook(s) for long tool outputs (web/doc) while preserving source metadata.
+- Phase 2: add a `/context budget` report showing effective caps and what was clamped.

--- a/src/agents/context-budget.ts
+++ b/src/agents/context-budget.ts
@@ -15,16 +15,20 @@ export function resolveContextBudget(cfg?: OpenClawConfig): ContextBudget {
   const enabled = typeof raw.enabled === "boolean" ? raw.enabled : false;
 
   const readPosInt = (v: unknown): number | undefined => {
-    if (typeof v !== "number" || !Number.isFinite(v)) return undefined;
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      return undefined;
+    }
     const n = Math.floor(v);
     return n > 0 ? n : undefined;
   };
 
+  const rawObj = raw as Record<string, unknown>;
+
   return {
     enabled,
-    bootstrapMaxChars: readPosInt((raw as any).bootstrapMaxChars),
-    memoryMaxInjectedChars: readPosInt((raw as any).memoryMaxInjectedChars),
-    webFetchMaxChars: readPosInt((raw as any).webFetchMaxChars),
+    bootstrapMaxChars: readPosInt(rawObj.bootstrapMaxChars),
+    memoryMaxInjectedChars: readPosInt(rawObj.memoryMaxInjectedChars),
+    webFetchMaxChars: readPosInt(rawObj.webFetchMaxChars),
   };
 }
 
@@ -33,7 +37,9 @@ export function maybeClampMaxChars(params: {
   budget?: number;
   enabled: boolean;
 }): number {
-  if (!params.enabled) return params.configured;
+  if (!params.enabled) {
+    return params.configured;
+  }
   if (typeof params.budget !== "number" || !Number.isFinite(params.budget) || params.budget <= 0) {
     return params.configured;
   }

--- a/src/agents/context-budget.ts
+++ b/src/agents/context-budget.ts
@@ -1,0 +1,41 @@
+import type { OpenClawConfig } from "../config/config.js";
+
+export type ContextBudget = {
+  enabled: boolean;
+  bootstrapMaxChars?: number;
+  memoryMaxInjectedChars?: number;
+  webFetchMaxChars?: number;
+};
+
+export function resolveContextBudget(cfg?: OpenClawConfig): ContextBudget {
+  const raw = cfg?.agents?.defaults?.contextBudget;
+  if (!raw || typeof raw !== "object") {
+    return { enabled: false };
+  }
+  const enabled = typeof raw.enabled === "boolean" ? raw.enabled : false;
+
+  const readPosInt = (v: unknown): number | undefined => {
+    if (typeof v !== "number" || !Number.isFinite(v)) return undefined;
+    const n = Math.floor(v);
+    return n > 0 ? n : undefined;
+  };
+
+  return {
+    enabled,
+    bootstrapMaxChars: readPosInt((raw as any).bootstrapMaxChars),
+    memoryMaxInjectedChars: readPosInt((raw as any).memoryMaxInjectedChars),
+    webFetchMaxChars: readPosInt((raw as any).webFetchMaxChars),
+  };
+}
+
+export function maybeClampMaxChars(params: {
+  configured: number;
+  budget?: number;
+  enabled: boolean;
+}): number {
+  if (!params.enabled) return params.configured;
+  if (typeof params.budget !== "number" || !Number.isFinite(params.budget) || params.budget <= 0) {
+    return params.configured;
+  }
+  return Math.min(params.configured, Math.floor(params.budget));
+}

--- a/src/agents/pi-embedded-helpers/bootstrap.context-budget.test.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.context-budget.test.ts
@@ -1,32 +1,33 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { resolveBootstrapMaxChars, DEFAULT_BOOTSTRAP_MAX_CHARS } from "./bootstrap.js";
 
 describe("resolveBootstrapMaxChars (contextBudget)", () => {
   it("uses configured bootstrapMaxChars when no budget enabled", () => {
-    const cfg: any = { agents: { defaults: { bootstrapMaxChars: 1234 } } };
+    const cfg = { agents: { defaults: { bootstrapMaxChars: 1234 } } } as unknown as OpenClawConfig;
     expect(resolveBootstrapMaxChars(cfg)).toBe(1234);
   });
 
   it("caps bootstrapMaxChars when contextBudget is enabled", () => {
-    const cfg: any = {
+    const cfg = {
       agents: {
         defaults: {
           bootstrapMaxChars: 8000,
           contextBudget: { enabled: true, bootstrapMaxChars: 2000 },
         },
       },
-    };
+    } as unknown as OpenClawConfig;
     expect(resolveBootstrapMaxChars(cfg)).toBe(2000);
   });
 
   it("does not change defaults when budget is disabled", () => {
-    const cfg: any = {
+    const cfg = {
       agents: {
         defaults: {
           contextBudget: { enabled: false, bootstrapMaxChars: 2000 },
         },
       },
-    };
+    } as unknown as OpenClawConfig;
     expect(resolveBootstrapMaxChars(cfg)).toBe(DEFAULT_BOOTSTRAP_MAX_CHARS);
   });
 });

--- a/src/agents/pi-embedded-helpers/bootstrap.context-budget.test.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.context-budget.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveBootstrapMaxChars, DEFAULT_BOOTSTRAP_MAX_CHARS } from "./bootstrap.js";
+
+describe("resolveBootstrapMaxChars (contextBudget)", () => {
+  it("uses configured bootstrapMaxChars when no budget enabled", () => {
+    const cfg: any = { agents: { defaults: { bootstrapMaxChars: 1234 } } };
+    expect(resolveBootstrapMaxChars(cfg)).toBe(1234);
+  });
+
+  it("caps bootstrapMaxChars when contextBudget is enabled", () => {
+    const cfg: any = {
+      agents: {
+        defaults: {
+          bootstrapMaxChars: 8000,
+          contextBudget: { enabled: true, bootstrapMaxChars: 2000 },
+        },
+      },
+    };
+    expect(resolveBootstrapMaxChars(cfg)).toBe(2000);
+  });
+
+  it("does not change defaults when budget is disabled", () => {
+    const cfg: any = {
+      agents: {
+        defaults: {
+          contextBudget: { enabled: false, bootstrapMaxChars: 2000 },
+        },
+      },
+    };
+    expect(resolveBootstrapMaxChars(cfg)).toBe(DEFAULT_BOOTSTRAP_MAX_CHARS);
+  });
+});

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -94,10 +94,25 @@ type TrimBootstrapResult = {
 
 export function resolveBootstrapMaxChars(cfg?: OpenClawConfig): number {
   const raw = cfg?.agents?.defaults?.bootstrapMaxChars;
-  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
-    return Math.floor(raw);
+  const configured =
+    typeof raw === "number" && Number.isFinite(raw) && raw > 0
+      ? Math.floor(raw)
+      : DEFAULT_BOOTSTRAP_MAX_CHARS;
+
+  // Optional, upstream-friendly budget override (opt-in)
+  const budget = cfg?.agents?.defaults?.contextBudget;
+  const enabled = typeof budget?.enabled === "boolean" ? budget.enabled : false;
+  const override =
+    enabled &&
+    typeof budget?.bootstrapMaxChars === "number" &&
+    Number.isFinite(budget.bootstrapMaxChars)
+      ? Math.floor(budget.bootstrapMaxChars)
+      : undefined;
+
+  if (override && override > 0) {
+    return Math.min(configured, override);
   }
-  return DEFAULT_BOOTSTRAP_MAX_CHARS;
+  return configured;
 }
 
 function trimBootstrapContent(

--- a/src/agents/tools/web-fetch.context-budget.test.ts
+++ b/src/agents/tools/web-fetch.context-budget.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { createWebFetchTool } from "./web-fetch.js";
 
 // Minimal smoke: ensure tool creation works with contextBudget config.
 
 describe("web_fetch (contextBudget)", () => {
   it("creates tool with contextBudget enabled", () => {
-    const config: any = {
+    const config = {
       agents: { defaults: { contextBudget: { enabled: true, webFetchMaxChars: 1234 } } },
       tools: { web: { fetch: { enabled: true, maxChars: 9999, firecrawl: { enabled: false } } } },
-    };
+    } as unknown as OpenClawConfig;
     const tool = createWebFetchTool({ config, sandboxed: false });
     expect(tool?.name).toBe("web_fetch");
   });

--- a/src/agents/tools/web-fetch.context-budget.test.ts
+++ b/src/agents/tools/web-fetch.context-budget.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { createWebFetchTool } from "./web-fetch.js";
+
+// Minimal smoke: ensure tool creation works with contextBudget config.
+
+describe("web_fetch (contextBudget)", () => {
+  it("creates tool with contextBudget enabled", () => {
+    const config: any = {
+      agents: { defaults: { contextBudget: { enabled: true, webFetchMaxChars: 1234 } } },
+      tools: { web: { fetch: { enabled: true, maxChars: 9999, firecrawl: { enabled: false } } } },
+    };
+    const tool = createWebFetchTool({ config, sandboxed: false });
+    expect(tool?.name).toBe("web_fetch");
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -669,7 +669,7 @@ export function createWebFetchTool(options?: {
       const extractMode = readStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readNumberParam(params, "maxChars", { integer: true });
       const maxCharsCap = resolveFetchMaxCharsCap(fetch);
-      const budget = cfg?.agents?.defaults?.contextBudget;
+      const budget = options?.config?.agents?.defaults?.contextBudget;
       const budgetEnabled = typeof budget?.enabled === "boolean" ? budget.enabled : false;
       const budgetCap =
         budgetEnabled &&

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -181,7 +181,9 @@ async function resolveContextReport(
   const budget = params.cfg?.agents?.defaults?.contextBudget;
   const enabled = typeof budget?.enabled === "boolean" ? budget.enabled : false;
   const toPosInt = (v: unknown): number | undefined => {
-    if (typeof v !== "number" || !Number.isFinite(v)) return undefined;
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      return undefined;
+    }
     const n = Math.floor(v);
     return n > 0 ? n : undefined;
   };
@@ -290,8 +292,12 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
 
   const contextBudgetLine = (() => {
     const b = report.contextBudget;
-    if (!b) return "";
-    if (!b.enabled) return "";
+    if (!b) {
+      return "";
+    }
+    if (!b.enabled) {
+      return "";
+    }
     const eff = b.effective;
     const fmt = (n?: number) => (typeof n === "number" ? `${formatInt(n)} chars` : "?");
     return `Context budget: enabled (bootstrap≤${fmt(eff?.bootstrapMaxChars)} memory≤${fmt(eff?.memoryMaxInjectedChars)} web_fetch≤${fmt(eff?.webFetchMaxChars)})`;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -530,6 +530,16 @@ const FIELD_HELP: Record<string, string> = {
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
   "agents.defaults.bootstrapMaxChars":
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
+  "agents.defaults.contextBudget":
+    "Opt-in context budget caps (chars) to reduce token usage across bootstrap/memory/web_fetch.",
+  "agents.defaults.contextBudget.enabled":
+    "Enable agent-level context budget overrides (default: false).",
+  "agents.defaults.contextBudget.bootstrapMaxChars":
+    "When contextBudget is enabled, cap bootstrap injection max chars (overrides bootstrapMaxChars if lower).",
+  "agents.defaults.contextBudget.memoryMaxInjectedChars":
+    "When contextBudget is enabled, cap memory_search injected snippet chars (overrides memory.qmd.limits.maxInjectedChars if lower).",
+  "agents.defaults.contextBudget.webFetchMaxChars":
+    "When contextBudget is enabled, cap web_fetch max chars (overrides tools.web.fetch.maxChars if lower).",
   "agents.defaults.repoRoot":
     "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
   "agents.defaults.envelopeTimezone":

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -130,6 +130,19 @@ export type SessionSystemPromptReport = {
   model?: string;
   workspaceDir?: string;
   bootstrapMaxChars?: number;
+  /** Effective context budget caps (chars) when agents.defaults.contextBudget.enabled=true. */
+  contextBudget?: {
+    enabled: boolean;
+    bootstrapMaxChars?: number;
+    memoryMaxInjectedChars?: number;
+    webFetchMaxChars?: number;
+    /** Caps after merging configured + budget (min-clamp). */
+    effective?: {
+      bootstrapMaxChars?: number;
+      memoryMaxInjectedChars?: number;
+      webFetchMaxChars?: number;
+    };
+  };
   sandbox?: {
     mode?: string;
     sandboxed?: boolean;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -108,6 +108,19 @@ export type AgentDefaultsConfig = {
   skipBootstrap?: boolean;
   /** Max chars for injected bootstrap files before truncation (default: 20000). */
   bootstrapMaxChars?: number;
+  /**
+   * Opt-in context budget caps (chars) to reduce token usage.
+   * When enabled, these values override per-feature caps (bootstrap/memory/web_fetch).
+   */
+  contextBudget?: {
+    enabled?: boolean;
+    /** Override bootstrap injection cap when enabled. */
+    bootstrapMaxChars?: number;
+    /** Override memory snippet injection cap when enabled. */
+    memoryMaxInjectedChars?: number;
+    /** Override web_fetch output cap when enabled. */
+    webFetchMaxChars?: number;
+  };
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;
   /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -47,6 +47,15 @@ export const AgentDefaultsSchema = z
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
+    contextBudget: z
+      .object({
+        enabled: z.boolean().optional(),
+        bootstrapMaxChars: z.number().int().positive().optional(),
+        memoryMaxInjectedChars: z.number().int().positive().optional(),
+        webFetchMaxChars: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
     userTimezone: z.string().optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     envelopeTimezone: z.string().optional(),


### PR DESCRIPTION
# PR: Opt-in agent contextBudget caps (chars)

## Summary

Add an **opt-in**, agent-level `agents.defaults.contextBudget` config block to cap the biggest context/token cost drivers:

- bootstrap file injection (`bootstrapMaxChars`)
- memory search snippet injection (`memoryMaxInjectedChars`)
- `web_fetch` output size (`webFetchMaxChars`)

Default behavior is unchanged unless `contextBudget.enabled=true`.

## Motivation

OpenClaw already has per-feature caps (`bootstrapMaxChars`, `memory.qmd.limits.maxInjectedChars`, `tools.web.fetch.maxChars`), but deployments often want a single, upstream-friendly switch to keep costs predictable without rewriting workflow/policy.

This adds a small, backwards-compatible "budget override" layer.

## Config

```jsonc
{
  "agents": {
    "defaults": {
      "contextBudget": {
        "enabled": true,
        "bootstrapMaxChars": 8000,
        "memoryMaxInjectedChars": 2500,
        "webFetchMaxChars": 8000,
      },
    },
  },
}
```

## Behavior

When enabled, the effective caps become:

- bootstrap: `min(agents.defaults.bootstrapMaxChars, contextBudget.bootstrapMaxChars)`
- memory_search (qmd backend): `min(memory.qmd.limits.maxInjectedChars, contextBudget.memoryMaxInjectedChars)`
- web_fetch: `min(tools.web.fetch.maxChars, contextBudget.webFetchMaxChars)`

If any `contextBudget.*` value is missing/invalid, it is ignored.

## Tests

- `src/agents/pi-embedded-helpers/bootstrap.context-budget.test.ts`
- `src/agents/tools/web-fetch.context-budget.test.ts`

Run (example):

```bash
pnpm vitest run --config vitest.unit.config.ts \
  src/agents/pi-embedded-helpers/bootstrap.context-budget.test.ts \
  src/agents/tools/web-fetch.context-budget.test.ts
```

## Notes / Future work

- Phase 2 can add optional summarization/trimming hooks when a cap is hit, plus `/context` reporting of effective budgets.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an opt-in `agents.defaults.contextBudget` config block intended to cap major context size drivers (bootstrap file injection, memory snippet injection, and `web_fetch` output). It wires the budget into bootstrap max char resolution, memory tool result clamping, and `web_fetch`’s `maxChars` resolution, and extends `/context` reporting to show the effective (min-clamped) caps when enabled. New zod schema/types and a couple of targeted vitest tests accompany the change.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the memory budget semantics mismatch is resolved.
- Core changes are additive and behind an opt-in flag, with schema/types updates and tests. The main functional concern is the memory tool’s budget logic: when the configured qmd injection limit is unset, the new code can introduce a hard clamp to the budget value, which contradicts the documented min-clamp behavior and may change deployments that relied on the absence of a configured limit.
- src/agents/tools/memory-tool.ts; src/auto-reply/reply/commands-context-report.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->