### PR TITLE
fix: sanitize Copilot thinking blocks to avoid 400s

### DIFF
--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -1,0 +1,34 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object" || msg.role !== "assistant") {
+      out.push(msg);
+      continue;
+    }
+    const assistant = msg;
+    if (!Array.isArray(assistant.content)) {
+      out.push(msg);
+      continue;
+    }
+    type AssistantContentBlock = Extract<AgentMessage, { role: "assistant" }>["content"][number];
+    const nextContent: AssistantContentBlock[] = [];
+    let changed = false;
+    for (const block of assistant.content) {
+      if (block && typeof block === "object" && (block as { type?: unknown }).type === "thinking") {
+        touched = true;
+        changed = true;
+        continue;
+      }
+      nextContent.push(block);
+    }
+    if (nextContent.length === 0) {
+      touched = true;
+      continue;
+    }
+    out.push(changed ? { ...assistant, content: nextContent } : msg);
+  }
+  return touched ? out : messages;
+}

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -14,7 +14,8 @@ export type TranscriptPolicy = {
     allowBase64Only?: boolean;
     includeCamelCase?: boolean;
   };
-  normalizeAntigravityThinkingBlocks: boolean;
+  sanitizeThinkingSignatures: boolean;
+  dropThinkingBlocks: boolean;
   applyGoogleTurnOrdering: boolean;
   validateGeminiTurns: boolean;
   validateAnthropicTurns: boolean;
@@ -93,6 +94,11 @@ export function resolveTranscriptPolicy(params: {
     modelId,
   });
 
+  // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
+  // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
+  // Drop these blocks at send-time to keep sessions usable.
+  const dropThinkingBlocks = provider === "github-copilot";
+
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
   const sanitizeToolCallIds = isGoogle || isMistral;
@@ -105,7 +111,7 @@ export function resolveTranscriptPolicy(params: {
   const sanitizeThoughtSignatures = isOpenRouterGemini
     ? { allowBase64Only: true, includeCamelCase: true }
     : undefined;
-  const normalizeAntigravityThinkingBlocks = isAntigravityClaudeModel;
+  const sanitizeThinkingSignatures = isAntigravityClaudeModel;
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
@@ -114,7 +120,8 @@ export function resolveTranscriptPolicy(params: {
     repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
     preserveSignatures: isAntigravityClaudeModel,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
-    normalizeAntigravityThinkingBlocks,
+    sanitizeThinkingSignatures,
+    dropThinkingBlocks,
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -94,10 +94,12 @@ export function resolveTranscriptPolicy(params: {
     modelId,
   });
 
+  const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
+
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
   // Drop these blocks at send-time to keep sessions usable.
-  const dropThinkingBlocks = provider === "github-copilot";
+  const dropThinkingBlocks = isCopilotClaude;
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -21,12 +21,21 @@ const NEW_STATE_DIRNAME = ".openclaw";
 const CONFIG_FILENAME = "openclaw.json";
 const LEGACY_CONFIG_FILENAMES = ["clawdbot.json", "moltbot.json", "moldbot.json"] as const;
 
+function resolveHomeDir(homedir: () => string = os.homedir): string {
+  const home = homedir();
+  if (process.platform === "win32") {
+    return path.resolve(home);
+  }
+  return home;
+}
+
 function legacyStateDirs(homedir: () => string = os.homedir): string[] {
-  return LEGACY_STATE_DIRNAMES.map((dir) => path.join(homedir(), dir));
+  const home = resolveHomeDir(homedir);
+  return LEGACY_STATE_DIRNAMES.map((dir) => path.join(home, dir));
 }
 
 function newStateDir(homedir: () => string = os.homedir): string {
-  return path.join(homedir(), NEW_STATE_DIRNAME);
+  return path.join(resolveHomeDir(homedir), NEW_STATE_DIRNAME);
 }
 
 export function resolveLegacyStateDir(homedir: () => string = os.homedir): string {


### PR DESCRIPTION
Fixes #11993.

### Summary
GitHub Copilot can persist assistant `content` blocks with `type: "thinking"` and a provider-specific signature (e.g. `thinkingSignature: "reasoning_text"`). When those blocks are replayed on subsequent requests (especially during tool continuations), Copilot/Claude returns HTTP 400:

- `Invalid signature in thinking block`

This PR prevents those poisoned transcripts from bricking a session by stripping `type:"thinking"` blocks from the outgoing request history for Copilot.

### What changed
- **New transcript policy for Copilot:** `dropThinkingBlocks` is enabled for `provider=github-copilot`.
- **Sanitize on every outbound request:** in addition to session-level history sanitization, the embedded runner wraps the agent `streamFn` so that **tool follow-ups / continuations** also see a sanitized `messages` array.
- **Regression test:** adds a vitest case ensuring a transcript containing an assistant `type:"thinking"` block is sanitized for Copilot.

### Why this is needed
The failure commonly occurs when a model emits a tool call and the agent makes a second provider call to continue the turn. Without per-request sanitization, the continuation request replays the earlier `thinking` block and fails.

### Scope / compatibility
- Intentionally scoped to **GitHub Copilot** to avoid impacting providers that legitimately require thinking signatures (e.g. Anthropic/Bedrock Extended Thinking).
- Does not mutate persisted session files; sanitization operates on copies of `messages`.

### AI-assisted
This PR was AI-assisted.

- **Testing level:** lightly tested
  - `pnpm build`
  - targeted vitest: `src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
  - manual sandbox repro against Copilot showing tool-continuation no longer 400s
- **Understanding:** yes — the change drops `type:"thinking"` blocks for Copilot requests to avoid provider incompatibility.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a Copilot-specific transcript sanitization policy that drops persisted assistant `type:"thinking"` blocks (including provider-specific signatures like `thinkingSignature:"reasoning_text"`) to prevent Copilot/Claude HTTP 400s on replay, especially during tool continuations.

Changes include:
- New `dropThinkingBlocks` policy flag in `resolveTranscriptPolicy` (enabled for `provider=github-copilot`).
- `sanitizeSessionHistory` now optionally drops thinking blocks before other transcript repairs.
- The embedded runner wraps the agent `streamFn` so every outbound provider request (including tool-follow-up calls) sees sanitized `messages`.
- A vitest regression test verifying thinking blocks are removed for Copilot requests.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one policy-scoping concern to address.
- The change is narrowly targeted at preventing known Copilot replay failures by dropping assistant thinking blocks, and it also correctly handles tool continuations by sanitizing per outbound request. The main risk is that the drop policy is keyed only on `provider === "github-copilot"`, so if that provider ever routes to models where thinking blocks are meaningful, content could be silently lost.
- src/agents/transcript-policy.ts, src/agents/pi-embedded-runner/thinking.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->