### PR TITLE
feat(ollama): auto-detect vision capability via /api/show

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -122,7 +122,7 @@ export async function compactEmbeddedPiSessionDirect(
   const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
   const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
   await ensureOpenClawModelsJson(params.config, agentDir);
-  const { model, error, authStorage, modelRegistry } = resolveModel(
+  const { model, error, authStorage, modelRegistry } = await resolveModel(
     provider,
     modelId,
     agentDir,

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -116,7 +116,7 @@ describe("buildInlineProviderModels", () => {
 });
 
 describe("resolveModel", () => {
-  it("includes provider baseUrl in fallback model", () => {
+  it("includes provider baseUrl in fallback model", async () => {
     const cfg = {
       models: {
         providers: {
@@ -128,14 +128,14 @@ describe("resolveModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = resolveModel("custom", "missing-model", "/tmp/agent", cfg);
+    const result = await resolveModel("custom", "missing-model", "/tmp/agent", cfg);
 
     expect(result.model?.baseUrl).toBe("http://localhost:9000");
     expect(result.model?.provider).toBe("custom");
     expect(result.model?.id).toBe("missing-model");
   });
 
-  it("builds an openai-codex fallback for gpt-5.3-codex", () => {
+  it("builds an openai-codex fallback for gpt-5.3-codex", async () => {
     const templateModel = {
       id: "gpt-5.2-codex",
       name: "GPT-5.2 Codex",
@@ -158,7 +158,7 @@ describe("resolveModel", () => {
       }),
     } as unknown as ReturnType<typeof discoverModels>);
 
-    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+    const result = await resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
 
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject({
@@ -172,7 +172,7 @@ describe("resolveModel", () => {
     });
   });
 
-  it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
+  it("builds an anthropic forward-compat fallback for claude-opus-4-6", async () => {
     const templateModel = {
       id: "claude-opus-4-5",
       name: "Claude Opus 4.5",
@@ -195,7 +195,7 @@ describe("resolveModel", () => {
       }),
     } as unknown as ReturnType<typeof discoverModels>);
 
-    const result = resolveModel("anthropic", "claude-opus-4-6", "/tmp/agent");
+    const result = await resolveModel("anthropic", "claude-opus-4-6", "/tmp/agent");
 
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject({
@@ -207,13 +207,13 @@ describe("resolveModel", () => {
     });
   });
 
-  it("keeps unknown-model errors for non-gpt-5 openai-codex ids", () => {
-    const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
+  it("keeps unknown-model errors for non-gpt-5 openai-codex ids", async () => {
+    const result = await resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: openai-codex/gpt-4.1-mini");
   });
 
-  it("uses codex fallback even when openai-codex provider is configured", () => {
+  it("uses codex fallback even when openai-codex provider is configured", async () => {
     // This test verifies the ordering: codex fallback must fire BEFORE the generic providerCfg fallback.
     // If ordering is wrong, the generic fallback would use api: "openai-responses" (the default)
     // instead of "openai-codex-responses".
@@ -232,7 +232,7 @@ describe("resolveModel", () => {
       find: vi.fn(() => null),
     } as unknown as ReturnType<typeof discoverModels>);
 
-    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent", cfg);
+    const result = await resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent", cfg);
 
     expect(result.error).toBeUndefined();
     expect(result.model?.api).toBe("openai-codex-responses");

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -180,7 +180,7 @@ export async function runEmbeddedPiAgent(
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
       await ensureOpenClawModelsJson(params.config, agentDir);
 
-      const { model, error, authStorage, modelRegistry } = resolveModel(
+      const { model, error, authStorage, modelRegistry } = await resolveModel(
         provider,
         modelId,
         agentDir,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -920,7 +920,7 @@ async function summarizeText(params: {
 
   const startTime = Date.now();
   const { ref } = resolveSummaryModelRef(cfg, config);
-  const resolved = resolveModel(ref.provider, ref.model, undefined, cfg);
+  const resolved = await resolveModel(ref.provider, ref.model, undefined, cfg);
   if (!resolved.model) {
     throw new Error(resolved.error ?? `Unknown summary model: ${ref.provider}/${ref.model}`);
   }


### PR DESCRIPTION
## Summary

For Ollama models not explicitly configured in `openclaw.json`, the `resolveModel()` function falls back with `input: ["text"]` - no image support. This causes pi-ai to filter out all image content before sending to Ollama, even when the underlying model supports vision.

This PR adds automatic vision capability detection by querying Ollama's `/api/show` endpoint.

## Changes

- Added `queryOllamaVisionCapability()` helper that queries Ollama's `/api/show` endpoint to check if a model has `"vision"` in its capabilities
- Made `resolveModel()` async to support the API query
- Updated all callers (`run.ts`, `compact.ts`, `tts.ts`) to await the function
- Updated tests to be async

## How It Works

When falling back for Ollama models not in the explicit config:
1. Query `http://ollama-host/api/show` with the model name
2. Check if `capabilities` array includes `"vision"`
3. If yes, set `input: ["text", "image"]` instead of just `["text"]`

## Test Plan

1. Configure Ollama provider in `openclaw.json` without listing a vision-capable model
2. Use `/model ollama/llava` (or another vision model)
3. Send an image via the dashboard chat
4. Verify the model receives and processes the image

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `resolveModel()` asynchronous so it can query Ollama’s `/api/show` endpoint when falling back to an unconfigured Ollama model, enabling automatic detection of `vision` capability (and therefore allowing `input: ["text", "image"]` in the fallback model). Call sites in the embedded runner (`run.ts`, `compact.ts`) and TTS summarization (`tts.ts`) were updated to `await` the model resolution, and unit tests were adjusted accordingly.

Main concern is the new outbound HTTP call for capability detection: it currently uses raw `fetch()` rather than the project’s guarded fetch utilities/SSRF policy layer. If the Ollama `baseUrl` is configurable in environments where configs are untrusted, this could allow requests to arbitrary/private hosts.

<h3>Confidence Score: 3/5</h3>

- This PR is likely mergeable after addressing a security-relevant fetch/SSRF policy gap in the new Ollama capability probe.
- Core logic changes are localized and call sites were updated to await the new async `resolveModel()`. However, the new `/api/show` probe uses raw `fetch()` and may bypass existing SSRF/network policy protections applied elsewhere to configurable base URLs, which is important to fix before merging.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->