### PR TITLE
feat(subagents): configurable announce timeout + same-run dedupe + stale gate

### DIFF
--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -104,7 +104,7 @@ function getAnnounceQueue(
 
 async function sendIfFresh(queue: AnnounceQueueState, key: string, item: AnnounceQueueItem) {
   if (isStaleItem(queue, item)) {
-    defaultRuntime.warn?.(`announce stale dropped for ${key}`);
+    defaultRuntime.log?.(`announce stale dropped for ${key}`);
     return;
   }
   await queue.send(item);

--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentTimeoutMs, resolveSubagentAnnounceDeliveryTimeoutMs } from "./timeout.js";
+import {
+  resolveAgentTimeoutMs,
+  resolveSubagentAnnounceDeliveryTimeoutMs,
+  resolveSubagentAnnounceMaxAgeMs,
+} from "./timeout.js";
 
 describe("resolveAgentTimeoutMs", () => {
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
@@ -10,6 +14,20 @@ describe("resolveAgentTimeoutMs", () => {
   it("clamps very large timeout overrides to timer-safe values", () => {
     expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(2_147_000_000);
     expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(2_147_000_000);
+  });
+
+  it("resolves subagent announce max age from config with sane defaults", () => {
+    expect(resolveSubagentAnnounceMaxAgeMs()).toBe(10 * 60 * 1000);
+    expect(
+      resolveSubagentAnnounceMaxAgeMs({
+        agents: { defaults: { subagents: { announceMaxAgeMs: 30_000 } } },
+      } as any),
+    ).toBe(30_000);
+    expect(
+      resolveSubagentAnnounceMaxAgeMs({
+        agents: { defaults: { subagents: { announceMaxAgeMs: -1 } } },
+      } as any),
+    ).toBe(10 * 60 * 1000);
   });
 });
 

--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentTimeoutMs } from "./timeout.js";
+import { resolveAgentTimeoutMs, resolveSubagentAnnounceDeliveryTimeoutMs } from "./timeout.js";
 
 describe("resolveAgentTimeoutMs", () => {
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
@@ -10,5 +10,32 @@ describe("resolveAgentTimeoutMs", () => {
   it("clamps very large timeout overrides to timer-safe values", () => {
     expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(2_147_000_000);
     expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(2_147_000_000);
+  });
+});
+
+describe("resolveSubagentAnnounceDeliveryTimeoutMs", () => {
+  it("defaults to 60s when config is unset", () => {
+    expect(resolveSubagentAnnounceDeliveryTimeoutMs(undefined)).toBe(60_000);
+  });
+
+  it("reads configured value", () => {
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: 300_000 } } },
+      }),
+    ).toBe(300_000);
+  });
+
+  it("clamps invalid values to timer-safe bounds", () => {
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: -10 } } },
+      }),
+    ).toBe(1);
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: 9_999_999_999 } } },
+      }),
+    ).toBe(2_147_000_000);
   });
 });

--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveAgentTimeoutMs,
   resolveSubagentAnnounceDeliveryTimeoutMs,
@@ -21,12 +22,12 @@ describe("resolveAgentTimeoutMs", () => {
     expect(
       resolveSubagentAnnounceMaxAgeMs({
         agents: { defaults: { subagents: { announceMaxAgeMs: 30_000 } } },
-      } as any),
+      } as OpenClawConfig),
     ).toBe(30_000);
     expect(
       resolveSubagentAnnounceMaxAgeMs({
         agents: { defaults: { subagents: { announceMaxAgeMs: -1 } } },
-      } as any),
+      } as OpenClawConfig),
     ).toBe(10 * 60 * 1000);
   });
 });

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
 const DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS = 60_000;
+const DEFAULT_SUBAGENT_ANNOUNCE_MAX_AGE_MS = 10 * 60 * 1000;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 const normalizeNumber = (value: unknown): number | undefined =>
@@ -17,6 +18,14 @@ export function resolveSubagentAnnounceDeliveryTimeoutMs(cfg?: OpenClawConfig): 
   const raw = normalizeNumber(cfg?.agents?.defaults?.subagents?.announceDeliveryTimeoutMs);
   const timeoutMs = raw ?? DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS;
   return Math.min(Math.max(timeoutMs, 1), MAX_SAFE_TIMEOUT_MS);
