### PR TITLE
Exec approvals: render forwarded commands in monospace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec approvals: format forwarded command text as inline/fenced monospace for safer approval scanning across channels. (#11917)
 - Thinking: allow xhigh for `github-copilot/gpt-5.2-codex` and `github-copilot/gpt-5.2`. (#11646) Thanks @seans-openclawbot.
 - Discord: support forum/media `thread create` starter messages, wire `message thread create --message`, and harden thread-create routing. (#10062) Thanks @jarvis89757.
 - Web UI: make chat refresh smoothly scroll to the latest messages and suppress new-messages badge flash during manual refresh.

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -134,7 +134,7 @@ describe("exec approval forwarder", () => {
       },
     });
 
-    expect(getFirstDeliveryText(deliver)).toContain("Command: ```\necho `uname`\necho done\n```");
+    expect(getFirstDeliveryText(deliver)).toContain("Command:\n```\necho `uname`\necho done\n```");
   });
 
   it("uses a longer fence when command already contains triple backticks", async () => {
@@ -165,6 +165,6 @@ describe("exec approval forwarder", () => {
       },
     });
 
-    expect(getFirstDeliveryText(deliver)).toContain("Command: ````\necho ```danger```\n````");
+    expect(getFirstDeliveryText(deliver)).toContain("Command:\n````\necho ```danger```\n````");
   });
 });

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -17,6 +17,13 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+function getFirstDeliveryText(deliver: ReturnType<typeof vi.fn>): string {
+  const firstCall = deliver.mock.calls[0]?.[0] as
+    | { payloads?: Array<{ text?: string }> }
+    | undefined;
+  return firstCall?.payloads?.[0]?.text ?? "";
+}
+
 describe("exec approval forwarder", () => {
   it("forwards to session target and resolves", async () => {
     vi.useFakeTimers();
@@ -72,5 +79,92 @@ describe("exec approval forwarder", () => {
 
     await vi.runAllTimersAsync();
     expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
+  it("formats single-line commands as inline code", async () => {
+    vi.useFakeTimers();
+    const deliver = vi.fn().mockResolvedValue([]);
+    const cfg = {
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "telegram", to: "123" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const forwarder = createExecApprovalForwarder({
+      getConfig: () => cfg,
+      deliver,
+      nowMs: () => 1000,
+      resolveSessionTarget: () => null,
+    });
+
+    await forwarder.handleRequested(baseRequest);
+
+    expect(getFirstDeliveryText(deliver)).toContain("Command: `echo hello`");
+  });
+
+  it("formats complex commands as fenced code blocks", async () => {
+    vi.useFakeTimers();
+    const deliver = vi.fn().mockResolvedValue([]);
+    const cfg = {
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "telegram", to: "123" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const forwarder = createExecApprovalForwarder({
+      getConfig: () => cfg,
+      deliver,
+      nowMs: () => 1000,
+      resolveSessionTarget: () => null,
+    });
+
+    await forwarder.handleRequested({
+      ...baseRequest,
+      request: {
+        ...baseRequest.request,
+        command: "echo `uname`\necho done",
+      },
+    });
+
+    expect(getFirstDeliveryText(deliver)).toContain("Command: ```\necho `uname`\necho done\n```");
+  });
+
+  it("uses a longer fence when command already contains triple backticks", async () => {
+    vi.useFakeTimers();
+    const deliver = vi.fn().mockResolvedValue([]);
+    const cfg = {
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "telegram", to: "123" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const forwarder = createExecApprovalForwarder({
+      getConfig: () => cfg,
+      deliver,
+      nowMs: () => 1000,
+      resolveSessionTarget: () => null,
+    });
+
+    await forwarder.handleRequested({
+      ...baseRequest,
+      request: {
+        ...baseRequest.request,
+        command: "echo ```danger```",
+      },
+    });
+
+    expect(getFirstDeliveryText(deliver)).toContain("Command: ````\necho ```danger```\n````");
   });
 });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -115,21 +115,27 @@ function buildTargetKey(target: ExecApprovalForwardTarget): string {
   return [channel, target.to, accountId, threadId].join(":");
 }
 
-function formatApprovalCommand(command: string): string {
+function formatApprovalCommand(command: string): { inline: boolean; text: string } {
   if (!command.includes("\n") && !command.includes("`")) {
-    return `\`${command}\``;
+    return { inline: true, text: `\`${command}\`` };
   }
 
   let fence = "```";
   while (command.includes(fence)) {
     fence += "`";
   }
-  return `${fence}\n${command}\n${fence}`;
+  return { inline: false, text: `${fence}\n${command}\n${fence}` };
 }
 
 function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   const lines: string[] = ["🔒 Exec approval required", `ID: ${request.id}`];
-  lines.push(`Command: ${formatApprovalCommand(request.request.command)}`);
+  const command = formatApprovalCommand(request.request.command);
+  if (command.inline) {
+    lines.push(`Command: ${command.text}`);
+  } else {
+    lines.push("Command:");
+    lines.push(command.text);
+  }
   if (request.request.cwd) {
     lines.push(`CWD: ${request.request.cwd}`);
   }

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -115,9 +115,21 @@ function buildTargetKey(target: ExecApprovalForwardTarget): string {
   return [channel, target.to, accountId, threadId].join(":");
 }
 
+function formatApprovalCommand(command: string): string {
+  if (!command.includes("\n") && !command.includes("`")) {
+    return `\`${command}\``;
+  }
+
+  let fence = "```";
+  while (command.includes(fence)) {
+    fence += "`";
+  }
+  return `${fence}\n${command}\n${fence}`;
+}
+
 function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   const lines: string[] = ["🔒 Exec approval required", `ID: ${request.id}`];
-  lines.push(`Command: ${request.request.command}`);
+  lines.push(`Command: ${formatApprovalCommand(request.request.command)}`);
   if (request.request.cwd) {
     lines.push(`CWD: ${request.request.cwd}`);
   }


### PR DESCRIPTION
## Summary
- Closes #11917.
- Format forwarded exec approval command text as monospace in request messages.
- Use inline code for simple single-line commands (easy to scan at a glance).
- Auto-switch to fenced code blocks for multiline commands or commands containing backticks.
- Auto-expand fence length when command already contains triple backticks.
- Add targeted tests for inline, fenced, and fence-expansion cases.
- Add changelog entry under `2026.2.6-4` fixes.

## Compromises / tradeoffs
- Kept formatting channel-agnostic in the forwarder (no per-channel branching).
  - Channels with markdown/code rendering get proper monospace.
  - Channels without markdown support may show literal backticks (acceptable fallback, no behavior break).
- Scoped this to **request** messages only; resolved/expired notices remain unchanged to keep risk/blast radius low.

## Validation
- `pnpm tsgo`
- `pnpm test src/infra/exec-approval-forwarder.test.ts`
- `pnpm exec oxfmt --check src/infra/exec-approval-forwarder.ts src/infra/exec-approval-forwarder.test.ts CHANGELOG.md`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates exec-approval request message formatting so the forwarded command is rendered in monospace: single-line/no-backtick commands use inline code, and more complex commands use fenced code blocks with an auto-expanded fence length if the command contains ```.

Adds focused Vitest coverage for inline formatting, fenced formatting, and fence expansion, and records the change in the 2026.2.6-4 changelog section.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge once the changelog reference is corrected.
- Behavior change is localized to exec approval request message rendering with targeted unit tests. Only clear issue found is an incorrect PR number in the changelog entry, which would create a broken/misleading release note reference.
- CHANGELOG.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->