### PR TITLE
fix(ui): agent model dropdown not reflecting actual primary model

### DIFF
--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -201,8 +201,9 @@ describe("agents view", () => {
     expect(primarySelect).not.toBeNull();
     expect(primarySelect!.value).toBe("some-unlisted/model");
     // Should have a "Current (...)" option prepended
-    const currentOption =
-      primarySelect!.querySelector<HTMLOptionElement>('option[value="some-unlisted/model"]');
+    const currentOption = primarySelect!.querySelector<HTMLOptionElement>(
+      'option[value="some-unlisted/model"]',
+    );
     expect(currentOption).toBeDefined();
     expect(currentOption?.textContent).toContain("Current");
   });

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -95,11 +95,11 @@ describe("agents view", () => {
     );
     await Promise.resolve();
 
-    const selects = container.querySelectorAll("select");
-    // The first select in the overview panel is the primary model dropdown
-    const primarySelect = selects[0] as HTMLSelectElement | undefined;
-    expect(primarySelect).toBeDefined();
-    expect(primarySelect?.value).toBe("groq/openai/gpt-oss-120b");
+    const primarySelect = container.querySelector(
+      ".agent-model-select select",
+    ) as HTMLSelectElement | null;
+    expect(primarySelect).not.toBeNull();
+    expect(primarySelect!.value).toBe("groq/openai/gpt-oss-120b");
   });
 
   it("selects agent-specific primary when it differs from default", async () => {
@@ -132,10 +132,11 @@ describe("agents view", () => {
     );
     await Promise.resolve();
 
-    const selects = container.querySelectorAll("select");
-    const primarySelect = selects[0] as HTMLSelectElement | undefined;
-    expect(primarySelect).toBeDefined();
-    expect(primarySelect?.value).toBe("groq/openai/gpt-oss-120b");
+    const primarySelect = container.querySelector(
+      ".agent-model-select select",
+    ) as HTMLSelectElement | null;
+    expect(primarySelect).not.toBeNull();
+    expect(primarySelect!.value).toBe("groq/openai/gpt-oss-120b");
   });
 
   it("non-default agent without own model inherits the default primary", async () => {
@@ -168,13 +169,14 @@ describe("agents view", () => {
     );
     await Promise.resolve();
 
-    const selects = container.querySelectorAll("select");
-    const primarySelect = selects[0] as HTMLSelectElement | undefined;
-    expect(primarySelect).toBeDefined();
+    const primarySelect = container.querySelector(
+      ".agent-model-select select",
+    ) as HTMLSelectElement | null;
+    expect(primarySelect).not.toBeNull();
     // effectivePrimary falls through to defaultPrimary, so the default model is selected
-    expect(primarySelect?.value).toBe("cloudflare/claude-sonnet-4-5");
+    expect(primarySelect!.value).toBe("cloudflare/claude-sonnet-4-5");
     // The "Inherit default" option should still be present for non-default agents
-    const inheritOption = primarySelect?.querySelector('option[value=""]') as
+    const inheritOption = primarySelect!.querySelector('option[value=""]') as
       | HTMLOptionElement
       | undefined;
     expect(inheritOption).toBeDefined();
@@ -203,14 +205,15 @@ describe("agents view", () => {
     );
     await Promise.resolve();
 
-    const selects = container.querySelectorAll("select");
-    const primarySelect = selects[0] as HTMLSelectElement | undefined;
-    expect(primarySelect).toBeDefined();
-    expect(primarySelect?.value).toBe("some-unlisted/model");
+    const primarySelect = container.querySelector(
+      ".agent-model-select select",
+    ) as HTMLSelectElement | null;
+    expect(primarySelect).not.toBeNull();
+    expect(primarySelect!.value).toBe("some-unlisted/model");
     // Should have a "Current (...)" option prepended
-    const currentOption = primarySelect?.querySelector(
-      'option[value="some-unlisted/model"]',
-    ) as HTMLOptionElement | undefined;
+    const currentOption = primarySelect!.querySelector('option[value="some-unlisted/model"]') as
+      | HTMLOptionElement
+      | undefined;
     expect(currentOption).toBeDefined();
     expect(currentOption?.textContent).toContain("Current");
   });

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -1,0 +1,217 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderAgents, type AgentsProps } from "./agents.ts";
+
+function noop() {
+  /* no-op */
+}
+
+function buildProps(overrides: Partial<AgentsProps> = {}): AgentsProps {
+  return {
+    loading: false,
+    error: null,
+    agentsList: {
+      defaultId: "main",
+      mainKey: "agent:main:main",
+      scope: "default",
+      agents: [{ id: "main" }],
+    },
+    selectedAgentId: "main",
+    activePanel: "overview",
+    configForm: null,
+    configLoading: false,
+    configSaving: false,
+    configDirty: false,
+    channelsLoading: false,
+    channelsError: null,
+    channelsSnapshot: null,
+    channelsLastSuccess: null,
+    cronLoading: false,
+    cronStatus: null,
+    cronJobs: [],
+    cronError: null,
+    agentFilesLoading: false,
+    agentFilesError: null,
+    agentFilesList: null,
+    agentFileActive: null,
+    agentFileContents: {},
+    agentFileDrafts: {},
+    agentFileSaving: false,
+    agentIdentityLoading: false,
+    agentIdentityError: null,
+    agentIdentityById: {},
+    agentSkillsLoading: false,
+    agentSkillsReport: null,
+    agentSkillsError: null,
+    agentSkillsAgentId: null,
+    skillsFilter: "",
+    onRefresh: noop,
+    onSelectAgent: noop,
+    onSelectPanel: noop,
+    onLoadFiles: noop,
+    onSelectFile: noop,
+    onFileDraftChange: noop,
+    onFileReset: noop,
+    onFileSave: noop,
+    onToolsProfileChange: noop,
+    onToolsOverridesChange: noop,
+    onConfigReload: noop,
+    onConfigSave: noop,
+    onModelChange: noop,
+    onModelFallbacksChange: noop,
+    onChannelsRefresh: noop,
+    onCronRefresh: noop,
+    onSkillsFilterChange: noop,
+    onSkillsRefresh: noop,
+    onAgentSkillToggle: noop,
+    onAgentSkillsClear: noop,
+    onAgentSkillsDisableAll: noop,
+    ...overrides,
+  };
+}
+
+describe("agents view", () => {
+  it("selects the configured primary model in the dropdown", async () => {
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        buildProps({
+          configForm: {
+            agents: {
+              defaults: {
+                model: "groq/openai/gpt-oss-120b",
+                models: {
+                  "cloudflare/claude-sonnet-4-5": {},
+                  "groq/openai/gpt-oss-120b": {},
+                  "anthropic/claude-opus-4": { alias: "Opus" },
+                },
+              },
+              list: [{ id: "main" }],
+            },
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const selects = container.querySelectorAll("select");
+    // The first select in the overview panel is the primary model dropdown
+    const primarySelect = selects[0] as HTMLSelectElement | undefined;
+    expect(primarySelect).toBeDefined();
+    expect(primarySelect?.value).toBe("groq/openai/gpt-oss-120b");
+  });
+
+  it("selects agent-specific primary when it differs from default", async () => {
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        buildProps({
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "default",
+            agents: [{ id: "main" }, { id: "helper" }],
+          },
+          selectedAgentId: "helper",
+          configForm: {
+            agents: {
+              defaults: {
+                model: "cloudflare/claude-sonnet-4-5",
+                models: {
+                  "cloudflare/claude-sonnet-4-5": {},
+                  "groq/openai/gpt-oss-120b": {},
+                },
+              },
+              list: [{ id: "main" }, { id: "helper", model: "groq/openai/gpt-oss-120b" }],
+            },
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const selects = container.querySelectorAll("select");
+    const primarySelect = selects[0] as HTMLSelectElement | undefined;
+    expect(primarySelect).toBeDefined();
+    expect(primarySelect?.value).toBe("groq/openai/gpt-oss-120b");
+  });
+
+  it("non-default agent without own model inherits the default primary", async () => {
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        buildProps({
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "default",
+            agents: [{ id: "main" }, { id: "helper" }],
+          },
+          selectedAgentId: "helper",
+          configForm: {
+            agents: {
+              defaults: {
+                model: "cloudflare/claude-sonnet-4-5",
+                models: {
+                  "cloudflare/claude-sonnet-4-5": {},
+                  "groq/openai/gpt-oss-120b": {},
+                },
+              },
+              list: [{ id: "main" }, { id: "helper" }],
+            },
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const selects = container.querySelectorAll("select");
+    const primarySelect = selects[0] as HTMLSelectElement | undefined;
+    expect(primarySelect).toBeDefined();
+    // effectivePrimary falls through to defaultPrimary, so the default model is selected
+    expect(primarySelect?.value).toBe("cloudflare/claude-sonnet-4-5");
+    // The "Inherit default" option should still be present for non-default agents
+    const inheritOption = primarySelect?.querySelector('option[value=""]') as
+      | HTMLOptionElement
+      | undefined;
+    expect(inheritOption).toBeDefined();
+    expect(inheritOption?.textContent).toContain("Inherit default");
+  });
+
+  it("shows current model even when not in configured models list", async () => {
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        buildProps({
+          configForm: {
+            agents: {
+              defaults: {
+                model: "some-unlisted/model",
+                models: {
+                  "cloudflare/claude-sonnet-4-5": {},
+                },
+              },
+              list: [{ id: "main" }],
+            },
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const selects = container.querySelectorAll("select");
+    const primarySelect = selects[0] as HTMLSelectElement | undefined;
+    expect(primarySelect).toBeDefined();
+    expect(primarySelect?.value).toBe("some-unlisted/model");
+    // Should have a "Current (...)" option prepended
+    const currentOption = primarySelect?.querySelector(
+      'option[value="some-unlisted/model"]',
+    ) as HTMLOptionElement | undefined;
+    expect(currentOption).toBeDefined();
+    expect(currentOption?.textContent).toContain("Current");
+  });
+});

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -95,9 +95,7 @@ describe("agents view", () => {
     );
     await Promise.resolve();
 
-    const primarySelect = container.querySelector(
-      ".agent-model-select select",
-    ) as HTMLSelectElement | null;
+    const primarySelect = container.querySelector<HTMLSelectElement>(".agent-model-select select");
     expect(primarySelect).not.toBeNull();
     expect(primarySelect!.value).toBe("groq/openai/gpt-oss-120b");
   });
@@ -132,9 +130,7 @@ describe("agents view", () => {
     );
     await Promise.resolve();
 
-    const primarySelect = container.querySelector(
-      ".agent-model-select select",
-    ) as HTMLSelectElement | null;
+    const primarySelect = container.querySelector<HTMLSelectElement>(".agent-model-select select");
     expect(primarySelect).not.toBeNull();
     expect(primarySelect!.value).toBe("groq/openai/gpt-oss-120b");
   });
@@ -169,16 +165,12 @@ describe("agents view", () => {
     );
     await Promise.resolve();
 
-    const primarySelect = container.querySelector(
-      ".agent-model-select select",
-    ) as HTMLSelectElement | null;
+    const primarySelect = container.querySelector<HTMLSelectElement>(".agent-model-select select");
     expect(primarySelect).not.toBeNull();
     // effectivePrimary falls through to defaultPrimary, so the default model is selected
     expect(primarySelect!.value).toBe("cloudflare/claude-sonnet-4-5");
     // The "Inherit default" option should still be present for non-default agents
-    const inheritOption = primarySelect!.querySelector('option[value=""]') as
-      | HTMLOptionElement
-      | undefined;
+    const inheritOption = primarySelect!.querySelector<HTMLOptionElement>('option[value=""]');
     expect(inheritOption).toBeDefined();
     expect(inheritOption?.textContent).toContain("Inherit default");
   });
@@ -205,15 +197,12 @@ describe("agents view", () => {
     );
     await Promise.resolve();
 
-    const primarySelect = container.querySelector(
-      ".agent-model-select select",
-    ) as HTMLSelectElement | null;
+    const primarySelect = container.querySelector<HTMLSelectElement>(".agent-model-select select");
     expect(primarySelect).not.toBeNull();
     expect(primarySelect!.value).toBe("some-unlisted/model");
     // Should have a "Current (...)" option prepended
-    const currentOption = primarySelect!.querySelector('option[value="some-unlisted/model"]') as
-      | HTMLOptionElement
-      | undefined;
+    const currentOption =
+      primarySelect!.querySelector<HTMLOptionElement>('option[value="some-unlisted/model"]');
     expect(currentOption).toBeDefined();
     expect(currentOption?.textContent).toContain("Current");
   });

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -448,7 +448,12 @@ function buildModelOptions(configForm: Record<string, unknown> | null, current?:
       <option value="" disabled>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === current}>
+        ${option.label}
+      </option>`,
+  );
 }
 
 type CompiledPattern =
@@ -877,7 +882,6 @@ function renderAgentOverview(params: {
           <label class="field" style="min-width: 260px; flex: 1;">
             <span>Primary model${isDefault ? " (default)" : ""}</span>
             <select
-              .value=${effectivePrimary ?? ""}
               ?disabled=${!configForm || configLoading || configSaving}
               @change=${(e: Event) =>
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}
@@ -886,7 +890,7 @@ function renderAgentOverview(params: {
                 isDefault
                   ? nothing
                   : html`
-                      <option value="">
+                      <option value="" ?selected=${!effectivePrimary}>
                         ${
                           defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"
                         }

--- a/ui/src/ui/views/agents.visual-demo.test.ts
+++ b/ui/src/ui/views/agents.visual-demo.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Visual demo test for the model dropdown fix.
+ * Records a video showing the dropdown correctly reflects the configured
+ * primary model instead of falling back to the first option.
+ *
+ * Run with:
+ *   npx vitest run --config vitest.video.config.ts src/ui/views/agents.visual-demo.test.ts
+ */
+import "../../styles.css";
+import { render } from "lit";
+import { describe, it, expect } from "vitest";
+import { renderAgents, type AgentsProps } from "./agents.ts";
+
+function noop() {
+  /* no-op */
+}
+
+function buildProps(overrides: Partial<AgentsProps> = {}): AgentsProps {
+  return {
+    loading: false,
+    error: null,
+    agentsList: {
+      defaultId: "main",
+      mainKey: "agent:main:main",
+      scope: "default",
+      agents: [{ id: "main" }],
+    },
+    selectedAgentId: "main",
+    activePanel: "overview",
+    configForm: null,
+    configLoading: false,
+    configSaving: false,
+    configDirty: false,
+    channelsLoading: false,
+    channelsError: null,
+    channelsSnapshot: null,
+    channelsLastSuccess: null,
+    cronLoading: false,
+    cronStatus: null,
+    cronJobs: [],
+    cronError: null,
+    agentFilesLoading: false,
+    agentFilesError: null,
+    agentFilesList: null,
+    agentFileActive: null,
+    agentFileContents: {},
+    agentFileDrafts: {},
+    agentFileSaving: false,
+    agentIdentityLoading: false,
+    agentIdentityError: null,
+    agentIdentityById: {},
+    agentSkillsLoading: false,
+    agentSkillsReport: null,
+    agentSkillsError: null,
+    agentSkillsAgentId: null,
+    skillsFilter: "",
+    onRefresh: noop,
+    onSelectAgent: noop,
+    onSelectPanel: noop,
+    onLoadFiles: noop,
+    onSelectFile: noop,
+    onFileDraftChange: noop,
+    onFileReset: noop,
+    onFileSave: noop,
+    onToolsProfileChange: noop,
+    onToolsOverridesChange: noop,
+    onConfigReload: noop,
+    onConfigSave: noop,
+    onModelChange: noop,
+    onModelFallbacksChange: noop,
+    onChannelsRefresh: noop,
+    onCronRefresh: noop,
+    onSkillsFilterChange: noop,
+    onSkillsRefresh: noop,
+    onAgentSkillToggle: noop,
+    onAgentSkillsClear: noop,
+    onAgentSkillsDisableAll: noop,
+    ...overrides,
+  };
+}
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("model dropdown visual demo", () => {
+  it("shows configured primary model is correctly selected", async () => {
+    // Set dark background matching the app theme
+    document.documentElement.style.colorScheme = "dark";
+    document.body.style.background = "var(--bg, #12141a)";
+    document.body.style.color = "var(--text, #e4e4e7)";
+    document.body.style.margin = "0";
+    document.body.style.padding = "24px";
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    render(
+      renderAgents(
+        buildProps({
+          configForm: {
+            agents: {
+              defaults: {
+                model: "groq/openai/gpt-oss-120b",
+                models: {
+                  "cloudflare/claude-sonnet-4-5": { alias: "Sonnet 4.5" },
+                  "groq/openai/gpt-oss-120b": {},
+                  "anthropic/claude-opus-4": { alias: "Opus" },
+                },
+              },
+              list: [{ id: "main" }],
+            },
+          },
+        }),
+      ),
+      container,
+    );
+
+    // Wait for Lit rendering + CSS
+    await sleep(500);
+
+    // Verify the dropdown shows the correct model
+    const select = container.querySelector<HTMLSelectElement>(".agent-model-select select");
+    expect(select).not.toBeNull();
+    expect(select!.value).toBe("groq/openai/gpt-oss-120b");
+
+    // Highlight the model selection area for the video
+    const modelSection = container.querySelector<HTMLElement>(".agent-model-select");
+    if (modelSection) {
+      modelSection.style.outline = "2px solid var(--accent, #ff5c5c)";
+      modelSection.style.outlineOffset = "6px";
+      modelSection.style.borderRadius = "8px";
+    }
+
+    // Scroll the model section into view
+    modelSection?.scrollIntoView({ behavior: "smooth", block: "center" });
+    await sleep(1500);
+
+    // Expand the dropdown to show all options
+    if (select) {
+      select.setAttribute("size", String(select.options.length));
+      select.style.position = "relative";
+      select.style.zIndex = "999";
+    }
+    await sleep(3000);
+
+    // Collapse
+    select?.removeAttribute("size");
+    await sleep(1000);
+
+    // Clean up
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary

- Fix Lit rendering race condition where `<select .value=...>` fires before dynamically generated `<option>` children are in the DOM, causing the model dropdown to always show the first option instead of the configured primary model
- Use `?selected` on individual `<option>` elements instead, matching the pattern already used in `sessions.ts` and `usage.ts`
- Add test coverage for the agents model dropdown (`agents.test.ts`)

## Test plan

- [x] All 4 new tests in `agents.test.ts` pass (configured primary selected, agent-specific override, inherit-default fallback, unlisted model shown as "Current")
- [x] Full UI test suite passes (167/168 — 1 pre-existing failure in `navigation.browser.test.ts` unrelated to this change)
- [x] Manual: open Agents page, confirm dropdown reflects actual primary model, not first option

https://github.com/user-attachments/assets/24a4ed86-f239-4a07-bb22-95cf22c63807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Agents “Primary model” dropdown rendering to avoid a Lit timing issue where setting `<select .value=…>` can run before dynamically generated `<option>` elements exist. It does this by moving selection logic onto each `<option>` via `?selected`, and adds a new `agents.test.ts` file with coverage for selecting the configured default, agent overrides, inheritance behavior, and handling an unlisted “current” model.

The change is localized to the Agents view (`ui/src/ui/views/agents.ts`) and its new view-level tests (`ui/src/ui/views/agents.test.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after fixing a correctness issue in the “Inherit default” selection logic.
- The core fix (moving selection to `?selected` on `<option>`) aligns with existing patterns and should address the reported Lit rendering race. However, the new logic makes the empty-value “Inherit default” option effectively unselectable/never-selected because `effectivePrimary` is always populated when a default exists, which changes UX semantics for non-default agents. Tests also appear a bit brittle in how they locate the dropdown.
- ui/src/ui/views/agents.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->