### PR TITLE
TTS voice bubbles, node role auth, media fixes, CI lint cleanup

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -178,6 +178,7 @@ actor TalkModeRuntime {
 
         self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
         self.recognitionRequest?.shouldReportPartialResults = true
+        self.recognitionRequest?.taskHint = .dictation
         guard let request = self.recognitionRequest else { return }
 
         if self.audioEngine == nil {

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -104,7 +104,11 @@ export type RunEmbeddedPiAgentParams = {
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onReasoningEnd?: () => void | Promise<void>;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  }) => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
   lane?: string;
   enqueue?: typeof enqueueCommand;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -1,10 +1,15 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { InlineCodeState } from "../markdown/code-spans.js";
+import type {
+  EmbeddedPiSubscribeContext,
+  EmbeddedPiSubscribeState,
+} from "./pi-embedded-subscribe.handlers.types.js";
+import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import {
@@ -12,12 +17,7 @@ import {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
-import type {
-  EmbeddedPiSubscribeContext,
-  EmbeddedPiSubscribeState,
-} from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
-import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
@@ -321,15 +321,16 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!params.onToolResult) {
       return;
     }
-    const { text: cleanedText, mediaUrls } = parseReplyDirectives(message);
+    const { text: cleanedText, mediaUrls, audioAsVoice } = parseReplyDirectives(message);
     const filteredMediaUrls = filterToolResultMediaUrls(toolName, mediaUrls ?? []);
-    if (!cleanedText && filteredMediaUrls.length === 0) {
+    if (!cleanedText && filteredMediaUrls.length === 0 && !audioAsVoice) {
       return;
     }
     try {
       void params.onToolResult({
         text: cleanedText,
         mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
+        audioAsVoice,
       });
     } catch {
       // ignore tool result delivery failures
@@ -345,11 +346,37 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!output) {
       return;
     }
+    // Parse directives from raw output BEFORE code-fence wrapping,
+    // since fenced code blocks prevent MEDIA/audioAsVoice extraction.
+    const rawDirectives = parseReplyDirectives(output);
     const agg = formatToolAggregate(toolName, meta ? [meta] : undefined, {
       markdown: useMarkdown,
     });
-    const message = `${agg}\n${formatToolOutputBlock(output)}`;
-    emitToolResultMessage(toolName, message);
+    const wrappedOutput = rawDirectives.text ? formatToolOutputBlock(rawDirectives.text) : "";
+    const message = wrappedOutput ? `${agg}\n${wrappedOutput}` : agg;
+    const {
+      text: cleanedText,
+      mediaUrls: aggMediaUrls,
+      audioAsVoice: aggAudioAsVoice,
+    } = parseReplyDirectives(message);
+    const mediaUrls = [...new Set([...(rawDirectives.mediaUrls ?? []), ...(aggMediaUrls ?? [])])];
+    const audioAsVoice = rawDirectives.audioAsVoice || aggAudioAsVoice;
+    const filteredMediaUrls = filterToolResultMediaUrls(toolName, mediaUrls);
+    if (!cleanedText && filteredMediaUrls.length === 0 && !audioAsVoice) {
+      return;
+    }
+    if (!params.onToolResult) {
+      return;
+    }
+    try {
+      void params.onToolResult({
+        text: cleanedText,
+        mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
+        audioAsVoice,
+      });
+    } catch {
+      // ignore tool result delivery failures
+    }
   };
 
   const stripBlockTags = (

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -16,7 +16,11 @@ export type SubscribeEmbeddedPiSessionParams = {
   toolResultFormat?: ToolResultFormat;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  }) => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */
   onReasoningEnd?: () => void | Promise<void>;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,5 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import type { TemplateContext } from "../templating.js";
+import type { VerboseLevel } from "../thinking.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { FollowupRun } from "./queue.js";
+import type { TypingSignaler } from "./typing-mode.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
@@ -28,24 +33,19 @@ import {
 } from "../../utils/message-channel.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
-import type { TemplateContext } from "../templating.js";
-import type { VerboseLevel } from "../thinking.js";
 import {
   HEARTBEAT_TOKEN,
   isSilentReplyPrefixText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
 } from "../tokens.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
-import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
-import type { TypingSignaler } from "./typing-mode.js";
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -439,6 +439,7 @@ export async function runAgentTurnWithFallback(params: {
                           await onToolResult({
                             text,
                             mediaUrls: payload.mediaUrls,
+                            audioAsVoice: payload.audioAsVoice,
                           });
                         })
                         .catch((err) => {

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -26,6 +26,26 @@ const NODE_ROLE_METHODS = new Set([
   "skills.bins",
 ]);
 
+// Methods that mobile/desktop node apps (iOS/Android/macOS) need for their
+// built-in chat UI. Allowed for both node and operator roles.
+const NODE_ALSO_ALLOWED = new Set([
+  "health",
+  "config.get",
+  "config.schema",
+  "chat.send",
+  "chat.history",
+  "chat.abort",
+  "voicewake.get",
+  "talk.mode",
+  "talk.config",
+  "sessions.list",
+  "sessions.preview",
+  "status",
+  "node.list",
+  "tts.status",
+  "tts.providers",
+]);
+
 const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
   [APPROVALS_SCOPE]: [
     "exec.approval.request",
@@ -165,6 +185,10 @@ export function isWriteMethod(method: string): boolean {
 
 export function isNodeRoleMethod(method: string): boolean {
   return NODE_ROLE_METHODS.has(method);
+}
+
+export function isNodeAlsoAllowedMethod(method: string): boolean {
+  return NODE_ALSO_ALLOWED.has(method);
 }
 
 export function isAdminOnlyMethod(method: string): boolean {

--- a/src/gateway/role-policy.ts
+++ b/src/gateway/role-policy.ts
@@ -1,4 +1,4 @@
-import { isNodeRoleMethod } from "./method-scopes.js";
+import { isNodeAlsoAllowedMethod, isNodeRoleMethod } from "./method-scopes.js";
 
 export const GATEWAY_ROLES = ["operator", "node"] as const;
 
@@ -18,6 +18,9 @@ export function roleCanSkipDeviceIdentity(role: GatewayRole, sharedAuthOk: boole
 export function isRoleAuthorizedForMethod(role: GatewayRole, method: string): boolean {
   if (isNodeRoleMethod(method)) {
     return role === "node";
+  }
+  if (isNodeAlsoAllowedMethod(method)) {
+    return true; // allowed for both node and operator
   }
   return role === "operator";
 }

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -1,17 +1,24 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-  collectProviderApiKeysForExecution,
-  executeWithApiKeyRotation,
-} from "../agents/api-key-rotation.js";
-import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { MsgContext } from "../auto-reply/templating.js";
-import { applyTemplate } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type {
   MediaUnderstandingConfig,
   MediaUnderstandingModelConfig,
 } from "../config/types.tools.js";
+import type {
+  MediaUnderstandingCapability,
+  MediaUnderstandingDecision,
+  MediaUnderstandingModelDecision,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
+import {
+  collectProviderApiKeysForExecution,
+  executeWithApiKeyRotation,
+} from "../agents/api-key-rotation.js";
+import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { applyTemplate } from "../auto-reply/templating.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -29,13 +36,6 @@ import { extractGeminiResponse } from "./output-extract.js";
 import { describeImageWithModel } from "./providers/image.js";
 import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./providers/index.js";
 import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
-import type {
-  MediaUnderstandingCapability,
-  MediaUnderstandingDecision,
-  MediaUnderstandingModelDecision,
-  MediaUnderstandingOutput,
-  MediaUnderstandingProvider,
-} from "./types.js";
 import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
 export type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
@@ -599,8 +599,29 @@ export async function runCliEntry(params: {
   const outputDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-cli-"),
   );
-  const mediaPath = pathResult.path;
+  let mediaPath = pathResult.path;
   const outputBase = path.join(outputDir, path.parse(mediaPath).name);
+
+  // whisper-cli only accepts WAV input; convert other audio formats via ffmpeg.
+  const cmdId = commandBase(command);
+  if ((cmdId === "whisper-cli" || cmdId === "whisper") && !mediaPath.endsWith(".wav")) {
+    const wavPath = path.join(outputDir, `${path.parse(mediaPath).name}.wav`);
+    try {
+      await runExec(
+        "ffmpeg",
+        ["-y", "-i", mediaPath, "-ar", "16000", "-ac", "1", "-f", "wav", wavPath],
+        {
+          timeoutMs: 30_000,
+        },
+      );
+      mediaPath = wavPath;
+    } catch (convErr) {
+      // ffmpeg not available or conversion failed; proceed with original path
+      if (shouldLogVerbose()) {
+        logVerbose(`ffmpeg conversion failed, proceeding with original: ${String(convErr)}`);
+      }
+    }
+  }
 
   const templCtx: MsgContext = {
     ...ctx,

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import { fileTypeFromBuffer } from "file-type";
+import path from "node:path";
 import { type MediaKind, mediaKindFromMime } from "./constants.js";
 
 // Map common mimes to preferred file extensions.
@@ -11,6 +11,7 @@ const EXT_BY_MIME: Record<string, string> = {
   "image/webp": ".webp",
   "image/gif": ".gif",
   "audio/ogg": ".ogg",
+  "audio/opus": ".opus",
   "audio/mpeg": ".mp3",
   "audio/x-m4a": ".m4a",
   "audio/mp4": ".m4a",


### PR DESCRIPTION
## Summary

- **Gateway: allow node role to call UI methods** — Mac/iOS apps connect as `role: "node"` but need `config.get`, `config.schema`, `chat.send`, `talk.mode`, etc. for Settings and Talk Mode to function. Adds a `NODE_ALSO_ALLOWED` whitelist in `server-methods.ts`.
- **macOS: set speech recognition `taskHint` for Talk Mode** — adds `.dictation` hint to `SFSpeechAudioBufferRecognitionRequest`, matching Voice Wake.
- **Media: auto-convert non-WAV audio to WAV for whisper-cli** — Telegram voice notes arrive as OGG Opus; adds an ffmpeg conversion step so local whisper.cpp transcription works.
- **TTS: deliver tool audio as Telegram voice bubble** — fixes `isValidMedia()` rejecting absolute temp paths and plumbs the `audioAsVoice` flag through the full `onToolResult` callback chain. Adds `audio/opus` MIME mapping.
- **Security: block symlink traversal in media loading** — resolves symlinks via `fs.realpath()` before reading local media files to prevent exfiltration outside temp directories.
- **Extract binary-resolution utilities from runner.ts** — moves `findBinary`/`hasBinary`/`fileExists` to `runner-binary.ts` to fix CI code-size check.
- **Fix symlink traversal check for Windows temp paths** — `fs.realpath()` resolves Windows 8.3 short names, causing false rejections; uses `os.tmpdir()` resolved through realpath as baseline.
- **Fix CI: SwiftLint + docker-setup test** — exclude generated `GatewayModels.swift` from SwiftLint, resolve bash path cross-platform in docker-setup test, extract helpers to reduce cyclomatic complexity and function body length warnings.

## Security

`isValidMedia()` allows absolute paths only under:
- `os.tmpdir()` (cross-platform, handles Windows 8.3 names)
- `/tmp/`, `/private/tmp/` (Unix standard)
- `/var/folders/<xx>/<hash>/T/` (macOS temp only — not `/C/` caches or `/0/` cleanup)

Symlinks are resolved before the prefix check. All original LFI rejection tests pass unchanged.

## Test plan

- [x] `pnpm build` — no type errors
- [x] `vitest run src/media/parse.test.ts` — 11/11 passing
- [x] `vitest run src/docker-setup.test.ts` — 5/5 passing
- [x] `swiftlint` — 0 warnings, 0 errors
- [x] Telegram voice bubble confirmed on device
- [x] LFI paths (`/etc/passwd`, `/Users/...`, `~/...`, `../../`) still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)