### PR TITLE
fix(cron): forward agent-specific exec config to isolated cron sessions

### DIFF
--- a/src/cron/isolated-agent.exec-overrides.test.ts
+++ b/src/cron/isolated-agent.exec-overrides.test.ts
@@ -1,0 +1,254 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { CronJob } from "./types.js";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { telegramOutbound } from "../channels/plugins/outbound/telegram.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+vi.mock("../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn(),
+}));
+
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-cron-exec-" });
+}
+
+async function writeSessionStore(home: string) {
+  const dir = path.join(home, ".openclaw", "sessions");
+  await fs.mkdir(dir, { recursive: true });
+  const storePath = path.join(dir, "sessions.json");
+  await fs.writeFile(
+    storePath,
+    JSON.stringify(
+      {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "webchat",
+          lastTo: "",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  return storePath;
+}
+
+function makeCfg(
+  home: string,
+  storePath: string,
+  overrides: Partial<OpenClawConfig> = {},
+): OpenClawConfig {
+  const base: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-opus-4-5",
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+  } as OpenClawConfig;
+  return { ...base, ...overrides };
+}
+
+function makeJob(payload: CronJob["payload"]): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-exec-1",
+    name: "job-exec-1",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload,
+    state: {},
+  };
+}
+
+function makeDeps(): CliDeps {
+  return {
+    sendMessageWhatsApp: vi.fn(),
+    sendMessageTelegram: vi.fn().mockResolvedValue({ messageId: "t1", chatId: "123" }),
+    sendMessageDiscord: vi.fn(),
+    sendMessageSignal: vi.fn(),
+    sendMessageIMessage: vi.fn(),
+  };
+}
+
+describe("runCronIsolatedAgentTurn – exec overrides (#11559)", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+    vi.mocked(runSubagentAnnounceFlow).mockReset().mockResolvedValue(true);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          plugin: createOutboundTestPlugin({ id: "telegram", outbound: telegramOutbound }),
+          source: "test",
+        },
+      ]),
+    );
+  });
+
+  it("passes global tools.exec config as execOverrides", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const cfg = makeCfg(home, storePath, {
+        tools: { exec: { ask: "off", host: "gateway", security: "full" } },
+      });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: makeDeps(),
+        job: makeJob({ kind: "agentTurn", message: "test exec" }),
+        message: "test exec",
+        sessionKey: "cron:job-exec-1",
+        lane: "cron",
+      });
+
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.execOverrides).toEqual(
+        expect.objectContaining({ ask: "off", host: "gateway", security: "full" }),
+      );
+    });
+  });
+
+  it("agent-specific exec config takes precedence over global", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const cfg = makeCfg(home, storePath, {
+        tools: { exec: { ask: "always", host: "sandbox", security: "deny" } },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-5",
+            workspace: path.join(home, "openclaw"),
+          },
+          list: [
+            {
+              id: "cron_bot",
+              tools: { exec: { ask: "off", host: "gateway", security: "full" } },
+            },
+          ],
+        },
+      });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: makeDeps(),
+        job: {
+          ...makeJob({ kind: "agentTurn", message: "exec test" }),
+          agentId: "cron_bot",
+        },
+        message: "exec test",
+        sessionKey: "cron:job-exec-1",
+        lane: "cron",
+      });
+
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      // Agent-specific exec config should win.
+      expect(call?.execOverrides).toEqual(
+        expect.objectContaining({ ask: "off", host: "gateway", security: "full" }),
+      );
+    });
+  });
+
+  it("falls back to global exec when agent has no tools.exec", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const cfg = makeCfg(home, storePath, {
+        tools: { exec: { ask: "off", host: "sandbox", security: "allowlist" } },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-5",
+            workspace: path.join(home, "openclaw"),
+          },
+          list: [
+            {
+              id: "writer",
+              model: "openai/gpt-4o",
+              // No tools.exec here — global should be used.
+            },
+          ],
+        },
+      });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: makeDeps(),
+        job: {
+          ...makeJob({ kind: "agentTurn", message: "write" }),
+          agentId: "writer",
+        },
+        message: "write",
+        sessionKey: "cron:job-exec-1",
+        lane: "cron",
+      });
+
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.execOverrides).toEqual(
+        expect.objectContaining({ ask: "off", host: "sandbox", security: "allowlist" }),
+      );
+    });
+  });
+
+  it("does not pass execOverrides when no exec config is set", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const cfg = makeCfg(home, storePath);
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: makeDeps(),
+        job: makeJob({ kind: "agentTurn", message: "check" }),
+        message: "check",
+        sessionKey: "cron:job-exec-1",
+        lane: "cron",
+      });
+
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.execOverrides).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
#### Summary

Cron-launched isolated agents ignored per-agent `tools.exec` overrides (e.g. `ask: "off"`) and always fell back to global defaults. This PR resolves agent- and global-level exec config and passes it as `execOverrides` to `runEmbeddedPiAgent`, mirroring the auto-reply path.

Closes #11559

lobster-biscuit

#### Repro Steps

1. Configure an agent with `tools.exec.ask: "off"` in `agents.list`
2. Start the agent through the cron isolated-agent runner
3. Trigger execution requiring the exec tool
4. Observe that execution still behaves as if approval is required (gateway mode)

#### Root Cause

`runEmbeddedPiAgent` in `src/cron/isolated-agent/run.ts` was called without `execOverrides`. The auto-reply path already resolves agent → global exec config via `resolveExecDefaults`, but the cron runner did not.

#### Behavior Changes

- Cron-launched isolated agent sessions now respect per-agent `tools.exec` config (host, security, ask, node)
- Agent-specific exec config takes precedence over global config (same precedence as `resolveExecDefaults` in auto-reply)
- When no exec config is set at either level, no `execOverrides` are passed (preserves existing defaults)

#### Codebase and GitHub Search

- Reviewed `resolveExecDefaults` in `src/auto-reply/reply/directive-handling.impl.ts` for the reference implementation
- Verified `runEmbeddedPiAgent` accepts `execOverrides` via `src/agents/pi-embedded-runner/run/params.ts`
- Confirmed `resolveAgentConfig` returns `tools` field from agent entries

#### Tests

4 new unit tests in `src/cron/isolated-agent.exec-overrides.test.ts`:
- passes global `tools.exec` config as `execOverrides` ✅
- agent-specific exec config takes precedence over global ✅
- falls back to global exec when agent has no `tools.exec` ✅
- does not pass `execOverrides` when no exec config is set ✅

All 91 cron tests pass. `pnpm build`, `pnpm check` pass.

**Sign-Off**

- Models used: Claude (AI-assisted)
- Submitter effort: Investigated issue, reviewed reference implementation, implemented fix, wrote tests
- Agent notes: Fix mirrors the established `resolveExecDefaults` pattern from the auto-reply path. The resolution order is agent-specific → global, matching precedence used elsewhere.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cron-launched isolated agent runs so they honor per-agent and global `tools.exec` configuration.

In `src/cron/isolated-agent/run.ts`, it resolves `tools.exec` from the selected agent config (preferred) and falls back to global config, then forwards that as `execOverrides` into `runEmbeddedPiAgent`. This mirrors the auto-reply path’s precedence logic.

It adds `src/cron/isolated-agent.exec-overrides.test.ts` to assert the `execOverrides` passed to `runEmbeddedPiAgent` for: global-only config, agent-over-global precedence, global fallback when agent has no `tools.exec`, and the no-config case (no overrides passed).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped (only forwards already-configured exec defaults into cron isolated runs) and is covered by targeted unit tests verifying precedence and the no-config behavior. No other control flow or security boundaries are altered.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->