### PR TITLE
fix: resolve 403 auth error for GithubCopilot imageModel (#10277)

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -264,7 +264,17 @@ async function runImagePrompt(params: {
         agentDir: params.agentDir,
       });
       const apiKey = requireApiKey(apiKeyInfo, model.provider);
-      authStorage.setRuntimeApiKey(model.provider, apiKey);
+      let requestApiKey = apiKey;
+      if (model.provider === "github-copilot") {
+        const { resolveCopilotApiToken } = await import("../../providers/github-copilot-token.js");
+        const copilotToken = await resolveCopilotApiToken({
+          githubToken: apiKey,
+        });
+        authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+        requestApiKey = copilotToken.token;
+      } else {
+        authStorage.setRuntimeApiKey(model.provider, apiKey);
+      }
       const imageDataUrl = `data:${params.mimeType};base64,${params.base64}`;
 
       if (model.provider === "minimax") {
@@ -279,7 +289,7 @@ async function runImagePrompt(params: {
 
       const context = buildImageContext(params.prompt, params.base64, params.mimeType);
       const message = await complete(model, context, {
-        apiKey,
+        apiKey: requestApiKey,
         maxTokens: 512,
       });
       const text = coerceImageAssistantText({


### PR DESCRIPTION
## Description
The image tool and media-understanding provider were passing the raw GitHub token directly to the `complete()` API, but GitHub Copilot requires exchanging the GitHub token for a Copilot API token first (via the token endpoint). This exchange was already implemented in the main embedding runner but missing in the image-only flows.


## Related Issue
Closes #10277

## Changes

- [src/agents/tools/image-tool.ts](src/agents/tools/image-tool.ts): Exchange GitHub token for Copilot token in `runImagePrompt()` before calling `complete()`.
- [src/media-understanding/providers/image.ts](src/media-understanding/providers/image.ts): Same exchange in `describeImageWithModel()`.

Both now mirror the token exchange pattern from the main runner ([src/agents/pi-embedded-runner/run.ts](src/agents/pi-embedded-runner/run.ts) and [src/agents/pi-embedded-runner/compact.ts](src/agents/pi-embedded-runner/compact.ts)).

## Testing

The fix applies the same auth flow already in use elsewhere, so existing tests for GitHub Copilot token exchange should cover this. 
I tested this by building and running the application
Confirm by:
- Setting `agents.defaults.imageModel.primary = "github-copilot/gpt-5-mini"` with a different primary model
- Sending an image and verifying it no longer throws 403

## Fixes

#10277

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes GitHub Copilot vision/image flows by exchanging the user’s GitHub token for a Copilot API token before calling `complete()`, matching the existing auth pattern used by the embedded runner. The change updates both the `image` agent tool and the media-understanding image provider to set the runtime API key to the exchanged Copilot token and to pass that token as the request `apiKey` for Copilot models, preventing 403s from using the raw GitHub token.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and aligns image auth with existing Copilot token exchange behavior.
- Changes are small and localized, and they reuse the existing Copilot token exchange implementation. Main concern is the new dynamic import path uses `github-copilot-token.js` while the repo appears to have `github-copilot-token.ts`, which could be a runtime module-resolution issue depending on the build output/TS config.
- src/agents/tools/image-tool.ts, src/media-understanding/providers/image.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->