### PR TITLE
TTS: strip markdown formatting before speech synthesis

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -32,6 +32,7 @@ import {
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import { logVerbose } from "../globals.js";
+import { stripMarkdown } from "../line/markdown-to-line.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 
@@ -1423,6 +1424,23 @@ export async function textToSpeechTelephony(params: {
   };
 }
 
+/**
+ * Clean text for TTS: strip fenced code blocks, markdown links, and
+ * standard markdown formatting so engines don't vocalize symbols.
+ */
+function stripMarkdownForTts(text: string): string {
+  let result = text;
+  // Remove fenced code blocks entirely (not useful as speech)
+  result = result.replace(/```[\s\S]*?```/g, "");
+  // Convert markdown links [text](url) → text
+  result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+  // Delegate remaining markdown (bold, italic, headers, etc.)
+  result = stripMarkdown(result);
+  // Collapse excessive whitespace left behind
+  result = result.replace(/\n{3,}/g, "\n\n").trim();
+  return result;
+}
+
 export async function maybeApplyTtsToPayload(params: {
   payload: ReplyPayload;
   cfg: OpenClawConfig;
@@ -1487,7 +1505,8 @@ export async function maybeApplyTtsToPayload(params: {
   }
 
   const maxLength = getTtsMaxLength(prefsPath);
-  let textForAudio = ttsText.trim();
+  // Strip markdown formatting so TTS engines don't vocalize symbols like ** or `
+  let textForAudio = stripMarkdownForTts(ttsText.trim());
   let wasSummarized = false;
 
   if (textForAudio.length > maxLength) {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -1507,6 +1507,9 @@ export async function maybeApplyTtsToPayload(params: {
   const maxLength = getTtsMaxLength(prefsPath);
   // Strip markdown formatting so TTS engines don't vocalize symbols like ** or `
   let textForAudio = stripMarkdownForTts(ttsText.trim());
+  if (textForAudio.length < 10) {
+    return nextPayload;
+  }
   let wasSummarized = false;
 
   if (textForAudio.length > maxLength) {


### PR DESCRIPTION
## Summary

- TTS engines vocalize markdown symbols (e.g. `**bold**` becomes "star star bold star star"), producing garbled speech
- Added `stripMarkdownForTts()` that cleans text before passing it to the TTS engine:
  - Removes fenced code blocks (``` ``` ```)
  - Converts markdown links `[text](url)` → `text`
  - Strips bold (`**`), italic (`*`), headers (`#`), blockquotes (`>`), inline code, and horizontal rules via the existing `stripMarkdown()` utility
- Applied in `maybeApplyTtsToPayload` before text is sent to any TTS provider (OpenAI, ElevenLabs, Edge)

## Testing

- All existing TTS tests pass (`src/tts/tts.test.ts` — 71 tests)
- `stripMarkdown` unit tests pass (`src/line/markdown-to-line.test.ts`)
- `pnpm build` succeeds

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change introduces `stripMarkdownForTts()` in `src/tts/tts.ts` to pre-clean text before sending it to any TTS provider. The helper removes fenced code blocks, converts markdown links to their label text, then delegates remaining markdown cleanup to the existing `stripMarkdown()` utility, and finally normalizes whitespace. The cleaned string is now used in `maybeApplyTtsToPayload()` when building `textForAudio`, reducing cases where providers vocalize markdown symbols.


<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge after a small correctness fix around post-strip length validation.
- The change is localized and uses existing markdown-stripping utilities, but it alters the TTS input pipeline; the current pre-strip minimum-length gating can be bypassed by markdown-heavy text, which can result in empty/too-short text being sent to providers.
- src/tts/tts.ts (maybeApplyTtsToPayload length gating around stripMarkdownForTts)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->