### PR TITLE
feat: Add agent-level node routing

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,91 @@
+# Add agent-level node routing
+
+## Summary
+
+This PR adds support for routing agent execution to specific paired nodes. When an agent is configured with a `node` field, agent runs will be proxied to that node's gateway instead of running locally.
+
+## Motivation
+
+This enables powerful distributed setups where:
+
+- A central gateway receives messages from all channels
+- Specific agents are routed to dedicated machines (e.g., a Mac Studio for heavy coding tasks)
+- Each machine can have different resources, tools, and capabilities
+
+## Changes
+
+### 1. TypeScript Types (`src/config/types.agents.ts`)
+
+- Added `node?: string` field to `AgentConfig` with JSDoc documentation
+
+### 2. Zod Schema (`src/config/zod-schema.agent-runtime.ts`)
+
+- Added `node` field as optional string to `AgentEntrySchema`
+
+### 3. Agent Scope (`src/agents/agent-scope.ts`)
+
+- Added `node` to `ResolvedAgentConfig` type
+- Created `resolveAgentNodeRouting()` helper function to get the node target
+
+### 4. Node Routing Module (`src/agents/node-routing.ts`) [NEW]
+
+- `resolveNodeByIdOrName()`: Resolves a node by ID or display name
+- `invokeAgentOnNode()`: Forwards agent requests to the target node
+
+### 5. Agent Handler (`src/gateway/server-methods/agent.ts`)
+
+- Added node routing check before local execution
+- Forwards request to target node if configured
+- Returns `routedToNode` field in response for visibility
+
+## Configuration Example
+
+```yaml
+agents:
+  list:
+    - id: main
+      # No node - runs locally (default gateway)
+
+    - id: builder
+      node: mac-studio # Route to the "mac-studio" node
+      model: anthropic/claude-opus-4-5
+```
+
+## Requirements for Target Nodes
+
+The target node must:
+
+1. Be paired with the gateway
+2. Be currently connected
+3. Support the `agent.run` command or have the `agent` capability
+
+## Error Handling
+
+The implementation handles these error cases:
+
+- **NOT_FOUND**: Node doesn't exist
+- **NOT_CONNECTED**: Node is paired but not currently connected
+- **NO_AGENT_CAP**: Node doesn't support agent execution
+
+## Testing
+
+Added unit tests for:
+
+- `resolveNodeByIdOrName` - node resolution by ID/name
+- `invokeAgentOnNode` - agent invocation on remote nodes
+- `resolveAgentNodeRouting` - config resolution for node routing
+
+## Breaking Changes
+
+None. The `node` field is optional and defaults to local execution.
+
+## TODO (Future enhancements)
+
+- [ ] Add `agent.run` command support to node-host for nodes without full gateway
+- [ ] Add node health checks before routing
+- [ ] Support fallback nodes when primary is unavailable
+- [ ] Add node routing metrics/logging
+
+---
+
+Fixes #XXXX (if applicable)

