### PR TITLE
fix(ollama): accept /model directive for configured providers

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -363,6 +363,20 @@ export function resolveModelSelectionFromDirective(params: {
           explicit.ref.model === params.defaultModel,
         ...(explicit.alias ? { alias: explicit.alias } : {}),
       };
+    } else {
+      // Allow any model from explicitly configured providers (e.g. ollama)
+      // even if not in the curated catalog
+      const configuredProviders = (params.cfg.models?.providers ?? {}) as Record<string, unknown>;
+      if (configuredProviders[normalizeProviderId(explicit.ref.provider)] != null) {
+        modelSelection = {
+          provider: explicit.ref.provider,
+          model: explicit.ref.model,
+          isDefault:
+            explicit.ref.provider === params.defaultProvider &&
+            explicit.ref.model === params.defaultModel,
+          ...(explicit.alias ? { alias: explicit.alias } : {}),
+        };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

When using `/model ollama/modelname`, the directive was rejected because the model wasn't in the curated catalog (`models.json`), even though the Ollama provider was explicitly configured in `openclaw.json`.

This PR adds a fallback check: if a model isn't in the catalog but the provider is explicitly configured, allow the directive.

## Changes

- Added fallback check in `directive-handling.model.ts` to allow models from configured providers

## Test Plan

1. Configure Ollama provider in `openclaw.json` without listing every model
2. Use `/model ollama/some-dynamic-model` 
3. Verify the model switch is accepted

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates model directive handling so that `/model <provider>/<model>` is accepted even when the specified model isn’t in the curated catalog, as long as the provider is explicitly configured in `openclaw.json` (intended to support dynamic providers like Ollama).

The key behavioral change is in `resolveModelSelectionFromDirective`, where a new fallback checks `cfg.models.providers` to allow provider/model pairs that would otherwise be rejected by the allowlist check against `allowedModelKeys`.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after fixing an allowlist-bypass behavior change in /model directives.
- The change is small and localized, but the new fallback currently permits selecting arbitrary models for any configured provider even when an explicit allowlist is present, which contradicts existing allowlist enforcement and could weaken intended restrictions.
- src/auto-reply/reply/directive-handling.model.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->