### PR TITLE
fix: MSTeams attachment fetch follows redirects before allowlist checks

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -117,7 +117,7 @@ describe("msteams attachments", () => {
         fetchFn: fetchMock as unknown as typeof fetch,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith("https://x/img");
+      expect(fetchMock).toHaveBeenCalledWith("https://x/img", { redirect: "manual" });
       expect(saveMediaBufferMock).toHaveBeenCalled();
       expect(media).toHaveLength(1);
       expect(media[0]?.path).toBe("/tmp/saved.png");
@@ -144,7 +144,7 @@ describe("msteams attachments", () => {
         fetchFn: fetchMock as unknown as typeof fetch,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith("https://x/dl");
+      expect(fetchMock).toHaveBeenCalledWith("https://x/dl", { redirect: "manual" });
       expect(media).toHaveLength(1);
     });
 
@@ -169,7 +169,7 @@ describe("msteams attachments", () => {
         fetchFn: fetchMock as unknown as typeof fetch,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith("https://x/doc.pdf");
+      expect(fetchMock).toHaveBeenCalledWith("https://x/doc.pdf", { redirect: "manual" });
       expect(media).toHaveLength(1);
       expect(media[0]?.path).toBe("/tmp/saved.pdf");
       expect(media[0]?.placeholder).toBe("<media:document>");
@@ -197,7 +197,7 @@ describe("msteams attachments", () => {
       });
 
       expect(media).toHaveLength(1);
-      expect(fetchMock).toHaveBeenCalledWith("https://x/inline.png");
+      expect(fetchMock).toHaveBeenCalledWith("https://x/inline.png", { redirect: "manual" });
     });
 
     it("stores inline data:image base64 payloads", async () => {
@@ -248,6 +248,64 @@ describe("msteams attachments", () => {
       expect(fetchMock).toHaveBeenCalled();
       expect(media).toHaveLength(1);
       expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("follows redirects only when the target host is allowlisted", async () => {
+      const { downloadMSTeamsAttachments } = await load();
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url === "https://x/img") {
+          return new Response("redirect", {
+            status: 302,
+            headers: { location: "https://x/cdn/img" },
+          });
+        }
+        if (url === "https://x/cdn/img") {
+          return new Response(Buffer.from("png"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const media = await downloadMSTeamsAttachments({
+        attachments: [{ contentType: "image/png", contentUrl: "https://x/img" }],
+        maxBytes: 1024 * 1024,
+        allowHosts: ["x"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      expect(media).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenNthCalledWith(1, "https://x/img", { redirect: "manual" });
+      expect(fetchMock).toHaveBeenNthCalledWith(2, "https://x/cdn/img", { redirect: "manual" });
+    });
+
+    it("blocks redirects to hosts outside the allowlist", async () => {
+      const { downloadMSTeamsAttachments } = await load();
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url === "https://x/img") {
+          return new Response("redirect", {
+            status: 302,
+            headers: { location: "https://internal.service.local/secret" },
+          });
+        }
+        return new Response(Buffer.from("png"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        });
+      });
+
+      const media = await downloadMSTeamsAttachments({
+        attachments: [{ contentType: "image/png", contentUrl: "https://x/img" }],
+        maxBytes: 1024 * 1024,
+        allowHosts: ["x"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      expect(media).toHaveLength(0);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith("https://x/img", { redirect: "manual" });
     });
 
     it("skips auth retries when the host is not in auth allowlist", async () => {

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -90,56 +90,80 @@ async function fetchWithAuthFallback(params: {
   authAllowHosts: string[];
 }): Promise<Response> {
   const fetchFn = params.fetchFn ?? fetch;
-  const firstAttempt = await fetchFn(params.url);
-  if (firstAttempt.ok) {
-    return firstAttempt;
+  const firstAttempt = await fetchWithAllowlistedRedirects({
+    url: params.url,
+    fetchFn,
+    allowHosts: params.allowHosts,
+  });
+  if (firstAttempt.response.ok) {
+    return firstAttempt.response;
   }
   if (!params.tokenProvider) {
-    return firstAttempt;
+    return firstAttempt.response;
   }
-  if (firstAttempt.status !== 401 && firstAttempt.status !== 403) {
-    return firstAttempt;
+  if (firstAttempt.response.status !== 401 && firstAttempt.response.status !== 403) {
+    return firstAttempt.response;
   }
-  if (!isUrlAllowed(params.url, params.authAllowHosts)) {
-    return firstAttempt;
+  if (!isUrlAllowed(firstAttempt.finalUrl, params.authAllowHosts)) {
+    return firstAttempt.response;
   }
 
-  const scopes = scopeCandidatesForUrl(params.url);
+  const scopes = scopeCandidatesForUrl(firstAttempt.finalUrl);
   for (const scope of scopes) {
     try {
       const token = await params.tokenProvider.getAccessToken(scope);
-      const res = await fetchFn(params.url, {
-        headers: { Authorization: `Bearer ${token}` },
-        redirect: "manual",
+      const authAttempt = await fetchWithAllowlistedRedirects({
+        url: firstAttempt.finalUrl,
+        fetchFn,
+        allowHosts: params.allowHosts,
+        requestInitForUrl: (currentUrl) =>
+          isUrlAllowed(currentUrl, params.authAllowHosts)
+            ? { headers: { Authorization: `Bearer ${token}` } }
+            : undefined,
       });
-      if (res.ok) {
-        return res;
-      }
-      const redirectUrl = readRedirectUrl(params.url, res);
-      if (redirectUrl && isUrlAllowed(redirectUrl, params.allowHosts)) {
-        const redirectRes = await fetchFn(redirectUrl);
-        if (redirectRes.ok) {
-          return redirectRes;
-        }
-        if (
-          (redirectRes.status === 401 || redirectRes.status === 403) &&
-          isUrlAllowed(redirectUrl, params.authAllowHosts)
-        ) {
-          const redirectAuthRes = await fetchFn(redirectUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-            redirect: "manual",
-          });
-          if (redirectAuthRes.ok) {
-            return redirectAuthRes;
-          }
-        }
+      if (authAttempt.response.ok) {
+        return authAttempt.response;
       }
     } catch {
       // Try the next scope.
     }
   }
 
-  return firstAttempt;
+  return firstAttempt.response;
+}
+
+async function fetchWithAllowlistedRedirects(params: {
+  url: string;
+  fetchFn: typeof fetch;
+  allowHosts: string[];
+  requestInitForUrl?: (url: string) => RequestInit | undefined;
+  maxRedirects?: number;
+}): Promise<{ response: Response; finalUrl: string }> {
+  const maxRedirects = params.maxRedirects ?? 5;
+  let currentUrl = params.url;
+
+  for (let redirects = 0; redirects <= maxRedirects; redirects++) {
+    const initForUrl = params.requestInitForUrl?.(currentUrl);
+    const response = await params.fetchFn(currentUrl, {
+      ...(initForUrl ?? {}),
+      redirect: "manual",
+    });
+    const redirectUrl = readRedirectUrl(currentUrl, response);
+    if (!redirectUrl) {
+      return { response, finalUrl: currentUrl };
+    }
+    if (!isUrlAllowed(redirectUrl, params.allowHosts)) {
+      return { response, finalUrl: currentUrl };
+    }
+    currentUrl = redirectUrl;
+  }
+
+  const initForUrl = params.requestInitForUrl?.(currentUrl);
+  const response = await params.fetchFn(currentUrl, {
+    ...(initForUrl ?? {}),
+    redirect: "manual",
+  });
+  return { response, finalUrl: currentUrl };
 }
 
 function readRedirectUrl(baseUrl: string, res: Response): string | null {


### PR DESCRIPTION
## Fix Summary

The MSTeams attachment downloader performs an initial fetch with default redirect behavior before enforcing redirect-target allowlist checks. An attacker-controlled allowed URL can redirect to an internal or otherwise disallowed host, causing server-side request forgery (SSRF).

## Issue Linkage

Fixes #11811

## Security Snapshot

- CVSS v3.1: 8.5 (High)
- CVSS v4.0: 8.4 (High)

## Implementation Details

### Files Changed
- `extensions/msteams/src/attachments.test.ts` (+94/-4)
- `extensions/msteams/src/attachments/download.ts` (+56/-34)

### Technical Analysis
The MSTeams attachment downloader performs an initial fetch with default redirect behavior before enforcing redirect-target allowlist checks. An attacker-controlled allowed URL can redirect to an internal or otherwise disallowed host, causing server-side request forgery (SSRF).

## Validation Evidence

- Command: `pnpm vitest run extensions/msteams/src/attachments.test.ts`
- Status: passed

## Risk and Compatibility

non-breaking; no known regression impact

## AI-Assisted Disclosure

GPT-5.3-Codex

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the MSTeams attachment downloader against SSRF via redirects by switching requests to `redirect: "manual"`, validating each redirect hop against the host allowlist, and only applying auth headers on redirect hops whose host is in `authAllowHosts`. Tests were updated and extended to cover allowlisted vs non-allowlisted redirect behavior.

The core logic change is isolated to `extensions/msteams/src/attachments/download.ts`, with corresponding unit tests in `extensions/msteams/src/attachments.test.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and closes the redirect-based SSRF gap, with one redirect-limit logic bug to fix first.
- Redirect handling is correctly moved to manual mode and each hop is checked against the allowlist; auth headers are also constrained to auth-allowlisted hosts. However, `fetchWithAllowlistedRedirects` currently allows one more redirect hop than intended due to an off-by-one loop condition, which weakens the redirect cap and should be corrected.
- extensions/msteams/src/attachments/download.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
