### PR TITLE
feat(skills): add serenai skill for database and API queries

### DIFF
--- a/skills/serenai/SKILL.md
+++ b/skills/serenai/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: serenai
+description: Query databases and APIs via SerenAI gateway. Pay-per-query access to SQL databases, web scraping, and search APIs.
+homepage: https://serendb.com
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🌊",
+        "requires": { "bins": ["curl"], "env": ["SEREN_API_KEY"] },
+        "primaryEnv": "SEREN_API_KEY",
+      },
+  }
+---
+
+# SerenAI
+
+Query databases and call APIs through SerenAI's gateway. Pay per query with a prepaid wallet.
+
+## Setup
+
+Register (no auth required):
+
+```bash
+curl -X POST https://api.serendb.com/auth/agent \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-agent"}'
+```
+
+Save the `api_key` from response:
+
+```bash
+export SEREN_API_KEY="seren_xxxx"
+```
+
+## Commands
+
+Check balance:
+
+```bash
+curl https://api.serendb.com/wallet/balance \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
+
+List publishers:
+
+```bash
+curl https://api.serendb.com/publishers
+```
+
+Query a database:
+
+```bash
+curl -X POST "https://api.serendb.com/publishers/{slug}/query" \
+  -H "Authorization: Bearer $SEREN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "SELECT * FROM table LIMIT 10"}'
+```
+
+Call an API:
+
+```bash
+curl -X POST "https://api.serendb.com/publishers/{slug}/proxy" \
+  -H "Authorization: Bearer $SEREN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"method": "GET", "path": "/v1/endpoint"}'
+```
+
+Estimate cost:
+
+```bash
+curl -X POST "https://api.serendb.com/publishers/{slug}/estimate" \
+  -H "Authorization: Bearer $SEREN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "SELECT * FROM large_table"}'
+```
+
+Claim free daily credits:
+
+```bash
+curl -X POST https://api.serendb.com/wallet/free-credits/claim \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
+
+## Notes
+
+- Pricing: ~$0.001-0.10 per call (varies by publisher)
+- Use `LIMIT` clauses to control query costs
+- Check balance before expensive operations


### PR DESCRIPTION
## Summary

Adds a skill for querying databases and calling APIs through the SerenAI gateway.

## What it does

- **Agent registration**: Simple curl-based setup, no pre-existing auth required
- **Database queries**: Execute SQL queries against publishers
- **API proxy**: Call REST APIs through the gateway
- **Cost estimation**: Check query costs before execution
- **Wallet management**: Balance checking and free daily credits

## Requirements

- `curl` (standard on most systems)
- `SEREN_API_KEY` environment variable

## Format

Follows the standard skill format with YAML frontmatter metadata. Concise documentation (~89 lines, similar to github/goplaces skills).

## Test plan

- [ ] Verify SKILL.md parses correctly
- [ ] Test curl commands against live API
- [ ] Confirm env var detection works in OpenClaw

---

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `serenai` skill definition under `skills/serenai/SKILL.md`, documenting how to register for a SerenAI API key and use `curl` to query publisher databases, proxy REST API calls, estimate query cost, and manage wallet credits via the SerenAI gateway.

This follows the repo’s “skill as SKILL.md with YAML frontmatter + usage docs” pattern used by other entries under `skills/*/SKILL.md` (e.g. `skills/weather/SKILL.md`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but the skill frontmatter metadata parsing likely breaks as written.
- Only a single documentation file is added, but the current frontmatter uses a multi-line JSON blob under `metadata` and includes a trailing comma, which will likely fail YAML/JSON parsing and prevent the skill from being registered/loaded correctly.
- skills/serenai/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->