### PR TITLE
fix: Make HEARTBEAT.md creation match documentation

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -179,8 +179,8 @@ export async function ensureAgentWorkspace(params?: {
   await writeFileIfMissing(toolsPath, toolsTemplate);
   await writeFileIfMissing(identityPath, identityTemplate);
   await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
   if (isBrandNewWorkspace) {
+    await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
     await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);


### PR DESCRIPTION
fixes #11766 - Missing HEARTBEAT.md behaviour doesn't match documentation

## Summary

The documentation states that "If the file is missing, the heartbeat still runs and the model decides what to do." However, the actual behavior was that a missing HEARTBEAT.md disabled the heartbeat completely because OpenClaw silently created an empty one. This commit fixes the logic to match the documented behavior by creating HEARTBEAT.md only when the workspace is brand new, ensuring existing workspaces with missing HEARTBEAT.md files can still execute heartbeats as intended.

## Change

Moved the HEARTBEAT.md creation inside the `isBrandNewWorkspace` check to prevent overwriting or creating empty files in existing workspaces.

## Impact

This change technically is a behavioural change, but it now matches what the documentation promises, i.e. exactly what users expect.

## Testing

pnpm check and test passed

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts workspace bootstrapping so `HEARTBEAT.md` is only created for *brand new* workspaces (inside the `isBrandNewWorkspace` branch) rather than being created opportunistically whenever it’s missing.

That aligns `ensureAgentWorkspace` (`src/agents/workspace.ts`) with the heartbeat runner behavior (`src/infra/heartbeat-runner.ts`), which explicitly proceeds when `HEARTBEAT.md` is absent (letting the model decide) but skips when the file exists and is “effectively empty.”

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized logic adjustment in workspace bootstrapping that better matches the documented/expected heartbeat semantics. It removes an unintended side effect (creating an empty HEARTBEAT.md in existing workspaces) and is consistent with the heartbeat runner’s explicit behavior when the file is missing.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->