### PR TITLE
fix(gateway): include scripts in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "openclaw.mjs",
     "README-header.png",
     "README.md",
+    "scripts/ui.js",
     "skills/"
   ],
   "type": "module",

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -9,6 +9,13 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 const uiDir = path.join(repoRoot, "ui");
 
+if (!fs.existsSync(uiDir)) {
+  process.stderr.write(
+    "Control UI source directory (ui/) not found. This command is only available in source installs.\n",
+  );
+  process.exit(1);
+}
+
 function usage() {
   // keep this tiny; it's invoked from npm scripts too
   process.stderr.write("Usage: node scripts/ui.js <install|dev|build|test> [...args]\n");


### PR DESCRIPTION
## Summary
- ensure the npm package includes the `scripts/` directory so the Control UI build helper (`scripts/ui.js`) is available after `npm i` installs
- this lets `ensureControlUiAssetsBuilt` fall back to running `pnpm ui:build` even for global installs, eliminating the repeated "missing Control UI assets" warning described in #11883

## Testing
- pnpm lint

Fixes #11883

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the root `package.json` publish whitelist (`files`) to include `scripts/ui.js`, with the intent of making the Control UI build helper available after `npm i` / global installs.

However, the Control UI build fallback (`ensureControlUiAssetsBuilt`) relies on `scripts/ui.js` *and* the `ui/` workspace being present. In the published npm package, `ui/` is not included, so exposing `scripts/ui.js` alone can lead to a hard failure (`ui/package.json` missing) when the fallback path is exercised.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a runtime failure path in packaged installs.
- The change exposes `scripts/ui.js` in the published package without packaging its required `ui/` directory, so the Control UI build fallback can crash with missing-file errors instead of gracefully warning/building.
- package.json (publish files whitelist) and the Control UI build fallback path (`src/infra/control-ui-assets.ts`, `scripts/ui.js`).

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->