+}
+
+export function resolveSubagentAnnounceMaxAgeMs(cfg?: OpenClawConfig): number {
+  const raw = normalizeNumber(cfg?.agents?.defaults?.subagents?.announceMaxAgeMs);
+  if (raw === undefined || raw < 0) {
+    return DEFAULT_SUBAGENT_ANNOUNCE_MAX_AGE_MS;
+  }
+  return Math.min(raw, MAX_SAFE_TIMEOUT_MS);
 }
 
 export function resolveAgentTimeoutMs(opts: {

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+const DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS = 60_000;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 const normalizeNumber = (value: unknown): number | undefined =>
@@ -10,6 +11,12 @@ export function resolveAgentTimeoutSeconds(cfg?: OpenClawConfig): number {
   const raw = normalizeNumber(cfg?.agents?.defaults?.timeoutSeconds);
   const seconds = raw ?? DEFAULT_AGENT_TIMEOUT_SECONDS;
   return Math.max(seconds, 1);
+}
+
+export function resolveSubagentAnnounceDeliveryTimeoutMs(cfg?: OpenClawConfig): number {
+  const raw = normalizeNumber(cfg?.agents?.defaults?.subagents?.announceDeliveryTimeoutMs);
+  const timeoutMs = raw ?? DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS;
+  return Math.min(Math.max(timeoutMs, 1), MAX_SAFE_TIMEOUT_MS);
 }
 
 export function resolveAgentTimeoutMs(opts: {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,13 +281,11 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
-=======
 
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
-=======
 
   return grok as GrokConfig;
 }
@@ -297,7 +295,6 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
-=======
 
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
@@ -481,14 +478,6 @@ async function runWebSearch(params: {
   grokModel?: string;
   grokInlineCitations?: boolean;
 }): Promise<Record<string, unknown>> {
-  const cacheKey = normalizeCacheKey(
-    params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : params.provider === "perplexity"
-        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
-  );
-=======
   let rawCacheKey: string;
   switch (params.provider) {
     case "brave":

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,10 +281,14 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
+=======
+
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
+=======
+
   return grok as GrokConfig;
 }
 
@@ -293,6 +297,8 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
+=======
+
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
 }
@@ -482,6 +488,24 @@ async function runWebSearch(params: {
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
+=======
+  let rawCacheKey: string;
+  switch (params.provider) {
+    case "brave":
+      rawCacheKey = `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`;
+      break;
+    case "perplexity":
+      rawCacheKey = `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`;
+      break;
+    case "grok":
+      rawCacheKey = `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${params.grokInlineCitations ?? false}`;
+      break;
+    default:
+      rawCacheKey = `${String(params.provider)}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`;
+      break;
+  }
+
+  const cacheKey = normalizeCacheKey(rawCacheKey);
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -206,6 +206,8 @@ export type AgentDefaultsConfig = {
     maxConcurrent?: number;
     /** Auto-archive sub-agent sessions after N minutes (default: 60). */
     archiveAfterMinutes?: number;
+    /** Max age in ms for queued subagent announce messages before dropping (default: 600000). */
+    announceMaxAgeMs?: number;
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -210,6 +210,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Timeout (ms) for sub-agent announce delivery to the requester. Default: 60000. */
+    announceDeliveryTimeoutMs?: number;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -141,6 +141,7 @@ export const AgentDefaultsSchema = z
       .object({
         maxConcurrent: z.number().int().positive().optional(),
         archiveAfterMinutes: z.number().int().positive().optional(),
+        announceMaxAgeMs: z.number().int().nonnegative().optional(),
         model: z
           .union([
             z.string(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -153,6 +153,7 @@ export const AgentDefaultsSchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        announceDeliveryTimeoutMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
This stacked PR builds on #11785 and completes PR1 for stale/duplicate subagent announces:

- same-run announce dedupe (do not repeat same runId+status)
- multi-run detection and explicit user-facing alert hint
- stale gate for queued announces with configurable max age
- keep high-priority multi-run alerts from stale dropping

## Why stacked on #11785
This change overlaps the same announce/config surfaces touched by #11785 (`subagent-announce.ts`, `timeout.ts`, config schema/types). Stacking reduces review conflict and keeps the rollout narrative coherent.

## Behavior guarantees
- **Do dedupe** duplicate delivery for the same actual run.
- **Do NOT hide** true repeated execution: different runIds still announce and include alert guidance.

## Config
- `agents.defaults.subagents.announceMaxAgeMs` (default: `600000` ms)

## Tests
- `src/agents/subagent-announce.format.test.ts`
  - adds same-run dedupe case
  - adds multi-run alert case
- `src/agents/timeout.test.ts`
  - adds max-age resolver tests

Ran:
- `pnpm test src/agents/subagent-announce.format.test.ts src/agents/timeout.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enhances subagent announcement delivery by adding (1) configurable delivery timeout, (2) same-run announcement deduplication keyed by requester+task identity+runId+status, (3) multi-run detection with an explicit user-facing alert, and (4) a stale-age gate for queued announces with a configurable `announceMaxAgeMs` while allowing high-priority alerts to bypass stale dropping. It wires these behaviors through the announce queue (`maxAgeMs`, `highPriority`), the announce flow (`runSubagentAnnounceFlow`), and the agent-defaults config schema/types, with tests covering dedupe/multi-run formatting and timeout/max-age resolvers.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a cleanup/return-path bug that can leak subagent sessions when dedupe triggers.
- Core changes are straightforward and tests cover the new timeout/max-age resolver and announce formatting behaviors, but the new early-return dedupe path in `runSubagentAnnounceFlow` bypasses the `finally` cleanup that patches labels and deletes child sessions, which is a functional regression when `cleanup: "delete"` is used.
- src/agents/subagent-announce.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->