### PR TITLE
fix: exec tool wraps shebang scripts in heredoc to use correct interpreter

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1043,8 +1043,12 @@ export function createExecTool(
         if (nodeEnv) {
           applyPathPrepend(nodeEnv, defaultPathPrepend, { requireExisting: true });
         }
+        // Evaluate the actual command that will be executed (which may be
+        // wrapped in a heredoc for shebang scripts) so the allowlist analysis
+        // matches what the node runs.
+        const actualCommand = argv[argv.length - 1];
         const baseAllowlistEval = evaluateShellAllowlist({
-          command: params.command,
+          command: actualCommand,
           allowlist: [],
           safeBins: new Set(),
           cwd: workdir,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -20,7 +20,7 @@ import {
   resolveExecApprovalsFromFile,
 } from "../infra/exec-approvals.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
-import { buildNodeShellCommand } from "../infra/node-shell.js";
+import { buildNodeShellCommand, wrapScriptCommand } from "../infra/node-shell.js";
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
@@ -436,6 +436,9 @@ async function runExecProcess(opts: {
 }): Promise<ExecProcessHandle> {
   const startedAt = Date.now();
   const sessionId = createSessionSlug();
+  // Wrap shebang-prefixed scripts in a heredoc so the shell delegates to
+  // the correct interpreter instead of executing lines as shell commands.
+  const shellCommand = wrapScriptCommand(opts.command);
   let child: ChildProcessWithoutNullStreams | null = null;
   let pty: PtyHandle | null = null;
   let stdin: SessionStdin | undefined;
@@ -446,7 +449,7 @@ async function runExecProcess(opts: {
         "docker",
         ...buildDockerExecArgs({
           containerName: opts.sandbox.containerName,
-          command: opts.command,
+          command: shellCommand,
           workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
           env: opts.env,
           tty: opts.usePty,
@@ -485,7 +488,7 @@ async function runExecProcess(opts: {
       if (!spawnPty) {
         throw new Error("PTY support is unavailable (node-pty spawn not found).");
       }
-      pty = spawnPty(shell, [...shellArgs, opts.command], {
+      pty = spawnPty(shell, [...shellArgs, shellCommand], {
         cwd: opts.workdir,
         env: opts.env,
         name: process.env.TERM ?? "xterm-256color",
@@ -517,7 +520,7 @@ async function runExecProcess(opts: {
       logWarn(`exec: PTY spawn failed (${errText}); retrying without PTY for "${opts.command}".`);
       opts.warnings.push(warning);
       const { child: spawned } = await spawnWithFallback({
-        argv: [shell, ...shellArgs, opts.command],
+        argv: [shell, ...shellArgs, shellCommand],
         options: {
           cwd: opts.workdir,
           env: opts.env,
@@ -544,7 +547,7 @@ async function runExecProcess(opts: {
   } else {
     const { shell, args: shellArgs } = getShellConfig();
     const { child: spawned } = await spawnWithFallback({
-      argv: [shell, ...shellArgs, opts.command],
+      argv: [shell, ...shellArgs, shellCommand],
       options: {
         cwd: opts.workdir,
         env: opts.env,

--- a/src/infra/node-shell.test.ts
+++ b/src/infra/node-shell.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildNodeShellCommand } from "./node-shell.js";
+import { buildNodeShellCommand, wrapScriptCommand } from "./node-shell.js";
 
 describe("buildNodeShellCommand", () => {
   it("uses cmd.exe for win32", () => {
@@ -35,5 +35,88 @@ describe("buildNodeShellCommand", () => {
 
   it("uses /bin/sh when platform missing", () => {
     expect(buildNodeShellCommand("echo hi")).toEqual(["/bin/sh", "-lc", "echo hi"]);
+  });
+
+  it("wraps shebang-prefixed scripts in a heredoc", () => {
+    const script = "#!/usr/bin/env python3\nimport os\nprint(os.getcwd())";
+    const result = buildNodeShellCommand(script, "darwin");
+    expect(result[0]).toBe("/bin/sh");
+    expect(result[1]).toBe("-lc");
+    expect(result[2]).toContain("/usr/bin/env python3 <<'OPENCLAW_SCRIPT_EOF'");
+    expect(result[2]).toContain("import os");
+    expect(result[2]).toContain("OPENCLAW_SCRIPT_EOF");
+  });
+});
+
+describe("wrapScriptCommand", () => {
+  it("passes through regular shell commands unchanged", () => {
+    expect(wrapScriptCommand("echo hello")).toBe("echo hello");
+    expect(wrapScriptCommand("python3 script.py")).toBe("python3 script.py");
+    expect(wrapScriptCommand('python3 -c "import os; print(os.getcwd())"')).toBe(
+      'python3 -c "import os; print(os.getcwd())"',
+    );
+  });
+
+  it("wraps Python shebang scripts in a heredoc", () => {
+    const script = "#!/usr/bin/env python3\nimport os\nprint(os.getcwd())";
+    const result = wrapScriptCommand(script);
+    expect(result).toBe(
+      "/usr/bin/env python3 <<'OPENCLAW_SCRIPT_EOF'\nimport os\nprint(os.getcwd())\nOPENCLAW_SCRIPT_EOF",
+    );
+  });
+
+  it("wraps scripts with absolute interpreter paths", () => {
+    const script = "#!/usr/bin/python3\nimport sys\nprint(sys.version)";
+    const result = wrapScriptCommand(script);
+    expect(result).toContain("/usr/bin/python3 <<'OPENCLAW_SCRIPT_EOF'");
+    expect(result).toContain("import sys");
+    expect(result).toEndWith("OPENCLAW_SCRIPT_EOF");
+  });
+
+  it("wraps Ruby shebang scripts", () => {
+    const script = '#!/usr/bin/env ruby\nputs "hello"';
+    const result = wrapScriptCommand(script);
+    expect(result).toContain("/usr/bin/env ruby <<'OPENCLAW_SCRIPT_EOF'");
+    expect(result).toContain('puts "hello"');
+  });
+
+  it("wraps Node.js shebang scripts", () => {
+    const script = '#!/usr/bin/env node\nconsole.log("hello")';
+    const result = wrapScriptCommand(script);
+    expect(result).toContain("/usr/bin/env node <<'OPENCLAW_SCRIPT_EOF'");
+    expect(result).toContain('console.log("hello")');
+  });
+
+  it("handles shebang-only commands (no body)", () => {
+    expect(wrapScriptCommand("#!/usr/bin/env python3")).toBe("#!/usr/bin/env python3");
+  });
+
+  it("handles shebang with empty body", () => {
+    expect(wrapScriptCommand("#!/usr/bin/env python3\n")).toBe("#!/usr/bin/env python3\n");
+    expect(wrapScriptCommand("#!/usr/bin/env python3\n  \n")).toBe(
+      "#!/usr/bin/env python3\n  \n",
+    );
+  });
+
+  it("handles \\r\\n line endings in shebang line", () => {
+    const script = "#!/usr/bin/env python3\r\nimport os\nprint(os.getcwd())";
+    const result = wrapScriptCommand(script);
+    expect(result).toContain("/usr/bin/env python3 <<'OPENCLAW_SCRIPT_EOF'");
+    expect(result).toContain("import os");
+  });
+
+  it("preserves leading whitespace before shebang passthrough", () => {
+    const regular = "  echo hello";
+    expect(wrapScriptCommand(regular)).toBe("  echo hello");
+  });
+
+  it("handles shebang with leading whitespace", () => {
+    const script = "  #!/usr/bin/env python3\nimport os\nprint(os.getcwd())";
+    const result = wrapScriptCommand(script);
+    expect(result).toContain("/usr/bin/env python3 <<'OPENCLAW_SCRIPT_EOF'");
+  });
+
+  it("does not transform commands starting with # but not #!", () => {
+    expect(wrapScriptCommand("# comment\necho hello")).toBe("# comment\necho hello");
   });
 });

--- a/src/infra/node-shell.ts
+++ b/src/infra/node-shell.ts
@@ -1,3 +1,41 @@
+/**
+ * Detects shebang-prefixed multiline scripts and wraps the body in a heredoc
+ * so the shell delegates execution to the interpreter specified in the shebang.
+ *
+ * Without this, `sh -c` interprets each line of the script as a separate shell
+ * command, causing e.g. Python's `import os` to invoke ImageMagick's `import`.
+ */
+export function wrapScriptCommand(command: string): string {
+  const trimmed = command.trimStart();
+  if (!trimmed.startsWith("#!")) {
+    return command;
+  }
+
+  const newlineIdx = trimmed.indexOf("\n");
+  if (newlineIdx === -1) {
+    // Shebang-only, no script body to wrap.
+    return command;
+  }
+
+  const interpreter = trimmed
+    .slice(2, newlineIdx)
+    .replace(/\r$/, "")
+    .trim();
+  if (!interpreter) {
+    return command;
+  }
+
+  const scriptBody = trimmed.slice(newlineIdx + 1);
+  if (!scriptBody.trim()) {
+    return command;
+  }
+
+  // Use a heredoc with a single-quoted marker to prevent shell variable
+  // expansion inside the script body.
+  const marker = "OPENCLAW_SCRIPT_EOF";
+  return `${interpreter} <<'${marker}'\n${scriptBody}\n${marker}`;
+}
+
 export function buildNodeShellCommand(command: string, platform?: string | null) {
   const normalized = String(platform ?? "")
     .trim()
@@ -5,5 +43,5 @@ export function buildNodeShellCommand(command: string, platform?: string | null)
   if (normalized.startsWith("win")) {
     return ["cmd.exe", "/d", "/s", "/c", command];
   }
-  return ["/bin/sh", "-lc", command];
+  return ["/bin/sh", "-lc", wrapScriptCommand(command)];
 }


### PR DESCRIPTION
## Summary

Fixes #11724 - Exec tool cannot execute Python scripts with import statements.

- **Root cause**: When multiline scripts with a shebang (e.g. `#!/usr/bin/env python3`) are passed to the exec tool, all execution paths (`sh -c`, `bash -c`, Docker `sh -lc`) treat the shebang as a comment and interpret subsequent lines as shell commands. This causes Python's `import os` to invoke ImageMagick's `import` binary.
- **Fix**: Add `wrapScriptCommand()` in `node-shell.ts` that detects shebang-prefixed commands and wraps the script body in a single-quoted heredoc (`<<'EOF'`), so the shell delegates execution to the interpreter declared in the shebang line.
- Applied across all four exec paths: sandbox (Docker), PTY, PTY fallback, regular spawn, and node-host (`buildNodeShellCommand`).

### Before
```
sh -c '#!/usr/bin/env python3
import os          # <-- executed as ImageMagick "import" command
print(os.getcwd()) # <-- shell error
'
```

### After
```
sh -c '/usr/bin/env python3 <<'\''OPENCLAW_SCRIPT_EOF'\''
import os
print(os.getcwd())
OPENCLAW_SCRIPT_EOF'
```

The heredoc uses a single-quoted marker to prevent shell variable expansion inside the script body. Non-shebang commands pass through unchanged.

## Test plan

- [x] Added unit tests for `wrapScriptCommand()` covering Python, Ruby, Node.js shebangs, edge cases (empty body, no shebang, `\r\n` line endings, shebang-only, leading whitespace)
- [x] Added integration test for `buildNodeShellCommand` with shebang-prefixed scripts
- [x] Existing `buildNodeShellCommand` tests pass unchanged (regular commands are not affected)
- [ ] Manual verification: run `exec` with a multiline Python script containing `import os`
- [ ] Verify Docker sandbox path handles shebang scripts correctly


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes execution of multi-line shebang scripts (e.g. Python with `import`) by adding `wrapScriptCommand()` in `src/infra/node-shell.ts` and applying it across exec paths (local spawn/PTY, Docker sandbox, and node-host via `buildNodeShellCommand`). It wraps shebang-prefixed commands into a single-quoted heredoc so the declared interpreter receives the script body instead of `/bin/sh` interpreting subsequent lines as shell commands.

Tests were added for `wrapScriptCommand()` and for `buildNodeShellCommand` behavior with a shebang script (`src/infra/node-shell.test.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has two correctness/safety issues in the new shebang-heredoc wrapping and approval/analysis consistency.
- The core approach is sound and well-tested, but (1) a fixed heredoc marker can be prematurely terminated by script content, and (2) node exec allowlist/approval analysis is performed on the unwrapped command while execution uses the wrapped command, which can invalidate approvals/allowlist matching and produce misleading audit logs for shebang scripts.
- src/infra/node-shell.ts, src/agents/bash-tools.exec.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->