### PR TITLE
feat(ollama): add native /api/chat provider for streaming + tool calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Config: keep legacy audio transcription migration strict by rejecting non-string/unsafe command tokens while still migrating valid custom script executables. (#5042) Thanks @shayan919293.
 - Status/Sessions: stop clamping derived `totalTokens` to context-window size, keep prompt-token snapshots wired through session accounting, and surface context usage as unknown when fresh snapshot data is missing to avoid false 100% reports. (#15114) Thanks @echoVic.
 - Providers/MiniMax: switch implicit MiniMax API-key provider from `openai-completions` to `anthropic-messages` with the correct Anthropic-compatible base URL, fixing `invalid role: developer (2013)` errors on MiniMax M2.5. (#15275) Thanks @lailoo.
+- Ollama/Agents: use resolved model/provider base URLs for native `/api/chat` streaming (including aliased providers), normalize `/v1` endpoints, and forward abort + `maxTokens` stream options for reliable cancellation and token caps. (#11853) Thanks @BrokenFinger98.
 
 ## 2026.2.12
 

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -17,12 +17,12 @@ import {
   buildHuggingfaceModelDefinition,
 } from "./huggingface-models.js";
 import { resolveAwsSdkEnvVarName, resolveEnvApiKey } from "./model-auth.js";
+import { OLLAMA_NATIVE_BASE_URL } from "./ollama-stream.js";
 import {
   buildSyntheticModelDefinition,
   SYNTHETIC_BASE_URL,
   SYNTHETIC_MODEL_CATALOG,
 } from "./synthetic-models.js";
-import { OLLAMA_NATIVE_BASE_URL } from "./ollama-stream.js";
 import {
   TOGETHER_BASE_URL,
   TOGETHER_MODEL_CATALOG,

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -22,6 +22,7 @@ import {
   SYNTHETIC_BASE_URL,
   SYNTHETIC_MODEL_CATALOG,
 } from "./synthetic-models.js";
+import { OLLAMA_NATIVE_BASE_URL } from "./ollama-stream.js";
 import {
   TOGETHER_BASE_URL,
   TOGETHER_MODEL_CATALOG,
@@ -79,7 +80,7 @@ const QWEN_PORTAL_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
-const OLLAMA_BASE_URL = "http://127.0.0.1:11434";
+const OLLAMA_BASE_URL = OLLAMA_NATIVE_BASE_URL;
 const OLLAMA_API_BASE_URL = OLLAMA_BASE_URL;
 const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;
 const OLLAMA_DEFAULT_MAX_TOKENS = 8192;

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -79,8 +79,8 @@ const QWEN_PORTAL_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
-const OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
-const OLLAMA_API_BASE_URL = "http://127.0.0.1:11434";
+const OLLAMA_BASE_URL = "http://127.0.0.1:11434";
+const OLLAMA_API_BASE_URL = OLLAMA_BASE_URL;
 const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;
 const OLLAMA_DEFAULT_MAX_TOKENS = 8192;
 const OLLAMA_DEFAULT_COST = {
@@ -180,11 +180,6 @@ async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionCo
         cost: OLLAMA_DEFAULT_COST,
         contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
         maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
-        // Disable streaming by default for Ollama to avoid SDK issue #1205
-        // See: https://github.com/badlogic/pi-mono/issues/1205
-        params: {
-          streaming: false,
-        },
       };
     });
   } catch (error) {
@@ -541,8 +536,8 @@ async function buildVeniceProvider(): Promise<ProviderConfig> {
 async function buildOllamaProvider(configuredBaseUrl?: string): Promise<ProviderConfig> {
   const models = await discoverOllamaModels(configuredBaseUrl);
   return {
-    baseUrl: configuredBaseUrl ?? OLLAMA_BASE_URL,
-    api: "openai-completions",
+    baseUrl: resolveOllamaApiBase(configuredBaseUrl),
+    api: "ollama",
     models,
   };
 }

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -63,6 +63,19 @@ describe("convertToOllamaMessages", () => {
     expect(result).toEqual([{ role: "tool", content: "command output here" }]);
   });
 
+  it("includes tool_name from SDK toolResult messages", () => {
+    const messages = [{ role: "toolResult", content: "file contents here", toolName: "read" }];
+    const result = convertToOllamaMessages(messages);
+    expect(result).toEqual([{ role: "tool", content: "file contents here", tool_name: "read" }]);
+  });
+
+  it("omits tool_name when not provided in toolResult", () => {
+    const messages = [{ role: "toolResult", content: "output" }];
+    const result = convertToOllamaMessages(messages);
+    expect(result).toEqual([{ role: "tool", content: "output" }]);
+    expect(result[0]).not.toHaveProperty("tool_name");
+  });
+
   it("handles empty messages array", () => {
     const result = convertToOllamaMessages([]);
     expect(result).toEqual([]);

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { convertToOllamaMessages, buildAssistantMessage } from "./ollama-stream.js";
+
+describe("convertToOllamaMessages", () => {
+  it("converts user text messages", () => {
+    const messages = [{ role: "user", content: "hello" }];
+    const result = convertToOllamaMessages(messages);
+    expect(result).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  it("converts user messages with content parts", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "image", data: "base64data" },
+        ],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result).toEqual([
+      { role: "user", content: "describe this", images: ["base64data"] },
+    ]);
+  });
+
+  it("prepends system message when provided", () => {
+    const messages = [{ role: "user", content: "hello" }];
+    const result = convertToOllamaMessages(messages, "You are helpful.");
+    expect(result[0]).toEqual({ role: "system", content: "You are helpful." });
+    expect(result[1]).toEqual({ role: "user", content: "hello" });
+  });
+
+  it("converts assistant messages with tool calls", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "tool_use", id: "call_1", name: "bash", input: { command: "ls" } },
+        ],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].role).toBe("assistant");
+    expect(result[0].content).toBe("Let me check.");
+    expect(result[0].tool_calls).toEqual([
+      { function: { name: "bash", arguments: { command: "ls" } } },
+    ]);
+  });
+
+  it("converts tool result messages", () => {
+    const messages = [{ role: "tool", content: "file1.txt\nfile2.txt" }];
+    const result = convertToOllamaMessages(messages);
+    expect(result).toEqual([{ role: "tool", content: "file1.txt\nfile2.txt" }]);
+  });
+
+  it("handles empty messages array", () => {
+    const result = convertToOllamaMessages([]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("buildAssistantMessage", () => {
+  const modelInfo = { api: "ollama", provider: "ollama", id: "qwen3:32b" };
+
+  it("builds text-only response", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: { role: "assistant" as const, content: "Hello!" },
+      done: true,
+      prompt_eval_count: 10,
+      eval_count: 5,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.role).toBe("assistant");
+    expect(result.content).toEqual([{ type: "text", text: "Hello!" }]);
+    expect(result.stopReason).toBe("stop");
+    expect(result.usage.input).toBe(10);
+    expect(result.usage.output).toBe(5);
+    expect(result.usage.totalTokens).toBe(15);
+  });
+
+  it("builds response with tool calls", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        tool_calls: [
+          { function: { name: "bash", arguments: { command: "ls -la" } } },
+        ],
+      },
+      done: true,
+      prompt_eval_count: 20,
+      eval_count: 10,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.content.length).toBe(2); // empty text + tool_use
+    expect(result.content[1].type).toBe("tool_use");
+    const toolUse = result.content[1] as { type: "tool_use"; name: string; input: Record<string, unknown> };
+    expect(toolUse.name).toBe("bash");
+    expect(toolUse.input).toEqual({ command: "ls -la" });
+  });
+
+  it("sets all costs to zero for local models", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: { role: "assistant" as const, content: "ok" },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.usage.cost).toEqual({
+      input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0,
+    });
+  });
+});

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -274,8 +274,11 @@ describe("createOllamaStreamFn", () => {
       const [url, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
       expect(url).toBe("http://ollama-host:11434/api/chat");
       expect(requestInit.signal).toBe(signal);
+      if (typeof requestInit.body !== "string") {
+        throw new Error("Expected string request body");
+      }
 
-      const requestBody = JSON.parse(String(requestInit.body)) as {
+      const requestBody = JSON.parse(requestInit.body) as {
         options: { num_ctx?: number; num_predict?: number };
       };
       expect(requestBody.options.num_ctx).toBe(131072);

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -85,7 +85,7 @@ function extractTextContent(content: unknown): string {
     .join("");
 }
 
-function extractImages(content: unknown): string[] {
+function extractOllamaImages(content: unknown): string[] {
   if (!Array.isArray(content)) {
     return [];
   }
@@ -125,7 +125,7 @@ export function convertToOllamaMessages(
 
     if (role === "user") {
       const text = extractTextContent(msg.content);
-      const images = extractImages(msg.content);
+      const images = extractOllamaImages(msg.content);
       result.push({
         role: "user",
         content: text,

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -25,6 +25,7 @@ interface OllamaChatMessage {
   content: string;
   images?: string[];
   tool_calls?: OllamaToolCall[];
+  tool_name?: string;
 }
 
 interface OllamaTool {
@@ -140,9 +141,17 @@ export function convertToOllamaMessages(
       });
     } else if (role === "tool" || role === "toolResult") {
       // SDK uses "toolResult" (camelCase) for tool result messages.
-      // Ollama API expects "tool" role.
+      // Ollama API expects "tool" role with tool_name per the native spec.
       const text = extractTextContent(msg.content);
-      result.push({ role: "tool", content: text });
+      const toolName =
+        typeof (msg as { toolName?: unknown }).toolName === "string"
+          ? (msg as { toolName?: string }).toolName
+          : undefined;
+      result.push({
+        role: "tool",
+        content: text,
+        ...(toolName ? { tool_name: toolName } : {}),
+      });
     }
   }
 

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -1,0 +1,375 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { AssistantMessageEventStream } from "@mariozechner/pi-ai";
+
+// ── Ollama /api/chat request types ──────────────────────────────────────────
+
+interface OllamaChatRequest {
+  model: string;
+  messages: OllamaChatMessage[];
+  stream: boolean;
+  tools?: OllamaTool[];
+  options?: Record<string, unknown>;
+}
+
+interface OllamaChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+  images?: string[];
+  tool_calls?: OllamaToolCall[];
+}
+
+interface OllamaTool {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+interface OllamaToolCall {
+  function: {
+    name: string;
+    arguments: Record<string, unknown>;
+  };
+}
+
+// ── Ollama /api/chat response types ─────────────────────────────────────────
+
+interface OllamaChatResponse {
+  model: string;
+  created_at: string;
+  message: {
+    role: "assistant";
+    content: string;
+    tool_calls?: OllamaToolCall[];
+  };
+  done: boolean;
+  done_reason?: string;
+  total_duration?: number;
+  load_duration?: number;
+  prompt_eval_count?: number;
+  prompt_eval_duration?: number;
+  eval_count?: number;
+  eval_duration?: number;
+}
+
+// ── Message conversion ──────────────────────────────────────────────────────
+
+type AgentMessage = {
+  role: string;
+  content: unknown;
+  [key: string]: unknown;
+};
+
+type ContentPart =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mediaType?: string }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+  | { type: "tool_result"; tool_use_id: string; content: string };
+
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return (content as ContentPart[])
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+function extractImages(content: unknown): string[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return (content as ContentPart[])
+    .filter((part): part is { type: "image"; data: string } => part.type === "image")
+    .map((part) => part.data);
+}
+
+function extractToolCalls(content: unknown): OllamaToolCall[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return (content as ContentPart[])
+    .filter(
+      (part): part is { type: "tool_use"; id: string; name: string; input: Record<string, unknown> } =>
+        part.type === "tool_use",
+    )
+    .map((part) => ({
+      function: {
+        name: part.name,
+        arguments: part.input,
+      },
+    }));
+}
+
+export function convertToOllamaMessages(
+  messages: AgentMessage[],
+  system?: string,
+): OllamaChatMessage[] {
+  const result: OllamaChatMessage[] = [];
+
+  if (system) {
+    result.push({ role: "system", content: system });
+  }
+
+  for (const msg of messages) {
+    const role = msg.role as string;
+
+    if (role === "user") {
+      const text = extractTextContent(msg.content);
+      const images = extractImages(msg.content);
+      result.push({
+        role: "user",
+        content: text,
+        ...(images.length > 0 ? { images } : {}),
+      });
+    } else if (role === "assistant") {
+      const text = extractTextContent(msg.content);
+      const toolCalls = extractToolCalls(msg.content);
+      result.push({
+        role: "assistant",
+        content: text,
+        ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+      });
+    } else if (role === "tool") {
+      const text = extractTextContent(msg.content);
+      result.push({ role: "tool", content: text });
+    }
+  }
+
+  return result;
+}
+
+// ── Response conversion ─────────────────────────────────────────────────────
+
+interface AssistantMessageLike {
+  role: "assistant";
+  content: ContentPart[];
+  stopReason: string;
+  api: string;
+  provider: string;
+  model: string;
+  usage: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    totalTokens: number;
+    cost: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+      total: number;
+    };
+  };
+  timestamp: number;
+}
+
+let toolCallIdCounter = 0;
+
+export function buildAssistantMessage(
+  response: OllamaChatResponse,
+  modelInfo: { api: string; provider: string; id: string },
+): AssistantMessageLike {
+  const content: ContentPart[] = [];
+
+  if (response.message.content) {
+    content.push({ type: "text", text: response.message.content });
+  }
+
+  const toolCalls = response.message.tool_calls;
+  if (toolCalls && toolCalls.length > 0) {
+    for (const tc of toolCalls) {
+      toolCallIdCounter += 1;
+      content.push({
+        type: "tool_use",
+        id: `ollama_call_${toolCallIdCounter}_${Date.now()}`,
+        name: tc.function.name,
+        input: tc.function.arguments,
+      });
+    }
+  }
+
+  const hasToolCalls = toolCalls && toolCalls.length > 0;
+  const stopReason = hasToolCalls ? "end_turn" : "stop";
+
+  return {
+    role: "assistant",
+    content,
+    stopReason,
+    api: modelInfo.api,
+    provider: modelInfo.provider,
+    model: modelInfo.id,
+    usage: {
+      input: response.prompt_eval_count ?? 0,
+      output: response.eval_count ?? 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: (response.prompt_eval_count ?? 0) + (response.eval_count ?? 0),
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    timestamp: Date.now(),
+  };
+}
+
+// ── NDJSON streaming parser ─────────────────────────────────────────────────
+
+export async function* parseNdjsonStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): AsyncGenerator<OllamaChatResponse> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      try {
+        yield JSON.parse(trimmed) as OllamaChatResponse;
+      } catch {
+        // Skip malformed lines
+      }
+    }
+  }
+
+  if (buffer.trim()) {
+    try {
+      yield JSON.parse(buffer.trim()) as OllamaChatResponse;
+    } catch {
+      // Skip malformed trailing data
+    }
+  }
+}
+
+// ── Main StreamFn factory ───────────────────────────────────────────────────
+
+export function createOllamaStreamFn(baseUrl: string): StreamFn {
+  const chatUrl = `${baseUrl.replace(/\/+$/, "")}/api/chat`;
+
+  return (model, context, options) => {
+    const stream = new AssistantMessageEventStream();
+
+    const run = async () => {
+      try {
+        const ctx = context as { messages?: AgentMessage[]; system?: string };
+        const ollamaMessages = convertToOllamaMessages(ctx.messages ?? [], ctx.system as string);
+
+        const body: OllamaChatRequest = {
+          model: model.id,
+          messages: ollamaMessages,
+          stream: true,
+          ...(typeof options?.temperature === "number"
+            ? { options: { temperature: options.temperature } }
+            : {}),
+        };
+
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          ...(options?.headers ?? {}),
+        };
+        if (options?.apiKey) {
+          headers.Authorization = `Bearer ${options.apiKey}`;
+        }
+
+        const response = await fetch(chatUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "unknown error");
+          throw new Error(`Ollama API error ${response.status}: ${errorText}`);
+        }
+
+        if (!response.body) {
+          throw new Error("Ollama API returned empty response body");
+        }
+
+        const reader = response.body.getReader();
+        let accumulatedContent = "";
+        let finalResponse: OllamaChatResponse | undefined;
+
+        for await (const chunk of parseNdjsonStream(reader)) {
+          if (chunk.done) {
+            finalResponse = chunk;
+            if (chunk.message?.content) {
+              accumulatedContent += chunk.message.content;
+            }
+            break;
+          }
+
+          if (chunk.message?.content) {
+            accumulatedContent += chunk.message.content;
+          }
+        }
+
+        if (!finalResponse) {
+          throw new Error("Ollama API stream ended without a final response");
+        }
+
+        finalResponse.message.content = accumulatedContent;
+
+        const assistantMessage = buildAssistantMessage(finalResponse, {
+          api: model.api as string,
+          provider: model.provider as string,
+          id: model.id,
+        });
+
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: assistantMessage,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        stream.push({
+          type: "done",
+          reason: "error",
+          message: {
+            role: "assistant" as const,
+            content: [],
+            stopReason: "error",
+            errorMessage,
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        });
+      } finally {
+        stream.end();
+      }
+    };
+
+    queueMicrotask(() => void run());
+    return stream;
+  };
+}
+
+export const OLLAMA_NATIVE_BASE_URL = "http://127.0.0.1:11434";

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2,7 +2,6 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
-import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-stream.js";
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
@@ -32,6 +31,7 @@ import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
+import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-stream.js";
 import {
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -588,8 +588,13 @@ export async function runEmbeddedAttempt(
       // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
       // for reliable streaming + tool calling support (#11828).
       if (params.model.api === "ollama") {
-        const providerConfig = params.config?.models?.providers?.ollama;
-        const ollamaBaseUrl = providerConfig?.baseUrl ?? OLLAMA_NATIVE_BASE_URL;
+        // Use the resolved model baseUrl first so custom provider aliases work.
+        const providerConfig = params.config?.models?.providers?.[params.model.provider];
+        const modelBaseUrl =
+          typeof params.model.baseUrl === "string" ? params.model.baseUrl.trim() : "";
+        const providerBaseUrl =
+          typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
+        const ollamaBaseUrl = modelBaseUrl || providerBaseUrl || OLLAMA_NATIVE_BASE_URL;
         activeSession.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
       } else {
         // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -4,7 +4,8 @@ export type ModelApi =
   | "anthropic-messages"
   | "google-generative-ai"
   | "github-copilot"
-  | "bedrock-converse-stream";
+  | "bedrock-converse-stream"
+  | "ollama";
 
 export type ModelCompatConfig = {
   supportsStore?: boolean;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -9,6 +9,7 @@ export const ModelApiSchema = z.union([
   z.literal("google-generative-ai"),
   z.literal("github-copilot"),
   z.literal("bedrock-converse-stream"),
+  z.literal("ollama"),
 ]);
 
 export const ModelCompatSchema = z


### PR DESCRIPTION
## Summary

Adds a native Ollama `/api/chat` provider to enable streaming + tool calling with local LLMs.

**Three critical fixes for Ollama tool calling:**
- Switch from broken OpenAI compat endpoint to native `/api/chat` (tool_calls were silently dropped)
- Accumulate tool_calls from intermediate streaming chunks (Ollama sends them in `done:false`, not `done:true`)
- Set `num_ctx` from model's `contextWindow` config (Ollama defaults to 4096, truncating system prompts)

## Changes

| File | Change |
|------|--------|
| `src/agents/ollama-stream.ts` | New native Ollama streaming client with message/tool conversion, NDJSON parser, `num_ctx` config |
| `src/agents/ollama-stream.test.ts` | 13 unit tests covering message conversion, response building, and streaming |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Inject `createOllamaStreamFn` when `model.api === "ollama"` |
| `src/agents/providers.ts` | Register `"ollama"` as valid API type |

## Verified with local testing

- `qwen3:32b` + 23 tools + system prompt → tool_calls generated correctly (with `num_ctx=65536`)
- Streaming text works with all tested Ollama models
- All 13 unit tests pass, oxlint clean, oxfmt clean

## Test plan

- [x] Unit tests: `vitest run src/agents/ollama-stream.test.ts` (13 tests)
- [x] Lint: `oxlint src/agents/ollama-stream.ts` (0 errors)
- [x] Format: `oxfmt src/agents/ollama-stream.ts`
- [x] curl verification: native API + 23 tools + `num_ctx=65536` → tool_calls work
- [x] E2E: Run OpenClaw with `api: "ollama"` and verify tool calling loop

Closes #11828
Fixes #4028
Fixes #8630