### PR TITLE
feat: implement plugin lifecycle interception architecture

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -82,13 +82,50 @@ See [Hooks](/automation/hooks) for setup and examples.
 These run inside the agent loop or gateway pipeline:
 
 - **`before_agent_start`**: inject context or override system prompt before the run starts.
+- **`before_recall`**: intercept memory recall query/options immediately before memory vector search.
 - **`agent_end`**: inspect the final message list and run metadata after completion.
+- **`agent_error`**: observe failed runs without coupling to successful completion hooks.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
 - **`tool_result_persist`**: synchronously transform tool results before they are written to the session transcript.
 - **`message_received` / `message_sending` / `message_sent`**: inbound + outbound message hooks.
 - **`session_start` / `session_end`**: session lifecycle boundaries.
-- **`gateway_start` / `gateway_stop`**: gateway lifecycle events.
+- **`gateway_pre_start` / `gateway_start` / `gateway_pre_stop` / `gateway_stop`**: gateway lifecycle events.
+
+Plugins can register these via either:
+
+- `api.on("<hook_name>", handler, { priority, timeoutMs, mode, condition })`
+- `api.lifecycle.on("<phase>", handler, { priority, timeoutMs, mode, condition })`
+
+Lifecycle phase aliases exposed by `api.lifecycle.on(...)`:
+
+- `boot.pre` -> `gateway_pre_start`
+- `boot.post` -> `gateway_start`
+- `message.pre` -> `message_sending`
+- `message.post` -> `message_sent`
+- `tool.pre` -> `before_tool_call`
+- `tool.post` -> `after_tool_call`
+- `agent.pre` -> `before_agent_start`
+- `agent.post` -> `agent_end`
+- `recall.pre` -> `before_recall`
+- `error` -> `agent_error`
+- `memory.compaction.pre` -> `before_compaction`
+- `memory.compaction.post` -> `after_compaction`
+- `shutdown.pre` -> `gateway_pre_stop`
+- `shutdown.post` -> `gateway_stop`
+
+Proposal-style aliases exposed by `api.lifecycle.on(...)`:
+
+- `preRequest` -> `message.pre`
+- `preRecall` -> `recall.pre`
+- `preResponse` -> `message.pre`
+- `preToolExecution` -> `tool.pre`
+- `preCompaction` -> `memory.compaction.pre`
+- `postRequest` -> `agent.post`
+- `postResponse` -> `message.post`
+- `postToolExecution` -> `tool.post`
+- `postCompaction` -> `memory.compaction.post`
+- `onError` -> `error` (only runs when `success === false`)
 
 See [Plugins](/tools/plugin#plugin-hooks) for the hook API and registration details.
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -327,6 +327,69 @@ Notes:
 - Plugin-managed hooks show up in `openclaw hooks list` with `plugin:<id>`.
 - You cannot enable/disable plugin-managed hooks via `openclaw hooks`; enable/disable the plugin instead.
 
+### Typed lifecycle hooks (plugin runtime)
+
+Plugins can also register typed lifecycle interception hooks with `api.lifecycle.on(...)`.
+This is separate from `registerPluginHooksFromDir` and maps to runtime lifecycle events.
+
+Use:
+
+- `api.on("hook_name", handler, opts)` for raw runtime hook names.
+- `api.lifecycle.on("phase", handler, opts)` for phase aliases (including proposal-style names like `preRecall` and `onError`).
+
+Example:
+
+```ts
+export default function register(api) {
+  api.lifecycle.on(
+    "tool.pre",
+    (payload) => {
+      // inspect or annotate tool invocation payload
+      if (payload.toolName === "dangerous_tool") {
+        return { block: true, blockReason: "blocked by policy" };
+      }
+      return { params: payload.params };
+    },
+    {
+      priority: 100,
+      timeoutMs: 500,
+      mode: "fail-open",
+      condition: (payload) => payload.toolName !== "dangerous_tool",
+    },
+  );
+}
+```
+
+Current canonical lifecycle phases:
+
+- `boot.pre` / `boot.post`
+- `message.pre` / `message.post`
+- `tool.pre` / `tool.post`
+- `agent.pre` / `agent.post`
+- `recall.pre` / `error`
+- `memory.compaction.pre` / `memory.compaction.post`
+- `shutdown.pre` / `shutdown.post`
+
+Proposal-style aliases supported by `api.lifecycle.on(...)`:
+
+- `preRequest` -> `message.pre`
+- `preRecall` -> `recall.pre` -> `before_recall`
+- `preResponse` -> `message.pre`
+- `preToolExecution` -> `tool.pre`
+- `preCompaction` -> `memory.compaction.pre`
+- `postRequest` -> `agent.post`
+- `postResponse` -> `message.post`
+- `postToolExecution` -> `tool.post`
+- `postCompaction` -> `memory.compaction.post`
+- `onError` -> `error` -> `agent_error` (only triggered for failed agent runs)
+
+Execution options:
+
+- `priority`: higher runs first
+- `timeoutMs`: max time per hook handler
+- `mode`: `fail-open` (log and continue) or `fail-closed` (throw)
+- `condition`: skip handler when it returns false
+
 ## Provider plugins (model auth)
 
 Plugins can register **model provider auth** flows so users can run OAuth or

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -849,15 +849,18 @@ export async function runEmbeddedAttempt(
         });
         anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
 
