### PR TITLE
fix(ci): update SwiftFormat and SwiftLint excludes for OpenClawProtocol rebrand

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -48,4 +48,4 @@
 --allman false
 
 # Exclusions
---exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Peekaboo,Swabble,apps/android,apps/ios,apps/shared,apps/macos/Sources/MoltbotProtocol
+--exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Peekaboo,Swabble,apps/android,apps/ios,apps/shared,apps/macos/Sources/OpenClawProtocol

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,7 +18,7 @@ excluded:
   - coverage
   - "*.playground"
   # Generated (protocol-gen-swift.ts)
-  - apps/macos/Sources/MoltbotProtocol/GatewayModels.swift
+  - apps/macos/Sources/OpenClawProtocol
 
 analyzer_rules:
   - unused_declaration


### PR DESCRIPTION
## Summary

Update `.swiftformat` and `.swiftlint.yml` to exclude the renamed `OpenClawProtocol` directory instead of the stale `MoltbotProtocol` path. The generated `GatewayModels.swift` file is no longer excluded from Swift linting/formatting, causing `macos` CI checks to fail on every open PR.

Fixes #10727

## Root Cause

After the Moltbot -> OpenClaw rebrand, the generated protocol models moved from `apps/macos/Sources/MoltbotProtocol/` to `apps/macos/Sources/OpenClawProtocol/`. The exclude paths in `.swiftformat` and `.swiftlint.yml` were not updated, so `swiftformat --lint` now runs against the generated `GatewayModels.swift` and fails (100/204 files require formatting).

## Changes

- `.swiftformat`: replace `MoltbotProtocol` with `OpenClawProtocol` in `--exclude` list
- `.swiftlint.yml`: replace specific file path `MoltbotProtocol/GatewayModels.swift` with entire `OpenClawProtocol` directory (consistent with `.swiftformat` approach, future-proof for additional generated files)

## Behavior Changes

None. Generated files were always intended to be excluded from Swift lint/format checks.

## Codebase and GitHub Search

- Confirmed `apps/macos/Sources/MoltbotProtocol/` no longer exists on disk
- Confirmed `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift` is the only file in that directory (auto-generated by `protocol-gen-swift.ts`)
- Issue #10727 by @mcaxtr documents the same problem

## Tests

- `swiftformat --lint` should now skip the generated protocol directory
- All `macos` CI checks across open PRs should pass after this lands

lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates SwiftFormat and SwiftLint configuration to exclude the renamed macOS generated protocol models path (`apps/macos/Sources/OpenClawProtocol`) instead of the old `MoltbotProtocol` location, preventing generated `GatewayModels.swift` from being linted/formatted in CI.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to updating exclude paths in `.swiftformat` and `.swiftlint.yml`, and the new path matches the existing generated directory used by `scripts/protocol-gen-swift.ts`. No functional code changes or behavior changes beyond lint/format scope.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->