### PR TITLE
fix(cli): prevent config set/unset from leaking runtime defaults

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1,0 +1,190 @@
+import { Command } from "commander";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Test for issue #6070:
+ * `openclaw config set` should use snapshot.parsed (raw user config) instead of
+ * snapshot.config (runtime-merged config with defaults), to avoid overwriting
+ * the entire config with defaults when validation fails or config is unreadable.
+ */
+
+const mockLog = vi.fn();
+const mockError = vi.fn();
+const mockExit = vi.fn((code: number) => {
+  const errorMessages = mockError.mock.calls.map((c) => c.join(" ")).join("; ");
+  throw new Error(`__exit__:${code} - ${errorMessages}`);
+});
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    log: (...args: unknown[]) => mockLog(...args),
+    error: (...args: unknown[]) => mockError(...args),
+    exit: (code: number) => mockExit(code),
+  },
+}));
+
+async function withTempHome(run: (home: string) => Promise<void>): Promise<void> {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-cli-"));
+  const originalEnv = { ...process.env };
+  try {
+    // Override config path to use temp directory
+    process.env.OPENCLAW_CONFIG_PATH = path.join(home, ".openclaw", "openclaw.json");
+    await fs.mkdir(path.join(home, ".openclaw"), { recursive: true });
+    await run(home);
+  } finally {
+    process.env = originalEnv;
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+async function readConfigFile(home: string): Promise<Record<string, unknown>> {
+  const configPath = path.join(home, ".openclaw", "openclaw.json");
+  const content = await fs.readFile(configPath, "utf-8");
+  return JSON.parse(content);
+}
+
+async function writeConfigFile(home: string, config: Record<string, unknown>): Promise<void> {
+  const configPath = path.join(home, ".openclaw", "openclaw.json");
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2));
+}
+
+describe("config cli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("config set - issue #6070", () => {
+    it("preserves existing config keys when setting a new value", async () => {
+      await withTempHome(async (home) => {
+        // Set up a config file with multiple existing settings (using valid schema)
+        const initialConfig = {
+          agents: {
+            list: [{ id: "main" }, { id: "oracle", workspace: "~/oracle-workspace" }],
+          },
+          gateway: {
+            port: 18789,
+          },
+          tools: {
+            allow: ["group:fs"],
+          },
+          logging: {
+            level: "debug",
+          },
+        };
+        await writeConfigFile(home, initialConfig);
+
+        // Run config set to add a new value
+        const { registerConfigCli } = await import("./config-cli.js");
+        const program = new Command();
+        program.exitOverride();
+        registerConfigCli(program);
+
+        await program.parseAsync(["config", "set", "gateway.auth.mode", "token"], { from: "user" });
+
+        // Read the config file and verify ALL original keys are preserved
+        const finalConfig = await readConfigFile(home);
+
+        // The new value should be set
+        expect((finalConfig.gateway as Record<string, unknown>).auth).toEqual({ mode: "token" });
+
+        // ALL original settings must still be present (this is the key assertion for #6070)
+        // The key bug in #6070 was that runtime defaults (like agents.defaults) were being
+        // written to the file, and paths were being expanded. This test verifies the fix.
+        expect(finalConfig.agents).not.toHaveProperty("defaults"); // No runtime defaults injected
+        expect((finalConfig.agents as Record<string, unknown>).list).toEqual(
+          initialConfig.agents.list,
+        );
+        expect((finalConfig.gateway as Record<string, unknown>).port).toBe(18789);
+        expect(finalConfig.tools).toEqual(initialConfig.tools);
+        expect(finalConfig.logging).toEqual(initialConfig.logging);
+      });
+    });
+
+    it("does not inject runtime defaults into the written config", async () => {
+      await withTempHome(async (home) => {
+        // Set up a minimal config file
+        const initialConfig = {
+          gateway: { port: 18789 },
+        };
+        await writeConfigFile(home, initialConfig);
+
+        // Run config set
+        const { registerConfigCli } = await import("./config-cli.js");
+        const program = new Command();
+        program.exitOverride();
+        registerConfigCli(program);
+
+        await program.parseAsync(["config", "set", "gateway.auth.mode", "token"], {
+          from: "user",
+        });
+
+        // Read the config file
+        const finalConfig = await readConfigFile(home);
+
+        // The config should NOT contain runtime defaults that weren't originally in the file
+        // These are examples of defaults that get merged in by applyModelDefaults, applyAgentDefaults, etc.
+        expect(finalConfig).not.toHaveProperty("agents.defaults.model");
+        expect(finalConfig).not.toHaveProperty("agents.defaults.contextWindow");
+        expect(finalConfig).not.toHaveProperty("agents.defaults.maxTokens");
+        expect(finalConfig).not.toHaveProperty("messages.ackReaction");
+        expect(finalConfig).not.toHaveProperty("sessions.persistence");
+
+        // Original config should still be present
+        expect((finalConfig.gateway as Record<string, unknown>).port).toBe(18789);
+        // New value should be set
+        expect((finalConfig.gateway as Record<string, unknown>).auth).toEqual({ mode: "token" });
+      });
+    });
+  });
+
+  describe("config unset - issue #6070", () => {
+    it("preserves existing config keys when unsetting a value", async () => {
+      await withTempHome(async (home) => {
+        // Set up a config file with multiple existing settings (using valid schema)
+        const initialConfig = {
+          agents: { list: [{ id: "main" }] },
+          gateway: { port: 18789 },
+          tools: {
+            profile: "coding",
+            alsoAllow: ["agents_list"],
+          },
+          logging: {
+            level: "debug",
+          },
+        };
+        await writeConfigFile(home, initialConfig);
+
+        // Run config unset to remove a value
+        const { registerConfigCli } = await import("./config-cli.js");
+        const program = new Command();
+        program.exitOverride();
+        registerConfigCli(program);
+
+        await program.parseAsync(["config", "unset", "tools.alsoAllow"], { from: "user" });
+
+        // Read the config file and verify ALL original keys (except the unset one) are preserved
+        const finalConfig = await readConfigFile(home);
+
+        // The value should be removed
+        expect(finalConfig.tools as Record<string, unknown>).not.toHaveProperty("alsoAllow");
+
+        // ALL other original settings must still be present (no runtime defaults injected)
+        expect(finalConfig.agents).not.toHaveProperty("defaults");
+        expect((finalConfig.agents as Record<string, unknown>).list).toEqual(
+          initialConfig.agents.list,
+        );
+        expect(finalConfig.gateway).toEqual(initialConfig.gateway);
+        expect((finalConfig.tools as Record<string, unknown>).profile).toBe("coding");
+        expect(finalConfig.logging).toEqual(initialConfig.logging);
+      });
+    });
+  });
+});

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -306,7 +306,9 @@ export function registerConfigCli(program: Command) {
         }
         const parsedValue = parseValue(value, opts);
         const snapshot = await loadValidConfig();
