### PR TITLE
feat(cli): add 'openclaw guide' for new user onboarding

### DIFF
--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -11,6 +11,7 @@ import { registerConfigCli } from "../config-cli.js";
 import { registerMemoryCli, runMemoryStatus } from "../memory-cli.js";
 import { registerAgentCommands } from "./register.agent.js";
 import { registerConfigureCommand } from "./register.configure.js";
+import { registerGuideCommand } from "./register.guide.js";
 import { registerMaintenanceCommands } from "./register.maintenance.js";
 import { registerMessageCommands } from "./register.message.js";
 import { registerOnboardCommand } from "./register.onboard.js";
@@ -120,6 +121,10 @@ export const commandRegistry: CommandRegistration[] = [
   {
     id: "onboard",
     register: ({ program }) => registerOnboardCommand(program),
+  },
+  {
+    id: "guide",
+    register: ({ program }) => registerGuideCommand(program),
   },
   {
     id: "configure",

--- a/src/cli/program/register.guide.ts
+++ b/src/cli/program/register.guide.ts
@@ -1,0 +1,18 @@
+import type { Command } from "commander";
+import { runGuideCommand } from "../../commands/guide.js";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+
+export function registerGuideCommand(program: Command) {
+  program
+    .command("guide")
+    .description("Show starter tasks to help you get started with OpenClaw")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/start/getting-started", "docs.openclaw.ai/start/getting-started")}\n`,
+    )
+    .action(async () => {
+      await runGuideCommand();
+    });
+}

--- a/src/commands/guide.ts
+++ b/src/commands/guide.ts
@@ -1,0 +1,186 @@
+/**
+ * Starter Guide - Simple onboarding checklist for new users
+ *
+ * Shows a friendly list of tasks to help users get started with OpenClaw.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import { resolveUserPath } from "../utils.js";
+
+export interface GuideTask {
+  id: string;
+  title: string;
+  description: string;
+  command?: string;
+  check: (config: OpenClawConfig | null, workspacePath: string) => boolean;
+}
+
+const GUIDE_TASKS: GuideTask[] = [
+  {
+    id: "model",
+    title: "Set up an AI model",
+    description: "Connect to an AI provider (Anthropic, OpenAI, etc.)",
+    command: "openclaw onboard",
+    check: (config) => {
+      if (!config) {
+        return false;
+      }
+      const model = config.agents?.defaults?.model?.primary;
+      return Boolean(model && model !== "");
+    },
+  },
+  {
+    id: "channel",
+    title: "Connect a chat channel",
+    description: "Link Telegram, Discord, WhatsApp, or another messaging app",
+    command: "openclaw onboard --channels",
+    check: (config) => {
+      if (!config?.channels) {
+        return false;
+      }
+      const channels = ["telegram", "discord", "whatsapp", "slack", "signal"] as const;
+      return channels.some((ch) => {
+        const channelConfig = config.channels?.[ch];
+        return (
+          channelConfig &&
+          typeof channelConfig === "object" &&
+          Object.keys(channelConfig).length > 0
+        );
+      });
+    },
+  },
+  {
+    id: "identity",
+    title: "Create your identity",
+    description: "Tell your agent who you are in IDENTITY.md",
+    command: "edit ~/.openclaw/workspace/IDENTITY.md",
+    check: (_config, workspacePath) => {
+      const identityPath = path.join(workspacePath, "IDENTITY.md");
+      if (!fs.existsSync(identityPath)) {
+        return false;
+      }
+      const content = fs.readFileSync(identityPath, "utf-8");
+      // Check if it's been customized (not just the template)
+      return content.length > 100 && !content.includes("_(待确认)_");
+    },
+  },
+  {
+    id: "skill",
+    title: "Install a skill",
+    description: "Add capabilities like weather, calendar, or notes",
+    command: "openclaw skill install weather",
+    check: (config) => {
+      // Check if skills.install array has entries
+      const install = config?.skills?.install;
+      return Array.isArray(install) && install.length > 0;
+    },
+  },
+  {
+    id: "first-message",
+    title: "Send your first message",
+    description: "Say hello to your agent!",
+    check: (_config, workspacePath) => {
+      // Check if any session transcript exists
+      const sessionsPath = path.join(workspacePath, "..", "sessions");
+      if (!fs.existsSync(sessionsPath)) {
+        return false;
+      }
+      try {
+        const files = fs.readdirSync(sessionsPath);
+        return files.some((f) => f.endsWith(".jsonl"));
+      } catch {
+        return false;
+      }
+    },
+  },
+];
+
+export interface GuideResult {
+  tasks: Array<{
+    task: GuideTask;
+    completed: boolean;
+  }>;
+  completedCount: number;
+  totalCount: number;
+  allDone: boolean;
+}
+
+export function checkGuideTasks(config: OpenClawConfig | null, workspacePath: string): GuideResult {
+  const results = GUIDE_TASKS.map((task) => ({
+    task,
+    completed: task.check(config, workspacePath),
+  }));
+
+  const completedCount = results.filter((r) => r.completed).length;
+
+  return {
+    tasks: results,
+    completedCount,
+    totalCount: results.length,
+    allDone: completedCount === results.length,
+  };
+}
+
+export function formatGuideOutput(result: GuideResult): string {
+  const lines: string[] = [];
+
+  const progressBar = (completed: number, total: number) => {
+    const filled = Math.round((completed / total) * 10);
+    const empty = 10 - filled;
+    return "█".repeat(filled) + "░".repeat(empty);
+  };
+
+  lines.push("");
+  lines.push("🦞 Welcome to OpenClaw!");
+  lines.push("");
+
+  if (result.allDone) {
+    lines.push("🎉 You've completed all starter tasks! You're ready to go.");
+    lines.push("");
+    lines.push("Next steps:");
+    lines.push("  • Explore more skills: openclaw skill search");
+    lines.push("  • Read the docs: https://docs.openclaw.ai");
+    lines.push("  • Join the community: https://discord.gg/openclaw");
+  } else {
+    lines.push(
+      `Progress: ${progressBar(result.completedCount, result.totalCount)} ${result.completedCount}/${result.totalCount}`,
+    );
+    lines.push("");
+    lines.push("Get started:");
+    lines.push("");
+
+    for (const { task, completed } of result.tasks) {
+      const icon = completed ? "✓" : "○";
+      const status = completed ? "\x1b[32m" : "\x1b[0m"; // green or default
+      const reset = "\x1b[0m";
+
+      lines.push(`  ${status}${icon}${reset} ${task.title}`);
+      if (!completed) {
+        lines.push(`    ${task.description}`);
+        if (task.command) {
+          lines.push(`    → ${task.command}`);
+        }
+      }
+    }
+  }
+
+  lines.push("");
+  lines.push("Run \x1b[36mopenclaw guide\x1b[0m anytime to see this list.");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export async function runGuideCommand(): Promise<void> {
+  const configSnapshot = await readConfigFileSnapshot();
+  const config = configSnapshot?.config ?? null;
+  const workspacePath = resolveUserPath(
+    config?.agents?.defaults?.workspace ?? "~/.openclaw/workspace",
+  );
+
+  const result = checkGuideTasks(config, workspacePath);
+  console.log(formatGuideOutput(result));
+}


### PR DESCRIPTION
## Summary

A simple, game-like starter guide command that helps new users get started with OpenClaw.

## Motivation

New users often don't know what to do after `openclaw onboard`. This command provides a friendly checklist of next steps, similar to a game tutorial.

## Features

- **Progress bar** showing completion status
- **5 starter tasks**:
  1. Set up an AI model
  2. Connect a chat channel (Telegram/Discord/etc.)
  3. Create your identity (IDENTITY.md)
  4. Install a skill
  5. Send your first message
- **Color-coded** task status (green ✓ for completed)
- **Helpful commands** for each pending task

## Example Output

```
🦞 Welcome to OpenClaw!

Progress: ███░░░░░░░ 3/5

Get started:

  ✓ Set up an AI model
  ✓ Connect a chat channel
  ○ Create your identity
    Tell your agent who you are in IDENTITY.md
    → edit ~/.openclaw/workspace/IDENTITY.md
  ✓ Install a skill
  ○ Send your first message
    Say hello to your agent!

Run openclaw guide anytime to see this list.
```

## Usage

```bash
openclaw guide
```

## Files Changed

| File | Description |
|------|-------------|
| `src/commands/guide.ts` | Core logic + task definitions |
| `src/cli/program/register.guide.ts` | CLI command registration |
| `src/cli/program/command-registry.ts` | Added to registry |

## Future Ideas (not in this PR)

- XP/level system
- Achievement badges
- Auto-show on first run

## AI-Assisted Contribution 🤖

- [x] AI-assisted (Claude)
- [x] Tested locally

lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `openclaw guide` CLI command, registered in the command registry, that prints a checklist-style onboarding guide with a progress bar. The command evaluates completion by inspecting the user config (model/channels/skills), checking for `IDENTITY.md` in the workspace, and looking for session transcripts.

Main issues to address before merge are around task completion detection: the IDENTITY.md check currently keys off a locale-specific placeholder string that doesn’t match the shipped template, and the “first message” check looks in a workspace-relative `../sessions` directory rather than the actual sessions/transcripts location under the OpenClaw state dir.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but the guide’s completion checks will be wrong for common user setups.
- The CLI wiring is straightforward, but two checks (IDENTITY.md customization and session transcript detection) are misaligned with the repo’s actual templates/storage paths, so the guide will report incorrect progress for many users until fixed.
- src/commands/guide.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->