### PR TITLE
my branch

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,110 @@
+# OpenClaw Multi-stage Optimized Dockerfile
+# Target: < 500MB final image
+#
+# Build: docker build -f Dockerfile.slim -t openclaw:slim .
+# Analyze: ./scripts/docker-image-analyze.sh openclaw:slim
+
+# ============================================
+# Stage 1: Build stage (full tooling)
+# ============================================
+FROM node:22-bookworm AS builder
+
+# Install Bun (required for build scripts)
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+RUN corepack enable
+
+WORKDIR /app
+
+# Copy package files first for better cache
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+COPY scripts ./scripts
+
+# Install all dependencies (including dev) for building
+RUN pnpm install --frozen-lockfile
+
+# Copy source and build
+COPY . .
+RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
+
+# Build UI
+ENV OPENCLAW_PREFER_PNPM=1
+RUN pnpm ui:build
+
+# ============================================
+# Stage 2: Production dependencies only
+# ============================================
+FROM node:22-bookworm-slim AS prod-deps
+
+RUN corepack enable
+WORKDIR /app
+ARG OPENCLAW_PRUNE_EXTRA=0
+
+# Copy package files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches ./patches
+
+# Install production dependencies only for the root CLI package.
+# In a pnpm workspace this avoids pulling runtime deps for every workspace package.
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts --filter openclaw...
+
+# Remove large optional binaries that aren't needed in most deployments
+# These are primarily for local LLM inference
+RUN rm -rf node_modules/.pnpm/@node-llama-cpp* 2>/dev/null || true && \
+    rm -rf node_modules/.pnpm/*node-llama-cpp* 2>/dev/null || true && \
+    rm -rf node_modules/.pnpm/*cuda* 2>/dev/null || true && \
+    rm -rf node_modules/.pnpm/*vulkan* 2>/dev/null || true && \
+    rm -rf node_modules/.pnpm/*tensorflow* 2>/dev/null || true && \
+    rm -rf node_modules/.pnpm/*linux-x64-musl* 2>/dev/null || true && \
+    rm -rf node_modules/.pnpm/*linuxmusl* 2>/dev/null || true && \
+    rm -rf node_modules/.pnpm/typescript@* 2>/dev/null || true && \
+    find node_modules -type f -name "*.map" -delete && \
+    find node_modules -type d \( -name "__tests__" -o -name "test" -o -name "tests" -o -name "docs" -o -name "examples" -o -name "benchmark" \) -prune -exec rm -rf '{}' +
+
+# Optional aggressive prune for channel-specific SDKs.
+# Enable with: --build-arg OPENCLAW_PRUNE_EXTRA=1
+RUN if [ "$OPENCLAW_PRUNE_EXTRA" = "1" ]; then \
+      rm -rf node_modules/.pnpm/@larksuiteoapi+node-sdk@* 2>/dev/null || true; \
+      rm -rf node_modules/.pnpm/@line+bot-sdk@* 2>/dev/null || true; \
+      rm -rf node_modules/.pnpm/@slack+bolt@* 2>/dev/null || true; \
+      rm -rf node_modules/.pnpm/@slack+web-api@* 2>/dev/null || true; \
+      rm -rf node_modules/.pnpm/playwright-core@* 2>/dev/null || true; \
+    fi
+
+# ============================================
+# Stage 3: Runtime image (minimal)
+# ============================================
+FROM node:22-slim AS runtime
+
+WORKDIR /app
+
+# Runtime only: remove package-manager/tooling payload from the Node base image.
+RUN rm -rf \
+    /usr/local/lib/node_modules/npm \
+    /usr/local/lib/node_modules/corepack \
+    /usr/local/include/node \
+    /usr/local/share/doc \
+    /usr/local/share/man \
+    /usr/local/share/systemtap
+
+# Copy production node_modules from prod-deps stage
+COPY --from=prod-deps --chown=1000:1000 /app/node_modules ./node_modules
+
+# Copy built artifacts from builder
+COPY --from=builder --chown=1000:1000 /app/dist ./dist
+
+# Copy runtime files
+COPY --chown=1000:1000 openclaw.mjs ./
+COPY --chown=1000:1000 package.json ./
+COPY --chown=1000:1000 extensions ./extensions
+
+ENV NODE_ENV=production
+
+# Security: run as non-root
+USER node
+
+# Gateway default command
+CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]

--- a/scripts/docker-build-slim.sh
+++ b/scripts/docker-build-slim.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Build optimized Docker image for OpenClaw
+# Usage: ./scripts/docker-build-slim.sh [tag]
+#
+# This builds a minimal Docker image (~500MB target) using multi-stage build
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+TAG="${1:-openclaw:slim}"
+DOCKERFILE="${ROOT_DIR}/Dockerfile.slim"
+PRUNE_EXTRA="${OPENCLAW_PRUNE_EXTRA:-0}"
+
+echo "Building optimized Docker image..."
+echo "  Tag: $TAG"
+echo "  Dockerfile: $DOCKERFILE"
+echo "  OPENCLAW_PRUNE_EXTRA: $PRUNE_EXTRA"
+echo ""
+
+# Build with progress
+docker build \
+  -f "$DOCKERFILE" \
+  -t "$TAG" \
+  --build-arg "OPENCLAW_PRUNE_EXTRA=$PRUNE_EXTRA" \
+  --progress=plain \
+  "$ROOT_DIR"
+
+echo ""
+echo "Build complete!"
+echo ""
+
+# Show size
+SIZE=$(docker images "$TAG" --format "{{.Size}}")
+echo "Final image size: $SIZE"
+echo ""
+
+# Parse size and normalize to MB without requiring bc.
+SIZE_VALUE=$(printf '%s' "$SIZE" | grep -oE '^[0-9]+([.][0-9]+)?' || echo "0")
+SIZE_UNIT=$(printf '%s' "$SIZE" | grep -oE '[A-Za-z]+$' || echo "MB")
+SIZE_MB=$(awk -v value="$SIZE_VALUE" -v unit="$SIZE_UNIT" '
+  BEGIN {
+    if (unit == "GB") { print value * 1024; exit }
+    if (unit == "MB") { print value; exit }
+    if (unit == "kB" || unit == "KB") { print value / 1024; exit }
+    print value
+  }
+')
+
+if awk -v mb="$SIZE_MB" 'BEGIN { exit !(mb < 500) }'; then
+  echo "Target achieved: Image is under 500MB."
+else
+  printf 'Target not met: %.2fMB (goal: <500MB).\n' "$SIZE_MB"
+fi
+
+echo ""
+echo "To analyze the image in detail, run:"
+echo "  ./scripts/docker-image-analyze.sh $TAG"
+echo ""
+echo "To run the container:"
+echo "  docker run -it --rm $TAG"

--- a/scripts/docker-image-analyze.sh
+++ b/scripts/docker-image-analyze.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Docker Image Size Analyzer for OpenClaw
+# Usage: ./scripts/docker-image-analyze.sh [IMAGE_NAME]
+#
+# This script analyzes a Docker image and provides a detailed breakdown of:
+# - Layer sizes and commands
+# - Directory sizes inside the container
+# - Largest npm packages
+# - Recommendations for size reduction
+
+set -euo pipefail
+
+IMAGE_NAME="${1:-openclaw:analyze}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Docker Image Size Analyzer${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Check if image exists
+if ! docker image inspect "$IMAGE_NAME" &>/dev/null; then
+    echo -e "${RED}Error: Image '$IMAGE_NAME' not found${NC}"
+    echo "Build it first: docker build -t $IMAGE_NAME ."
+    exit 1
+fi
+
+# Get total image size
+TOTAL_SIZE=$(docker images "$IMAGE_NAME" --format "{{.Size}}")
+echo -e "${GREEN}Total Image Size:${NC} ${YELLOW}$TOTAL_SIZE${NC}"
+echo ""
+
+# Layer analysis
+echo -e "${BLUE}Top 15 Largest Layers:${NC}"
+echo "----------------------------------------"
+docker history "$IMAGE_NAME" --no-trunc --format "{{.Size}}\t{{.CreatedBy}}" 2>/dev/null | \
+grep -v "^0B" | \
+sort -hr | \
+head -15 | \
+while IFS=$'\t' read -r size cmd; do
+    # Truncate long commands
+    cmd_short=$(echo "$cmd" | cut -c1-80)
+    if [ ${#cmd} -gt 80 ]; then
+        cmd_short="${cmd_short}..."
+    fi
+    printf "%-10s %s\n" "$size" "$cmd_short"
+done
+echo ""
+
+# Directory sizes inside container
+echo -e "${BLUE}Directory Sizes Inside Container:${NC}"
+echo "----------------------------------------"
+docker run --rm "$IMAGE_NAME" sh -c '
+  echo "Key directories:"
+  for dir in /app/node_modules /app/dist /app/extensions; do
+    if [ -d "$dir" ]; then
+      size=$(du -sh "$dir" 2>/dev/null | cut -f1)
+      printf "%-12s %s\n" "$size" "$dir"
+    fi
+  done
+  echo ""
+  echo "System directories:"
+  for dir in /usr/local/lib/node_modules /root/.bun /usr/lib /var/cache; do
+    if [ -d "$dir" ]; then
+      size=$(du -sh "$dir" 2>/dev/null | cut -f1)
+      printf "%-12s %s\n" "$size" "$dir"
+    fi
+  done
+' 2>/dev/null || echo "(Could not analyze - container may not have du command)"
+echo ""
+
+# Largest npm packages (pnpm-specific)
+echo -e "${BLUE}Top 20 Largest npm Packages:${NC}"
+echo "----------------------------------------"
+docker run --rm "$IMAGE_NAME" sh -c '
+  if [ -d /app/node_modules/.pnpm ]; then
+    du -sh /app/node_modules/.pnpm/* 2>/dev/null | sort -hr | head -20
+  else
+    du -sh /app/node_modules/* 2>/dev/null | sort -hr | head -20
+  fi
+' 2>/dev/null || echo "(Could not analyze)"
+echo ""
+
+# Dev vs Prod dependencies analysis
+echo -e "${BLUE}Dev Dependencies Analysis:${NC}"
+echo "----------------------------------------"
+docker run --rm "$IMAGE_NAME" sh -c '
+  dev_deps="typescript oxlint vitest esbuild rolldown tsdown node-llama-cpp"
+  total_dev=0
+  for pkg in $dev_deps; do
+    size=$(du -sh /app/node_modules/.pnpm/*"$pkg"* 2>/dev/null | awk "{sum+=\$1} END {print sum}" || echo 0)
+    if [ -n "$size" ] && [ "$size" != "0" ]; then
+      echo "  ${pkg}: found"
+    fi
+  done
+' 2>/dev/null || echo "(Could not analyze)"
+echo ""
+
+# Size breakdown summary
+echo -e "${BLUE}Size Breakdown Summary:${NC}"
+echo "----------------------------------------"
+docker run --rm "$IMAGE_NAME" sh -c '
+  # Get sizes in MB for comparison
+  nm_size=$(du -sm /app/node_modules 2>/dev/null | cut -f1 || echo 0)
+  dist_size=$(du -sm /app/dist 2>/dev/null | cut -f1 || echo 0)
+  ext_size=$(du -sm /app/extensions 2>/dev/null | cut -f1 || echo 0)
+
+  total=$((nm_size + dist_size + ext_size))
+
+  echo "node_modules:  ${nm_size}MB"
+  echo "dist:          ${dist_size}MB"
+  echo "extensions:    ${ext_size}MB"
+  echo "-------------------"
+  echo "App total:     ~${total}MB"
+' 2>/dev/null || echo "(Could not analyze)"
+echo ""
+
+# Recommendations
+echo -e "${BLUE}Recommendations:${NC}"
+echo "----------------------------------------"
+echo "1. Use multi-stage build to separate build and runtime"
+echo "2. Install only root package prod deps (pnpm --filter openclaw...)"
+echo "3. Install only production dependencies in final stage"
+echo "4. Remove optional heavy deps: node-llama-cpp/CUDA/musl artifacts"
+echo "5. Use --chown flag in COPY instead of separate RUN chown"
+echo "6. Remove Bun from runtime if not needed"
+echo "7. For single-channel VPS use, try OPENCLAW_PRUNE_EXTRA=1 in Dockerfile.slim (also prunes playwright-core)"
+echo ""
+echo -e "${GREEN}Run ./scripts/docker-build-slim.sh to build an optimized image${NC}"


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `Dockerfile.slim` multi-stage build intended to produce a smaller runtime image, plus helper scripts to build it (`scripts/docker-build-slim.sh`) and inspect image/layer/package size (`scripts/docker-image-analyze.sh`). The Dockerfile builds the project in a full `node:22-bookworm` stage, installs prod-only deps in a separate stage, then copies `dist/`, `node_modules/`, and runtime entrypoints into a `node:22-slim` runtime image running as the `node` user.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after addressing a couple correctness/security issues in the Docker build and analysis script.
- The change is additive and isolated to Docker/build tooling, but it introduces an unpinned `curl | bash` install in the Dockerfile (supply-chain + non-reproducible builds) and the image analyzer reports incorrect dev-dependency sizes due to summing human-readable `du -sh` output.
- Dockerfile.slim; scripts/docker-image-analyze.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->