### PR TITLE
Docs: seed ja-JP docs translations (POC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: add node command allowlists (default-deny unknown node commands; configurable via `gateway.nodes.allowCommands` / `gateway.nodes.denyCommands`). (#11755) Thanks @mbelinky.
 - Plugins: add `device-pair` (Telegram `/pair` flow) and `phone-control` (iOS/Android node controls). (#11755) Thanks @mbelinky.
 - iOS: add alpha iOS node app (Telegram setup-code pairing + Talk/Chat surfaces). (#11756) Thanks @mbelinky.
+- Docs: seed initial ja-JP translations (POC) and make docs-i18n prompts language-pluggable for Japanese. (#11988) Thanks @joshp123.
 
 ### Fixes
 

--- a/docs/.i18n/glossary.ja-JP.json
+++ b/docs/.i18n/glossary.ja-JP.json
@@ -1,0 +1,14 @@
+[
+  { "source": "OpenClaw", "target": "OpenClaw" },
+  { "source": "Gateway", "target": "Gateway" },
+  { "source": "Pi", "target": "Pi" },
+  { "source": "Skills", "target": "Skills" },
+  { "source": "local loopback", "target": "local loopback" },
+  { "source": "Tailscale", "target": "Tailscale" },
+  { "source": "Getting Started", "target": "はじめに" },
+  { "source": "Getting started", "target": "はじめに" },
+  { "source": "Quick start", "target": "クイックスタート" },
+  { "source": "Quick Start", "target": "クイックスタート" },
+  { "source": "Onboarding", "target": "オンボーディング" },
+  { "source": "wizard", "target": "ウィザード" }
+]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1274,6 +1274,24 @@
         ]
       },
       {
+        "language": "ja",
+        "tabs": [
+          {
+            "tab": "はじめに",
+            "groups": [
+              {
+                "group": "概要",
+                "pages": ["ja-JP/index"]
+              },
+              {
+                "group": "初回セットアップ",
+                "pages": ["ja-JP/start/getting-started", "ja-JP/start/wizard"]
+              }
+            ]
+          }
+        ]
+      },
+      {
         "language": "zh-Hans",
         "tabs": [
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1274,7 +1274,7 @@
         ]
       },
       {
-        "language": "ja",
+        "language": "ja-jp",
         "tabs": [
           {
             "tab": "はじめに",

--- a/docs/ja-JP/AGENTS.md
+++ b/docs/ja-JP/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md - ja-JP docs translation workspace
+
+## Read When
+
+- Maintaining `docs/ja-JP/**`
+- Updating the Japanese translation pipeline (glossary/TM/prompt)
+- Handling Japanese translation feedback or regressions
+
+## Pipeline (docs-i18n)
+
+- Source docs: `docs/**/*.md`
+- Target docs: `docs/ja-JP/**/*.md`
+- Glossary: `docs/.i18n/glossary.ja-JP.json`
+- Translation memory: `docs/.i18n/ja-JP.tm.jsonl`
+- Prompt rules: `scripts/docs-i18n/prompt.go`
+
+Common runs:
+
+```bash
+# Bulk (doc mode; parallel OK)
+cd scripts/docs-i18n
+go run . -docs ../../docs -lang ja-JP -mode doc -parallel 6 ../../docs/**/*.md
+
+# Single file
+cd scripts/docs-i18n
+go run . -docs ../../docs -lang ja-JP -mode doc ../../docs/start/getting-started.md
+
+# Small patches (segment mode; uses TM; no parallel)
+cd scripts/docs-i18n
+go run . -docs ../../docs -lang ja-JP -mode segment ../../docs/start/getting-started.md
+```
+
+Notes:
+
+- Prefer `doc` mode for whole-page translation; `segment` mode for small fixes.
+- If a very large file times out, do targeted edits or split the page before rerunning.
+- After translation, spot-check: code spans/blocks unchanged, links/anchors unchanged, placeholders preserved.

--- a/docs/ja-JP/index.md
+++ b/docs/ja-JP/index.md
@@ -1,0 +1,186 @@
+---
+read_when:
+  - 新規ユーザーにOpenClawを紹介するとき
+summary: OpenClawは、あらゆるOSで動作するAIエージェント向けのマルチチャネルgatewayです。
+title: OpenClaw
+x-i18n:
+  generated_at: "2026-02-08T17:15:47Z"
+  model: claude-opus-4-5
+  provider: pi
+  source_hash: fc8babf7885ef91d526795051376d928599c4cf8aff75400138a0d7d9fa3b75f
+  source_path: index.md
+  workflow: 15
+---
+
+# OpenClaw 🦞
+
+<p align="center">
+    <img
+        src="/assets/openclaw-logo-text-dark.png"
+        alt="OpenClaw"
+        width="500"
+        class="dark:hidden"
+    />
+    <img
+        src="/assets/openclaw-logo-text.png"
+        alt="OpenClaw"
+        width="500"
+        class="hidden dark:block"
+    />
+</p>
+
+> _「EXFOLIATE! EXFOLIATE!」_ — たぶん宇宙ロブスター
+
+<p align="center">
+  <strong>WhatsApp、Telegram、Discord、iMessageなどに対応した、あらゆるOS向けのAIエージェントgateway。</strong><br />
+  メッセージを送信すれば、ポケットからエージェントの応答を受け取れます。プラグインでMattermostなどを追加できます。
+</p>
+
+<Columns>
+  <Card title="はじめに" href="/start/getting-started" icon="rocket">
+    OpenClawをインストールし、数分でGatewayを起動できます。
+  </Card>
+  <Card title="ウィザードを実行" href="/start/wizard" icon="sparkles">
+    `openclaw onboard`とペアリングフローによるガイド付きセットアップ。
+  </Card>
+  <Card title="Control UIを開く" href="/web/control-ui" icon="layout-dashboard">
+    チャット、設定、セッション用のブラウザダッシュボードを起動します。
+  </Card>
+</Columns>
+
+OpenClawは、単一のGatewayプロセスを通じてチャットアプリをPiのようなコーディングエージェントに接続します。OpenClawアシスタントを駆動し、ローカルまたはリモートのセットアップをサポートします。
+
+## 仕組み
+
+```mermaid
+flowchart LR
+  A["チャットアプリ + プラグイン"] --> B["Gateway"]
+  B --> C["Piエージェント"]
+  B --> D["CLI"]
+  B --> E["Web Control UI"]
+  B --> F["macOSアプリ"]
+  B --> G["iOSおよびAndroidノード"]
+```
+
+Gatewayは、セッション、ルーティング、チャネル接続の信頼できる唯一の情報源です。
+
+## 主な機能
+
+<Columns>
+  <Card title="マルチチャネルgateway" icon="network">
+    単一のGatewayプロセスでWhatsApp、Telegram、Discord、iMessageに対応。
+  </Card>
+  <Card title="プラグインチャネル" icon="plug">
+    拡張パッケージでMattermostなどを追加。
+  </Card>
+  <Card title="マルチエージェントルーティング" icon="route">
+    エージェント、ワークスペース、送信者ごとに分離されたセッション。
+  </Card>
+  <Card title="メディアサポート" icon="image">
+    画像、音声、ドキュメントの送受信。
+  </Card>
+  <Card title="Web Control UI" icon="monitor">
+    チャット、設定、セッション、ノード用のブラウザダッシュボード。
+  </Card>
+  <Card title="モバイルノード" icon="smartphone">
+    Canvas対応のiOSおよびAndroidノードをペアリング。
+  </Card>
+</Columns>
+
+## クイックスタート
+
+<Steps>
+  <Step title="OpenClawをインストール">
+    ```bash
+    npm install -g openclaw@latest
+    ```
+  </Step>
+  <Step title="オンボーディングとサービスのインストール">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+  </Step>
+  <Step title="WhatsAppをペアリングしてGatewayを起動">
+    ```bash
+    openclaw channels login
+    openclaw gateway --port 18789
+    ```
+  </Step>
+</Steps>
+
+完全なインストールと開発セットアップが必要ですか？[クイックスタート](/start/quickstart)をご覧ください。
+
+## ダッシュボード
+
+Gatewayの起動後、ブラウザでControl UIを開きます。
+
+- ローカルデフォルト: http://127.0.0.1:18789/
+- リモートアクセス: [Webサーフェス](/web)および[Tailscale](/gateway/tailscale)
+
+<p align="center">
+  <img src="whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
+</p>
+
+## 設定（オプション）
+
+設定は`~/.openclaw/openclaw.json`にあります。
+
+- **何もしなければ**、OpenClawはバンドルされたPiバイナリをRPCモードで使用し、送信者ごとのセッションを作成します。
+- 制限を設けたい場合は、`channels.whatsapp.allowFrom`と（グループの場合）メンションルールから始めてください。
+
+例：
+
+```json5
+{
+  channels: {
+    whatsapp: {
+      allowFrom: ["+15555550123"],
+      groups: { "*": { requireMention: true } },
+    },
+  },
+  messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+}
+```
+
+## ここから始める
+
+<Columns>
+  <Card title="ドキュメントハブ" href="/start/hubs" icon="book-open">
+    ユースケース別に整理されたすべてのドキュメントとガイド。
+  </Card>
+  <Card title="設定" href="/gateway/configuration" icon="settings">
+    Gatewayのコア設定、トークン、プロバイダー設定。
+  </Card>
+  <Card title="リモートアクセス" href="/gateway/remote" icon="globe">
+    SSHおよびtailnetアクセスパターン。
+  </Card>
+  <Card title="チャネル" href="/channels/telegram" icon="message-square">
+    WhatsApp、Telegram、Discordなどのチャネル固有のセットアップ。
+  </Card>
+  <Card title="ノード" href="/nodes" icon="smartphone">
+    ペアリングとCanvas対応のiOSおよびAndroidノード。
+  </Card>
+  <Card title="ヘルプ" href="/help" icon="life-buoy">
+    一般的な修正とトラブルシューティングのエントリーポイント。
+  </Card>
+</Columns>
+
+## 詳細
+
+<Columns>
+  <Card title="全機能リスト" href="/concepts/features" icon="list">
+    チャネル、ルーティング、メディア機能の完全な一覧。
+  </Card>
+  <Card title="マルチエージェントルーティング" href="/concepts/multi-agent" icon="route">
+    ワークスペースの分離とエージェントごとのセッション。
+  </Card>
+  <Card title="セキュリティ" href="/gateway/security" icon="shield">
+    トークン、許可リスト、安全制御。
+  </Card>
+  <Card title="トラブルシューティング" href="/gateway/troubleshooting" icon="wrench">
+    Gatewayの診断と一般的なエラー。
+  </Card>
+  <Card title="概要とクレジット" href="/reference/credits" icon="info">
+    プロジェクトの起源、貢献者、ライセンス。
+  </Card>
+</Columns>

--- a/docs/ja-JP/start/getting-started.md
+++ b/docs/ja-JP/start/getting-started.md
@@ -1,0 +1,125 @@
+---
+read_when:
+  - ゼロからの初回セットアップ
+  - 動作するチャットへの最短ルートを知りたい
+summary: OpenClawをインストールし、数分で最初のチャットを実行しましょう。
+title: はじめに
+x-i18n:
+  generated_at: "2026-02-08T17:15:16Z"
+  model: claude-opus-4-5
+  provider: pi
+  source_hash: 27aeeb3d18c495380e94e6b011b0df3def518535c9f1eee504f04871d8a32269
+  source_path: start/getting-started.md
+  workflow: 15
+---
+
+# はじめに
+
+目標：ゼロから最小限のセットアップで最初の動作するチャットを実現する。
+
+<Info>
+最速のチャット方法：Control UIを開く（チャンネル設定は不要）。`openclaw dashboard`を実行してブラウザでチャットするか、<Tooltip headline="Gatewayホスト" tip="OpenClaw Gatewayサービスを実行しているマシン。">Gatewayホスト</Tooltip>で`http://127.0.0.1:18789/`を開きます。
+ドキュメント：[Dashboard](/web/dashboard)と[Control UI](/web/control-ui)。
+</Info>
+
+## 前提条件
+
+- Node 22以降
+
+<Tip>
+不明な場合は`node --version`でNodeのバージョンを確認してください。
+</Tip>
+
+## クイックセットアップ（CLI）
+
+<Steps>
+  <Step title="OpenClawをインストール（推奨）">
+    <Tabs>
+      <Tab title="macOS/Linux">
+        ```bash
+        curl -fsSL https://openclaw.ai/install.sh | bash
+        ```
+      </Tab>
+      <Tab title="Windows (PowerShell)">
+        ```powershell
+        iwr -useb https://openclaw.ai/install.ps1 | iex
+        ```
+      </Tab>
+    </Tabs>
+
+    <Note>
+    その他のインストール方法と要件：[インストール](/install)。
+    </Note>
+
+  </Step>
+  <Step title="オンボーディングウィザードを実行">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+
+    ウィザードは認証、Gateway設定、およびオプションのチャンネルを構成します。
+    詳細は[オンボーディングウィザード](/start/wizard)を参照してください。
+
+  </Step>
+  <Step title="Gatewayを確認">
+    サービスをインストールした場合、すでに実行されているはずです：
+
+    ```bash
+    openclaw gateway status
+    ```
+
+  </Step>
+  <Step title="Control UIを開く">
+    ```bash
+    openclaw dashboard
+    ```
+  </Step>
+</Steps>
+
+<Check>
+Control UIが読み込まれれば、Gatewayは使用可能な状態です。
+</Check>
+
+## オプションの確認と追加機能
+
+<AccordionGroup>
+  <Accordion title="Gatewayをフォアグラウンドで実行">
+    クイックテストやトラブルシューティングに便利です。
+
+    ```bash
+    openclaw gateway --port 18789
+    ```
+
+  </Accordion>
+  <Accordion title="テストメッセージを送信">
+    構成済みのチャンネルが必要です。
+
+    ```bash
+    openclaw message send --target +15555550123 --message "Hello from OpenClaw"
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
+## さらに詳しく
+
+<Columns>
+  <Card title="オンボーディングウィザード（詳細）" href="/start/wizard">
+    完全なCLIウィザードリファレンスと高度なオプション。
+  </Card>
+  <Card title="macOSアプリのオンボーディング" href="/start/onboarding">
+    macOSアプリの初回実行フロー。
+  </Card>
+</Columns>
+
+## 完了後の状態
+
+- 実行中のGateway
+- 構成済みの認証
+- Control UIアクセスまたは接続済みのチャンネル
+
+## 次のステップ
+
+- DMの安全性と承認：[ペアリング](/start/pairing)
+- さらにチャンネルを接続：[チャンネル](/channels)
+- 高度なワークフローとソースからのビルド：[セットアップ](/start/setup)

--- a/docs/ja-JP/start/wizard.md
+++ b/docs/ja-JP/start/wizard.md
@@ -1,0 +1,77 @@
+---
+read_when:
+  - オンボーディングウィザードの実行または設定時
+  - 新しいマシンのセットアップ時
+sidebarTitle: Wizard (CLI)
+summary: CLIオンボーディングウィザード：Gateway、ワークスペース、チャンネル、Skillsの対話式セットアップ
+title: オンボーディングウィザード（CLI）
+x-i18n:
+  generated_at: "2026-02-08T17:15:18Z"
+  model: claude-opus-4-5
+  provider: pi
+  source_hash: 9a650d46044a930aa4aaec30b35f1273ca3969bf676ab67bf4e1575b5c46db4c
+  source_path: start/wizard.md
+  workflow: 15
+---
+
+# オンボーディングウィザード（CLI）
+
+CLIオンボーディングウィザードは、macOS、Linux、Windows（WSL2経由）でOpenClawをセットアップする際の推奨パスです。ローカルGatewayまたはリモートGateway接続に加えて、ワークスペースのデフォルト設定、チャンネル、Skillsを構成します。
+
+```bash
+openclaw onboard
+```
+
+<Info>
+最速で初回チャットを開始する方法：Control UI を開きます（チャンネル設定は不要）。`openclaw dashboard` を実行してブラウザでチャットできます。ドキュメント：[Dashboard](/web/dashboard)。
+</Info>
+
+## クイックスタート vs 詳細設定
+
+ウィザードは**クイックスタート**（デフォルト設定）と**詳細設定**（完全な制御）のどちらかを選択して開始します。
+
+<Tabs>
+  <Tab title="クイックスタート（デフォルト設定）">
+    - loopback上のローカルGateway
+    - 既存のワークスペースまたはデフォルトワークスペース
+    - Gatewayポート `18789`
+    - Gateway認証トークンは自動生成（loopback上でも生成されます）
+    - Tailscale公開はオフ
+    - TelegramとWhatsAppのDMはデフォルトで許可リスト（電話番号の入力を求められる場合があります）
+  </Tab>
+  <Tab title="詳細設定（完全な制御）">
+    - モード、ワークスペース、Gateway、チャンネル、デーモン、Skillsの完全なプロンプトフローを表示
+  </Tab>
+</Tabs>
+
+## CLIオンボーディングの詳細
+
+<Columns>
+  <Card title="CLIリファレンス" href="/start/wizard-cli-reference">
+    ローカルおよびリモートフローの完全な説明、認証とモデルマトリックス、設定出力、ウィザードRPC、signal-cliの動作。
+  </Card>
+  <Card title="自動化とスクリプト" href="/start/wizard-cli-automation">
+    非対話式オンボーディングのレシピと自動化された `agents add` の例。
+  </Card>
+</Columns>
+
+## よく使うフォローアップコマンド
+
+```bash
+openclaw configure
+openclaw agents add <name>
+```
+
+<Note>
+`--json` は非対話モードを意味しません。スクリプトでは `--non-interactive` を使用してください。
+</Note>
+
+<Tip>
+推奨：エージェントが `web_search` を使用できるように、Brave Search APIキーを設定してください（`web_fetch` はキーなしで動作します）。最も簡単な方法：`openclaw configure --section web` を実行すると `tools.web.search.apiKey` が保存されます。ドキュメント：[Webツール](/tools/web)。
+</Tip>
+
+## 関連ドキュメント
+
+- CLIコマンドリファレンス：[`openclaw onboard`](/cli/onboard)
+- macOSアプリのオンボーディング：[オンボーディング](/start/onboarding)
+- エージェント初回起動の手順：[エージェントブートストラップ](/start/bootstrapping)

--- a/scripts/docs-i18n/prompt.go
+++ b/scripts/docs-i18n/prompt.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func prettyLanguageLabel(lang string) string {
+	trimmed := strings.TrimSpace(lang)
+	if trimmed == "" {
+		return lang
+	}
+	switch {
+	case strings.EqualFold(trimmed, "en"):
+		return "English"
+	case strings.EqualFold(trimmed, "zh-CN"):
+		return "Simplified Chinese"
+	case strings.EqualFold(trimmed, "ja-JP"):
+		return "Japanese"
+	default:
+		return trimmed
+	}
+}
+
+func translationPrompt(srcLang, tgtLang string, glossary []GlossaryEntry) string {
+	srcLabel := prettyLanguageLabel(srcLang)
+	tgtLabel := prettyLanguageLabel(tgtLang)
+	glossaryBlock := buildGlossaryPrompt(glossary)
+
+	switch {
+	case strings.EqualFold(tgtLang, "zh-CN"):
+		// Keep this prompt as stable as possible; it has lots of tuning baked into the wording.
+		return strings.TrimSpace(fmt.Sprintf(zhCNPromptTemplate, srcLabel, tgtLabel, glossaryBlock))
+	case strings.EqualFold(tgtLang, "ja-JP"):
+		return strings.TrimSpace(fmt.Sprintf(jaJPPromptTemplate, srcLabel, tgtLabel, glossaryBlock))
+	default:
+		return strings.TrimSpace(fmt.Sprintf(genericPromptTemplate, srcLabel, tgtLabel, glossaryBlock))
+	}
+}
+
+const zhCNPromptTemplate = `You are a translation function, not a chat assistant.
+Translate from %s to %s.
+
+Rules:
+- Output ONLY the translated text. No preamble, no questions, no commentary.
+- Translate all English prose; do not leave English unless it is code, a URL, or a product name.
+- All prose must be Chinese. If any English sentence remains outside code/URLs/product names, it is wrong.
+- If the input contains <frontmatter> and <body> tags, keep them exactly and output exactly one of each.
+- Translate only the contents inside those tags.
+- Preserve YAML structure inside <frontmatter>; translate only values.
+- Preserve all [[[FM_*]]] markers exactly and translate only the text between each START/END pair.
+- Translate headings/labels like "Exit codes" and "Optional scripts".
+- Preserve Markdown syntax exactly (headings, lists, tables, emphasis).
+- Preserve HTML tags and attributes exactly.
+- Do not translate code spans/blocks, config keys, CLI flags, or env vars.
+- Do not alter URLs or anchors.
+- Preserve placeholders exactly: __OC_I18N_####__.
+- Do not remove, reorder, or summarize content.
+- Use fluent, idiomatic technical Chinese; avoid slang or jokes.
+- Use neutral documentation tone; prefer “你/你的”, avoid “您/您的”.
+- Insert a space between Latin characters and CJK text (W3C CLREQ), e.g., “Gateway 网关”, “Skills 配置”.
+- Use Chinese quotation marks “ and ” for Chinese prose; keep ASCII quotes inside code spans/blocks or literal CLI/keys.
+- Keep product names in English: OpenClaw, Pi, WhatsApp, Telegram, Discord, iMessage, Slack, Microsoft Teams, Google Chat, Signal.
+- For the OpenClaw Gateway, use “Gateway 网关”.
+- Keep these terms in English: Skills, local loopback, Tailscale.
+- Never output an empty response; if unsure, return the source text unchanged.
+
+%s
+
+If the input is empty, output empty.
+If the input contains only placeholders, output it unchanged.`
+
+const jaJPPromptTemplate = `You are a translation function, not a chat assistant.
+Translate from %s to %s.
+
+Rules:
+- Output ONLY the translated text. No preamble, no questions, no commentary.
+- Translate all English prose; do not leave English unless it is code, a URL, or a product name.
+- All prose must be Japanese. If any English sentence remains outside code/URLs/product names, it is wrong.
+- If the input contains <frontmatter> and <body> tags, keep them exactly and output exactly one of each.
+- Translate only the contents inside those tags.
+- Preserve YAML structure inside <frontmatter>; translate only values.
+- Preserve all [[[FM_*]]] markers exactly and translate only the text between each START/END pair.
+- Translate headings/labels like "Exit codes" and "Optional scripts".
+- Preserve Markdown syntax exactly (headings, lists, tables, emphasis).
+- Preserve HTML tags and attributes exactly.
+- Do not translate code spans/blocks, config keys, CLI flags, or env vars.
+- Do not alter URLs or anchors.
+- Preserve placeholders exactly: __OC_I18N_####__.
+- Do not remove, reorder, or summarize content.
+- Use fluent, idiomatic technical Japanese; avoid slang or jokes.
+- Use neutral documentation tone; avoid overly formal honorifics (e.g., avoid “〜でございます”).
+- Use Japanese quotation marks 「 and 」 for Japanese prose; keep ASCII quotes inside code spans/blocks or literal CLI/keys.
+- Do not add or remove spacing around Latin text just because it borders Japanese; keep spacing stable unless required by Japanese grammar.
+- Keep product names in English: OpenClaw, Pi, WhatsApp, Telegram, Discord, iMessage, Slack, Microsoft Teams, Google Chat, Signal.
+- Keep these terms in English: Skills, local loopback, Tailscale.
+- Never output an empty response; if unsure, return the source text unchanged.
+
+%s
+
+If the input is empty, output empty.
+If the input contains only placeholders, output it unchanged.`
+
+const genericPromptTemplate = `You are a translation function, not a chat assistant.
+Translate from %s to %s.
+
+Rules:
+- Output ONLY the translated text. No preamble, no questions, no commentary.
+- Translate all English prose; do not leave English unless it is code, a URL, or a product name.
+- If any English sentence remains outside code/URLs/product names, it is likely wrong.
+- If the input contains <frontmatter> and <body> tags, keep them exactly and output exactly one of each.
+- Translate only the contents inside those tags.
+- Preserve YAML structure inside <frontmatter>; translate only values.
+- Preserve all [[[FM_*]]] markers exactly and translate only the text between each START/END pair.
+- Translate headings/labels like "Exit codes" and "Optional scripts".
+- Preserve Markdown syntax exactly (headings, lists, tables, emphasis).
+- Preserve HTML tags and attributes exactly.
+- Do not translate code spans/blocks, config keys, CLI flags, or env vars.
+- Do not alter URLs or anchors.
+- Preserve placeholders exactly: __OC_I18N_####__.
+- Do not remove, reorder, or summarize content.
+- Use fluent, idiomatic technical language in the target language; avoid slang or jokes.
+- Use neutral documentation tone.
+- Keep product names in English: OpenClaw, Pi, WhatsApp, Telegram, Discord, iMessage, Slack, Microsoft Teams, Google Chat, Signal.
+- Keep these terms in English: Skills, local loopback, Tailscale.
+- Never output an empty response; if unsure, return the source text unchanged.
+
+%s
+
+If the input is empty, output empty.
+If the input contains only placeholders, output it unchanged.`
+
+func buildGlossaryPrompt(glossary []GlossaryEntry) string {
+	if len(glossary) == 0 {
+		return ""
+	}
+	var lines []string
+	lines = append(lines, "Preferred translations (use when natural):")
+	for _, entry := range glossary {
+		if entry.Source == "" || entry.Target == "" {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("- %s -> %s", entry.Source, entry.Target))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/scripts/docs-i18n/translator.go
+++ b/scripts/docs-i18n/translator.go
@@ -237,64 +237,6 @@ func extractContentText(content json.RawMessage) (string, error) {
 	return strings.Join(parts, ""), nil
 }
 
-func translationPrompt(srcLang, tgtLang string, glossary []GlossaryEntry) string {
-	srcLabel := srcLang
-	tgtLabel := tgtLang
-	if strings.EqualFold(srcLang, "en") {
-		srcLabel = "English"
-	}
-	if strings.EqualFold(tgtLang, "zh-CN") {
-		tgtLabel = "Simplified Chinese"
-	}
-	glossaryBlock := buildGlossaryPrompt(glossary)
-	return strings.TrimSpace(fmt.Sprintf(`You are a translation function, not a chat assistant.
-Translate from %s to %s.
-
-Rules:
-- Output ONLY the translated text. No preamble, no questions, no commentary.
-- Translate all English prose; do not leave English unless it is code, a URL, or a product name.
-- All prose must be Chinese. If any English sentence remains outside code/URLs/product names, it is wrong.
-- If the input contains <frontmatter> and <body> tags, keep them exactly and output exactly one of each.
-- Translate only the contents inside those tags.
-- Preserve YAML structure inside <frontmatter>; translate only values.
-- Preserve all [[[FM_*]]] markers exactly and translate only the text between each START/END pair.
-- Translate headings/labels like "Exit codes" and "Optional scripts".
-- Preserve Markdown syntax exactly (headings, lists, tables, emphasis).
-- Preserve HTML tags and attributes exactly.
-- Do not translate code spans/blocks, config keys, CLI flags, or env vars.
-- Do not alter URLs or anchors.
-- Preserve placeholders exactly: __OC_I18N_####__.
-- Do not remove, reorder, or summarize content.
-- Use fluent, idiomatic technical Chinese; avoid slang or jokes.
-- Use neutral documentation tone; prefer “你/你的”, avoid “您/您的”.
-- Insert a space between Latin characters and CJK text (W3C CLREQ), e.g., “Gateway 网关”, “Skills 配置”.
-- Use Chinese quotation marks “ and ” for Chinese prose; keep ASCII quotes inside code spans/blocks or literal CLI/keys.
-- Keep product names in English: OpenClaw, Pi, WhatsApp, Telegram, Discord, iMessage, Slack, Microsoft Teams, Google Chat, Signal.
-- For the OpenClaw Gateway, use “Gateway 网关”.
-- Keep these terms in English: Skills, local loopback, Tailscale.
-- Never output an empty response; if unsure, return the source text unchanged.
-
-%s
-
-If the input is empty, output empty.
-If the input contains only placeholders, output it unchanged.`, srcLabel, tgtLabel, glossaryBlock))
-}
-
-func buildGlossaryPrompt(glossary []GlossaryEntry) string {
-	if len(glossary) == 0 {
-		return ""
-	}
-	var lines []string
-	lines = append(lines, "Preferred translations (use when natural):")
-	for _, entry := range glossary {
-		if entry.Source == "" || entry.Target == "" {
-			continue
-		}
-		lines = append(lines, fmt.Sprintf("- %s -> %s", entry.Source, entry.Target))
-	}
-	return strings.Join(lines, "\n")
-}
-
 func normalizeThinking(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "low", "high":


### PR DESCRIPTION
Summary
- Make docs-i18n translation prompt language-pluggable by target language.
- Add initial ja-JP glossary + empty TM file.
- Seed initial ja-JP docs pages (index + getting-started + wizard).
- Add minimal Mintlify navigation entry for Japanese.

Notes
- For doc generation, run from the Go module directory:

  cd scripts/docs-i18n
  go run . -docs ../../docs -lang ja-JP -mode doc -parallel 3 \
    ../../docs/index.md \
    ../../docs/start/getting-started.md \
    ../../docs/start/wizard.md

Testing
- cd scripts/docs-i18n && go test ./...
- pnpm docs:build

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR seeds initial Japanese (ja-JP) documentation pages (index + getting-started + wizard), adds a ja-JP glossary and an empty translation memory file, and updates the Mintlify `docs/docs.json` navigation to include Japanese tabs/groups.

On the tooling side, it refactors the docs-i18n translation prompt into a dedicated `scripts/docs-i18n/prompt.go` and makes the prompt language-pluggable based on target language (keeping the existing tuned zh-CN prompt while adding a ja-JP prompt and a generic fallback).

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but there are a couple of i18n/nav correctness issues to fix first.
- The Go refactor is straightforward, but the docs navigation language identifier likely won’t match the ja-JP content slug, which can break discoverability of the new pages. Also one translated page appears to introduce extra content (emoji) that can change anchors vs the source doc.
- docs/docs.json, docs/ja-JP/index.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->