### PR TITLE
fix: don't auto-create HEARTBEAT.md during workspace bootstrap

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1453,7 +1453,7 @@ working directory). The path must exist to be used.
 
 ### `agents.defaults.skipBootstrap`
 
-Disables automatic creation of the workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, and `BOOTSTRAP.md`).
+Disables automatic creation of the workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, and `BOOTSTRAP.md`). Note: `HEARTBEAT.md` is not auto-created; create it manually to enable heartbeat tasks.
 
 Use this for pre-seeded deployments where your workspace files come from a repo.
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -80,7 +80,7 @@ When onboarding finishes, we auto-open the dashboard and print a clean (non-toke
 
 OpenClaw reads operating instructions and “memory” from its workspace directory.
 
-By default, OpenClaw uses `~/.openclaw/workspace` as the agent workspace, and will create it (plus starter `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`) automatically on setup/first agent run. `BOOTSTRAP.md` is only created when the workspace is brand new (it should not come back after you delete it). `MEMORY.md` is optional (not auto-created); when present, it is loaded for normal sessions. Subagent sessions only inject `AGENTS.md` and `TOOLS.md`.
+By default, OpenClaw uses `~/.openclaw/workspace` as the agent workspace, and will create it (plus starter `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`) automatically on setup/first agent run. `BOOTSTRAP.md` is only created when the workspace is brand new (it should not come back after you delete it). `HEARTBEAT.md` and `MEMORY.md` are optional (not auto-created); when present, they are loaded for their respective features. Subagent sessions only inject `AGENTS.md` and `TOOLS.md`.
 
 Tip: treat this folder like OpenClaw’s “memory” and make it a git repo (ideally private) so your `AGENTS.md` + memory files are backed up. If git is installed, brand-new workspaces are auto-initialized.
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -152,7 +152,7 @@ export async function ensureAgentWorkspace(params?: {
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
 
   const isBrandNewWorkspace = await (async () => {
-    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
+    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath];
     const existing = await Promise.all(
       paths.map(async (p) => {
         try {
@@ -171,7 +171,6 @@ export async function ensureAgentWorkspace(params?: {
   const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
   const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
-  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
 
   await writeFileIfMissing(agentsPath, agentsTemplate);
@@ -179,7 +178,6 @@ export async function ensureAgentWorkspace(params?: {
   await writeFileIfMissing(toolsPath, toolsTemplate);
   await writeFileIfMissing(identityPath, identityTemplate);
   await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
   if (isBrandNewWorkspace) {
     await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
   }


### PR DESCRIPTION
## Summary

Fixes #11766 — "Missing HEARTBEAT.md behaviour doesn't match documentation"

**Root cause**: `ensureAgentWorkspace()` auto-creates `HEARTBEAT.md` from a template that contains only markdown headers. The heartbeat runner's `isHeartbeatContentEffectivelyEmpty()` treats this as empty content, causing all subsequent heartbeats to be silently skipped with reason `"empty-heartbeat-file"`.

The documented behavior states: *"If the file is missing, the heartbeat still runs and the model decides what to do."* But the auto-creation means the file is never truly "missing" after the first heartbeat run.

**Fix**: Remove `HEARTBEAT.md` from the workspace bootstrap file set so it is not auto-created. A missing file correctly falls through to the catch block in `heartbeat-runner.ts`, allowing the heartbeat to proceed as documented.

### Changes

- **`src/agents/workspace.ts`**: Remove HEARTBEAT.md from `ensureAgentWorkspace()` bootstrap — stop loading its template, stop writing it via `writeFileIfMissing()`, and remove it from the "brand new workspace" detection check.

### Why this is safe

- The `heartbeat-runner.ts` catch block at line ~543 already handles a missing file correctly (proceeds with the heartbeat run).
- The existing test `"runs heartbeat when HEARTBEAT.md does not exist (lets LLM decide)"` validates this path.
- `heartbeatPath` is still returned from `ensureAgentWorkspace()` for callers that reference the path.
- Users who want the checklist can still create `HEARTBEAT.md` manually, as documented.

## Test plan

- [ ] Existing test `"runs heartbeat when HEARTBEAT.md does not exist (lets LLM decide)"` passes
- [ ] Existing test `"skips heartbeat when HEARTBEAT.md is effectively empty"` still passes (user-created empty file)
- [ ] Existing test `"runs heartbeat when HEARTBEAT.md has actionable content"` still passes
- [ ] Manual: start with no HEARTBEAT.md, verify heartbeat runs on schedule across multiple ticks
- [ ] Manual: create HEARTBEAT.md with tasks, verify heartbeat reads and follows them
- [ ] Manual: create empty HEARTBEAT.md, verify heartbeat is skipped (saves API cost)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `ensureAgentWorkspace()` (`src/agents/workspace.ts`) so `HEARTBEAT.md` is no longer treated as a bootstrap file: it is removed from the “brand new workspace” detection set and is no longer loaded from templates / written via `writeFileIfMissing()`. The returned `heartbeatPath` is preserved so downstream code can still refer to the conventional path.

The intent is to align runtime behavior with the heartbeat runner’s documented semantics: missing `HEARTBEAT.md` should allow the heartbeat to proceed (the runner already falls through on `fs.readFile` failure), while an explicitly present but effectively-empty `HEARTBEAT.md` should still skip to save API calls.

Main issue to address before merge: user-facing docs and configuration docs currently claim `HEARTBEAT.md` is auto-created as part of workspace bootstrap and that `agents.defaults.skipBootstrap` disables creating it; those statements become incorrect with this change and should be updated accordingly.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after aligning documentation with the new workspace bootstrap behavior.
- The code change is small and consistent with the heartbeat runner’s existing missing-file fallback, so runtime impact is limited. The main concrete problem is that multiple docs pages and config docs will become incorrect about which files are auto-created and what `skipBootstrap` does.
- docs/start/openclaw.md, docs/gateway/configuration.md (and any other docs referencing HEARTBEAT.md bootstrap behavior)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->