### PR TITLE
Config: migrate legacy browser profile patch path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Agents: recover from context overflow caused by oversized tool results (pre-emptive capping + fallback truncation). (#11579) Thanks @tyler6204.
 - Telegram: render markdown spoilers with `<tg-spoiler>` HTML tags. (#11543) Thanks @ezhikkk.
 - Gateway/CLI: when `gateway.bind=lan`, use a LAN IP for probe URLs and Control UI links. (#11448) Thanks @AnonO6.
+- Config: migrate legacy `agents.defaults.tools.browser.profile` patches to `browser.defaultProfile` to avoid `config.patch` validation failures. (fixes #11631)
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
 - Memory/QMD: run boot refresh in background by default, add configurable QMD maintenance timeouts, and retry QMD after fallback failures. (#9690, #9705)
 - Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.

--- a/extensions/matrix/src/channel.directory.test.ts
+++ b/extensions/matrix/src/channel.directory.test.ts
@@ -1,8 +1,33 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CoreConfig } from "./types.js";
 import { matrixPlugin } from "./channel.js";
 import { setMatrixRuntime } from "./runtime.js";
+
+vi.mock("./actions.js", () => ({
+  matrixMessageActions: {
+    listActions: () => [],
+    supportsAction: () => false,
+    handleAction: async () => ({ ok: true }),
+  },
+}));
+
+vi.mock("./matrix/client.js", () => ({
+  resolveMatrixAuth: async () => ({
+    homeserver: "https://matrix.example.org",
+    userId: "@bot:example.org",
+    accessToken: "test-token",
+    encryption: false,
+  }),
+}));
+
+vi.mock("./matrix/probe.js", () => ({
+  probeMatrix: async () => ({ ok: true }),
+}));
+
+vi.mock("./matrix/send.js", () => ({
+  sendMessageMatrix: async () => ({ messageId: "evt_test", roomId: "!room:example.org" }),
+}));
 
 describe("matrix directory", () => {
   beforeEach(() => {

--- a/extensions/matrix/src/matrix/accounts.ts
+++ b/extensions/matrix/src/matrix/accounts.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
 import type { CoreConfig, MatrixConfig } from "../types.js";
-import { resolveMatrixConfig } from "./client.js";
+import { resolveMatrixConfig } from "./client/config.js";
 import { credentialsMatchConfig, loadMatrixCredentials } from "./credentials.js";
 
 export type ResolvedMatrixAccount = {

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CoreConfig } from "../types.js";
-import { resolveMatrixConfig } from "./client.js";
+import { resolveMatrixConfig } from "./client/config.js";
 
 describe("resolveMatrixConfig", () => {
   it("prefers config over env", () => {

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -1,8 +1,6 @@
-import { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { CoreConfig } from "../types.js";
 import type { MatrixAuth, MatrixResolvedConfig } from "./types.js";
 import { getMatrixRuntime } from "../../runtime.js";
-import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 
 function clean(value?: string): string {
   return value?.trim() ?? "";
@@ -67,6 +65,8 @@ export async function resolveMatrixAuth(params?: {
     let userId = resolved.userId;
     if (!userId) {
       // Fetch userId from access token via whoami
+      const { ensureMatrixSdkLoggingConfigured } = await import("./logging.js");
+      const { MatrixClient } = await import("@vector-im/matrix-bot-sdk");
       ensureMatrixSdkLoggingConfigured();
       const tempClient = new MatrixClient(resolved.homeserver, resolved.accessToken);
       const whoami = await tempClient.getUserId();

--- a/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
+++ b/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
@@ -148,6 +148,32 @@ describe("legacy config detection", () => {
     expect(res.config?.messages?.tts?.auto).toBe("always");
     expect(res.config?.messages?.tts?.enabled).toBeUndefined();
   });
+  it("migrates agents.defaults.tools.browser.profile to browser.defaultProfile", async () => {
+    vi.resetModules();
+    const { migrateLegacyConfig, validateConfigObject } = await import("./config.js");
+    const res = migrateLegacyConfig({
+      agents: {
+        defaults: {
+          tools: {
+            browser: {
+              profile: "openclaw",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved agents.defaults.tools.browser.profile → browser.defaultProfile.",
+    );
+    expect(res.config?.browser?.defaultProfile).toBe("openclaw");
+
+    const tools = res.config?.agents?.defaults?.tools as Record<string, unknown> | undefined;
+    expect(tools?.browser).toBeUndefined();
+
+    const validated = validateConfigObject(res.config ?? {});
+    expect(validated.ok).toBe(true);
+  });
   it("migrates legacy model config to agent.models + model lists", async () => {
     vi.resetModules();
     const { migrateLegacyConfig } = await import("./config.js");

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -83,7 +83,13 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
     apply: (raw, changes) => {
       const agents = getRecord(raw.agents);
       const defaults = getRecord(agents?.defaults);
-      const tools = getRecord(defaults?.tools);
+      if (!defaults) {
+        return;
+      }
+      const tools = getRecord(defaults.tools);
+      if (!tools) {
+        return;
+      }
       const legacyBrowser = getRecord(tools?.browser);
       if (!legacyBrowser) {
         return;

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -78,6 +78,42 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
     },
   },
   {
+    id: "agents.defaults.tools.browser.profile->browser.defaultProfile",
+    describe: "Move agents.defaults.tools.browser.profile to browser.defaultProfile",
+    apply: (raw, changes) => {
+      const agents = getRecord(raw.agents);
+      const defaults = getRecord(agents?.defaults);
+      const tools = getRecord(defaults?.tools);
+      const legacyBrowser = getRecord(tools?.browser);
+      if (!legacyBrowser) {
+        return;
+      }
+
+      const legacyProfile =
+        typeof legacyBrowser.profile === "string" ? legacyBrowser.profile.trim() : "";
+      if (legacyProfile) {
+        const browser = ensureRecord(raw, "browser");
+        const currentDefault =
+          typeof browser.defaultProfile === "string" ? browser.defaultProfile.trim() : "";
+        if (!currentDefault) {
+          browser.defaultProfile = legacyProfile;
+          changes.push("Moved agents.defaults.tools.browser.profile → browser.defaultProfile.");
+        } else {
+          changes.push(
+            "Removed agents.defaults.tools.browser.profile (browser.defaultProfile already set).",
+          );
+        }
+      } else {
+        changes.push("Removed unsupported agents.defaults.tools.browser section.");
+      }
+
+      delete tools.browser;
+      if (Object.keys(tools).length === 0) {
+        delete defaults.tools;
+      }
+    },
+  },
+  {
     id: "agent.defaults-v2",
     describe: "Move agent config to agents.defaults and tools",
     apply: (raw, changes) => {


### PR DESCRIPTION
## Summary
- migrate legacy `agents.defaults.tools.browser.profile` input to `browser.defaultProfile`
- drop leftover invalid `agents.defaults.tools` when it becomes empty
- add regression coverage for this migration path
- add changelog note for the user-visible fix

## Validation
- `pnpm exec vitest run src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts`

Fixes #11631

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a legacy config migration that moves `agents.defaults.tools.browser.profile` into the new top-level `browser.defaultProfile` field. As part of that migration it also removes the legacy `agents.defaults.tools.browser` section and prunes `agents.defaults.tools` entirely when it becomes empty, to avoid schema validation failures. Coverage is added to the existing legacy-config detection test suite to assert the migration happens and that the resulting config validates. A changelog entry documents the user-visible behavior change.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to legacy migration code + a regression test and changelog note. The migration follows existing patterns (getRecord/ensureRecord), preserves existing `browser.defaultProfile` if set, and cleans up legacy keys to satisfy schema validation.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->