### PR TITLE
fix(chat): filter HEARTBEAT_OK messages in chat.history when showOk is false

### DIFF
--- a/src/gateway/server-methods/chat.heartbeat-filter.test.ts
+++ b/src/gateway/server-methods/chat.heartbeat-filter.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "vitest";
+import { HEARTBEAT_TOKEN } from "../../auto-reply/tokens.js";
+
+// Inline the helper functions for testing (same logic as in chat.ts)
+function isHeartbeatOnlyMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
+  if (role !== "assistant") {
+    return false;
+  }
+
+  if (typeof entry.content === "string") {
+    const trimmed = entry.content.trim();
+    return trimmed === HEARTBEAT_TOKEN || trimmed.startsWith(`${HEARTBEAT_TOKEN}\n`);
+  }
+
+  if (Array.isArray(entry.content)) {
+    const textParts = entry.content
+      .filter(
+        (item) => item && typeof item === "object" && (item as { type?: string }).type === "text",
+      )
+      .map((item) => ((item as { text?: string }).text ?? "").trim())
+      .filter((t) => t.length > 0);
+    if (textParts.length === 0) {
+      return false;
+    }
+    const combined = textParts.join(" ").trim();
+    return combined === HEARTBEAT_TOKEN || combined.startsWith(`${HEARTBEAT_TOKEN} `);
+  }
+
+  return false;
+}
+
+function filterHeartbeatMessages(messages: unknown[], showOk: boolean): unknown[] {
+  if (showOk) {
+    return messages;
+  }
+  return messages.filter((msg) => !isHeartbeatOnlyMessage(msg));
+}
+
+describe("chat.history heartbeat filtering", () => {
+  test("isHeartbeatOnlyMessage returns true for assistant HEARTBEAT_OK string content", () => {
+    const msg = { role: "assistant", content: "HEARTBEAT_OK" };
+    expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+  });
+
+  test("isHeartbeatOnlyMessage returns true for assistant HEARTBEAT_OK with whitespace", () => {
+    const msg = { role: "assistant", content: "  HEARTBEAT_OK  " };
+    expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+  });
+
+  test("isHeartbeatOnlyMessage returns true for assistant HEARTBEAT_OK with trailing newline content", () => {
+    const msg = { role: "assistant", content: "HEARTBEAT_OK\n" };
+    expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+  });
+
+  test("isHeartbeatOnlyMessage returns false for assistant with additional content", () => {
+    const msg = { role: "assistant", content: "HEARTBEAT_OK but also this message" };
+    expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+  });
+
+  test("isHeartbeatOnlyMessage returns false for user messages", () => {
+    const msg = { role: "user", content: "HEARTBEAT_OK" };
+    expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+  });
+
+  test("isHeartbeatOnlyMessage returns true for array content with single HEARTBEAT_OK text block", () => {
+    const msg = {
+      role: "assistant",
+      content: [{ type: "text", text: "HEARTBEAT_OK" }],
+    };
+    expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+  });
+
+  test("isHeartbeatOnlyMessage returns false for array content with real message", () => {
+    const msg = {
+      role: "assistant",
+      content: [{ type: "text", text: "Here's a helpful response." }],
+    };
+    expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+  });
+
+  test("isHeartbeatOnlyMessage returns false for empty content", () => {
+    const msg = { role: "assistant", content: [] };
+    expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+  });
+
+  test("filterHeartbeatMessages removes HEARTBEAT_OK when showOk is false", () => {
+    const messages = [
+      { role: "user", content: "ping" },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "Hello! How can I help?" },
+    ];
+    const filtered = filterHeartbeatMessages(messages, false);
+    expect(filtered).toHaveLength(3);
+    expect(filtered.map((m) => (m as { role: string }).role)).toEqual([
+      "user",
+      "user",
+      "assistant",
+    ]);
+  });
+
+  test("filterHeartbeatMessages keeps all messages when showOk is true", () => {
+    const messages = [
+      { role: "user", content: "ping" },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "Hello! How can I help?" },
+    ];
+    const filtered = filterHeartbeatMessages(messages, true);
+    expect(filtered).toHaveLength(4);
+  });
+
+  test("filterHeartbeatMessages handles multiple HEARTBEAT_OK messages", () => {
+    const messages = [
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "assistant", content: "Actual content here" },
+    ];
+    const filtered = filterHeartbeatMessages(messages, false);
+    expect(filtered).toHaveLength(1);
+    expect((filtered[0] as { content: string }).content).toBe("Actual content here");
+  });
+});

--- a/src/gateway/server-methods/chat.heartbeat-filter.test.ts
+++ b/src/gateway/server-methods/chat.heartbeat-filter.test.ts
@@ -1,128 +1,138 @@
 import { describe, expect, test } from "vitest";
