### PR TITLE
cron: avoid holding store lock during long job execution

### DIFF
--- a/notes-cron-lock-contention.md
+++ b/notes-cron-lock-contention.md
@@ -1,0 +1,56 @@
+# Draft: cron lock contention blocks cron.list/status during long-running jobs
+
+## Summary
+Clawdbot cron service currently holds a per-storePath async lock (`cron/service/locked.ts`) for the entire duration of job execution. If a job takes minutes (e.g. isolated agent work or main-lane heartbeat wake), then *all* cron RPCs that use `locked(...)` (`cron.list`, `cron.status`, `cron.add/update/remove/run`, plus the timer tick) are blocked until the job completes.
+
+This manifests as gateway RPC latency/backpressure and frequent client-side timeouts for `cron.list/status` (e.g. 60–110s).
+
+## Evidence
+### Code
+- `src/cron/service/locked.ts` chains `state.op` and a per-`storePath` promise.
+- `src/cron/service/timer.ts:onTimer()`:
+  - `await locked(state, async () => { ... await runDueJobs(state); ... })`
+  - `runDueJobs()` loops: `await executeJob(...)`
+  - `executeJob()` can await long work:
+    - `runIsolatedAgentJob(...)` (isolated session agent turn)
+    - `runHeartbeatOnce(...)` (main lane), including polling up to 2 minutes on `requests-in-flight`
+- `src/cron/service/ops.ts:run()` similarly does `await locked(...)` then `await executeJob(...)`.
+
+So one long job blocks reads like `cron.list/status` for minutes.
+
+### Observed behavior
+- `cron.list` sometimes takes 50–110s even when successful; often times out at 10s/60s.
+- cron job runs recorded as 168s, 220s, 246s, 400s etc (even when status=ok).
+
+## Proposed fix (high level)
+Don’t hold the store lock across the awaited job execution.
+
+Split execution into phases:
+1) Under lock:
+   - load store
+   - select due jobs
+   - mark each due job as running (`runningAtMs`, clear `lastError`)
+   - persist
+   - arm timer / recompute next runs as appropriate
+2) Outside lock:
+   - run the job payload (agent work / heartbeat wake)
+3) Under lock:
+   - re-load store (or use in-memory store) and apply finish state (`lastStatus`, `lastDurationMs`, `nextRunAtMs`, disable/delete)
+   - persist
+   - arm timer
+
+This allows `cron.list/status` to remain responsive while jobs run.
+
+## Notes / edge cases
+- **Update/remove while running** (now possible because we release the lock during execution):
+  - safest: reject update/remove when `runningAtMs` is set (return a clear error)
+  - acceptable: allow update/remove, but “finish” phase must tolerate job missing and/or treat patch as “next run only”.
+  - if removed while running: finish phase should no-op if job not found.
+- **Crash safety / restart**: once `runningAtMs` is persisted, a restart can leave jobs “stuck running” forever unless we:
+  - clear `runningAtMs` on boot if older than a threshold, or
+  - treat `runningAtMs` as advisory and allow list/status to show it but still permit rescheduling.
+- **Timer drift / recompute**: if we recompute `nextRunAtMs` too early, a late timer tick can skip intended runs (#9788). The current phase-1 flow intentionally loads with `skipRecompute`.
+- **RPC tool timeouts from inside cron jobs**: calling cron.* management operations from within a cron-triggered agent turn can still time out even with large timeouts because the cron service lock can be held by the executing job. This is exactly what the patch is meant to fix; until then, avoid cron management inside cron jobs.
+
+## Why this matters
+Cron is often used for delivery/notifications. If the management RPCs are blocked by long jobs, it becomes difficult to observe and operate the scheduler, and leads to cascading tool timeouts/backpressure at the gateway.

--- a/notes-cron-lock-contention.md
+++ b/notes-cron-lock-contention.md
@@ -1,12 +1,15 @@
 # Draft: cron lock contention blocks cron.list/status during long-running jobs
 
 ## Summary
-Clawdbot cron service currently holds a per-storePath async lock (`cron/service/locked.ts`) for the entire duration of job execution. If a job takes minutes (e.g. isolated agent work or main-lane heartbeat wake), then *all* cron RPCs that use `locked(...)` (`cron.list`, `cron.status`, `cron.add/update/remove/run`, plus the timer tick) are blocked until the job completes.
+
+Clawdbot cron service currently holds a per-storePath async lock (`cron/service/locked.ts`) for the entire duration of job execution. If a job takes minutes (e.g. isolated agent work or main-lane heartbeat wake), then _all_ cron RPCs that use `locked(...)` (`cron.list`, `cron.status`, `cron.add/update/remove/run`, plus the timer tick) are blocked until the job completes.
 
 This manifests as gateway RPC latency/backpressure and frequent client-side timeouts for `cron.list/status` (e.g. 60–110s).
 
 ## Evidence
+
 ### Code
+
 - `src/cron/service/locked.ts` chains `state.op` and a per-`storePath` promise.
 - `src/cron/service/timer.ts:onTimer()`:
   - `await locked(state, async () => { ... await runDueJobs(state); ... })`
@@ -19,22 +22,31 @@ This manifests as gateway RPC latency/backpressure and frequent client-side time
 So one long job blocks reads like `cron.list/status` for minutes.
 
 ### Observed behavior
+
 - `cron.list` sometimes takes 50–110s even when successful; often times out at 10s/60s.
 - cron job runs recorded as 168s, 220s, 246s, 400s etc (even when status=ok).
 
 ## Proposed fix (high level)
+
 Don’t hold the store lock across the awaited job execution.
 
+Implemented WIP in branch `fix/cron-lock-do-not-hold-during-execute`:
+
+- commit 522e7e7: split timer tick + ops.run into phases (mark running under lock → execute outside lock → persist under lock), plus persist after each job in timer path.
+- commit 7541489: manual `cron.run()` marks running under lock but does **not** persist the running marker until completion (fixes a subtle force-reload interaction in wakeMode-now tests).
+- commit 53dab10: make timer tick awaitable under vitest fake timers (async setTimeout callback) + make tmpdir cleanup in cron tests tolerant to ENOTEMPTY races.
+
 Split execution into phases:
-1) Under lock:
+
+1. Under lock:
    - load store
    - select due jobs
    - mark each due job as running (`runningAtMs`, clear `lastError`)
    - persist
    - arm timer / recompute next runs as appropriate
