### PR TITLE
Exec: surface skill hints on command-not-found failures

### DIFF
--- a/src/agents/bash-tools.exec.skill-hints.test.ts
+++ b/src/agents/bash-tools.exec.skill-hints.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { buildSkillHint, extractBinaryName, type SkillBinHint } from "./bash-tools.exec.js";
+
+describe("extractBinaryName", () => {
+  it("extracts simple command", () => {
+    expect(extractBinaryName("gog gmail search 'newer_than:7d'")).toBe("gog");
+  });
+
+  it("extracts command with leading whitespace", () => {
+    expect(extractBinaryName("  gog gmail search")).toBe("gog");
+  });
+
+  it("strips path prefix", () => {
+    expect(extractBinaryName("/usr/local/bin/gog gmail search")).toBe("gog");
+  });
+
+  it("skips sudo prefix", () => {
+    expect(extractBinaryName("sudo gog auth list")).toBe("gog");
+  });
+
+  it("skips env prefix", () => {
+    expect(extractBinaryName("env gog auth list")).toBe("gog");
+  });
+
+  it("skips env var assignments", () => {
+    expect(extractBinaryName("FOO=bar GOG_ACCOUNT=x gog gmail search")).toBe("gog");
+  });
+
+  it("skips nohup prefix", () => {
+    expect(extractBinaryName("nohup gog gmail search")).toBe("gog");
+  });
+
+  it("skips combined prefixes", () => {
+    expect(extractBinaryName("sudo env FOO=bar gog gmail send")).toBe("gog");
+  });
+
+  it("returns undefined for empty command", () => {
+    expect(extractBinaryName("")).toBeUndefined();
+  });
+
+  it("returns undefined for only env vars", () => {
+    expect(extractBinaryName("FOO=bar BAZ=qux")).toBeUndefined();
+  });
+
+  it("handles single-word command", () => {
+    expect(extractBinaryName("ls")).toBe("ls");
+  });
+});
+
+describe("buildSkillHint", () => {
+  const hints: ReadonlyMap<string, SkillBinHint> = new Map([
+    ["gog", { skillName: "gog", skillPath: "skills/gog/SKILL.md" }],
+    ["himalaya", { skillName: "himalaya", skillPath: "skills/himalaya/SKILL.md" }],
+  ]);
+
+  it("returns hint when exit code is 127 and binary matches a skill", () => {
+    const result = buildSkillHint("gog gmail search 'newer_than:7d'", 127, hints);
+    expect(result).toContain('"gog"');
+    expect(result).toContain("skills/gog/SKILL.md");
+    expect(result).toContain("Read");
+  });
+
+  it("returns undefined when exit code is not 127", () => {
+    expect(buildSkillHint("gog gmail search", 1, hints)).toBeUndefined();
+    expect(buildSkillHint("gog gmail search", 0, hints)).toBeUndefined();
+    expect(buildSkillHint("gog gmail search", null, hints)).toBeUndefined();
+  });
+
+  it("returns undefined when binary does not match any skill", () => {
+    expect(buildSkillHint("unknown-tool --help", 127, hints)).toBeUndefined();
+  });
+
+  it("returns undefined when hints map is undefined", () => {
+    expect(buildSkillHint("gog gmail search", 127, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when hints map is empty", () => {
+    expect(buildSkillHint("gog gmail search", 127, new Map())).toBeUndefined();
+  });
+
+  it("matches binary through sudo prefix", () => {
+    const result = buildSkillHint("sudo gog gmail search", 127, hints);
+    expect(result).toContain('"gog"');
+    expect(result).toContain("skills/gog/SKILL.md");
+  });
+
+  it("matches binary through env var assignment", () => {
+    const result = buildSkillHint("GOG_ACCOUNT=x gog gmail search", 127, hints);
+    expect(result).toContain('"gog"');
+  });
+
+  it("matches binary through path prefix", () => {
+    const result = buildSkillHint("/usr/local/bin/gog gmail search", 127, hints);
+    expect(result).toContain('"gog"');
+  });
+
+  it("works with different skill binaries", () => {
+    const result = buildSkillHint("himalaya list", 127, hints);
+    expect(result).toContain('"himalaya"');
+    expect(result).toContain("skills/himalaya/SKILL.md");
+  });
+});

--- a/src/agents/bash-tools.ts
+++ b/src/agents/bash-tools.ts
@@ -3,6 +3,7 @@ export type {
   ExecElevatedDefaults,
   ExecToolDefaults,
   ExecToolDetails,
+  SkillBinHint,
 } from "./bash-tools.exec.js";
 export { createExecTool, execTool } from "./bash-tools.exec.js";
 export type { ProcessToolDefaults } from "./bash-tools.process.js";

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -190,7 +190,10 @@ export async function runEmbeddedAttempt(
     });
 
     // Build a bin→skill map so the exec tool can hint the model on "command not found".
-    const skillBinHints = buildSkillBinHintsFromEntries(skillEntries);
+    // When the snapshot path skips loading entries, load them cheaply just for bin hints.
+    const skillBinHints = buildSkillBinHintsFromEntries(
+      skillEntries.length > 0 ? skillEntries : loadWorkspaceSkillEntries(effectiveWorkspace),
+    );
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4,6 +4,7 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs/promises";
 import os from "node:os";
+import type { SkillBinHint } from "../../bash-tools.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
@@ -55,6 +56,7 @@ import {
   applySkillEnvOverridesFromSnapshot,
   loadWorkspaceSkillEntries,
   resolveSkillsPromptForRun,
+  type SkillEntry,
 } from "../../skills.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
@@ -187,6 +189,9 @@ export async function runEmbeddedAttempt(
       workspaceDir: effectiveWorkspace,
     });
 
