### PR TITLE
fix(matrix): handle downloadContent returning {data, contentType} object

### DIFF
--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -29,11 +29,14 @@ async function fetchMatrixMediaBuffer(params: {
 
   // Use the client's download method which handles auth
   try {
-    const buffer = await params.client.downloadContent(params.mxcUrl);
-    if (buffer.byteLength > params.maxBytes) {
+    const result = await params.client.downloadContent(params.mxcUrl);
+    // downloadContent may return {data: Buffer, contentType: string} or a raw Buffer
+    const raw = (result as any)?.data ?? result;
+    const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+    if (buf.byteLength > params.maxBytes) {
       throw new Error("Matrix media exceeds configured size limit");
     }
-    return { buffer: Buffer.from(buffer) };
+    return { buffer: buf, headerType: (result as any)?.contentType };
   } catch (err) {
     throw new Error(`Matrix media download failed: ${String(err)}`, { cause: err });
   }


### PR DESCRIPTION
## Bug

`@vector-im/matrix-bot-sdk`'s `downloadContent` returns `{data: Buffer, contentType: string}`, not a raw `Buffer`. The existing code passed this object directly to `Buffer.from()`, causing `ERR_INVALID_ARG_TYPE` for **all** inbound Matrix media (images, files, audio, video).

## Fix

Unwrap the `data` property from the response before creating the Buffer. Also extracts `contentType` from the response for proper MIME type detection.

```typescript
// Before (broken):
const buffer = await params.client.downloadContent(params.mxcUrl);
return { buffer: Buffer.from(buffer) };  // buffer is {data, contentType}, not a Buffer

// After:
const result = await params.client.downloadContent(params.mxcUrl);
const raw = (result as any)?.data ?? result;
const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
return { buffer: buf, headerType: (result as any)?.contentType };
```

## Testing

Verified on a local Synapse homeserver — images sent from Element iOS now download and are passed to the agent correctly.