-import { HEARTBEAT_TOKEN } from "../../auto-reply/tokens.js";
-
-// Inline the helper functions for testing (same logic as in chat.ts)
-function isHeartbeatOnlyMessage(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const entry = message as Record<string, unknown>;
-  const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
-  if (role !== "assistant") {
-    return false;
-  }
-
-  if (typeof entry.content === "string") {
-    const trimmed = entry.content.trim();
-    return trimmed === HEARTBEAT_TOKEN || trimmed.startsWith(`${HEARTBEAT_TOKEN}\n`);
-  }
-
-  if (Array.isArray(entry.content)) {
-    const textParts = entry.content
-      .filter(
-        (item) => item && typeof item === "object" && (item as { type?: string }).type === "text",
-      )
-      .map((item) => ((item as { text?: string }).text ?? "").trim())
-      .filter((t) => t.length > 0);
-    if (textParts.length === 0) {
-      return false;
-    }
-    const combined = textParts.join(" ").trim();
-    return combined === HEARTBEAT_TOKEN || combined.startsWith(`${HEARTBEAT_TOKEN} `);
-  }
-
-  return false;
-}
-
-function filterHeartbeatMessages(messages: unknown[], showOk: boolean): unknown[] {
-  if (showOk) {
-    return messages;
-  }
-  return messages.filter((msg) => !isHeartbeatOnlyMessage(msg));
-}
+import { isHeartbeatOnlyMessage, filterHeartbeatMessages } from "./chat.js";
 
 describe("chat.history heartbeat filtering", () => {
-  test("isHeartbeatOnlyMessage returns true for assistant HEARTBEAT_OK string content", () => {
-    const msg = { role: "assistant", content: "HEARTBEAT_OK" };
-    expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+  describe("isHeartbeatOnlyMessage", () => {
+    test("returns true for assistant HEARTBEAT_OK string content", () => {
+      const msg = { role: "assistant", content: "HEARTBEAT_OK" };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+    });
+
+    test("returns true for assistant HEARTBEAT_OK with whitespace", () => {
+      const msg = { role: "assistant", content: "  HEARTBEAT_OK  " };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+    });
+
+    test("returns true for assistant HEARTBEAT_OK with trailing newline only", () => {
+      const msg = { role: "assistant", content: "HEARTBEAT_OK\n" };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+    });
+
+    test("returns false for assistant with additional content after newline", () => {
+      // This is the key fix: HEARTBEAT_OK followed by real content should NOT be filtered
+      const msg = { role: "assistant", content: "HEARTBEAT_OK\nActual response here" };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+    });
+
+    test("returns false for assistant with additional content on same line", () => {
+      const msg = { role: "assistant", content: "HEARTBEAT_OK but also this message" };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+    });
+
+    test("returns false for user messages", () => {
+      const msg = { role: "user", content: "HEARTBEAT_OK" };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+    });
+
+    test("returns true for array content with single HEARTBEAT_OK text block", () => {
+      const msg = {
+        role: "assistant",
+        content: [{ type: "text", text: "HEARTBEAT_OK" }],
+      };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(true);
+    });
+
+    test("returns false for array content with HEARTBEAT_OK and additional text block", () => {
+      // This is the key fix: multiple text blocks where one is HEARTBEAT_OK should NOT be filtered
+      const msg = {
+        role: "assistant",
+        content: [
+          { type: "text", text: "HEARTBEAT_OK" },
+          { type: "text", text: "But here's some real content" },
+        ],
+      };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+    });
+
+    test("returns false for array content with real message", () => {
+      const msg = {
+        role: "assistant",
+        content: [{ type: "text", text: "Here's a helpful response." }],
+      };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+    });
+
+    test("returns false for empty array content", () => {
+      const msg = { role: "assistant", content: [] };
+      expect(isHeartbeatOnlyMessage(msg)).toBe(false);
+    });
+
+    test("returns false for null/undefined message", () => {
+      expect(isHeartbeatOnlyMessage(null)).toBe(false);
+      expect(isHeartbeatOnlyMessage(undefined)).toBe(false);
+    });
+
+    test("returns false for non-object message", () => {
+      expect(isHeartbeatOnlyMessage("HEARTBEAT_OK")).toBe(false);
+      expect(isHeartbeatOnlyMessage(123)).toBe(false);
+    });
   });
 
-  test("isHeartbeatOnlyMessage returns true for assistant HEARTBEAT_OK with whitespace", () => {
-    const msg = { role: "assistant", content: "  HEARTBEAT_OK  " };
-    expect(isHeartbeatOnlyMessage(msg)).toBe(true);
-  });
+  describe("filterHeartbeatMessages", () => {
+    test("removes HEARTBEAT_OK when showOk is false", () => {
+      const messages = [
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "HEARTBEAT_OK" },
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "Hello! How can I help?" },
+      ];
+      const filtered = filterHeartbeatMessages(messages, false);
+      expect(filtered).toHaveLength(3);
+      expect(filtered.map((m) => (m as { role: string }).role)).toEqual([
+        "user",
+        "user",
+        "assistant",
+      ]);
+    });
 
-  test("isHeartbeatOnlyMessage returns true for assistant HEARTBEAT_OK with trailing newline content", () => {
-    const msg = { role: "assistant", content: "HEARTBEAT_OK\n" };
-    expect(isHeartbeatOnlyMessage(msg)).toBe(true);
-  });
+    test("keeps all messages when showOk is true", () => {
+      const messages = [
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "HEARTBEAT_OK" },
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "Hello! How can I help?" },
+      ];
+      const filtered = filterHeartbeatMessages(messages, true);
+      expect(filtered).toHaveLength(4);
+    });
 
-  test("isHeartbeatOnlyMessage returns false for assistant with additional content", () => {
-    const msg = { role: "assistant", content: "HEARTBEAT_OK but also this message" };
-    expect(isHeartbeatOnlyMessage(msg)).toBe(false);
-  });
+    test("handles multiple HEARTBEAT_OK messages", () => {
+      const messages = [
+        { role: "assistant", content: "HEARTBEAT_OK" },
+        { role: "assistant", content: "HEARTBEAT_OK" },
+        { role: "assistant", content: "Actual content here" },
+      ];
+      const filtered = filterHeartbeatMessages(messages, false);
+      expect(filtered).toHaveLength(1);
+      expect((filtered[0] as { content: string }).content).toBe("Actual content here");
+    });
 
-  test("isHeartbeatOnlyMessage returns false for user messages", () => {
-    const msg = { role: "user", content: "HEARTBEAT_OK" };
-    expect(isHeartbeatOnlyMessage(msg)).toBe(false);
-  });
+    test("preserves messages with HEARTBEAT_OK prefix followed by real content", () => {
+      // Critical: messages that START with HEARTBEAT_OK but have more content should be kept
+      const messages = [
+        { role: "assistant", content: "HEARTBEAT_OK\nBut I also wanted to mention something" },
+        { role: "assistant", content: "HEARTBEAT_OK" },
+      ];
+      const filtered = filterHeartbeatMessages(messages, false);
+      expect(filtered).toHaveLength(1);
+      expect((filtered[0] as { content: string }).content).toBe(
+        "HEARTBEAT_OK\nBut I also wanted to mention something",
+      );
+    });
 
-  test("isHeartbeatOnlyMessage returns true for array content with single HEARTBEAT_OK text block", () => {
-    const msg = {
-      role: "assistant",
-      content: [{ type: "text", text: "HEARTBEAT_OK" }],
-    };
-    expect(isHeartbeatOnlyMessage(msg)).toBe(true);
-  });
-
-  test("isHeartbeatOnlyMessage returns false for array content with real message", () => {
-    const msg = {
-      role: "assistant",
-      content: [{ type: "text", text: "Here's a helpful response." }],
-    };
-    expect(isHeartbeatOnlyMessage(msg)).toBe(false);
-  });
-
-  test("isHeartbeatOnlyMessage returns false for empty content", () => {
-    const msg = { role: "assistant", content: [] };
-    expect(isHeartbeatOnlyMessage(msg)).toBe(false);
-  });
-
-  test("filterHeartbeatMessages removes HEARTBEAT_OK when showOk is false", () => {
-    const messages = [
-      { role: "user", content: "ping" },
-      { role: "assistant", content: "HEARTBEAT_OK" },
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "Hello! How can I help?" },
-    ];
-    const filtered = filterHeartbeatMessages(messages, false);
-    expect(filtered).toHaveLength(3);
-    expect(filtered.map((m) => (m as { role: string }).role)).toEqual([
-      "user",
-      "user",
-      "assistant",
-    ]);
-  });
-
-  test("filterHeartbeatMessages keeps all messages when showOk is true", () => {
-    const messages = [
-      { role: "user", content: "ping" },
-      { role: "assistant", content: "HEARTBEAT_OK" },
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "Hello! How can I help?" },
-    ];
-    const filtered = filterHeartbeatMessages(messages, true);
-    expect(filtered).toHaveLength(4);
-  });
-
-  test("filterHeartbeatMessages handles multiple HEARTBEAT_OK messages", () => {
-    const messages = [
-      { role: "assistant", content: "HEARTBEAT_OK" },
-      { role: "assistant", content: "HEARTBEAT_OK" },
-      { role: "assistant", content: "Actual content here" },
-    ];
-    const filtered = filterHeartbeatMessages(messages, false);
-    expect(filtered).toHaveLength(1);
-    expect((filtered[0] as { content: string }).content).toBe("Actual content here");
+    test("handles empty message array", () => {
+      const filtered = filterHeartbeatMessages([], false);
+      expect(filtered).toHaveLength(0);
+    });
   });
 });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -189,7 +189,11 @@ function broadcastChatError(params: {
  * Check if a message is an assistant heartbeat-only message (just HEARTBEAT_OK).
  * Returns true if the message should be filtered when showOk is false.
  */
-function isHeartbeatOnlyMessage(message: unknown): boolean {
+/**
+ * Check if a message is a heartbeat-only message (assistant message containing only HEARTBEAT_OK).
+ * Exported for testing.
+ */
+export function isHeartbeatOnlyMessage(message: unknown): boolean {
   if (!message || typeof message !== "object") {
     return false;
   }
@@ -199,13 +203,13 @@ function isHeartbeatOnlyMessage(message: unknown): boolean {
     return false;
   }
 
-  // Check string content
+  // Check string content - must be exactly HEARTBEAT_OK (with optional whitespace)
   if (typeof entry.content === "string") {
     const trimmed = entry.content.trim();
-    return trimmed === HEARTBEAT_TOKEN || trimmed.startsWith(`${HEARTBEAT_TOKEN}\n`);
+    return trimmed === HEARTBEAT_TOKEN;
   }
 
-  // Check array content (text blocks)
+  // Check array content (text blocks) - combined text must be exactly HEARTBEAT_OK
   if (Array.isArray(entry.content)) {
     const textParts = entry.content
       .filter(
@@ -217,7 +221,7 @@ function isHeartbeatOnlyMessage(message: unknown): boolean {
       return false;
     }
     const combined = textParts.join(" ").trim();
-    return combined === HEARTBEAT_TOKEN || combined.startsWith(`${HEARTBEAT_TOKEN} `);
+    return combined === HEARTBEAT_TOKEN;
   }
 
   return false;
@@ -225,8 +229,9 @@ function isHeartbeatOnlyMessage(message: unknown): boolean {
 
 /**
  * Filter heartbeat-only messages from chat history when showOk is false.
+ * Exported for testing.
  */
-function filterHeartbeatMessages(messages: unknown[], showOk: boolean): unknown[] {
+export function filterHeartbeatMessages(messages: unknown[], showOk: boolean): unknown[] {
   if (showOk) {
     return messages;
   }


### PR DESCRIPTION
## Summary

Fixes #11630 - HEARTBEAT_OK messages appearing in webchat after page refresh.

## Problem

The live broadcast path correctly suppresses heartbeat messages via `shouldSuppressHeartbeatBroadcast()`, but `chat.history` returned raw transcript messages with no heartbeat filtering applied.

This caused HEARTBEAT_OK messages to appear in the control-ui chat tab after any page load/refresh, even though they were correctly suppressed in real-time.

## Solution

Apply heartbeat visibility filtering in the `chat.history` handler:

- Check webchat heartbeat visibility using `resolveHeartbeatVisibility({ cfg, channel: "webchat" })`
- When `showOk` is false (the default), filter out assistant messages that are only HEARTBEAT_OK
- This matches the behavior of `shouldSuppressHeartbeatBroadcast()` used for live broadcasts

## Changes

- `src/gateway/server-methods/chat.ts`: Add `isHeartbeatOnlyMessage()` and `filterHeartbeatMessages()` helpers, apply filtering in `chat.history` handler
- `src/gateway/server-methods/chat.heartbeat-filter.test.ts`: Unit tests for the filtering logic

## Testing

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm check`)
- [x] Unit tests pass (`pnpm exec vitest run src/gateway/server-methods/chat.heartbeat-filter.test.ts`)
- [x] Manually verified against the reproduction steps in #11630

## AI-Assisted

- [x] Built with AI assistance (OpenClaw/Claude)
- [x] Fully tested
- [x] I understand what the code does

---

*My first contribution to OpenClaw! 🦞*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `chat.history` to apply the same heartbeat visibility rules used by the live broadcast path, filtering `HEARTBEAT_OK` assistant messages out of returned transcript history when `resolveHeartbeatVisibility({ channel: "webchat" }).showOk` is false. It also adds a Vitest file to validate the intended filtering behavior.

The change fits into the gateway chat stack by aligning history replay (`src/gateway/server-methods/chat.ts`) with the existing broadcast suppression logic in `src/gateway/server-chat.ts` (`shouldSuppressHeartbeatBroadcast`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness risk in heartbeat-only detection that can drop real assistant content from history.
- The overall approach (apply heartbeat visibility in chat.history) is sound and matches existing broadcast behavior, but the current `startsWith` logic will treat some non-heartbeat messages as heartbeat-only and filter them, which is user-visible data loss in history. Tests also currently re-implement the logic, so they wouldn’t catch divergence/regressions.
- src/gateway/server-methods/chat.ts; src/gateway/server-methods/chat.heartbeat-filter.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->