### PR TITLE
fix(mattermost): add WebSocket ping/pong heartbeat to detect stale connections (#11796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Mattermost: add WebSocket ping/pong heartbeat to detect and recover from stale connections. (#11796)
 - Cron: route text-only isolated agent announces through the shared subagent announce flow; add exponential backoff for repeated errors; preserve future `nextRunAtMs` on restart; include current-boundary schedule matches; prevent stale threadId reuse across targets; and add per-job execution timeout. (#11641) Thanks @tyler6204.
 - Subagents: stabilize announce timing, preserve compaction metrics across retries, clamp overflow-prone long timeouts, and cap impossible context usage token totals. (#11551) Thanks @tyler6204.
 - Agents: recover from context overflow caused by oversized tool results (pre-emptive capping + fallback truncation). (#11579) Thanks @tyler6204.

--- a/extensions/mattermost/src/mattermost/monitor.heartbeat.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.heartbeat.test.ts
@@ -45,4 +45,9 @@ describe("mattermost monitor websocket heartbeat (#11796)", () => {
     );
     expect(messageSection).toMatch(/lastPongAt\s*=\s*Date\.now\(\)/);
   });
+
+  it("cleans up heartbeat intervals on error", () => {
+    const errorSection = connectOnceBody.slice(connectOnceBody.indexOf('ws.on("error"'));
+    expect(errorSection).toContain("clearHeartbeat");
+  });
 });

--- a/extensions/mattermost/src/mattermost/monitor.heartbeat.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.heartbeat.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test for #11796: Mattermost WebSocket must have ping/pong
+ * heartbeat to detect stale connections caused by silent network failures.
+ *
+ * The monitor's connectOnce function uses raw WebSocket APIs that are hard
+ * to unit-test without a real server, so we verify the heartbeat mechanism
+ * structurally to prevent accidental removal.
+ */
+describe("mattermost monitor websocket heartbeat (#11796)", () => {
+  const monitorSource = fs.readFileSync(path.resolve(import.meta.dirname, "monitor.ts"), "utf-8");
+
+  const connectOnceStart = monitorSource.indexOf("const connectOnce");
+  const reconnectLoop = monitorSource.indexOf("while (!opts.abortSignal?.aborted)");
+  const connectOnceBody = monitorSource.slice(connectOnceStart, reconnectLoop);
+
+  it("sends periodic WebSocket pings", () => {
+    expect(connectOnceBody).toMatch(/ws\.ping\s*\(/);
+  });
+
+  it("listens for pong events to track liveness", () => {
+    expect(connectOnceBody).toMatch(/ws\.on\s*\(\s*["']pong["']/);
+  });
+
+  it("tracks last pong timestamp", () => {
+    expect(connectOnceBody).toContain("lastPongAt");
+  });
+
+  it("terminates stale connections when no pong received", () => {
+    expect(connectOnceBody).toMatch(/ws\.terminate\s*\(/);
+  });
+
+  it("cleans up heartbeat intervals on close", () => {
+    const closeSection = connectOnceBody.slice(connectOnceBody.indexOf('ws.on("close"'));
+    expect(closeSection).toContain("clearHeartbeat");
+  });
+
+  it("resets liveness on incoming messages", () => {
+    const messageSection = connectOnceBody.slice(
+      connectOnceBody.indexOf('ws.on("message"'),
+      connectOnceBody.indexOf('ws.on("close"'),
+    );
+    expect(messageSection).toMatch(/lastPongAt\s*=\s*Date\.now\(\)/);
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1005,6 +1005,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       });
 
       ws.on("error", (err) => {
+        clearHeartbeat();
         runtime.error?.(`mattermost websocket error: ${String(err)}`);
         opts.statusSink?.({
           lastError: String(err),


### PR DESCRIPTION
## Summary

Fixes #11796

## Problem

The Mattermost WebSocket monitor in `extensions/mattermost/src/mattermost/monitor.ts` has no ping/pong heartbeat mechanism. The reconnect loop only triggers on `ws.on("close")` events, but silent network failures (router restarts, IP changes, firewall drops) can leave the TCP connection in a half-open state where no `close` event fires. When this happens, the gateway believes it is still connected but receives no messages — and never reconnects until manually restarted.

**Root cause:** `connectOnce()` registers handlers for `open`, `message`, `close`, and `error`, but never sends WebSocket pings or monitors for stale connections.

## Fix

Add a standard WebSocket ping/pong heartbeat inside `connectOnce()`:

- **Ping interval (30s):** Sends `ws.ping()` every 30 seconds when the connection is open.
- **Pong listener:** Tracks `lastPongAt` timestamp on each `pong` event.
- **Message activity:** Also resets `lastPongAt` on incoming messages (any server data proves liveness).
- **Health check (15s poll, 90s threshold):** Every 15 seconds, checks if `lastPongAt` is older than 90 seconds. If stale, logs a warning and calls `ws.terminate()` to force a `close` event, which triggers the existing reconnect loop.
- **Cleanup:** `clearHeartbeat()` is called in the `close` handler to prevent timer leaks.

### Before (no heartbeat):
```typescript
ws.on("open", () => { /* auth only */ });
ws.on("message", async (data) => { /* handle posted */ });
ws.on("close", () => { /* reconnect */ });
ws.on("error", () => { /* log */ });
```

### After (with heartbeat):
```typescript
ws.on("open", () => {
  /* auth */
  pingInterval = setInterval(() => ws.ping(), 30_000);
  healthInterval = setInterval(() => {
    if (Date.now() - lastPongAt > 90_000) ws.terminate();
  }, 15_000);
});
ws.on("pong", () => { lastPongAt = Date.now(); });
ws.on("message", async (data) => { lastPongAt = Date.now(); /* handle posted */ });
ws.on("close", () => { clearHeartbeat(); /* reconnect */ });
```

## Effect on User Experience

**Before fix:**
- Self-hosted Mattermost users experience silent disconnections after network interruptions
- `openclaw status --deep` still shows "OK" even though no messages are being received
- Gateway never reconnects until manually restarted
- Users lose all bot functionality without any visible error

**After fix:**
- Gateway detects stale WebSocket connections within ~90 seconds
- Automatic reconnection triggers via the existing reconnect loop
- Log message warns: `mattermost websocket stale (no pong in 90s), forcing reconnect`
- No manual intervention needed after transient network failures

## Testing

- ✅ 6 regression tests pass (`monitor.heartbeat.test.ts`)
- ✅ Lint passes (oxlint + oxfmt)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a WebSocket heartbeat to the Mattermost monitor by periodically sending `ping` frames, tracking liveness via `pong`/message activity, and terminating stale connections to trigger the existing reconnect loop. Also updates the changelog and introduces a regression test that structurally asserts the heartbeat code remains present in `connectOnce()`.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge after addressing cleanup/test robustness issues
- Core heartbeat logic is straightforward and localized, but the current error-path cleanup can leak intervals if `error` doesn’t lead to `close`, and the regression test relies on fragile string slicing without guarding against missing anchors.
- extensions/mattermost/src/mattermost/monitor.ts; extensions/mattermost/src/mattermost/monitor.heartbeat.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->