### PR TITLE
feat(subagents): make announce delivery timeout configurable

### DIFF
--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentTimeoutMs } from "./timeout.js";
+import { resolveAgentTimeoutMs, resolveSubagentAnnounceDeliveryTimeoutMs } from "./timeout.js";
 
 describe("resolveAgentTimeoutMs", () => {
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
@@ -10,5 +10,19 @@ describe("resolveAgentTimeoutMs", () => {
   it("clamps very large timeout overrides to timer-safe values", () => {
     expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(2_147_000_000);
     expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(2_147_000_000);
+  });
+});
+
+describe("resolveSubagentAnnounceDeliveryTimeoutMs", () => {
+  it("defaults to 60s when unset", () => {
+    expect(resolveSubagentAnnounceDeliveryTimeoutMs({})).toBe(60_000);
+  });
+
+  it("reads configured timeout from agents.defaults.subagents.announceDeliveryTimeoutMs", () => {
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: 300_000 } } },
+      }),
+    ).toBe(300_000);
   });
 });

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+const DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS = 60_000;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 const normalizeNumber = (value: unknown): number | undefined =>
@@ -45,4 +46,12 @@ export function resolveAgentTimeoutMs(opts: {
     return clampTimeoutMs(overrideSeconds * 1000);
   }
   return defaultMs;
+}
+
+export function resolveSubagentAnnounceDeliveryTimeoutMs(cfg?: OpenClawConfig): number {
+  const raw = normalizeNumber(cfg?.agents?.defaults?.subagents?.announceDeliveryTimeoutMs);
+  if (raw === undefined) {
+    return DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS;
+  }
+  return Math.min(Math.max(raw, 1), MAX_SAFE_TIMEOUT_MS);
 }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -210,6 +210,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Timeout in ms for sub-agent announce delivery calls (default: 60000). */
+    announceDeliveryTimeoutMs?: number;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -153,6 +153,7 @@ export const AgentDefaultsSchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        announceDeliveryTimeoutMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary\n- add  config field\n- use configured timeout for subagent announce delivery calls (both queued and direct paths)\n- keep default at 60s when unset, with safe clamping\n\n## Why\nUnder bursty channel flow-control (e.g. Feishu rate limiting), announce queue delivery may exceed 60s and fail with . This makes the timeout tunable (e.g. 5-10 minutes) without code changes.\n\n## Validation\n- 
> openclaw@2026.2.6-3 test /home/alfadb/openclaw-worktrees/configurable-announce-timeout
> node scripts/test-parallel.mjs src/agents/timeout.test.ts


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/alfadb/openclaw-worktrees/configurable-announce-timeout[39m

 [32m✓[39m src/agents/timeout.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 11[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m4 passed[39m[22m[90m (4)[39m
[2m   Start at [22m 17:09:37
[2m   Duration [22m 3.26s[2m (transform 1.38s, setup 2.89s, import 18ms, tests 11ms, environment 0ms)[22m\n- 
> openclaw@2026.2.6-3 test /home/alfadb/openclaw-worktrees/configurable-announce-timeout
> node scripts/test-parallel.mjs src/agents/subagent-announce.format.test.ts


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/alfadb/openclaw-worktrees/configurable-announce-timeout[39m

 [32m✓[39m src/agents/subagent-announce.format.test.ts [2m([22m[2m14 tests[22m[2m)[22m[33m 2966[2mms[22m[39m
     [33m[2m✓[22m[39m sends instructional message to main agent with status and findings [33m 1715[2mms[22m[39m
     [33m[2m✓[22m[39m retries reading subagent output when early lifecycle completion had no text [33m 1105[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m14 passed[39m[22m[90m (14)[39m
[2m   Start at [22m 17:09:43
[2m   Duration [22m 6.23s[2m (transform 2.11s, setup 2.88s, import 49ms, tests 2.97s, environment 0ms)[22m\n

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `agents.defaults.subagents.announceDeliveryTimeoutMs` config field and uses it to control the `callGateway({ method: "agent", ... timeoutMs })` used for subagent announce delivery (both the queued announce path and the direct delivery path). A helper `resolveSubagentAnnounceDeliveryTimeoutMs()` is introduced in `src/agents/timeout.ts` to default to 60s when unset and clamp configured values to a timer-safe maximum.

Config typing and validation are updated via `src/config/types.agent-defaults.ts` and `src/config/zod-schema.agent-defaults.ts`, and unit tests cover the default and configured timeout behavior in `src/agents/timeout.test.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR looks safe to merge with low risk.
- Changes are small, localized, and covered by targeted unit tests; config schema/type updates match the new resolver and the announce paths now use the configured timeout while keeping the 60s default.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->