### PR TITLE
media: suppress CUDA probe errors for whisper CLI

### DIFF
--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -67,6 +67,8 @@ export type MediaUnderstandingModelConfig = {
   profile?: string;
   /** Preferred profile id if multiple are available. */
   preferredProfile?: string;
+  /** Extra environment variables merged into process.env for CLI entries. */
+  env?: Record<string, string>;
 };
 
 export type MediaUnderstandingConfig = {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -321,6 +321,8 @@ async function resolveLocalWhisperEntry(): Promise<MediaUnderstandingModelConfig
       "False",
       "{{MediaPath}}",
     ],
+    // Suppress noisy CUDA/GPU probe errors when GPU is unavailable (e.g. WSL2)
+    env: { CUDA_VISIBLE_DEVICES: "" },
   };
 }
 
@@ -1045,6 +1047,8 @@ async function runCliEntry(params: {
     const { stdout } = await runExec(argv[0], argv.slice(1), {
       timeoutMs,
       maxBuffer: CLI_OUTPUT_MAX_BUFFER,
+      // Merge entry-level env vars (e.g. CUDA_VISIBLE_DEVICES for whisper)
+      ...(entry.env ? { env: { ...process.env, ...entry.env } } : {}),
     });
     const resolved = await resolveCliOutput({
       command,

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -33,7 +33,7 @@ function resolveCommand(command: string): string {
 export async function runExec(
   command: string,
   args: string[],
-  opts: number | { timeoutMs?: number; maxBuffer?: number } = 10_000,
+  opts: number | { timeoutMs?: number; maxBuffer?: number; env?: NodeJS.ProcessEnv } = 10_000,
 ): Promise<{ stdout: string; stderr: string }> {
   const options =
     typeof opts === "number"
@@ -42,6 +42,7 @@ export async function runExec(
           timeout: opts.timeoutMs,
           maxBuffer: opts.maxBuffer,
           encoding: "utf8" as const,
+          ...(opts.env ? { env: opts.env } : {}),
         };
   try {
     const { stdout, stderr } = await execFileAsync(resolveCommand(command), args, options);


### PR DESCRIPTION
## Summary

On systems without a compatible GPU (e.g. WSL2 without GPU passthrough), the auto-detected `whisper` CLI entry floods the logs with dozens of CUDA/GPU probe error lines before falling back to CPU — which works fine, just noisily.

This PR:
1. **Adds `env` option to `runExec`** (`src/process/exec.ts`) so callers can pass extra environment variables to child processes
2. **Adds `env` field to `MediaUnderstandingModelConfig`** (`src/config/types.tools.ts`) so CLI media entries can declare env vars in config
3. **Sets `CUDA_VISIBLE_DEVICES=""`** on the auto-detected whisper entry (`src/media-understanding/runner.ts`) to suppress GPU probing
4. **Wires it through `runCliEntry`** — merges `entry.env` into `process.env` when spawning the CLI process

### Before
```
CUDA error: no CUDA-capable device is detected
CUDA error: no CUDA-capable device is detected
... (30+ lines of GPU errors)
[whisper] falling back to CPU
[actual transcription output]
```

### After
```
[actual transcription output]
```

## Files Changed
- `src/process/exec.ts` — add optional `env` to `runExec` opts
- `src/config/types.tools.ts` — add `env?: Record<string, string>` to `MediaUnderstandingModelConfig`
- `src/media-understanding/runner.ts` — set `CUDA_VISIBLE_DEVICES=""` on whisper entry + pass `entry.env` in `runCliEntry`

## Notes
- Users can also use the `env` field in their config to set custom env vars for any CLI media entry
- The `env` is spread on top of `process.env`, so existing vars are preserved unless explicitly overridden

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an `env` passthrough for CLI-based media understanding entries and uses it to set `CUDA_VISIBLE_DEVICES=""` for the auto-detected `whisper` CLI entry, reducing noisy CUDA probe logs on systems without a usable GPU. It wires the new `MediaUnderstandingModelConfig.env` through `runCliEntry` into `runExec` so child processes can receive extra environment variables.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but env handling in runExec can break CLI execution when callers pass partial envs.
- The change is small and scoped, but `runExec` forwards `env` directly without merging with `process.env`, which will drop PATH and other required variables if any caller uses the new option with a partial env object. That would cause runtime failures in affected CLI calls.
- src/process/exec.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->