### PR TITLE
fix: add missing error handler to execDocker child process

### DIFF
--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -22,6 +22,7 @@ export function execDocker(args: string[], opts?: { allowFailure?: boolean }) {
     child.stderr?.on("data", (chunk) => {
       stderr += chunk.toString();
     });
+    child.on("error", (err) => reject(err));
     child.on("close", (code) => {
       const exitCode = code ?? 0;
       if (exitCode !== 0 && !opts?.allowFailure) {


### PR DESCRIPTION
## Summary
- `execDocker()` in `src/agents/sandbox/docker.ts` only attaches a `close` event handler to the spawned child process
- If `docker` is not installed or cannot be executed, `spawn` emits an `error` event (ENOENT) that goes unhandled — the returned Promise hangs indefinitely and Node.js may crash with an unhandled exception
- Adds `child.on("error", reject)` to match the pattern used by other spawn callsites in the project (`bash-tools.exec.ts:767`, `runner.ts:474`, `entry.ts:67`, etc.)

## Test plan
- [x] Existing sandbox tests pass
- [x] One-line change, follows established project pattern

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `execDocker()` (`src/agents/sandbox/docker.ts`) to attach an `error` event handler to the spawned `docker` child process (`child.on("error", reject)`). This ensures the returned Promise rejects (instead of hanging / crashing on an unhandled error event) when `spawn("docker", ...)` fails immediately (e.g., `ENOENT` when Docker is not installed or executable). The change aligns `execDocker()` with other spawn callsites in the repo that already handle `error` events.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, targeted addition that fixes a definite failure mode (unhandled child process `error` events) without altering normal-success behavior. It matches established patterns for `spawn()` usage and narrows the chance of hung Promises or process crashes when Docker is missing/unexecutable.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->