### PR TITLE
Add Pre-Reset Hook

### DIFF
--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -78,6 +78,21 @@ export type SessionResetByTypeConfig = {
   thread?: SessionResetConfig;
 };
 
+/**
+ * Pre-reset hook configuration.
+ * When enabled, triggers an agent turn before session reset to allow wrap-up tasks.
+ */
+export type SessionPreResetConfig = {
+  /** Enable the pre-reset hook. Default: false */
+  enabled?: boolean;
+  /** Prompt to send to the agent before reset */
+  prompt?: string;
+  /** Timeout in seconds for the agent turn. Default: 30 */
+  timeoutSeconds?: number;
+  /** Skip hook if session has no messages. Default: true */
+  skipIfEmpty?: boolean;
+};
+
 export type SessionConfig = {
   scope?: SessionScope;
   /** DM session scoping (default: "main"). */
@@ -90,6 +105,8 @@ export type SessionConfig = {
   resetByType?: SessionResetByTypeConfig;
   /** Channel-specific reset overrides (e.g. { discord: { mode: "idle", idleMinutes: 10080 } }). */
   resetByChannel?: Record<string, SessionResetConfig>;
+  /** Pre-reset hook: trigger agent turn before session reset for wrap-up tasks */
+  preReset?: SessionPreResetConfig;
   store?: string;
   typingIntervalSeconds?: number;
   typingMode?: TypingMode;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -18,6 +18,23 @@ const SessionResetConfigSchema = z
   })
   .strict();
 
