### PR TITLE
Telegram: create forum topics via message tool (thread-create)

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -266,6 +266,24 @@ Telegram forum topics include a `message_thread_id` per message. OpenClaw:
 
 Private chats can include `message_thread_id` in some edge cases. OpenClaw keeps the DM session key unchanged, but still uses the thread id for replies/draft streaming when it is present.
 
+### Creating topics (message tool)
+
+To create a new forum topic from the agent, use the `thread-create` action:
+
+```json5
+{
+  action: "thread-create",
+  channel: "telegram",
+  to: "-1001234567890",
+  threadName: "Support",
+}
+```
+
+Requirements:
+
+- The target chat must be a forum-enabled supergroup.
+- The bot must be an admin with `can_manage_topics`.
+
 ## Inline Buttons
 
 Telegram supports inline keyboards with callback buttons.
@@ -626,8 +644,9 @@ Outbound Telegram API calls retry on transient network/429 errors with exponenti
 - Tool: `telegram` with `sendMessage` action (`to`, `content`, optional `mediaUrl`, `replyToMessageId`, `messageThreadId`).
 - Tool: `telegram` with `react` action (`chatId`, `messageId`, `emoji`).
 - Tool: `telegram` with `deleteMessage` action (`chatId`, `messageId`).
+- Tool: `telegram` with `createForumTopic` action (`to` or `chatId`, `threadName`, optional `iconColor`/`iconCustomEmojiId`).
 - Reaction removal semantics: see [/tools/reactions](/tools/reactions).
-- Tool gating: `channels.telegram.actions.reactions`, `channels.telegram.actions.sendMessage`, `channels.telegram.actions.deleteMessage` (default: enabled), and `channels.telegram.actions.sticker` (default: disabled).
+- Tool gating: `channels.telegram.actions.reactions`, `channels.telegram.actions.sendMessage`, `channels.telegram.actions.deleteMessage`, `channels.telegram.actions.createTopic` (default: enabled), and `channels.telegram.actions.sticker` (default: disabled).
 
 ## Reaction notifications
 
@@ -758,6 +777,7 @@ Provider options:
 - `channels.telegram.actions.reactions`: gate Telegram tool reactions.
 - `channels.telegram.actions.sendMessage`: gate Telegram tool message sends.
 - `channels.telegram.actions.deleteMessage`: gate Telegram tool message deletes.
+- `channels.telegram.actions.createTopic`: gate Telegram forum topic creation.
 - `channels.telegram.actions.sticker`: gate Telegram sticker actions — send and search (default: false).
 - `channels.telegram.reactionNotifications`: `off | own | all` — control which reactions trigger system events (default: `own` when not set).
 - `channels.telegram.reactionLevel`: `off | ack | minimal | extensive` — control agent's reaction capability (default: `minimal` when not set).

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -176,6 +176,12 @@ function buildThreadSchema() {
   return {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
+    iconColor: Type.Optional(
+      Type.Number({ description: "Telegram forum topic icon color (numeric id)." }),
+    ),
+    iconCustomEmojiId: Type.Optional(
+      Type.String({ description: "Telegram forum topic custom emoji id." }),
+    ),
   };
 }
 

--- a/src/channels/plugins/actions/telegram.test.ts
+++ b/src/channels/plugins/actions/telegram.test.ts
@@ -14,6 +14,7 @@ describe("telegramMessageActions", () => {
     const actions = telegramMessageActions.listActions({ cfg });
     expect(actions).not.toContain("sticker");
     expect(actions).not.toContain("sticker-search");
+    expect(actions).toContain("thread-create");
   });
 
   it("allows media-only sends and passes asVoice", async () => {
@@ -92,6 +93,34 @@ describe("telegramMessageActions", () => {
         messageId: 42,
         content: "Updated",
         buttons: [],
+        accountId: undefined,
+      },
+      cfg,
+    );
+  });
+
+  it("maps thread-create into createForumTopic", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = { channels: { telegram: { botToken: "tok" } } } as OpenClawConfig;
+
+    await telegramMessageActions.handleAction({
+      action: "thread-create",
+      params: {
+        to: "-100123",
+        threadName: "Support",
+        iconColor: 123,
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      {
+        action: "createForumTopic",
+        to: "-100123",
+        threadName: "Support",
+        iconColor: 123,
+        iconCustomEmojiId: undefined,
         accountId: undefined,
       },
       cfg,

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -60,6 +60,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       actions.add("sticker");
       actions.add("sticker-search");
     }
+    if (gate("createTopic")) {
+      actions.add("thread-create");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -193,6 +196,30 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "searchSticker",
           query,
           limit: limit ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "thread-create") {
+      const to =
+        readStringParam(params, "to") ??
+        readStringParam(params, "target") ??
+        readStringOrNumberParam(params, "channelId");
+      if (!to) {
+        throw new Error("to required");
+      }
+      const threadName = readStringParam(params, "threadName", { required: true });
+      const iconColor = readNumberParam(params, "iconColor", { integer: true });
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "createForumTopic",
+          to,
+          threadName,
+          iconColor: iconColor ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -16,6 +16,7 @@ export type TelegramActionConfig = {
   sendMessage?: boolean;
   deleteMessage?: boolean;
   editMessage?: boolean;
+  createTopic?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
 };

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -131,6 +131,7 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        createTopic: z.boolean().optional(),
         sticker: z.boolean().optional(),
       })
       .strict()


### PR DESCRIPTION
Closes #10427

  What
  - Add Telegram support for creating forum topics via the message tool using the existing `thread-create` action (calls Bot API `createForumTopic`).
  - Expose optional topic icon params (`iconColor`, `iconCustomEmojiId`).
  - Add `channels.telegram.actions.createTopic` gate (default enabled).
  - Document usage in docs.

  Why
  - Sending to `threadId` only routes to existing topics; this enables programmatic creation of new topics in forum supergroups.

  Testing
  - Manual: created a topic in a forum-enabled supergroup and sent messages into the returned thread id.
  - Unit: added coverage for Telegram action handling and message action adapter mapping.

  AI-assisted
  - This PR was AI-assisted (Codex).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Telegram support for creating forum topics via the message tool by mapping the existing `thread-create` action to a new Telegram tool action `createForumTopic` (Bot API `createForumTopic`). Adds optional topic icon parameters (`iconColor`, `iconCustomEmojiId`), a new action gate `channels.telegram.actions.createTopic` (default enabled), and updates docs plus unit tests to cover the new mapping and handler.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are additive and covered by unit tests, but CI should verify since tests couldn't be run locally in this environment.
- Reviewed the full diff: implementation routes `thread-create` to Telegram Bot API `createForumTopic`, adds config schema/types and docs updates, and includes unit tests for both the action handler and adapter mapping. No obvious runtime/type errors or unsafe behavior were introduced. Local test execution wasn't possible here (tooling missing), so confidence is slightly reduced pending CI.
- src/telegram/send.ts; src/agents/tools/telegram-actions.ts; src/channels/plugins/actions/telegram.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->