-        const next = snapshot.config as Record<string, unknown>;
+        // Use snapshot.parsed (raw user config) instead of snapshot.config (runtime-merged with defaults)
+        // This prevents runtime defaults from leaking into the written config file (issue #6070)
+        const next = structuredClone(snapshot.parsed) as Record<string, unknown>;
         setAtPath(next, parsedPath, parsedValue);
         await writeConfigFile(next);
         defaultRuntime.log(info(`Updated ${path}. Restart the gateway to apply.`));
@@ -327,7 +329,9 @@ export function registerConfigCli(program: Command) {
           throw new Error("Path is empty.");
         }
         const snapshot = await loadValidConfig();
-        const next = snapshot.config as Record<string, unknown>;
+        // Use snapshot.parsed (raw user config) instead of snapshot.config (runtime-merged with defaults)
+        // This prevents runtime defaults from leaking into the written config file (issue #6070)
+        const next = structuredClone(snapshot.parsed) as Record<string, unknown>;
         const removed = unsetAtPath(next, parsedPath);
         if (!removed) {
           defaultRuntime.error(danger(`Config path not found: ${path}`));

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -306,9 +306,10 @@ export function registerConfigCli(program: Command) {
         }
         const parsedValue = parseValue(value, opts);
         const snapshot = await loadValidConfig();
-        // Use snapshot.parsed (raw user config) instead of snapshot.config (runtime-merged with defaults)
+        // Use snapshot.resolved (config after $include and ${ENV} resolution, but BEFORE runtime defaults)
+        // instead of snapshot.config (runtime-merged with defaults).
         // This prevents runtime defaults from leaking into the written config file (issue #6070)
-        const next = structuredClone(snapshot.parsed) as Record<string, unknown>;
+        const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
         setAtPath(next, parsedPath, parsedValue);
         await writeConfigFile(next);
         defaultRuntime.log(info(`Updated ${path}. Restart the gateway to apply.`));
@@ -329,9 +330,10 @@ export function registerConfigCli(program: Command) {
           throw new Error("Path is empty.");
         }
         const snapshot = await loadValidConfig();
-        // Use snapshot.parsed (raw user config) instead of snapshot.config (runtime-merged with defaults)
+        // Use snapshot.resolved (config after $include and ${ENV} resolution, but BEFORE runtime defaults)
+        // instead of snapshot.config (runtime-merged with defaults).
         // This prevents runtime defaults from leaking into the written config file (issue #6070)
-        const next = structuredClone(snapshot.parsed) as Record<string, unknown>;
+        const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
         const removed = unsetAtPath(next, parsedPath);
         if (!removed) {
           defaultRuntime.error(danger(`Config path not found: ${path}`));

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,5 +10,9 @@ export { migrateLegacyConfig } from "./legacy-migrate.js";
 export * from "./paths.js";
 export * from "./runtime-overrides.js";
 export * from "./types.js";
-export { validateConfigObject, validateConfigObjectWithPlugins } from "./validation.js";
+export {
+  validateConfigObject,
+  validateConfigObjectRaw,
+  validateConfigObjectWithPlugins,
+} from "./validation.js";
 export { OpenClawSchema } from "./zod-schema.js";

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -13,6 +13,7 @@ export * from "./types.js";
 export {
   validateConfigObject,
   validateConfigObjectRaw,
+  validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
 export { OpenClawSchema } from "./zod-schema.js";

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
@@ -28,10 +29,14 @@ import { MissingEnvVarError, resolveConfigEnvVars } from "./env-substitution.js"
 import { collectConfigEnvVars } from "./env-vars.js";
 import { ConfigIncludeError, resolveConfigIncludes } from "./includes.js";
 import { findLegacyConfigIssues } from "./legacy.js";
+import { applyMergePatch } from "./merge-patch.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
 import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
-import { validateConfigObjectWithPlugins } from "./validation.js";
+import {
+  validateConfigObjectRawWithPlugins,
+  validateConfigObjectWithPlugins,
+} from "./validation.js";
 import { compareOpenClawVersions } from "./version.js";
 
 // Re-export for backwards compatibility
@@ -90,6 +95,49 @@ function coerceConfig(value: unknown): OpenClawConfig {
     return {};
   }
   return value as OpenClawConfig;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneUnknown<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function createMergePatch(base: unknown, target: unknown): unknown {
+  if (!isPlainObject(base) || !isPlainObject(target)) {
+    return cloneUnknown(target);
+  }
+
+  const patch: Record<string, unknown> = {};
+  const keys = new Set([...Object.keys(base), ...Object.keys(target)]);
+  for (const key of keys) {
+    const hasBase = key in base;
+    const hasTarget = key in target;
+    if (!hasTarget) {
+      patch[key] = null;
+      continue;
+    }
+    const targetValue = target[key];
+    if (!hasBase) {
+      patch[key] = cloneUnknown(targetValue);
+      continue;
+    }
+    const baseValue = base[key];
+    if (isPlainObject(baseValue) && isPlainObject(targetValue)) {
+      const childPatch = createMergePatch(baseValue, targetValue);
+      if (isPlainObject(childPatch) && Object.keys(childPatch).length === 0) {
+        continue;
+      }
+      patch[key] = childPatch;
+      continue;
+    }
+    if (!isDeepStrictEqual(baseValue, targetValue)) {
+      patch[key] = cloneUnknown(targetValue);
+    }
+  }
+  return patch;
 }
 
 async function rotateConfigBackups(configPath: string, ioFs: typeof fs.promises): Promise<void> {
@@ -502,7 +550,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
   async function writeConfigFile(cfg: OpenClawConfig) {
     clearConfigCache();
-    const validated = validateConfigObjectWithPlugins(cfg);
+    let persistCandidate: unknown = cfg;
+    const snapshot = await readConfigFileSnapshot();
+    if (snapshot.valid && snapshot.exists) {
+      const patch = createMergePatch(snapshot.config, cfg);
+      persistCandidate = applyMergePatch(snapshot.resolved, patch);
+    }
+
+    const validated = validateConfigObjectRawWithPlugins(persistCandidate);
     if (!validated.ok) {
       const issue = validated.issues[0];
       const pathLabel = issue?.path ? issue.path : "<root>";
@@ -518,7 +573,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     await deps.fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
     // Do NOT apply runtime defaults when writing — user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
-    const json = JSON.stringify(stampConfigVersion(cfg), null, 2).trimEnd().concat("\n");
+    const json = JSON.stringify(stampConfigVersion(validated.config), null, 2)
+      .trimEnd()
+      .concat("\n");
 
     const tmp = path.join(
       dir,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createConfigIO } from "./io.js";
+import { withTempHome } from "./test-helpers.js";
+
+describe("config io write", () => {
+  it("persists caller changes onto resolved config without leaking runtime defaults", async () => {
+    await withTempHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { port: 18789 } }, null, 2),
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+      });
+
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(true);
+
+      const next = structuredClone(snapshot.config);
+      next.gateway = {
+        ...next.gateway,
+        auth: { mode: "token" },
+      };
+
+      await io.writeConfigFile(next);
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+      expect(persisted.gateway).toEqual({
+        port: 18789,
+        auth: { mode: "token" },
+      });
+      expect(persisted).not.toHaveProperty("agents.defaults");
+      expect(persisted).not.toHaveProperty("messages.ackReaction");
+      expect(persisted).not.toHaveProperty("sessions.persistence");
+    });
+  });
+});

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -12,6 +12,7 @@ function makeSnapshot(config: Record<string, unknown>, raw?: string): ConfigFile
     exists: true,
     raw: raw ?? JSON.stringify(config),
     parsed: config,
