### PR TITLE
fix(cron): clear stale running markers based on job timeout

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -193,7 +193,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       const timeoutMs =
         job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
           ? job.payload.timeoutSeconds * 1_000
-          : 10 * 60_000;
+          : DEFAULT_JOB_TIMEOUT_MS;
       const staleAfterMs = timeoutMs + 30_000;
       if (now - job.state.runningAtMs > staleAfterMs) {
         state.deps.log.warn(

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -12,6 +12,7 @@ import {
 import { locked } from "./locked.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
 import { armTimer, emit, executeJob, runMissedJobs, stopTimer, wake } from "./timer.js";
+import { DEFAULT_JOB_TIMEOUT_MS } from "./timer.js";
 
 export async function start(state: CronServiceState) {
   await locked(state, async () => {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -188,7 +188,22 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
     await ensureLoaded(state, { skipRecompute: true });
     const job = findJobOrThrow(state, id);
     if (typeof job.state.runningAtMs === "number") {
-      return { ok: true, ran: false, reason: "already-running" as const };
+      const now = state.deps.nowMs();
+      const timeoutMs =
+        job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+          ? job.payload.timeoutSeconds * 1_000
+          : 10 * 60_000;
+      const staleAfterMs = timeoutMs + 30_000;
+      if (now - job.state.runningAtMs > staleAfterMs) {
+        state.deps.log.warn(
+          { jobId: job.id, runningAtMs: job.state.runningAtMs, staleAfterMs },
+          "cron: clearing stale running marker (run command)",
+        );
+        job.state.runningAtMs = undefined;
+        await persist(state);
+      } else {
+        return { ok: true, ran: false, reason: "already-running" as const };
+      }
     }
     const now = state.deps.nowMs();
     const due = isJobDue(job, now, { forced: mode === "force" });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -174,10 +174,10 @@ export async function onTimer(state: CronServiceState) {
 
       const now = state.deps.nowMs();
       if (changed) {
-    await persist(state);
-  }
+        await persist(state);
+      }
 
-  for (const job of due) {
+      for (const job of due) {
         job.state.runningAtMs = now;
         job.state.lastError = undefined;
       }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -292,7 +292,20 @@ function findDueJobs(state: CronServiceState): CronJob[] {
       return false;
     }
     if (typeof j.state.runningAtMs === "number") {
-      return false;
+      const timeoutMs =
+        j.payload.kind === "agentTurn" && typeof j.payload.timeoutSeconds === "number"
+          ? j.payload.timeoutSeconds * 1_000
+          : DEFAULT_JOB_TIMEOUT_MS;
+      const staleAfterMs = timeoutMs + 30_000;
+      if (now - j.state.runningAtMs > staleAfterMs) {
+        state.deps.log.warn(
+          { jobId: j.id, runningAtMs: j.state.runningAtMs, staleAfterMs },
+          "cron: clearing stale running marker",
+        );
+        j.state.runningAtMs = undefined;
+      } else {
+        return false;
+      }
     }
     const next = j.state.nextRunAtMs;
     return typeof next === "number" && now >= next;
@@ -312,7 +325,20 @@ export async function runMissedJobs(state: CronServiceState) {
       return false;
     }
     if (typeof j.state.runningAtMs === "number") {
-      return false;
+      const timeoutMs =
+        j.payload.kind === "agentTurn" && typeof j.payload.timeoutSeconds === "number"
+          ? j.payload.timeoutSeconds * 1_000
+          : DEFAULT_JOB_TIMEOUT_MS;
+      const staleAfterMs = timeoutMs + 30_000;
+      if (now - j.state.runningAtMs > staleAfterMs) {
+        state.deps.log.warn(
+          { jobId: j.id, runningAtMs: j.state.runningAtMs, staleAfterMs },
+          "cron: clearing stale running marker",
+        );
+        j.state.runningAtMs = undefined;
+      } else {
+        return false;
+      }
     }
     const next = j.state.nextRunAtMs;
     if (j.schedule.kind === "at" && j.state.lastStatus === "ok") {
@@ -345,7 +371,20 @@ export async function runDueJobs(state: CronServiceState) {
       return false;
     }
     if (typeof j.state.runningAtMs === "number") {
-      return false;
+      const timeoutMs =
+        j.payload.kind === "agentTurn" && typeof j.payload.timeoutSeconds === "number"
+          ? j.payload.timeoutSeconds * 1_000
+          : DEFAULT_JOB_TIMEOUT_MS;
+      const staleAfterMs = timeoutMs + 30_000;
+      if (now - j.state.runningAtMs > staleAfterMs) {
+        state.deps.log.warn(
+          { jobId: j.id, runningAtMs: j.state.runningAtMs, staleAfterMs },
+          "cron: clearing stale running marker",
+        );
+        j.state.runningAtMs = undefined;
+      } else {
+        return false;
+      }
     }
     const next = j.state.nextRunAtMs;
     return typeof next === "number" && now >= next;


### PR DESCRIPTION
## Problem\nCron jobs can get stuck as "already running" if a run crashes after setting runningAtMs but before applyJobResult clears it. The lock only clears after 2h (STUCK_RUN_MS), which causes false "already running" for short interval jobs.\n\n## Fix\nClear stale running markers when:\n- now - runningAtMs > (job timeout + 30s grace)\nThis is applied in:\n- cron run (manual) path\n- findDueJobs (scheduler)\n\n## Notes\nThis keeps long jobs safe by honoring job timeoutSeconds when set, or DEFAULT_JOB_TIMEOUT_MS.\n

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR attempts to reduce false “already running” cron locks by clearing `runningAtMs` markers once they exceed a job-specific timeout (+30s grace), applying the logic both in the manual `run` path and in the scheduler’s due/missed job selection.

Main concern: the scheduler-side clearing is currently performed inside filter predicates without guaranteeing a subsequent `persist()`, so in common cases where a job is stale-but-not-due the marker may be cleared only in-memory and then reappear after the next reload, continuing to block execution.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after fixing the stale-lock persistence issue and aligning timeout constants.
- Core idea is sound, but clearing `runningAtMs` without persisting can leave the system effectively unchanged after reload; additionally, differing fallback timeout constants between manual and scheduler paths can cause inconsistent staleness behavior.
- src/cron/service/timer.ts, src/cron/service/ops.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->