+    // Build a bin→skill map so the exec tool can hint the model on "command not found".
+    const skillBinHints = buildSkillBinHintsFromEntries(skillEntries);
+
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
       await resolveBootstrapContextForRun({
@@ -212,6 +217,7 @@ export async function runEmbeddedAttempt(
           exec: {
             ...params.execOverrides,
             elevated: params.bashElevated,
+            skillBinHints,
           },
           sandbox,
           messageProvider: params.messageChannel ?? params.messageProvider,
@@ -925,4 +931,31 @@ export async function runEmbeddedAttempt(
     restoreSkillEnv?.();
     process.chdir(prevCwd);
   }
+}
+
+/** Map required skill binaries to their skill name + SKILL.md path for exec hints. */
+function buildSkillBinHintsFromEntries(
+  entries: SkillEntry[],
+): ReadonlyMap<string, SkillBinHint> | undefined {
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const hints = new Map<string, SkillBinHint>();
+  for (const entry of entries) {
+    const bins = entry.metadata?.requires?.bins;
+    if (!bins || bins.length === 0) {
+      continue;
+    }
+    for (const bin of bins) {
+      // First-seen wins; entries are already in priority order from loadWorkspaceSkillEntries.
+      if (hints.has(bin)) {
+        continue;
+      }
+      hints.set(bin, {
+        skillName: entry.skill.name,
+        skillPath: entry.skill.filePath,
+      });
+    }
+  }
+  return hints.size > 0 ? hints : undefined;
 }


### PR DESCRIPTION
## Summary
When the exec tool encounters exit code 127 ("command not found"), it now checks if the failed binary matches a loaded skill's requires.bins and appends a hint pointing the model to the relevant SKILL.md. This helps weaker models (e.g. Sonnet 4) self-correct when they skip skill indexing and guess at commands with typos or wrong syntax.

## Behavior Changes

- **Error-path only:** only fires when exit code is exactly 127 and the binary matches a loaded skill. Zero impact on successful commands or other failure types.
- The hint is appended to the error message the model receives, not shown to end users.

## Codebase and GitHub Search

- Searched for existing skill-exec integration: none exists. Skills are prompt-injected only; exec tool was completely skill-unaware.
- Searched for "command not found" handling: no existing post-exec hinting.

## Tests

- 20 new unit tests in `bash-tools.exec.skill-hints.test.ts`
- Tests cover: binary extraction (simple, path prefix, sudo, env vars, nohup, combined prefixes, empty, edge cases), hint building (exit 127 match, non-127 codes, missing hints, empty map, undefined map, prefix traversal)
- All 52 bash-tools tests pass (8 test files)

**Sign-Off**

- Models used: Claude claude-4.6-opus
- Submitter effort: spec + review
- Agent notes: lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes the `exec` tool skill-aware for the specific error path where a command fails with exit code `127` (command not found). It adds helpers to extract the invoked binary from a shell command and, when that binary matches a loaded skill’s `requires.bins`, appends a hint telling the model to read the corresponding `SKILL.md` before retrying. The hint is wired into both the local exec failure path and the node/gateway exec response path, and unit tests are added for binary extraction + hint generation.

The wiring currently builds the bin→skill hint map inside the embedded runner and passes it into `createOpenClawCodingTools` via exec defaults, so the exec tool can conditionally append the hint to the text returned to the model.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one code path likely prevents the new behavior from triggering in snapshot-based embedded runs.
- Changes are scoped to the exec error path and are covered by unit tests, but `skillBinHints` is currently derived only from `loadWorkspaceSkillEntries()` output. When a skills snapshot is present, entries are not loaded (set to `[]`), so hints won’t be generated in that common execution mode, making the feature ineffective there.
- src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->