+    resolved: config as ConfigFileSnapshot["resolved"],
     valid: true,
     config: config as ConfigFileSnapshot["config"],
     hash: "abc123",
@@ -188,12 +189,23 @@ describe("redactConfigSnapshot", () => {
     expect(parsed.channels.discord.token).toBe(REDACTED_SENTINEL);
   });
 
+  it("redacts resolved object as well", () => {
+    const config = {
+      gateway: { auth: { token: "supersecrettoken123456" } },
+    };
+    const snapshot = makeSnapshot(config);
+    const result = redactConfigSnapshot(snapshot);
+    const resolved = result.resolved as Record<string, Record<string, Record<string, string>>>;
+    expect(resolved.gateway.auth.token).toBe(REDACTED_SENTINEL);
+  });
+
   it("handles null raw gracefully", () => {
     const snapshot: ConfigFileSnapshot = {
       path: "/test",
       exists: false,
       raw: null,
       parsed: null,
+      resolved: {} as ConfigFileSnapshot["resolved"],
       valid: false,
       config: {} as ConfigFileSnapshot["config"],
       issues: [],

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -137,12 +137,15 @@ export function redactConfigSnapshot(snapshot: ConfigFileSnapshot): ConfigFileSn
   const redactedConfig = redactConfigObject(snapshot.config);
   const redactedRaw = snapshot.raw ? redactRawText(snapshot.raw, snapshot.config) : null;
   const redactedParsed = snapshot.parsed ? redactConfigObject(snapshot.parsed) : snapshot.parsed;
+  // Also redact the resolved config (contains values after ${ENV} substitution)
+  const redactedResolved = redactConfigObject(snapshot.resolved);
 
   return {
     ...snapshot,
     config: redactedConfig,
     raw: redactedRaw,
     parsed: redactedParsed,
+    resolved: redactedResolved,
   };
 }
 

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -114,6 +114,12 @@ export type ConfigFileSnapshot = {
   exists: boolean;
   raw: string | null;
   parsed: unknown;
+  /**
+   * Config after $include resolution and ${ENV} substitution, but BEFORE runtime
+   * defaults are applied. Use this for config set/unset operations to avoid
+   * leaking runtime defaults into the written config file.
+   */
+  resolved: OpenClawConfig;
   valid: boolean;
   config: OpenClawConfig;
   hash?: string;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -83,7 +83,11 @@ function validateIdentityAvatar(config: OpenClawConfig): ConfigValidationIssue[]
   return issues;
 }
 
-export function validateConfigObject(
+/**
+ * Validates config without applying runtime defaults.
+ * Use this when you need the raw validated config (e.g., for writing back to file).
+ */
+export function validateConfigObjectRaw(
   raw: unknown,
 ): { ok: true; config: OpenClawConfig } | { ok: false; issues: ConfigValidationIssue[] } {
   const legacyIssues = findLegacyConfigIssues(raw);
@@ -124,9 +128,20 @@ export function validateConfigObject(
   }
   return {
     ok: true,
-    config: applyModelDefaults(
-      applyAgentDefaults(applySessionDefaults(validated.data as OpenClawConfig)),
-    ),
+    config: validated.data as OpenClawConfig,
+  };
+}
+
+export function validateConfigObject(
+  raw: unknown,
+): { ok: true; config: OpenClawConfig } | { ok: false; issues: ConfigValidationIssue[] } {
+  const result = validateConfigObjectRaw(raw);
+  if (!result.ok) {
+    return result;
+  }
+  return {
+    ok: true,
+    config: applyModelDefaults(applyAgentDefaults(applySessionDefaults(result.config))),
   };
 }
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -156,7 +156,38 @@ export function validateConfigObjectWithPlugins(raw: unknown):
       issues: ConfigValidationIssue[];
       warnings: ConfigValidationIssue[];
     } {
-  const base = validateConfigObject(raw);
+  return validateConfigObjectWithPluginsBase(raw, { applyDefaults: true });
+}
+
+export function validateConfigObjectRawWithPlugins(raw: unknown):
+  | {
+      ok: true;
+      config: OpenClawConfig;
+      warnings: ConfigValidationIssue[];
+    }
+  | {
+      ok: false;
+      issues: ConfigValidationIssue[];
+      warnings: ConfigValidationIssue[];
+    } {
+  return validateConfigObjectWithPluginsBase(raw, { applyDefaults: false });
+}
+
+function validateConfigObjectWithPluginsBase(
+  raw: unknown,
+  opts: { applyDefaults: boolean },
+):
+  | {
+      ok: true;
+      config: OpenClawConfig;
+      warnings: ConfigValidationIssue[];
+    }
+  | {
+      ok: false;
+      issues: ConfigValidationIssue[];
+      warnings: ConfigValidationIssue[];
+    } {
+  const base = opts.applyDefaults ? validateConfigObject(raw) : validateConfigObjectRaw(raw);
   if (!base.ok) {
     return { ok: false, issues: base.issues, warnings: [] };
   }


### PR DESCRIPTION
## Summary

Fixes #6070

- `config set` and `config unset` now use the resolved config (after `$include` and `${ENV}` substitution) instead of the runtime-merged config with defaults
- Adds a new `resolved` field to `ConfigFileSnapshot` containing the config before runtime defaults are applied
- Removes `applyModelDefaults` from `writeConfigFile` since runtime defaults should only be applied at load time
- Adds proper redaction for the new `resolved` field to prevent credential leaks

The bug caused runtime defaults (like `agents.defaults.maxConcurrent`) to leak into the user's config file whenever `config set` or `config unset` was used.

## Test plan

- [x] All 3 new tests in `config-cli.test.ts` fail before fix, pass after
- [x] New test for `resolved` redaction in `redact-snapshot.test.ts` passes
- [x] Full test suite passes (5426 tests)
- [x] `pnpm build && pnpm check` passes
- [x] Codex review addressed (security issue with unredacted `resolved` field)

## Changes

1. **`src/config/types.openclaw.ts`**: Added `resolved` field to `ConfigFileSnapshot`
2. **`src/config/io.ts`**: Populate `resolved` field with pre-defaults config; removed `applyModelDefaults` from `writeConfigFile`
3. **`src/config/validation.ts`**: Added `validateConfigObjectRaw` for validation without defaults
4. **`src/cli/config-cli.ts`**: Use `snapshot.resolved` instead of `snapshot.config`
5. **`src/config/redact-snapshot.ts`**: Redact the new `resolved` field
6. **`src/config/config.ts`**: Export `validateConfigObjectRaw`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `openclaw config set/unset` writing back *runtime-merged* config (including defaults) by introducing a `resolved` snapshot (post `$include` + `${ENV}` substitution, pre-runtime-defaults) and using that for mutations before persisting. It also removes applying runtime defaults at write time, adds a raw validation entrypoint (`validateConfigObjectRaw`) to validate without defaults, and updates snapshot redaction to cover `resolved` so secrets substituted from env don’t leak into logs/snapshots.

These changes fit the existing config pipeline by separating: (1) raw/parsed/resolved config used for persistence and user-facing edits vs (2) runtime config used for execution with defaults and path normalization applied only on load.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to config snapshot representation and CLI writeback behavior, with accompanying unit tests for the regression and for redaction of the new snapshot field. The updated validation API preserves existing behavior via `validateConfigObject` while enabling pre-default validation where needed.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->