### PR TITLE
fix: guard .trim() on undefined values in subagent system prompt + spawn path

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -147,7 +147,7 @@ function resolveRequesterStoreKey(
   cfg: ReturnType<typeof loadConfig>,
   requesterSessionKey: string,
 ): string {
-  const raw = requesterSessionKey.trim();
+  const raw = (requesterSessionKey ?? "").trim();
   if (!raw) {
     return raw;
   }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -717,7 +717,7 @@ export function markSubagentRunTerminated(params: {
 }
 
 export function listSubagentRunsForRequester(requesterSessionKey: string): SubagentRunRecord[] {
-  const key = requesterSessionKey.trim();
+  const key = (requesterSessionKey ?? "").trim();
   if (!key) {
     return [];
   }

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -216,7 +216,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
     const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(request.attachments);
 
-    let message = request.message.trim();
+    let message = (request.message ?? "").trim();
     let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
     if (normalizedAttachments.length > 0) {
       try {
@@ -663,7 +663,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       return;
     }
     const p = params;
-    const runId = p.runId.trim();
+    const runId = (p.runId ?? "").trim();
     const timeoutMs =
       typeof p.timeoutMs === "number" && Number.isFinite(p.timeoutMs)
         ? Math.max(0, Math.floor(p.timeoutMs))

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -425,7 +425,7 @@ export function resolveSessionStoreKey(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
 }): string {
-  const raw = params.sessionKey.trim();
+  const raw = (params.sessionKey ?? "").trim();
   if (!raw) {
     return raw;
   }


### PR DESCRIPTION
## Summary

Sub-agent sessions crash at ~34ms during `buildAgentSystemPrompt()` because context file entries can have `path: undefined`. The `.trim()` call on `file.path` throws `Cannot read properties of undefined (reading 'trim')`.

Main sessions never hit this because their context files always have valid paths. Sub-agent sessions have entries with `path: undefined` — specifically from injected workspace context.

## Root Cause

`buildAgentSystemPrompt()` in `src/agents/system-prompt.ts` calls `file.path.trim()` (line ~555) and uses `file.path` in a template literal (line ~567) without null checks. Sub-agent context file arrays include entries where `path` is undefined.

Stack trace from production:
```
at buildAgentSystemPrompt (system-prompt.ts:555)
at buildEmbeddedSystemPrompt
at runEmbeddedAttempt
```

## Fix

- Guard `file.path.trim()` → `(file.path ?? "").trim()` in `system-prompt.ts`
- Guard `file.path` in template literal → `(file.path ?? "unknown")`
- Apply same defensive pattern to 4 additional `.trim()` calls in the subagent spawn/announce path:
  - `src/gateway/server-methods/agent.ts` (request.message, p.runId)
  - `src/gateway/session-utils.ts` (params.sessionKey)
  - `src/agents/subagent-registry.ts` (requesterSessionKey)
  - `src/agents/subagent-announce.ts` (requesterSessionKey)

## Testing

- Confirmed sub-agents crash **before** fix (immediate crash at 34ms, no transcript created)
- Confirmed sub-agents spawn successfully **after** fix (tested with trivial task, completes in ~2s)
- Build passes (`pnpm build` clean, `pnpm check` no warnings)
- Existing tests pass (`deliver.test.ts` 12/12)

## Related Issues

Fixes sub-agent spawn crash. No existing issue found — this appears to be an unreported regression where context file entries lack a `path` property.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens several request/session/system-prompt code paths against `undefined` inputs by guarding `.trim()` calls (notably in `buildAgentSystemPrompt` for injected context files, and in gateway agent request handling / session key normalization). The primary goal is preventing sub-agent sessions from crashing when context file entries (from injected workspace context) lack a `path`.

The approach is consistently to coerce possibly-undefined strings to `""` before trimming. One behavioral change to double-check is the system-prompt rendering fallback for missing context file paths, which now prints a literal `"undefined"` heading; that will affect the text seen by the model and may not be the intended placeholder.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and addresses the reported crash, with one small prompt-output behavior to confirm.
- All changes are narrow defensive guards around `.trim()` and should prevent the runtime exception that was crashing sub-agent startup. The only notable behavior change is that missing context file paths are now rendered as the literal string `"undefined"` in the system prompt, which is user/model-visible text and may be unintended vs a neutral placeholder.
- src/agents/system-prompt.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->