### PR TITLE
docs(subagents): clarify allowAgents is per-agent only, add config example

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -56,6 +56,39 @@ Allowlist:
 
 - `agents.list[].subagents.allowAgents`: list of agent ids that can be targeted via `agentId` (`["*"]` to allow any). Default: only the requester agent.
 
+> **Note:** `allowAgents` is **per-agent only** — it must be set on the agent entry in `agents.list[]`, not in `agents.defaults.subagents`. Placing it in defaults will cause a config validation error (`Unrecognized key: "allowAgents"`).
+
+Example — allow the `main` agent to spawn `coder` and `reviewer` sub-agents:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "subagents": {
+          "allowAgents": ["coder", "reviewer"]
+        }
+      },
+      {
+        "id": "coder",
+        "name": "Code Agent",
+        "model": "your-provider/model-id",
+        "workspace": "/home/node/.openclaw/workspace-coder",
+        "agentDir": "/home/node/.openclaw/agents/coder"
+      },
+      {
+        "id": "reviewer",
+        "name": "Review Agent",
+        "model": "your-provider/another-model-id",
+        "workspace": "/home/node/.openclaw/workspace-reviewer",
+        "agentDir": "/home/node/.openclaw/agents/reviewer"
+      }
+    ]
+  }
+}
+```
+
 Discovery:
 
 - Use `agents_list` to see which agent ids are currently allowed for `sessions_spawn`.


### PR DESCRIPTION
## Summary

- Add a note clarifying that `allowAgents` must be set on the agent entry in `agents.list[]`, not in `agents.defaults.subagents`
- Add a complete configuration example showing how to set up multi-agent spawning

## Motivation

When configuring `sessions_spawn` with `agentId`, it's natural to put `allowAgents` under `agents.defaults.subagents` (since other subagent settings like `maxConcurrent` and `model` work there). However, this causes a config schema validation error and crashes the gateway:

```
agents.defaults.subagents: Unrecognized key: "allowAgents"
```

The current doc mentions `agents.list[].subagents.allowAgents` in one line, but doesn't explicitly warn against the defaults placement. This small addition should save users from a crash-loop debugging session.

Related: #11982

## Test plan

- [ ] Verify the note renders correctly in the docs site
- [ ] Verify the JSON example is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/tools/subagents.md` to clarify that `allowAgents` is a per-agent configuration (`agents.list[].subagents.allowAgents`) and cannot be set in `agents.defaults.subagents`. It also adds a full JSON configuration example demonstrating how a `main` agent can spawn specific sub-agents (`coder`, `reviewer`) via `sessions_spawn` with `agentId`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to documentation and the added configuration example is valid JSON and consistent with the existing configuration keys described in the same document.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->