### PR TITLE
fix: don't auto-create HEARTBEAT.md on workspace init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Heartbeat: stop auto-creating `HEARTBEAT.md` during workspace bootstrap so missing files continue to run heartbeat as documented. (#11766) Thanks @shadril238.
 - CLI: lazily load outbound provider dependencies and remove forced success-path exits so commands terminate naturally without killing intentional long-running foreground actions. (#12906) Thanks @DrCrinkle.
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.

--- a/src/agents/workspace.e2e.test.ts
+++ b/src/agents/workspace.e2e.test.ts
@@ -31,7 +31,9 @@ describe("ensureAgentWorkspace", () => {
     const result = await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
 
     await expect(fs.access(path.join(tempDir, DEFAULT_AGENTS_FILENAME))).resolves.toBeUndefined();
-    await expect(fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME))).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME)),
+    ).resolves.toBeUndefined();
     await expect(fs.access(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME))).rejects.toThrow();
     expect("heartbeatPath" in result).toBe(false);
   });

--- a/src/agents/workspace.e2e.test.ts
+++ b/src/agents/workspace.e2e.test.ts
@@ -1,9 +1,14 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_BOOTSTRAP_FILENAME,
+  DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
   DEFAULT_MEMORY_FILENAME,
+  ensureAgentWorkspace,
   loadWorkspaceBootstrapFiles,
   resolveDefaultAgentWorkspaceDir,
 } from "./workspace.js";
@@ -16,6 +21,19 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
     } as NodeJS.ProcessEnv);
 
     expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
+  });
+});
+
+describe("ensureAgentWorkspace", () => {
+  it("does not create HEARTBEAT.md during bootstrap file initialization", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-init-");
+
+    const result = await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expect(fs.access(path.join(tempDir, DEFAULT_AGENTS_FILENAME))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME))).rejects.toThrow();
+    expect("heartbeatPath" in result).toBe(false);
   });
 });
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -173,7 +173,6 @@ export async function ensureAgentWorkspace(params?: {
   toolsPath?: string;
   identityPath?: string;
   userPath?: string;
-  heartbeatPath?: string;
   bootstrapPath?: string;
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
@@ -189,11 +188,13 @@ export async function ensureAgentWorkspace(params?: {
   const toolsPath = path.join(dir, DEFAULT_TOOLS_FILENAME);
   const identityPath = path.join(dir, DEFAULT_IDENTITY_FILENAME);
   const userPath = path.join(dir, DEFAULT_USER_FILENAME);
-  const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME);
+  // HEARTBEAT.md is intentionally NOT created from template.
+  // Per docs: "If the file is missing, the heartbeat still runs and the model decides what to do."
+  // Creating it from template (which is effectively empty) would cause heartbeat to be skipped.
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
 
   const isBrandNewWorkspace = await (async () => {
-    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
+    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath];
     const existing = await Promise.all(
       paths.map(async (p) => {
         try {
@@ -212,7 +213,6 @@ export async function ensureAgentWorkspace(params?: {
   const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
   const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
-  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
 
   await writeFileIfMissing(agentsPath, agentsTemplate);
@@ -220,7 +220,6 @@ export async function ensureAgentWorkspace(params?: {
   await writeFileIfMissing(toolsPath, toolsTemplate);
   await writeFileIfMissing(identityPath, identityTemplate);
   await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
   if (isBrandNewWorkspace) {
     await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
   }
@@ -233,7 +232,6 @@ export async function ensureAgentWorkspace(params?: {
     toolsPath,
     identityPath,
     userPath,
-    heartbeatPath,
     bootstrapPath,
   };
 }


### PR DESCRIPTION
Fixes #11766
## Problem
Documentation states "If the file is missing, the heartbeat still runs and the model decides what to do." However, workspace initialization was auto-creating HEARTBEAT.md from a template containing only comments/headers, causing heartbeat to be silently disabled.
## Solution
Remove HEARTBEAT.md from workspace initialization. The file should only exist if the user explicitly creates it with tasks.
## Testing
- 32 heartbeat tests pass
- 12 workspace tests pass
- 16 agent-mutate tests pass
## Behavior After Fix
| Scenario | Before | After |
|----------|--------|-------|
| User deletes HEARTBEAT.md | File recreated, heartbeat skipped | File stays deleted, heartbeat runs |
| Empty HEARTBEAT.md | Skipped | Skipped (unchanged) |
| HEARTBEAT.md with tasks | Runs | Runs (unchanged) |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `ensureAgentWorkspace` (`src/agents/workspace.ts`) to stop auto-creating `HEARTBEAT.md` from the workspace templates during workspace initialization, aligning behavior with the docs (“if missing, heartbeat still runs”). It removes HEARTBEAT.md from the “brand new workspace” detection list and from the set of files written via `writeFileIfMissing`, while keeping other bootstrap files (AGENTS/SOUL/TOOLS/IDENTITY/USER and BOOTSTRAP on first init) unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and is narrowly scoped to workspace bootstrap behavior.
- Change is small and consistent with the stated behavior change (stop creating HEARTBEAT.md). The main remaining concern is a type/API mismatch: `ensureAgentWorkspace` still exposes `heartbeatPath`/heartbeat bootstrap naming even though the file is no longer created or returned, which can mislead callers and future changes.
- src/agents/workspace.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->