--- a/src/agents/agent-scope.node-routing.test.ts
+++ b/src/agents/agent-scope.node-routing.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { resolveAgentNodeRouting } from "./agent-scope.js";
+import type { OpenClawConfig } from "../config/config.js";
+
+describe("resolveAgentNodeRouting", () => {
+  it("returns undefined for agent without node config", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }],
+      },
+    };
+
+    const result = resolveAgentNodeRouting(cfg, "main");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns node ID for agent with node routing configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main" },
+          { id: "builder", node: "mac-studio" },
+        ],
+      },
+    };
+
+    const result = resolveAgentNodeRouting(cfg, "builder");
+    expect(result).toBe("mac-studio");
+  });
+
+  it("returns undefined for unknown agent", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }],
+      },
+    };
+
+    const result = resolveAgentNodeRouting(cfg, "unknown");
+    expect(result).toBeUndefined();
+  });
+
+  it("trims whitespace from node value", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "builder", node: "  mac-studio  " }],
+      },
+    };
+
+    const result = resolveAgentNodeRouting(cfg, "builder");
+    expect(result).toBe("mac-studio");
+  });
+
+  it("returns undefined for empty node string", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "builder", node: "   " }],
+      },
+    };
+
+    const result = resolveAgentNodeRouting(cfg, "builder");
+    expect(result).toBeUndefined();
+  });
+
+  it("normalizes agent ID case", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "Builder", node: "mac-studio" }],
+      },
+    };
+
+    const result = resolveAgentNodeRouting(cfg, "BUILDER");
+    expect(result).toBe("mac-studio");
+  });
+});

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -18,6 +18,11 @@ type ResolvedAgentConfig = {
   name?: string;
   workspace?: string;
   agentDir?: string;
+  /**
+   * Route agent execution to a specific paired node.
+   * When set, agent runs will be proxied to the specified node's gateway.
+   */
+  node?: string;
   model?: AgentEntry["model"];
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
@@ -109,6 +114,7 @@ export function resolveAgentConfig(
     name: typeof entry.name === "string" ? entry.name : undefined,
     workspace: typeof entry.workspace === "string" ? entry.workspace : undefined,
     agentDir: typeof entry.agentDir === "string" ? entry.agentDir : undefined,
+    node: typeof entry.node === "string" && entry.node.trim() ? entry.node.trim() : undefined,
     model:
       typeof entry.model === "string" || (entry.model && typeof entry.model === "object")
         ? entry.model
@@ -189,4 +195,20 @@ export function resolveAgentDir(cfg: OpenClawConfig, agentId: string) {
   }
   const root = resolveStateDir(process.env, os.homedir);
   return path.join(root, "agents", id, "agent");
+}
+
+/**
+ * Resolve the target node for agent execution routing.
+ * Returns undefined if the agent should run locally (no node routing).
+ *
+ * @param cfg - The OpenClaw configuration
+ * @param agentId - The agent ID to check for node routing
+ * @returns The node ID/name to route to, or undefined for local execution
+ */
+export function resolveAgentNodeRouting(
+  cfg: OpenClawConfig,
+  agentId: string,
+): string | undefined {
+  const id = normalizeAgentId(agentId);
+  return resolveAgentConfig(cfg, id)?.node;
 }

--- a/src/agents/node-routing.test.ts
+++ b/src/agents/node-routing.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the callGateway function
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(),
+}));
+
+import { resolveNodeByIdOrName, invokeAgentOnNode } from "./node-routing.js";
+import { callGateway } from "../gateway/call.js";
+
+const mockCallGateway = vi.mocked(callGateway);
+
+describe("resolveNodeByIdOrName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves node by exact nodeId", async () => {
+    mockCallGateway.mockResolvedValueOnce({
+      nodes: [
+        { nodeId: "mac-studio-001", displayName: "Mac Studio", connected: true, commands: ["agent.run"] },
+        { nodeId: "other-node", displayName: "Other", connected: true, commands: ["system.run"] },
+      ],
+    });
+
+    const result = await resolveNodeByIdOrName("mac-studio-001");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.node.nodeId).toBe("mac-studio-001");
+      expect(result.node.displayName).toBe("Mac Studio");
+    }
+  });
+
+  it("resolves node by displayName (case-insensitive)", async () => {
+    mockCallGateway.mockResolvedValueOnce({
+      nodes: [
+        { nodeId: "mac-studio-001", displayName: "Mac Studio", connected: true, commands: ["agent.run"] },
+      ],
+    });
+
+    const result = await resolveNodeByIdOrName("mac studio");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.node.nodeId).toBe("mac-studio-001");
+    }
+  });
+
+  it("returns NOT_FOUND for unknown node", async () => {
+    mockCallGateway.mockResolvedValueOnce({
+      nodes: [
+        { nodeId: "mac-studio-001", displayName: "Mac Studio", connected: true, commands: ["agent.run"] },
+      ],
+    });
+
+    const result = await resolveNodeByIdOrName("unknown-node");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("NOT_FOUND");
+      expect(result.error).toContain("not found");
+    }
+  });
+
+  it("returns NOT_CONNECTED for disconnected node", async () => {
+    mockCallGateway.mockResolvedValueOnce({
+      nodes: [
+        { nodeId: "mac-studio-001", displayName: "Mac Studio", connected: false, commands: ["agent.run"] },
+      ],
+    });
+
+    const result = await resolveNodeByIdOrName("mac-studio-001");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("NOT_CONNECTED");
+      expect(result.error).toContain("not connected");
+    }
+  });
+
+  it("returns NO_AGENT_CAP for node without agent.run command", async () => {
+    mockCallGateway.mockResolvedValueOnce({
+      nodes: [
+        { nodeId: "mac-studio-001", displayName: "Mac Studio", connected: true, commands: ["system.run"] },
+      ],
+    });
+
+    const result = await resolveNodeByIdOrName("mac-studio-001");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("NO_AGENT_CAP");
+      expect(result.error).toContain("agent.run");
+    }
+  });
+
+  it("accepts node with agent capability", async () => {
+    mockCallGateway.mockResolvedValueOnce({
+      nodes: [
+        { nodeId: "mac-studio-001", displayName: "Mac Studio", connected: true, caps: ["agent"] },
+      ],
+    });
+
+    const result = await resolveNodeByIdOrName("mac-studio-001");
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns error for empty target", async () => {
+    const result = await resolveNodeByIdOrName("  ");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("NOT_FOUND");
+      expect(result.error).toContain("empty");
+    }
+  });
+});
+
+describe("invokeAgentOnNode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invokes agent.run command on node", async () => {
+    mockCallGateway.mockResolvedValueOnce({
+      ok: true,
+      payload: { runId: "run-123", status: "accepted" },
+    });
+
+    const result = await invokeAgentOnNode({
+      nodeId: "mac-studio-001",
+      message: "Hello, world!",
+      sessionKey: "agent:main:123",
+      idempotencyKey: "idem-456",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.runId).toBe("run-123");
+    expect(mockCallGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.invoke",
+        params: expect.objectContaining({
+          nodeId: "mac-studio-001",
+          command: "agent.run",
+          params: expect.objectContaining({
+            message: "Hello, world!",
+            sessionKey: "agent:main:123",
+            idempotencyKey: "idem-456",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns error when node invocation fails", async () => {
+    mockCallGateway.mockResolvedValueOnce({
+      ok: false,
+      error: { message: "node unavailable" },
+    });
+
+    const result = await invokeAgentOnNode({
+      nodeId: "mac-studio-001",
+      message: "Hello",
+      idempotencyKey: "idem-789",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("node unavailable");
+  });
+
+  it("handles callGateway exceptions", async () => {
+    mockCallGateway.mockRejectedValueOnce(new Error("connection timeout"));
+
+    const result = await invokeAgentOnNode({
+      nodeId: "mac-studio-001",
+      message: "Hello",
+      idempotencyKey: "idem-abc",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("connection timeout");
+  });
+});

--- a/src/agents/node-routing.ts
+++ b/src/agents/node-routing.ts
@@ -177,10 +177,28 @@ export async function invokeAgentOnNode(params: {
       };
     }
 
+    // Validate nested payload for remote errors
+    // The transport may return ok:true but the remote agent could have failed
+    const payload = response.payload;
+    if (payload?.error) {
+      return {
+        ok: false,
+        error: payload.error,
+        payload,
+      };
+    }
+    if (payload?.status === "error" || payload?.status === "failed") {
+      return {
+        ok: false,
+        error: payload.error ?? `remote agent returned status: ${payload.status}`,
+        payload,
+      };
+    }
+
     return {
       ok: true,
-      runId: response.payload?.runId,
-      payload: response.payload,
+      runId: payload?.runId,
+      payload,
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/agents/node-routing.ts
+++ b/src/agents/node-routing.ts
@@ -1,0 +1,185 @@
+/**
+ * Node routing utilities for agent execution.
+ *
+ * This module provides functions to resolve and validate node targets
+ * for routing agent execution to paired nodes.
+ */
+
+import { callGateway } from "../gateway/call.js";
+
+export type ConnectedNode = {
+  nodeId: string;
+  displayName?: string;
+  platform?: string;
+  caps?: string[];
+  commands?: string[];
+  connected: boolean;
+};
+
+export type NodeResolutionResult =
+  | { ok: true; node: ConnectedNode }
+  | { ok: false; error: string; code: "NOT_FOUND" | "NOT_CONNECTED" | "NO_AGENT_CAP" };
+
+/**
+ * Resolve a node by ID or display name.
+ *
+ * This function queries the gateway for available nodes and matches
+ * by either exact nodeId or case-insensitive displayName.
+ *
+ * @param nodeIdOrName - The node ID or display name to resolve
+ * @param timeoutMs - Optional timeout for the gateway call
+ * @returns Resolution result with the matched node or error details
+ */
+export async function resolveNodeByIdOrName(
+  nodeIdOrName: string,
+  timeoutMs = 10_000,
+): Promise<NodeResolutionResult> {
+  const target = nodeIdOrName.trim();
+  if (!target) {
+    return { ok: false, error: "node target is empty", code: "NOT_FOUND" };
+  }
+
+  try {
+    const response = await callGateway<{
+      nodes: Array<{
+        nodeId: string;
+        displayName?: string;
+        platform?: string;
+        caps?: string[];
+        commands?: string[];
+        connected: boolean;
+      }>;
+    }>({
+      method: "node.list",
+      params: {},
+      timeoutMs,
+    });
+
+    const nodes = response?.nodes ?? [];
+
+    // Try exact nodeId match first
+    let match = nodes.find((n) => n.nodeId === target);
+
+    // Fall back to case-insensitive displayName match
+    if (!match) {
+      const lowerTarget = target.toLowerCase();
+      match = nodes.find(
+        (n) =>
+          n.displayName?.toLowerCase() === lowerTarget ||
+          n.nodeId.toLowerCase() === lowerTarget,
+      );
+    }
+
+    if (!match) {
+      return {
+        ok: false,
+        error: `node "${target}" not found`,
+        code: "NOT_FOUND",
+      };
+    }
+
+    if (!match.connected) {
+      return {
+        ok: false,
+        error: `node "${target}" is not connected`,
+        code: "NOT_CONNECTED",
+      };
+    }
+
+    // Check if node has agent.run capability
+    const hasAgentCap =
+      match.commands?.includes("agent.run") || match.caps?.includes("agent");
+
+    if (!hasAgentCap) {
+      return {
+        ok: false,
+        error: `node "${target}" does not support agent execution (requires agent.run command)`,
+        code: "NO_AGENT_CAP",
+      };
+    }
+
+    return { ok: true, node: match };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `failed to resolve node: ${message}`,
+      code: "NOT_FOUND",
+    };
+  }
+}
+
+/**
+ * Invoke an agent run on a remote node.
+ *
+ * This function proxies an agent request to a paired node that has
+ * the agent.run capability. The node must be running an OpenClaw
+ * gateway or compatible agent runtime.
+ *
+ * @param params - Agent invocation parameters
+ * @returns The result from the remote agent run
+ */
+export async function invokeAgentOnNode(params: {
+  nodeId: string;
+  message: string;
+  sessionKey?: string;
+  agentId?: string;
+  channel?: string;
+  accountId?: string;
+  threadId?: string;
+  idempotencyKey: string;
+  timeoutMs?: number;
+  extraParams?: Record<string, unknown>;
+}): Promise<{
+  ok: boolean;
+  runId?: string;
+  error?: string;
+  payload?: unknown;
+}> {
+  try {
+    const response = await callGateway<{
+      ok: boolean;
+      payload?: {
+        runId?: string;
+        status?: string;
+        error?: string;
+      };
+      error?: { message?: string };
+    }>({
+      method: "node.invoke",
+      params: {
+        nodeId: params.nodeId,
+        command: "agent.run",
+        params: {
+          message: params.message,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
+          channel: params.channel,
+          accountId: params.accountId,
+          threadId: params.threadId,
+          idempotencyKey: params.idempotencyKey,
+          ...params.extraParams,
+        },
+        idempotencyKey: params.idempotencyKey,
+        timeoutMs: params.timeoutMs ?? 300_000, // 5 min default for agent runs
+      },
+      timeoutMs: (params.timeoutMs ?? 300_000) + 10_000, // Add buffer for network overhead
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: response.error?.message ?? "node agent invocation failed",
+      };
+    }
+
+    return {
+      ok: true,
+      runId: response.payload?.runId,
+      payload: response.payload,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -23,6 +23,20 @@ export type AgentConfig = {
   name?: string;
   workspace?: string;
   agentDir?: string;
+  /**
+   * Route agent execution to a specific paired node.
+   * When set, agent runs will be proxied to the specified node's gateway
+   * instead of running locally. Accepts node ID or node name.
+   *
+   * @example
+   * ```yaml
+   * agents:
+   *   list:
+   *     - id: builder
+   *       node: mac-studio  # Route to the "mac-studio" node
+   * ```
+   */
+  node?: string;
   model?: AgentModelConfig;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -436,6 +436,12 @@ export const AgentEntrySchema = z
     name: z.string().optional(),
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
+    /**
+     * Route agent execution to a specific paired node.
+     * When set, agent runs will be proxied to the specified node's gateway
+     * instead of running locally. Accepts node ID or node name.
+     */
+    node: z.string().optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../config/config.js", () => ({
 
 vi.mock("../../agents/agent-scope.js", () => ({
   listAgentIds: () => ["main"],
+  resolveAgentNodeRouting: () => undefined,
 }));
 
 vi.mock("../../infra/agent-events.js", () => ({


### PR DESCRIPTION
# Add agent-level node routing

## Summary

This PR adds support for routing agent execution to specific paired nodes. When an agent is configured with a `node` field, agent runs will be proxied to that node's gateway instead of running locally.

## Motivation

This enables powerful distributed setups where:

- A central gateway receives messages from all channels
- Specific agents are routed to dedicated machines (e.g., a Mac Studio for heavy coding tasks)
- Each machine can have different resources, tools, and capabilities

## Changes

### 1. TypeScript Types (`src/config/types.agents.ts`)

- Added `node?: string` field to `AgentConfig` with JSDoc documentation

### 2. Zod Schema (`src/config/zod-schema.agent-runtime.ts`)

- Added `node` field as optional string to `AgentEntrySchema`

### 3. Agent Scope (`src/agents/agent-scope.ts`)

- Added `node` to `ResolvedAgentConfig` type
- Created `resolveAgentNodeRouting()` helper function to get the node target

### 4. Node Routing Module (`src/agents/node-routing.ts`) [NEW]

- `resolveNodeByIdOrName()`: Resolves a node by ID or display name
- `invokeAgentOnNode()`: Forwards agent requests to the target node

### 5. Agent Handler (`src/gateway/server-methods/agent.ts`)

- Added node routing check before local execution
- Forwards request to target node if configured
- Returns `routedToNode` field in response for visibility

## Configuration Example

```yaml
agents:
  list:
    - id: main
      # No node - runs locally (default gateway)

    - id: builder
      node: mac-studio # Route to the "mac-studio" node
      model: anthropic/claude-opus-4-5
```

## Requirements for Target Nodes

The target node must:

1. Be paired with the gateway
2. Be currently connected
3. Support the `agent.run` command or have the `agent` capability

## Error Handling

The implementation handles these error cases:

- **NOT_FOUND**: Node doesn't exist
- **NOT_CONNECTED**: Node is paired but not currently connected
- **NO_AGENT_CAP**: Node doesn't support agent execution

## Testing

Added unit tests for:

- `resolveNodeByIdOrName` - node resolution by ID/name
- `invokeAgentOnNode` - agent invocation on remote nodes
- `resolveAgentNodeRouting` - config resolution for node routing

## Breaking Changes

None. The `node` field is optional and defaults to local execution.

## TODO (Future enhancements)

- [ ] Add `agent.run` command support to node-host for nodes without full gateway
- [ ] Add node health checks before routing
- [ ] Support fallback nodes when primary is unavailable
- [ ] Add node routing metrics/logging

---

Fixes #XXXX (if applicable)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `node` field to agent configuration and introduces a node-routing path in the gateway agent handler. When configured, `agent` requests are forwarded to a paired node via `node.list` (resolution/validation) and `node.invoke` (`agent.run`), and the response includes a `routedToNode` hint.

The core integration lives in `src/gateway/server-methods/agent.ts`, with routing helpers in `src/agents/node-routing.ts` and config plumbing in `src/agents/agent-scope.ts` plus schema/type updates. Unit tests cover node resolution, invocation plumbing, and agent-scope routing lookup.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge after fixing a couple of correctness issues in the routing/acknowledgement path.
- The feature is well-contained and has tests, but the current implementation can (1) return a cached successful `accepted` response on retries before routing actually succeeds, and (2) treat remote `node.invoke` successes as accepted without validating the nested payload status/error, which can misreport failures as successes.
- src/gateway/server-methods/agent.ts, src/agents/node-routing.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->