### PR TITLE
feat: Add Contact Guard extension with hooks for contact state management

### DIFF
--- a/extensions/contact-guard/README.md
+++ b/extensions/contact-guard/README.md
@@ -1,0 +1,136 @@
+# Contact Guard Extension
+
+Manages contact state files and enforces project authorization to prevent data leaks across sessions.
+
+## Overview
+
+Contact Guard provides three key hooks for maintaining contact context and preventing unauthorized project information from being shared:
+
+1. **Auto-inject contact state on session start** (`before_agent_start`)
+   - Loads contact info from `memory/contacts/<phone>.md`
+   - Injects into system context so the agent knows who they're talking to
+   - Includes authorized projects list to guide the agent's responses
+
+2. **Scan outgoing messages for leaks** (`message_sending`)
+   - Hooks before message delivery
+   - Checks for unauthorized project keywords
+   - Can warn, block, or redact based on configuration
+
+3. **Preserve contact context during compaction** (`before_compaction`/`after_compaction`)
+   - Clears caches after compaction
+   - Contact context is automatically re-injected on next agent start
+
+## Configuration
+
+```json
+{
+  "plugins": {
+    "contact-guard": {
+      "contactStateDir": "memory/contacts",
+      "projectRegistry": "projects/registry.json",
+      "ownerPhones": ["+1234567890", "+0987654321"],
+      "enableAutoInject": true,
+      "enableLeakDetection": true,
+      "enableCompactionPreserve": true,
+      "leakAction": "warn"
+    }
+  }
+}
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `contactStateDir` | string | `memory/contacts` | Directory containing contact state files |
+| `projectRegistry` | string | `projects/registry.json` | Path to project registry JSON |
+| `ownerPhones` | string[] | `[]` | Phone numbers that bypass all authorization checks |
+| `enableAutoInject` | boolean | `true` | Auto-inject contact state into agent context |
+| `enableLeakDetection` | boolean | `true` | Scan outgoing messages for project leaks |
+| `enableCompactionPreserve` | boolean | `true` | Preserve contact context during compaction |
+| `leakAction` | string | `warn` | Action on leak: `warn`, `block`, or `redact` |
+
+## Contact State Files
+
+Contact state files are markdown files named after the phone number (e.g., `+2348151259975.md`):
+
+```markdown
+# Contact: John Doe (+2348151259975)
+
+**Name:** John Doe
+**Relation:** Client
+**Active project:** Project Alpha
+**Last topic:** Bug fixes for API
+
+## Authorized Projects
+- Project Alpha
+- Project Beta
+
+## Recent Work
+- 2024-01-15: Reviewed API changes
+- 2024-01-14: Fixed authentication bug
+```
+
+## Project Registry
+
+The project registry defines what projects exist and who is authorized:
+
+```json
+{
+  "projects": [
+    {
+      "id": "project-alpha",
+      "name": "Project Alpha",
+      "authorized_contacts": ["owner", "+2348151259975"],
+      "keywords": ["alpha", "project-a"]
+    }
+  ],
+  "contact_aliases": {
+    "owner": ["+1234567890", "+0987654321"]
+  }
+}
+```
+
+## CLI Commands
+
+```bash
+# Check contact authorization
+clawdbot contact-guard check +2348151259975
+```
+
+## How It Works
+
+### Session Start Flow
+1. Message arrives from phone number
+2. `before_agent_start` hook fires
+3. Contact state file is loaded
+4. Project registry is checked for authorization
+5. Context block is prepended to agent prompt
+
+### Message Sending Flow
+1. Agent generates response
+2. `message_sending` hook fires
+3. Response is scanned for project keywords
+4. If unauthorized project found:
+   - `warn`: Log and continue
+   - `block`: Cancel message
+   - `redact`: Remove keywords and send
+
+### Compaction Flow
+1. Context gets truncated
+2. `before_compaction` hook logs the event
+3. `after_compaction` clears caches
+4. Next message triggers `before_agent_start`
+5. Fresh contact context is re-injected
+
+## Security
+
+This extension helps prevent data leaks but is not a complete security solution. It:
+
+- ✅ Adds guardrails against accidental project mentions
+- ✅ Provides context continuity across session truncations
+- ✅ Logs potential leak attempts
+- ❌ Cannot prevent determined circumvention
+- ❌ Does not encrypt or sanitize at the protocol level
+
+Always combine with proper access controls and review practices.

--- a/extensions/contact-guard/clawdbot.plugin.json
+++ b/extensions/contact-guard/clawdbot.plugin.json
@@ -1,0 +1,47 @@
+{
+  "id": "contact-guard",
+  "name": "Contact Guard",
+  "description": "Manages contact state files and enforces project authorization to prevent data leaks across sessions. Auto-injects contact context on session start and scans outgoing messages for unauthorized project mentions.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "contactStateDir": {
+        "type": "string",
+        "default": "memory/contacts",
+        "description": "Directory containing contact state files (relative to workspace)"
+      },
+      "projectRegistry": {
+        "type": "string",
+        "default": "projects/registry.json",
+        "description": "Path to project registry with authorization rules"
+      },
+      "ownerPhones": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Phone numbers that count as 'owner' in authorization"
+      },
+      "enableAutoInject": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-inject contact state into agent context on session start"
+      },
+      "enableLeakDetection": {
+        "type": "boolean",
+        "default": true,
+        "description": "Scan outgoing messages for project keyword leaks"
+      },
+      "enableCompactionPreserve": {
+        "type": "boolean",
+        "default": true,
+        "description": "Preserve contact context when context is truncated/compacted"
+      },
+      "leakAction": {
+        "type": "string",
+        "enum": ["warn", "block", "redact"],
+        "default": "warn",
+        "description": "Action to take when a potential leak is detected: warn (log only), block (cancel send), redact (remove keywords)"
+      }
+    }
+  }
+}

--- a/extensions/contact-guard/index.ts
+++ b/extensions/contact-guard/index.ts
@@ -1,0 +1,303 @@
+/**
+ * Contact Guard Extension for Clawdbot
+ *
+ * Provides contact state management and project authorization hooks
+ * to prevent data leaks across sessions.
+ *
+ * Hooks:
+ * 1. before_agent_start - Auto-inject contact state into system context
+ * 2. message_sending - Scan outgoing messages for project info leaks
+ * 3. before_compaction - Preserve contact context in truncation summaries
+ */
+
+import type { OpenClawPluginApi } from "../../src/plugins/types.js";
+import {
+  loadContactState,
+  extractPhoneFromSessionKey,
+  clearContactCache,
+  type ContactState,
+} from "./src/contact-state.js";
+import {
+  loadProjectRegistry,
+  getAuthorizedProjects,
+  detectProjectLeaks,
+  redactProjectKeywords,
+  clearRegistryCache,
+  type ProjectRegistry,
+} from "./src/project-auth.js";
+
+interface ContactGuardConfig {
+  contactStateDir: string;
+  projectRegistry: string;
+  ownerPhones: string[];
+  enableAutoInject: boolean;
+  enableLeakDetection: boolean;
+  enableCompactionPreserve: boolean;
+  leakAction: "warn" | "block" | "redact";
+}
+
+const DEFAULT_CONFIG: ContactGuardConfig = {
+  contactStateDir: "memory/contacts",
+  projectRegistry: "projects/registry.json",
+  ownerPhones: [],
+  enableAutoInject: true,
+  enableLeakDetection: true,
+  enableCompactionPreserve: true,
+  leakAction: "warn",
+};
+
+/**
+ * Build context injection for a contact
+ */
+function buildContactContextBlock(
+  contact: ContactState,
+  authorizedProjects: string[],
+): string {
+  const lines: string[] = [
+    "<contact-context>",
+    `Current contact: ${contact.name ?? "Unknown"} (${contact.phone})`,
+  ];
+
+  if (contact.relation) {
+    lines.push(`Relation: ${contact.relation}`);
+  }
+
+  if (contact.activeProject) {
+    lines.push(`Active project: ${contact.activeProject}`);
+  }
+
+  if (contact.lastTopic) {
+    lines.push(`Last topic: ${contact.lastTopic}`);
+  }
+
+  if (authorizedProjects.length > 0) {
+    lines.push(`Authorized to know about: ${authorizedProjects.join(", ")}`);
+  } else {
+    lines.push("Not authorized for any project discussions.");
+  }
+
+  lines.push("");
+  lines.push("IMPORTANT: Only discuss projects this contact is authorized for.");
+  lines.push("If context was truncated, use this info to maintain continuity.");
+  lines.push("</contact-context>");
+
+  return lines.join("\n");
+}
+
+export default function register(api: OpenClawPluginApi) {
+  const pluginConfig = api.pluginConfig ?? {};
+  const config: ContactGuardConfig = {
+    ...DEFAULT_CONFIG,
+    ...(typeof pluginConfig === "object" ? pluginConfig : {}),
+  };
+
+  // Resolve workspace directory
+  const workspaceDir = api.runtime.state.resolveStateDir(api.config);
+
+  api.logger.info?.("[contact-guard] Extension loaded");
+  api.logger.info?.(`[contact-guard] Contact state dir: ${config.contactStateDir}`);
+  api.logger.info?.(`[contact-guard] Project registry: ${config.projectRegistry}`);
+
+  // =========================================================================
+  // Hook 1: Auto-inject contact state on session start
+  // =========================================================================
+  if (config.enableAutoInject) {
+    api.on("before_agent_start", async (event, ctx) => {
+      if (!ctx.sessionKey) {
+        return;
+      }
+
+      // Extract phone from session key
+      const phone = extractPhoneFromSessionKey(ctx.sessionKey);
+      if (!phone) {
+        return;
+      }
+
+      // Skip for owner phones (they can see everything)
+      if (config.ownerPhones.includes(phone)) {
+        api.logger.debug?.(`[contact-guard] Skipping injection for owner: ${phone}`);
+        return;
+      }
+
+      // Load contact state
+      const contact = loadContactState(workspaceDir, config.contactStateDir, phone);
+      if (!contact) {
+        api.logger.debug?.(`[contact-guard] No contact state found for: ${phone}`);
+        return;
+      }
+
+      // Load project registry and get authorized projects
+      const registry = loadProjectRegistry(workspaceDir, config.projectRegistry);
+      const authorizedProjects = registry
+        ? getAuthorizedProjects(registry, phone, config.ownerPhones)
+        : contact.authorizedProjects;
+
+      // Build and inject context
+      const contextBlock = buildContactContextBlock(contact, authorizedProjects);
+      api.logger.info?.(
+        `[contact-guard] Injecting context for ${contact.name ?? phone} ` +
+          `(${authorizedProjects.length} authorized projects)`,
+      );
+
+      return {
+        prependContext: contextBlock,
+      };
+    });
+  }
+
+  // =========================================================================
+  // Hook 2: Scan outgoing messages for project leaks
+  // =========================================================================
+  if (config.enableLeakDetection) {
+    api.on("message_sending", async (event, ctx) => {
+      if (!event.content || !event.to) {
+        return;
+      }
+
+      // Extract phone from target
+      const phone = event.to.replace(/[^\d+]/g, "");
+      if (!phone.startsWith("+")) {
+        // Not a phone number, skip
+        return;
+      }
+
+      // Skip for owner phones
+      if (config.ownerPhones.includes(phone)) {
+        return;
+      }
+
+      // Load project registry
+      const registry = loadProjectRegistry(workspaceDir, config.projectRegistry);
+      if (!registry) {
+        return;
+      }
+
+      // Get authorized projects for this contact
+      const authorizedProjects = getAuthorizedProjects(registry, phone, config.ownerPhones);
+
+      // Scan for leaks
+      const leaks = detectProjectLeaks(registry, event.content, authorizedProjects);
+
+      if (leaks.length === 0) {
+        return;
+      }
+
+      // Handle based on configured action
+      const leakDetails = leaks.map((l) => `${l.projectName} (keyword: "${l.keyword}")`).join(", ");
+      api.logger.warn?.(
+        `[contact-guard] Potential project leak detected to ${phone}: ${leakDetails}`,
+      );
+
+      switch (config.leakAction) {
+        case "block":
+          api.logger.error?.(
+            `[contact-guard] Blocking message to ${phone} due to project leak`,
+          );
+          return {
+            cancel: true,
+          };
+
+        case "redact": {
+          const keywords = leaks.map((l) => l.keyword);
+          const redactedContent = redactProjectKeywords(event.content, keywords);
+          api.logger.warn?.(`[contact-guard] Redacted ${keywords.length} project keywords`);
+          return {
+            content: redactedContent,
+          };
+        }
+
+        case "warn":
+        default:
+          // Just log, don't modify or block
+          return;
+      }
+    });
+  }
+
+  // =========================================================================
+  // Hook 3: Preserve contact context during compaction
+  // =========================================================================
+  if (config.enableCompactionPreserve) {
+    api.on("before_compaction", async (_event, ctx) => {
+      if (!ctx.sessionKey) {
+        return;
+      }
+
+      const phone = extractPhoneFromSessionKey(ctx.sessionKey);
+      if (!phone) {
+        return;
+      }
+
+      // Load contact for logging/debugging
+      const contact = loadContactState(workspaceDir, config.contactStateDir, phone);
+      if (contact) {
+        api.logger.info?.(
+          `[contact-guard] Compaction for ${contact.name ?? phone} session - ` +
+            `contact context will be re-injected on next agent start`,
+        );
+      }
+
+      // Note: The actual context preservation happens automatically because
+      // before_agent_start runs after compaction and will re-inject the
+      // contact context into the new, compacted conversation.
+    });
+
+    api.on("after_compaction", async (_event, ctx) => {
+      if (!ctx.sessionKey) {
+        return;
+      }
+
+      const phone = extractPhoneFromSessionKey(ctx.sessionKey);
+      if (!phone) {
+        return;
+      }
+
+      // Clear caches to ensure fresh data on next injection
+      clearContactCache();
+      clearRegistryCache();
+
+      api.logger.debug?.(
+        `[contact-guard] Cleared caches after compaction for session: ${ctx.sessionKey}`,
+      );
+    });
+  }
+
+  // =========================================================================
+  // CLI command for testing/debugging
+  // =========================================================================
+  api.registerCli(
+    ({ program }) => {
+      program
+        .command("contact-guard")
+        .description("Contact guard utilities")
+        .command("check")
+        .description("Check contact authorization")
+        .argument("<phone>", "Phone number to check")
+        .action(async (phone: string) => {
+          const normalizedPhone = phone.replace(/[^\d+]/g, "");
+          const contact = loadContactState(workspaceDir, config.contactStateDir, normalizedPhone);
+
+          if (!contact) {
+            console.log(`No contact file found for: ${normalizedPhone}`);
+            return;
+          }
+
+          console.log(`\nContact: ${contact.name ?? "Unknown"}`);
+          console.log(`Phone: ${contact.phone}`);
+          console.log(`Relation: ${contact.relation ?? "N/A"}`);
+          console.log(`Active Project: ${contact.activeProject ?? "None"}`);
+          console.log(`Last Topic: ${contact.lastTopic ?? "N/A"}`);
+
+          const registry = loadProjectRegistry(workspaceDir, config.projectRegistry);
+          if (registry) {
+            const authorized = getAuthorizedProjects(registry, normalizedPhone, config.ownerPhones);
+            console.log(`\nAuthorized Projects (${authorized.length}):`);
+            for (const proj of authorized) {
+              console.log(`  - ${proj}`);
+            }
+          }
+        });
+    },
+    { commands: ["contact-guard"] },
+  );
+}

--- a/extensions/contact-guard/package.json
+++ b/extensions/contact-guard/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@clawdbot/contact-guard",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Contact state management and project authorization hooks for preventing data leaks across sessions",
+  "exports": {
+    ".": "./index.ts"
+  }
+}

--- a/extensions/contact-guard/src/contact-state.ts
+++ b/extensions/contact-guard/src/contact-state.ts
@@ -1,0 +1,128 @@
+/**
+ * Contact State Management
+ *
+ * Handles loading, caching, and updating contact state files
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export interface ContactState {
+  phone: string;
+  name?: string;
+  relation?: string;
+  authorizedProjects: string[];
+  activeProject?: string;
+  lastTopic?: string;
+  recentWork: Array<{ date: string; description: string }>;
+  notes?: string;
+}
+
+const contactCache = new Map<string, ContactState>();
+
+/**
+ * Parse a contact state markdown file into structured data
+ */
+export function parseContactFile(content: string, phone: string): ContactState {
+  const state: ContactState = {
+    phone,
+    authorizedProjects: [],
+    recentWork: [],
+  };
+
+  // Extract name from header
+  const nameMatch = content.match(/^# Contact: ([^\n]+)/m);
+  if (nameMatch) {
+    state.name = nameMatch[1].replace(/\([^)]*\)/, "").trim();
+  }
+
+  // Extract key fields
+  const fieldPatterns: Record<string, RegExp> = {
+    name: /\*\*Name:\*\*\s*(.+)/,
+    relation: /\*\*Relation:\*\*\s*(.+)/,
+    activeProject: /\*\*Active project:\*\*\s*(.+)/,
+    lastTopic: /\*\*Last topic:\*\*\s*(.+)/,
+  };
+
+  for (const [field, pattern] of Object.entries(fieldPatterns)) {
+    const match = content.match(pattern);
+    if (match) {
+      (state as Record<string, unknown>)[field] = match[1].trim();
+    }
+  }
+
+  // Extract authorized projects (bullet list under ## Authorized Projects)
+  const projectSection = content.match(/## Authorized Projects\n([\s\S]*?)(?=\n##|$)/);
+  if (projectSection) {
+    const projects = projectSection[1].match(/^-\s*(.+)$/gm);
+    if (projects) {
+      state.authorizedProjects = projects
+        .map((p) => p.replace(/^-\s*/, "").trim())
+        .filter((p) => p && p !== "None" && !p.includes("not tech projects"));
+    }
+  }
+
+  // Extract recent work
+  const recentSection = content.match(/## Recent Work\n([\s\S]*?)(?=\n##|$)/);
+  if (recentSection) {
+    const items = recentSection[1].match(/^-\s*(\d{4}-\d{2}-\d{2}):\s*(.+)$/gm);
+    if (items) {
+      state.recentWork = items
+        .map((item) => {
+          const match = item.match(/^-\s*(\d{4}-\d{2}-\d{2}):\s*(.+)$/);
+          return match ? { date: match[1], description: match[2] } : null;
+        })
+        .filter((x): x is { date: string; description: string } => x !== null);
+    }
+  }
+
+  return state;
+}
+
+/**
+ * Load contact state from file
+ */
+export function loadContactState(
+  workspaceDir: string,
+  contactStateDir: string,
+  phone: string,
+): ContactState | null {
+  // Normalize phone number for filename
+  const normalizedPhone = phone.replace(/[^\d+]/g, "");
+  const filePath = path.join(workspaceDir, contactStateDir, `${normalizedPhone}.md`);
+
+  // Check cache first
+  const cached = contactCache.get(normalizedPhone);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const content = fs.readFileSync(filePath, "utf-8");
+    const state = parseContactFile(content, normalizedPhone);
+    contactCache.set(normalizedPhone, state);
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract phone number from session key
+ * Handles formats like: whatsapp:+2348151259975:user or agent:main:whatsapp:+2348151259975
+ */
+export function extractPhoneFromSessionKey(sessionKey: string): string | null {
+  // Match E.164 format phone numbers
+  const phoneMatch = sessionKey.match(/(\+\d{10,15})/);
+  return phoneMatch ? phoneMatch[1] : null;
+}
+
+/**
+ * Clear contact cache (useful for testing or refresh)
+ */
+export function clearContactCache(): void {
+  contactCache.clear();
+}

--- a/extensions/contact-guard/src/project-auth.ts
+++ b/extensions/contact-guard/src/project-auth.ts
@@ -1,0 +1,190 @@
+/**
+ * Project Authorization
+ *
+ * Checks if a contact is authorized to know about specific projects
+ * and detects potential project information leaks in outgoing messages.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export interface ProjectConfig {
+  id: string;
+  name: string;
+  authorized_contacts: string[];
+  keywords?: string[];
+}
+
+export interface ProjectRegistry {
+  projects: ProjectConfig[];
+  contact_aliases: Record<string, string | string[]>;
+}
+
+let registryCache: ProjectRegistry | null = null;
+
+/**
+ * Load project registry
+ */
+export function loadProjectRegistry(
+  workspaceDir: string,
+  registryPath: string,
+): ProjectRegistry | null {
+  if (registryCache) {
+    return registryCache;
+  }
+
+  const fullPath = path.join(workspaceDir, registryPath);
+
+  try {
+    if (!fs.existsSync(fullPath)) {
+      return null;
+    }
+    const content = fs.readFileSync(fullPath, "utf-8");
+    registryCache = JSON.parse(content) as ProjectRegistry;
+    return registryCache;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve contact alias to actual phone numbers
+ */
+export function resolveContactAlias(registry: ProjectRegistry, alias: string): string[] {
+  const resolved = registry.contact_aliases?.[alias];
+  if (!resolved) {
+    return [alias];
+  }
+  return Array.isArray(resolved) ? resolved : [resolved];
+}
+
+/**
+ * Check if a phone number is authorized for a project
+ */
+export function isAuthorizedForProject(
+  registry: ProjectRegistry,
+  phone: string,
+  projectId: string,
+  ownerPhones: string[] = [],
+): boolean {
+  const normalizedPhone = phone.replace(/[^\d+]/g, "");
+
+  const project = registry.projects.find((p) => p.id === projectId);
+  if (!project) {
+    // Unknown project - default to owner-only
+    return ownerPhones.includes(normalizedPhone);
+  }
+
+  for (const authorized of project.authorized_contacts) {
+    // Check if it's an alias
+    const resolved = resolveContactAlias(registry, authorized);
+
+    for (const authorizedPhone of resolved) {
+      const normalizedAuth = authorizedPhone.replace(/[^\d+]/g, "");
+
+      // "owner" is a special alias
+      if (authorized === "owner" && ownerPhones.includes(normalizedPhone)) {
+        return true;
+      }
+
+      if (normalizedAuth === normalizedPhone) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Get all projects a contact is authorized for
+ */
+export function getAuthorizedProjects(
+  registry: ProjectRegistry,
+  phone: string,
+  ownerPhones: string[] = [],
+): string[] {
+  return registry.projects
+    .filter((p) => isAuthorizedForProject(registry, phone, p.id, ownerPhones))
+    .map((p) => p.id);
+}
+
+/**
+ * Extract project keywords from registry for leak detection
+ */
+export function extractProjectKeywords(registry: ProjectRegistry): Map<string, string> {
+  const keywords = new Map<string, string>();
+
+  for (const project of registry.projects) {
+    // Project name (case-insensitive)
+    keywords.set(project.name.toLowerCase(), project.id);
+
+    // Project ID
+    keywords.set(project.id.toLowerCase(), project.id);
+
+    // Custom keywords if defined
+    if (project.keywords) {
+      for (const kw of project.keywords) {
+        keywords.set(kw.toLowerCase(), project.id);
+      }
+    }
+  }
+
+  return keywords;
+}
+
+/**
+ * Scan text for potential project leaks
+ * Returns list of unauthorized project mentions found
+ */
+export function detectProjectLeaks(
+  registry: ProjectRegistry,
+  text: string,
+  authorizedProjects: string[],
+): Array<{ keyword: string; projectId: string; projectName: string }> {
+  const leaks: Array<{ keyword: string; projectId: string; projectName: string }> = [];
+  const keywords = extractProjectKeywords(registry);
+  const textLower = text.toLowerCase();
+
+  for (const [keyword, projectId] of keywords) {
+    if (textLower.includes(keyword) && !authorizedProjects.includes(projectId)) {
+      const project = registry.projects.find((p) => p.id === projectId);
+      leaks.push({
+        keyword,
+        projectId,
+        projectName: project?.name ?? projectId,
+      });
+    }
+  }
+
+  // Deduplicate by projectId
+  const seen = new Set<string>();
+  return leaks.filter((leak) => {
+    if (seen.has(leak.projectId)) return false;
+    seen.add(leak.projectId);
+    return true;
+  });
+}
+
+/**
+ * Redact project keywords from text
+ */
+export function redactProjectKeywords(
+  text: string,
+  keywords: string[],
+  replacement = "[REDACTED]",
+): string {
+  let result = text;
+  for (const keyword of keywords) {
+    const regex = new RegExp(keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gi");
+    result = result.replace(regex, replacement);
+  }
+  return result;
+}
+
+/**
+ * Clear registry cache
+ */
+export function clearRegistryCache(): void {
+  registryCache = null;
+}

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -21,6 +21,7 @@ import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
 import { sendMessageSignal } from "../../signal/send.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
@@ -318,9 +319,45 @@ export async function deliverOutboundPayloads(params: {
     };
   };
   const normalizedPayloads = normalizeReplyPayloadsForDelivery(payloads);
+  const hookRunner = getGlobalHookRunner();
+
   for (const payload of normalizedPayloads) {
+    let payloadText = payload.text ?? "";
+
+    // Run message_sending hook to allow plugins to modify or cancel the message
+    if (hookRunner?.hasHooks("message_sending") && payloadText) {
+      try {
+        const hookResult = await hookRunner.runMessageSending(
+          {
+            to,
+            content: payloadText,
+            metadata: {
+              channel,
+              accountId,
+              mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
+            },
+          },
+          {
+            channelId: channel,
+            accountId,
+            conversationId: to,
+          },
+        );
+        if (hookResult?.cancel) {
+          // Skip this payload if hook requested cancellation
+          continue;
+        }
+        if (hookResult?.content !== undefined) {
+          // Use modified content from hook
+          payloadText = hookResult.content;
+        }
+      } catch {
+        // Ignore hook errors, continue with original payload
+      }
+    }
+
     const payloadSummary: NormalizedOutboundPayload = {
-      text: payload.text ?? "",
+      text: payloadText,
       mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
       channelData: payload.channelData,
     };
@@ -328,7 +365,11 @@ export async function deliverOutboundPayloads(params: {
       throwIfAborted(abortSignal);
       params.onPayload?.(payloadSummary);
       if (handler.sendPayload && payload.channelData) {
-        results.push(await handler.sendPayload(payload));
+        // Use potentially modified text from hook
+        const modifiedPayload = payloadText !== (payload.text ?? "")
+          ? { ...payload, text: payloadText }
+          : payload;
+        results.push(await handler.sendPayload(modifiedPayload));
         continue;
       }
       if (payloadSummary.mediaUrls.length === 0) {


### PR DESCRIPTION
## Summary

This PR adds the contact-guard extension which provides hook points for contact state management and project authorization to prevent data leaks across sessions.

## Changes

### 1. New Extension: contact-guard (`extensions/contact-guard/`)

Provides three key hooks:

#### Auto-inject contact state on session start (`before_agent_start`)
- Loads contact info from `memory/contacts/<phone>.md`
- Injects into system context with authorized projects list
- Helps maintain context continuity after truncation

#### Scan outgoing messages for project leaks (`message_sending`)
- Checks for unauthorized project keywords before message delivery
- Configurable actions: `warn` (log only), `block` (cancel send), `redact` (remove keywords)
- Uses project registry for authorization rules

#### Preserve contact context during compaction (`before_compaction`/`after_compaction`)
- Clears caches after compaction
- Context is automatically re-injected on next agent start

### 2. Wire up `message_sending` hook in outbound delivery

Added hook trigger in `src/infra/outbound/deliver.ts` so plugins can:
- Inspect outgoing message content
- Modify the content before sending
- Cancel the message entirely

## Configuration

```json
{
  "plugins": {
    "contact-guard": {
      "contactStateDir": "memory/contacts",
      "projectRegistry": "projects/registry.json",
      "ownerPhones": ["+1234567890"],
      "enableAutoInject": true,
      "enableLeakDetection": true,
      "enableCompactionPreserve": true,
      "leakAction": "warn"
    }
  }
}
```

## Files

- `extensions/contact-guard/index.ts` - Main extension with all hooks
- `extensions/contact-guard/src/contact-state.ts` - Contact state file parsing
- `extensions/contact-guard/src/project-auth.ts` - Project authorization logic
- `extensions/contact-guard/clawdbot.plugin.json` - Plugin configuration schema
- `extensions/contact-guard/README.md` - Full documentation
- `src/infra/outbound/deliver.ts` - Added message_sending hook trigger

## Testing

The extension can be enabled by adding `contact-guard` to your plugins configuration. Use the CLI command to test:

```bash
clawdbot contact-guard check +2348151259975
```

## Related

This addresses the need for contact-aware session handling to prevent accidental project information leaks when context is truncated or when talking to multiple contacts.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `contact-guard` extension that:

- Injects contact context at `before_agent_start` based on per-contact markdown files.
- Adds a `message_sending` hook implementation to detect/optionally block or redact unauthorized project mentions using a JSON project registry.
- Clears internal caches on compaction hooks.

It also wires the core outbound delivery path (`src/infra/outbound/deliver.ts`) to invoke the global `message_sending` hook runner so plugins can cancel or modify outgoing message content before it is sent.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to mis-resolved paths and silent hook failure behavior that can disable the intended leak protection.
- Score reduced because (1) the extension resolves files relative to the state dir instead of the workspace, so key features likely won’t run in real deployments, (2) outbound hook failures are swallowed silently, and (3) leak detection logs can themselves disclose the sensitive keywords/projects being protected.
- extensions/contact-guard/index.ts, src/infra/outbound/deliver.ts, extensions/contact-guard/package.json

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->