### PR TITLE
fix: add session-growth guard to prevent unbounded session store growth

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -26,6 +26,7 @@ import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
+import { estimateMessagesTokens } from "../compaction.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
@@ -497,4 +498,25 @@ export async function compactEmbeddedPiSession(
   return enqueueCommandInLane(sessionLane, () =>
     enqueueGlobal(async () => compactEmbeddedPiSessionDirect(params)),
   );
+}
+
+/**
+ * Estimates total tokens stored in a session file without creating a full
+ * agent session.  Used by the session-growth guard in run.ts to detect when
+ * context pruning or history limiting has masked unbounded session growth
+ * from the library's auto-compaction trigger.  (#11971)
+ */
+export async function estimateSessionFileTokens(sessionFile: string): Promise<number> {
+  try {
+    await fs.access(sessionFile);
+  } catch {
+    return 0;
+  }
+  try {
+    const sm = SessionManager.open(sessionFile);
+    const ctx = sm.buildSessionContext();
+    return estimateMessagesTokens(ctx.messages);
+  } catch {
+    return 0;
+  }
 }

--- a/src/agents/pi-embedded-runner/run.session-growth-guard.test.ts
+++ b/src/agents/pi-embedded-runner/run.session-growth-guard.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("./run/attempt.js", () => ({
+  runEmbeddedAttempt: vi.fn(),
+}));
+
+vi.mock("./compact.js", () => ({
+  compactEmbeddedPiSessionDirect: vi.fn(),
+  estimateSessionFileTokens: vi.fn(),
+}));
+
+vi.mock("./model.js", () => ({
+  resolveModel: vi.fn(() => ({
+    model: {
+      id: "test-model",
+      provider: "anthropic",
+      contextWindow: 200000,
+      api: "messages",
+    },
+    error: null,
+    authStorage: {
+      setRuntimeApiKey: vi.fn(),
+    },
+    modelRegistry: {},
+  })),
+}));
+
+vi.mock("../model-auth.js", () => ({
+  ensureAuthProfileStore: vi.fn(() => ({})),
+  getApiKeyForModel: vi.fn(async () => ({
+    apiKey: "test-key",
+    profileId: "test-profile",
+    source: "test",
+  })),
+  resolveAuthProfileOrder: vi.fn(() => []),
+}));
+
+vi.mock("../models-config.js", () => ({
+  ensureOpenClawModelsJson: vi.fn(async () => {}),
+}));
+
+vi.mock("../context-window-guard.js", () => ({
+  CONTEXT_WINDOW_HARD_MIN_TOKENS: 1000,
+  CONTEXT_WINDOW_WARN_BELOW_TOKENS: 5000,
+  evaluateContextWindowGuard: vi.fn(() => ({
+    shouldWarn: false,
+    shouldBlock: false,
+    tokens: 200000,
+    source: "model",
+  })),
+  resolveContextWindowInfo: vi.fn(() => ({
+    tokens: 200000,
+    source: "model",
+  })),
+}));
+
+vi.mock("../../process/command-queue.js", () => ({
+  enqueueCommandInLane: vi.fn((_lane: string, task: () => unknown) => task()),
+}));
+
+vi.mock("../../utils.js", () => ({
+  resolveUserPath: vi.fn((p: string) => p),
+}));
+
+vi.mock("../../utils/message-channel.js", () => ({
+  isMarkdownCapableMessageChannel: vi.fn(() => true),
+}));
+
+vi.mock("../agent-paths.js", () => ({
+  resolveOpenClawAgentDir: vi.fn(() => "/tmp/agent-dir"),
+}));
+
+vi.mock("../auth-profiles.js", () => ({
+  markAuthProfileFailure: vi.fn(async () => {}),
+  markAuthProfileGood: vi.fn(async () => {}),
+  markAuthProfileUsed: vi.fn(async () => {}),
+  isProfileInCooldown: vi.fn(() => false),
+}));
+
+vi.mock("../defaults.js", () => ({
+  DEFAULT_CONTEXT_TOKENS: 200000,
+  DEFAULT_MODEL: "test-model",
+  DEFAULT_PROVIDER: "anthropic",
+}));
+
+vi.mock("../failover-error.js", () => ({
+  FailoverError: class extends Error {},
+  resolveFailoverStatus: vi.fn(),
+}));
+
+vi.mock("../usage.js", () => ({
+  normalizeUsage: vi.fn(() => undefined),
+  hasNonzeroUsage: vi.fn(() => false),
+}));
+
+vi.mock("./lanes.js", () => ({
+  resolveSessionLane: vi.fn(() => "session-lane"),
+  resolveGlobalLane: vi.fn(() => "global-lane"),
+}));
+
+vi.mock("./logger.js", () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("./run/payloads.js", () => ({
+  buildEmbeddedRunPayloads: vi.fn(() => []),
+}));
+
+vi.mock("./tool-result-truncation.js", () => ({
+  truncateOversizedToolResultsInSession: vi.fn(async () => ({
+    truncated: false,
+    truncatedCount: 0,
+    reason: "no oversized tool results",
+  })),
+  sessionLikelyHasOversizedToolResults: vi.fn(() => false),
+}));
+
+vi.mock("./utils.js", () => ({
+  describeUnknownError: vi.fn((err: unknown) => {
+    if (err instanceof Error) {
+      return err.message;
+    }
+    return String(err);
+  }),
+}));
+
+vi.mock("../pi-embedded-helpers.js", async () => {
+  return {
+    isCompactionFailureError: () => false,
+    isContextOverflowError: () => false,
+    isFailoverAssistantError: vi.fn(() => false),
+    isFailoverErrorMessage: vi.fn(() => false),
+    isAuthAssistantError: vi.fn(() => false),
+    isRateLimitAssistantError: vi.fn(() => false),
+    isBillingAssistantError: vi.fn(() => false),
+    classifyFailoverReason: vi.fn(() => null),
+    formatAssistantErrorText: vi.fn(() => ""),
+    parseImageSizeError: vi.fn(() => null),
+    pickFallbackThinkingLevel: vi.fn(() => null),
+    isTimeoutErrorMessage: vi.fn(() => false),
+    parseImageDimensionError: vi.fn(() => null),
+  };
+});
+
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+import { compactEmbeddedPiSessionDirect, estimateSessionFileTokens } from "./compact.js";
+import { log } from "./logger.js";
+import { runEmbeddedPiAgent } from "./run.js";
+import { runEmbeddedAttempt } from "./run/attempt.js";
+
+const mockedRunEmbeddedAttempt = vi.mocked(runEmbeddedAttempt);
+const mockedCompactDirect = vi.mocked(compactEmbeddedPiSessionDirect);
+const mockedEstimateTokens = vi.mocked(estimateSessionFileTokens);
+
+function makeAttemptResult(
+  overrides: Partial<EmbeddedRunAttemptResult> = {},
+): EmbeddedRunAttemptResult {
+  return {
+    aborted: false,
+    timedOut: false,
+    promptError: null,
+    sessionIdUsed: "test-session",
+    assistantTexts: ["Hello!"],
+    toolMetas: [],
+    lastAssistant: undefined,
+    messagesSnapshot: [],
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentTargets: [],
+    cloudCodeAssistFormatError: false,
+    ...overrides,
+  };
+}
+
+const baseParams = {
+  sessionId: "test-session",
+  sessionKey: "test-key",
+  sessionFile: "/tmp/session.json",
+  workspaceDir: "/tmp/workspace",
+  prompt: "hello",
+  timeoutMs: 30000,
+  runId: "run-1",
+};
+
+describe("session-growth guard (#11971)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: session is small, no guard action needed
+    mockedEstimateTokens.mockResolvedValue(0);
+  });
+
+  it("forces pre-prompt compaction when session store exceeds threshold", async () => {
+    // Session store has 180k tokens (90% of 200k context window, above 80% threshold)
+    mockedEstimateTokens.mockResolvedValue(180_000);
+
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "Compacted bloated session",
+        firstKeptEntryId: "entry-5",
+        tokensBefore: 180_000,
+        tokensAfter: 30_000,
+      },
+    });
+
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    // Guard should have fired compaction before the attempt
+    expect(mockedEstimateTokens).toHaveBeenCalledWith("/tmp/session.json");
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedCompactDirect).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionFile: "/tmp/session.json" }),
+    );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("[session-growth-guard]"));
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Pre-prompt compaction succeeded"),
+    );
+    // Attempt should proceed normally after compaction
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("does not compact when session store is below threshold", async () => {
+    // Session store has 100k tokens (50% of 200k, below 80% threshold)
+    mockedEstimateTokens.mockResolvedValue(100_000);
+
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    // Guard should have checked but not compacted
+    expect(mockedEstimateTokens).toHaveBeenCalledWith("/tmp/session.json");
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("proceeds normally when pre-prompt compaction fails", async () => {
+    // Session is bloated
+    mockedEstimateTokens.mockResolvedValue(180_000);
+
+    // Compaction fails
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "nothing to compact",
+    });
+
+    // Attempt still succeeds (provider may have large context or pruning helps)
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("did not compact"));
+    // Should still attempt the run
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("skips guard when no session file is provided", async () => {
+    const paramsNoFile = { ...baseParams, sessionFile: undefined as unknown as string };
+
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
+
+    await runEmbeddedPiAgent(paramsNoFile);
+
+    expect(mockedEstimateTokens).not.toHaveBeenCalled();
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+  });
+
+  it("counts pre-prompt compaction in autoCompactionCount", async () => {
+    mockedEstimateTokens.mockResolvedValue(180_000);
+
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "Compacted",
+        firstKeptEntryId: "entry-3",
+        tokensBefore: 180_000,
+        tokensAfter: 25_000,
+      },
+    });
+
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    // The compaction count should be reflected in the result
+    expect(result.meta.agentMeta?.compactionCount).toBe(1);
+  });
+
+  it("handles estimateSessionFileTokens errors gracefully", async () => {
+    // Estimation throws (e.g., corrupt session file)
+    mockedEstimateTokens.mockRejectedValue(new Error("file corrupt"));
+
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
+
+    // Should not crash — guard is best-effort
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.error).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -46,7 +46,7 @@ import {
 } from "../pi-embedded-helpers.js";
 import { normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
-import { compactEmbeddedPiSessionDirect } from "./compact.js";
+import { compactEmbeddedPiSessionDirect, estimateSessionFileTokens } from "./compact.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
@@ -59,6 +59,14 @@ import {
 import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
+
+/**
+ * When the session store exceeds this fraction of the context window, force
+ * compaction before prompting.  This prevents unbounded session growth that
+ * context pruning (cache-ttl) or DM history limiting would otherwise mask
+ * from the library's auto-compaction trigger.  (#11971)
+ */
+const SESSION_GROWTH_COMPACTION_THRESHOLD = 0.8;
 
 // Avoid Anthropic's refusal test token poisoning session transcripts.
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
@@ -389,6 +397,64 @@ export async function runEmbeddedPiAgent(
       const usageAccumulator = createUsageAccumulator();
       let autoCompactionCount = 0;
       try {
+        // Session-growth guard: the session store may grow unbounded when
+        // context pruning (cache-ttl) or DM history limiting masks the true
+        // session size from the library's auto-compaction trigger.  Check the
+        // actual stored token count and force compaction if needed.  (#11971)
+        if (params.sessionFile) {
+          try {
+            const storeTokens = await estimateSessionFileTokens(params.sessionFile);
+            const compactionThreshold = Math.floor(
+              ctxInfo.tokens * SESSION_GROWTH_COMPACTION_THRESHOLD,
+            );
+            if (storeTokens > compactionThreshold) {
+              log.warn(
+                `[session-growth-guard] Session store (${storeTokens} tokens) exceeds ` +
+                  `${Math.round(SESSION_GROWTH_COMPACTION_THRESHOLD * 100)}% of context ` +
+                  `window (${ctxInfo.tokens}); forcing pre-prompt compaction`,
+              );
+              const preCompactResult = await compactEmbeddedPiSessionDirect({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                messageChannel: params.messageChannel,
+                messageProvider: params.messageProvider,
+                agentAccountId: params.agentAccountId,
+                authProfileId: lastProfileId,
+                sessionFile: params.sessionFile,
+                workspaceDir: resolvedWorkspace,
+                agentDir,
+                config: params.config,
+                skillsSnapshot: params.skillsSnapshot,
+                senderIsOwner: params.senderIsOwner,
+                provider,
+                model: modelId,
+                thinkLevel,
+                reasoningLevel: params.reasoningLevel,
+                bashElevated: params.bashElevated,
+                extraSystemPrompt: params.extraSystemPrompt,
+                ownerNumbers: params.ownerNumbers,
+              });
+              if (preCompactResult.compacted) {
+                autoCompactionCount += 1;
+                log.info(
+                  `[session-growth-guard] Pre-prompt compaction succeeded ` +
+                    `(${preCompactResult.result?.tokensBefore} -> ` +
+                    `${preCompactResult.result?.tokensAfter ?? "?"} tokens)`,
+                );
+              } else {
+                log.warn(
+                  `[session-growth-guard] Pre-prompt compaction did not compact: ` +
+                    `${preCompactResult.reason ?? "unknown"}`,
+                );
+              }
+            }
+          } catch (guardErr) {
+            log.warn(
+              `[session-growth-guard] Failed to check session size: ${describeUnknownError(guardErr)}`,
+            );
+          }
+        }
+
         while (true) {
           attemptedThinking.add(thinkLevel);
           await fs.mkdir(resolvedWorkspace, { recursive: true });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -443,8 +443,7 @@ export async function runEmbeddedPiAgent(
                 );
               } else {
                 log.warn(
-                  `[session-growth-guard] Pre-prompt compaction did not compact: ` +
-                    `${preCompactResult.reason ?? "unknown"}`,
+                  `[session-growth-guard] Pre-prompt compaction did not compact: ${preCompactResult.reason ?? "unknown"}`,
                 );
               }
             }


### PR DESCRIPTION
## Summary

Fixes #11971.

- Context pruning (cache-ttl) and DM history limiting modify messages in-flight before the API call but never touch the session store. This masks the true session size from the pi-coding-agent library's auto-compaction trigger, causing the JSONL store to grow unbounded.
- Non-Anthropic providers sharing the same session then receive the full unpruned history (854K+ tokens observed in production, costing $0.66 in wasted API calls).
- Adds a **provider-agnostic pre-prompt guard** in `runEmbeddedPiAgent` that estimates actual stored tokens via `SessionManager.open()` and forces compaction when the store exceeds 80% of the context window.

### Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/compact.ts` | Add `estimateSessionFileTokens()` helper |
| `src/agents/pi-embedded-runner/run.ts` | Add `SESSION_GROWTH_COMPACTION_THRESHOLD` and pre-prompt guard with try/catch |
| `src/agents/pi-embedded-runner/run.session-growth-guard.test.ts` | 6 new tests |

### Design decisions

- **Provider-agnostic**: fires regardless of current provider, catching both cache-ttl pruning (Anthropic) and `limitHistoryTurns` (DM sessions)
- **Best-effort**: errors in session estimation are caught and logged, never block the prompt
- **Runs once** before the retry loop (existing overflow handling covers subsequent growth)
- **Threshold at 80%**: above pruning ratios (30-50%) to avoid interference, but catches clearly bloated sessions

## Test plan

- [x] 6 new tests pass (threshold logic, compaction success/failure, error resilience, no-session-file, compaction counting)
- [x] 8 existing overflow-compaction tests pass (no regressions)
- [x] Linter passes (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a pre-prompt “session-growth guard” to `runEmbeddedPiAgent` that estimates the *stored* token count from the session JSONL and forces compaction when it exceeds 80% of the model context window. This is intended to prevent unbounded session store growth when downstream pruning/history-limiting modifies messages only in-flight.

Also introduces `estimateSessionFileTokens()` to compute an approximate token count from the on-disk session context, and adds a dedicated test suite for the guard behavior.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge after fixing a test that relies on an invalid type cast.
- The runtime change is isolated (best-effort guard + existing compaction path) and covered by new tests, but one test currently bypasses the real params contract by casting `undefined` to a required `string`, which can mask mismatches between intended and actual runtime states.
- src/agents/pi-embedded-runner/run.session-growth-guard.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->