### PR TITLE
feat(plugins): pass chatId and messageId to plugin command handlers

### DIFF
--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -44,8 +44,14 @@ export const handlePluginCommand: CommandHandler = async (
     accountId: params.ctx.AccountId ?? undefined,
     messageThreadId:
       typeof params.ctx.MessageThreadId === "number" ? params.ctx.MessageThreadId : undefined,
-    chatId: command.to?.replace(/^telegram:/, "") ?? command.from?.replace(/^telegram:/, ""),
-    messageId: params.ctx.MessageSid,
+    // Only derive chatId/messageId for channels where the ID format is known.
+    // Other channels leave these undefined so plugins can safely feature-detect.
+    ...(command.channel === "telegram"
+      ? {
+          chatId: command.to?.replace(/^telegram:/, "") ?? command.from?.replace(/^telegram:/, ""),
+          messageId: params.ctx.MessageSid,
+        }
+      : {}),
   });
 
   return {

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -44,6 +44,8 @@ export const handlePluginCommand: CommandHandler = async (
     accountId: params.ctx.AccountId ?? undefined,
     messageThreadId:
       typeof params.ctx.MessageThreadId === "number" ? params.ctx.MessageThreadId : undefined,
+    chatId: command.to?.replace(/^telegram:/, "") ?? command.from?.replace(/^telegram:/, ""),
+    messageId: params.ctx.MessageSid,
   });
 
   return {

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -251,8 +251,6 @@ export async function executePluginCommand(params: {
     isAuthorizedSender,
     commandBody,
     config,
-    chatId,
-    messageId,
   } = params;
 
   // Check authorization

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -243,15 +243,7 @@ export async function executePluginCommand(params: {
   chatId?: string;
   messageId?: string;
 }): Promise<PluginCommandResult> {
-  const {
-    command,
-    args,
-    senderId,
-    channel,
-    isAuthorizedSender,
-    commandBody,
-    config,
-  } = params;
+  const { command, args, senderId, channel, isAuthorizedSender, commandBody, config } = params;
 
   // Check authorization
   const requireAuth = command.requireAuth !== false; // Default to true

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -240,8 +240,20 @@ export async function executePluginCommand(params: {
   to?: PluginCommandContext["to"];
   accountId?: PluginCommandContext["accountId"];
   messageThreadId?: PluginCommandContext["messageThreadId"];
+  chatId?: string;
+  messageId?: string;
 }): Promise<PluginCommandResult> {
-  const { command, args, senderId, channel, isAuthorizedSender, commandBody, config } = params;
+  const {
+    command,
+    args,
+    senderId,
+    channel,
+    isAuthorizedSender,
+    commandBody,
+    config,
+    chatId,
+    messageId,
+  } = params;
 
   // Check authorization
   const requireAuth = command.requireAuth !== false; // Default to true
@@ -267,6 +279,8 @@ export async function executePluginCommand(params: {
     to: params.to,
     accountId: params.accountId,
     messageThreadId: params.messageThreadId,
+    chatId: params.chatId,
+    messageId: params.messageId,
   };
 
   // Lock registry during execution to prevent concurrent modifications

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -159,6 +159,10 @@ export type PluginCommandContext = {
   accountId?: string;
   /** Thread/topic id if available */
   messageThreadId?: number;
+  /** Chat/channel ID (e.g., Telegram chat ID) — for message management */
+  chatId?: string;
+  /** Original message ID — for message deletion (e.g., passphrase scrubbing) */
+  messageId?: string;
 };
 
 /**

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -716,6 +716,8 @@ export const registerTelegramNativeCommands = ({
             to,
             accountId,
             messageThreadId: threadSpec.id,
+            chatId: String(chatId),
+            messageId: String(msg.message_id),
           });
 
           await deliverReplies({


### PR DESCRIPTION
## Summary

Adds optional `chatId` and `messageId` fields to `PluginCommandContext` so plugins can manage messages — e.g., auto-deleting sensitive input like passphrases after handling a command.

**4 files changed, ~13 lines added, 0 removed.**

## Changes

- `src/plugins/types.ts` — Added `chatId?` and `messageId?` to `PluginCommandContext`
- `src/plugins/commands.ts` — Accept and pass through in `executePluginCommand`
- `src/telegram/bot-native-commands.ts` — Supply values at the Telegram native command call site
- `src/auto-reply/reply/commands-plugin.ts` — Supply values at the auto-reply call site

## Backward Compatibility

Both fields are optional — **zero impact on existing plugins**. No breaking changes.

## Design Notes

See discussion in #11903 for design considerations around context object shape and cross-channel compatibility.

Fixes #11903

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the plugin command execution pipeline by adding optional `chatId` and `messageId` fields to `PluginCommandContext` (`src/plugins/types.ts`), threading those values through `executePluginCommand` (`src/plugins/commands.ts`), and populating them from Telegram native commands (`src/telegram/bot-native-commands.ts`) and the auto-reply plugin-command handler (`src/auto-reply/reply/commands-plugin.ts`).

The intent is to let plugin handlers manage originating messages (e.g., delete sensitive inputs) without breaking existing plugins (fields are optional).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but the auto-reply call site appears to pass incorrect IDs for non-Telegram channels, which could cause plugins to act on the wrong message/chat.
- Core type/threading changes are minimal and optional, and the Telegram native command call site supplies IDs consistently. However, the auto-reply handler currently derives IDs from `to/from` strings and `MessageSid` in a way that is provider-specific and will be wrong outside Telegram; since these fields are meant for message management, incorrect values are a functional bug for plugins that use them.
- src/auto-reply/reply/commands-plugin.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->