### PR TITLE
fix: add missing methods to BASE_METHODS for client discovery

### DIFF
--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { listGatewayMethods } from "./server-methods-list.js";
+import { coreGatewayHandlers } from "./server-methods.js";
+
+// "connect" is the WebSocket handshake handler, not a client-callable RPC method.
+const INTERNAL_METHODS = new Set(["connect"]);
+
+describe("listGatewayMethods", () => {
+  it("includes all core handler methods", () => {
+    const methods = listGatewayMethods();
+    const handlerMethods = Object.keys(coreGatewayHandlers).filter((m) => !INTERNAL_METHODS.has(m));
+    const missing = handlerMethods.filter((m) => !methods.includes(m));
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -51,6 +51,10 @@ const BASE_METHODS = [
   "sessions.reset",
   "sessions.delete",
   "sessions.compact",
+  "sessions.resolve",
+  "sessions.usage",
+  "sessions.usage.timeseries",
+  "sessions.usage.logs",
   "last-heartbeat",
   "set-heartbeats",
   "wake",
@@ -80,14 +84,19 @@ const BASE_METHODS = [
   "system-presence",
   "system-event",
   "send",
+  "poll",
   "agent",
   "agent.identity.get",
   "agent.wait",
   "browser.request",
+  // WebChat browser-based login
+  "web.login.start",
+  "web.login.wait",
   // WebChat WebSocket-native chat methods
   "chat.history",
   "chat.abort",
   "chat.send",
+  "chat.inject",
 ];
 
 export function listGatewayMethods(): string[] {


### PR DESCRIPTION
## Summary
- Several gateway handler methods (`sessions.resolve`, `sessions.usage`, `sessions.usage.timeseries`, `sessions.usage.logs`, `web.login.start`, `web.login.wait`, `chat.inject`, `poll`) have registered handlers in `coreGatewayHandlers` but were not listed in `BASE_METHODS`
- This means clients never see these methods in the `features.methods` field of the hello-ok handshake response, so they cannot discover that the gateway supports them
- Adds a regression test verifying all core handler methods (except the internal `connect` handshake handler) are included in `listGatewayMethods()`

## Test plan
- [x] New test `server-methods-list.test.ts` passes — verifies no handler methods are missing from `BASE_METHODS`
- [x] Existing gateway tests unaffected

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway method discovery list by adding several core RPC methods (notably `sessions.resolve`, `sessions.usage*`, `web.login.*`, `chat.inject`, and `poll`) to `BASE_METHODS` so they appear in the `features.methods` handshake response. It also adds a regression test that asserts every method registered in `coreGatewayHandlers` (except the internal `connect` handshake handler) is present in `listGatewayMethods()`, preventing future drift between handler registration and the advertised method list.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a straightforward extension of a static allowlist (`BASE_METHODS`) to match already-registered core handlers, plus a regression test that enforces consistency going forward. No behavior changes to handlers themselves; the new test is deterministic and only checks for missing method advertisement.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->