### PR TITLE
feat(core): externalize large tool results + default-on context pruning

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -16,6 +16,7 @@ import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+import { createToolResultGetTool } from "./tools/tool-result-get-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
 import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
 
@@ -142,6 +143,9 @@ export function createOpenClawTools(options?: {
     createSessionStatusTool({
       agentSessionKey: options?.agentSessionKey,
       config: options?.config,
+    }),
+    createToolResultGetTool({
+      agentSessionKey: options?.agentSessionKey,
     }),
     ...(webSearchTool ? [webSearchTool] : []),
     ...(webFetchTool ? [webFetchTool] : []),

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -10,7 +10,7 @@ import { setContextPruningRuntime } from "../pi-extensions/context-pruning/runti
 import { computeEffectiveSettings } from "../pi-extensions/context-pruning/settings.js";
 import { makeToolPrunablePredicate } from "../pi-extensions/context-pruning/tools.js";
 import { ensurePiCompactionReserveTokens } from "../pi-settings.js";
-import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
+import { readLastCacheTtlTimestamp } from "./cache-ttl.js";
 
 function resolvePiExtensionPath(id: string): string {
   const self = fileURLToPath(import.meta.url);
@@ -43,13 +43,6 @@ function buildContextPruningExtension(params: {
   model: Model<Api> | undefined;
 }): { additionalExtensionPaths?: string[] } {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
-  if (raw?.mode !== "cache-ttl") {
-    return {};
-  }
-  if (!isCacheTtlEligibleProvider(params.provider, params.modelId)) {
-    return {};
-  }
-
   const settings = computeEffectiveSettings(raw);
   if (!settings) {
     return {};
@@ -59,7 +52,8 @@ function buildContextPruningExtension(params: {
     settings,
     contextWindowTokens: resolveContextWindowTokens(params),
     isToolPrunable: makeToolPrunablePredicate(settings.tools),
-    lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager),
+    lastCacheTouchAt:
+      settings.mode === "cache-ttl" ? readLastCacheTtlTimestamp(params.sessionManager) : null,
   });
 
   return {

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -27,6 +27,7 @@ export const TOOL_GROUPS: Record<string, string[]> = {
     "sessions_send",
     "sessions_spawn",
     "session_status",
+    "tool_result_get",
   ],
   // UI helpers
   "group:ui": ["browser", "canvas"],
@@ -50,6 +51,7 @@ export const TOOL_GROUPS: Record<string, string[]> = {
     "sessions_send",
     "sessions_spawn",
     "session_status",
+    "tool_result_get",
     "memory_search",
     "memory_get",
     "web_search",

--- a/src/agents/tool-result-store.ts
+++ b/src/agents/tool-result-store.ts
@@ -1,0 +1,182 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { TextContent } from "@mariozechner/pi-ai";
+import fs from "node:fs";
+import path from "node:path";
+
+export type StoredToolResultRef = {
+  /** Relative to the session transcripts dir (agent-scoped). */
+  ref: string;
+  bytes: number;
+  totalTextChars: number;
+  previewHead: string;
+  previewTail: string;
+};
+
+export type ToolResultStoreOptions = {
+  /** Base directory that contains session transcript jsonl files. */
+  sessionDir: string;
+  sessionId: string;
+  toolCallId: string;
+};
+
+function safeMkdirp(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function extractToolResultTextBlocks(message: AgentMessage): string[] {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return [];
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const type = (block as { type?: unknown }).type;
+    if (type !== "text") {
+      continue;
+    }
+    const text = (block as TextContent).text;
+    if (typeof text === "string") {
+      parts.push(text);
+    }
+  }
+  return parts;
+}
+
+function sumLengths(parts: string[]): number {
+  let len = 0;
+  for (const p of parts) {
+    len += p.length;
+  }
+  return len;
+}
+
+export function storeToolResultPayload(params: {
+  message: AgentMessage;
+  options: ToolResultStoreOptions;
+  preview?: { headChars?: number; tailChars?: number };
+}): StoredToolResultRef | null {
+  const parts = extractToolResultTextBlocks(params.message);
+  const totalTextChars = sumLengths(parts);
+  const headChars = Math.max(0, Math.floor(params.preview?.headChars ?? 1500));
+  const tailChars = Math.max(0, Math.floor(params.preview?.tailChars ?? 1500));
+  const previewHead = takeHead(parts[0] ?? "", headChars);
+  const previewTail = takeTail(parts.at(-1) ?? "", tailChars);
+
+  const payload = {
+    version: 1,
+    sessionId: params.options.sessionId,
+    toolCallId: params.options.toolCallId,
+    storedAt: new Date().toISOString(),
+    textBlocks: parts,
+  };
+
+  const baseDir = params.options.sessionDir;
+  const relDir = path.join("_tool_results", params.options.sessionId);
+  const outDir = path.join(baseDir, relDir);
+  safeMkdirp(outDir);
+
+  const fileName = `${encodeURIComponent(params.options.toolCallId)}.json`;
+  const absPath = path.join(outDir, fileName);
+
+  const json = JSON.stringify(payload);
+  fs.writeFileSync(absPath, json, "utf-8");
+  const bytes = Buffer.byteLength(json, "utf8");
+
+  return {
+    ref: path.join(relDir, fileName),
+    bytes,
+    totalTextChars,
+    previewHead,
+    previewTail,
+  };
+}
+
+function takeHead(text: string, maxChars: number): string {
+  if (maxChars <= 0) {
+    return "";
+  }
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return text.slice(0, maxChars);
+}
+
+function takeTail(text: string, maxChars: number): string {
+  if (maxChars <= 0) {
+    return "";
+  }
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return text.slice(text.length - maxChars);
+}
+
+export function makeExternalizedToolResultDigest(params: {
+  toolName?: string;
+  toolCallId: string;
+  storedRef: string;
+  originalChars: number;
+  previewHead: string;
+  previewTail: string;
+  maxDigestChars?: number;
+}): string {
+  const maxDigestChars = Math.max(0, Math.floor(params.maxDigestChars ?? 4000));
+
+  const header = `[Tool result externalized${params.toolName ? `: ${params.toolName}` : ""}]
+ToolCallId: ${params.toolCallId}
+StoredRef: ${params.storedRef}
+Original: ${params.originalChars} chars
+`;
+
+  const preview = `${params.previewHead}
+...
+${params.previewTail}`.trim();
+
+  const howTo = `
+[Fetch full or slice]
+Use tool_result_get with:
+  { ref: "${params.storedRef}", offsetChars: 0, maxChars: 4000 }
+`;
+
+  const raw = `${header}
+${preview}
+
+${howTo}`;
+  if (raw.length <= maxDigestChars) {
+    return raw;
+  }
+
+  const clipped = takeHead(raw, Math.max(0, maxDigestChars - 20));
+  return `${clipped}
+…(truncated)…`;
+}
+
+export function readStoredToolResultText(params: {
+  sessionDir: string;
+  ref: string;
+}): { ok: true; text: string } | { ok: false; error: string } {
+  const base = path.resolve(params.sessionDir);
+  const target = path.resolve(path.join(base, params.ref));
+  if (!target.startsWith(base + path.sep)) {
+    return { ok: false, error: "Invalid ref path." };
+  }
+  if (!fs.existsSync(target)) {
+    return { ok: false, error: `Not found: ${params.ref}` };
+  }
+  try {
+    const json = fs.readFileSync(target, "utf-8");
+    const data = JSON.parse(json) as { textBlocks?: unknown };
+    const blocks = Array.isArray(data.textBlocks) ? data.textBlocks : [];
+    const parts = blocks.filter((b): b is string => typeof b === "string");
+    return { ok: true, text: parts.join("\n") };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: msg };
+  }
+}

--- a/src/agents/tools/tool-result-get-tool.ts
+++ b/src/agents/tools/tool-result-get-tool.ts
@@ -1,0 +1,62 @@
+import { Type } from "@sinclair/typebox";
+import type { AnyAgentTool } from "./common.js";
+import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions/paths.js";
+// (no config dependency)
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { readStoredToolResultText } from "../tool-result-store.js";
+import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const ToolResultGetSchema = Type.Object({
+  ref: Type.String({ description: "Tool result ref string emitted by externalized tool results." }),
+  offsetChars: Type.Optional(Type.Number({ minimum: 0 })),
+  maxChars: Type.Optional(Type.Number({ minimum: 1 })),
+});
+
+const DEFAULT_MAX_CHARS = 4000;
+const HARD_MAX_CHARS = 20_000;
+
+function clampMaxChars(v: number | undefined): number {
+  const raw = typeof v === "number" && Number.isFinite(v) ? Math.floor(v) : DEFAULT_MAX_CHARS;
+  return Math.max(1, Math.min(HARD_MAX_CHARS, raw));
+}
+
+export function createToolResultGetTool(opts?: { agentSessionKey?: string }): AnyAgentTool {
+  return {
+    label: "Tool Result Get",
+    name: "tool_result_get",
+    description:
+      "Fetch full/sliced content for a tool result that was externalized to save context tokens.",
+    parameters: ToolResultGetSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const ref = readStringParam(params, "ref", { required: true });
+      const offsetChars = readNumberParam(params, "offsetChars", { integer: true });
+      const maxChars = clampMaxChars(readNumberParam(params, "maxChars", { integer: true }));
+
+      // config not required
+      const agentId = resolveAgentIdFromSessionKey(opts?.agentSessionKey);
+      const sessionDir = resolveSessionTranscriptsDirForAgent(agentId);
+
+      const result = readStoredToolResultText({ sessionDir, ref });
+      if (!result.ok) {
+        return jsonResult({ status: "not_found", error: result.error });
+      }
+
+      const start =
+        typeof offsetChars === "number" && Number.isFinite(offsetChars) && offsetChars > 0
+          ? Math.floor(offsetChars)
+          : 0;
+      const text = result.text;
+      const slice = text.slice(start, Math.min(text.length, start + maxChars));
+
+      return jsonResult({
+        status: "ok",
+        ref,
+        offsetChars: start,
+        returnedChars: slice.length,
+        totalChars: text.length,
+        text: slice,
+      });
+    },
+  };
+}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -355,31 +355,22 @@ export function applyContextPruningDefaults(cfg: OpenClawConfig): OpenClawConfig
   }
 
   const authMode = resolveAnthropicDefaultAuthMode(cfg);
-  if (!authMode) {
-    return cfg;
-  }
 
   let mutated = false;
   const nextDefaults = { ...defaults };
   const contextPruning = defaults.contextPruning ?? {};
-  const heartbeat = defaults.heartbeat ?? {};
 
   if (defaults.contextPruning?.mode === undefined) {
+    // Default ON (always) for token efficiency. Users can disable with mode="off".
     nextDefaults.contextPruning = {
       ...contextPruning,
-      mode: "cache-ttl",
-      ttl: defaults.contextPruning?.ttl ?? "1h",
+      mode: "always",
     };
     mutated = true;
   }
 
-  if (defaults.heartbeat?.every === undefined) {
-    nextDefaults.heartbeat = {
-      ...heartbeat,
-      every: authMode === "oauth" ? "1h" : "30m",
-    };
-    mutated = true;
-  }
+  // Heartbeat defaults were previously tuned for Anthropic caching; keep them opt-in.
+  // (User preference: proactive/heartbeat default off.)
 
   if (authMode === "api_key") {
     const nextModels = defaults.models ? { ...defaults.models } : {};

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -26,7 +26,7 @@ export type AgentModelListConfig = {
 };
 
 export type AgentContextPruningConfig = {
-  mode?: "off" | "cache-ttl";
+  mode?: "off" | "cache-ttl" | "always";
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -57,7 +57,7 @@ export const AgentDefaultsSchema = z
     memorySearch: MemorySearchSchema,
     contextPruning: z
       .object({
-        mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
+        mode: z.union([z.literal("off"), z.literal("cache-ttl"), z.literal("always")]).optional(),
         ttl: z.string().optional(),
         keepLastAssistants: z.number().int().nonnegative().optional(),
         softTrimRatio: z.number().min(0).max(1).optional(),


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces two related changes in the agent runtime:

- **Externalizes large tool results** during transcript persistence by storing full text blocks under the session transcripts directory (e.g., `_tool_results/<sessionId>/<toolCallId>.json`) and replacing the persisted transcript content with a compact digest + instructions to fetch slices via the new `tool_result_get` tool.
- **Turns on context pruning by default** (`mode: "always"`) and broadens pruning activation (removing provider eligibility gating), along with updated default thresholds and schema/type updates to include the new `always` mode.

Overall, the core externalization + fetch path looks consistent (path traversal is guarded in `readStoredToolResultText`, and persistence falls back to hard truncation as a safety net). The main issue found is a test change that weakens cache-TTL pruning guarantees.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but a correctness guarantee is no longer covered by tests.
- Core functionality (tool result externalization + retrieval, default-on pruning + schema updates) is internally consistent and includes safety checks (e.g., ref path containment, hard truncation fallback). The remaining issue is a weakened cache-TTL gating test, which could allow regressions in TTL behavior to slip through unnoticed.
- src/agents/pi-extensions/context-pruning.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->