### PR TITLE
chore: fix vitest standalone configs and update package description

### DIFF
--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -1,5 +1,4 @@
-export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
-export type GroupPolicy = "open" | "disabled" | "allowlist";
+export type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk";
 
 export type BlueBubblesGroupConfig = {
   /** If true, only respond in this group when mentioned. */

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -1,3 +1,4 @@
+import type { DmPolicy } from "openclaw/plugin-sdk";
 import {
   addWildcardAllowFrom,
   formatDocsLink,
@@ -6,7 +7,7 @@ import {
   type ChannelOnboardingDmPolicy,
   type WizardPrompter,
 } from "openclaw/plugin-sdk";
-import type { CoreConfig, DmPolicy } from "./types.js";
+import type { CoreConfig } from "./types.js";
 import { listMatrixDirectoryGroupsLive } from "./directory-live.js";
 import { resolveMatrixAccount } from "./matrix/accounts.js";
 import { ensureMatrixSdkInstalled, isMatrixSdkAvailable } from "./matrix/deps.js";

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -1,6 +1,6 @@
+export type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk";
+
 export type ReplyToMode = "off" | "first" | "all";
-export type GroupPolicy = "open" | "disabled" | "allowlist";
-export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
 
 export type MatrixDmConfig = {
   /** If false, ignore all incoming Matrix DMs. Default: true. */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openclaw",
   "version": "2026.2.6-3",
-  "description": "WhatsApp gateway CLI (Baileys web) with Pi RPC agent",
+  "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "license": "MIT",
   "author": "",

--- a/src/utils/time-format.ts
+++ b/src/utils/time-format.ts
@@ -1,6 +1,0 @@
-import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
-
-/** Delegates to centralized formatRelativeTimestamp with date fallback for >7d. */
-export function formatRelativeTime(timestamp: number): string {
-  return formatRelativeTimestamp(timestamp, { dateFallback: true, fallback: "unknown" });
-}

--- a/ui/vitest.node.config.ts
+++ b/ui/vitest.node.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 // Node-only tests for pure logic (no Playwright/browser dependency).
 export default defineConfig({
   test: {
+    testTimeout: 120_000,
     include: ["src/**/*.node.test.ts"],
     environment: "node",
   },

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -7,7 +7,7 @@ const cpuCount = os.cpus().length;
 const e2eWorkers = isCI ? 2 : Math.min(4, Math.max(1, Math.floor(cpuCount * 0.25)));
 
 const baseTest = (baseConfig as { test?: { exclude?: string[] } }).test ?? {};
-const exclude = baseTest.exclude ?? [];
+const exclude = (baseTest.exclude ?? []).filter((p) => p !== "**/*.e2e.test.ts");
 
 export default defineConfig({
   ...baseConfig,

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,22 +1,20 @@
 import os from "node:os";
 import { defineConfig } from "vitest/config";
+import baseConfig from "./vitest.config.ts";
 
 const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
 const cpuCount = os.cpus().length;
 const e2eWorkers = isCI ? 2 : Math.min(4, Math.max(1, Math.floor(cpuCount * 0.25)));
 
+const baseTest = (baseConfig as { test?: { exclude?: string[] } }).test ?? {};
+const exclude = baseTest.exclude ?? [];
+
 export default defineConfig({
+  ...baseConfig,
   test: {
-    pool: "forks",
+    ...baseTest,
     maxWorkers: e2eWorkers,
     include: ["test/**/*.e2e.test.ts", "src/**/*.e2e.test.ts"],
-    setupFiles: ["test/setup.ts"],
-    exclude: [
-      "dist/**",
-      "apps/macos/**",
-      "apps/macos/.build/**",
-      "**/vendor/**",
-      "dist/OpenClaw.app/**",
-    ],
+    exclude,
   },
 });

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 import baseConfig from "./vitest.config.ts";
 
 const baseTest = (baseConfig as { test?: { exclude?: string[] } }).test ?? {};
-const exclude = baseTest.exclude ?? [];
+const exclude = (baseTest.exclude ?? []).filter((p) => p !== "**/*.live.test.ts");
 
 export default defineConfig({
   ...baseConfig,

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -1,17 +1,15 @@
 import { defineConfig } from "vitest/config";
+import baseConfig from "./vitest.config.ts";
+
+const baseTest = (baseConfig as { test?: { exclude?: string[] } }).test ?? {};
+const exclude = baseTest.exclude ?? [];
 
 export default defineConfig({
+  ...baseConfig,
   test: {
-    pool: "forks",
+    ...baseTest,
     maxWorkers: 1,
     include: ["src/**/*.live.test.ts"],
-    setupFiles: ["test/setup.ts"],
-    exclude: [
-      "dist/**",
-      "apps/macos/**",
-      "apps/macos/.build/**",
-      "**/vendor/**",
-      "dist/OpenClaw.app/**",
-    ],
+    exclude,
   },
 });


### PR DESCRIPTION
## Summary

Fixes standalone vitest configs that were missing timeouts and aliases, updates the stale npm package description, and deduplicates types in extensions.

## Changes

### Vitest Configs
- **vitest.live.config.ts** and **vitest.e2e.config.ts** now extend root config via `...baseConfig` and `...baseTest`
- Inherits `testTimeout: 120_000` (was defaulting to Vitest's 5s)
- Inherits `resolve.alias` for `openclaw/plugin-sdk`
- Inherits `pool: "forks"`, `setupFiles`, and exclude patterns
- Filters inherited excludes to not exclude `.live.test.ts` / `.e2e.test.ts` patterns in their respective configs
- **ui/vitest.node.config.ts** gets explicit 120s timeout (can't extend root since UI root pulls in Playwright browser config)

### Package Description
- Updated from `"WhatsApp gateway CLI (Baileys web) with Pi RPC agent"` to `"Multi-channel AI gateway with extensible messaging integrations"`

### Type Deduplication
- **extensions/matrix/src/types.ts** and **extensions/bluebubbles/src/types.ts** now re-export `GroupPolicy` and `DmPolicy` from `openclaw/plugin-sdk` instead of re-declaring identical types
- Updated **extensions/matrix/src/onboarding.ts** to import `DmPolicy` from `openclaw/plugin-sdk`

### Cleanup
- Removed unused `src/utils/time-format.ts` (dead code from prior refactor)

---

**Note on `NormalizedChatType` vs `RoutePeerKind`:** These two types represent the same concept but use `"direct"` vs `"dm"` respectively. `NormalizedChatType` is dominant (19 refs, exposed in plugin SDK) while `RoutePeerKind` is internal to routing (5 refs). Unifying them would require touching 100+ literal `"dm"` usages across many channels. Deferring to a separate PR.