### PR TITLE
fix(exec): Handle Python scripts with import statements (Issue #11724)

### DIFF
--- a/.codex-prompt-1770652480708.txt
+++ b/.codex-prompt-1770652480708.txt
@@ -1,0 +1,25 @@
+Fix the following code review issues:
+
+GREPTILE FEEDBACK (Score: null/5):
+
+
+SPECIFIC ISSUES TO FIX:
+1. *`src/agents/bash-tools.exec.ts`**
+2. *Temp script deleted too early**
+3. *Temp script deleted too early**
+4. *`src/agents/bash-tools.exec.ts`**
+5. *Temp file leaks when backgrounded**
+6. *Temp file leaks when backgrounded**
+
+FILES TO MODIFY:
+src/agents/bash-process-registry.ts
+src/agents/bash-tools.exec.ts
+
+Instructions:
+1. Read the feedback carefully and understand all issues
+2. Make minimal, focused changes to fix each issue
+3. Ensure code compiles and tests pass
+4. Write clean, maintainable code
+5. Do NOT over-fix - only address the specific issues mentioned
+
+After making changes, verify the fixes are correct.

--- a/docs/fix-11724-plan.md
+++ b/docs/fix-11724-plan.md
@@ -1,0 +1,81 @@
+# Fix for Issue #11724: Python Scripts with Import Statements Fail
+
+**Status:** ✅ Implemented
+
+## Problem
+
+When OpenClaw's exec tool runs commands containing Python code with `import` statements, it mistakenly interprets them as ImageMagick commands. This happens because:
+
+1. Multi-line commands with newlines are passed directly to the shell
+2. The shell tries to execute each line as a separate command
+3. `import` is also an ImageMagick command
+
+Example error:
+
+```
+import-im6.q16: unable to open X server
+/bin/bash: line 6: from: command not found
+```
+
+## Solution Implemented
+
+Auto-detect multi-line scripts and execute them via temporary files for local execution:
+
+1. **Detection** (`detectScriptContent`): Check for:
+   - Shebang (`#!`)
+   - Newlines + Python keywords (`import`, `from`, `def`, `class`)
+
+2. **Temp File Creation** (for `host=gateway` or sandbox only):
+   - Write script to temp file with executable permissions
+   - Handle shebang parsing (including `/usr/bin/env` style)
+   - Use workspace temp path for sandbox compatibility
+   - Return command to execute temp file
+
+3. **`host=node` Rejection**: Multi-line scripts are rejected with a clear error message because the temp file won't exist on remote nodes.
+
+4. **Cleanup**: Remove temp file after execution (success or failure)
+
+## Files Modified
+
+- `src/agents/bash-tools.exec.ts` - Added script detection and temp file handling
+- `src/agents/bash-tools.exec.script-content.test.ts` - New test file with Python availability checks
+
+## Changes Summary
+
+### Added Functions
+
+```typescript
+function detectScriptContent(command: string): { isScript: boolean; reason?: string };
+```
+
+### Modified Logic
+
+- After workdir/env setup, detect if command contains script content
+- If detected and `host=node`: throw error with helpful message
+- If detected and `host=gateway` or sandbox:
+  - Parse shebang to extract interpreter (handles `env` style)
+  - Create temp file in appropriate location (tmpdir for gateway, workspace for sandbox)
+  - Execute temp file with detected interpreter
+  - Clean up temp file in promise handlers
+
+## Host Behavior
+
+| Host      | Multi-line Script Behavior                  |
+| --------- | ------------------------------------------- |
+| `gateway` | ✅ Auto-convert to temp file                |
+| `sandbox` | ✅ Auto-convert to temp file (in workspace) |
+| `node`    | ❌ Rejected with helpful error              |
+
+## Testing
+
+Run tests with:
+
+```bash
+pnpm test src/agents/bash-tools.exec.script-content.test.ts
+```
+
+Tests check for Python availability and skip if not present.
+
+## Related
+
+- Issue: https://github.com/openclaw/openclaw/issues/11724

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -49,6 +49,8 @@ export interface ProcessSession {
   exited: boolean;
   truncated: boolean;
   backgrounded: boolean;
+  // Cleanup callback for temp files/resources - called when session exits
+  onExit?: () => void;
 }
 
 export interface FinishedSession {
@@ -148,6 +150,14 @@ export function markExited(
   session.exitCode = exitCode;
   session.exitSignal = exitSignal;
   session.tail = tail(session.aggregated, 2000);
+  // Call cleanup callback if registered
+  if (session.onExit) {
+    try {
+      session.onExit();
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
   moveToFinished(session, status);
 }
 

--- a/src/agents/bash-tools.exec.script-content.test.ts
+++ b/src/agents/bash-tools.exec.script-content.test.ts
@@ -1,0 +1,171 @@
+import { execSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import type { ExecApprovalsResolved } from "../infra/exec-approvals.js";
+
+const isWin = process.platform === "win32";
+
+// Check if Python is available (with timeout to prevent hanging)
+// Note: We specifically check for python3 since that's what the code prefers
+let pythonAvailable = false;
+try {
+  execSync("python3 --version", { stdio: "ignore", timeout: 5000 });
+  pythonAvailable = true;
+} catch {
+  pythonAvailable = false;
+}
+
+vi.mock("../infra/shell-env.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../infra/shell-env.js")>();
+  return {
+    ...mod,
+    getShellPathFromLoginShell: vi.fn(() => "/custom/bin:/opt/bin"),
+    resolveShellEnvFallbackTimeoutMs: vi.fn(() => 1234),
+  };
+});
+
+vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../infra/exec-approvals.js")>();
+  const approvals: ExecApprovalsResolved = {
+    path: "/tmp/exec-approvals.json",
+    socketPath: "/tmp/exec-approvals.sock",
+    token: "token",
+    defaults: {
+      security: "full",
+      ask: "off",
+      askFallback: "full",
+      autoAllowSkills: false,
+    },
+    agent: {
+      security: "full",
+      ask: "off",
+      askFallback: "full",
+      autoAllowSkills: false,
+    },
+    allowlist: [],
+    file: {
+      version: 1,
+      socket: { path: "/tmp/exec-approvals.sock", token: "token" },
+      defaults: {
+        security: "full",
+        ask: "off",
+        askFallback: "full",
+        autoAllowSkills: false,
+      },
+      agents: {},
+    },
+  };
+  return { ...mod, resolveExecApprovals: () => approvals };
+});
+
+describe("exec script content detection (Issue #11724)", () => {
+  it("should handle Python code with import statements via temp file", async () => {
+    if (isWin || !pythonAvailable) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+
+    // This would previously fail with ImageMagick errors
+    const pythonScript = `import json
+print("Hello from Python")`;
+
+    const result = await tool.execute("call1", { command: pythonScript });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+
+    // Should execute successfully via temp file
+    expect(text).toContain("Hello from Python");
+    expect(text).toContain("Note: Multi-line script detected");
+  });
+
+  it("should handle shebang scripts via temp file", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+
+    // Use /bin/sh which is more portable than /bin/bash
+    const shellScript = `#!/bin/sh
+echo "Hello from Shell"`;
+
+    const result = await tool.execute("call1", { command: shellScript });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+
+    expect(text).toContain("Hello from Shell");
+    expect(text).toContain("Note: Multi-line script detected");
+  });
+
+  it("should handle shebang with env via temp file", async () => {
+    if (isWin || !pythonAvailable) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+
+    const pythonScript = `#!/usr/bin/env python3
+import json
+print("Hello from env shebang")`;
+
+    const result = await tool.execute("call1", { command: pythonScript });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+
+    expect(text).toContain("Hello from env shebang");
+  });
+
+  it("should reject multi-line scripts with host=node", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({
+      host: "node",
+      security: "full",
+      ask: "off",
+      node: "test-node",
+    });
+
+    const pythonScript = `import json
+print("Hello")`;
+
+    await expect(tool.execute("call1", { command: pythonScript })).rejects.toThrow(
+      "Multi-line scripts cannot be executed with host=node",
+    );
+  });
+
+  it("should handle single-line Python commands normally", async () => {
+    if (isWin || !pythonAvailable) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+
+    // Single-line command should work normally
+    const result = await tool.execute("call1", {
+      command: 'python3 -c "import json; print(1)"',
+    });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+
+    expect(text).toContain("1");
+    expect(text).not.toContain("Note: Multi-line script detected");
+  });
+
+  it("should handle regular shell commands without detection", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+
+    const result = await tool.execute("call1", { command: "echo Hello" });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+
+    expect(text).toContain("Hello");
+    expect(text).not.toContain("Note: Multi-line script detected");
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -2,6 +2,8 @@ import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import {
@@ -55,6 +57,52 @@ import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
 import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
 import { callGatewayTool } from "./tools/gateway.js";
 import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
+
+/**
+ * Detects if a command string contains multi-line script content that would fail
+ * when executed directly through a shell (e.g., Python code with 'import' statements
+ * being interpreted as ImageMagick commands).
+ *
+ * See: https://github.com/openclaw/openclaw/issues/11724
+ */
+function detectScriptContent(command: string): { isScript: boolean; reason?: string } {
+  // Quick check: must contain newlines to be multi-line
+  if (!command.includes("\n") && !command.includes("\r")) {
+    return { isScript: false };
+  }
+
+  const trimmed = command.trim();
+
+  // Check for shebang - definitely a script
+  if (trimmed.startsWith("#!")) {
+    return {
+      isScript: true,
+      reason: "Shebang detected (#!). Multi-line scripts must be written to a file first.",
+    };
+  }
+
+  // Check for Python-specific keywords that would fail in shell
+  // Use multiline flag (/m) so ^ matches start of any line, not just start of string
+  const pythonIndicators = [
+    /^import\s+\w+/m, // import statements at start of line
+    /^from\s+\w+\s+import/m, // from ... import statements
+    /^def\s+\w+\s*\(/m, // function definitions
+    /^class\s+\w+/m, // class definitions
+    /print\s*\(/, // Python 3 print
+  ];
+
+  for (const pattern of pythonIndicators) {
+    if (pattern.test(trimmed)) {
+      return {
+        isScript: true,
+        reason:
+          "Python code detected. 'import' and similar keywords are interpreted as shell commands (e.g., ImageMagick). Write the script to a file first.",
+      };
+    }
+  }
+
+  return { isScript: false };
+}
 
 // Security: Blocklist of environment variables that could alter execution flow
 // or inject code when running on non-sandboxed hosts (Gateway/Node).
@@ -992,6 +1040,74 @@ export function createExecTool(
       }
       applyPathPrepend(env, defaultPathPrepend);
 
+      // Fix for Issue #11724: Detect and handle multi-line script content
+      // https://github.com/openclaw/openclaw/issues/11724
+      const scriptDetection = detectScriptContent(params.command);
+      let command = params.command;
+      let tempScriptFile: string | undefined;
+
+      if (scriptDetection.isScript) {
+        // Only apply temp file fix for local gateway execution
+        // host=node won't work because the temp file won't exist on the remote node
+        if (host === "node") {
+          throw new Error(
+            "Multi-line scripts cannot be executed with host=node. " +
+              "The script content would need to be on the remote node. " +
+              "Please write the script to a file on the target node first, then execute it.",
+          );
+        }
+
+        // For sandbox or gateway, we can use temp files (sandbox mounts workspace)
+        if (host === "gateway" || sandbox) {
+          // Auto-convert script to temp file execution
+          // Detect interpreter from shebang or default to bash
+          let interpreterCmd = "bash";
+          const trimmedCommand = params.command.trim();
+          if (trimmedCommand.startsWith("#!/")) {
+            const shebangMatch = trimmedCommand.match(/^#!(.+)$/m);
+            if (shebangMatch) {
+              // Extract interpreter and arguments from shebang
+              // Handle: /usr/bin/python3, /usr/bin/env python3, /usr/bin/env python3 -u
+              const shebang = shebangMatch[1].trim();
+              const envMatch = shebang.match(/env\s+(.+)$/);
+              if (envMatch) {
+                // /usr/bin/env python3 [args] -> python3 [args]
+                interpreterCmd = envMatch[1];
+              } else {
+                // /usr/bin/python3 [args] -> /usr/bin/python3 [args]
+                interpreterCmd = shebang;
+              }
+            }
+          } else if (/^(import\s|from\s+\w+\s+import|def\s|class\s)/m.test(trimmedCommand)) {
+            // Auto-detect python availability: prefer python3, fall back to python
+            interpreterCmd = fs.existsSync("/usr/bin/python3") ? "python3" : "python";
+          }
+
+          // For sandbox, use workspace root so the temp file is accessible in the container
+          const scriptFileName = `openclaw-script-${crypto.randomUUID()}`;
+
+          if (sandbox) {
+            // Always write to workspace root for sandbox - this is the only guaranteed
+            // mounted location that maps consistently between host and container
+            tempScriptFile = path.join(sandbox.workspaceDir, scriptFileName);
+            fs.writeFileSync(tempScriptFile, params.command, { mode: 0o700 });
+
+            // In container, the file is at the container workdir root
+            const containerTempFile = path.posix.join(sandbox.containerWorkdir, scriptFileName);
+            command = `${interpreterCmd} "${containerTempFile}"`;
+          } else {
+            // For gateway, use system temp directory
+            tempScriptFile = path.join(os.tmpdir(), scriptFileName);
+            fs.writeFileSync(tempScriptFile, params.command, { mode: 0o700 });
+            command = `${interpreterCmd} "${tempScriptFile}"`;
+          }
+
+          warnings.push(
+            `Note: Multi-line script detected and written to temp file. ${scriptDetection.reason}`,
+          );
+        }
+      }
+
       if (host === "node") {
         const approvals = resolveExecApprovals(agentId, { security, ask });
         const hostSecurity = minSecurity(security, approvals.agent.security);
@@ -1033,7 +1149,9 @@ export function createExecTool(
             "exec host=node requires a node that supports system.run (companion app or node host).",
           );
         }
-        const argv = buildNodeShellCommand(params.command, nodeInfo?.platform);
+        // Use 'command' (not 'params.command') for consistency. For host=node with scripts,
+        // we would have already thrown an error, so 'command' equals 'params.command' here.
+        const argv = buildNodeShellCommand(command, nodeInfo?.platform);
 
         const nodeEnv = params.env ? { ...params.env } : undefined;
 
@@ -1041,7 +1159,7 @@ export function createExecTool(
           applyPathPrepend(nodeEnv, defaultPathPrepend, { requireExisting: true });
         }
         const baseAllowlistEval = evaluateShellAllowlist({
-          command: params.command,
+          command,
           allowlist: [],
           safeBins: new Set(),
           cwd: workdir,
@@ -1069,7 +1187,7 @@ export function createExecTool(
               });
               // Allowlist-only precheck; safe bins are node-local and may diverge.
               const allowlistEval = evaluateShellAllowlist({
-                command: params.command,
+                command,
                 allowlist: resolved.allowlist,
                 safeBins: new Set(),
                 cwd: workdir,
@@ -1089,7 +1207,7 @@ export function createExecTool(
           analysisOk,
           allowlistSatisfied,
         });
-        const commandText = params.command;
+        const commandText = command;
         const invokeTimeoutMs = Math.max(
           10_000,
           (typeof params.timeout === "number" ? params.timeout : defaultTimeoutSec) * 1000 + 5_000,
@@ -1104,7 +1222,7 @@ export function createExecTool(
             command: "system.run",
             params: {
               command: argv,
-              rawCommand: params.command,
+              rawCommand: command,
               cwd: workdir,
               env: nodeEnv,
               timeoutMs: typeof params.timeout === "number" ? params.timeout * 1000 : undefined,
@@ -1181,6 +1299,14 @@ export function createExecTool(
             }
 
             if (deniedReason) {
+              // Clean up temp file on early exit
+              if (tempScriptFile) {
+                try {
+                  fs.unlinkSync(tempScriptFile);
+                } catch {
+                  // Ignore cleanup errors
+                }
+              }
               emitExecSystemEvent(
                 `Exec denied (node=${nodeId} id=${approvalId}, ${deniedReason}): ${commandText}`,
                 { sessionKey: notifySessionKey, contextKey },
@@ -1210,6 +1336,14 @@ export function createExecTool(
                 { sessionKey: notifySessionKey, contextKey },
               );
             } finally {
+              // Clean up temp file after execution completes
+              if (tempScriptFile) {
+                try {
+                  fs.unlinkSync(tempScriptFile);
+                } catch {
+                  // Ignore cleanup errors
+                }
+              }
               if (runningTimer) {
                 clearTimeout(runningTimer);
               }
@@ -1279,7 +1413,7 @@ export function createExecTool(
           throw new Error("exec denied: host=gateway security=deny");
         }
         const allowlistEval = evaluateShellAllowlist({
-          command: params.command,
+          command,
           allowlist: approvals.allowlist,
           safeBins,
           cwd: workdir,
@@ -1304,7 +1438,7 @@ export function createExecTool(
           const contextKey = `exec:${approvalId}`;
           const resolvedPath = allowlistEval.segments[0]?.resolution?.resolvedPath;
           const noticeSeconds = Math.max(1, Math.round(approvalRunningNoticeMs / 1000));
-          const commandText = params.command;
+          const commandText = command;
           const effectiveTimeout =
             typeof params.timeout === "number" ? params.timeout : defaultTimeoutSec;
           const warningText = warnings.length ? `${warnings.join("\n")}\n\n` : "";
@@ -1381,6 +1515,14 @@ export function createExecTool(
             }
 
             if (deniedReason) {
+              // Clean up temp file on early exit
+              if (tempScriptFile) {
+                try {
+                  fs.unlinkSync(tempScriptFile);
+                } catch {
+                  // Ignore cleanup errors
+                }
+              }
               emitExecSystemEvent(
                 `Exec denied (gateway id=${approvalId}, ${deniedReason}): ${commandText}`,
                 { sessionKey: notifySessionKey, contextKey },
@@ -1423,6 +1565,14 @@ export function createExecTool(
                 timeoutSec: effectiveTimeout,
               });
             } catch {
+              // Clean up temp file on spawn failure
+              if (tempScriptFile) {
+                try {
+                  fs.unlinkSync(tempScriptFile);
+                } catch {
+                  // Ignore cleanup errors
+                }
+              }
               emitExecSystemEvent(
                 `Exec denied (gateway id=${approvalId}, spawn-failed): ${commandText}`,
                 { sessionKey: notifySessionKey, contextKey },
@@ -1443,6 +1593,16 @@ export function createExecTool(
             }
 
             const outcome = await run.promise;
+
+            // Clean up temp file after execution completes
+            if (tempScriptFile) {
+              try {
+                fs.unlinkSync(tempScriptFile);
+              } catch {
+                // Ignore cleanup errors
+              }
+            }
+
             if (runningTimer) {
               clearTimeout(runningTimer);
             }
@@ -1471,7 +1631,7 @@ export function createExecTool(
               approvalSlug,
               expiresAtMs,
               host: "gateway",
-              command: params.command,
+              command,
               cwd: workdir,
             },
           };
@@ -1492,7 +1652,7 @@ export function createExecTool(
               approvals.file,
               agentId,
               match,
-              params.command,
+              command,
               allowlistEval.segments[0]?.resolution?.resolvedPath,
             );
           }
@@ -1504,7 +1664,7 @@ export function createExecTool(
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
       const run = await runExecProcess({
-        command: params.command,
+        command,
         workdir,
         env,
         sandbox,
@@ -1585,8 +1745,20 @@ export function createExecTool(
           }
         }
 
+        // Ensure temp file is always cleaned up, even if yielded/backgrounded
+        const cleanupTempFile = () => {
+          if (tempScriptFile) {
+            try {
+              fs.unlinkSync(tempScriptFile);
+            } catch {
+              // Ignore cleanup errors
+            }
+          }
+        };
+
         run.promise
           .then((outcome) => {
+            cleanupTempFile();
             if (yieldTimer) {
               clearTimeout(yieldTimer);
             }
@@ -1614,6 +1786,7 @@ export function createExecTool(
             });
           })
           .catch((err) => {
+            cleanupTempFile();
             if (yieldTimer) {
               clearTimeout(yieldTimer);
             }


### PR DESCRIPTION
Previously, multi-line Python scripts with 'import' statements would fail when executed through the exec tool because:
1. The shell interpreted 'import' as ImageMagick's import command
2. Python keywords like 'from' were treated as shell commands

This fix:
- Detects multi-line script content (shebang or Python keywords)
- Automatically writes scripts to temp files
- Executes via the appropriate interpreter (detected from shebang or content)
- Cleans up temp files after execution

Fixes #11724

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds multi-line script detection to the `exec` tool to prevent Python snippets (notably `import`/`from`) from being interpreted by the shell, by writing detected scripts to a temporary file and executing that file via an interpreter inferred from the shebang or Python keywords. It also introduces a `ProcessSession.onExit` hook to ensure temp files are cleaned up when sessions exit, and adds a dedicated vitest suite covering Python/shebang detection and the host=node rejection path.

The changes primarily live in `src/agents/bash-tools.exec.ts`, integrating script detection into the existing gateway/sandbox execution flow (including approval/allowlist paths) and registering cleanup on the process session to prevent leaks when yielded/backgrounded.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge yet due to a deterministic shebang parsing bug and a temp-file creation security flaw.
- The exec temp-script path is a good direction, but `#!/usr/bin/env ...` shebangs are parsed incorrectly and will fail at runtime, and the gateway temp file is created in a way that enables symlink/TOCTOU issues in shared /tmp environments. There is also risk around the new single `onExit` callback being overwritten by multiple features, leading to missed cleanup.
- src/agents/bash-tools.exec.ts and src/agents/bash-process-registry.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->