### PR TITLE
Add Nexos provider scaffold

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -164,6 +164,34 @@ Kimi K2 model IDs:
 }
 ```
 
+### Nexos.ai (Gateway)
+
+Nexos provides an OpenAI-compatible gateway. Configure it as a custom provider:
+
+- Provider: `nexos`
+- Auth: `NEXOS_API_KEY`
+- Example model: `nexos/<model-id>`
+
+```json5
+{
+  env: { NEXOS_API_KEY: "sk-..." },
+  agents: {
+    defaults: { model: { primary: "nexos/<model-id>" } },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      nexos: {
+        baseUrl: "https://api.nexos.ai/v1",
+        apiKey: "${NEXOS_API_KEY}",
+        api: "openai-completions",
+        models: [{ id: "<model-id>", name: "Nexos Model" }],
+      },
+    },
+  },
+}
+```
+
 ### Kimi Coding
 
 Kimi Coding uses Moonshot AI's Anthropic-compatible endpoint:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1006,6 +1006,7 @@
                   "bedrock",
                   "providers/vercel-ai-gateway",
                   "providers/moonshot",
+                  "providers/nexos",
                   "providers/minimax",
                   "providers/opencode",
                   "providers/glm",

--- a/docs/providers/nexos.md
+++ b/docs/providers/nexos.md
@@ -1,0 +1,49 @@
+---
+summary: "Use Nexos.ai Gateway in OpenClaw"
+read_when:
+  - You want to use Nexos.ai as a model provider
+  - You need Nexos.ai setup guidance
+title: "Nexos.ai"
+---
+
+# Nexos.ai
+
+Nexos provides an OpenAI‑compatible gateway API. Configure it as a provider and
+point OpenClaw at your Nexos Gateway base URL.
+
+## Quick setup (API key)
+
+```json5
+{
+  env: { NEXOS_API_KEY: "sk-..." },
+  agents: {
+    defaults: { model: { primary: "nexos/<model-id>" } },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      nexos: {
+        baseUrl: "https://api.nexos.ai/v1",
+        apiKey: "${NEXOS_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "<model-id>",
+            name: "Nexos Model",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+## Notes
+
+- Replace `<model-id>` with the Nexos model ID you want to expose.
+- If Nexos issues OAuth tokens, prefer a provider auth plugin to mint bearer tokens and store them in auth profiles.

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -296,6 +296,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
     moonshot: "MOONSHOT_API_KEY",
+    nexos: "NEXOS_API_KEY",
     minimax: "MINIMAX_API_KEY",
     xiaomi: "XIAOMI_API_KEY",
     synthetic: "SYNTHETIC_API_KEY",

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -36,6 +36,17 @@ const MINIMAX_API_COST = {
   cacheWrite: 10,
 };
 
+const NEXOS_BASE_URL = "https://api.nexos.ai/v1";
+const NEXOS_DEFAULT_MODEL_ID = "nexos-default";
+const NEXOS_DEFAULT_CONTEXT_WINDOW = 128000;
+const NEXOS_DEFAULT_MAX_TOKENS = 8192;
+const NEXOS_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 const XIAOMI_BASE_URL = "https://api.xiaomimimo.com/anthropic";
 export const XIAOMI_DEFAULT_MODEL_ID = "mimo-v2-flash";
 const XIAOMI_DEFAULT_CONTEXT_WINDOW = 262144;
@@ -343,6 +354,24 @@ function buildMoonshotProvider(): ProviderConfig {
   };
 }
 
+function buildNexosProvider(): ProviderConfig {
+  return {
+    baseUrl: NEXOS_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: NEXOS_DEFAULT_MODEL_ID,
+        name: "Nexos Default",
+        reasoning: false,
+        input: ["text"],
+        cost: NEXOS_DEFAULT_COST,
+        contextWindow: NEXOS_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: NEXOS_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}
+
 function buildQwenPortalProvider(): ProviderConfig {
   return {
     baseUrl: QWEN_PORTAL_BASE_URL,
@@ -469,6 +498,13 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
     providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+  }
+
+  const nexosKey =
+    resolveEnvApiKeyVarName("nexos") ??
+    resolveApiKeyFromProfiles({ provider: "nexos", store: authStore });
+  if (nexosKey) {
+    providers.nexos = { ...buildNexosProvider(), apiKey: nexosKey };
   }
 
   const syntheticKey =


### PR DESCRIPTION
## Summary
- add Nexos provider scaffold with env mapping and implicit provider injection
- add Nexos docs page + add to docs navigation
- add Nexos example in model provider docs

## Notes
- Default model id is placeholder  until real model IDs are provided.
- Base URL set to https://api.nexos.ai/v1 and auth via NEXOS_API_KEY (Bearer).
