### PR TITLE
fix(slack): preserve thread_ts in queue drain and deliveryContext

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -44,13 +44,14 @@ export function scheduleFollowupDrain(
             const to = item.originatingTo;
             const accountId = item.originatingAccountId;
             const threadId = item.originatingThreadId;
-            if (!channel && !to && !accountId && typeof threadId !== "number") {
+            if (!channel && !to && !accountId && (threadId == null || threadId === "")) {
               return {};
             }
             if (!isRoutableChannel(channel) || !to) {
               return { cross: true };
             }
-            const threadKey = typeof threadId === "number" ? String(threadId) : "";
+            // Support both number (Telegram topic IDs) and string (Slack thread_ts) thread IDs.
+            const threadKey = threadId != null && threadId !== "" ? String(threadId) : "";
             return {
               key: [channel, to, accountId || "", threadKey].join("|"),
             };
@@ -79,8 +80,9 @@ export function scheduleFollowupDrain(
           const originatingAccountId = items.find(
             (i) => i.originatingAccountId,
           )?.originatingAccountId;
+          // Support both number (Telegram topic) and string (Slack thread_ts) thread IDs.
           const originatingThreadId = items.find(
-            (i) => typeof i.originatingThreadId === "number",
+            (i) => i.originatingThreadId != null && i.originatingThreadId !== "",
           )?.originatingThreadId;
 
           const prompt = buildCollectPrompt({

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -30,6 +30,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         channel: "slack",
         to: `user:${message.user}`,
         accountId: route.accountId,
+        threadId: prepared.ctxPayload.MessageThreadId,
       },
       ctx: prepared.ctxPayload,
     });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -541,6 +541,7 @@ export async function prepareSlackMessage(params: {
           channel: "slack",
           to: `user:${message.user}`,
           accountId: route.accountId,
+          threadId: threadContext.messageThreadId,
         }
       : undefined,
     onRecordError: (err) => {


### PR DESCRIPTION
## Summary

Two related fixes for Slack thread reply routing that cause replies meant for threads to leak to the main channel.

### Bug 1: Queue drain drops string thread_ts (#11195)

`typeof threadId === "number"` in `drain.ts` only matches Telegram numeric topic IDs. Slack `thread_ts` is a string like `"1770474140.187459"` which fails the check, causing `threadKey` to become empty. Queued replies then lose their thread context and land in the main channel.

**Fix:** Changed to `threadId != null && threadId !== ""` to accept both number and string thread IDs. Applied to all 3 occurrences in drain.ts:
- Cross-channel detection guard
- Thread key building for collect grouping  
- Collected `originatingThreadId` extraction

### Bug 2: DM deliveryContext missing thread_ts (#10837)

`updateLastRoute` calls for Slack DMs in both `prepare.ts` and `dispatch.ts` built the `deliveryContext` without `threadId`, so the session's delivery context never included `thread_ts` for DM threads.

**Fix:** Added `threadId` from `threadContext.messageThreadId` / `ctxPayload.MessageThreadId` to both `updateLastRoute` call sites.

### Files Changed

| File | Change |
|------|--------|
| `src/auto-reply/reply/queue/drain.ts` | Accept string thread IDs (3 locations) |
| `src/slack/monitor/message-handler/prepare.ts` | Include threadId in DM updateLastRoute |
| `src/slack/monitor/message-handler/dispatch.ts` | Include threadId in DM updateLastRoute |
| `src/auto-reply/reply/queue.collect-routing.test.ts` | 3 new test cases |

### Tests

3 new cases in `queue.collect-routing.test.ts`:
- ✅ Collects messages with matching string `thread_ts` (same Slack thread)
- ✅ Separates messages with different string `thread_ts` (different threads)
- ✅ Treats empty string threadId same as absent

```
pnpm test src/auto-reply/reply/queue.collect-routing.test.ts
 ✓ 9 tests passed
```

### Prior Art

- PR #11194 addresses the drain.ts portion — this PR includes the same fix plus the deliveryContext fix
- PRs #4389, #4749, #5245 attempted the drain.ts fix but missed the empty-string edge case

### Behavior Changes

- String thread IDs (Slack `thread_ts`) now preserved during queue drain
- Empty string `""` treated as absent (prevents spurious thread grouping)
- DM sessions now include thread_ts in deliveryContext when applicable
- No change for numeric thread IDs (Telegram)

Closes #10837, closes #11195

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Slack thread reply routing in two places:

- In the followup queue drain logic, thread IDs are now treated as present when they are non-null and non-empty, so Slack `thread_ts` (string) is preserved when building the collect-grouping key and when extracting `originatingThreadId` for the collected run.
- For Slack DMs, both `prepareSlackMessage` and `dispatchPreparedSlackMessage` now include `threadId` in the `updateLastRoute` deliveryContext so DM thread sessions retain `thread_ts`.

Tests were expanded in `queue.collect-routing.test.ts` to cover collecting/separating runs by string thread IDs and treating empty string as absent.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to routing keys and session deliveryContext, align with Slack thread_ts being a string, and are covered by targeted unit tests for collect routing behavior (including empty-string edge case).
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->