### PR TITLE
feat: support ANTHROPIC_AUTH_TOKEN environment variable

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -26,6 +26,22 @@ openclaw onboard
 openclaw onboard --anthropic-api-key "$ANTHROPIC_API_KEY"
 ```
 
+### Environment variables
+
+OpenClaw supports the following environment variables for Anthropic API authentication (checked in order):
+
+| Variable                | Priority | Description                       |
+| ----------------------- | -------- | --------------------------------- |
+| `ANTHROPIC_OAUTH_TOKEN` | 1st      | OAuth token authentication        |
+| `ANTHROPIC_API_KEY`     | 2nd      | Standard API key (sk-ant-...)     |
+| `ANTHROPIC_AUTH_TOKEN`  | 3rd      | Alternative auth token (fallback) |
+
+```bash
+# Set any of these (higher priority takes precedence)
+export ANTHROPIC_API_KEY="sk-ant-..."
+export ANTHROPIC_AUTH_TOKEN="your_token_here"
+```
+
 ### Config snippet
 
 ```json5

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -249,7 +249,9 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
   }
 
   if (normalized === "anthropic") {
-    return pick("ANTHROPIC_OAUTH_TOKEN") ?? pick("ANTHROPIC_API_KEY");
+    return (
+      pick("ANTHROPIC_OAUTH_TOKEN") ?? pick("ANTHROPIC_API_KEY") ?? pick("ANTHROPIC_AUTH_TOKEN")
+    );
   }
 
   if (normalized === "chutes") {


### PR DESCRIPTION
## Summary

Add support for the `ANTHROPIC_AUTH_TOKEN` environment variable as a fallback option for Anthropic authentication, alongside `ANTHROPIC_OAUTH_TOKEN` and `ANTHROPIC_API_KEY`.

This allows users who have `ANTHROPIC_AUTH_TOKEN` configured in their environment to use OpenClaw without renaming the variable.

## Changes

- **src/agents/model-auth.ts**: Added `ANTHROPIC_AUTH_TOKEN` as fallback in environment variable resolution
- **docs/providers/anthropic.md**: Updated documentation with environment variable priority table

## Testing

Tested with local OpenClaw instance using custom API endpoint:
```bash
export ANTHROPIC_AUTH_TOKEN="cr_..."
export ANTHROPIC_BASE_URL="https://custom.api.endpoint"
openclaw agent --agent main --message "test"
```

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `ANTHROPIC_AUTH_TOKEN` as an additional environment-variable fallback when resolving Anthropic credentials, and documents the env var priority order in the Anthropic provider docs.

The new env var integrates into the shared auth resolution path (`resolveEnvApiKey` -> `resolveApiKeyForProvider`), which is also used to drive user-facing status output and certain provider-specific defaults (e.g., Anthropic cache retention defaults for API-key auth).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but may misclassify `ANTHROPIC_AUTH_TOKEN` auth mode in a way that changes runtime behavior.
- The change is small and localized, but auth mode is inferred from env var names; adding a new token-like env var without updating mode inference can cause incorrect mode selection, impacting defaults (prompt caching) and status/cost reporting.
- src/agents/model-auth.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->