### PR TITLE
feat(subagents): make announce delivery timeout configurable

### DIFF
--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentTimeoutMs } from "./timeout.js";
+import { resolveAgentTimeoutMs, resolveSubagentAnnounceDeliveryTimeoutMs } from "./timeout.js";
 
 describe("resolveAgentTimeoutMs", () => {
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
@@ -10,5 +10,32 @@ describe("resolveAgentTimeoutMs", () => {
   it("clamps very large timeout overrides to timer-safe values", () => {
     expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(2_147_000_000);
     expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(2_147_000_000);
+  });
+});
+
+describe("resolveSubagentAnnounceDeliveryTimeoutMs", () => {
+  it("defaults to 60s when config is unset", () => {
+    expect(resolveSubagentAnnounceDeliveryTimeoutMs(undefined)).toBe(60_000);
+  });
+
+  it("reads configured value", () => {
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: 300_000 } } },
+      }),
+    ).toBe(300_000);
+  });
+
+  it("clamps invalid values to timer-safe bounds", () => {
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: -10 } } },
+      }),
+    ).toBe(1);
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: 9_999_999_999 } } },
+      }),
+    ).toBe(2_147_000_000);
   });
 });

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+const DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS = 60_000;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 const normalizeNumber = (value: unknown): number | undefined =>
@@ -10,6 +11,12 @@ export function resolveAgentTimeoutSeconds(cfg?: OpenClawConfig): number {
   const raw = normalizeNumber(cfg?.agents?.defaults?.timeoutSeconds);
   const seconds = raw ?? DEFAULT_AGENT_TIMEOUT_SECONDS;
   return Math.max(seconds, 1);
+}
+
+export function resolveSubagentAnnounceDeliveryTimeoutMs(cfg?: OpenClawConfig): number {
+  const raw = normalizeNumber(cfg?.agents?.defaults?.subagents?.announceDeliveryTimeoutMs);
+  const timeoutMs = raw ?? DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS;
+  return Math.min(Math.max(timeoutMs, 1), MAX_SAFE_TIMEOUT_MS);
 }
 
 export function resolveAgentTimeoutMs(opts: {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,13 +281,11 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
-=======
 
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
-=======
 
   return grok as GrokConfig;
 }
@@ -297,7 +295,6 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
-=======
 
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
@@ -481,14 +478,6 @@ async function runWebSearch(params: {
   grokModel?: string;
   grokInlineCitations?: boolean;
 }): Promise<Record<string, unknown>> {
-  const cacheKey = normalizeCacheKey(
-    params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : params.provider === "perplexity"
-        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
-  );
-=======
   let rawCacheKey: string;
   switch (params.provider) {
     case "brave":

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,10 +281,14 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
+=======
+
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
+=======
+
   return grok as GrokConfig;
 }
 
@@ -293,6 +297,8 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
+=======
+
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
 }
@@ -482,6 +488,24 @@ async function runWebSearch(params: {
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
+=======
+  let rawCacheKey: string;
+  switch (params.provider) {
+    case "brave":
+      rawCacheKey = `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`;
+      break;
+    case "perplexity":
+      rawCacheKey = `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`;
+      break;
+    case "grok":
+      rawCacheKey = `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${params.grokInlineCitations ?? false}`;
+      break;
+    default:
+      rawCacheKey = `${String(params.provider)}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`;
+      break;
+  }
+
+  const cacheKey = normalizeCacheKey(rawCacheKey);
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };

--- a/src/config/config.nix-integration-u3-u5-u9.test.ts
+++ b/src/config/config.nix-integration-u3-u5-u9.test.ts
@@ -50,18 +50,18 @@ describe("Nix integration (U3, U5, U9)", () => {
     });
 
     it("STATE_DIR respects OPENCLAW_HOME when state override is unset", async () => {
-      const customHome = path.join(path.sep, "custom", "home");
+      const customHome = process.platform === "win32" ? "C:/custom/home" : "/custom/home";
       await withEnvOverride(
         { OPENCLAW_HOME: customHome, OPENCLAW_STATE_DIR: undefined },
         async () => {
           const { STATE_DIR } = await import("./config.js");
-          expect(STATE_DIR).toBe(path.join(path.resolve(customHome), ".openclaw"));
+          expect(STATE_DIR).toBe(path.resolve(path.join(customHome, ".openclaw")));
         },
       );
     });
 
     it("CONFIG_PATH defaults to OPENCLAW_HOME/.openclaw/openclaw.json", async () => {
-      const customHome = path.join(path.sep, "custom", "home");
+      const customHome = process.platform === "win32" ? "C:/custom/home" : "/custom/home";
       await withEnvOverride(
         {
           OPENCLAW_HOME: customHome,
@@ -71,7 +71,7 @@ describe("Nix integration (U3, U5, U9)", () => {
         async () => {
           const { CONFIG_PATH } = await import("./config.js");
           expect(CONFIG_PATH).toBe(
-            path.join(path.resolve(customHome), ".openclaw", "openclaw.json"),
+            path.resolve(path.join(customHome, ".openclaw", "openclaw.json")),
           );
         },
       );

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -210,6 +210,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Timeout (ms) for sub-agent announce delivery to the requester. Default: 60000. */
+    announceDeliveryTimeoutMs?: number;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -153,6 +153,7 @@ export const AgentDefaultsSchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        announceDeliveryTimeoutMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
- add `agents.defaults.subagents.announceDeliveryTimeoutMs` config field
- use this field for subagent announce delivery calls (both queued and direct announce paths)
- preserve default behavior at 60_000ms when unset
- clamp configured values to timer-safe bounds

## Why
In bursty channel conditions (e.g. provider flow control), subagent announce delivery can exceed 60s and fail with `announce queue drain failed ... gateway timeout`. This makes the timeout tunable without changing default behavior.

## Validation
- `pnpm exec vitest run src/agents/timeout.test.ts src/config/config.identity-defaults.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new agent defaults config field (`agents.defaults.subagents.announceDeliveryTimeoutMs`) and wires it into the subagent announce delivery paths (both queued `sendAnnounce` and the direct delivery in `runSubagentAnnounceFlow`). The timeout resolution preserves the existing 60s default when unset, and clamps configured values to timer-safe bounds via `resolveSubagentAnnounceDeliveryTimeoutMs` in `src/agents/timeout.ts`.

The change fits the codebase by following the existing pattern of central timeout normalization (`resolveAgentTimeoutMs`), extending it with a similarly-scoped resolver, and validating the new config field through the existing Zod schema and type definition updates.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, self-contained, and follow existing timeout normalization patterns; schema/type updates match the new config usage, and tests cover defaulting and clamping behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->