### PR TITLE
fix(tts): handle undefined error.message in provider fallback chain

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -496,12 +496,12 @@ describe("tts", () => {
 
     it("handles null gracefully", () => {
       const result = formatTtsError("edge", null);
-      expect(result).toBe("edge: null");
+      expect(result).toBe("edge: unknown error");
     });
 
     it("handles undefined gracefully", () => {
       const result = formatTtsError("edge", undefined);
-      expect(result).toBe("edge: undefined");
+      expect(result).toBe("edge: unknown error");
     });
   });
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -585,14 +585,6 @@ export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: Tts
   return Boolean(resolveTtsApiKey(config, provider));
 }
 
-function formatTtsProviderError(provider: TtsProvider, err: unknown): string {
-  const error = err instanceof Error ? err : new Error(String(err));
-  if (error.name === "AbortError") {
-    return `${provider}: request timed out`;
-  }
-  return `${provider}: ${error.message}`;
-}
-
 export async function textToSpeech(params: {
   text: string;
   cfg: OpenClawConfig;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -512,6 +512,23 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
 }
 
+/**
+ * Formats a TTS provider error message, handling cases where error.message
+ * may be undefined or empty.
+ */
+export function formatTtsError(provider: string, error: Error): string {
+  if (error.name === "AbortError") {
+    return `${provider}: request timed out`;
+  }
+  const message = error.message?.trim();
+  if (message) {
+    return `${provider}: ${message}`;
+  }
+  // Fallback to error name or string representation when message is unavailable
+  const fallback = error.name || String(error) || "unknown error";
+  return `${provider}: ${fallback}`;
+}
+
 export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: TtsProvider): boolean {
   if (provider === "edge") {
     return config.edge.enabled;
@@ -683,7 +700,7 @@ export async function textToSpeech(params: {
         voiceCompatible: output.voiceCompatible,
       };
     } catch (err) {
-      lastError = formatTtsProviderError(provider, err);
+      lastError = formatTtsError(provider, err as Error);
     }
   }
 
@@ -772,7 +789,7 @@ export async function textToSpeechTelephony(params: {
         sampleRate: output.sampleRate,
       };
     } catch (err) {
-      lastError = formatTtsProviderError(provider, err);
+      lastError = formatTtsError(provider, err as Error);
     }
   }
 
@@ -938,4 +955,5 @@ export const _test = {
   summarizeText,
   resolveOutputFormat,
   resolveEdgeOutputFormat,
+  formatTtsError,
 };

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -517,6 +517,11 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
  * may not be an Error instance (e.g., string, object) or error.message is undefined.
  */
 export function formatTtsError(provider: string, error: unknown): string {
+  // Handle null/undefined explicitly to avoid "provider: undefined" output
+  if (error === null || error === undefined) {
+    return `${provider}: unknown error`;
+  }
+
   // Handle string throws directly
   if (typeof error === "string") {
     return `${provider}: ${error.trim() || "unknown error"}`;
@@ -558,11 +563,18 @@ export function formatTtsError(provider: string, error: unknown): string {
     }
   }
 
-  // Last resort fallback
-  const str = String(error);
-  if (str && str !== "[object Object]") {
-    return `${provider}: ${str}`;
+  // Handle remaining primitive types (number, boolean, symbol, bigint, function)
+  // These all have sensible string representations
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
+    return `${provider}: ${String(error)}`;
   }
+  if (typeof error === "function") {
+    return `${provider}: ${error.name || "unknown error"}`;
+  }
+  if (typeof error === "symbol") {
+    return `${provider}: ${error.description || "unknown error"}`;
+  }
+
   return `${provider}: unknown error`;
 }
 


### PR DESCRIPTION
## Problem

When a TTS provider throws an error object without a `message` property (common with certain error types), the catch block in `textToSpeech()` produced:

```
edge: undefined
```

This is confusing because:
1. It doesn't indicate what actually went wrong
2. The word "undefined" looks like a bug rather than an error message

## Root Cause

In `src/tts/tts.ts`, the catch blocks did:
```typescript
lastError = `${provider}: ${error.message}`;
```

When `error.message` is undefined, JavaScript string interpolation produces `"edge: undefined"`.

## Solution

Added `formatTtsError()` helper that:
1. Preserves existing `AbortError` handling ("request timed out")
2. Uses `error.message` when available and non-empty
3. Falls back to `error.name` (e.g., "NetworkError", "TypeError")
4. Falls back to `String(error)` as last resort
5. Uses "unknown error" if all else fails

Applied to both `textToSpeech()` and `textToSpeechTelephony()` catch blocks.

## Testing

- 5 new tests for `formatTtsError()` covering all branches
- 1 new test for explicit provider configuration
- All 6 tests fail before fix, pass after (TDD)
- Full TTS test suite passes (39 tests)

Fixes #11201

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `formatTtsError()` helper to handle provider errors robustly, preventing `"edge: undefined"` output when `error.message` is missing. The fix covers all error types (Error instances, strings, plain objects, primitives, null/undefined) with comprehensive test coverage (11 new tests).

- Handles `null`/`undefined` explicitly → returns `"unknown error"`
- Preserves `AbortError` → `"request timed out"` behavior
- Extracts messages from Error instances, strings, and error-like objects
- Falls back to JSON serialization for objects with useful data
- Applied to both `textToSpeech()` and `textToSpeechTelephony()` catch blocks
- Old `formatTtsProviderError()` function at `src/tts/tts.ts:588-594` is now dead code and can be removed

<h3>Confidence Score: 5/5</h3>

- Safe to merge - addresses the original issue comprehensively with thorough test coverage
- The implementation is thorough and well-tested. All previous review feedback has been addressed (null/undefined handling, non-Error throws, string throws, plain objects). The only issue is minor dead code cleanup that doesn't affect functionality.
- No files require special attention

<sub>Last reviewed commit: 98a9f07</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->