### PR TITLE
fix(bluebubbles): remove loopback address auth bypass in webhook handler

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -1531,10 +1531,6 @@ export async function handleBlueBubblesWebhookRequest(
     if (guid && guid.trim() === token) {
       return true;
     }
-    const remote = req.socket?.remoteAddress ?? "";
-    if (remote === "127.0.0.1" || remote === "::1" || remote === "::ffff:127.0.0.1") {
-      return true;
-    }
     return false;
   });
 


### PR DESCRIPTION
## Fix Summary

Remove implicit trust of loopback addresses (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`) in the BlueBubbles webhook authentication handler. When deployed behind a same-host reverse proxy (nginx, Traefik, Caddy), all inbound traffic appears from loopback, allowing unauthenticated attackers to inject forged BlueBubbles events that are processed as legitimate messages.

Webhook secret validation is now required unconditionally when a password is configured. Accounts without a password configured continue to accept all requests (existing behavior).

**Changes:**
- Remove 4-line loopback bypass block from `monitor.ts` webhook filter
- Update test to expect 401 for localhost requests when password is configured
- Add new test verifying requests are accepted when no password is configured

## Issue Linkage

Fixes #11739

## Security Snapshot

- CVSS v3.1: 8.6 (High)
- CVSS v4.0: 8.8 (High)

## Implementation Details

### Files Changed
- `extensions/bluebubbles/src/monitor.test.ts` (+37/-2)
- `extensions/bluebubbles/src/monitor.ts` (+0/-4)

### Technical Analysis
Remove implicit trust of loopback addresses (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`) in the BlueBubbles webhook authentication handler. When deployed behind a same-host reverse proxy (nginx, Traefik, Caddy), all inbound traffic appears from loopback, allowing unauthenticated attackers to inject forged BlueBubbles events that are processed as legitimate messages.

## Validation Evidence

- Command: `monitor.test.ts`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the BlueBubbles webhook “loopback address” authentication bypass and updates tests to require a configured password even when the request originates from localhost, while preserving the existing behavior of accepting all requests when no password is configured.

The core handler (`extensions/bluebubbles/src/monitor.ts`) now authenticates webhook requests solely via the configured shared secret provided as a query param (`guid`/`password`) or via headers (`x-guid`/`x-password`/`x-bluebubbles-guid`), and the test suite adds coverage to ensure localhost no longer bypasses auth when a password is set.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one concrete auth-handling issue to address.
- The loopback bypass removal is straightforward and tests were updated accordingly. The remaining concern is that accepting the raw `authorization` header without parsing common schemes (e.g., `Bearer`) can cause valid requests to be rejected, which is a functional regression for callers relying on that header path.
- extensions/bluebubbles/src/monitor.ts (webhook auth header handling)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
