### PR TITLE
fix: resolve per-agent tools.exec config in pi-tools

### DIFF
--- a/src/agents/pi-tools.resolve-exec-config.test.ts
+++ b/src/agents/pi-tools.resolve-exec-config.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { __testing } from "./pi-tools.js";
+
+const { resolveExecConfig } = __testing;
+
+describe("resolveExecConfig", () => {
+  it("returns global exec config when no agentId is provided", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "allowlist",
+          safeBins: ["/usr/bin/echo"],
+        },
+      },
+    };
+    const result = resolveExecConfig(cfg, undefined);
+    expect(result.host).toBe("gateway");
+    expect(result.security).toBe("allowlist");
+    expect(result.safeBins).toEqual(["/usr/bin/echo"]);
+  });
+
+  it("returns global exec config when agent has no exec override", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "deny",
+        },
+      },
+      agents: {
+        list: [{ id: "main", workspace: "~/openclaw" }],
+      },
+    };
+    const result = resolveExecConfig(cfg, "main");
+    expect(result.host).toBe("gateway");
+    expect(result.security).toBe("deny");
+  });
+
+  it("prefers agent-specific exec config over global", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          host: "sandbox",
+          security: "deny",
+          safeBins: ["/global/bin"],
+          timeoutSec: 30,
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "team",
+            workspace: "~/team",
+            tools: {
+              exec: {
+                host: "gateway",
+                security: "allowlist",
+                safeBins: ["/agent/bin"],
+              },
+            },
+          },
+        ],
+      },
+    };
+    const result = resolveExecConfig(cfg, "team");
+    expect(result.host).toBe("gateway");
+    expect(result.security).toBe("allowlist");
+    expect(result.safeBins).toEqual(["/agent/bin"]);
+    // Falls back to global for fields not overridden by agent
+    expect(result.timeoutSec).toBe(30);
+  });
+
+  it("falls back to global when agent does not override a field", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          host: "sandbox",
+          security: "deny",
+          ask: "on-miss",
+          node: "remote-node",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "restricted",
+            workspace: "~/restricted",
+            tools: {
+              exec: {
+                security: "allowlist",
+              },
+            },
+          },
+        ],
+      },
+    };
+    const result = resolveExecConfig(cfg, "restricted");
+    expect(result.security).toBe("allowlist");
+    expect(result.host).toBe("sandbox");
+    expect(result.ask).toBe("on-miss");
+    expect(result.node).toBe("remote-node");
+  });
+
+  it("handles undefined config gracefully", () => {
+    const result = resolveExecConfig(undefined, "main");
+    expect(result.host).toBeUndefined();
+    expect(result.security).toBeUndefined();
+  });
+});

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -13,6 +13,7 @@ import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import {
   createExecTool,
@@ -86,21 +87,23 @@ function isApplyPatchAllowedForModel(params: {
   });
 }
 
-function resolveExecConfig(cfg: OpenClawConfig | undefined) {
+function resolveExecConfig(cfg: OpenClawConfig | undefined, agentId?: string) {
   const globalExec = cfg?.tools?.exec;
+  const agentExec = cfg && agentId ? resolveAgentConfig(cfg, agentId)?.tools?.exec : undefined;
   return {
-    host: globalExec?.host,
-    security: globalExec?.security,
-    ask: globalExec?.ask,
-    node: globalExec?.node,
-    pathPrepend: globalExec?.pathPrepend,
-    safeBins: globalExec?.safeBins,
-    backgroundMs: globalExec?.backgroundMs,
-    timeoutSec: globalExec?.timeoutSec,
-    approvalRunningNoticeMs: globalExec?.approvalRunningNoticeMs,
-    cleanupMs: globalExec?.cleanupMs,
-    notifyOnExit: globalExec?.notifyOnExit,
-    applyPatch: globalExec?.applyPatch,
+    host: agentExec?.host ?? globalExec?.host,
+    security: agentExec?.security ?? globalExec?.security,
+    ask: agentExec?.ask ?? globalExec?.ask,
+    node: agentExec?.node ?? globalExec?.node,
+    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
+    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    backgroundMs: agentExec?.backgroundMs ?? globalExec?.backgroundMs,
+    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    approvalRunningNoticeMs:
+      agentExec?.approvalRunningNoticeMs ?? globalExec?.approvalRunningNoticeMs,
+    cleanupMs: agentExec?.cleanupMs ?? globalExec?.cleanupMs,
+    notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
+    applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
   };
 }
 
@@ -110,6 +113,7 @@ export const __testing = {
   patchToolSchemaForClaudeCompatibility,
   wrapToolParamNormalization,
   assertRequiredParams,
+  resolveExecConfig,
 } as const;
 
 export function createOpenClawCodingTools(options?: {
@@ -228,7 +232,7 @@ export function createOpenClawCodingTools(options?: {
     sandbox?.tools,
     subagentPolicy,
   ]);
-  const execConfig = resolveExecConfig(options?.config);
+  const execConfig = resolveExecConfig(options?.config, agentId);
   const sandboxRoot = sandbox?.workspaceDir;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = options?.workspaceDir ?? process.cwd();

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -236,7 +236,7 @@ export function createOpenClawCodingTools(options?: {
   const sandboxRoot = sandbox?.workspaceDir;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = options?.workspaceDir ?? process.cwd();
-  const applyPatchConfig = options?.config?.tools?.exec?.applyPatch;
+  const applyPatchConfig = execConfig.applyPatch;
   const applyPatchEnabled =
     !!applyPatchConfig?.enabled &&
     isOpenAIProvider(options?.modelProvider) &&


### PR DESCRIPTION
## Summary

`resolveExecConfig()` in `pi-tools.ts` only reads global `tools.exec` config, ignoring agent-specific overrides in `agents.list[].tools.exec`. This causes agents configured with restricted exec settings (e.g., `security: "allowlist"`, `host: "gateway"`) to silently inherit global defaults, potentially running with more permissive settings than intended.

- Update `resolveExecConfig` to accept `agentId` and merge agent-specific config with `??` fallback
- Follow the same pattern already used in `directive-handling.impl.ts` (`resolveExecDefaults`)
- `agentId` was already available in scope (resolved by `resolveEffectiveToolPolicy`)

Closes #11832

## Test plan

- [x] Added unit tests for `resolveExecConfig` covering:
  - Global-only config (no agent override)
  - Agent-specific config overriding global
  - Partial agent override (non-overridden fields fall back to global)
  - Undefined config handled gracefully
- [x] Existing `pi-tools-agent-config`, `pi-tools.safe-bins` tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveExecConfig()` in `src/agents/pi-tools.ts` to merge global `tools.exec` config with per-agent overrides from `agents.list[].tools.exec`, using `agentId` (already resolved by `resolveEffectiveToolPolicy`) to select the agent scope. It also adds a new Vitest suite covering global-only config, full and partial agent overrides, and undefined config.

This fits into the tool wiring in `createOpenClawCodingTools()` by ensuring the `exec`/`process` tools receive the correct agent-scoped defaults rather than silently inheriting global settings, aligning behavior with other agent-scoped config resolution patterns in the codebase.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but there is one agent-scoped config hole remaining.
- The core change (merging agent exec settings with global defaults) is straightforward and covered by unit tests. However, apply-patch configuration is still sourced only from the global `tools.exec.applyPatch` path, so agent-level overrides for that nested config won’t work despite the rest of exec config being agent-aware.
- src/agents/pi-tools.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->