### PR TITLE
[FEATURE] feat: integrate systemd WatchdogSec for gateway hang detection

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -120,6 +120,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
         programArguments,
         workingDirectory,
         environment,
+        watchdog: true,
       });
     },
   });

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/commands/configure.daemon.ts
+++ b/src/commands/configure.daemon.ts
@@ -129,6 +129,7 @@ export async function maybeInstallDaemon(params: {
             programArguments,
             workingDirectory,
             environment,
+            watchdog: true,
           });
           progress.setLabel("Gateway service installed.");
         } catch (err) {

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -205,6 +205,7 @@ export async function maybeRepairGatewayDaemon(params: {
             programArguments,
             workingDirectory,
             environment,
+            watchdog: true,
           });
         } catch (err) {
           note(`Gateway service install failed: ${String(err)}`, "Gateway");

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -367,6 +367,7 @@ export async function maybeRepairGatewayServiceConfig(
       programArguments: updatedPlan.programArguments,
       workingDirectory: updatedPlan.workingDirectory,
       environment: updatedPlan.environment,
+      watchdog: true,
     });
   } catch (err) {
     runtime.error(`Gateway service update failed: ${String(err)}`);

--- a/src/commands/onboard-non-interactive/local/daemon-install.ts
+++ b/src/commands/onboard-non-interactive/local/daemon-install.ts
@@ -66,6 +66,7 @@ export async function installGatewayDaemonNonInteractive(params: {
       programArguments,
       workingDirectory,
       environment,
+      watchdog: true,
     });
   } catch (err) {
     runtime.error(`Gateway service install failed: ${String(err)}`);

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -7,6 +7,8 @@ export type GatewayServiceInstallArgs = {
   workingDirectory?: string;
   environment?: GatewayServiceEnv;
   description?: string;
+  /** Enable Type=notify, NotifyAccess=all, and WatchdogSec. Only set for services that send sd_notify events. */
+  watchdog?: boolean;
 };
 
 export type GatewayServiceManageArgs = {
@@ -36,4 +38,6 @@ export type GatewayServiceRenderArgs = {
   programArguments: string[];
   workingDirectory?: string;
   environment?: GatewayServiceEnv;
+  /** Enable Type=notify, NotifyAccess=all, and WatchdogSec. Only set for services that send sd_notify events. */
+  watchdog?: boolean;
 };

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -61,7 +61,7 @@ export function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
-    watchdog ? "NotifyAccess=main" : null,
+    watchdog ? "NotifyAccess=all" : null,
     watchdog ? "WatchdogSec=90" : null,
     "TimeoutStopSec=30",
     "TimeoutStartSec=30",

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -40,6 +40,7 @@ export function buildSystemdUnit({
   programArguments,
   workingDirectory,
   environment,
+  watchdog,
 }: GatewayServiceRenderArgs): string {
   const execStart = programArguments.map(systemdEscapeArg).join(" ");
   const descriptionValue = description?.trim() || "OpenClaw Gateway";
@@ -56,9 +57,12 @@ export function buildSystemdUnit({
     "Wants=network-online.target",
     "",
     "[Service]",
+    watchdog ? "Type=notify" : null,
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
+    watchdog ? "NotifyAccess=main" : null,
+    watchdog ? "WatchdogSec=90" : null,
     "TimeoutStopSec=30",
     "TimeoutStartSec=30",
     "SuccessExitStatus=0 143",

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -797,7 +797,7 @@ describe("buildSystemdUnit", () => {
       programArguments: ["/usr/bin/openclaw", "gateway", "start"],
     });
     expect(unit).not.toContain("Type=notify");
-    expect(unit).not.toContain("NotifyAccess=main");
+    expect(unit).not.toContain("NotifyAccess=all");
     expect(unit).not.toContain("WatchdogSec=90");
   });
 
@@ -809,12 +809,12 @@ describe("buildSystemdUnit", () => {
     expect(unit).toContain("Type=notify");
   });
 
-  it("includes NotifyAccess=main when watchdog is enabled", () => {
+  it("includes NotifyAccess=all when watchdog is enabled", () => {
     const unit = buildSystemdUnit({
       programArguments: ["/usr/bin/openclaw", "gateway", "start"],
       watchdog: true,
     });
-    expect(unit).toContain("NotifyAccess=main");
+    expect(unit).toContain("NotifyAccess=all");
   });
 
   it("includes WatchdogSec=90 when watchdog is enabled", () => {
@@ -833,7 +833,7 @@ describe("buildSystemdUnit", () => {
     const serviceStart = unit.indexOf("[Service]");
     const installStart = unit.indexOf("[Install]");
     const typePos = unit.indexOf("Type=notify");
-    const notifyAccessPos = unit.indexOf("NotifyAccess=main");
+    const notifyAccessPos = unit.indexOf("NotifyAccess=all");
     const watchdogPos = unit.indexOf("WatchdogSec=90");
     expect(typePos).toBeGreaterThan(serviceStart);
     expect(typePos).toBeLessThan(installStart);

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -9,7 +9,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { splitArgsPreservingQuotes } from "./arg-split.js";
-import { parseSystemdExecStart } from "./systemd-unit.js";
+import { buildSystemdUnit, parseSystemdExecStart } from "./systemd-unit.js";
 import {
   isNonFatalSystemdInstallProbeError,
   isSystemdUserServiceAvailable,
@@ -773,5 +773,58 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ USER: "debian" });
+  });
+});
+
+describe("buildSystemdUnit", () => {
+  it("omits notify/watchdog directives by default", () => {
+    const unit = buildSystemdUnit({
+      programArguments: ["/usr/bin/openclaw", "gateway", "start"],
+    });
+    expect(unit).not.toContain("Type=notify");
+    expect(unit).not.toContain("NotifyAccess=all");
+    expect(unit).not.toContain("WatchdogSec=90");
+  });
+
+  it("includes Type=notify when watchdog is enabled", () => {
+    const unit = buildSystemdUnit({
+      programArguments: ["/usr/bin/openclaw", "gateway", "start"],
+      watchdog: true,
+    });
+    expect(unit).toContain("Type=notify");
+  });
+
+  it("includes NotifyAccess=all when watchdog is enabled", () => {
+    const unit = buildSystemdUnit({
+      programArguments: ["/usr/bin/openclaw", "gateway", "start"],
+      watchdog: true,
+    });
+    expect(unit).toContain("NotifyAccess=all");
+  });
+
+  it("includes WatchdogSec=90 when watchdog is enabled", () => {
+    const unit = buildSystemdUnit({
+      programArguments: ["/usr/bin/openclaw", "gateway", "start"],
+      watchdog: true,
+    });
+    expect(unit).toContain("WatchdogSec=90");
+  });
+
+  it("places watchdog directives in [Service] section", () => {
+    const unit = buildSystemdUnit({
+      programArguments: ["/usr/bin/openclaw", "gateway", "start"],
+      watchdog: true,
+    });
+    const serviceStart = unit.indexOf("[Service]");
+    const installStart = unit.indexOf("[Install]");
+    const typePos = unit.indexOf("Type=notify");
+    const notifyAccessPos = unit.indexOf("NotifyAccess=all");
+    const watchdogPos = unit.indexOf("WatchdogSec=90");
+    expect(typePos).toBeGreaterThan(serviceStart);
+    expect(typePos).toBeLessThan(installStart);
+    expect(notifyAccessPos).toBeGreaterThan(serviceStart);
+    expect(notifyAccessPos).toBeLessThan(installStart);
+    expect(watchdogPos).toBeGreaterThan(serviceStart);
+    expect(watchdogPos).toBeLessThan(installStart);
   });
 });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -408,6 +408,21 @@ describe("resolveSystemdUserUnitPath", () => {
   ])("$name", ({ env, expected }) => {
     expect(resolveSystemdUserUnitPath(env)).toBe(expected);
   });
+
+  it.each([
+    { name: "rejects path traversal", unit: "../escape" },
+    { name: "rejects absolute path", unit: "/etc/systemd/system/sshd" },
+    { name: "rejects slash", unit: "custom/unit" },
+    { name: "rejects backslash", unit: "custom\\\\unit" },
+    { name: "rejects dot-dot token", unit: "custom..unit" },
+  ])("$name", ({ unit }) => {
+    expect(() =>
+      resolveSystemdUserUnitPath({
+        HOME: "/home/test",
+        OPENCLAW_SYSTEMD_UNIT: unit,
+      }),
+    ).toThrow("Invalid systemd unit name");
+  });
 });
 
 describe("splitArgsPreservingQuotes", () => {
@@ -782,7 +797,7 @@ describe("buildSystemdUnit", () => {
       programArguments: ["/usr/bin/openclaw", "gateway", "start"],
     });
     expect(unit).not.toContain("Type=notify");
-    expect(unit).not.toContain("NotifyAccess=all");
+    expect(unit).not.toContain("NotifyAccess=main");
     expect(unit).not.toContain("WatchdogSec=90");
   });
 
@@ -794,12 +809,12 @@ describe("buildSystemdUnit", () => {
     expect(unit).toContain("Type=notify");
   });
 
-  it("includes NotifyAccess=all when watchdog is enabled", () => {
+  it("includes NotifyAccess=main when watchdog is enabled", () => {
     const unit = buildSystemdUnit({
       programArguments: ["/usr/bin/openclaw", "gateway", "start"],
       watchdog: true,
     });
-    expect(unit).toContain("NotifyAccess=all");
+    expect(unit).toContain("NotifyAccess=main");
   });
 
   it("includes WatchdogSec=90 when watchdog is enabled", () => {
@@ -818,7 +833,7 @@ describe("buildSystemdUnit", () => {
     const serviceStart = unit.indexOf("[Service]");
     const installStart = unit.indexOf("[Install]");
     const typePos = unit.indexOf("Type=notify");
-    const notifyAccessPos = unit.indexOf("NotifyAccess=all");
+    const notifyAccessPos = unit.indexOf("NotifyAccess=main");
     const watchdogPos = unit.indexOf("WatchdogSec=90");
     expect(typePos).toBeGreaterThan(serviceStart);
     expect(typePos).toBeLessThan(installStart);

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -61,7 +61,7 @@ export type { SystemdUserLingerStatus };
 export async function readSystemdServiceExecStart(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceCommandConfig | null> {
-  const unitPath = resolveSystemdUnitPath(env);
+  const unitPath = resolveSystemdUnitPathForName(env, serviceName);
   try {
     const content = await fs.readFile(unitPath, "utf8");
     let execStart = "";
@@ -455,10 +455,15 @@ export async function installSystemdService({
   workingDirectory,
   environment,
   description,
+  watchdog,
 }: GatewayServiceInstallArgs): Promise<{ unitPath: string }> {
   await assertSystemdAvailable(env);
 
-  const unitPath = resolveSystemdUnitPath(env);
+  // Derive the service name first so unitPath, enable, and restart all
+  // operate on the same resolved name (respects OPENCLAW_SYSTEMD_UNIT).
+  const serviceName = resolveSystemdServiceName(env);
+  const unitName = `${serviceName}.service`;
+  const unitPath = resolveSystemdUnitPathForName(env, serviceName);
   await fs.mkdir(path.dirname(unitPath), { recursive: true });
 
   // Preserve user customizations: back up existing unit file before overwriting.
@@ -478,11 +483,10 @@ export async function installSystemdService({
     programArguments,
     workingDirectory,
     environment,
+    watchdog,
   });
   await fs.writeFile(unitPath, unit, "utf8");
 
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
-  const unitName = `${serviceName}.service`;
   const reload = await execSystemctlUser(env, ["daemon-reload"]);
   if (reload.code !== 0) {
     throw new Error(`systemctl daemon-reload failed: ${reload.stderr || reload.stdout}`.trim());
@@ -496,6 +500,20 @@ export async function installSystemdService({
   const restart = await execSystemctlUser(env, ["restart", unitName]);
   if (restart.code !== 0) {
     throw new Error(`systemctl restart failed: ${restart.stderr || restart.stdout}`.trim());
+  }
+
+  // When OPENCLAW_SYSTEMD_UNIT overrides the name, disable the previous
+  // profile-based unit so two units don't compete for the same gateway.
+  const defaultName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  if (serviceName !== defaultName) {
+    const prevUnit = `${defaultName}.service`;
+    await execSystemctlUser(env, ["disable", "--now", prevUnit]);
+    const prevPath = resolveSystemdUnitPathForName(env, defaultName);
+    try {
+      await fs.unlink(prevPath);
+    } catch {
+      // Previous unit may not exist — that's fine.
+    }
   }
 
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
@@ -525,16 +543,31 @@ export async function uninstallSystemdService({
   stdout,
 }: GatewayServiceManageArgs): Promise<void> {
   await assertSystemdAvailable(env);
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
   await execSystemctlUser(env, ["disable", "--now", unitName]);
 
-  const unitPath = resolveSystemdUnitPath(env);
+  const unitPath = resolveSystemdUnitPathForName(env, serviceName);
   try {
     await fs.unlink(unitPath);
     stdout.write(`${formatLine("Removed systemd service", unitPath)}\n`);
   } catch {
     stdout.write(`Systemd service not found at ${unitPath}\n`);
+  }
+
+  // When OPENCLAW_SYSTEMD_UNIT overrides the name, also disable the previous
+  // profile-based unit so it doesn't remain enabled as a dangling service.
+  const defaultName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  if (serviceName !== defaultName) {
+    const prevUnit = `${defaultName}.service`;
+    await execSystemctlUser(env, ["disable", "--now", prevUnit]);
+    const prevPath = resolveSystemdUnitPathForName(env, defaultName);
+    try {
+      await fs.unlink(prevPath);
+      stdout.write(`${formatLine("Removed previous systemd service", prevPath)}\n`);
+    } catch {
+      // Previous unit may not exist — that's fine.
+    }
   }
 }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -32,17 +32,46 @@ import {
   parseSystemdExecStart,
 } from "./systemd-unit.js";
 
+const SYSTEMD_SERVICE_NAME_PATTERN = /^[A-Za-z0-9@:_.-]+$/;
+
+function normalizeSystemdServiceName(raw: string): string {
+  const trimmed = raw.trim();
+  return trimmed.endsWith(".service") ? trimmed.slice(0, -".service".length) : trimmed;
+}
+
+function assertValidSystemdServiceName(name: string): void {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error("Invalid systemd unit name: empty value.");
+  }
+  if (
+    trimmed.includes("/") ||
+    trimmed.includes("\\") ||
+    trimmed.includes("..") ||
+    !SYSTEMD_SERVICE_NAME_PATTERN.test(trimmed)
+  ) {
+    throw new Error(`Invalid systemd unit name: ${name}`);
+  }
+}
+
 function resolveSystemdUnitPathForName(env: GatewayServiceEnv, name: string): string {
+  assertValidSystemdServiceName(name);
   const home = toPosixPath(resolveHomeDir(env));
-  return path.posix.join(home, ".config", "systemd", "user", `${name}.service`);
+  const baseDir = path.posix.join(home, ".config", "systemd", "user");
+  const resolved = path.posix.resolve(baseDir, `${name}.service`);
+  if (!resolved.startsWith(`${baseDir}/`)) {
+    throw new Error("Resolved unit path escapes systemd user directory.");
+  }
+  return resolved;
 }
 
 function resolveSystemdServiceName(env: GatewayServiceEnv): string {
   const override = env.OPENCLAW_SYSTEMD_UNIT?.trim();
-  if (override) {
-    return override.endsWith(".service") ? override.slice(0, -".service".length) : override;
-  }
-  return resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const candidate = override
+    ? normalizeSystemdServiceName(override)
+    : resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  assertValidSystemdServiceName(candidate);
+  return candidate;
 }
 
 function resolveSystemdUnitPath(env: GatewayServiceEnv): string {
@@ -61,6 +90,7 @@ export type { SystemdUserLingerStatus };
 export async function readSystemdServiceExecStart(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceCommandConfig | null> {
+  const serviceName = resolveSystemdServiceName(env);
   const unitPath = resolveSystemdUnitPathForName(env, serviceName);
   try {
     const content = await fs.readFile(unitPath, "utf8");

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
+import { isSystemdNotifyAvailable } from "../infra/sd-notify.js";
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import {
   LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
@@ -489,6 +490,16 @@ export async function installSystemdService({
 }: GatewayServiceInstallArgs): Promise<{ unitPath: string }> {
   await assertSystemdAvailable(env);
 
+  // Gate watchdog on systemd-notify availability: if the binary is not at a
+  // trusted path (non-FHS layouts like NixOS), fall back to Type=simple so
+  // the service doesn't enter a restart loop waiting for READY=1.
+  const effectiveWatchdog = watchdog && isSystemdNotifyAvailable();
+  if (watchdog && !effectiveWatchdog) {
+    stdout.write(
+      "Warning: systemd-notify not found; installing without Type=notify/WatchdogSec.\n",
+    );
+  }
+
   // Derive the service name first so unitPath, enable, and restart all
   // operate on the same resolved name (respects OPENCLAW_SYSTEMD_UNIT).
   const serviceName = resolveSystemdServiceName(env);
@@ -513,7 +524,7 @@ export async function installSystemdService({
     programArguments,
     workingDirectory,
     environment,
-    watchdog,
+    watchdog: effectiveWatchdog,
   });
   await fs.writeFile(unitPath, unit, "utf8");
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -527,13 +527,9 @@ export async function installSystemdService({
     throw new Error(`systemctl enable failed: ${enable.stderr || enable.stdout}`.trim());
   }
 
-  const restart = await execSystemctlUser(env, ["restart", unitName]);
-  if (restart.code !== 0) {
-    throw new Error(`systemctl restart failed: ${restart.stderr || restart.stdout}`.trim());
-  }
-
-  // When OPENCLAW_SYSTEMD_UNIT overrides the name, disable the previous
-  // profile-based unit so two units don't compete for the same gateway.
+  // When OPENCLAW_SYSTEMD_UNIT overrides the name, stop the previous
+  // profile-based unit before restarting the new one so both don't
+  // compete for the same port/lock.
   const defaultName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
   if (serviceName !== defaultName) {
     const prevUnit = `${defaultName}.service`;
@@ -544,6 +540,11 @@ export async function installSystemdService({
     } catch {
       // Previous unit may not exist — that's fine.
     }
+  }
+
+  const restart = await execSystemctlUser(env, ["restart", unitName]);
+  if (restart.code !== 0) {
+    throw new Error(`systemctl restart failed: ${restart.stderr || restart.stdout}`.trim());
   }
 
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -31,6 +31,7 @@ export function createGatewayCloseHandler(params: {
   wss: WebSocketServer;
   httpServer: HttpServer;
   httpServers?: HttpServer[];
+  stopWatchdog?: (() => void) | undefined;
 }) {
   return async (opts?: { reason?: string; restartExpectedMs?: number | null }) => {
     const reasonRaw = typeof opts?.reason === "string" ? opts.reason.trim() : "";
@@ -91,6 +92,7 @@ export function createGatewayCloseHandler(params: {
     if (params.mediaCleanup) {
       clearInterval(params.mediaCleanup);
     }
+    params.stopWatchdog?.();
     if (params.agentUnsub) {
       try {
         params.agentUnsub();

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -36,6 +36,11 @@ import { getMachineDisplayName } from "../infra/machine-name.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
 import {
+  sdNotifyExtendTimeout,
+  sdNotifyReady,
+  startWatchdogHeartbeat,
+} from "../infra/sd-notify.js";
+import {
   primeRemoteSkillsCache,
   refreshRemoteBinsForConnectedNodes,
   setSkillsRemoteRegistry,
@@ -534,6 +539,9 @@ export async function startGatewayServer(
       cwd: process.cwd(),
     });
     if (!resolvedRoot) {
+      // Asset build can take several minutes on source installs; extend the
+      // systemd startup timeout so we aren't killed before READY=1 is sent.
+      sdNotifyExtendTimeout(600);
       const ensureResult = await ensureControlUiAssetsBuilt(gatewayRuntime);
       if (!ensureResult.ok && ensureResult.message) {
         log.warn(`gateway: ${ensureResult.message}`);
@@ -911,6 +919,13 @@ export async function startGatewayServer(
         logTailscale,
       });
 
+  // Signal readiness before sidecar startup — the HTTP/WS server is already
+  // listening and can accept connections.  Sidecars (plugins, browser control)
+  // may block for an extended period (e.g. Gmail watcher ≤120 s) which can
+  // exceed systemd's default TimeoutStartSec and cause restart loops.
+  sdNotifyReady();
+  const stopWatchdog = startWatchdogHeartbeat();
+
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
   if (!minimalTestGateway) {
     ({ browserControl, pluginServices } = await startGatewaySidecars({
@@ -1027,6 +1042,7 @@ export async function startGatewayServer(
     wss,
     httpServer,
     httpServers,
+    stopWatchdog,
   });
 
   return {

--- a/src/infra/sd-notify.test.ts
+++ b/src/infra/sd-notify.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+import {
+  _resetWatchdogWarned,
+  sdNotifyExtendTimeout,
+  sdNotifyReady,
+  sdNotifyWatchdog,
+  startWatchdogHeartbeat,
+} from "./sd-notify.js";
+
+describe("sdNotifyReady", () => {
+  const origNotifySocket = process.env.NOTIFY_SOCKET;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (origNotifySocket === undefined) {
+      delete process.env.NOTIFY_SOCKET;
+    } else {
+      process.env.NOTIFY_SOCKET = origNotifySocket;
+    }
+  });
+
+  it("is a no-op when NOTIFY_SOCKET is not set", () => {
+    delete process.env.NOTIFY_SOCKET;
+    sdNotifyReady();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("calls systemd-notify --ready when NOTIFY_SOCKET is set", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    sdNotifyReady();
+    expect(execFileMock).toHaveBeenCalledOnce();
+    expect(execFileMock).toHaveBeenCalledWith(
+      "systemd-notify",
+      ["--ready"],
+      { timeout: 5000 },
+      expect.any(Function),
+    );
+  });
+
+  it("warns on stderr when execFile fails", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null) => void) => {
+        cb(new Error("spawn ENOENT"));
+      },
+    );
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    sdNotifyReady();
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("failed to send READY=1"));
+    stderrSpy.mockRestore();
+  });
+});
+
+describe("sdNotifyExtendTimeout", () => {
+  const origNotifySocket = process.env.NOTIFY_SOCKET;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (origNotifySocket === undefined) {
+      delete process.env.NOTIFY_SOCKET;
+    } else {
+      process.env.NOTIFY_SOCKET = origNotifySocket;
+    }
+  });
+
+  it("is a no-op when NOTIFY_SOCKET is not set", () => {
+    delete process.env.NOTIFY_SOCKET;
+    sdNotifyExtendTimeout(300);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("sends EXTEND_TIMEOUT_USEC with correct microsecond value", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    sdNotifyExtendTimeout(600);
+    expect(execFileMock).toHaveBeenCalledOnce();
+    expect(execFileMock).toHaveBeenCalledWith(
+      "systemd-notify",
+      ["EXTEND_TIMEOUT_USEC=600000000"],
+      { timeout: 5000 },
+      expect.any(Function),
+    );
+  });
+
+  it("warns on stderr when execFile fails", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null) => void) => {
+        cb(new Error("spawn ENOENT"));
+      },
+    );
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    sdNotifyExtendTimeout(600);
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to extend startup timeout"),
+    );
+    stderrSpy.mockRestore();
+  });
+});
+
+describe("sdNotifyWatchdog", () => {
+  const origNotifySocket = process.env.NOTIFY_SOCKET;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    _resetWatchdogWarned();
+  });
+
+  afterEach(() => {
+    if (origNotifySocket === undefined) {
+      delete process.env.NOTIFY_SOCKET;
+    } else {
+      process.env.NOTIFY_SOCKET = origNotifySocket;
+    }
+  });
+
+  it("is a no-op when NOTIFY_SOCKET is not set", () => {
+    delete process.env.NOTIFY_SOCKET;
+    sdNotifyWatchdog();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("calls systemd-notify WATCHDOG=1 when NOTIFY_SOCKET is set", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    sdNotifyWatchdog();
+    expect(execFileMock).toHaveBeenCalledOnce();
+    expect(execFileMock).toHaveBeenCalledWith(
+      "systemd-notify",
+      ["WATCHDOG=1"],
+      { timeout: 5000 },
+      expect.any(Function),
+    );
+  });
+
+  it("warns on stderr on first error only", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null) => void) => {
+        cb(new Error("spawn ENOENT"));
+      },
+    );
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    sdNotifyWatchdog();
+    sdNotifyWatchdog();
+    sdNotifyWatchdog();
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("failed to send WATCHDOG=1"));
+    stderrSpy.mockRestore();
+  });
+
+  it("skips when a previous call is still in flight", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    // Hold the callback — simulate a slow execFile that hasn't completed yet
+    let pendingCb: ((err: Error | null) => void) | undefined;
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null) => void) => {
+        pendingCb = cb;
+      },
+    );
+
+    sdNotifyWatchdog(); // first call — in flight
+    expect(execFileMock).toHaveBeenCalledOnce();
+
+    sdNotifyWatchdog(); // second call — should be skipped (first still pending)
+    expect(execFileMock).toHaveBeenCalledOnce();
+
+    // Complete the first call
+    pendingCb!(null);
+
+    sdNotifyWatchdog(); // third call — should proceed (first completed)
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("startWatchdogHeartbeat", () => {
+  const origNotifySocket = process.env.NOTIFY_SOCKET;
+  const origWatchdogUsec = process.env.WATCHDOG_USEC;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    _resetWatchdogWarned();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (origNotifySocket === undefined) {
+      delete process.env.NOTIFY_SOCKET;
+    } else {
+      process.env.NOTIFY_SOCKET = origNotifySocket;
+    }
+    if (origWatchdogUsec === undefined) {
+      delete process.env.WATCHDOG_USEC;
+    } else {
+      process.env.WATCHDOG_USEC = origWatchdogUsec;
+    }
+  });
+
+  it("returns undefined when NOTIFY_SOCKET is not set", () => {
+    delete process.env.NOTIFY_SOCKET;
+    process.env.WATCHDOG_USEC = "90000000";
+    expect(startWatchdogHeartbeat()).toBeUndefined();
+  });
+
+  it("returns undefined when WATCHDOG_USEC is not set", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    delete process.env.WATCHDOG_USEC;
+    expect(startWatchdogHeartbeat()).toBeUndefined();
+  });
+
+  it("sends immediate heartbeat and starts interval at half WATCHDOG_USEC", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    process.env.WATCHDOG_USEC = "90000000"; // 90s
+    // Mock calls the callback immediately so the in-flight guard clears
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null) => void) => {
+        cb(null);
+      },
+    );
+    const cleanup = startWatchdogHeartbeat();
+    expect(cleanup).toBeTypeOf("function");
+
+    // Immediate heartbeat on start
+    expect(execFileMock).toHaveBeenCalledOnce();
+
+    // Advance to half of 90s = 45s
+    vi.advanceTimersByTime(45_000);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+
+    // Another 45s
+    vi.advanceTimersByTime(45_000);
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+
+    cleanup!();
+  });
+
+  it("cleanup stops the interval", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    process.env.WATCHDOG_USEC = "90000000";
+    // Mock calls the callback immediately so the in-flight guard clears
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null) => void) => {
+        cb(null);
+      },
+    );
+    const cleanup = startWatchdogHeartbeat();
+    expect(execFileMock).toHaveBeenCalledOnce();
+
+    cleanup!();
+    vi.advanceTimersByTime(90_000);
+    // No additional calls after cleanup
+    expect(execFileMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/infra/sd-notify.test.ts
+++ b/src/infra/sd-notify.test.ts
@@ -1,13 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
+const accessSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   execFile: execFileMock,
 }));
+vi.mock("node:fs", () => ({
+  default: {
+    accessSync: accessSyncMock,
+    constants: { X_OK: 1 },
+  },
+  accessSync: accessSyncMock,
+  constants: { X_OK: 1 },
+}));
 
 import {
   _resetWatchdogWarned,
+  _resetSystemdNotifyPathForTests,
   sdNotifyExtendTimeout,
   sdNotifyReady,
   sdNotifyWatchdog,
@@ -19,6 +29,14 @@ describe("sdNotifyReady", () => {
 
   beforeEach(() => {
     execFileMock.mockReset();
+    accessSyncMock.mockReset();
+    accessSyncMock.mockImplementation((candidate: string) => {
+      if (candidate === "/usr/bin/systemd-notify") {
+        return;
+      }
+      throw new Error("ENOENT");
+    });
+    _resetSystemdNotifyPathForTests();
   });
 
   afterEach(() => {
@@ -40,7 +58,7 @@ describe("sdNotifyReady", () => {
     sdNotifyReady();
     expect(execFileMock).toHaveBeenCalledOnce();
     expect(execFileMock).toHaveBeenCalledWith(
-      "systemd-notify",
+      "/usr/bin/systemd-notify",
       ["--ready"],
       { timeout: 5000 },
       expect.any(Function),
@@ -60,6 +78,22 @@ describe("sdNotifyReady", () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("failed to send READY=1"));
     stderrSpy.mockRestore();
   });
+
+  it("warns once and no-ops when systemd-notify binary is unavailable", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    accessSyncMock.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    sdNotifyReady();
+    sdNotifyReady();
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("could not find systemd-notify"),
+    );
+    stderrSpy.mockRestore();
+  });
 });
 
 describe("sdNotifyExtendTimeout", () => {
@@ -67,6 +101,14 @@ describe("sdNotifyExtendTimeout", () => {
 
   beforeEach(() => {
     execFileMock.mockReset();
+    accessSyncMock.mockReset();
+    accessSyncMock.mockImplementation((candidate: string) => {
+      if (candidate === "/usr/bin/systemd-notify") {
+        return;
+      }
+      throw new Error("ENOENT");
+    });
+    _resetSystemdNotifyPathForTests();
   });
 
   afterEach(() => {
@@ -88,7 +130,7 @@ describe("sdNotifyExtendTimeout", () => {
     sdNotifyExtendTimeout(600);
     expect(execFileMock).toHaveBeenCalledOnce();
     expect(execFileMock).toHaveBeenCalledWith(
-      "systemd-notify",
+      "/usr/bin/systemd-notify",
       ["EXTEND_TIMEOUT_USEC=600000000"],
       { timeout: 5000 },
       expect.any(Function),
@@ -117,6 +159,14 @@ describe("sdNotifyWatchdog", () => {
 
   beforeEach(() => {
     execFileMock.mockReset();
+    accessSyncMock.mockReset();
+    accessSyncMock.mockImplementation((candidate: string) => {
+      if (candidate === "/usr/bin/systemd-notify") {
+        return;
+      }
+      throw new Error("ENOENT");
+    });
+    _resetSystemdNotifyPathForTests();
     _resetWatchdogWarned();
   });
 
@@ -139,7 +189,7 @@ describe("sdNotifyWatchdog", () => {
     sdNotifyWatchdog();
     expect(execFileMock).toHaveBeenCalledOnce();
     expect(execFileMock).toHaveBeenCalledWith(
-      "systemd-notify",
+      "/usr/bin/systemd-notify",
       ["WATCHDOG=1"],
       { timeout: 5000 },
       expect.any(Function),
@@ -184,6 +234,25 @@ describe("sdNotifyWatchdog", () => {
     sdNotifyWatchdog(); // third call — should proceed (first completed)
     expect(execFileMock).toHaveBeenCalledTimes(2);
   });
+
+  it("does not get stuck in-flight when systemd-notify binary is missing", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    accessSyncMock.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    sdNotifyWatchdog(); // binary missing; should not leave in-flight stuck
+
+    accessSyncMock.mockImplementation((candidate: string) => {
+      if (candidate === "/usr/bin/systemd-notify") {
+        return;
+      }
+      throw new Error("ENOENT");
+    });
+    _resetSystemdNotifyPathForTests();
+    sdNotifyWatchdog();
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("startWatchdogHeartbeat", () => {
@@ -192,6 +261,14 @@ describe("startWatchdogHeartbeat", () => {
 
   beforeEach(() => {
     execFileMock.mockReset();
+    accessSyncMock.mockReset();
+    accessSyncMock.mockImplementation((candidate: string) => {
+      if (candidate === "/usr/bin/systemd-notify") {
+        return;
+      }
+      throw new Error("ENOENT");
+    });
+    _resetSystemdNotifyPathForTests();
     _resetWatchdogWarned();
     vi.useFakeTimers();
   });

--- a/src/infra/sd-notify.test.ts
+++ b/src/infra/sd-notify.test.ts
@@ -342,4 +342,25 @@ describe("startWatchdogHeartbeat", () => {
     // No additional calls after cleanup
     expect(execFileMock).toHaveBeenCalledOnce();
   });
+
+  it("resets watchdog warning state across heartbeat restarts", () => {
+    process.env.NOTIFY_SOCKET = "/run/user/1000/systemd/notify";
+    process.env.WATCHDOG_USEC = "90000000";
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null) => void) => {
+        cb(new Error("spawn failed"));
+      },
+    );
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const stop1 = startWatchdogHeartbeat();
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    stop1!();
+
+    const stop2 = startWatchdogHeartbeat();
+    expect(stderrSpy).toHaveBeenCalledTimes(2);
+    stop2!();
+
+    stderrSpy.mockRestore();
+  });
 });

--- a/src/infra/sd-notify.ts
+++ b/src/infra/sd-notify.ts
@@ -1,0 +1,112 @@
+import { execFile } from "node:child_process";
+
+function warnNotify(message: string, error: Error): void {
+  try {
+    process.stderr.write(`sd-notify: ${message}: ${error.message}\n`);
+  } catch {
+    // stderr may be closed (EPIPE) when the service runs with stdio detached.
+  }
+}
+
+/**
+ * Send sd_notify READY=1 to systemd, signalling the service is fully started.
+ * No-op when not running under a systemd Type=notify unit.
+ */
+export function sdNotifyReady(): void {
+  if (!process.env.NOTIFY_SOCKET) {
+    return;
+  }
+  execFile("systemd-notify", ["--ready"], { timeout: 5000 }, (error) => {
+    if (error) {
+      warnNotify(
+        "failed to send READY=1 — systemd will kill this unit after TimeoutStartSec",
+        error,
+      );
+    }
+  });
+}
+
+/**
+ * Reset systemd's remaining startup timeout to the given number of seconds
+ * from now (EXTEND_TIMEOUT_USEC). This is not additive — it replaces the
+ * current remaining deadline. Useful before long-running initialization
+ * steps (e.g. asset builds) that may exceed the default TimeoutStartSec
+ * before READY=1 is sent.
+ * No-op when not running under a systemd Type=notify unit.
+ */
+export function sdNotifyExtendTimeout(seconds: number): void {
+  if (!process.env.NOTIFY_SOCKET) {
+    return;
+  }
+  const usec = Math.max(0, Math.round(seconds * 1_000_000));
+  execFile("systemd-notify", [`EXTEND_TIMEOUT_USEC=${usec}`], { timeout: 5000 }, (error) => {
+    if (error) {
+      warnNotify("failed to extend startup timeout", error);
+    }
+  });
+}
+
+let watchdogWarnedOnce = false;
+let watchdogInFlight = false;
+
+/** Reset watchdog warning state. Exported for testing only. */
+export function _resetWatchdogWarned(): void {
+  watchdogWarnedOnce = false;
+  watchdogInFlight = false;
+}
+
+/**
+ * Send sd_notify WATCHDOG=1 heartbeat to systemd.
+ * No-op when not running under a systemd WatchdogSec unit.
+ * Skips if a previous heartbeat call is still in flight to prevent
+ * overlapping `execFile()` calls from piling up under resource pressure.
+ */
+export function sdNotifyWatchdog(): void {
+  if (!process.env.NOTIFY_SOCKET) {
+    return;
+  }
+  if (watchdogInFlight) {
+    return;
+  }
+  watchdogInFlight = true;
+  execFile("systemd-notify", ["WATCHDOG=1"], { timeout: 5000 }, (error) => {
+    watchdogInFlight = false;
+    if (error && !watchdogWarnedOnce) {
+      watchdogWarnedOnce = true;
+      warnNotify(
+        "failed to send WATCHDOG=1 — systemd will restart this unit after WatchdogSec",
+        error,
+      );
+    }
+  });
+}
+
+/**
+ * Start the watchdog heartbeat loop, deriving the interval from systemd's
+ * WATCHDOG_USEC env var (standard sd_watchdog_enabled(3) pattern).
+ * Sends WATCHDOG=1 at half the configured WatchdogSec so the cadence
+ * automatically tracks the unit file without hardcoded coupling.
+ * No-op when WATCHDOG_USEC or NOTIFY_SOCKET is unset.
+ * Returns a cleanup function to stop the timer.
+ */
+export function startWatchdogHeartbeat(): (() => void) | undefined {
+  if (!process.env.NOTIFY_SOCKET) {
+    return undefined;
+  }
+  const usecRaw = process.env.WATCHDOG_USEC;
+  if (!usecRaw) {
+    return undefined;
+  }
+  const usec = Number.parseInt(usecRaw, 10);
+  if (!Number.isFinite(usec) || usec <= 0) {
+    return undefined;
+  }
+  const intervalMs = Math.floor(usec / 1000 / 2);
+  if (intervalMs <= 0) {
+    return undefined;
+  }
+  const timer = setInterval(() => sdNotifyWatchdog(), intervalMs);
+  timer.unref();
+  sdNotifyWatchdog();
+  return () => clearInterval(timer);
+}

--- a/src/infra/sd-notify.ts
+++ b/src/infra/sd-notify.ts
@@ -139,6 +139,10 @@ export function startWatchdogHeartbeat(): (() => void) | undefined {
   if (!process.env.NOTIFY_SOCKET) {
     return undefined;
   }
+  // New heartbeat lifecycle: clear prior warning state so a previous run's
+  // failure does not suppress warnings after an in-process restart.
+  watchdogWarnedOnce = false;
+  watchdogInFlight = false;
   const usecRaw = process.env.WATCHDOG_USEC;
   if (!usecRaw) {
     return undefined;
@@ -154,7 +158,11 @@ export function startWatchdogHeartbeat(): (() => void) | undefined {
   const timer = setInterval(() => sdNotifyWatchdog(), intervalMs);
   timer.unref();
   sdNotifyWatchdog();
-  return () => clearInterval(timer);
+  return () => {
+    clearInterval(timer);
+    watchdogInFlight = false;
+    watchdogWarnedOnce = false;
+  };
 }
 
 /** @internal Reset notify command resolution cache. Exported for testing only. */

--- a/src/infra/sd-notify.ts
+++ b/src/infra/sd-notify.ts
@@ -1,4 +1,9 @@
 import { execFile } from "node:child_process";
+import fs from "node:fs";
+
+const SYSTEMD_NOTIFY_CANDIDATES = ["/usr/bin/systemd-notify", "/bin/systemd-notify"];
+let resolvedSystemdNotifyPath: string | null | undefined;
+let warnedSystemdNotifyMissing = false;
 
 function warnNotify(message: string, error: Error): void {
   try {
@@ -6,6 +11,44 @@ function warnNotify(message: string, error: Error): void {
   } catch {
     // stderr may be closed (EPIPE) when the service runs with stdio detached.
   }
+}
+
+function resolveSystemdNotifyPath(): string | undefined {
+  if (resolvedSystemdNotifyPath !== undefined) {
+    return resolvedSystemdNotifyPath ?? undefined;
+  }
+  for (const candidate of SYSTEMD_NOTIFY_CANDIDATES) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      resolvedSystemdNotifyPath = candidate;
+      return candidate;
+    } catch {
+      // Try next candidate.
+    }
+  }
+  resolvedSystemdNotifyPath = null;
+  if (!warnedSystemdNotifyMissing) {
+    warnedSystemdNotifyMissing = true;
+    try {
+      process.stderr.write(
+        `sd-notify: could not find systemd-notify in ${SYSTEMD_NOTIFY_CANDIDATES.join(", ")}\n`,
+      );
+    } catch {
+      // stderr may be closed (EPIPE) when the service runs with stdio detached.
+    }
+  }
+  return undefined;
+}
+
+function execSystemdNotify(args: string[], onDone: (error: Error | null) => void): boolean {
+  const binary = resolveSystemdNotifyPath();
+  if (!binary) {
+    return false;
+  }
+  execFile(binary, args, { timeout: 5000 }, (error) => {
+    onDone(error ?? null);
+  });
+  return true;
 }
 
 /**
@@ -16,13 +59,11 @@ export function sdNotifyReady(): void {
   if (!process.env.NOTIFY_SOCKET) {
     return;
   }
-  execFile("systemd-notify", ["--ready"], { timeout: 5000 }, (error) => {
-    if (error) {
-      warnNotify(
-        "failed to send READY=1 — systemd will kill this unit after TimeoutStartSec",
-        error,
-      );
+  execSystemdNotify(["--ready"], (error) => {
+    if (!error) {
+      return;
     }
+    warnNotify("failed to send READY=1 — systemd will kill this unit after TimeoutStartSec", error);
   });
 }
 
@@ -39,10 +80,11 @@ export function sdNotifyExtendTimeout(seconds: number): void {
     return;
   }
   const usec = Math.max(0, Math.round(seconds * 1_000_000));
-  execFile("systemd-notify", [`EXTEND_TIMEOUT_USEC=${usec}`], { timeout: 5000 }, (error) => {
-    if (error) {
-      warnNotify("failed to extend startup timeout", error);
+  execSystemdNotify([`EXTEND_TIMEOUT_USEC=${usec}`], (error) => {
+    if (!error) {
+      return;
     }
+    warnNotify("failed to extend startup timeout", error);
   });
 }
 
@@ -69,16 +111,20 @@ export function sdNotifyWatchdog(): void {
     return;
   }
   watchdogInFlight = true;
-  execFile("systemd-notify", ["WATCHDOG=1"], { timeout: 5000 }, (error) => {
+  if (
+    !execSystemdNotify(["WATCHDOG=1"], (error) => {
+      watchdogInFlight = false;
+      if (error && !watchdogWarnedOnce) {
+        watchdogWarnedOnce = true;
+        warnNotify(
+          "failed to send WATCHDOG=1 — systemd will restart this unit after WatchdogSec",
+          error,
+        );
+      }
+    })
+  ) {
     watchdogInFlight = false;
-    if (error && !watchdogWarnedOnce) {
-      watchdogWarnedOnce = true;
-      warnNotify(
-        "failed to send WATCHDOG=1 — systemd will restart this unit after WatchdogSec",
-        error,
-      );
-    }
-  });
+  }
 }
 
 /**
@@ -109,4 +155,10 @@ export function startWatchdogHeartbeat(): (() => void) | undefined {
   timer.unref();
   sdNotifyWatchdog();
   return () => clearInterval(timer);
+}
+
+/** @internal Reset notify command resolution cache. Exported for testing only. */
+export function _resetSystemdNotifyPathForTests(): void {
+  resolvedSystemdNotifyPath = undefined;
+  warnedSystemdNotifyMissing = false;
 }

--- a/src/infra/sd-notify.ts
+++ b/src/infra/sd-notify.ts
@@ -165,6 +165,14 @@ export function startWatchdogHeartbeat(): (() => void) | undefined {
   };
 }
 
+/**
+ * Check whether the systemd-notify binary is available at a trusted path.
+ * Used at install time to decide whether to emit Type=notify/WatchdogSec.
+ */
+export function isSystemdNotifyAvailable(): boolean {
+  return resolveSystemdNotifyPath() !== undefined;
+}
+
 /** @internal Reset notify command resolution cache. Exported for testing only. */
 export function _resetSystemdNotifyPathForTests(): void {
   resolvedSystemdNotifyPath = undefined;

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -197,6 +197,7 @@ export async function finalizeOnboardingWizard(
             programArguments,
             workingDirectory,
             environment,
+            watchdog: true,
           });
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

- Add `sd-notify` wrapper (`src/infra/sd-notify.ts`) that sends `READY=1` on startup and `WATCHDOG=1` heartbeats every 30s via the existing tick interval
- Update the generated systemd unit with `Type=notify`, `NotifyAccess=main`, and `WatchdogSec=90` so systemd automatically kills and restarts the gateway if the event loop freezes
- All calls are no-ops when `$NOTIFY_SOCKET` is unset (macOS, manual dev, tests)

Fixes #11973
Discussion: https://github.com/openclaw/openclaw/discussions/12026

## Review fixes

Addressed functional regressions flagged during code review:

- **[P1] Chat routing**: Restored canonical session key destructuring from `loadSessionEntry()` so `resolveSessionAgentId` and `resolveSendPolicy` use the resolved key instead of raw aliases (`chat.ts`)
- **[P1] iOS disconnect recovery**: Restored `handleChannelDisconnected` to call `resetConnectionState()` before `onDisconnected`, so `notifyConnectedIfNeeded()` re-fires after reconnect (`GatewayNodeSession.swift`)
- **[P2] UI state clobbering**: Added connected short-circuit in the reconnection loop so a healthy connection isn't repeatedly shown as "Connecting…" (`NodeAppModel.swift`)
- **[P2] Challenge timeout**: Restored `connectChallengeTimeoutSeconds` from 0.75s to 3.0s to avoid nonce handshake failures on remote/Tailscale links (`GatewayChannel.swift`)

## Test plan

- [x] `sdNotifyReady()` is a no-op when `NOTIFY_SOCKET` is not set
- [x] `sdNotifyReady()` calls `systemd-notify --ready` when `NOTIFY_SOCKET` is set
- [x] `sdNotifyWatchdog()` is a no-op when `NOTIFY_SOCKET` is not set
- [x] `sdNotifyWatchdog()` calls `systemd-notify WATCHDOG=1` when `NOTIFY_SOCKET` is set
- [x] Generated systemd unit includes `Type=notify`
- [x] Generated systemd unit includes `NotifyAccess=main`
- [x] Generated systemd unit includes `WatchdogSec=90`
- [x] All directives placed in `[Service]` section
- [x] All 8 new tests fail before implementation, pass after
- [x] `pnpm build` compiles cleanly
- [x] `pnpm check` passes (types, lint, format)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `sd-notify` wrapper (`src/infra/sd-notify.ts`) and integrates it into the gateway startup/shutdown path to support `Type=notify` readiness notifications and periodic `WATCHDOG=1` heartbeats. It also threads an opt-in `watchdog` flag through gateway systemd installation/update flows so generated user units include `Type=notify`, `NotifyAccess=main`, and `WatchdogSec=90`, and adjusts systemd unit naming resolution to respect `OPENCLAW_SYSTEMD_UNIT` consistently during install/uninstall.

<h3>Confidence Score: 5/5</h3>

- This PR looks safe to merge with minimal risk.
- Reviewed the diffs around systemd unit generation, unit name resolution, and gateway startup/shutdown integration. The sd-notify helper is gated on NOTIFY_SOCKET/WATCHDOG_USEC, watchdog calls are cleaned up on shutdown, and install/uninstall now consistently respect OPENCLAW_SYSTEMD_UNIT to avoid competing units. No definite functional regressions were found in the changed code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
