### PR TITLE
fix(build): compile bundled hook handlers into dist

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -36,4 +36,16 @@ export default defineConfig([
     fixedExtension: false,
     platform: "node",
   },
+  // Bundled hook handlers — compiled so npm installs include handler.js.  #11810
+  {
+    entry: {
+      "hooks/bundled/boot-md/handler": "src/hooks/bundled/boot-md/handler.ts",
+      "hooks/bundled/command-logger/handler": "src/hooks/bundled/command-logger/handler.ts",
+      "hooks/bundled/session-memory/handler": "src/hooks/bundled/session-memory/handler.ts",
+      "hooks/bundled/soul-evil/handler": "src/hooks/bundled/soul-evil/handler.ts",
+    },
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
 ]);


### PR DESCRIPTION
#### Summary

Bundled hooks (boot-md, command-logger, session-memory, soul-evil) were missing their `handler.js` files in the npm package, causing `openclaw hooks list` to return "No hooks found" after installing v2026.2.6-3. The build only compiled main entry points via tsdown and copied `HOOK.md` files via `copy-hook-metadata.ts`, but never compiled the handler `.ts` files.

Closes #11810
Closes #11624

lobster-biscuit

#### Repro Steps

1. Install `openclaw@2026.2.6-3` via npm
2. Run `openclaw hooks list`
3. Result: "No hooks found" — `dist/hooks/bundled/*/` directories only contain `HOOK.md`, no `handler.js`

#### Root Cause

`tsdown.config.ts` only compiled main entry points (`src/index.ts`, `src/entry.ts`, etc.) but not the individual hook handler files. `scripts/copy-hook-metadata.ts` only copied `HOOK.md` files. The hook discovery code in `src/hooks/workspace.ts` looks for `handler.ts`/`handler.js` in each hook directory — with no `handler.js` present, hooks are silently skipped.

#### Behavior Changes

- All four bundled hook handlers (`boot-md`, `command-logger`, `session-memory`, `soul-evil`) are now compiled to `dist/hooks/bundled/*/handler.js` during the build
- `openclaw hooks list` will correctly discover bundled hooks after npm install

#### Codebase and GitHub Search

- Reviewed `tsdown.config.ts` for existing entry point patterns
- Reviewed `scripts/copy-hook-metadata.ts` to understand what was already copied
- Reviewed `src/hooks/bundled-dir.ts` for dist path resolution
- Reviewed `src/hooks/workspace.ts` for handler file discovery logic
- Confirmed no existing PRs for #11810 or #11624

#### Tests

- `pnpm build` succeeds; verified `dist/hooks/bundled/*/handler.js` exists for all 4 hooks
- All 88 hooks tests pass (`npx vitest run src/hooks/`)
- `pnpm check` passes for changed files (pre-existing doc format issues unrelated)

**Sign-Off**

- Models used: Claude (AI-assisted)
- Submitter effort: Traced build pipeline, identified gap, added tsdown entries, verified output
- Agent notes: Minimal change — single config file edit. The handler files import from the main codebase so they must be compiled (not just copied). tsdown bundles them with their dependencies into standalone handler.js files.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `tsdown.config.ts` to explicitly compile the four bundled hook handler entry points (boot-md, command-logger, session-memory, soul-evil) into `dist/hooks/bundled/*/handler.js`. This aligns the build output with the hook discovery logic (which looks for `handler.{ts,js}` alongside `HOOK.md`), fixing npm installs where only `HOOK.md` was present and `openclaw hooks list` found no bundled hooks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is isolated to build configuration and adds explicit bundle entries for files that already exist in-tree; output paths match the runtime hook discovery expectations, and the dist/ directory is already included in the npm package files list.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->