### PR TITLE
feat: add AIsa provider — production-grade China AI models

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,6 +95,10 @@
       "destination": "/providers/qianfan"
     },
     {
+      "source": "/aisa",
+      "destination": "/providers/aisa"
+    },
+    {
       "source": "/mattermost",
       "destination": "/channels/mattermost"
     },
@@ -1037,7 +1041,8 @@
                   "providers/glm",
                   "providers/zai",
                   "providers/synthetic",
-                  "providers/qianfan"
+                  "providers/qianfan",
+                  "providers/aisa"
                 ]
               }
             ]
@@ -1546,7 +1551,8 @@
                   "zh-CN/providers/glm",
                   "zh-CN/providers/zai",
                   "zh-CN/providers/synthetic",
-                  "zh-CN/providers/qianfan"
+                  "zh-CN/providers/qianfan",
+                  "zh-CN/providers/aisa"
                 ]
               }
             ]

--- a/docs/providers/aisa.md
+++ b/docs/providers/aisa.md
@@ -1,0 +1,185 @@
+---
+summary: "Production-grade access to China's top AI models (Qwen, DeepSeek, Kimi, GLM) via AIsa"
+read_when:
+  - You want production-grade Chinese AI models
+  - You want discounted Qwen pricing
+  - You need one API key for all China models
+  - You need AIsa setup guidance
+title: "AIsa"
+---
+
+# AIsa — China AI Models (Production)
+
+**AIsa** provides production-grade access to China's top AI models through a single API key. As an Alibaba Cloud Qwen Key Account partner, AIsa offers the full Qwen model family at discounted pricing, plus all models aggregated on the [Alibaba Bailian platform](https://bailian.console.alibabacloud.com/) — including Kimi, DeepSeek, and GLM.
+
+> **How does this differ from the [Qwen Portal](/providers/qwen)?**
+> The Qwen Portal provider uses a free-tier OAuth flow limited to 2 models and 2,000 requests/day.
+> AIsa gives you the full Qwen lineup (Flash, Plus, Max, VL, Coder, Audio) with no daily request caps, at negotiated Key Account pricing.
+
+## Why AIsa
+
+- **Full Qwen model family** — Flash, Plus, Max, VL, Coder, Audio, and more. Not just 2 models.
+- **Key Account pricing** — Negotiated discounts on Qwen models through Alibaba Cloud partnership.
+- **All China models, one key** — Qwen, Kimi (Moonshot), DeepSeek, GLM (Zhipu) via the Bailian aggregation platform.
+- **No daily request limits** — Production-ready, not free-tier.
+- **OpenAI-compatible** — Standard `/v1` endpoints, works with any OpenAI SDK.
+
+## Supported Models
+
+### Qwen Family (Alibaba) — Key Account Pricing
+
+| Model ID | Name | Best For |
+| --- | --- | --- |
+| `qwen3-plus` | Qwen3 Plus | General-purpose (default) |
+| `qwen-max` | Qwen Max | Complex reasoning |
+| `qwen-plus` | Qwen Plus | Balanced cost/quality |
+| `qwen-turbo` | Qwen Turbo | Fast, low-cost |
+| `qwen-vl-max` | Qwen VL Max | Vision tasks |
+| `qwen2.5-coder-32b-instruct` | Qwen Coder 32B | Code generation |
+| `qwen-audio-turbo` | Qwen Audio Turbo | Audio understanding |
+
+### Other China Models (via Bailian)
+
+| Model ID | Name | Developer |
+| --- | --- | --- |
+| `deepseek-v3` | DeepSeek V3 | DeepSeek |
+| `deepseek-r1` | DeepSeek R1 | DeepSeek |
+| `moonshot-v1-128k` | Kimi (Moonshot) | Moonshot AI |
+| `glm-4-plus` | GLM-4 Plus | Zhipu AI |
+
+### Global Models
+
+| Model ID | Name | Developer |
+| --- | --- | --- |
+| `claude-sonnet-4-5` | Claude Sonnet 4.5 | Anthropic |
+| `gpt-4.1` | GPT 4.1 | OpenAI |
+| `gemini-2.5-flash` | Gemini 2.5 Flash | Google |
+
+Browse the full catalogue and pricing at [marketplace.aisa.one/pricing](https://marketplace.aisa.one/pricing).
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit the [AIsa Marketplace](https://marketplace.aisa.one/)
+2. Sign up or log in
+3. Navigate to API Keys and generate a new key
+4. Copy the key
+
+New signups get a minimum of $1 credit instantly.
+
+### 2. Configure OpenClaw
+
+**Option A: Interactive Setup (Recommended)**
+
+```bash
+openclaw onboard --auth-choice aisa-api-key
+```
+
+**Option B: Environment Variable**
+
+```bash
+export AISA_API_KEY="your-api-key-here"
+```
+
+### 3. Verify
+
+```bash
+openclaw chat --model aisa/qwen3-plus "Hello, are you working?"
+```
+
+## Which Model Should I Use?
+
+| Use Case | Recommended Model | Why |
+| --- | --- | --- |
+| **General chat** | `qwen3-plus` | Best balance of quality and cost (default) |
+| **Complex reasoning** | `qwen-max` | Strongest Qwen model |
+| **Fast & cheap** | `qwen-turbo` | Lowest latency and cost |
+| **Coding** | `qwen2.5-coder-32b-instruct` | Code-optimized |
+| **Vision tasks** | `qwen-vl-max` | Image understanding |
+| **Deep reasoning** | `deepseek-r1` | Chain-of-thought reasoning |
+
+Change your default model anytime:
+
+```bash
+openclaw models set aisa/qwen3-plus
+openclaw models set aisa/qwen-max
+openclaw models set aisa/deepseek-r1
+```
+
+## Configuration
+
+After onboarding, your `openclaw.json` will include:
+
+```json5
+{
+  models: {
+    providers: {
+      aisa: {
+        baseUrl: "https://api.aisa.one/v1",
+        api: "openai-completions",
+        models: [
+          { id: "qwen3-plus", name: "Qwen3 Plus" },
+          { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+          { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" }
+        ]
+      }
+    }
+  },
+  agents: {
+    defaults: {
+      model: { primary: "aisa/qwen3-plus" }
+    }
+  }
+}
+```
+
+## Usage
+
+```bash
+# Use the default model (Qwen3 Plus)
+openclaw chat
+
+# Qwen models
+openclaw chat --model aisa/qwen3-plus
+openclaw chat --model aisa/qwen-max
+openclaw chat --model aisa/qwen-turbo
+
+# Other China models
+openclaw chat --model aisa/deepseek-r1
+openclaw chat --model aisa/moonshot-v1-128k
+
+# Global models
+openclaw chat --model aisa/claude-sonnet-4-5
+openclaw chat --model aisa/gemini-2.5-flash
+```
+
+## AIsa vs Qwen Portal
+
+| Aspect | AIsa | Qwen Portal (OAuth) |
+| --- | --- | --- |
+| **Models** | Full Qwen family + DeepSeek, Kimi, GLM | 2 models (Coder, Vision) |
+| **Daily limit** | No cap | 2,000 requests/day |
+| **Pricing** | Key Account discounts | Free tier |
+| **Other providers** | DeepSeek, Kimi, GLM, Claude, GPT | Qwen only |
+| **Best for** | Production workloads | Quick testing |
+
+## Troubleshooting
+
+### API key not recognized
+
+```bash
+echo $AISA_API_KEY
+openclaw models list | grep aisa
+```
+
+### Connection issues
+
+AIsa API is at `https://api.aisa.one/v1`. Ensure your network allows HTTPS connections.
+
+## Related Documentation
+
+- [Qwen Portal (free tier)](/providers/qwen)
+- [OpenClaw Configuration](/gateway/configuration)
+- [Model Providers](/concepts/model-providers)
+- [AIsa API Documentation](https://aisa.mintlify.app/api-reference/introduction)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -51,6 +51,7 @@ See [Venice AI](/providers/venice).
 - [Venice (Venice AI, privacy-focused)](/providers/venice)
 - [Ollama (local models)](/providers/ollama)
 - [Qianfan](/providers/qianfan)
+- [AIsa (China AI models, production-grade)](/providers/aisa)
 
 ## Transcription providers
 

--- a/docs/zh-CN/providers/aisa.md
+++ b/docs/zh-CN/providers/aisa.md
@@ -1,0 +1,185 @@
+---
+summary: 通过 AIsa 在 OpenClaw 中生产级接入中国主流大模型（通义千问、DeepSeek、Kimi、GLM）
+read_when:
+  - 你想要生产级的中国大模型接入
+  - 你想要通义千问折扣价格
+  - 你需要一个 API key 访问所有中国大模型
+  - 你需要 AIsa 配置指引
+title: AIsa
+---
+
+# AIsa — 中国 AI 模型（生产级）
+
+**AIsa** 通过单一 API key 提供中国主流大模型的生产级接入。作为阿里云通义千问的大客户合作伙伴，AIsa 以协议折扣价提供完整的 Qwen 模型家族，同时聚合了[阿里云百炼平台](https://bailian.console.alibabacloud.com/)上的所有模型——包括 Kimi（月之暗面）、DeepSeek、GLM（智谱）。
+
+> **与 [Qwen Portal](/zh-CN/providers/qwen) 有什么区别？**
+> Qwen Portal 使用免费层 OAuth 流程，仅限 2 个模型、每天 2,000 次请求。
+> AIsa 提供完整的 Qwen 模型系列（Flash、Plus、Max、VL、Coder、Audio），无每日请求限制，享受大客户协议价。
+
+## 为什么选择 AIsa
+
+- **完整 Qwen 模型家族** — Flash、Plus、Max、VL、Coder、Audio 等，不只 2 个模型。
+- **大客户协议价** — 通过阿里云合作伙伴关系获得 Qwen 模型折扣。
+- **所有中国模型，一个 key** — 通义千问、Kimi（月之暗面）、DeepSeek、GLM（智谱），通过百炼聚合平台统一接入。
+- **无每日请求限制** — 面向生产环境，非免费试用。
+- **OpenAI 兼容** — 标准 `/v1` 接口，兼容所有 OpenAI SDK。
+
+## 支持的模型
+
+### 通义千问家族（阿里巴巴）— 大客户协议价
+
+| 模型 ID | 名称 | 最佳用途 |
+| --- | --- | --- |
+| `qwen3-plus` | Qwen3 Plus | 通用（默认模型） |
+| `qwen-max` | Qwen Max | 复杂推理 |
+| `qwen-plus` | Qwen Plus | 性价比均衡 |
+| `qwen-turbo` | Qwen Turbo | 快速、低成本 |
+| `qwen-vl-max` | Qwen VL Max | 图像理解 |
+| `qwen2.5-coder-32b-instruct` | Qwen Coder 32B | 代码生成 |
+| `qwen-audio-turbo` | Qwen Audio Turbo | 音频理解 |
+
+### 其他中国模型（通过百炼平台）
+
+| 模型 ID | 名称 | 开发商 |
+| --- | --- | --- |
+| `deepseek-v3` | DeepSeek V3 | DeepSeek（深度求索） |
+| `deepseek-r1` | DeepSeek R1 | DeepSeek（深度求索） |
+| `moonshot-v1-128k` | Kimi（月之暗面） | Moonshot AI |
+| `glm-4-plus` | GLM-4 Plus | 智谱 AI |
+
+### 全球模型
+
+| 模型 ID | 名称 | 开发商 |
+| --- | --- | --- |
+| `claude-sonnet-4-5` | Claude Sonnet 4.5 | Anthropic |
+| `gpt-4.1` | GPT 4.1 | OpenAI |
+| `gemini-2.5-flash` | Gemini 2.5 Flash | Google |
+
+完整模型目录和价格请访问 [marketplace.aisa.one/pricing](https://marketplace.aisa.one/pricing)。
+
+## 快速开始
+
+### 1. 获取 API Key
+
+1. 访问 [AIsa Marketplace](https://marketplace.aisa.one/)
+2. 注册或登录
+3. 进入 API Keys 页面，生成新密钥
+4. 复制密钥
+
+新用户注册即获最低 $1 赠送额度。
+
+### 2. 配置 OpenClaw
+
+**方式 A：交互式设置（推荐）**
+
+```bash
+openclaw onboard --auth-choice aisa-api-key
+```
+
+**方式 B：环境变量**
+
+```bash
+export AISA_API_KEY="your-api-key-here"
+```
+
+### 3. 验证
+
+```bash
+openclaw chat --model aisa/qwen3-plus "你好，测试一下"
+```
+
+## 如何选择模型？
+
+| 使用场景 | 推荐模型 | 原因 |
+| --- | --- | --- |
+| **日常对话** | `qwen3-plus` | 质量与成本最佳平衡（默认） |
+| **复杂推理** | `qwen-max` | Qwen 系列最强模型 |
+| **快速低成本** | `qwen-turbo` | 最低延迟和成本 |
+| **代码生成** | `qwen2.5-coder-32b-instruct` | 代码优化模型 |
+| **图像理解** | `qwen-vl-max` | 视觉理解 |
+| **深度推理** | `deepseek-r1` | 链式思维推理 |
+
+随时切换默认模型：
+
+```bash
+openclaw models set aisa/qwen3-plus
+openclaw models set aisa/qwen-max
+openclaw models set aisa/deepseek-r1
+```
+
+## 配置
+
+完成配置后，你的 `openclaw.json` 将包含：
+
+```json5
+{
+  models: {
+    providers: {
+      aisa: {
+        baseUrl: "https://api.aisa.one/v1",
+        api: "openai-completions",
+        models: [
+          { id: "qwen3-plus", name: "Qwen3 Plus" },
+          { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+          { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" }
+        ]
+      }
+    }
+  },
+  agents: {
+    defaults: {
+      model: { primary: "aisa/qwen3-plus" }
+    }
+  }
+}
+```
+
+## 使用示例
+
+```bash
+# 使用默认模型（Qwen3 Plus）
+openclaw chat
+
+# Qwen 模型
+openclaw chat --model aisa/qwen3-plus
+openclaw chat --model aisa/qwen-max
+openclaw chat --model aisa/qwen-turbo
+
+# 其他中国模型
+openclaw chat --model aisa/deepseek-r1
+openclaw chat --model aisa/moonshot-v1-128k
+
+# 全球模型
+openclaw chat --model aisa/claude-sonnet-4-5
+openclaw chat --model aisa/gemini-2.5-flash
+```
+
+## AIsa 与 Qwen Portal 对比
+
+| 对比项 | AIsa | Qwen Portal（OAuth） |
+| --- | --- | --- |
+| **模型数量** | 完整 Qwen 家族 + DeepSeek、Kimi、GLM | 2 个模型（Coder、Vision） |
+| **每日限制** | 无上限 | 每天 2,000 次请求 |
+| **价格** | 大客户协议折扣 | 免费层 |
+| **其他厂商** | DeepSeek、Kimi、GLM、Claude、GPT | 仅 Qwen |
+| **适用场景** | 生产环境 | 快速测试 |
+
+## 故障排查
+
+### API key 未识别
+
+```bash
+echo $AISA_API_KEY
+openclaw models list | grep aisa
+```
+
+### 连接问题
+
+AIsa API 地址为 `https://api.aisa.one/v1`，请确保网络允许 HTTPS 连接。
+
+## 相关文档
+
+- [Qwen Portal（免费层）](/zh-CN/providers/qwen)
+- [OpenClaw 配置](/zh-CN/gateway/configuration)
+- [模型提供商](/zh-CN/concepts/model-providers)
+- [AIsa API 文档](https://aisa.mintlify.app/api-reference/introduction)

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -303,6 +303,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
     qianfan: "QIANFAN_API_KEY",
+    aisa: "AISA_API_KEY",
     ollama: "OLLAMA_API_KEY",
   };
   const envVar = envMap[normalized];

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -80,6 +80,17 @@ const OLLAMA_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+export const AISA_BASE_URL = "https://api.aisa.one/v1";
+export const AISA_DEFAULT_MODEL_ID = "qwen3-plus";
+const AISA_DEFAULT_CONTEXT_WINDOW = 128000;
+const AISA_DEFAULT_MAX_TOKENS = 8192;
+const AISA_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 export const QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2";
 export const QIANFAN_DEFAULT_MODEL_ID = "deepseek-v3.2";
 const QIANFAN_DEFAULT_CONTEXT_WINDOW = 98304;
@@ -441,6 +452,42 @@ export function buildQianfanProvider(): ProviderConfig {
   };
 }
 
+export function buildAisaProvider(): ProviderConfig {
+  return {
+    baseUrl: AISA_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: AISA_DEFAULT_MODEL_ID,
+        name: "Qwen3 Plus",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: AISA_DEFAULT_COST,
+        contextWindow: AISA_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: AISA_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: AISA_DEFAULT_COST,
+        contextWindow: 200000,
+        maxTokens: AISA_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "gemini-2.5-flash",
+        name: "Gemini 2.5 Flash",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: AISA_DEFAULT_COST,
+        contextWindow: 1048576,
+        maxTokens: AISA_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}
+
 export async function resolveImplicitProviders(params: {
   agentDir: string;
 }): Promise<ModelsConfig["providers"]> {
@@ -541,6 +588,13 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "qianfan", store: authStore });
   if (qianfanKey) {
     providers.qianfan = { ...buildQianfanProvider(), apiKey: qianfanKey };
+  }
+
+  const aisaKey =
+    resolveEnvApiKeyVarName("aisa") ??
+    resolveApiKeyFromProfiles({ provider: "aisa", store: authStore });
+  if (aisaKey) {
+    providers.aisa = { ...buildAisaProvider(), apiKey: aisaKey };
   }
 
   return providers;

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -24,6 +24,7 @@ export type AuthChoiceGroupId =
   | "venice"
   | "qwen"
   | "qianfan"
+  | "aisa"
   | "xai";
 
 export type AuthChoiceGroup = {
@@ -100,6 +101,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     choices: ["qianfan-api-key"],
   },
   {
+    value: "aisa",
+    label: "AIsa",
+    hint: "China AI models, production-grade (Qwen, DeepSeek, Kimi, GLM)",
+    choices: ["aisa-api-key"],
+  },
+  {
     value: "copilot",
     label: "Copilot",
     hint: "GitHub + local proxy",
@@ -166,6 +173,11 @@ export function buildAuthChoiceOptions(params: {
   options.push({
     value: "qianfan-api-key",
     label: "Qianfan API key",
+  });
+  options.push({
+    value: "aisa-api-key",
+    label: "AIsa API key",
+    hint: "China AI models: Qwen (discounted), DeepSeek, Kimi, GLM & more",
   });
   options.push({ value: "openrouter-api-key", label: "OpenRouter API key" });
   options.push({

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -5,8 +5,10 @@ import {
   resolveCloudflareAiGatewayBaseUrl,
 } from "../agents/cloudflare-ai-gateway.js";
 import {
+  buildAisaProvider,
   buildQianfanProvider,
   buildXiaomiProvider,
+  AISA_DEFAULT_MODEL_ID,
   QIANFAN_DEFAULT_MODEL_ID,
   XIAOMI_DEFAULT_MODEL_ID,
 } from "../agents/models-config.providers.js";
@@ -33,6 +35,8 @@ import {
 import {
   buildMoonshotModelDefinition,
   buildXaiModelDefinition,
+  AISA_BASE_URL,
+  AISA_DEFAULT_MODEL_REF,
   QIANFAN_BASE_URL,
   QIANFAN_DEFAULT_MODEL_REF,
   KIMI_CODING_MODEL_REF,
@@ -710,6 +714,83 @@ export function applyAuthProfileConfig(
       ...cfg.auth,
       profiles,
       ...(order ? { order } : {}),
+    },
+  };
+}
+
+export function applyAisaProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[AISA_DEFAULT_MODEL_REF] = {
+    ...models[AISA_DEFAULT_MODEL_REF],
+    alias: models[AISA_DEFAULT_MODEL_REF]?.alias ?? "AIsa",
+  };
+
+  const providers = { ...cfg.models?.providers };
+  const existingProvider = providers.aisa;
+  const defaultProvider = buildAisaProvider();
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
+  const defaultModels = defaultProvider.models ?? [];
+  const hasDefaultModel = existingModels.some((model) => model.id === AISA_DEFAULT_MODEL_ID);
+  const mergedModels =
+    existingModels.length > 0
+      ? hasDefaultModel
+        ? existingModels
+        : [...existingModels, ...defaultModels]
+      : defaultModels;
+  const {
+    apiKey: existingApiKey,
+    baseUrl: existingBaseUrl,
+    api: existingApi,
+    ...existingProviderRest
+  } = (existingProvider ?? {}) as Record<string, unknown> as {
+    apiKey?: string;
+    baseUrl?: string;
+    api?: ModelApi;
+  };
+  const resolvedApiKey = typeof existingApiKey === "string" ? existingApiKey : undefined;
+  const normalizedApiKey = resolvedApiKey?.trim();
+  providers.aisa = {
+    ...existingProviderRest,
+    baseUrl: existingBaseUrl ?? AISA_BASE_URL,
+    api: existingApi ?? "openai-completions",
+    ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
+    models: mergedModels.length > 0 ? mergedModels : defaultProvider.models,
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+    models: {
+      mode: cfg.models?.mode ?? "merge",
+      providers,
+    },
+  };
+}
+
+export function applyAisaConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next = applyAisaProviderConfig(cfg);
+  const existingModel = next.agents?.defaults?.model;
+  return {
+    ...next,
+    agents: {
+      ...next.agents,
+      defaults: {
+        ...next.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? {
+                fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks,
+              }
+            : undefined),
+          primary: AISA_DEFAULT_MODEL_REF,
+        },
+      },
     },
   };
 }

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -205,6 +205,18 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
   });
 }
 
+export function setAisaApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "aisa:default",
+    credential: {
+      type: "api_key",
+      provider: "aisa",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
 export function setQianfanApiKey(key: string, agentDir?: string) {
   upsertAuthProfile({
     profileId: "qianfan:default",

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -1,5 +1,5 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
-import { QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";
+import { AISA_BASE_URL, AISA_DEFAULT_MODEL_ID, QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";
 
 export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 export const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
@@ -19,6 +19,9 @@ export const KIMI_CODING_MODEL_REF = `kimi-coding/${KIMI_CODING_MODEL_ID}`;
 
 export { QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID };
 export const QIANFAN_DEFAULT_MODEL_REF = `qianfan/${QIANFAN_DEFAULT_MODEL_ID}`;
+
+export { AISA_BASE_URL, AISA_DEFAULT_MODEL_ID };
+export const AISA_DEFAULT_MODEL_REF = `aisa/${AISA_DEFAULT_MODEL_ID}`;
 
 // Pricing: MiniMax doesn't publish public rates. Override in models.json for accurate costs.
 export const MINIMAX_API_COST = {

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -4,6 +4,8 @@ export {
 } from "../agents/synthetic-models.js";
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
+  applyAisaConfig,
+  applyAisaProviderConfig,
   applyAuthProfileConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
@@ -45,6 +47,7 @@ export {
 export {
   CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
+  setAisaApiKey,
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
   setQianfanApiKey,
@@ -70,6 +73,9 @@ export {
   buildMinimaxApiModelDefinition,
   buildMinimaxModelDefinition,
   buildMoonshotModelDefinition,
+  AISA_BASE_URL,
+  AISA_DEFAULT_MODEL_ID,
+  AISA_DEFAULT_MODEL_REF,
   DEFAULT_MINIMAX_BASE_URL,
   MOONSHOT_CN_BASE_URL,
   QIANFAN_BASE_URL,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -37,6 +37,7 @@ export type AuthChoice =
   | "qwen-portal"
   | "xai-api-key"
   | "qianfan-api-key"
+  | "aisa-api-key"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
@@ -83,6 +84,7 @@ export type OnboardOptions = {
   opencodeZenApiKey?: string;
   xaiApiKey?: string;
   qianfanApiKey?: string;
+  aisaApiKey?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
Add AIsa as a first-class provider in OpenClaw, giving users production-grade access to China's top AI models through a single API key and OpenAI-compatible endpoint.

AIsa is an Alibaba Cloud Qwen Key Account partner, offering the full Qwen model family at discounted pricing, plus all models on the Alibaba Bailian aggregation platform (Kimi, DeepSeek, GLM).

Features:
- AISA_API_KEY environment variable support
- Interactive onboarding: openclaw onboard --auth-choice aisa-api-key
- Provider auto-registration when API key detected
- Default model: qwen3-plus (Qwen Key Account pricing)
- Full Qwen catalog + DeepSeek, Kimi, GLM via Bailian
- Global models also available (Claude, GPT, Gemini)
- Full documentation (en + zh-CN)

Complements the existing free-tier Qwen Portal (2 models, 2k req/day) by providing the full model lineup with no daily request caps.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new first-class model provider, **AIsa**, including documentation (EN + zh-CN), env var support (`AISA_API_KEY`), provider auto-registration when the key is detected, and an onboarding path (`openclaw onboard --auth-choice aisa-api-key`) that writes an `aisa:default` auth profile and sets `aisa/qwen3-plus` as the default model.

Codewise, it extends env key resolution (`src/agents/model-auth.ts`), adds an implicit provider definition (`buildAisaProvider` + implicit registration in `src/agents/models-config.providers.ts`), introduces AIsa to the auth-choice UI (`src/commands/auth-choice-options.ts`), and wires a new auth-choice handler branch that applies provider config + default model (`src/commands/auth-choice.apply.api-providers.ts`, `src/commands/onboard-auth.config-core.ts`).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one onboarding correctness issue to address.
- The provider integration is straightforward and follows existing patterns (env key resolution, implicit provider registration, onboarding config application). The main functional gap is that the new `OnboardOptions.aisaApiKey` field is never consumed in the AIsa auth-choice flow, so non-interactive usage is likely broken/ignored for AIsa while the type suggests it should work.
- src/commands/auth-choice.apply.api-providers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->