### PR TITLE
fix(boot): use ephemeral session per boot to prevent stale context

### DIFF
--- a/src/gateway/boot.ts
+++ b/src/gateway/boot.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { CliDeps } from "../cli/deps.js";
@@ -11,7 +12,8 @@ import { type RuntimeEnv, defaultRuntime } from "../runtime.js";
 function generateBootSessionId(): string {
   const now = new Date();
   const ts = now.toISOString().replace(/[:.]/g, "-").replace("T", "_").replace("Z", "");
-  return `boot-${ts}`;
+  const suffix = crypto.randomUUID().slice(0, 8);
+  return `boot-${ts}-${suffix}`;
 }
 
 const log = createSubsystemLogger("gateway/boot");

--- a/src/gateway/boot.ts
+++ b/src/gateway/boot.ts
@@ -8,6 +8,12 @@ import { resolveMainSessionKey } from "../config/sessions/main-session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { type RuntimeEnv, defaultRuntime } from "../runtime.js";
 
+function generateBootSessionId(): string {
+  const now = new Date();
+  const ts = now.toISOString().replace(/[:.]/g, "-").replace("T", "_").replace("Z", "");
+  return `boot-${ts}`;
+}
+
 const log = createSubsystemLogger("gateway/boot");
 const BOOT_FILENAME = "BOOT.md";
 
@@ -75,12 +81,14 @@ export async function runBootOnce(params: {
 
   const sessionKey = resolveMainSessionKey(params.cfg);
   const message = buildBootPrompt(result.content ?? "");
+  const sessionId = generateBootSessionId();
 
   try {
     await agentCommand(
       {
         message,
         sessionKey,
+        sessionId,
         deliver: false,
       },
       bootRuntime,


### PR DESCRIPTION
#### Summary

The boot-md hook shares the main session key, so prior boot prompts and responses accumulate in the session transcript. After several gateway restarts the agent sees repeated identical "You are running a boot check" messages and skips the notification — it concludes the requests are duplicates and refuses to send another WhatsApp message.

#### Repro Steps

1. Configure `BOOT.md` with a restart notification (e.g. send WhatsApp message)
2. Restart the gateway multiple times within the same session freshness window
3. After ~3-5 restarts, the agent stops sending notifications
4. Session transcript shows agent thinking: "This is the 6th identical boot check request... Skipping duplicate"

#### Root Cause

`runBootOnce` in `src/gateway/boot.ts` passes only `sessionKey` to `agentCommand`. The session resolver reuses the existing transcript if it is still fresh (within the daily reset window). Each boot appends another identical prompt+response pair, giving the LLM the false impression of repeated/duplicate invocations.

#### Behavior Changes

- Each boot run now gets a unique, timestamped session ID (e.g. `boot-2026-02-08_21-07-28-123`)
- The agent always starts with a clean context — no prior boot history
- Boot transcripts are individually identifiable by timestamp in the sessions directory
- No change to session key routing or delivery behavior

#### Codebase and GitHub Search

- Searched for `runBootOnce`, `generateBootSessionId`, `BOOT_FILENAME` — no conflicting implementations
- Checked `agentCommand` types — `sessionId` is an existing optional field on `AgentCommandOpts`
- Reviewed `resolveSession` — a provided `sessionId` is used directly, bypassing stale session reuse

#### Tests

```
pnpm vitest run src/gateway/boot.test.ts
# ✓ 3 tests passed
```

- Existing boot tests continue to pass
- No new tests needed — the fix is a session isolation change, not new logic

#### Manual Testing

##### Prerequisites

- OpenClaw instance with `BOOT.md` configured to send a WhatsApp notification on restart

##### Steps

1. Restart gateway — agent sends notification ✅
2. Restart gateway again within same session window — agent sends notification again ✅ (previously would skip after ~3 restarts)
3. Verify session directory contains separate `boot-<timestamp>.jsonl` files per restart

#### Evidence

Before fix — agent thinking after 6th restart:
> "This is now the 6th identical boot check request. Something is clearly misconfigured and triggering repeated boot checks. I should not keep sending WhatsApp messages to Jake."

After fix — each boot gets a clean session with no prior context, so the agent always follows BOOT.md instructions.

lobster-biscuit

**Sign-Off**

- Models used: claude-sonnet-4-20250514
- Submitter effort: diagnosed via gateway logs + session transcript analysis, one-line fix
- Agent notes: root cause confirmed by reading session transcript showing 6 accumulated boot prompts in a single session

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change isolates BOOT.md runs into their own session transcript by generating a fresh `sessionId` on each gateway boot and passing it through to `agentCommand`. This prevents the boot hook from reusing a “fresh” main session transcript (keyed by `sessionKey`) and accumulating repeated boot prompts/responses, which previously led the agent to treat later boots as duplicates and skip notifications.

The change is localized to `src/gateway/boot.ts`: a `generateBootSessionId()` helper creates a timestamp-based id (e.g. `boot-2026-02-08_21-07-28-123`) and `runBootOnce` now includes `sessionId` in the `agentCommand` options. The rest of session routing (via `sessionKey`) remains unchanged, but transcript storage is split per boot run.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; one edge-case can defeat the intended session isolation.
- The change is small and uses an existing `sessionId` plumbing path, but the new timestamp-based `sessionId` can collide if `runBootOnce` runs twice within the same millisecond, causing transcript reuse and undermining the fix.
- src/gateway/boot.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->