### PR TITLE
fix(memory): enable SQLite WAL mode for concurrent access safety

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -53,7 +53,10 @@ export async function handleToolExecutionStart(
 
   if (toolName === "read") {
     const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-    const filePath = typeof record.path === "string" ? record.path.trim() : "";
+    // Accept both "path" and "file_path" (tool schema allows either)
+    const filePath =
+      (typeof record.path === "string" ? record.path.trim() : "") ||
+      (typeof record.file_path === "string" ? record.file_path.trim() : "");
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
       ctx.log.warn(

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -711,7 +711,11 @@ export class MemoryIndexManager implements MemorySearchManager {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    // Enable WAL mode for concurrent read/write safety (prevents corruption
+    // when file-watcher, session-delta, and batch sync run simultaneously).
+    db.exec(`PRAGMA journal_mode=WAL;`);
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -7,7 +7,15 @@ export function ensureMemoryIndexSchema(params: {
   ftsEnabled: boolean;
 }): { ftsAvailable: boolean; ftsError?: string } {
   // Enable WAL mode for concurrent read/write safety
-  params.db.exec(`PRAGMA journal_mode=WAL;`);
+  const walResult = params.db.prepare("PRAGMA journal_mode=WAL;").get() as
+    | { journal_mode?: string }
+    | undefined;
+  if (walResult?.journal_mode !== "wal") {
+    // Log to stderr directly — no subsystem logger available in schema helpers.
+    console.warn(
+      `[memory-schema] SQLite WAL mode not enabled (got: ${walResult?.journal_mode ?? "unknown"})`,
+    );
+  }
   params.db.exec(`
     CREATE TABLE IF NOT EXISTS meta (
       key TEXT PRIMARY KEY,

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -6,6 +6,8 @@ export function ensureMemoryIndexSchema(params: {
   ftsTable: string;
   ftsEnabled: boolean;
 }): { ftsAvailable: boolean; ftsError?: string } {
+  // Enable WAL mode for concurrent read/write safety
+  params.db.exec(`PRAGMA journal_mode=WAL;`);
   params.db.exec(`
     CREATE TABLE IF NOT EXISTS meta (
       key TEXT PRIMARY KEY,


### PR DESCRIPTION
## Problem

The memory SQLite database can experience corruption or SQLITE_BUSY errors when multiple processes access it concurrently — specifically when file-watcher, session-delta sync, and batch memory sync run simultaneously. This was observed in production with heartbeat-triggered memory indexing coinciding with cron job writes.

## Solution

Enable SQLite WAL (Write-Ahead Logging) journal mode on database open. WAL allows concurrent readers and a single writer without blocking, which is exactly the access pattern of the memory index (multiple read queries during agent turns + background write operations).

The change adds `PRAGMA journal_mode=WAL` in two places:
- `src/memory/manager.ts` — when opening the database connection  
- `src/memory/memory-schema.ts` — during initial schema creation

## Additional fix

The `read` tool handler in `pi-embedded-subscribe.handlers.tools.ts` now accepts both `path` and `file_path` parameter names, matching the tool schema that advertises both.

## Testing

Tested in production over 48+ hours with 30-minute heartbeat intervals, concurrent cron jobs, and active sub-agent sessions. No SQLITE_BUSY errors or corruption since applying WAL mode.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enables SQLite write-ahead logging (WAL) for the memory index by executing `PRAGMA journal_mode=WAL` when opening the DB connection (`src/memory/manager.ts`) and again during schema initialization (`src/memory/memory-schema.ts`). It also updates the embedded tool event handler to accept both `path` and `file_path` for the `read` tool (`src/agents/pi-embedded-subscribe.handlers.tools.ts`).

Overall this fits the memory subsystem’s access pattern (many reads + background writes) and should reduce `SQLITE_BUSY` issues, but the current implementation assumes WAL is successfully enabled without verifying the effective journal mode.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but it may not fully fix the concurrency issue in environments where WAL cannot be enabled.
- Changes are small and localized, but WAL activation isn’t verified; if SQLite refuses WAL for the underlying filesystem/config, the code will continue as before and the original production issue can persist without visibility.
- src/memory/memory-schema.ts and src/memory/manager.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->