### PR TITLE
fix(diagnostics-otel): use @opentelemetry/resources v2 API

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -83,16 +83,11 @@ vi.mock("@opentelemetry/sdk-trace-base", () => ({
 }));
 
 vi.mock("@opentelemetry/resources", () => ({
-  Resource: class {
-    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-    constructor(_value?: unknown) {}
-  },
+  resourceFromAttributes: (_attrs?: unknown) => ({}),
 }));
 
 vi.mock("@opentelemetry/semantic-conventions", () => ({
-  SemanticResourceAttributes: {
-    SERVICE_NAME: "service.name",
-  },
+  ATTR_SERVICE_NAME: "service.name",
 }));
 
 vi.mock("openclaw/plugin-sdk", async () => {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -4,12 +4,12 @@ import { metrics, trace, SpanStatusCode } from "@opentelemetry/api";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ParentBasedSampler, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-base";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { onDiagnosticEvent, registerLogTransport } from "openclaw/plugin-sdk";
 
 const DEFAULT_SERVICE_NAME = "openclaw";
@@ -73,8 +73,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
-      const resource = new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+      const resource = resourceFromAttributes({
+        [ATTR_SERVICE_NAME]: serviceName,
       });
 
       const traceUrl = resolveOtelUrl(endpoint, "v1/traces");


### PR DESCRIPTION
## Summary

- Replaces `new Resource(...)` with `resourceFromAttributes(...)` from `@opentelemetry/resources` v2, fixing the `TypeError: _resources.Resource is not a constructor` crash.
- Migrates from the deprecated `SemanticResourceAttributes.SERVICE_NAME` to the stable `ATTR_SERVICE_NAME` export from `@opentelemetry/semantic-conventions`.
- Updates the vitest mocks in `service.test.ts` to match the new API surface.

## Root Cause

`package.json` declares `"@opentelemetry/resources": "^2.5.0"`, but the source code used the v1 class-based API (`new Resource({...})`). In `@opentelemetry/resources` v2, the `Resource` class constructor was removed and replaced with the `resourceFromAttributes()` function, causing a `TypeError` at runtime when the plugin initializes.

## Test Plan

- [ ] Existing `service.test.ts` passes with the updated mocks
- [ ] Plugin starts successfully with OTEL diagnostics enabled
- [ ] Traces, metrics, and logs are exported correctly to an OTLP endpoint

Fixes #11839

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the diagnostics OpenTelemetry extension to be compatible with `@opentelemetry/resources` v2 by replacing the removed `new Resource(...)` constructor usage with `resourceFromAttributes(...)`. It also migrates service name resource attributes from the deprecated `SemanticResourceAttributes.SERVICE_NAME` to the stable `ATTR_SERVICE_NAME` constant from `@opentelemetry/semantic-conventions`, and adjusts the vitest mocks in `extensions/diagnostics-otel/src/service.test.ts` accordingly.

These changes are localized to the OTEL diagnostics plugin initialization in `extensions/diagnostics-otel/src/service.ts`, where the created resource is passed into `NodeSDK` and `LoggerProvider` during startup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, targeted to the reported runtime crash, and update both implementation and tests/mocks consistently. No additional behavioral changes were identified beyond adapting to the v2 OpenTelemetry resources API.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->