### PR TITLE
auth: list available agents in provider auth error

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -12,6 +12,7 @@ import {
   resolveAuthProfileOrder,
   resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
+import { listAgentIds } from "./agent-scope.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 export { ensureAuthProfileStore, resolveAuthProfileOrder } from "./auth-profiles.js";
@@ -220,13 +221,17 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
-  throw new Error(
-    [
-      `No API key found for provider "${provider}".`,
-      `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
-      `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
-    ].join(" "),
-  );
+  const parts = [
+    `No API key found for provider "${provider}".`,
+    `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
+    `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
+  ];
+  // When the agent directory doesn't exist, list available agents to help diagnose typos
+  if (cfg) {
+    const available = listAgentIds(cfg);
+    parts.push(`Available agents: ${available.join(", ")}.`);
+  }
+  throw new Error(parts.join(" "));
 }
 
 export type EnvApiKeyResult = { apiKey: string; source: string };


### PR DESCRIPTION
## Summary

When `resolveApiKeyForProvider` throws because no API key is found, the error message now includes the list of configured agent IDs (via `listAgentIds()`). This helps users quickly diagnose typos in `agentId` references — for example, when a cron job still points to a renamed agent like `main` instead of the current `x`.

### Before
```
No API key found for provider "anthropic". Auth store: .../agents/main/agent/auth-profiles.json (agentDir: .../agents/main/agent). Configure auth for this agent...
```

### After
```
No API key found for provider "anthropic". Auth store: .../agents/main/agent/auth-profiles.json (agentDir: .../agents/main/agent). Configure auth for this agent... Available agents: x, jingzhe.
```

## Changes
- `src/agents/model-auth.ts`: Import `listAgentIds` from `agent-scope.ts` and append `Available agents: ...` to the error when config is available.

## Testing
- Verified the import path resolves correctly
- The change is additive (only appends to existing error message) and guarded by `if (cfg)`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `resolveApiKeyForProvider` to append a list of configured agent IDs to the existing “No API key found…” error message, using `listAgentIds(cfg)` when a config object is available. The intent is to make it easier to spot typos or stale `agentId` references by surfacing what agents are currently configured.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, additive modification to an error message path and uses an existing helper (`listAgentIds`) without affecting auth resolution behavior. No functional control flow changes beyond composing the thrown error string were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->