### PR TITLE
fix: ensure /compact honors per-agent agentDir

### DIFF
--- a/src/agents/pi-embedded-runner/compact.agentdir.test.ts
+++ b/src/agents/pi-embedded-runner/compact.agentdir.test.ts
@@ -1,0 +1,96 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveCompactionAgentDir } from "./compact.js";
+
+describe("resolveCompactionAgentDir", () => {
+  it("prefers the configured directory for the active agent", () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "main", agentDir: path.resolve("/tmp/agent-main") },
+          { id: "support", agentDir: path.resolve("/tmp/agent-support") },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const agentDir = resolveCompactionAgentDir({
+      config: cfg,
+      sessionKey: "agent:support:main",
+    });
+
+    expect(agentDir).toBe(path.resolve("/tmp/agent-support"));
+  });
+
+  it("respects an explicit agentDir override", () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "main", agentDir: path.resolve("/tmp/agent-main") },
+          { id: "support", agentDir: path.resolve("/tmp/agent-support") },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const agentDir = resolveCompactionAgentDir({
+      agentDir: path.resolve("/tmp/custom"),
+      config: cfg,
+      sessionKey: "agent:support:main",
+    });
+
+    expect(agentDir).toBe(path.resolve("/tmp/custom"));
+  });
+
+  it("resolves distinct directories for different agents (#11625)", () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "main", agentDir: path.resolve("/data/agents/main") },
+          { id: "alice", agentDir: path.resolve("/data/agents/alice") },
+          { id: "bob", agentDir: path.resolve("/data/agents/bob") },
+        ],
+      },
+    } as OpenClawConfig;
+
+    // Without explicit agentDir, should derive from session key
+    const mainDir = resolveCompactionAgentDir({
+      config: cfg,
+      sessionKey: "agent:main:main",
+    });
+    const aliceDir = resolveCompactionAgentDir({
+      config: cfg,
+      sessionKey: "agent:alice:main",
+    });
+    const bobDir = resolveCompactionAgentDir({
+      config: cfg,
+      sessionKey: "agent:bob:dm:user123",
+    });
+
+    expect(mainDir).toBe(path.resolve("/data/agents/main"));
+    expect(aliceDir).toBe(path.resolve("/data/agents/alice"));
+    expect(bobDir).toBe(path.resolve("/data/agents/bob"));
+
+    // Ensure they are all distinct
+    expect(new Set([mainDir, aliceDir, bobDir]).size).toBe(3);
+  });
+
+  it("does not fall back to global dir when session key specifies agent with configured dir", () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "main", agentDir: path.resolve("/home/user/.openclaw/agents/main/agent") },
+          { id: "work", agentDir: path.resolve("/home/user/.openclaw/agents/work/agent") },
+        ],
+      },
+    } as OpenClawConfig;
+
+    // Session key for "work" agent should resolve to work's agentDir, not main's
+    const workDir = resolveCompactionAgentDir({
+      config: cfg,
+      sessionKey: "agent:work:main",
+    });
+
+    expect(workDir).toBe(path.resolve("/home/user/.openclaw/agents/work/agent"));
+    expect(workDir).not.toBe(path.resolve("/home/user/.openclaw/agents/main/agent"));
+  });
+});

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -6,6 +6,7 @@ vi.mock("./run/attempt.js", () => ({
 
 vi.mock("./compact.js", () => ({
   compactEmbeddedPiSessionDirect: vi.fn(),
+  resolveCompactionAgentDir: vi.fn(() => "/tmp/agent-dir"),
 }));
 
 vi.mock("./model.js", () => ({

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultDeps } from "../cli/deps.js";
+import * as agentModule from "../commands/agent.js";
+import { loadConfig } from "../config/config.js";
+import {
+  clearSessionStoreCacheForTest,
+  resolveStorePath,
+  saveSessionStore,
+} from "../config/sessions.js";
+import * as targets from "../infra/outbound/targets.js";
+import { writeRestartSentinel } from "../infra/restart-sentinel.js";
+import { scheduleRestartSentinelWake } from "./server-restart-sentinel.js";
+
+describe("server restart sentinel", () => {
+  let tempStateDir: string;
+  let prevStateDir: string | undefined;
+  let prevConfigPath: string | undefined;
+
+  beforeEach(async () => {
+    prevStateDir = process.env.OPENCLAW_STATE_DIR;
+    prevConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-state-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    const configPath = path.join(tempStateDir, "openclaw.json");
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, "{}", "utf-8");
+    clearSessionStoreCacheForTest();
+  });
+
+  afterEach(async () => {
+    if (prevStateDir) {
+      process.env.OPENCLAW_STATE_DIR = prevStateDir;
+    } else {
+      delete process.env.OPENCLAW_STATE_DIR;
+    }
+    if (prevConfigPath) {
+      process.env.OPENCLAW_CONFIG_PATH = prevConfigPath;
+    } else {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    }
+    await fs.rm(tempStateDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("routes restart pings using the session lastAccountId", async () => {
+    const sessionKey = "agent:main:whatsapp:dm:+15555550123";
+
+    // We must ensure we get the same store path that the production code will use.
+    // By passing the store config from the loaded config, we ensure alignment.
+    const cfg = loadConfig();
+    const storePath = resolveStorePath(cfg.session?.store, { agentId: "main" });
+
+    const entry = {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      channel: "whatsapp",
+      deliveryContext: { channel: "whatsapp", to: "+15555550123" },
+      lastChannel: "whatsapp",
+      lastTo: "+15555550123",
+      lastAccountId: "work",
+    };
+
+    // Use saveSessionStore to ensure correct normalization and cache invalidation
+    await saveSessionStore(storePath, { [sessionKey]: entry });
+
+    await writeRestartSentinel({
+      kind: "restart",
+      status: "ok",
+      ts: Date.now(),
+      sessionKey,
+      deliveryContext: { channel: "whatsapp", to: "+15555550123" },
+      message: "restart",
+      doctorHint: "hint",
+      stats: { mode: "gateway.restart", reason: "test" },
+    });
+
+    const resolveTargetSpy = vi
+      .spyOn(targets, "resolveOutboundTarget")
+      // oxlint-disable-next-line typescript/no-explicit-any
+      .mockReturnValue({ ok: true, to: "+15555550123" } as any);
+    const agentCommandSpy = vi.spyOn(agentModule, "agentCommand").mockResolvedValue(undefined);
+
+    await scheduleRestartSentinelWake({ deps: createDefaultDeps() });
+
+    expect(resolveTargetSpy).toHaveBeenCalled();
+    const calledWith = resolveTargetSpy.mock.calls[0][0];
+    expect(calledWith.accountId).toBe("work");
+    expect(agentCommandSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Problem
The `/compact` command does not consistently honor the per-agent `agentDir` configuration. When a manual compaction is triggered, the system often defaults to the global agent directory instead of the specific workspace defined for the active agent. In multi-agent environments, this leads to data confusion and failure to locate the correct memory/context files for compaction.

# Changes
- Introduced `resolveCompactionAgentDir` in `src/agents/pi-embedded-runner/compact.ts`. This utility derives the target directory by resolving the active agent from the `sessionKey` and checking for configured `agentDir` overrides before falling back to the global default.
- Updated `compactEmbeddedPiSessionDirect` to use this dynamic resolution logic, ensuring both manual and automated compaction events target the correct physical path.
- Added a new regression test suite: `src/agents/pi-embedded-runner/compact.agentdir.test.ts`. This test simulates a multi-agent environment with distinct directories to verify that the compaction helper accurately selects the intended target.

# Validation
- ✅ Verified that manual `/compact` commands now correctly target agent-specific directories.
- ✅ New regression tests passed.
- ✅ `pnpm lint` and `pnpm build` passed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes `/compact` in the embedded runner to honor per-agent `agentDir` configuration. It introduces `resolveCompactionAgentDir`, which derives the active agent id from `sessionKey` (via `resolveSessionAgentId`) and prefers an explicit `agentDir` override, otherwise falling back to the agent’s configured/default directory (`resolveAgentDir`) and finally the global agent dir (`resolveOpenClawAgentDir`). `compactEmbeddedPiSessionDirect` now uses this resolved directory for model config/auth and settings. A new Vitest suite asserts the resolution behavior in a multi-agent config and verifies that an explicit override still wins.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized: agentDir resolution now consistently uses existing agent-scope helpers, and the new behavior is covered by a targeted regression test. No new I/O patterns or security-sensitive flows were introduced beyond selecting the correct directory.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->