### PR TITLE
fix(heartbeat): solve session context loss & wake coalescing drop

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -392,7 +392,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey });
 }
 
 function createApprovalSlug(id: string) {
@@ -415,7 +415,7 @@ function emitExecSystemEvent(text: string, opts: { sessionKey?: string; contextK
     return;
   }
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 async function runExecProcess(opts: {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -61,7 +61,10 @@ describe("node exec events", () => {
       "Exec started (node=node-1 id=run-1): ls -la",
       { sessionKey: "agent:main:main", contextKey: "exec:run-1" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+    });
   });
 
   it("enqueues exec.finished events with output", async () => {
@@ -80,7 +83,10 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "node-node-2", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("enqueues exec.denied events with reason", async () => {
@@ -99,6 +105,9 @@ describe("node exec events", () => {
       "Exec denied (node=node-3 id=run-3, allowlist-miss): rm -rf /",
       { sessionKey: "agent:demo:main", contextKey: "exec:run-3" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:demo:main",
+    });
   });
 });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -239,7 +239,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event" });
+      requestHeartbeatNow({ reason: "exec-event", sessionKey });
       return;
     }
     default:

--- a/src/infra/heartbeat-wake.coalesce.test.ts
+++ b/src/infra/heartbeat-wake.coalesce.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requestHeartbeatNow, setHeartbeatWakeHandler } from "./heartbeat-wake.js";
+
+describe("Heartbeat Wake Coalescing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    setHeartbeatWakeHandler(null);
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("processes all unique session keys when requests are coalesced", async () => {
+    // Setup a handler that resolves successfully
+    const handler = vi.fn().mockResolvedValue({ status: "ran" as const, durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    // Call requestHeartbeatNow multiple times with different session keys
+    // within the default coalesce window (250ms)
+    requestHeartbeatNow({ reason: "exec-1", sessionKey: "session-A" });
+    requestHeartbeatNow({ reason: "exec-2", sessionKey: "session-B" });
+
+    // Advance time past the coalesce window
+    await vi.advanceTimersByTimeAsync(300);
+
+    // Collect all sessionKeys passed to the handler
+    // The handler now receives sessionKeys: string[]
+    const calledSessionKeys = handler.mock.calls
+      .flatMap((call) => call[0].sessionKeys || [])
+      .filter((key): key is string => key !== undefined);
+
+    // Expect both "session-A" and "session-B" to have been processed.
+    expect(calledSessionKeys).toContain("session-A");
+    expect(calledSessionKeys).toContain("session-B");
+    expect(calledSessionKeys.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## 📝 Description
This PR addresses two critical issues in the heartbeat/runner infrastructure that prevented asynchronous execution results (e.g., `exec` after approval) from reaching users in non-main sessions (Discord channels, DMs, Slack).

1. **Session Context Loss**: Previously, the heartbeat runner defaulted to the `Main Session`, ignoring the specific session queue where the async result was actually deposited.
2. **Wake Coalescing Race Condition**: The `pendingSessionKey` was a single value. Multiple heartbeat requests within the 250ms coalesce window would overwrite each other, causing all but the last session to be "forgotten" until a subsequent wake.

## 🛠 Changes

### 1. Infrastructure (`infra/`)
- **`heartbeat-wake.ts`**: 
    - Upgraded `pendingSessionKey` (string) to `pendingSessionKeys` (**`Set<string>`**).
    - `requestHeartbeatNow` now adds keys to the set, ensuring no session is dropped during the debounce period.
    - If a wake is skipped due to `requests-in-flight`, keys are preserved in the set for the next retry.
- **`heartbeat-runner.ts`**: 
    - **Updated heartbeat runner logic** to iterate through the provided `sessionKeys` list and pass specific keys to `runHeartbeatOnce`, enabling targeted queue processing.
    - Enhanced `resolveHeartbeatSession` to prioritize `overrideSessionKey` when directed routing is active.

### 2. Tools & Gateway (`agents/`, `gateway/`)
- **`bash-tools.exec.ts`**: Captures and propagates the `sessionKey` during `emitExecSystemEvent` and `maybeNotifyOnExit`.
- **`server-node-events.ts`**: Ensures `exec.finished/started/denied` events carry the originating `sessionKey` to the heartbeat system.

### 3. Testing (`test/`)
- **Added**: `heartbeat-wake.coalesce.test.ts` to verify that concurrent wake requests are correctly merged into a `Set` without data loss.
- **Updated**: `server-node-events.test.ts` assertions to validate session-aware routing.

## 🤖 AI/Vibe-Coding Transparency
- **AI-Assisted**: Yes (Opencode / Gemini 3.0 Pro + Claude Opus 4.5).
- **Insight**: AI identified that the global singleton `pendingSessionKey` created a bottleneck for concurrent users. 
- **Understanding**: I have reviewed the `Set`-based implementation and confirmed it correctly handles the "Last Writer Wins" flaw while maintaining backward compatibility with the main polling loop.

## 🧪 Testing (Fully Tested)
- [x] **Concurrency Test**: Verified multiple Discord sessions completing `exec` tasks simultaneously; all received replies.
- [x] **Build & Lint**: `pnpm build && pnpm check` (Fixed formatting in `heartbeat-runner.ts`). **Status: Pass**.
- [x] **Unit Tests**: `pnpm test`. **Status: Pass**. (Added regression tests for coalescing).

## 💡 Why this matters
Restores the feedback loop for async actions. Users in DMs or sub-channels will no longer be "ghosted" by the bot after approving sensitive commands.
Fixes #14191