### PR TITLE
fix(sandbox): remap container paths in sandboxed file tools

### DIFF
--- a/src/agents/bash-tools.exec.remap-media.test.ts
+++ b/src/agents/bash-tools.exec.remap-media.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { splitMediaFromOutput } from "../media/parse.js";
+import { remapMediaContainerPaths } from "./bash-tools.exec.js";
+
+describe("remapMediaContainerPaths", () => {
+  it("remaps container-absolute MEDIA path to relative ./", () => {
+    const result = remapMediaContainerPaths("MEDIA:/workspace/ghost.png", "/workspace");
+    expect(result).toBe("MEDIA:./ghost.png");
+  });
+
+  it("remaps with trailing slash on containerWorkdir", () => {
+    const result = remapMediaContainerPaths("MEDIA:/workspace/ghost.png", "/workspace/");
+    expect(result).toBe("MEDIA:./ghost.png");
+  });
+
+  it("remaps nested paths", () => {
+    const result = remapMediaContainerPaths("MEDIA:/workspace/images/photo.jpg", "/workspace");
+    expect(result).toBe("MEDIA:./images/photo.jpg");
+  });
+
+  it("remaps multiple MEDIA tokens in the same text", () => {
+    const text = "MEDIA:/workspace/a.png\nsome text\nMEDIA:/workspace/b.jpg";
+    const result = remapMediaContainerPaths(text, "/workspace");
+    expect(result).toBe("MEDIA:./a.png\nsome text\nMEDIA:./b.jpg");
+  });
+
+  it("does not remap HTTP URLs", () => {
+    const text = "MEDIA:https://example.com/image.png";
+    const result = remapMediaContainerPaths(text, "/workspace");
+    expect(result).toBe("MEDIA:https://example.com/image.png");
+  });
+
+  it("does not remap relative paths", () => {
+    const text = "MEDIA:./local.png";
+    const result = remapMediaContainerPaths(text, "/workspace");
+    expect(result).toBe("MEDIA:./local.png");
+  });
+
+  it("returns text unchanged without containerWorkdir", () => {
+    const text = "MEDIA:/workspace/ghost.png";
+    const result = remapMediaContainerPaths(text, undefined);
+    expect(result).toBe("MEDIA:/workspace/ghost.png");
+  });
+
+  it("returns text unchanged when no MEDIA: token present", () => {
+    const text = "just regular output";
+    const result = remapMediaContainerPaths(text, "/workspace");
+    expect(result).toBe("just regular output");
+  });
+
+  it("does not remap paths outside the container workdir", () => {
+    const text = "MEDIA:/other/path/ghost.png";
+    const result = remapMediaContainerPaths(text, "/workspace");
+    expect(result).toBe("MEDIA:/other/path/ghost.png");
+  });
+
+  it("handles MEDIA: with whitespace before path", () => {
+    const result = remapMediaContainerPaths("MEDIA: /workspace/ghost.png", "/workspace");
+    expect(result).toBe("MEDIA: ./ghost.png");
+  });
+
+  it("is case-insensitive for MEDIA token", () => {
+    const result = remapMediaContainerPaths("media:/workspace/ghost.png", "/workspace");
+    expect(result).toBe("media:./ghost.png");
+  });
+
+  it("remaps double-quoted container path", () => {
+    const result = remapMediaContainerPaths('MEDIA:"/workspace/ghost.png"', "/workspace");
+    expect(result).toBe('MEDIA:"./ghost.png"');
+  });
+
+  it("remaps single-quoted container path", () => {
+    const result = remapMediaContainerPaths("MEDIA:'/workspace/ghost.png'", "/workspace");
+    expect(result).toBe("MEDIA:'./ghost.png'");
+  });
+
+  it("remaps backtick-wrapped container path", () => {
+    const result = remapMediaContainerPaths("MEDIA:`/workspace/ghost.png`", "/workspace");
+    expect(result).toBe("MEDIA:`./ghost.png`");
+  });
+});
+
+describe("remapMediaContainerPaths + splitMediaFromOutput integration", () => {
+  it("remapped container path is accepted by splitMediaFromOutput", () => {
+    const remapped = remapMediaContainerPaths("MEDIA:/workspace/ghost.png", "/workspace");
+    const parsed = splitMediaFromOutput(remapped);
+    expect(parsed.mediaUrls).toEqual(["./ghost.png"]);
+    expect(parsed.mediaUrl).toBe("./ghost.png");
+  });
+
+  it("un-remapped container path is rejected by splitMediaFromOutput", () => {
+    const parsed = splitMediaFromOutput("MEDIA:/workspace/ghost.png");
+    expect(parsed.mediaUrls).toBeUndefined();
+  });
+
+  it("quoted remapped container path is accepted by splitMediaFromOutput", () => {
+    const remapped = remapMediaContainerPaths('MEDIA:"/workspace/ghost.png"', "/workspace");
+    const parsed = splitMediaFromOutput(remapped);
+    expect(parsed.mediaUrls).toEqual(["./ghost.png"]);
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -265,7 +265,12 @@ export function remapContainerPath(
     return hostRoot;
   }
   if (filePath.startsWith(prefix)) {
-    return path.join(hostRoot, filePath.slice(prefix.length));
+    const suffix = path.normalize(filePath.slice(prefix.length));
+    const joined = path.join(hostRoot, suffix);
+    if (!joined.startsWith(hostRoot + "/") && joined !== hostRoot) {
+      return filePath;
+    }
+    return joined;
   }
   return filePath;
 }

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -245,7 +245,7 @@ export function createOpenClawCodingTools(options?: {
   const base = (codingTools as unknown as AnyAgentTool[]).flatMap((tool) => {
     if (tool.name === readTool.name) {
       if (sandboxRoot) {
-        return [createSandboxedReadTool(sandboxRoot)];
+        return [createSandboxedReadTool(sandboxRoot, sandbox?.containerWorkdir)];
       }
       const freshReadTool = createReadTool(workspaceRoot);
       return [createOpenClawReadTool(freshReadTool)];
@@ -315,7 +315,10 @@ export function createOpenClawCodingTools(options?: {
     ...base,
     ...(sandboxRoot
       ? allowWorkspaceWrites
-        ? [createSandboxedEditTool(sandboxRoot), createSandboxedWriteTool(sandboxRoot)]
+        ? [
+            createSandboxedEditTool(sandboxRoot, sandbox?.containerWorkdir),
+            createSandboxedWriteTool(sandboxRoot, sandbox?.containerWorkdir),
+          ]
         : []
       : []),
     ...(applyPatchTool ? [applyPatchTool as unknown as AnyAgentTool] : []),


### PR DESCRIPTION
## Problem

When a sandbox runs with `workspaceAccess: "none"`, the host sandbox directory (e.g. `/data/clawfront-data/{sandbox-id}/`) is bind-mounted into the Docker container at `/workspace`. Both paths point to the same physical files.

The agent executes commands inside Docker via `exec`, so it discovers files at container paths like `/workspace/projects/foo/package.json`. When it then tries to use the structured `read`/`write`/`edit` tools with those paths, the gateway-side `assertSandboxPath` rejects them — because `/workspace/...` on the host is not inside the sandbox root.

This forces the agent to fall back to `cat`/`echo >` via bash inside Docker, which works but bypasses the structured file tools entirely — losing MIME detection, image sanitization, path normalization, and the sandbox symlink guard.

## Fix

Add a `remapContainerPath` step in `wrapSandboxPathGuard` that translates container paths back to host paths before validation. For example, `/workspace/foo.txt` becomes `/data/clawfront-data/{sandbox-id}/foo.txt`. Paths that don't match the container workdir prefix pass through unchanged.

## Test plan

- [x] New tests: container-absolute read/write/edit paths resolve to sandbox dir
- [x] New test: paths outside the container workspace prefix are still rejected
- [x] Existing sandbox + workspace path tests pass
- [x] Full test suite passes (`pnpm build && pnpm check && pnpm test`)

🤖 AI-assisted (Claude Code) · fully tested · I understand what the code does

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change threads `sandbox.containerWorkdir` into the sandboxed `read`/`write`/`edit` tool wrappers and adds a `remapContainerPath` step inside `wrapSandboxPathGuard` so container-absolute paths (e.g. `/workspace/foo.txt`) are rewritten to the host sandbox root before running `assertSandboxPath`. The accompanying tests extend `pi-tools.workspace-paths.test.ts` to cover container-absolute read/write/edit paths and confirm that non-workdir-prefixed container paths remain blocked.


<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge once a path-traversal edge case in container path remapping is addressed.
- The change is localized and backed by new tests, but `remapContainerPath` can join `..` segments from a container path into a host path, which will cause unexpected rejections (and could become risky if surrounding validation changes).
- src/agents/pi-tools.read.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->