### PR TITLE
fix: filter HEARTBEAT_OK messages from chat.history when showOk is false

### DIFF
--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { stripEnvelopeFromMessage } from "./chat-sanitize.js";
+import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
+import { filterHeartbeatOkMessages, stripEnvelopeFromMessage } from "./chat-sanitize.js";
 
 describe("stripEnvelopeFromMessage", () => {
   test("removes message_id hint lines from user messages", () => {
@@ -38,5 +39,101 @@ describe("stripEnvelopeFromMessage", () => {
     };
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("note\n[message_id: 123]");
+  });
+});
+
+describe("filterHeartbeatOkMessages", () => {
+  test("removes heartbeat prompt + HEARTBEAT_OK response pair", () => {
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: HEARTBEAT_PROMPT },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "what's up?" },
+    ];
+    const result = filterHeartbeatOkMessages(messages);
+    expect(result).toHaveLength(3);
+    expect(result).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "what's up?" },
+    ]);
+  });
+
+  test("removes standalone HEARTBEAT_OK response without preceding prompt", () => {
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+    ];
+    const result = filterHeartbeatOkMessages(messages);
+    expect(result).toHaveLength(1);
+    expect(result).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  test("keeps heartbeat runs that produced actual content (alerts)", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_PROMPT },
+      { role: "assistant", content: "⚠️ Disk usage is at 95%!" },
+    ];
+    const result = filterHeartbeatOkMessages(messages);
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles HEARTBEAT_OK with markup wrapping", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_PROMPT },
+      { role: "assistant", content: "**HEARTBEAT_OK**" },
+    ];
+    const result = filterHeartbeatOkMessages(messages);
+    expect(result).toHaveLength(0);
+  });
+
+  test("handles HEARTBEAT_OK with underscore wrapping", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_PROMPT },
+      { role: "assistant", content: "_HEARTBEAT_OK_" },
+    ];
+    const result = filterHeartbeatOkMessages(messages);
+    expect(result).toHaveLength(0);
+  });
+
+  test("handles content array format", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: HEARTBEAT_PROMPT }] },
+      { role: "assistant", content: [{ type: "text", text: "HEARTBEAT_OK" }] },
+    ];
+    const result = filterHeartbeatOkMessages(messages);
+    expect(result).toHaveLength(0);
+  });
+
+  test("returns same array reference when no filtering needed", () => {
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ];
+    const result = filterHeartbeatOkMessages(messages);
+    expect(result).toBe(messages);
+  });
+
+  test("returns empty array for empty input", () => {
+    const result = filterHeartbeatOkMessages([]);
+    expect(result).toEqual([]);
+  });
+
+  test("removes multiple heartbeat pairs", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_PROMPT },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "real message" },
+      { role: "assistant", content: "real response" },
+      { role: "user", content: HEARTBEAT_PROMPT },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+    ];
+    const result = filterHeartbeatOkMessages(messages);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual([
+      { role: "user", content: "real message" },
+      { role: "assistant", content: "real response" },
+    ]);
   });
 });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -10,6 +10,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
+import { resolveHeartbeatVisibility } from "../../infra/heartbeat-visibility.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import {
@@ -19,7 +20,7 @@ import {
   resolveChatRunExpiresAtMs,
 } from "../chat-abort.js";
 import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
-import { stripEnvelopeFromMessages } from "../chat-sanitize.js";
+import { filterHeartbeatOkMessages, stripEnvelopeFromMessages } from "../chat-sanitize.js";
 import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
 import {
   ErrorCodes,
@@ -210,7 +211,10 @@ export const chatHandlers: GatewayRequestHandlers = {
     const max = Math.min(hardMax, requested);
     const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
     const sanitized = stripEnvelopeFromMessages(sliced);
-    const capped = capArrayByJsonBytes(sanitized, getMaxChatHistoryMessagesBytes()).items;
+    // Filter out HEARTBEAT_OK messages when showOk is false for webchat
+    const visibility = resolveHeartbeatVisibility({ cfg, channel: "webchat" });
+    const filtered = visibility.showOk ? sanitized : filterHeartbeatOkMessages(sanitized);
+    const capped = capArrayByJsonBytes(filtered, getMaxChatHistoryMessagesBytes()).items;
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
       const configured = cfg.agents?.defaults?.thinkingDefault;


### PR DESCRIPTION
## Summary

Fixes #11630.

`chat.history` returns raw transcript messages without heartbeat filtering, causing HEARTBEAT_OK messages to appear in the control-ui chat tab after page refresh — even though the live broadcast path correctly suppresses them via `shouldSuppressHeartbeatBroadcast()`.

## Changes

### `src/gateway/chat-sanitize.ts`
- Added `filterHeartbeatOkMessages()` that identifies and removes HEARTBEAT_OK response messages and their corresponding heartbeat prompt messages from the message array
- Detection uses content-based matching (checks for `HEARTBEAT_TOKEN` in assistant messages and `HEARTBEAT_PROMPT` in user messages), consistent with how `stripHeartbeatToken()` in `heartbeat.ts` handles markup normalization
- Heartbeat runs that produced actual content (alerts) are preserved

### `src/gateway/server-methods/chat.ts`
- After sanitization, applies `filterHeartbeatOkMessages()` when `resolveHeartbeatVisibility()` returns `showOk: false` for the webchat channel
- When `showOk` is true, no filtering is applied (all messages returned as before)

### `src/gateway/chat-sanitize.test.ts`
- 8 new test cases covering: prompt+response pair removal, standalone HEARTBEAT_OK removal, alert preservation, markdown markup wrapping, content array format, identity reference preservation, empty input, and multiple heartbeat pairs

## Design Notes

- The heartbeat prompt and HEARTBEAT_OK response are identified by content matching rather than metadata flags, since `isHeartbeat` is a runtime `AgentRunContext` property that is not persisted to the JSONL transcript
- The markup stripping in `isHeartbeatOkResponse()` mirrors the edge-stripping approach in `heartbeat.ts` (`stripHeartbeatToken`), removing `*`, backtick, `~` wrappers and HTML tags while preserving underscores in the token itself
- Filtering is applied after `stripEnvelopeFromMessages()` but before `capArrayByJsonBytes()`, so byte budget calculation uses the filtered (smaller) set

## Testing

```
✓ src/gateway/chat-sanitize.test.ts (12 tests) 4ms
✓ src/infra/heartbeat-visibility.test.ts (13 tests) 3ms
✓ src/auto-reply/heartbeat.test.ts (20 tests) 4ms
```

---

感谢 @AnthonyFrancis 提交了清晰的 bug report！

Thanks @AnthonyFrancis for the clear bug report!

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds transcript-side filtering of heartbeat noise in `chat.history`: after stripping envelope headers, it optionally removes HEARTBEAT prompt/HEARTBEAT_OK pairs when heartbeat visibility resolves to `showOk: false`, and introduces unit tests around the new filter.

The change plugs a gap where live broadcast already suppressed HEARTBEAT_OK but history replay returned raw transcript messages, causing the control-ui chat tab to show HEARTBEAT_OK on refresh.

<h3>Confidence Score: 3/5</h3>

- Moderately safe, but two logic issues can cause the bug to persist or change behavior for non-webchat consumers.
- Core idea and tests look reasonable, but HEARTBEAT_OK detection diverges from existing markup normalization (misses underscore emphasis), and `chat.history` now applies webchat heartbeat visibility unconditionally which can unintentionally filter history for other clients/tools.
- src/gateway/chat-sanitize.ts and src/gateway/server-methods/chat.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->