### PR TITLE
fix(ollama): don't auto-enable enforceFinalTag for Ollama models

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -6,7 +6,6 @@ import type { ReplyPayload } from "../types.js";
 import type { FollowupRun } from "./queue.js";
 import { getChannelDock } from "../../channels/dock.js";
 import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/registry.js";
-import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 
 const BUN_FETCH_SOCKET_ERROR_RE = /socket connection was closed unexpectedly/i;
@@ -132,5 +131,8 @@ export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPa
   return updated;
 };
 
-export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string) =>
-  Boolean(run.enforceFinalTag || isReasoningTagProvider(provider));
+// NOTE: enforceFinalTag requires models to wrap response in <final> tags.
+// Most providers (including ollama) use <think> tags but NOT <final> tags.
+// Only honor explicit run.enforceFinalTag, don't auto-enable based on provider.
+export const resolveEnforceFinalTag = (run: FollowupRun["run"], _provider: string) =>
+  Boolean(run.enforceFinalTag);

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -23,7 +23,6 @@ import {
 import { logVerbose } from "../../globals.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
-import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
 import { buildInboundMediaNote } from "../media-note.js";
 import {
@@ -401,7 +400,11 @@ export async function runPreparedReply(
       blockReplyBreak: resolvedBlockStreamingBreak,
       ownerNumbers: command.ownerList.length > 0 ? command.ownerList : undefined,
       extraSystemPrompt: extraSystemPrompt || undefined,
-      ...(isReasoningTagProvider(provider) ? { enforceFinalTag: true } : {}),
+      // NOTE: enforceFinalTag requires models to wrap response in <final> tags.
+      // Most providers (including ollama) use <think> tags but NOT <final> tags,
+      // so we don't set this automatically. If enabled incorrectly, all response
+      // content gets stripped because stripBlockTags returns empty when no <final>
+      // tags are found. Only enable this for providers known to emit <final> tags.
     },
   };
 


### PR DESCRIPTION
## Summary

`isReasoningTagProvider("ollama")` returns true for ALL Ollama models, which auto-enabled `enforceFinalTag`. This requires LLM output to be wrapped in `<final>` tags.

However, Ollama models (including reasoning models like deepseek-r1) use `<think>` tags for reasoning but output the final response as **plain text** - they do NOT wrap output in `<final>` tags. With `enforceFinalTag` enabled, `stripBlockTags` returned an empty string since no `<final>` tags were found, resulting in silent empty responses.

## Changes

- Removed automatic `enforceFinalTag: true` based on provider in `get-reply-run.ts`
- Changed `resolveEnforceFinalTag` in `agent-runner-utils.ts` to only honor explicit `run.enforceFinalTag` configuration
- The `<think>` tag stripping still works correctly without `enforceFinalTag`

## Test Plan

1. Configure an Ollama model (e.g., `gemma3`)
2. Send a message via the dashboard chat
3. Verify the response is displayed correctly (not empty)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change removes provider-based auto-enabling of `enforceFinalTag` for embedded Pi runs.

- In `src/auto-reply/reply/get-reply-run.ts`, the code no longer injects `enforceFinalTag: true` when `isReasoningTagProvider(provider)` is true.
- In `src/auto-reply/reply/agent-runner-utils.ts`, `resolveEnforceFinalTag` now only returns `true` when `run.enforceFinalTag` is explicitly set, rather than inferring it from the provider.

This is intended to prevent Ollama outputs from being stripped to an empty string when models emit `<think>` but do not wrap final output in `<final>` tags.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a behavior change that likely breaks existing reasoning-tag provider expectations and associated tests.
- The change removes all provider-based enforcement of `enforceFinalTag`, but the repository includes tests asserting that fallback reasoning-tag providers must run with `enforceFinalTag: true`. Unless call sites are updated to set `run.enforceFinalTag` for those providers, this alters behavior and will likely cause test failures or incorrect output parsing for providers that rely on `<final>` tags.
- src/auto-reply/reply/agent-runner-utils.ts, src/auto-reply/reply/get-reply-run.ts, and any tests/logic relying on isReasoningTagProvider-based enforcement (e.g. src/auto-reply/reply/agent-runner.reasoning-tags.test.ts)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->