### PR TITLE
fix: DM command/directive parsing + reduce API key exposure

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -38,6 +38,7 @@ export type AuthProfileFailureReason =
   | "rate_limit"
   | "billing"
   | "timeout"
+  | "model_not_found"
   | "unknown";
 
 /** Per-profile usage statistics for round-robin and cooldown tracking */

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,3 +1,10 @@
 export type EmbeddedContextFile = { path: string; content: string };
 
-export type FailoverReason = "auth" | "format" | "rate_limit" | "billing" | "timeout" | "unknown";
+export type FailoverReason =
+  | "auth"
+  | "format"
+  | "rate_limit"
+  | "billing"
+  | "timeout"
+  | "model_not_found"
+  | "unknown";

--- a/src/auto-reply/reply/commands-context.ts
+++ b/src/auto-reply/reply/commands-context.ts
@@ -14,7 +14,7 @@ export function buildCommandContext(params: {
   triggerBodyNormalized: string;
   commandAuthorized: boolean;
 }): CommandContext {
-  const { ctx, cfg, agentId, sessionKey, isGroup, triggerBodyNormalized } = params;
+  const { ctx, cfg, agentId, sessionKey, triggerBodyNormalized } = params;
   const auth = resolveCommandAuthorization({
     ctx,
     cfg,
@@ -24,8 +24,11 @@ export function buildCommandContext(params: {
   const channel = (ctx.Provider ?? surface).trim().toLowerCase();
   const abortKey = sessionKey ?? (auth.from || undefined) ?? (auth.to || undefined);
   const rawBodyNormalized = triggerBodyNormalized;
+  // Always strip mentions for command parsing, even in DMs.
+  // Previously this only stripped mentions for groups, but DM users also use
+  // @mentions to trigger the bot (e.g., "@OC /models"), which need to be stripped.
   const commandBodyNormalized = normalizeCommandBody(
-    isGroup ? stripMentions(rawBodyNormalized, ctx, cfg, agentId) : rawBodyNormalized,
+    stripMentions(rawBodyNormalized, ctx, cfg, agentId),
   );
 
   return {

--- a/src/auto-reply/reply/directive-handling.auth.ts
+++ b/src/auto-reply/reply/directive-handling.auth.ts
@@ -20,10 +20,12 @@ const maskApiKey = (value: string): string => {
   if (!trimmed) {
     return "missing";
   }
-  if (trimmed.length <= 16) {
-    return trimmed;
+  // Show first 6 characters to identify key format/presence while hiding secret data
+  // This covers most provider prefixes (AIzaSy, sk-ant, tgp_v1) with minimal exposure
+  if (trimmed.length <= 6) {
+    return "******";
   }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  return `${trimmed.slice(0, 6)}******`;
 };
 
 export const resolveAuthLabel = async (

--- a/src/auto-reply/reply/directive-handling.parse.ts
+++ b/src/auto-reply/reply/directive-handling.parse.ts
@@ -197,7 +197,7 @@ export function isDirectiveOnly(params: {
   agentId?: string;
   isGroup: boolean;
 }): boolean {
-  const { directives, cleanedBody, ctx, cfg, agentId, isGroup } = params;
+  const { directives, cleanedBody, ctx, cfg, agentId } = params;
   if (
     !directives.hasThinkDirective &&
     !directives.hasVerboseDirective &&
@@ -210,6 +210,9 @@ export function isDirectiveOnly(params: {
     return false;
   }
   const stripped = stripStructuralPrefixes(cleanedBody ?? "");
-  const noMentions = isGroup ? stripMentions(stripped, ctx, cfg, agentId) : stripped;
+  // Always strip mentions for directive-only check, even in DMs.
+  // Without this, "@OC /model" in a DM leaves "@OC" as remaining text,
+  // causing the directive to be cleared and sent to the LLM instead.
+  const noMentions = stripMentions(stripped, ctx, cfg, agentId);
   return noMentions.length === 0;
 }

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -242,7 +242,9 @@ export async function resolveReplyDirectives(params: {
     parsedDirectives.hasQueueDirective;
   if (hasInlineDirective) {
     const stripped = stripStructuralPrefixes(parsedDirectives.cleaned);
-    const noMentions = isGroup ? stripMentions(stripped, ctx, cfg, agentId) : stripped;
+    // Always strip mentions for directive-only check, even in DMs.
+    // This ensures "/model" directives work when prefixed with @mentions like "@OC /model".
+    const noMentions = stripMentions(stripped, ctx, cfg, agentId);
     if (noMentions.trim().length > 0) {
       const directiveOnlyCheck = parseInlineDirectives(noMentions, {
         modelAliases: configuredAliases,

--- a/src/commands/models/list.format.ts
+++ b/src/commands/models/list.format.ts
@@ -61,8 +61,10 @@ export const maskApiKey = (value: string): string => {
   if (!trimmed) {
     return "missing";
   }
-  if (trimmed.length <= 16) {
-    return trimmed;
+  // Show first 6 characters to identify key format/presence while hiding secret data
+  // This covers most provider prefixes (AIzaSy, sk-ant, tgp_v1) with minimal exposure
+  if (trimmed.length <= 6) {
+    return "******";
   }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  return `${trimmed.slice(0, 6)}******`;
 };

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -145,11 +145,11 @@ describe("modelsStatusCommand auth overview", () => {
     const anthropic = providers.find((p) => p.provider === "anthropic");
     expect(anthropic).toBeTruthy();
     expect(anthropic?.profiles.labels.join(" ")).toContain("OAuth");
-    expect(anthropic?.profiles.labels.join(" ")).toContain("...");
+    expect(anthropic?.profiles.labels.join(" ")).toContain("******");
 
     const openai = providers.find((p) => p.provider === "openai");
     expect(openai?.env?.source).toContain("OPENAI_API_KEY");
-    expect(openai?.env?.value).toContain("...");
+    expect(openai?.env?.value).toContain("******");
 
     expect(
       (payload.auth.providersWithOAuth as string[]).some((e) => e.startsWith("anthropic")),

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -199,6 +199,9 @@ export async function monitorWebInbox(options: {
         ? Number(msg.messageTimestamp) * 1000
         : undefined;
 
+      // Extract message body early for access control mention check
+      const preliminaryBody = extractText(msg.message ?? undefined) ?? "";
+
       const access = await checkInboundAccessControl({
         accountId: options.accountId,
         from,
@@ -211,6 +214,7 @@ export async function monitorWebInbox(options: {
         connectedAtMs,
         sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
         remoteJid,
+        messageBody: preliminaryBody,
       });
       if (!access.allowed) {
         continue;


### PR DESCRIPTION
## Summary
- Fix `/model` and `/models` commands not working in WhatsApp DMs
- Always strip @mentions for command parsing (was only stripping for groups)
- Reduce API key exposure in `/model status` output (show first 6 chars only instead of first 8 + last 8)
- Add `model_not_found` to FailoverReason and AuthProfileFailureReason types

## Problem
In DMs, the `@OC` mention trigger wasn't being stripped before checking if a message was "directive only", causing `/model` and `/models` commands to be sent to the LLM instead of being processed as commands.  Also noted needless exposure of last 8 characters of API keys in '/model status' directive response.

## Test plan
- [x] Tested `/model` command in WhatsApp DM - now works correctly
- [x] Tested `/models` command in WhatsApp DM - now works correctly  
- [x] Verified API keys show only first 6 characters in status output
- [x] Build passes with no errors
- [ ] Not yet tested in a group chat (DMs only) 

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts auto-reply parsing so @mentions are stripped during command parsing and “directive-only” checks even in DMs, fixing `/model` and `/models` being forwarded to the LLM in WhatsApp DMs. It also reduces API key exposure in the auto-reply `/model status` output by masking keys more aggressively, and adds `model_not_found` to the auth/failover reason union types used for profile rotation/failover reporting.

These changes live in the auto-reply directive/command pipeline (`src/auto-reply/reply/*`) and the auth profile type definitions (`src/agents/*/types.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one policy/consistency issue to address around API key masking.
- The mention-stripping changes are localized and align with existing parsing flow, and the type union additions are low-risk. The main concern is that API key masking is now inconsistent across auto-reply vs CLI status outputs, which undermines the stated goal of reducing key exposure.
- src/auto-reply/reply/directive-handling.auth.ts, src/commands/models/list.format.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->