### PR TITLE
fix: normalize // to / for Matrix client escaped commands

### DIFF
--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -367,12 +367,17 @@ export function resolveCommandArgMenu(params: {
 
 export function normalizeCommandBody(raw: string, options?: CommandNormalizeOptions): string {
   const trimmed = raw.trim();
-  if (!trimmed.startsWith("/")) {
-    return trimmed;
+
+  // Matrix clients (Element, nheko) escape unrecognized slash commands as //command
+  // Normalize // to / at the start of the message to handle this
+  const unescaped = trimmed.startsWith("//") ? trimmed.slice(1) : trimmed;
+
+  if (!unescaped.startsWith("/")) {
+    return unescaped;
   }
 
-  const newline = trimmed.indexOf("\n");
-  const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
+  const newline = unescaped.indexOf("\n");
+  const singleLine = newline === -1 ? unescaped : unescaped.slice(0, newline).trim();
 
   const colonMatch = singleLine.match(/^\/([^\s:]+)\s*:(.*)$/);
   const normalized = colonMatch

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -15,8 +15,9 @@ export function extractModelDirective(
     return { cleaned: "", hasDirective: false };
   }
 
+  // Match /model or //model (Matrix clients escape unrecognized slash commands as //)
   const modelMatch = body.match(
-    /(?:^|\s)\/model(?=$|\s|:)\s*:?\s*([A-Za-z0-9_.:@-]+(?:\/[A-Za-z0-9_.:@-]+)*)?/i,
+    /(?:^|\s)\/\/?model(?=$|\s|:)\s*:?\s*([A-Za-z0-9_.:@-]+(?:\/[A-Za-z0-9_.:@-]+)*)?/i,
   );
 
   const aliases = (options?.aliases ?? []).map((alias) => alias.trim()).filter(Boolean);
@@ -24,8 +25,9 @@ export function extractModelDirective(
     modelMatch || aliases.length === 0
       ? null
       : body.match(
+          // Match /alias or //alias (Matrix clients escape unrecognized slash commands as //)
           new RegExp(
-            `(?:^|\\s)\\/(${aliases.map(escapeRegExp).join("|")})(?=$|\\s|:)(?:\\s*:\\s*)?`,
+            `(?:^|\\s)\\/\\/?(${aliases.map(escapeRegExp).join("|")})(?=$|\\s|:)(?:\\s*:\\s*)?`,
             "i",
           ),
         );


### PR DESCRIPTION
Servus Peter and hi to all others involved :)

I am using Matrix and immediately started modifying the code base immediately, since i think these changes would make sense upstream for others as well i am going for some PRs. To following was written bt openclaw (opus):

Matrix clients like Element and nheko escape unrecognized slash commands as //command (e.g., //status becomes //status). This change normalizes // back to / at the start of messages so these commands work correctly.

Affected areas:
- normalizeCommandBody() in commands-registry.ts
- extractModelDirective() regex patterns in model.ts (both /model and aliases)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates text-command parsing to accommodate Matrix clients that escape unknown slash commands by doubling the leading slash. Specifically:

- `normalizeCommandBody()` now rewrites a leading `//...` into `/...` before command detection/alias normalization.
- `extractModelDirective()` extends its `/model` and alias patterns to accept `//model` and `//<alias>`.

These changes fit into the auto-reply pipeline where inbound message bodies are normalized and then inspected for commands/directives (command registry + directive handling) before routing to model selection/behavior changes.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with a small risk of unintended directive matches due to the relaxed `//` regex patterns.
- The `normalizeCommandBody` change is localized and straightforward, but the updated `/model` + alias regexes can match whitespace-separated slash sequences (e.g. `/ /model`) which would change behavior for certain inputs. Also, the new Matrix normalization behavior is not covered by tests in the existing command-registry test suite.
- src/auto-reply/model.ts; src/auto-reply/commands-registry.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->