### PR TITLE
fix(gateway): remove IP-based canvas auth fallback

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -39,8 +39,7 @@ import {
   resolveHookDeliver,
 } from "./hooks.js";
 import { sendUnauthorized } from "./http-common.js";
-import { getBearerToken, getHeader } from "./http-utils.js";
-import { resolveGatewayClientIp } from "./net.js";
+import { getBearerToken } from "./http-utils.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
@@ -80,22 +79,13 @@ function isCanvasPath(pathname: string): boolean {
   );
 }
 
-function hasAuthorizedWsClientForIp(clients: Set<GatewayWsClient>, clientIp: string): boolean {
-  for (const client of clients) {
-    if (client.clientIp && client.clientIp === clientIp) {
-      return true;
-    }
-  }
-  return false;
-}
-
 async function authorizeCanvasRequest(params: {
   req: IncomingMessage;
   auth: ResolvedGatewayAuth;
   trustedProxies: string[];
   clients: Set<GatewayWsClient>;
 }): Promise<boolean> {
-  const { req, auth, trustedProxies, clients } = params;
+  const { req, auth, trustedProxies } = params;
   if (isLocalDirectRequest(req, trustedProxies)) {
     return true;
   }
@@ -113,16 +103,7 @@ async function authorizeCanvasRequest(params: {
     }
   }
 
-  const clientIp = resolveGatewayClientIp({
-    remoteAddr: req.socket?.remoteAddress ?? "",
-    forwardedFor: getHeader(req, "x-forwarded-for"),
-    realIp: getHeader(req, "x-real-ip"),
-    trustedProxies,
-  });
-  if (!clientIp) {
-    return false;
-  }
-  return hasAuthorizedWsClientForIp(clients, clientIp);
+  return false;
 }
 
 export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;


### PR DESCRIPTION
## Fix Summary

Remove `hasAuthorizedWsClientForIp()` which allowed cross-user canvas authorization bypass in shared-IP environments (NAT, corporate proxy, shared hosting). When one user had an authenticated WebSocket connection from an IP, any other user on the same IP could access canvas endpoints without credentials.

Canvas requests now require either:
- Direct local access (loopback), or
- Explicit Bearer token authentication

**Changes:**
- Remove `hasAuthorizedWsClientForIp` function from `server-http.ts`
- Remove IP-based fallback in `authorizeCanvasRequest` — return `false` after bearer token check
- Remove unused imports (`getHeader`, `resolveGatewayClientIp`)
- Update e2e tests to expect 401 for IP-only auth attempts

## Issue Linkage

Fixes #11738

## Security Snapshot

- CVSS v3.1: 8.9 (High)
- CVSS v4.0: 9.5 (Critical)

## Implementation Details

### Files Changed
- `src/gateway/server-http.ts` (+3/-22)
- `src/gateway/server.canvas-auth.e2e.test.ts` (+26/-21)

### Technical Analysis
Remove `hasAuthorizedWsClientForIp()` which allowed cross-user canvas authorization bypass in shared-IP environments (NAT, corporate proxy, shared hosting). When one user had an authenticated WebSocket connection from an IP, any other user on the same IP could access canvas endpoints without credentials.

## Validation Evidence

- Command: `server.canvas-auth.e2e.test.ts`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the IP-based fallback (`hasAuthorizedWsClientForIp`) for authorizing canvas HTTP/WS requests, tightening access control so canvas endpoints require either a loopback/direct-local request or a valid Bearer token. It also updates the canvas auth e2e test to expect 401s for IP-only attempts and adds a positive assertion that Bearer token auth still succeeds.

Overall, the gateway’s `authorizeCanvasRequest` path in `src/gateway/server-http.ts` is simplified to a clear allowlist (local direct or bearer auth) which aligns with the stated security goal of preventing cross-user authorization in shared-IP environments.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; main remaining concern is the WS e2e regression test can pass without asserting the intended 401 behavior.
- The core security change (removing shared-IP fallback authorization) is straightforward and consistently applied to both HTTP and WS authorization paths. However, the updated e2e helper currently treats any WebSocket error as a successful rejection, which can mask failures and reduce confidence that the WS auth regression is actually being exercised in CI.
- src/gateway/server.canvas-auth.e2e.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
