### PR TITLE
fix: add guards for undefined mentionRegexes arrays

### DIFF
--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -73,7 +73,7 @@ export function normalizeMentionText(text: string): string {
 }
 
 export function matchesMentionPatterns(text: string, mentionRegexes: RegExp[]): boolean {
-  if (mentionRegexes.length === 0) {
+  if (!mentionRegexes || mentionRegexes.length === 0) {
     return false;
   }
   const cleaned = normalizeMentionText(text ?? "");
@@ -98,13 +98,14 @@ export function matchesMentionWithExplicit(params: {
   const explicit = params.explicit?.isExplicitlyMentioned === true;
   const explicitAvailable = params.explicit?.canResolveExplicit === true;
   const hasAnyMention = params.explicit?.hasAnyMention === true;
+  const regexes = params.mentionRegexes ?? [];
   if (hasAnyMention && explicitAvailable) {
-    return explicit || params.mentionRegexes.some((re) => re.test(cleaned));
+    return explicit || regexes.some((re) => re.test(cleaned));
   }
   if (!cleaned) {
     return explicit;
   }
-  return explicit || params.mentionRegexes.some((re) => re.test(cleaned));
+  return explicit || regexes.some((re) => re.test(cleaned));
 }
 
 export function stripStructuralPrefixes(text: string): string {

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -72,7 +72,7 @@ export function normalizeMentionText(text: string): string {
   return (text ?? "").replace(/[\u200b-\u200f\u202a-\u202e\u2060-\u206f]/g, "").toLowerCase();
 }
 
-export function matchesMentionPatterns(text: string, mentionRegexes: RegExp[]): boolean {
+export function matchesMentionPatterns(text: string, mentionRegexes?: RegExp[]): boolean {
   if (!mentionRegexes || mentionRegexes.length === 0) {
     return false;
   }
@@ -91,7 +91,7 @@ export type ExplicitMentionSignal = {
 
 export function matchesMentionWithExplicit(params: {
   text: string;
-  mentionRegexes: RegExp[];
+  mentionRegexes?: RegExp[];
   explicit?: ExplicitMentionSignal;
 }): boolean {
   const cleaned = normalizeMentionText(params.text ?? "");

--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -60,7 +60,7 @@ export function isBotMentionedFromTargets(
     // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in group chats triggers the bot.
   }
   const bodyClean = clean(msg.body);
-  if (mentionCfg.mentionRegexes.some((re) => re.test(bodyClean))) {
+  if ((mentionCfg.mentionRegexes ?? []).some((re) => re.test(bodyClean))) {
     return true;
   }
 


### PR DESCRIPTION
Prevents `Cannot read properties of undefined (reading some)` errors when `mentionRegexes` is undefined in group chat mention detection.

## Fixes
- `matchesMentionPatterns`: add `!mentionRegexes` check before `.length`
- `matchesMentionWithExplicit`: extract regexes with `?? []` fallback
- `isBotMentionedFromTargets`: add `?? []` fallback for `.some()` call

## Context
Observed intermittent crashes in group chat sessions with error:
```
Cannot read properties of undefined (reading 'some')
```

The issue occurs when `params.mentionRegexes` is undefined during mention detection, likely due to race conditions or edge cases in config resolution.

## Changes
- `src/auto-reply/reply/mentions.ts` - 2 functions fixed
- `src/web/auto-reply/mentions.ts` - 1 function fixed

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens group-chat mention detection against cases where `mentionRegexes` is unexpectedly `undefined`, preventing runtime crashes like `Cannot read properties of undefined (reading 'some')`.

Changes are localized to mention-matching helpers used by auto-reply and the web/WhatsApp inbound path: the core mention matcher now short-circuits when no regexes are available, and callers use `?? []` when iterating regex arrays so `.some()` is always safe.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but the type contract mismatch around `mentionRegexes` should be resolved to avoid future regressions.
- The runtime guard additions appear correct and directly address the reported crash. The main remaining issue is that `matchesMentionPatterns` now accepts `undefined` at runtime but is still typed as `RegExp[]`, which can hide incorrect call sites and undermines type safety.
- src/auto-reply/reply/mentions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->