-2) Outside lock:
+2. Outside lock:
    - run the job payload (agent work / heartbeat wake)
-3) Under lock:
+3. Under lock:
    - re-load store (or use in-memory store) and apply finish state (`lastStatus`, `lastDurationMs`, `nextRunAtMs`, disable/delete)
    - persist
    - arm timer
@@ -42,6 +54,7 @@ Split execution into phases:
 This allows `cron.list/status` to remain responsive while jobs run.
 
 ## Notes / edge cases
+
 - **Update/remove while running** (now possible because we release the lock during execution):
   - safest: reject update/remove when `runningAtMs` is set (return a clear error)
   - acceptable: allow update/remove, but “finish” phase must tolerate job missing and/or treat patch as “next run only”.
@@ -50,7 +63,8 @@ This allows `cron.list/status` to remain responsive while jobs run.
   - clear `runningAtMs` on boot if older than a threshold, or
   - treat `runningAtMs` as advisory and allow list/status to show it but still permit rescheduling.
 - **Timer drift / recompute**: if we recompute `nextRunAtMs` too early, a late timer tick can skip intended runs (#9788). The current phase-1 flow intentionally loads with `skipRecompute`.
-- **RPC tool timeouts from inside cron jobs**: calling cron.* management operations from within a cron-triggered agent turn can still time out even with large timeouts because the cron service lock can be held by the executing job. This is exactly what the patch is meant to fix; until then, avoid cron management inside cron jobs.
+- **RPC tool timeouts from inside cron jobs**: calling cron.\* management operations from within a cron-triggered agent turn can still time out even with large timeouts because the cron service lock can be held by the executing job. This is exactly what the patch is meant to fix; until then, avoid cron management inside cron jobs.
 
 ## Why this matters
+
 Cron is often used for delivery/notifications. If the management RPCs are blocked by long jobs, it becomes difficult to observe and operate the scheduler, and leads to cascading tool timeouts/backpressure at the gateway.

--- a/src/agents/tools/web-search.perplexity-model.test.ts
+++ b/src/agents/tools/web-search.perplexity-model.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizePerplexityModelForBaseUrl } from "./web-search.js";
+
+describe("web_search perplexity model normalization", () => {
+  it("strips provider namespace for Perplexity direct baseUrl", () => {
+    const model = normalizePerplexityModelForBaseUrl({
+      model: "perplexity/sonar-pro",
+      baseUrl: "https://api.perplexity.ai",
+    });
+    expect(model).toBe("sonar-pro");
+  });
+
+  it("keeps namespaced model for OpenRouter baseUrl", () => {
+    const model = normalizePerplexityModelForBaseUrl({
+      model: "perplexity/sonar-pro",
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+    expect(model).toBe("perplexity/sonar-pro");
+  });
+});

--- a/src/cron/service/cron.lock-contention.test.ts
+++ b/src/cron/service/cron.lock-contention.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { saveCronStore } from "../store.js";
+import * as ops from "./ops.js";
+import { createCronServiceState } from "./state.js";
+import { onTimer } from "./timer.js";
+
+function createTestLogger() {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, rej) => setTimeout(() => rej(new Error(`timeout: ${label}`)), ms)),
+  ]);
+}
+
+describe("cron service lock", () => {
+  it("does not block list() while a long job is executing (timer path)", async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-lock-test-"));
+    try {
+      const storePath = path.join(base, "cron", "jobs.json");
+
+      let started!: () => void;
+      const startedP = new Promise<void>((r) => (started = r));
+
+      let finish!: () => void;
+      const finishP = new Promise<void>((r) => (finish = r));
+
+      const job: CronJob = {
+        id: "job1",
+        name: "slow job",
+        enabled: true,
+        createdAtMs: 0,
+        updatedAtMs: 0,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "agentTurn", message: "do slow thing" },
+        state: { nextRunAtMs: 0 },
+      };
+
+      await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+      const state = createCronServiceState({
+        log: createTestLogger(),
+        storePath,
+        cronEnabled: true,
+        enqueueSystemEvent: () => {},
+        requestHeartbeatNow: () => {},
+        runIsolatedAgentJob: async () => {
+          started();
+          await finishP;
+          return { status: "ok", summary: "done" };
+        },
+      });
+
+      const timerP = onTimer(state);
+
+      // Wait until the job actually begins executing (i.e. we are in phase 2).
+      await withTimeout(startedP, 500, "job started");
+
+      // If onTimer incorrectly holds the store lock across executeJob, this list()
+      // would block until finish().
+      const jobs = await withTimeout(ops.list(state), 100, "ops.list while job running");
+      expect(jobs.map((j) => j.id)).toEqual(["job1"]);
+
+      finish();
+      await withTimeout(timerP, 2000, "timer completes");
+    } finally {
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -145,8 +145,10 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
     job.state.lastError = undefined;
     emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
 
-    await persist(state);
-    armTimer(state);
+    // NOTE: For manual runs, we intentionally do NOT persist the running marker here.
+    // Persisting requires filesystem I/O and can delay job start; we'll persist the
+    // finished state (which also clears runningAtMs) in phase 3.
+    // The scheduler timer path (onTimer) still persists before executing due jobs.
     return { ok: true, ran: true, nowMs: now } as const;
   });
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -27,10 +27,12 @@ export function armTimer(state: CronServiceState) {
   const delay = Math.max(nextAt - state.deps.nowMs(), 0);
   // Avoid TimeoutOverflowWarning when a job is far in the future.
   const clampedDelay = Math.min(delay, MAX_TIMEOUT_MS);
-  state.timer = setTimeout(() => {
-    void onTimer(state).catch((err) => {
+  state.timer = setTimeout(async () => {
+    try {
+      await onTimer(state);
+    } catch (err) {
       state.deps.log.error({ err: String(err) }, "cron: timer tick failed");
-    });
+    }
   }, clampedDelay);
 }
 


### PR DESCRIPTION
Fixes cron lock contention where cron.list/status are blocked while any cron job is executing.

Key changes:
- src/cron/service/timer.ts: split onTimer into phases so the store lock is not held across executeJob
- src/cron/service/ops.ts: split run() into lock → execute → lock (manual runs)

Regression tests:
- src/cron/service/cron.lock-contention.test.ts (assert ops.list completes while a long job is running)

Also included (related quality-of-life fix):
- src/agents/tools/web-search.ts: normalize Perplexity model when using the direct API baseUrl
- src/agents/tools/web-search.perplexity-model.test.ts

Impact:
- Cron RPCs stay responsive even when jobs take minutes (agent turns/heartbeat wakes).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR restructures cron execution so the per-storePath lock is not held across long-running job execution. `onTimer()` is split into lock → execute → lock phases (including persisting a running marker before executing due jobs), and `ops.run()` similarly runs the job outside the lock to keep `cron.list/status` responsive. Regression tests were added to ensure `list()` isn’t blocked during a long timer-driven job, plus a small web-search tweak to normalize Perplexity model IDs for direct API base URLs.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge until concurrent-update persistence is addressed.
- Main functional change (releasing the cron store lock during execution) introduces a concrete lost-update bug: the service persists an older in-memory store snapshot after long jobs complete, which can overwrite concurrent add/update/remove operations that legitimately occur while the lock is released. This impacts correctness of cron configuration and job state.
- src/cron/service/timer.ts and src/cron/service/ops.ts (persist-after-execute logic).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->