### PR TITLE
Docs: fix Japanese language switcher ordering + flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Exec approvals: format forwarded command text as inline/fenced monospace for safer approval scanning across channels. (#11937)
+- Docs: fix language switcher ordering and Japanese locale flag in Mintlify nav. (#12023) Thanks @joshp123.
 - Thinking: allow xhigh for `github-copilot/gpt-5.2-codex` and `github-copilot/gpt-5.2`. (#11646) Thanks @seans-openclawbot.
 - Discord: support forum/media `thread create` starter messages, wire `message thread create --message`, and harden thread-create routing. (#10062) Thanks @jarvis89757.
 - Gateway: stabilize chat routing by canonicalizing node session keys for node-originated chat methods. (#11755) Thanks @mbelinky.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1274,24 +1274,6 @@
         ]
       },
       {
-        "language": "ja-jp",
-        "tabs": [
-          {
-            "tab": "はじめに",
-            "groups": [
-              {
-                "group": "概要",
-                "pages": ["ja-JP/index"]
-              },
-              {
-                "group": "初回セットアップ",
-                "pages": ["ja-JP/start/getting-started", "ja-JP/start/wizard"]
-              }
-            ]
-          }
-        ]
-      },
-      {
         "language": "zh-Hans",
         "tabs": [
           {
@@ -1810,6 +1792,24 @@
               {
                 "group": "文档元信息",
                 "pages": ["zh-CN/start/hubs", "zh-CN/start/docs-directory"]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "language": "ja",
+        "tabs": [
+          {
+            "tab": "はじめに",
+            "groups": [
+              {
+                "group": "概要",
+                "pages": ["ja-JP/index"]
+              },
+              {
+                "group": "初回セットアップ",
+                "pages": ["ja-JP/start/getting-started", "ja-JP/start/wizard"]
               }
             ]
           }

--- a/docs/ja-JP/start/getting-started.md
+++ b/docs/ja-JP/start/getting-started.md
@@ -120,6 +120,6 @@ Control UIが読み込まれれば、Gatewayは使用可能な状態です。
 
 ## 次のステップ
 
-- DMの安全性と承認：[ペアリング](/start/pairing)
+- DMの安全性と承認：[ペアリング](/channels/pairing)
 - さらにチャンネルを接続：[チャンネル](/channels)
 - 高度なワークフローとソースからのビルド：[セットアップ](/start/setup)


### PR DESCRIPTION
Summary
- Reorder language switcher to EN → Simplified Chinese → Japanese.
- Use Mintlify language code `ja` (instead of `ja-jp`) so the switcher uses the Japanese locale/flag mapping.
- Fix a JP doc link to Pairing: `/start/pairing` → `/channels/pairing`.

Testing
- pnpm docs:build

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Mintlify docs configuration to reorder the language switcher (EN → zh-Hans → ja) and changes the Japanese locale identifier from `ja-jp` to `ja` so Mintlify uses the expected Japanese flag/locale mapping. It also fixes a broken Japanese “Pairing” link in `docs/ja-JP/start/getting-started.md` from `/start/pairing` to `/channels/pairing`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to docs configuration and a single internal link update; the edits are straightforward and consistent (locale key change + ordering), and no code execution paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->