### PR TITLE
fix(voice-call): pass stream auth token via TwiML Parameter, not URL query

### DIFF
--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { WebhookContext } from "../types.js";
 import { TwilioProvider } from "./twilio.js";
 
-const STREAM_URL_PREFIX = "wss://example.ngrok.app/voice/stream?token=";
+const STREAM_URL = "wss://example.ngrok.app/voice/stream";
 
 function createProvider(): TwilioProvider {
   return new TwilioProvider(
@@ -30,8 +30,9 @@ describe("TwilioProvider", () => {
 
     const result = provider.parseWebhookEvent(ctx);
 
-    expect(result.providerResponseBody).toContain(STREAM_URL_PREFIX);
+    expect(result.providerResponseBody).toContain(`url="${STREAM_URL}"`);
     expect(result.providerResponseBody).toContain("<Connect>");
+    expect(result.providerResponseBody).toContain('<Parameter name="token"');
   });
 
   it("returns empty TwiML for status callbacks", () => {
@@ -54,7 +55,8 @@ describe("TwilioProvider", () => {
 
     const result = provider.parseWebhookEvent(ctx);
 
-    expect(result.providerResponseBody).toContain(STREAM_URL_PREFIX);
+    expect(result.providerResponseBody).toContain(`url="${STREAM_URL}"`);
     expect(result.providerResponseBody).toContain("<Connect>");
+    expect(result.providerResponseBody).toContain('<Parameter name="token"');
   });
 });


### PR DESCRIPTION
## Summary

- **Twilio silently strips query parameters from `<Stream url="...">`**, so the media-stream auth token (`?token=...`) was dropped before reaching the WebSocket server
- Every outbound conversation-mode call rejected with `"Rejecting media stream: invalid token"`
- The token is now passed via a `<Parameter name="token">` TwiML element inside `<Stream>`, which Twilio delivers in the WebSocket start message's `customParameters` object
- The media-stream handler reads from `customParameters` with a URL query-param fallback for backward compatibility

## Details

The token-gating feature added in v2026.2.2 (commit 95cd221) constructs a WebSocket URL like:

```
wss://example.com/voice/stream?token=abc123
```

...and embeds it in TwiML:

```xml
<Stream url="wss://example.com/voice/stream?token=abc123" />
```

Per [Twilio's documentation](https://www.twilio.com/docs/voice/twiml/stream), the `<Stream>` URL **does not support query string parameters**. Custom data must use `<Parameter>` child elements instead. The fixed TwiML:

```xml
<Stream url="wss://example.com/voice/stream">
  <Parameter name="token" value="abc123" />
</Stream>
```

The token then arrives in `message.start.customParameters.token` on the WebSocket.

### Files changed

| File | Change |
|---|---|
| `extensions/voice-call/src/providers/twilio.ts` | `getStreamUrlForCall` returns `{url, token}` separately; `getStreamConnectXml` emits `<Parameter>` element |
| `extensions/voice-call/src/media-stream.ts` | Extract token from `start.customParameters`; add `customParameters` to `TwilioMediaMessage` type |
| `extensions/voice-call/src/providers/twilio.test.ts` | Update assertions for new TwiML format |

## Test plan

- [x] All 37 existing voice-call tests pass (`npx vitest run extensions/voice-call/src/`)
- [x] Verified on a live outbound conversation-mode call via Twilio + ngrok — stream connects, STT transcribes, AI responds, TTS plays back

Fixes #5732
Related #1634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Twilio Media Streams authentication by moving the per-call stream auth token from the `<Stream url="...">` query string (which Twilio strips) into a `<Parameter name="token" .../>` child element. The Twilio provider now returns `{url, token}` separately when generating TwiML, and the media-stream WebSocket handler reads the token from the `start.customParameters.token` field with a URL query-param fallback for older setups. Tests were updated to assert the new TwiML structure.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to TwiML generation and token extraction, align with Twilio’s documented Media Streams behavior, and preserve backward compatibility by falling back to URL query parameters. No additional call sites or security-sensitive logic paths appear to be impacted beyond the intended token transport mechanism, and tests were updated accordingly.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->