### PR TITLE
feat(context-pruning): add always mode (non-Anthropic, opt-in)

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.context-pruning-always.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.context-pruning-always.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { buildEmbeddedExtensionPaths } from "./extensions.js";
 
 describe("context pruning extension (always mode)", () => {
   it("enables context-pruning extension for non-anthropic providers when mode=always", () => {
-    const cfg: any = {
+    const cfg = {
       agents: {
         defaults: {
           contextPruning: {
@@ -17,7 +18,7 @@ describe("context pruning extension (always mode)", () => {
           },
         },
       },
-    };
+    } as unknown as OpenClawConfig;
 
     const paths = buildEmbeddedExtensionPaths({
       cfg,

--- a/src/agents/pi-embedded-runner/extensions.context-pruning-always.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.context-pruning-always.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildEmbeddedExtensionPaths } from "./extensions.js";
+
+describe("context pruning extension (always mode)", () => {
+  it("enables context-pruning extension for non-anthropic providers when mode=always", () => {
+    const cfg: any = {
+      agents: {
+        defaults: {
+          contextPruning: {
+            mode: "always",
+            tools: { allow: ["web_fetch"] },
+            softTrim: { maxChars: 2000, headChars: 800, tailChars: 800 },
+            softTrimRatio: 0,
+            hardClearRatio: 1,
+            minPrunableToolChars: 0,
+            hardClear: { enabled: false },
+          },
+        },
+      },
+    };
+
+    const paths = buildEmbeddedExtensionPaths({
+      cfg,
+      sessionManager: {},
+      provider: "openai-codex",
+      modelId: "gpt-5.3-codex",
+      model: undefined,
+    });
+
+    expect(paths.some((p) => p.includes("context-pruning"))).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -43,11 +43,13 @@ function buildContextPruningExtension(params: {
   model: Model<Api> | undefined;
 }): { additionalExtensionPaths?: string[] } {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
-  if (raw?.mode !== "cache-ttl") {
+  if (raw?.mode !== "cache-ttl" && raw?.mode !== "always") {
     return {};
   }
-  if (!isCacheTtlEligibleProvider(params.provider, params.modelId)) {
-    return {};
+  if (raw?.mode === "cache-ttl") {
+    if (!isCacheTtlEligibleProvider(params.provider, params.modelId)) {
+      return {};
+    }
   }
 
   const settings = computeEffectiveSettings(raw);
@@ -59,7 +61,8 @@ function buildContextPruningExtension(params: {
     settings,
     contextWindowTokens: resolveContextWindowTokens(params),
     isToolPrunable: makeToolPrunablePredicate(settings.tools),
-    lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager),
+    lastCacheTouchAt:
+      settings.mode === "cache-ttl" ? readLastCacheTtlTimestamp(params.sessionManager) : null,
   });
 
   return {

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -4,7 +4,7 @@ export type ContextPruningToolMatch = {
   allow?: string[];
   deny?: string[];
 };
-export type ContextPruningMode = "off" | "cache-ttl";
+export type ContextPruningMode = "off" | "cache-ttl" | "always";
 
 export type ContextPruningConfig = {
   mode?: ContextPruningMode;
@@ -69,14 +69,14 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
     return null;
   }
   const cfg = raw as ContextPruningConfig;
-  if (cfg.mode !== "cache-ttl") {
+  if (cfg.mode !== "cache-ttl" && cfg.mode !== "always") {
     return null;
   }
 
   const s: EffectiveContextPruningSettings = structuredClone(DEFAULT_CONTEXT_PRUNING_SETTINGS);
   s.mode = cfg.mode;
 
-  if (typeof cfg.ttl === "string") {
+  if (cfg.mode === "cache-ttl" && typeof cfg.ttl === "string") {
     try {
       s.ttlMs = parseDurationMs(cfg.ttl, { defaultUnit: "m" });
     } catch {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -530,6 +530,22 @@ const FIELD_HELP: Record<string, string> = {
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
   "agents.defaults.bootstrapMaxChars":
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
+  "agents.defaults.contextBudget":
+    "Opt-in context budget caps (chars) to reduce token usage across bootstrap/memory/web_fetch.",
+  "agents.defaults.contextBudget.enabled":
+    "Enable agent-level context budget overrides (default: false).",
+  "agents.defaults.contextBudget.bootstrapMaxChars":
+    "When contextBudget is enabled, cap bootstrap injection max chars (overrides bootstrapMaxChars if lower).",
+  "agents.defaults.contextBudget.memoryMaxInjectedChars":
+    "When contextBudget is enabled, cap memory_search injected snippet chars (overrides memory.qmd.limits.maxInjectedChars if lower).",
+  "agents.defaults.contextBudget.webFetchMaxChars":
+    "When contextBudget is enabled, cap web_fetch max chars (overrides tools.web.fetch.maxChars if lower).",
+  "agents.defaults.contextPruning":
+    "Opt-in: prune old tool results from the LLM context to reduce token usage.",
+  "agents.defaults.contextPruning.mode":
+    "Context pruning mode: off | cache-ttl | always. cache-ttl requires an eligible provider; always is fully opt-in.",
+  "agents.defaults.contextPruning.ttl":
+    "Context pruning TTL for cache-ttl mode (duration string; default unit minutes).",
   "agents.defaults.repoRoot":
     "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
   "agents.defaults.envelopeTimezone":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -26,7 +26,7 @@ export type AgentModelListConfig = {
 };
 
 export type AgentContextPruningConfig = {
-  mode?: "off" | "cache-ttl";
+  mode?: "off" | "cache-ttl" | "always";
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -57,7 +57,7 @@ export const AgentDefaultsSchema = z
     memorySearch: MemorySearchSchema,
     contextPruning: z
       .object({
-        mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
+        mode: z.union([z.literal("off"), z.literal("cache-ttl"), z.literal("always")]).optional(),
         ttl: z.string().optional(),
         keepLastAssistants: z.number().int().nonnegative().optional(),
         softTrimRatio: z.number().min(0).max(1).optional(),


### PR DESCRIPTION
## Summary

Add an opt-in `agents.defaults.contextPruning.mode="always"` to enable the existing context-pruning extension for non-Anthropic providers.

Default behavior is unchanged (`mode="off"`).

## Motivation

Some deployments want prompt/context trimming regardless of provider, to keep token usage predictable.

## Config

```jsonc
{
  "agents": {
    "defaults": {
      "contextPruning": {
        "mode": "always"
      }
    }
  }
}
```

Notes:
- `cacheTtlMinutes` only applies when `mode="cache-ttl"`.

## Changes

- Allow `contextPruning.mode` to be: `"off" | "cache-ttl" | "always"`
- Runner: if `mode="always"`, enable the extension without provider gating
- Update config schema UI hints / docs in `src/config/schema.ts`

## Tests

- `src/agents/pi-embedded-runner/extensions.context-pruning-always.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new opt-in context pruning mode (`agents.defaults.contextPruning.mode = "always"`) so the existing context-pruning extension can run for non-Anthropic providers. The runner gating in `src/agents/pi-embedded-runner/extensions.ts` is updated to allow `always` without provider eligibility checks, and the config types/schema/UI hints are extended to accept the new enum value. A new Vitest test was added to assert the extension is enabled when `mode=always`.


<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge; the only concern is test brittleness due to invalid mocks.
- Core logic changes are small and internally consistent (mode enum extended across runner, settings, and config schemas). The added test uses `any` config and an empty object for `SessionManager`, which can break with minor refactors and may fail in stricter runtime paths.
- src/agents/pi-embedded-runner/extensions.context-pruning-always.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->