### PR TITLE
CLI: scope /model and /new prompt messaging to fallback-only paths

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.runs-greeting-prompt-bare-reset.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.runs-greeting-prompt-bare-reset.e2e.test.ts
@@ -134,6 +134,13 @@ describe("trigger handling", () => {
       expect(runEmbeddedPiAgent).toHaveBeenCalledOnce();
       const prompt = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0]?.prompt ?? "";
       expect(prompt).toContain("A new session was started via /new or /reset");
+      expect(prompt).toContain(
+        "If the runtime model differs from default_model in the system prompt, add one plain-language line that names both the current model and the default model, and clarify that the current model is a fallback from the default.",
+      );
+      expect(prompt).toContain(
+        "If the runtime model matches default_model, do not mention model names.",
+      );
+      expect(prompt).toContain("plain-language line");
     });
   });
   it("does not reset for unauthorized /reset", async () => {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -121,13 +121,18 @@ export async function handleDirectiveOnly(params: {
   }).sandboxed;
   const shouldHintDirectRuntime = directives.hasElevatedDirective && !runtimeIsSandboxed;
 
+  const runtimeProvider = sessionEntry.modelProvider?.trim();
+  const runtimeModel = sessionEntry.model?.trim();
+  const effectiveProvider = runtimeProvider || provider;
+  const effectiveModel = runtimeModel || model;
+
   const modelInfo = await maybeHandleModelDirectiveInfo({
     directives,
     cfg: params.cfg,
     agentDir,
     activeAgentId,
-    provider,
-    model,
+    provider: effectiveProvider,
+    model: effectiveModel,
     defaultProvider,
     defaultModel,
     aliasIndex,

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -211,6 +211,40 @@ describe("/model chat UX", () => {
     });
     expect(resolved.errorText).toBeUndefined();
   });
+
+  it("uses runtime-served session model for /model fallback detection", async () => {
+    const directives = parseInlineDirectives("/model");
+    const sessionEntry: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      modelProvider: "openai",
+      model: "gpt-5.2",
+    };
+
+    const result = await handleDirectiveOnly({
+      cfg: baseConfig(),
+      directives,
+      sessionEntry,
+      sessionStore: { "agent:main:dm:1": sessionEntry },
+      sessionKey: "agent:main:dm:1",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys: new Set(),
+      allowedModelCatalog: [],
+      resetModelOverride: false,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+    });
+
+    expect(result?.text).toContain("Current: openai/gpt-5.2");
+    expect(result?.text).toContain("Fallback active");
+    expect(result?.text).toContain("Default: anthropic/claude-opus-4-5");
+  });
 });
 
 describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -215,19 +215,42 @@ export async function maybeHandleModelDirectiveInfo(params: {
 
   if (wantsSummary) {
     const current = `${params.provider}/${params.model}`;
+    const defaultLabel = `${params.defaultProvider}/${params.defaultModel}`;
+    const fallbackActive =
+      normalizeProviderId(params.provider) !== normalizeProviderId(params.defaultProvider) ||
+      params.model !== params.defaultModel;
     const isTelegram = params.surface === "telegram";
 
     if (isTelegram) {
       const buttons = buildBrowseProvidersButton();
+      const fallbackLines = fallbackActive
+        ? ["Fallback active", `Default: ${defaultLabel}`, ""]
+        : [];
       return {
         text: [
           `Current: ${current}`,
           "",
+          ...fallbackLines,
           "Tap below to browse models, or use:",
           "/model <provider/model> to switch",
           "/model status for details",
         ].join("\n"),
         channelData: { telegram: { buttons } },
+      };
+    }
+
+    if (fallbackActive) {
+      return {
+        text: [
+          `Current: ${current}`,
+          "",
+          "Fallback active",
+          `Default: ${defaultLabel}`,
+          "",
+          "Switch: /model <provider/model>",
+          "Browse: /models (providers) or /models <provider> (models)",
+          "More: /model status",
+        ].join("\n"),
       };
     }
 

--- a/src/auto-reply/reply/fallback-state.test.ts
+++ b/src/auto-reply/reply/fallback-state.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isFallbackModelActive } from "./fallback-state.js";
+
+describe("isFallbackModelActive", () => {
+  it("treats provider-prefixed default model as non-fallback when runtime matches", () => {
+    expect(
+      isFallbackModelActive({
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        defaultProvider: "anthropic",
+        defaultModel: "anthropic/claude-opus-4-5",
+      }),
+    ).toBe(false);
+  });
+
+  it("marks fallback active when provider differs", () => {
+    expect(
+      isFallbackModelActive({
+        provider: "openai",
+        model: "gpt-5.2",
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-5",
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/fallback-state.ts
+++ b/src/auto-reply/reply/fallback-state.ts
@@ -1,0 +1,28 @@
+import { normalizeProviderId } from "../../agents/model-selection.js";
+
+function normalizeModelId(provider: string, model: string): string {
+  const trimmed = String(model ?? "").trim();
+  if (!trimmed) {
+    return "";
+  }
+  const normalizedProvider = normalizeProviderId(provider);
+  const lower = trimmed.toLowerCase();
+  const providerPrefix = `${normalizedProvider}/`;
+  if (lower.startsWith(providerPrefix)) {
+    return trimmed.slice(providerPrefix.length).trim();
+  }
+  return trimmed;
+}
+
+export function isFallbackModelActive(params: {
+  provider: string;
+  model: string;
+  defaultProvider: string;
+  defaultModel: string;
+}): boolean {
+  const provider = normalizeProviderId(params.provider);
+  const defaultProvider = normalizeProviderId(params.defaultProvider);
+  const model = normalizeModelId(provider, params.model);
+  const defaultModel = normalizeModelId(defaultProvider, params.defaultModel);
+  return provider !== defaultProvider || model !== defaultModel;
+}

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -49,7 +49,7 @@ type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
 
 const BARE_SESSION_RESET_PROMPT =
-  "A new session was started via /new or /reset. Greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+  "A new session was started via /new or /reset. Greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, add one plain-language line that names both the current model and the default model, and clarify that the current model is a fallback from the default. If the runtime model matches default_model, do not mention model names. Do not mention internal steps, files, tools, or reasoning.";
 
 type RunPreparedReplyParams = {
   ctx: MsgContext;


### PR DESCRIPTION
## What / Why
This PR tightens two UX paths so model messaging only changes when fallback behavior is actually active, while preserving existing behavior on the normal path.

### What changed
1. **Fallback-scoped `/model` messaging**
   - Adjusts `/model`/status messaging so fallback-related wording is shown only when fallback is in use.
   - Non-fallback `/model` behavior remains aligned with `main`.
2. **`/new` prompt model line cleanup**
   - Updates reset prompt wording to only mention model differences when `current model != configured default`.
   - If current and default match, no extra model line is shown.

### Why
- Prevents confusing model/fallback language in non-fallback scenarios.
- Keeps user-facing messaging accurate to runtime state.
- Limits this change to a focused UX correctness fix without broad behavior changes.

## Focused scope statement
This PR is intentionally limited to:
- fallback-only model/status messaging behavior, and
- `/new` prompt wording for model-difference clarity.

No broader model selection flow, architecture, or unrelated UX changes are included.

## Local validation
Executed locally for this branch:

```bash
pnpm build && pnpm check && pnpm test
```

- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm test` ✅

### Manual local-instance validation
Validated behavior in a local OpenClaw instance:
- Confirmed fallback-only wording appears only when fallback is active.
- Confirmed non-fallback paths match `main` behavior.
- Confirmed `/new` model line only appears when current/default differ.

## AI-assisted disclosure
- [x] AI-assisted PR (description + implementation support)
- [x] Testing level: **fully tested locally** (`pnpm build && pnpm check && pnpm test` + manual local instance validation)
- [ ] Prompts/session logs attached (not included in this PR)
- [x] Author reviewed and understands the code and behavior changes