+/**
+ * Pre-reset hook configuration.
+ * When enabled, triggers an agent turn before session reset to allow wrap-up tasks.
+ */
+export const SessionPreResetConfigSchema = z
+  .object({
+    /** Enable the pre-reset hook. Default: false */
+    enabled: z.boolean().optional(),
+    /** Prompt to send to the agent before reset */
+    prompt: z.string().optional(),
+    /** Timeout in seconds for the agent turn. Default: 30 */
+    timeoutSeconds: z.number().int().min(5).max(120).optional(),
+    /** Skip hook if session has no messages. Default: true */
+    skipIfEmpty: z.boolean().optional(),
+  })
+  .strict();
+
 export const SessionSendPolicySchema = z
   .object({
     default: z.union([z.literal("allow"), z.literal("deny")]).optional(),
@@ -75,6 +92,8 @@ export const SessionSchema = z
       .strict()
       .optional(),
     resetByChannel: z.record(z.string(), SessionResetConfigSchema).optional(),
+    /** Pre-reset hook: trigger agent turn before session reset for wrap-up tasks */
+    preReset: SessionPreResetConfigSchema.optional(),
     store: z.string().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: z

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -14,6 +14,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { runPreResetHook } from "../../sessions/pre-reset-hook.js";
 import {
   ErrorCodes,
   errorShape,
@@ -281,6 +282,18 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const storePath = target.storePath;
     let oldSessionId: string | undefined;
     let oldSessionFile: string | undefined;
+
+    // Pre-reset hook: trigger an agent turn before resetting (best-effort, non-blocking)
+    const store = loadSessionStore(storePath);
+    const hookEntry = store[target.canonicalKey];
+    await runPreResetHook({
+      cfg,
+      sessionKey: key,
+      sessionEntry: hookEntry,
+      storePath,
+      agentId: target.agentId,
+    });
+
     const next = await updateSessionStore(storePath, (store) => {
       const { primaryKey } = migrateAndPruneSessionStoreKey({ cfg, key, store });
       const entry = store[primaryKey];

--- a/src/sessions/pre-reset-hook.ts
+++ b/src/sessions/pre-reset-hook.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
+import { callGateway } from "../gateway/call.js";
+import { resolveSessionTranscriptCandidates } from "../gateway/session-utils.fs.js";
+import { logDebug, logInfo, logWarn } from "../logger.js";
+
+/**
+ * Run the pre-reset hook (best-effort, non-blocking) before a session reset.
+ * Triggers an agent turn with the configured prompt so the agent can write
+ * notes to memory before the session is cleared.
+ *
+ * Returns `true` if the hook ran (regardless of outcome), `false` if skipped.
+ */
+export async function runPreResetHook(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  sessionEntry?: SessionEntry;
+  storePath?: string;
+  agentId?: string;
+}): Promise<boolean> {
+  const { cfg, sessionKey, sessionEntry, storePath, agentId } = params;
+  const preResetConfig = cfg.session?.preReset;
+  if (!preResetConfig?.enabled || !preResetConfig.prompt) {
+    return false;
+  }
+
+  const timeoutSeconds = preResetConfig.timeoutSeconds ?? 30;
+  const timeoutMs = timeoutSeconds * 1000;
+
+  // Check if we should skip due to empty session
+  if (preResetConfig.skipIfEmpty !== false) {
+    const sessionId = sessionEntry?.sessionId;
+    if (!sessionId) {
+      logDebug(`[pre-reset] Skipping hook for session ${sessionKey} (no session id)`);
+      return false;
+    }
+    const candidates = resolveSessionTranscriptCandidates(
+      sessionId,
+      storePath,
+      sessionEntry?.sessionFile,
+      agentId,
+    );
+    const transcriptPath = candidates.find((c) => fs.existsSync(c));
+    if (!transcriptPath) {
+      logDebug(`[pre-reset] Skipping hook for session ${sessionKey} (no transcript)`);
+      return false;
+    }
+    try {
+      const stat = fs.statSync(transcriptPath);
+      if (stat.size < 100) {
+        logDebug(`[pre-reset] Skipping hook for session ${sessionKey} (transcript too small)`);
+        return false;
+      }
+    } catch {
+      logDebug(`[pre-reset] Skipping hook for session ${sessionKey} (transcript stat failed)`);
+      return false;
+    }
+  }
+
+  logInfo(`[pre-reset] Running pre-reset hook for session: ${sessionKey}`);
+  try {
+    await Promise.race([
+      callGateway({
+        method: "agent",
+        params: {
+          message: preResetConfig.prompt,
+          sessionKey,
+          deliver: false,
+          lane: "pre-reset",
+          idempotencyKey: randomUUID(),
+        },
+        timeoutMs: timeoutMs + 5000,
+        expectFinal: true,
+      }),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("pre-reset timeout")), timeoutMs),
+      ),
+    ]);
+    logInfo(`[pre-reset] Hook completed successfully for session: ${sessionKey}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logWarn(
+      `[pre-reset] Hook failed for session ${sessionKey}: ${message} (continuing with reset)`,
+    );
+  }
+  return true;
+}


### PR DESCRIPTION
The agent isn't very vigilant about committing things to memory, and it's unnatural to force them to write to memory while they are still working. It also leads to a journal littered with exploration dead ends.

A more productive way would be to ask them to summarize notable things after the session breaks. It's possible to do this for implicit breaks using heartbeats, but for explicit `/reset` initiated by user, the context is immediately wiped.

A pre-reset hook allows the agent to be prompted to commit important bits they have learned, and/or unfinished businesses, to memory, in order that they will make future sessions more relevant. This is an optional setting which has no effect if unset.

Fully tested, has been running in my local instance for almost a week.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an optional `session.preReset` config (types + zod schema) and wires a new `runPreResetHook()` into both chat-triggered resets (`initSessionState` on `/reset`-style triggers) and the gateway `sessions.reset` endpoint. The hook performs a best-effort agent turn (non-delivered) with a configurable prompt and timeout, intended to let the agent write wrap-up notes to memory before the session is cleared.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is at least one correctness issue in the gateway reset hook wiring that can cause the hook to be skipped unexpectedly.
- The feature is isolated and guarded by config, but the gateway `sessions.reset` path appears to load the session entry using the raw request key rather than the resolved canonical key, which can yield an undefined entry and cause `skipIfEmpty` to skip incorrectly. Aside from that, the hook is best-effort and failures are contained/logged.
- src/gateway/server-methods/sessions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->