-        // Run agent_end hooks to allow plugins to analyze the conversation
-        // This is fire-and-forget, so we don't await
+        const runSucceeded = !aborted && !promptError;
+        const runError = promptError ? describeUnknownError(promptError) : undefined;
+
+        // Run agent_end hooks to allow plugins to analyze the conversation.
+        // This is fire-and-forget, so we don't await.
         if (hookRunner?.hasHooks("agent_end")) {
           hookRunner
             .runAgentEnd(
               {
                 messages: messagesSnapshot,
-                success: !aborted && !promptError,
-                error: promptError ? describeUnknownError(promptError) : undefined,
+                success: runSucceeded,
+                error: runError,
                 durationMs: Date.now() - promptStartedAt,
               },
               {
@@ -869,6 +872,28 @@ export async function runEmbeddedAttempt(
             )
             .catch((err) => {
               log.warn(`agent_end hook failed: ${err}`);
+            });
+        }
+
+        // Run agent_error hooks only for failed runs.
+        if (!runSucceeded && hookRunner?.hasHooks("agent_error")) {
+          hookRunner
+            .runAgentError(
+              {
+                messages: messagesSnapshot,
+                success: false,
+                error: runError ?? "agent run failed",
+                durationMs: Date.now() - promptStartedAt,
+              },
+              {
+                agentId: hookAgentId,
+                sessionKey: params.sessionKey,
+                workspaceDir: params.workspaceDir,
+                messageProvider: params.messageProvider ?? undefined,
+              },
+            )
+            .catch((err) => {
+              log.warn(`agent_error hook failed: ${err}`);
             });
         }
       } finally {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.hooks.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.hooks.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import {
+  handleAutoCompactionEnd,
+  handleAutoCompactionStart,
+} from "./pi-embedded-subscribe.handlers.lifecycle.js";
+
+vi.mock("../plugins/hook-runner-global.js");
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+describe("embedded subscribe lifecycle hook wiring", () => {
+  it("fires before_compaction and after_compaction around compaction events", () => {
+    const runBeforeCompaction = vi.fn().mockResolvedValue(undefined);
+    const runAfterCompaction = vi.fn().mockResolvedValue(undefined);
+    mockGetGlobalHookRunner.mockReturnValue({
+      hasHooks: (name: string) => name === "before_compaction" || name === "after_compaction",
+      runBeforeCompaction,
+      runAfterCompaction,
+    } as never);
+
+    const ctx = {
+      params: {
+        runId: "r1",
+        session: { messages: [{ role: "user" }, { role: "assistant" }, { role: "user" }] },
+      },
+      state: {
+        compactionInFlight: false,
+        compactionStartMessageCount: undefined,
+      },
+      log: { debug: vi.fn(), warn: vi.fn() },
+      incrementCompactionCount: vi.fn(),
+      ensureCompactionPromise: vi.fn(),
+      noteCompactionRetry: vi.fn(),
+      resetForCompactionRetry: vi.fn(),
+      maybeResolveCompactionWait: vi.fn(),
+      paramsOnAgentEvent: vi.fn(),
+    } as unknown as Parameters<typeof handleAutoCompactionStart>[0];
+
+    handleAutoCompactionStart(ctx);
+    ctx.params.session.messages = [{ role: "user" }];
+    handleAutoCompactionEnd(ctx, { type: "auto_compaction_end", willRetry: false });
+
+    expect(runBeforeCompaction).toHaveBeenCalledWith({ messageCount: 3 }, {});
+    expect(runAfterCompaction).toHaveBeenCalledWith({ messageCount: 1, compactedCount: 2 }, {});
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -52,6 +52,7 @@ export type EmbeddedPiSubscribeState = {
   lastReasoningSent?: string;
 
   compactionInFlight: boolean;
+  compactionStartMessageCount?: number;
   pendingCompactionRetry: number;
   compactionRetryResolve?: () => void;
   compactionRetryPromise: Promise<void> | null;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -61,6 +61,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     suppressBlockChunks: false, // Avoid late chunk inserts after final text merge.
     lastReasoningSent: undefined,
     compactionInFlight: false,
+    compactionStartMessageCount: undefined,
     pendingCompactionRetry: 0,
     compactionRetryResolve: undefined,
     compactionRetryPromise: null,

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -6,7 +6,7 @@ import type {
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
 import { logDebug, logError } from "../logger.js";
-import { runBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
+import { runAfterToolCallHook, runBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
 import { normalizeToolName } from "./tool-policy.js";
 import { jsonResult } from "./tools/common.js";
 
@@ -138,6 +138,7 @@ export function toClientToolDefinitions(
       parameters: func.parameters as any,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params } = splitToolExecuteArgs(args);
+        const startedAt = Date.now();
         const outcome = await runBeforeToolCallHook({
           toolName: func.name,
           params,
@@ -154,11 +155,19 @@ export function toClientToolDefinitions(
           onClientToolCall(func.name, paramsRecord);
         }
         // Return a pending result - the client will execute this tool
-        return jsonResult({
+        const pendingResult = jsonResult({
           status: "pending",
           tool: func.name,
           message: "Tool execution delegated to client",
         });
+        await runAfterToolCallHook({
+          toolName: func.name,
+          params: paramsRecord,
+          result: pendingResult,
+          durationMs: Date.now() - startedAt,
+          ctx: hookContext,
+        });
+        return pendingResult;
       },
     } satisfies ToolDefinition;
   });

--- a/src/agents/pi-tools.before-tool-call.test.ts
+++ b/src/agents/pi-tools.before-tool-call.test.ts
@@ -11,12 +11,14 @@ describe("before_tool_call hook integration", () => {
   let hookRunner: {
     hasHooks: ReturnType<typeof vi.fn>;
     runBeforeToolCall: ReturnType<typeof vi.fn>;
+    runAfterToolCall: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
     hookRunner = {
       hasHooks: vi.fn(),
       runBeforeToolCall: vi.fn(),
+      runAfterToolCall: vi.fn(),
     };
     // oxlint-disable-next-line typescript/no-explicit-any
     mockGetGlobalHookRunner.mockReturnValue(hookRunner as any);
@@ -34,6 +36,7 @@ describe("before_tool_call hook integration", () => {
     await tool.execute("call-1", { path: "/tmp/file" }, undefined, undefined);
 
     expect(hookRunner.runBeforeToolCall).not.toHaveBeenCalled();
+    expect(hookRunner.runAfterToolCall).not.toHaveBeenCalled();
     expect(execute).toHaveBeenCalledWith("call-1", { path: "/tmp/file" }, undefined, undefined);
   });
 
@@ -106,25 +109,76 @@ describe("before_tool_call hook integration", () => {
       },
     );
   });
+
+  it("emits after_tool_call on success", async () => {
+    hookRunner.hasHooks.mockImplementation((name: string) => name === "after_tool_call");
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithBeforeToolCallHook({ name: "exec", execute } as any, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    await tool.execute("call-6", { cmd: "pwd" }, undefined, undefined);
+
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "exec",
+        params: { cmd: "pwd" },
+        error: undefined,
+      }),
+      expect.objectContaining({
+        toolName: "exec",
+        agentId: "main",
+        sessionKey: "main",
+      }),
+    );
+  });
+
+  it("emits after_tool_call with error when execution throws", async () => {
+    hookRunner.hasHooks.mockImplementation((name: string) => name === "after_tool_call");
+    const execute = vi.fn().mockRejectedValue(new Error("tool exploded"));
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithBeforeToolCallHook({ name: "exec", execute } as any);
+
+    await expect(tool.execute("call-7", { cmd: "pwd" }, undefined, undefined)).rejects.toThrow(
+      "tool exploded",
+    );
+
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "exec",
+        params: { cmd: "pwd" },
+        error: "tool exploded",
+      }),
+      expect.objectContaining({
+        toolName: "exec",
+      }),
+    );
+  });
 });
 
 describe("before_tool_call hook integration for client tools", () => {
   let hookRunner: {
     hasHooks: ReturnType<typeof vi.fn>;
     runBeforeToolCall: ReturnType<typeof vi.fn>;
+    runAfterToolCall: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
     hookRunner = {
       hasHooks: vi.fn(),
       runBeforeToolCall: vi.fn(),
+      runAfterToolCall: vi.fn(),
     };
     // oxlint-disable-next-line typescript/no-explicit-any
     mockGetGlobalHookRunner.mockReturnValue(hookRunner as any);
   });
 
   it("passes modified params to client tool callbacks", async () => {
-    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.hasHooks.mockImplementation(
+      (name: string) => name === "before_tool_call" || name === "after_tool_call",
+    );
     hookRunner.runBeforeToolCall.mockResolvedValue({ params: { extra: true } });
     const onClientToolCall = vi.fn();
     const [tool] = toClientToolDefinitions(
@@ -148,5 +202,17 @@ describe("before_tool_call hook integration for client tools", () => {
       value: "ok",
       extra: true,
     });
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "client_tool",
+        params: { value: "ok", extra: true },
+        error: undefined,
+      }),
+      expect.objectContaining({
+        toolName: "client_tool",
+        agentId: "main",
+        sessionKey: "main",
+      }),
+    );
   });
 });

--- a/src/agents/tools/memory-tool.before-recall.test.ts
+++ b/src/agents/tools/memory-tool.before-recall.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+const search = vi.fn(async () => []);
+const status = vi.fn(() => ({
+  files: 0,
+  chunks: 0,
+  dirty: false,
+  workspaceDir: "/tmp",
+  dbPath: "/tmp/index.sqlite",
+  provider: "openai",
+  model: "text-embedding-3-small",
+  requestedProvider: "openai",
+}));
+
+const runBeforeRecall = vi.fn();
+const hasHooks = vi.fn(() => false);
+
+vi.mock("../../memory/index.js", () => ({
+  getMemorySearchManager: async () => ({
+    manager: {
+      search,
+      status,
+    },
+  }),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => ({
+    hasHooks,
+    runBeforeRecall,
+  }),
+}));
+
+import { createMemorySearchTool } from "./memory-tool.js";
+
+describe("memory_search before_recall hook integration", () => {
+  it("allows before_recall hooks to mutate query parameters", async () => {
+    hasHooks.mockReturnValue(true);
+    runBeforeRecall.mockResolvedValue({
+      query: "rewritten query",
+      maxResults: 2,
+      minScore: 0.8,
+    });
+
+    const cfg = { agents: { list: [{ id: "main", default: true }] } };
+    const tool = createMemorySearchTool({ config: cfg, agentSessionKey: "agent:main:dm" });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("call_1", { query: "original query", maxResults: 6, minScore: 0.2 });
+
+    expect(runBeforeRecall).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledWith("rewritten query", {
+      maxResults: 2,
+      minScore: 0.8,
+      sessionKey: "agent:main:dm",
+    });
+  });
+});

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -5,6 +5,7 @@ import type { MemorySearchResult } from "../../memory/types.js";
 import type { AnyAgentTool } from "./common.js";
 import { resolveMemoryBackendConfig } from "../../memory/backend-config.js";
 import { getMemorySearchManager } from "../../memory/index.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { resolveMemorySearchConfig } from "../memory-search.js";
@@ -47,6 +48,9 @@ export function createMemorySearchTool(options: {
       const query = readStringParam(params, "query", { required: true });
       const maxResults = readNumberParam(params, "maxResults");
       const minScore = readNumberParam(params, "minScore");
+      let effectiveQuery = query;
+      let effectiveMaxResults = maxResults;
+      let effectiveMinScore = minScore;
       const { manager, error } = await getMemorySearchManager({
         cfg,
         agentId,
@@ -55,14 +59,40 @@ export function createMemorySearchTool(options: {
         return jsonResult({ results: [], disabled: true, error });
       }
       try {
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("before_recall")) {
+          const hookResult = await hookRunner.runBeforeRecall(
+            {
+              query,
+              maxResults,
+              minScore,
+            },
+            {
+              agentId,
+              sessionKey: options.agentSessionKey,
+            },
+          );
+          if (typeof hookResult?.query === "string" && hookResult.query.trim()) {
+            effectiveQuery = hookResult.query;
+          }
+          if (
+            typeof hookResult?.maxResults === "number" &&
+            Number.isFinite(hookResult.maxResults)
+          ) {
+            effectiveMaxResults = hookResult.maxResults;
+          }
+          if (typeof hookResult?.minScore === "number" && Number.isFinite(hookResult.minScore)) {
+            effectiveMinScore = hookResult.minScore;
+          }
+        }
         const citationsMode = resolveMemoryCitationsMode(cfg);
         const includeCitations = shouldIncludeCitations({
           mode: citationsMode,
           sessionKey: options.agentSessionKey,
         });
-        const rawResults = await manager.search(query, {
-          maxResults,
-          minScore,
+        const rawResults = await manager.search(effectiveQuery, {
+          maxResults: effectiveMaxResults,
+          minScore: effectiveMinScore,
           sessionKey: options.agentSessionKey,
         });
         const status = manager.status();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -148,6 +148,35 @@ export async function dispatchReplyFromConfig(params: {
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = resolveSessionTtsAuto(ctx, cfg);
   const hookRunner = getGlobalHookRunner();
+  const emitMessageSentHook = async (args: {
+    to: string;
+    content: string;
+    success: boolean;
+    error?: string;
+    channelId: string;
+    conversationId?: string;
+  }) => {
+    if (!hookRunner?.hasHooks("message_sent")) {
+      return;
+    }
+    try {
+      await hookRunner.runMessageSent(
+        {
+          to: args.to,
+          content: args.content,
+          success: args.success,
+          error: args.error,
+        },
+        {
+          channelId: args.channelId,
+          accountId: ctx.AccountId,
+          conversationId: args.conversationId,
+        },
+      );
+    } catch (err) {
+      logVerbose(`dispatch-from-config: message_sent hook failed: ${String(err)}`);
+    }
+  };
   if (hookRunner?.hasHooks("message_received")) {
     const timestamp =
       typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp)
@@ -221,14 +250,14 @@ export async function dispatchReplyFromConfig(params: {
     payload: ReplyPayload,
     abortSignal?: AbortSignal,
     mirror?: boolean,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     // TypeScript doesn't narrow these from the shouldRouteToOriginating check,
     // but they're guaranteed non-null when this function is called.
     if (!originatingChannel || !originatingTo) {
-      return;
+      return false;
     }
     if (abortSignal?.aborted) {
-      return;
+      return false;
     }
     const result = await routeReply({
       payload,
@@ -241,9 +270,20 @@ export async function dispatchReplyFromConfig(params: {
       abortSignal,
       mirror,
     });
+    const channelId = originatingChannel.toLowerCase();
+    const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+    await emitMessageSentHook({
+      to: originatingTo,
+      content: payload.text ?? "",
+      success: result.ok,
+      error: result.ok ? undefined : (result.error ?? "route-reply failed"),
+      channelId,
+      conversationId,
+    });
     if (!result.ok) {
       logVerbose(`dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`);
     }
+    return result.ok;
   };
 
   markProcessing();
@@ -257,26 +297,24 @@ export async function dispatchReplyFromConfig(params: {
       let queuedFinal = false;
       let routedFinalCount = 0;
       if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-        const result = await routeReply({
-          payload,
-          channel: originatingChannel,
-          to: originatingTo,
-          sessionKey: ctx.SessionKey,
-          accountId: ctx.AccountId,
-          threadId: ctx.MessageThreadId,
-          cfg,
-        });
-        queuedFinal = result.ok;
-        if (result.ok) {
+        const sent = await sendPayloadAsync(payload);
+        queuedFinal = sent;
+        if (sent) {
           routedFinalCount += 1;
         }
-        if (!result.ok) {
-          logVerbose(
-            `dispatch-from-config: route-reply (abort) failed: ${result.error ?? "unknown error"}`,
-          );
-        }
       } else {
-        queuedFinal = dispatcher.sendFinalReply(payload);
+        const didQueue = dispatcher.sendFinalReply(payload);
+        queuedFinal = didQueue;
+        const channelId = (currentSurface ?? ctx.Provider ?? "").toLowerCase();
+        const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+        void emitMessageSentHook({
+          to: ctx.To ?? "",
+          content: payload.text ?? "",
+          success: didQueue,
+          error: didQueue ? undefined : "reply not queued",
+          channelId,
+          conversationId,
+        });
       }
       await dispatcher.waitForIdle();
       const counts = dispatcher.getQueuedCounts();
@@ -312,7 +350,17 @@ export async function dispatchReplyFromConfig(params: {
                 if (shouldRouteToOriginating) {
                   await sendPayloadAsync(ttsPayload, undefined, false);
                 } else {
-                  dispatcher.sendToolResult(ttsPayload);
+                  const didQueue = dispatcher.sendToolResult(ttsPayload);
+                  const channelId = (currentSurface ?? ctx.Provider ?? "").toLowerCase();
+                  const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+                  void emitMessageSentHook({
+                    to: ctx.To ?? "",
+                    content: ttsPayload.text ?? "",
+                    success: didQueue,
+                    error: didQueue ? undefined : "reply not queued",
+                    channelId,
+                    conversationId,
+                  });
                 }
               };
               return run();
@@ -339,7 +387,17 @@ export async function dispatchReplyFromConfig(params: {
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
             } else {
-              dispatcher.sendBlockReply(ttsPayload);
+              const didQueue = dispatcher.sendBlockReply(ttsPayload);
+              const channelId = (currentSurface ?? ctx.Provider ?? "").toLowerCase();
+              const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+              void emitMessageSentHook({
+                to: ctx.To ?? "",
+                content: ttsPayload.text ?? "",
+                success: didQueue,
+                error: didQueue ? undefined : "reply not queued",
+                channelId,
+                conversationId,
+              });
             }
           };
           return run();
@@ -362,27 +420,24 @@ export async function dispatchReplyFromConfig(params: {
         ttsAuto: sessionTtsAuto,
       });
       if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-        // Route final reply to originating channel.
-        const result = await routeReply({
-          payload: ttsReply,
-          channel: originatingChannel,
-          to: originatingTo,
-          sessionKey: ctx.SessionKey,
-          accountId: ctx.AccountId,
-          threadId: ctx.MessageThreadId,
-          cfg,
-        });
-        if (!result.ok) {
-          logVerbose(
-            `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
-          );
-        }
-        queuedFinal = result.ok || queuedFinal;
-        if (result.ok) {
+        const sent = await sendPayloadAsync(ttsReply);
+        queuedFinal = sent || queuedFinal;
+        if (sent) {
           routedFinalCount += 1;
         }
       } else {
-        queuedFinal = dispatcher.sendFinalReply(ttsReply) || queuedFinal;
+        const didQueue = dispatcher.sendFinalReply(ttsReply);
+        queuedFinal = didQueue || queuedFinal;
+        const channelId = (currentSurface ?? ctx.Provider ?? "").toLowerCase();
+        const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+        void emitMessageSentHook({
+          to: ctx.To ?? "",
+          content: ttsReply.text ?? "",
+          success: didQueue,
+          error: didQueue ? undefined : "reply not queued",
+          channelId,
+          conversationId,
+        });
       }
     }
 
@@ -413,27 +468,24 @@ export async function dispatchReplyFromConfig(params: {
             audioAsVoice: ttsSyntheticReply.audioAsVoice,
           };
           if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-            const result = await routeReply({
-              payload: ttsOnlyPayload,
-              channel: originatingChannel,
-              to: originatingTo,
-              sessionKey: ctx.SessionKey,
-              accountId: ctx.AccountId,
-              threadId: ctx.MessageThreadId,
-              cfg,
-            });
-            queuedFinal = result.ok || queuedFinal;
-            if (result.ok) {
+            const sent = await sendPayloadAsync(ttsOnlyPayload);
+            queuedFinal = sent || queuedFinal;
+            if (sent) {
               routedFinalCount += 1;
-            }
-            if (!result.ok) {
-              logVerbose(
-                `dispatch-from-config: route-reply (tts-only) failed: ${result.error ?? "unknown error"}`,
-              );
             }
           } else {
             const didQueue = dispatcher.sendFinalReply(ttsOnlyPayload);
             queuedFinal = didQueue || queuedFinal;
+            const channelId = (currentSurface ?? ctx.Provider ?? "").toLowerCase();
+            const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+            void emitMessageSentHook({
+              to: ctx.To ?? "",
+              content: ttsOnlyPayload.text ?? "",
+              success: didQueue,
+              error: didQueue ? undefined : "reply not queued",
+              channelId,
+              conversationId,
+            });
           }
         }
       } catch (err) {

--- a/src/gateway/server.lifecycle-hooks.test.ts
+++ b/src/gateway/server.lifecycle-hooks.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  hookRunner: {
+    runGatewayPreStart: vi.fn(async () => {}),
+    runGatewayStart: vi.fn(async () => {}),
+    runGatewayPreStop: vi.fn(async () => {}),
+    runGatewayStop: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => mocked.hookRunner,
+}));
+
+import { getFreePort, installGatewayTestHooks, startGatewayServer } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("gateway lifecycle hook wiring", () => {
+  beforeEach(() => {
+    mocked.hookRunner.runGatewayPreStart.mockClear();
+    mocked.hookRunner.runGatewayStart.mockClear();
+    mocked.hookRunner.runGatewayPreStop.mockClear();
+    mocked.hookRunner.runGatewayStop.mockClear();
+  });
+
+  test("fires gateway lifecycle hooks on startup and close", async () => {
+    const port = await getFreePort();
+    const server = await startGatewayServer(port);
+    try {
+      expect(mocked.hookRunner.runGatewayPreStart).toHaveBeenCalledWith({ port }, { port });
+      expect(mocked.hookRunner.runGatewayStart).toHaveBeenCalledWith({ port }, { port });
+    } finally {
+      await server.close({ reason: "test-shutdown" });
+    }
+
+    expect(mocked.hookRunner.runGatewayPreStop).toHaveBeenCalledWith(
+      { reason: "test-shutdown" },
+      { port },
+    );
+    expect(mocked.hookRunner.runGatewayStop).toHaveBeenCalledWith(
+      { reason: "test-shutdown" },
+      { port },
+    );
+  });
+});

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -60,6 +60,12 @@ export type {
 export type { ChannelConfigSchema, ChannelPlugin } from "../channels/plugins/types.plugin.js";
 export type {
   OpenClawPluginApi,
+  PluginHookExecutionMode,
+  PluginLifecycleHookContext,
+  PluginLifecycleHookOptions,
+  PluginLifecycleHookResult,
+  PluginLifecyclePayloadMap,
+  PluginLifecyclePhase,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
 } from "../plugins/types.js";

--- a/src/plugins/hooks.test.ts
+++ b/src/plugins/hooks.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginRegistry } from "./registry.js";
+import type { PluginHookRegistration } from "./types.js";
+import { createHookRunner, type HookRunnerLogger } from "./hooks.js";
+
+function createRegistryWithHooks(hooks: PluginHookRegistration[]): PluginRegistry {
+  return {
+    plugins: [],
+    tools: [],
+    hooks: [],
+    typedHooks: hooks,
+    channels: [],
+    providers: [],
+    gatewayHandlers: {},
+    httpHandlers: [],
+    httpRoutes: [],
+    cliRegistrars: [],
+    services: [],
+    commands: [],
+    diagnostics: [],
+  };
+}
+
+const noopLogger: HookRunnerLogger = {
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe("plugin hook runner policies", () => {
+  it("runs hooks in descending priority order", async () => {
+    const order: string[] = [];
+    const runner = createHookRunner(
+      createRegistryWithHooks([
+        {
+          pluginId: "high",
+          hookName: "before_agent_start",
+          priority: 10,
+          source: "high",
+          handler: () => {
+            order.push("high");
+          },
+        },
+        {
+          pluginId: "low",
+          hookName: "before_agent_start",
+          priority: 1,
+          source: "low",
+          handler: () => {
+            order.push("low");
+          },
+        },
+      ]),
+      { logger: noopLogger },
+    );
+
+    await runner.runBeforeAgentStart({ prompt: "x" }, {});
+    expect(order).toEqual(["high", "low"]);
+  });
+
+  it("skips handlers when condition returns false", async () => {
+    const handler = vi.fn();
+    const runner = createHookRunner(
+      createRegistryWithHooks([
+        {
+          pluginId: "p1",
+          hookName: "agent_end",
+          source: "src",
+          condition: () => false,
+          handler,
+        },
+      ]),
+      { logger: noopLogger },
+    );
+
+    await runner.runAgentEnd({ messages: [], success: true }, {});
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("continues after hook failures in fail-open mode", async () => {
+    const after = vi.fn();
+    const runner = createHookRunner(
+      createRegistryWithHooks([
+        {
+          pluginId: "bad",
+          hookName: "agent_end",
+          source: "bad",
+          handler: () => {
+            throw new Error("boom");
+          },
+        },
+        {
+          pluginId: "good",
+          hookName: "agent_end",
+          source: "good",
+          handler: after,
+        },
+      ]),
+      { logger: noopLogger },
+    );
+
+    await runner.runAgentEnd({ messages: [], success: true }, {});
+    expect(after).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws for fail-closed hook failures", async () => {
+    const after = vi.fn();
+    const runner = createHookRunner(
+      createRegistryWithHooks([
+        {
+          pluginId: "bad",
+          hookName: "before_tool_call",
+          source: "bad",
+          mode: "fail-closed",
+          handler: () => {
+            throw new Error("nope");
+          },
+        },
+        {
+          pluginId: "good",
+          hookName: "before_tool_call",
+          source: "good",
+          handler: after,
+        },
+      ]),
+      { logger: noopLogger, catchErrors: true },
+    );
+
+    await expect(
+      runner.runBeforeToolCall({ toolName: "echo", params: {} }, { toolName: "echo" }),
+    ).rejects.toThrow(/failed/);
+    expect(after).not.toHaveBeenCalled();
+  });
+
+  it("runs agent_error hooks independently from agent_end hooks", async () => {
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+    const runner = createHookRunner(
+      createRegistryWithHooks([
+        {
+          pluginId: "end",
+          hookName: "agent_end",
+          source: "end",
+          handler: onEnd,
+        },
+        {
+          pluginId: "error",
+          hookName: "agent_error",
+          source: "error",
+          handler: onError,
+        },
+      ]),
+      { logger: noopLogger },
+    );
+
+    await runner.runAgentEnd({ messages: [], success: true }, {});
+    await runner.runAgentError({ messages: [], success: false, error: "boom" }, {});
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies timeoutMs and continues for fail-open hooks", async () => {
+    const error = vi.fn();
+    const logger: HookRunnerLogger = { warn: vi.fn(), error };
+    const runner = createHookRunner(
+      createRegistryWithHooks([
+        {
+          pluginId: "slow",
+          hookName: "before_tool_call",
+          source: "slow",
+          timeoutMs: 5,
+          handler: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+          },
+        },
+        {
+          pluginId: "fast",
+          hookName: "before_tool_call",
+          source: "fast",
+          handler: () => ({ params: { safe: true } }),
+        },
+      ]),
+      { logger, catchErrors: true },
+    );
+
+    const out = await runner.runBeforeToolCall(
+      { toolName: "echo", params: {} },
+      { toolName: "echo" },
+    );
+    expect(out).toEqual({ params: { safe: true } });
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -10,13 +10,18 @@ import type {
   PluginHookAfterCompactionEvent,
   PluginHookAfterToolCallEvent,
   PluginHookAgentContext,
+  PluginHookAgentErrorEvent,
   PluginHookAgentEndEvent,
   PluginHookBeforeAgentStartEvent,
   PluginHookBeforeAgentStartResult,
+  PluginHookBeforeRecallEvent,
+  PluginHookBeforeRecallResult,
   PluginHookBeforeCompactionEvent,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookGatewayContext,
+  PluginHookGatewayPreStartEvent,
+  PluginHookGatewayPreStopEvent,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
   PluginHookMessageContext,
@@ -38,8 +43,11 @@ import type {
 // Re-export types for consumers
 export type {
   PluginHookAgentContext,
+  PluginHookAgentErrorEvent,
   PluginHookBeforeAgentStartEvent,
   PluginHookBeforeAgentStartResult,
+  PluginHookBeforeRecallEvent,
+  PluginHookBeforeRecallResult,
   PluginHookAgentEndEvent,
   PluginHookBeforeCompactionEvent,
   PluginHookAfterCompactionEvent,
@@ -59,6 +67,8 @@ export type {
   PluginHookSessionStartEvent,
   PluginHookSessionEndEvent,
   PluginHookGatewayContext,
+  PluginHookGatewayPreStartEvent,
+  PluginHookGatewayPreStopEvent,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
 };
@@ -93,6 +103,54 @@ function getHooksForName<K extends PluginHookName>(
 export function createHookRunner(registry: PluginRegistry, options: HookRunnerOptions = {}) {
   const logger = options.logger;
   const catchErrors = options.catchErrors ?? true;
+  const shouldThrowForFailure = (hook: PluginHookRegistration): boolean =>
+    !catchErrors || hook.mode === "fail-closed";
+
+  const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return promise;
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<T>((_resolve, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(new Error(`hook timeout after ${timeoutMs}ms`));
+          }, timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  };
+
+  const evaluateCondition = async <K extends PluginHookName>(
+    hook: PluginHookRegistration<K>,
+    event: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[0],
+    ctx: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[1],
+  ): Promise<boolean> => {
+    if (!hook.condition) {
+      return true;
+    }
+    const shouldRun = await hook.condition(event, ctx);
+    return shouldRun;
+  };
+
+  const handleHookError = <K extends PluginHookName>(
+    hookName: K,
+    hook: PluginHookRegistration<K>,
+    err: unknown,
+  ): never | void => {
+    const msg = `[hooks] ${hookName} handler from ${hook.pluginId} failed: ${String(err)}`;
+    if (shouldThrowForFailure(hook)) {
+      throw new Error(msg, { cause: err });
+    }
+    logger?.error(msg);
+  };
 
   /**
    * Run a hook that doesn't return a value (fire-and-forget style).
@@ -112,14 +170,18 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
 
     const promises = hooks.map(async (hook) => {
       try {
-        await (hook.handler as (event: unknown, ctx: unknown) => Promise<void>)(event, ctx);
-      } catch (err) {
-        const msg = `[hooks] ${hookName} handler from ${hook.pluginId} failed: ${String(err)}`;
-        if (catchErrors) {
-          logger?.error(msg);
-        } else {
-          throw new Error(msg, { cause: err });
+        const shouldRun = await evaluateCondition(hook, event, ctx);
+        if (!shouldRun) {
+          return;
         }
+        await withTimeout(
+          Promise.resolve(
+            (hook.handler as (event: unknown, ctx: unknown) => Promise<void>)(event, ctx),
+          ),
+          hook.timeoutMs ?? 0,
+        );
+      } catch (err) {
+        handleHookError(hookName, hook, err);
       }
     });
 
@@ -147,9 +209,16 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
 
     for (const hook of hooks) {
       try {
-        const handlerResult = await (
-          hook.handler as (event: unknown, ctx: unknown) => Promise<TResult>
-        )(event, ctx);
+        const shouldRun = await evaluateCondition(hook, event, ctx);
+        if (!shouldRun) {
+          continue;
+        }
+        const handlerResult = await withTimeout(
+          Promise.resolve(
+            (hook.handler as (event: unknown, ctx: unknown) => Promise<TResult>)(event, ctx),
+          ),
+          hook.timeoutMs ?? 0,
+        );
 
         if (handlerResult !== undefined && handlerResult !== null) {
           if (mergeResults && result !== undefined) {
@@ -159,12 +228,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           }
         }
       } catch (err) {
-        const msg = `[hooks] ${hookName} handler from ${hook.pluginId} failed: ${String(err)}`;
-        if (catchErrors) {
-          logger?.error(msg);
-        } else {
-          throw new Error(msg, { cause: err });
-        }
+        handleHookError(hookName, hook, err);
       }
     }
 
@@ -199,6 +263,27 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   /**
+   * Run before_recall hook.
+   * Allows plugins to mutate memory recall query parameters before vector search.
+   * Runs sequentially and applies last-writer-wins merge semantics.
+   */
+  async function runBeforeRecall(
+    event: PluginHookBeforeRecallEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeRecallResult | undefined> {
+    return runModifyingHook<"before_recall", PluginHookBeforeRecallResult>(
+      "before_recall",
+      event,
+      ctx,
+      (acc, next) => ({
+        query: next.query ?? acc?.query,
+        maxResults: next.maxResults ?? acc?.maxResults,
+        minScore: next.minScore ?? acc?.minScore,
+      }),
+    );
+  }
+
+  /**
    * Run agent_end hook.
    * Allows plugins to analyze completed conversations.
    * Runs in parallel (fire-and-forget).
@@ -208,6 +293,18 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     ctx: PluginHookAgentContext,
   ): Promise<void> {
     return runVoidHook("agent_end", event, ctx);
+  }
+
+  /**
+   * Run agent_error hook.
+   * Allows plugins to handle failed agent runs separately from success completion hooks.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runAgentError(
+    event: PluginHookAgentErrorEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<void> {
+    return runVoidHook("agent_error", event, ctx);
   }
 
   /**
@@ -335,6 +432,23 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
 
     for (const hook of hooks) {
       try {
+        if (hook.condition) {
+          const gated = hook.condition({ ...event, message: current } as never, ctx as never);
+          if (typeof (gated as Promise<unknown>)?.then === "function") {
+            const msg =
+              `[hooks] tool_result_persist condition from ${hook.pluginId} returned a Promise; ` +
+              "sync hooks require synchronous conditions.";
+            if (shouldThrowForFailure(hook)) {
+              throw new Error(msg);
+            }
+            logger?.warn?.(msg);
+            continue;
+          }
+          if (gated === false) {
+            continue;
+          }
+        }
+
         // oxlint-disable-next-line typescript/no-explicit-any
         const out = (hook.handler as any)({ ...event, message: current }, ctx) as
           | PluginHookToolResultPersistResult
@@ -347,7 +461,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           const msg =
             `[hooks] tool_result_persist handler from ${hook.pluginId} returned a Promise; ` +
             `this hook is synchronous and the result was ignored.`;
-          if (catchErrors) {
+          if (!shouldThrowForFailure(hook)) {
             logger?.warn?.(msg);
             continue;
           }
@@ -359,12 +473,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           current = next;
         }
       } catch (err) {
-        const msg = `[hooks] tool_result_persist handler from ${hook.pluginId} failed: ${String(err)}`;
-        if (catchErrors) {
-          logger?.error(msg);
-        } else {
-          throw new Error(msg, { cause: err });
-        }
+        handleHookError("tool_result_persist", hook, err);
       }
     }
 
@@ -400,6 +509,28 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   // =========================================================================
   // Gateway Hooks
   // =========================================================================
+
+  /**
+   * Run gateway_pre_start hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runGatewayPreStart(
+    event: PluginHookGatewayPreStartEvent,
+    ctx: PluginHookGatewayContext,
+  ): Promise<void> {
+    return runVoidHook("gateway_pre_start", event, ctx);
+  }
+
+  /**
+   * Run gateway_pre_stop hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runGatewayPreStop(
+    event: PluginHookGatewayPreStopEvent,
+    ctx: PluginHookGatewayContext,
+  ): Promise<void> {
+    return runVoidHook("gateway_pre_stop", event, ctx);
+  }
 
   /**
    * Run gateway_start hook.
@@ -444,7 +575,9 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   return {
     // Agent hooks
     runBeforeAgentStart,
+    runBeforeRecall,
     runAgentEnd,
+    runAgentError,
     runBeforeCompaction,
     runAfterCompaction,
     // Message hooks
@@ -459,6 +592,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runSessionStart,
     runSessionEnd,
     // Gateway hooks
+    runGatewayPreStart,
+    runGatewayPreStop,
     runGatewayStart,
     runGatewayStop,
     // Utility

--- a/src/plugins/lifecycle-alias.integration.test.ts
+++ b/src/plugins/lifecycle-alias.integration.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { createPluginRegistry, type PluginRecord } from "./registry.js";
+
+function createRecord(): PluginRecord {
+  return {
+    id: "alias-test-plugin",
+    name: "Alias Test Plugin",
+    source: "/tmp/alias-test-plugin.js",
+    origin: "workspace",
+    enabled: true,
+    status: "loaded",
+    toolNames: [],
+    hookNames: [],
+    channelIds: [],
+    providerIds: [],
+    gatewayMethods: [],
+    cliCommands: [],
+    services: [],
+    commands: [],
+    httpHandlers: 0,
+    hookCount: 0,
+    configSchema: false,
+  };
+}
+
+describe("lifecycle alias integration", () => {
+  it("fires preRequest on message_received events", async () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      coreGatewayHandlers: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+    const api = createApi(createRecord(), { config: {} as never });
+    const handler = vi.fn();
+    api.lifecycle.on("preRequest", handler);
+
+    const runner = createHookRunner(registry, { logger: { warn: vi.fn(), error: vi.fn() } });
+    await runner.runMessageReceived(
+      { from: "u1", content: "hello" },
+      { channelId: "telegram", conversationId: "c1" },
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]?.[1]).toMatchObject({ phase: "preRequest" });
+  });
+
+  it("fires preResponse on message_sending events", async () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      coreGatewayHandlers: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+    const api = createApi(createRecord(), { config: {} as never });
+    const handler = vi.fn();
+    api.lifecycle.on("preResponse", handler);
+
+    const runner = createHookRunner(registry, { logger: { warn: vi.fn(), error: vi.fn() } });
+    await runner.runMessageSending(
+      { to: "u1", content: "hello" },
+      { channelId: "telegram", conversationId: "c1" },
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]?.[1]).toMatchObject({ phase: "preResponse" });
+  });
+
+  it("fires preRecall on before_recall events", async () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      coreGatewayHandlers: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+    const api = createApi(createRecord(), { config: {} as never });
+    const handler = vi.fn();
+    api.lifecycle.on("preRecall", handler);
+
+    const runner = createHookRunner(registry, { logger: { warn: vi.fn(), error: vi.fn() } });
+    await runner.runBeforeRecall({ query: "pending tasks" }, { sessionKey: "s1" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]?.[1]).toMatchObject({ phase: "preRecall" });
+  });
+
+  it("fires preToolExecution and postToolExecution around tool hook events", async () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      coreGatewayHandlers: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+    const api = createApi(createRecord(), { config: {} as never });
+    const pre = vi.fn();
+    const post = vi.fn();
+    api.lifecycle.on("preToolExecution", pre);
+    api.lifecycle.on("postToolExecution", post);
+
+    const runner = createHookRunner(registry, { logger: { warn: vi.fn(), error: vi.fn() } });
+    await runner.runBeforeToolCall(
+      { toolName: "echo", params: { text: "ok" } },
+      { toolName: "echo", sessionKey: "s1" },
+    );
+    await runner.runAfterToolCall(
+      { toolName: "echo", params: { text: "ok" }, result: { ok: true } },
+      { toolName: "echo", sessionKey: "s1" },
+    );
+
+    expect(pre).toHaveBeenCalledTimes(1);
+    expect(pre.mock.calls[0]?.[1]).toMatchObject({ phase: "preToolExecution" });
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0]?.[1]).toMatchObject({ phase: "postToolExecution" });
+  });
+
+  it("fires preCompaction and postCompaction on compaction events", async () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      coreGatewayHandlers: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+    const api = createApi(createRecord(), { config: {} as never });
+    const pre = vi.fn();
+    const post = vi.fn();
+    api.lifecycle.on("preCompaction", pre);
+    api.lifecycle.on("postCompaction", post);
+
+    const runner = createHookRunner(registry, { logger: { warn: vi.fn(), error: vi.fn() } });
+    await runner.runBeforeCompaction({ messageCount: 10, tokenCount: 1200 }, { sessionKey: "s1" });
+    await runner.runAfterCompaction(
+      { messageCount: 6, tokenCount: 600, compactedCount: 4 },
+      { sessionKey: "s1" },
+    );
+
+    expect(pre).toHaveBeenCalledTimes(1);
+    expect(pre.mock.calls[0]?.[1]).toMatchObject({ phase: "preCompaction" });
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0]?.[1]).toMatchObject({ phase: "postCompaction" });
+  });
+
+  it("fires postRequest on agent_end and onError on agent_error", async () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      coreGatewayHandlers: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+    const api = createApi(createRecord(), { config: {} as never });
+    const postRequest = vi.fn();
+    const onError = vi.fn();
+    api.lifecycle.on("postRequest", postRequest);
+    api.lifecycle.on("onError", onError);
+
+    const runner = createHookRunner(registry, { logger: { warn: vi.fn(), error: vi.fn() } });
+    await runner.runAgentEnd({ messages: [], success: true }, { sessionKey: "s1" });
+    await runner.runAgentError(
+      { messages: [], success: false, error: "boom" },
+      { sessionKey: "s1" },
+    );
+
+    expect(postRequest).toHaveBeenCalledTimes(1);
+    expect(postRequest.mock.calls[0]?.[1]).toMatchObject({ phase: "postRequest" });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[1]).toMatchObject({ phase: "onError" });
+  });
+});

--- a/src/plugins/registry.test.ts
+++ b/src/plugins/registry.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginRegistry, type PluginRecord } from "./registry.js";
+
+function createRecord(): PluginRecord {
+  return {
+    id: "test-plugin",
+    name: "Test Plugin",
+    source: "/tmp/test-plugin.js",
+    origin: "workspace",
+    enabled: true,
+    status: "loaded",
+    toolNames: [],
+    hookNames: [],
+    channelIds: [],
+    providerIds: [],
+    gatewayMethods: [],
+    cliCommands: [],
+    services: [],
+    commands: [],
+    httpHandlers: 0,
+    hookCount: 0,
+    configSchema: false,
+  };
+}
+
+describe("plugin registry lifecycle mapping", () => {
+  it("maps boot.pre to gateway_pre_start", () => {
+    const { registry, createApi } = createPluginRegistry({
+      // Minimal shape needed by registry tests.
+      runtime: {} as never,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      coreGatewayHandlers: {},
+    });
+
+    const api = createApi(createRecord(), { config: {} as never });
+    const handler = vi.fn();
+    api.lifecycle.on("boot.pre", handler, { priority: 7, timeoutMs: 100, mode: "fail-closed" });
+
+    expect(registry.typedHooks).toHaveLength(1);
+    expect(registry.typedHooks[0]).toMatchObject({
+      hookName: "gateway_pre_start",
+      priority: 7,
+      timeoutMs: 100,
+      mode: "fail-closed",
+    });
+  });
+
+  it("maps shutdown.pre to gateway_pre_stop", () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      coreGatewayHandlers: {},
+    });
+
+    const api = createApi(createRecord(), { config: {} as never });
+    api.lifecycle.on("shutdown.pre", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(1);
+    expect(registry.typedHooks[0]?.hookName).toBe("gateway_pre_stop");
+  });
+
+  it("maps preRecall alias to before_recall", () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      coreGatewayHandlers: {},
+    });
+
+    const api = createApi(createRecord(), { config: {} as never });
+    api.lifecycle.on("preRecall", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(1);
+    expect(registry.typedHooks[0]?.hookName).toBe("before_recall");
+  });
+
+  it("maps onError alias to agent_error", () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      coreGatewayHandlers: {},
+    });
+
+    const api = createApi(createRecord(), { config: {} as never });
+    api.lifecycle.on("onError", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(1);
+    expect(registry.typedHooks[0]?.hookName).toBe("agent_error");
+  });
+
+  it("maps message.pre to message_sending", () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      coreGatewayHandlers: {},
+    });
+
+    const api = createApi(createRecord(), { config: {} as never });
+    api.lifecycle.on("message.pre", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(1);
+    expect(registry.typedHooks[0]?.hookName).toBe("message_sending");
+  });
+
+  it("maps preResponse alias to message_sending", () => {
+    const { registry, createApi } = createPluginRegistry({
+      runtime: {} as never,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      coreGatewayHandlers: {},
+    });
+
+    const api = createApi(createRecord(), { config: {} as never });
+    api.lifecycle.on("preResponse", vi.fn());
+
+    expect(registry.typedHooks).toHaveLength(1);
+    expect(registry.typedHooks[0]?.hookName).toBe("message_sending");
+  });
+});

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -9,6 +9,9 @@ import type {
 import type { HookEntry } from "../hooks/types.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import type {
+  PluginLifecycleHookHandlerMap,
+  PluginLifecycleHookOptions,
+  PluginLifecyclePhase,
   OpenClawPluginApi,
   OpenClawPluginChannelRegistration,
   OpenClawPluginCliRegistrar,
@@ -27,12 +30,40 @@ import type {
   PluginKind,
   PluginHookName,
   PluginHookHandlerMap,
+  PluginHookOptions,
   PluginHookRegistration as TypedPluginHookRegistration,
 } from "./types.js";
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";
+
+const LIFECYCLE_PHASE_TO_HOOK: Partial<Record<PluginLifecyclePhase, PluginHookName>> = {
+  preRequest: "message_received",
+  preRecall: "before_recall",
+  preResponse: "message_sending",
+  preToolExecution: "before_tool_call",
+  preCompaction: "before_compaction",
+  postRequest: "agent_end",
+  postResponse: "message_sent",
+  postToolExecution: "after_tool_call",
+  postCompaction: "after_compaction",
+  onError: "agent_error",
+  "boot.pre": "gateway_pre_start",
+  "agent.pre": "before_agent_start",
+  "agent.post": "agent_end",
+  "recall.pre": "before_recall",
+  error: "agent_error",
+  "message.pre": "message_sending",
+  "message.post": "message_sent",
+  "tool.pre": "before_tool_call",
+  "tool.post": "after_tool_call",
+  "memory.compaction.pre": "before_compaction",
+  "memory.compaction.post": "after_compaction",
+  "boot.post": "gateway_start",
+  "shutdown.pre": "gateway_pre_stop",
+  "shutdown.post": "gateway_stop",
+};
 
 export type PluginToolRegistration = {
   pluginId: string;
@@ -446,7 +477,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     record: PluginRecord,
     hookName: K,
     handler: PluginHookHandlerMap[K],
-    opts?: { priority?: number },
+    opts?: PluginHookOptions<K>,
   ) => {
     record.hookCount += 1;
     registry.typedHooks.push({
@@ -454,8 +485,48 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       hookName,
       handler,
       priority: opts?.priority,
+      timeoutMs: opts?.timeoutMs,
+      mode: opts?.mode,
+      condition: opts?.condition,
       source: record.source,
     } as TypedPluginHookRegistration);
+  };
+
+  const registerLifecycleHook = <P extends PluginLifecyclePhase>(
+    record: PluginRecord,
+    phase: P,
+    handler: PluginLifecycleHookHandlerMap[P],
+    options?: PluginLifecycleHookOptions<P>,
+  ) => {
+    const mappedHook = LIFECYCLE_PHASE_TO_HOOK[phase];
+    if (!mappedHook) {
+      pushDiagnostic({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `lifecycle phase not yet mapped to runtime events: ${phase}`,
+      });
+      return;
+    }
+
+    registerTypedHook(
+      record,
+      mappedHook,
+      ((event: unknown, _ctx: unknown) =>
+        handler(
+          event as never,
+          {
+            phase,
+            metadata: { hookName: mappedHook, pluginId: record.id },
+          } as never,
+        )) as PluginHookHandlerMap[typeof mappedHook],
+      {
+        priority: options?.priority,
+        timeoutMs: options?.timeoutMs,
+        mode: options?.mode,
+        condition: options?.condition as PluginHookOptions<typeof mappedHook>["condition"],
+      },
+    );
   };
 
   const normalizeLogger = (logger: PluginLogger): PluginLogger => ({
@@ -495,6 +566,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerCommand: (command) => registerCommand(record, command),
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) => registerTypedHook(record, hookName, handler, opts),
+      lifecycle: {
+        on: (phase, handler, options) => registerLifecycleHook(record, phase, handler, options),
+      },
     };
   };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -81,6 +81,8 @@ export type OpenClawPluginHookOptions = {
   register?: boolean;
 };
 
+export type PluginHookExecutionMode = "fail-open" | "fail-closed";
+
 export type ProviderAuthKind = "oauth" | "api_key" | "token" | "device_code" | "custom";
 
 export type ProviderAuthResult = {
@@ -267,8 +269,118 @@ export type OpenClawPluginApi = {
   on: <K extends PluginHookName>(
     hookName: K,
     handler: PluginHookHandlerMap[K],
-    opts?: { priority?: number },
+    opts?: PluginHookOptions<K>,
   ) => void;
+  lifecycle: {
+    on: <P extends PluginLifecyclePhase>(
+      phase: P,
+      handler: PluginLifecycleHookHandlerMap[P],
+      options?: PluginLifecycleHookOptions<P>,
+    ) => void;
+  };
+};
+
+export type PluginLifecyclePhase =
+  | "preRequest"
+  | "preRecall"
+  | "preResponse"
+  | "preToolExecution"
+  | "preCompaction"
+  | "postRequest"
+  | "postResponse"
+  | "postToolExecution"
+  | "postCompaction"
+  | "onError"
+  | "boot.pre"
+  | "boot.post"
+  | "message.pre"
+  | "message.post"
+  | "tool.pre"
+  | "tool.post"
+  | "agent.pre"
+  | "agent.post"
+  | "recall.pre"
+  | "error"
+  | "memory.compaction.pre"
+  | "memory.compaction.post"
+  | "shutdown.pre"
+  | "shutdown.post";
+
+type PluginCanonicalLifecyclePayloadMap = {
+  "boot.pre": PluginHookGatewayPreStartEvent;
+  "boot.post": PluginHookGatewayStartEvent;
+  "message.pre": PluginHookMessageSendingEvent;
+  "message.post": PluginHookMessageSentEvent;
+  "tool.pre": PluginHookBeforeToolCallEvent;
+  "tool.post": PluginHookAfterToolCallEvent;
+  "agent.pre": PluginHookBeforeAgentStartEvent;
+  "agent.post": PluginHookAgentEndEvent;
+  "recall.pre": PluginHookBeforeRecallEvent;
+  error: PluginHookAgentErrorEvent;
+  "memory.compaction.pre": PluginHookBeforeCompactionEvent;
+  "memory.compaction.post": PluginHookAfterCompactionEvent;
+  "shutdown.pre": { reason?: string };
+  "shutdown.post": PluginHookGatewayStopEvent;
+};
+
+type PluginLifecycleAliasToCanonicalPhaseMap = {
+  preRecall: "recall.pre";
+  preResponse: "message.pre";
+  preToolExecution: "tool.pre";
+  preCompaction: "memory.compaction.pre";
+  postRequest: "agent.post";
+  postResponse: "message.post";
+  postToolExecution: "tool.post";
+  postCompaction: "memory.compaction.post";
+  onError: "error";
+};
+
+type PluginLifecycleAliasPayloadMap = {
+  preRequest: PluginHookMessageReceivedEvent;
+} & {
+  [K in keyof PluginLifecycleAliasToCanonicalPhaseMap]: PluginCanonicalLifecyclePayloadMap[PluginLifecycleAliasToCanonicalPhaseMap[K]];
+};
+export type PluginLifecyclePayloadMap = PluginCanonicalLifecyclePayloadMap &
+  PluginLifecycleAliasPayloadMap;
+
+export type PluginLifecycleHookResult = {
+  continue?: boolean;
+  mutate?: Record<string, unknown>;
+  reason?: string;
+  data?: Record<string, unknown>;
+};
+
+export type PluginLifecycleHookContext<P extends PluginLifecyclePhase = PluginLifecyclePhase> = {
+  phase: P;
+  metadata?: Record<string, unknown>;
+  signal?: AbortSignal;
+};
+
+export type PluginLifecycleHookHandlerMap = {
+  [P in PluginLifecyclePhase]: (
+    payload: PluginLifecyclePayloadMap[P],
+    context: PluginLifecycleHookContext<P>,
+  ) => Promise<PluginLifecycleHookResult | void> | PluginLifecycleHookResult | void;
+};
+
+export type PluginLifecycleHookOptions<P extends PluginLifecyclePhase> = {
+  priority?: number;
+  timeoutMs?: number;
+  mode?: PluginHookExecutionMode;
+  condition?: (
+    payload: PluginLifecyclePayloadMap[P],
+    context: PluginLifecycleHookContext<P>,
+  ) => boolean | Promise<boolean>;
+};
+
+export type PluginHookOptions<K extends PluginHookName> = {
+  priority?: number;
+  timeoutMs?: number;
+  mode?: PluginHookExecutionMode;
+  condition?: (
+    event: Parameters<PluginHookHandlerMap[K]>[0],
+    ctx: Parameters<PluginHookHandlerMap[K]>[1],
+  ) => boolean | Promise<boolean>;
 };
 
 export type PluginOrigin = "bundled" | "global" | "workspace" | "config";
@@ -285,8 +397,12 @@ export type PluginDiagnostic = {
 // ============================================================================
 
 export type PluginHookName =
+  | "gateway_pre_start"
+  | "gateway_pre_stop"
   | "before_agent_start"
+  | "before_recall"
   | "agent_end"
+  | "agent_error"
   | "before_compaction"
   | "after_compaction"
   | "message_received"
@@ -319,6 +435,19 @@ export type PluginHookBeforeAgentStartResult = {
   prependContext?: string;
 };
 
+// before_recall hook
+export type PluginHookBeforeRecallEvent = {
+  query: string;
+  maxResults?: number;
+  minScore?: number;
+};
+
+export type PluginHookBeforeRecallResult = {
+  query?: string;
+  maxResults?: number;
+  minScore?: number;
+};
+
 // agent_end hook
 export type PluginHookAgentEndEvent = {
   messages: unknown[];
@@ -326,6 +455,9 @@ export type PluginHookAgentEndEvent = {
   error?: string;
   durationMs?: number;
 };
+
+// agent_error hook
+export type PluginHookAgentErrorEvent = PluginHookAgentEndEvent;
 
 // Compaction hooks
 export type PluginHookBeforeCompactionEvent = {
@@ -450,6 +582,16 @@ export type PluginHookGatewayContext = {
   port?: number;
 };
 
+// gateway_pre_start hook
+export type PluginHookGatewayPreStartEvent = {
+  port: number;
+};
+
+// gateway_pre_stop hook
+export type PluginHookGatewayPreStopEvent = {
+  reason?: string;
+};
+
 // gateway_start hook
 export type PluginHookGatewayStartEvent = {
   port: number;
@@ -462,11 +604,27 @@ export type PluginHookGatewayStopEvent = {
 
 // Hook handler types mapped by hook name
 export type PluginHookHandlerMap = {
+  gateway_pre_start: (
+    event: PluginHookGatewayPreStartEvent,
+    ctx: PluginHookGatewayContext,
+  ) => Promise<void> | void;
+  gateway_pre_stop: (
+    event: PluginHookGatewayPreStopEvent,
+    ctx: PluginHookGatewayContext,
+  ) => Promise<void> | void;
   before_agent_start: (
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
+  before_recall: (
+    event: PluginHookBeforeRecallEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeRecallResult | void> | PluginHookBeforeRecallResult | void;
   agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+  agent_error: (
+    event: PluginHookAgentErrorEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<void> | void;
   before_compaction: (
     event: PluginHookBeforeCompactionEvent,
     ctx: PluginHookAgentContext,
@@ -522,5 +680,11 @@ export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = 
   hookName: K;
   handler: PluginHookHandlerMap[K];
   priority?: number;
+  timeoutMs?: number;
+  mode?: PluginHookExecutionMode;
+  condition?: (
+    event: Parameters<PluginHookHandlerMap[K]>[0],
+    ctx: Parameters<PluginHookHandlerMap[K]>[1],
+  ) => boolean | Promise<boolean>;
   source: string;
 };


### PR DESCRIPTION
## Origin

This PR is derived from:

- Proposal gist: https://gist.github.com/openmetaloom/657c4668c09d235f8da1306e2438904b
- OpenClaw discussion: https://github.com/openclaw/openclaw/discussions/9872

## Summary

This PR implements lifecycle interception hooks for plugins and wires them to concrete runtime events across:

- gateway startup/shutdown
- agent loop start/end/error
- memory recall
- outbound/inbound messaging
- tool execution
- compaction lifecycle

It also adds execution policies for lifecycle handlers (`priority`, `timeoutMs`, `mode`, `condition`) and test coverage for alias mapping + runtime wiring.

## Lifecycle API

Use either:

- `api.on("<hook_name>", handler, opts)` for raw hook names
- `api.lifecycle.on("<phase>", handler, opts)` for lifecycle phases/aliases

### Canonical phase -> hook mapping

- `boot.pre` -> `gateway_pre_start`
- `boot.post` -> `gateway_start`
- `shutdown.pre` -> `gateway_pre_stop`
- `shutdown.post` -> `gateway_stop`
- `agent.pre` -> `before_agent_start`
- `agent.post` -> `agent_end`
- `error` -> `agent_error`
- `recall.pre` -> `before_recall`
- `tool.pre` -> `before_tool_call`
- `tool.post` -> `after_tool_call`
- `memory.compaction.pre` -> `before_compaction`
- `memory.compaction.post` -> `after_compaction`
- `message.pre` -> `message_sending` (interception/mutation point before send)
- `message.post` -> `message_sent` (post-send observation)

### Proposal alias -> canonical phase -> runtime hook

- `preRequest` -> `message.pre` (semantic alias) -> `message_received` (inbound event alias path)
- `preRecall` -> `recall.pre` -> `before_recall`
- `preResponse` -> `message.pre` -> `message_sending`
- `preToolExecution` -> `tool.pre` -> `before_tool_call`
- `preCompaction` -> `memory.compaction.pre` -> `before_compaction`
- `postRequest` -> `agent.post` -> `agent_end`
- `postResponse` -> `message.post` -> `message_sent`
- `postToolExecution` -> `tool.post` -> `after_tool_call`
- `postCompaction` -> `memory.compaction.post` -> `after_compaction`
- `onError` -> `error` -> `agent_error`

## Notable behavior enabled

- `before_recall` can mutate query/options immediately before memory vector search.
- `before_tool_call` can mutate params or block execution.
- `after_tool_call` receives success/error outcomes (including client-delegated tools).
- `agent_error` is emitted independently from `agent_end`.
- gateway lifecycle hooks fire at startup and shutdown boundaries.

## Validation

- `pnpm lint`
- `pnpm tsgo`
- `pnpm vitest run src/plugins/hooks.test.ts`
- `pnpm vitest run src/plugins/registry.test.ts`
- `pnpm vitest run src/plugins/lifecycle-alias.integration.test.ts`
- `pnpm vitest run src/agents/tools/memory-tool.before-recall.test.ts`
- `pnpm vitest run src/agents/pi-tools.before-tool-call.test.ts`
- `pnpm vitest run src/agents/pi-embedded-subscribe.handlers.lifecycle.hooks.test.ts`
- `pnpm vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts`
- `pnpm vitest run src/auto-reply/reply/dispatch-from-config.test.ts`
- `pnpm vitest run src/gateway/server.lifecycle-hooks.test.ts`
