### PR TITLE
fix: guard decodeURIComponent against malformed percent-encoding in browser relay

### DIFF
--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -429,7 +429,14 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
     const activateMatch = path.match(/^\/json\/activate\/(.+)$/);
     if (activateMatch && (req.method === "GET" || req.method === "PUT")) {
-      const targetId = decodeURIComponent(activateMatch[1] ?? "").trim();
+      let targetId: string;
+      try {
+        targetId = decodeURIComponent(activateMatch[1] ?? "").trim();
+      } catch {
+        res.writeHead(400);
+        res.end("invalid percent-encoding");
+        return;
+      }
       if (!targetId) {
         res.writeHead(400);
         res.end("targetId required");
@@ -453,7 +460,14 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
     const closeMatch = path.match(/^\/json\/close\/(.+)$/);
     if (closeMatch && (req.method === "GET" || req.method === "PUT")) {
-      const targetId = decodeURIComponent(closeMatch[1] ?? "").trim();
+      let targetId: string;
+      try {
+        targetId = decodeURIComponent(closeMatch[1] ?? "").trim();
+      } catch {
+        res.writeHead(400);
+        res.end("invalid percent-encoding");
+        return;
+      }
       if (!targetId) {
         res.writeHead(400);
         res.end("targetId required");

--- a/src/browser/routes/dispatcher.ts
+++ b/src/browser/routes/dispatcher.ts
@@ -88,7 +88,11 @@ export function createBrowserRouteDispatcher(ctx: BrowserRouteContext) {
         for (const [idx, name] of match.paramNames.entries()) {
           const value = exec[idx + 1];
           if (typeof value === "string") {
-            params[name] = decodeURIComponent(value);
+            try {
+              params[name] = decodeURIComponent(value);
+            } catch {
+              return { status: 400, body: { error: "invalid percent-encoding in path parameter" } };
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- `decodeURIComponent` throws `URIError` on malformed percent-encoded input (e.g. `%E0%A4%A`)
- In `extension-relay.ts`, `decodeURIComponent` is called inside a bare `createServer` request handler with no surrounding try-catch — a crafted URL like `/json/activate/%E0%A4%A` crashes the HTTP server
- In `dispatcher.ts`, `decodeURIComponent` is called before the route handler's try-catch block (line 108), so the error propagates as an unhandled rejection
- Wraps all three callsites in try-catch blocks that return appropriate 400 error responses

## Test plan
- [x] All 169 browser tests pass (28 test files)
- [x] Minimal change — only adds error handling around existing `decodeURIComponent` calls

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the browser-side routing/relay code against `decodeURIComponent` throwing `URIError` on malformed percent-encoded path segments.

- In `src/browser/extension-relay.ts`, the `/json/activate/:id` and `/json/close/:id` handlers now wrap `decodeURIComponent(...)` in a `try/catch` and return an HTTP 400 with a clear error message instead of letting a crafted URL crash the HTTP server.
- In `src/browser/routes/dispatcher.ts`, route param decoding is now guarded similarly; malformed path parameters return a `{ status: 400, body: { error: ... } }` response before the route handler runs.

These changes fit cleanly into the existing request/dispatch flow and are localized to the existing decode callsites.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are tightly scoped to guarding `decodeURIComponent` callsites with `try/catch` and returning 400s on invalid percent-encoding; no control-flow regressions were found in the edited handlers/dispatcher path and behavior is consistent with existing response patterns.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->