### PR TITLE
docs(subagents): clarify allowAgents is per-agent only

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -56,6 +56,10 @@ Allowlist:
 
 - `agents.list[].subagents.allowAgents`: list of agent ids that can be targeted via `agentId` (`["*"]` to allow any). Default: only the requester agent.
 
+<Warning>
+`allowAgents` is per-agent only and **cannot** be set in `agents.defaults.subagents`. Place it under the specific agent entry in `agents.list[]` that will initiate `sessions_spawn` (typically `main`).
+</Warning>
+
 Discovery:
 
 - Use `agents_list` to see which agent ids are currently allowed for `sessions_spawn`.


### PR DESCRIPTION
## Summary

Add a warning note clarifying that `allowAgents` cannot be set in `agents.defaults.subagents`.

Fixes #11982

## Pages Updated

- `docs/tools/subagents.md`

## Before/After

**Before:** Users try to put `allowAgents` in `agents.defaults.subagents`, get a cryptic config validation error.

**After:** Clear warning explains this is per-agent only and where to put it.

## Formatting

```bash
pnpm format
```

lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `docs/tools/subagents.md` to add an explicit warning that `allowAgents` is configured per-agent and is not valid under `agents.defaults.subagents`, directing users to place it under the initiating agent’s `agents.list[]` entry (often `main`) to avoid confusing config validation errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single, localized documentation-only change adding a warning note; no code paths or schemas are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->