### PR TITLE
fix: Change rootDir to project root to allow UI compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmitOnError": true,
     "outDir": "dist",
     "resolveJsonModule": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "skipLibCheck": true,
     "strict": true,
     "target": "es2023",


### PR DESCRIPTION
The rootDir: "src" setting conflicts with include: ["src/**/*", "ui/**/*"], preventing TypeScript from compiling files in the ui/ directory. Changed to "." to encompass both directories while maintaining output structure.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the root TypeScript configuration (`tsconfig.json`) to set `compilerOptions.rootDir` to the repository root (`"."`) instead of `"src"`. With the current `include: ["src/**/*", "ui/**/*"]`, this avoids TypeScript treating `ui/` files as being outside `rootDir`, which can block compilation/typechecking for the UI directory.

No additional code or build logic is modified; this is a configuration-only change affecting how TS computes the common source root for included files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line tsconfig change that aligns `rootDir` with the existing `include` patterns and is unlikely to affect outputs since the base config has `noEmit: true`. Related extending configs either inherit safely or override `rootDir` explicitly.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->