### PR TITLE
fix(cron): ensure 'at' schedule type correctly registers nextWakeAtMs during update

### DIFF
--- a/src/cron/repro_11795.test.ts
+++ b/src/cron/repro_11795.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { createJob, nextWakeAtMs } from "./service/jobs.js";
+import { update } from "./service/ops.js";
+import { createCronServiceState } from "./service/state.js";
+
+describe("reproduction of bug 11795", () => {
+  it("registers nextWakeAtMs for 'at' schedule type during update via ops", async () => {
+    const now = 1738987700000;
+    const at = "2026-02-08T09:28:00Z";
+    const atMs = Date.parse(at);
+    
+    const deps = {
+      nowMs: () => now,
+      log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      cronEnabled: true,
+      storePath: "/tmp/cron.json",
+      enqueueSystemEvent: () => {},
+      requestHeartbeatNow: () => {},
+      runIsolatedAgentJob: async () => ({ status: "ok" }),
+    } as any;
+
+    const state = createCronServiceState(deps);
+    state.store = {
+      jobs: [],
+    };
+
+    // 1. Create with recurring cron
+    const job = createJob(state, {
+      name: "test-update",
+      schedule: { kind: "cron", expr: "0 5 * * *" },
+      sessionTarget: "main",
+      payload: { kind: "systemEvent", text: "hello" },
+    });
+    state.store!.jobs.push(job);
+
+    // 2. Update to 'at' schedule via ops (in the past)
+    const pastAt = new Date(now - 60000).toISOString();
+    await update(state, job.id, {
+      schedule: { kind: "at", at: pastAt },
+    });
+
+    const wakeAt = nextWakeAtMs(state);
+    expect(wakeAt).toBeUndefined(); // Should be undefined because it's in the past and due immediately
+
+    // 3. Update to 'at' schedule (in the future)
+    const futureAt = new Date(now + 60000).toISOString();
+    const futureAtMs = Date.parse(futureAt);
+    await update(state, job.id, {
+      schedule: { kind: "at", at: futureAt },
+    });
+
+    const wakeAtFuture = nextWakeAtMs(state);
+    expect(wakeAtFuture).toBe(futureAtMs);
+  });
+});

--- a/src/cron/repro_11795.test.ts
+++ b/src/cron/repro_11795.test.ts
@@ -1,23 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { createJob, nextWakeAtMs } from "./service/jobs.js";
 import { update } from "./service/ops.js";
-import { createCronServiceState } from "./service/state.js";
+import { createCronServiceState, type CronServiceDeps } from "./service/state.js";
 
 describe("reproduction of bug 11795", () => {
   it("registers nextWakeAtMs for 'at' schedule type during update via ops", async () => {
     const now = 1738987700000;
     const at = "2026-02-08T09:28:00Z";
-    const atMs = Date.parse(at);
     
-    const deps = {
+    const deps: CronServiceDeps = {
       nowMs: () => now,
-      log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      log: { 
+        info: () => {}, 
+        warn: () => {}, 
+        error: () => {}, 
+        debug: () => {} 
+      },
       cronEnabled: true,
       storePath: "/tmp/cron.json",
       enqueueSystemEvent: () => {},
       requestHeartbeatNow: () => {},
       runIsolatedAgentJob: async () => ({ status: "ok" }),
-    } as any;
+    };
 
     const state = createCronServiceState(deps);
     state.store = {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -70,19 +70,7 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     if (job.state.lastStatus === "ok" && job.state.lastRunAtMs) {
       return undefined;
     }
-    // Handle both canonical `at` (string) and legacy `atMs` (number) fields.
-    // The store migration should convert atMs→at, but be defensive in case
-    // the migration hasn't run yet or was bypassed.
-    const schedule = job.schedule as { at?: string; atMs?: number | string };
-    const atMs =
-      typeof schedule.atMs === "number" && Number.isFinite(schedule.atMs) && schedule.atMs > 0
-        ? schedule.atMs
-        : typeof schedule.atMs === "string"
-          ? parseAbsoluteTimeMs(schedule.atMs)
-          : typeof schedule.at === "string"
-            ? parseAbsoluteTimeMs(schedule.at)
-            : null;
-    return atMs !== null ? atMs : undefined;
+    return computeNextRunAtMs(job.schedule, nowMs);
   }
   return computeNextRunAtMs(job.schedule, nowMs);
 }


### PR DESCRIPTION
Fixes #11795. This PR simplifies `computeJobNextRunAtMs` for 'at' schedules by delegating to `computeNextRunAtMs`, which correctly handles past/future checks. This ensures that when a job is updated to an 'at' schedule, the scheduler correctly registers the next wake time.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cron job updates for one-shot `at` schedules by simplifying `computeJobNextRunAtMs` to delegate to `computeNextRunAtMs`, which applies the past/future cutoff consistently (and still supports legacy `atMs`). It also adds a Vitest regression test reproducing issue #11795 by updating an existing cron job to an `at` schedule in the past and then in the future, asserting `nextWakeAtMs` behavior matches expectations.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after fixing minor test hygiene issues.
- The core logic change is small and delegates to the existing schedule computation, which already contains the legacy `atMs` handling and the past/future cutoff needed for the reported bug. The main remaining issues are in the new regression test (unused variables and loose typing via `as any`), which could fail CI or reduce test robustness.
- src/cron/repro_11795.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->