### PR TITLE
fix: 401 auth token expiry triggers API key fallback instead of crashing

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -40,10 +40,10 @@ describe("failover-error", () => {
   });
 
   it("coerces 401 auth errors into FailoverError with auth reason", () => {
-    const err = coerceToFailoverError(
-      Object.assign(new Error("Unauthorized"), { status: 401 }),
-      { provider: "anthropic", model: "claude-sonnet-4-5" },
-    );
+    const err = coerceToFailoverError(Object.assign(new Error("Unauthorized"), { status: 401 }), {
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+    });
     expect(err?.name).toBe("FailoverError");
     expect(err?.reason).toBe("auth");
     expect(err?.status).toBe(401);

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -6,6 +6,7 @@ export {
   stripThoughtSignatures,
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
+  AUTH_ERROR_USER_MESSAGE,
   BILLING_ERROR_USER_MESSAGE,
   classifyFailoverReason,
   formatRawAssistantErrorForUi,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -3,6 +3,10 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { FailoverReason } from "./types.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 
+export const AUTH_ERROR_USER_MESSAGE =
+  "\u26a0\ufe0f Authentication failed \u2014 your API token may have expired. " +
+  "Please re-authenticate or switch to a valid API key.";
+
 export const BILLING_ERROR_USER_MESSAGE =
   "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
 
@@ -389,6 +393,10 @@ export function formatAssistantErrorText(
     return BILLING_ERROR_USER_MESSAGE;
   }
 
+  if (isAuthErrorMessage(raw)) {
+    return AUTH_ERROR_USER_MESSAGE;
+  }
+
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
     return formatRawAssistantErrorForUi(raw);
   }
@@ -426,6 +434,10 @@ export function sanitizeUserFacingText(text: string): string {
 
   if (isBillingErrorMessage(trimmed)) {
     return BILLING_ERROR_USER_MESSAGE;
+  }
+
+  if (isAuthErrorMessage(trimmed)) {
+    return AUTH_ERROR_USER_MESSAGE;
   }
 
   if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -84,6 +84,7 @@ vi.mock("../defaults.js", () => ({
 vi.mock("../failover-error.js", () => ({
   FailoverError: class extends Error {},
   resolveFailoverStatus: vi.fn(),
+  resolveFailoverReasonFromError: vi.fn(() => null),
 }));
 
 vi.mock("../usage.js", () => ({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -661,7 +661,7 @@ export async function runEmbeddedPiAgent(
               });
             }
             if (
-              (promptFailoverReason ?? isFailoverErrorMessage(errorText)) &&
+              (promptFailoverReason || isFailoverErrorMessage(errorText)) &&
               promptFailoverReason !== "timeout" &&
               (await advanceAuthProfile())
             ) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -18,7 +18,11 @@ import {
   resolveContextWindowInfo,
 } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
-import { FailoverError, resolveFailoverReasonFromError, resolveFailoverStatus } from "../failover-error.js";
+import {
+  FailoverError,
+  resolveFailoverReasonFromError,
+  resolveFailoverStatus,
+} from "../failover-error.js";
 import {
   ensureAuthProfileStore,
   getApiKeyForModel,
@@ -650,7 +654,8 @@ export async function runEmbeddedPiAgent(
                 },
               };
             }
-            const promptFailoverReason = resolveFailoverReasonFromError(promptError) ?? classifyFailoverReason(errorText);
+            const promptFailoverReason =
+              resolveFailoverReasonFromError(promptError) ?? classifyFailoverReason(errorText);
             if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
               await markAuthProfileFailure({
                 store: authStore,


### PR DESCRIPTION
## Summary

- **Root cause**: The prompt error path in `runEmbeddedPiAgent` used only `classifyFailoverReason(errorText)` to decide if an error is failover-worthy. This function inspects the error **message text** for patterns like "unauthorized" or "401", but does not check the error object's `.status`/`.statusCode` property. When the provider SDK throws an error with HTTP status 401 on the object but a generic or JSON message body, the auth profile rotation is skipped and the raw error crashes the session or surfaces to users.
- **Fix**: Use `resolveFailoverReasonFromError(promptError)` first (which already handles `status === 401 || status === 403`), falling back to text-based classification. This ensures 401 errors trigger auth profile rotation to the next configured API key, then model fallback if all profiles are exhausted.
- **Error surfacing**: Added `AUTH_ERROR_USER_MESSAGE` and auth error detection in `formatAssistantErrorText` and `sanitizeUserFacingText`, matching the existing pattern for billing and rate-limit errors. Auth errors now show a clean message instead of raw HTTP payloads on messaging channels.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/run.ts` | Use `resolveFailoverReasonFromError` for prompt errors; use resolved reason in failover gate conditions |
| `src/agents/pi-embedded-helpers/errors.ts` | Add `AUTH_ERROR_USER_MESSAGE`; add auth checks in `formatAssistantErrorText` and `sanitizeUserFacingText` |
| `src/agents/pi-embedded-helpers.ts` | Re-export `AUTH_ERROR_USER_MESSAGE` |
| `src/agents/failover-error.test.ts` | Add 401 status code test; add 401 coercion tests including generic-message edge case |

## Test plan

- [ ] Verify `resolveFailoverReasonFromError({ status: 401 })` returns `"auth"` (new test case)
- [ ] Verify `coerceToFailoverError` with `statusCode: 401` and a generic message body produces a `FailoverError` with `reason: "auth"` (new test case)
- [ ] Simulate expired OAuth token → 401 response → confirm profile rotation to API key profile
- [ ] Verify auth errors on messaging channels show user-friendly message instead of raw JSON
- [ ] Verify existing 429/402/408 failover paths are not affected (existing tests)

Fixes #11674

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves failover behavior for embedded Pi runs when providers return authentication errors during prompt submission. It:

- Uses `resolveFailoverReasonFromError(promptError)` (status-aware) before falling back to text-based `classifyFailoverReason(errorText)` in `runEmbeddedPiAgent`, ensuring 401/403 errors reliably trigger auth profile rotation and (when configured) model fallback.
- Adds a dedicated auth-safe user-facing message (`AUTH_ERROR_USER_MESSAGE`) and returns it from `formatAssistantErrorText` / `sanitizeUserFacingText` when auth error patterns are detected, preventing raw HTTP/JSON payloads from being surfaced on messaging channels.
- Extends failover-error tests to cover 401 status/ statusCode classification and coercion.

These changes fit into the existing failover system (`FailoverError` + auth profile rotation) by making prompt-error handling use the same status-based reason resolution already present in `src/agents/failover-error.ts`, and aligning user-facing error sanitization with existing billing/rate-limit handling.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses the reported 401 failover gap, with one small logic expression that should be corrected for clarity/consistency.
- Core behavior change (status-aware failover reason) matches existing `resolveFailoverReasonFromError` behavior in `src/agents/failover-error.ts` and is covered by new tests. The only issue spotted is an inconsistent use of `??` vs `||` in a boolean gate in `runEmbeddedPiAgent` that doesn’t currently break behavior but is easy to misread and diverges from the adjacent condition.
- src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->