### PR TITLE
feat(telegram): add groupPolicy "members" mode

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -133,7 +133,7 @@ Control how group/room messages are handled per channel:
 {
   channels: {
     whatsapp: {
-      groupPolicy: "disabled", // "open" | "disabled" | "allowlist"
+      groupPolicy: "disabled", // "open" | "disabled" | "allowlist" | "members"
       groupAllowFrom: ["+15551234567"],
     },
     telegram: {
@@ -174,11 +174,12 @@ Control how group/room messages are handled per channel:
 }
 ```
 
-| Policy        | Behavior                                                     |
-| ------------- | ------------------------------------------------------------ |
-| `"open"`      | Groups bypass allowlists; mention-gating still applies.      |
-| `"disabled"`  | Block all group messages entirely.                           |
-| `"allowlist"` | Only allow groups/rooms that match the configured allowlist. |
+| Policy        | Behavior                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------ |
+| `"open"`      | Groups bypass allowlists; mention-gating still applies.                                          |
+| `"disabled"`  | Block all group messages entirely.                                                               |
+| `"allowlist"` | Only allow groups/rooms that match the configured allowlist.                                     |
+| `"members"`   | Verify all group members are in the trusted `groupAllowFrom` list (Telegram only; cached 5 min). |
 
 Notes:
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -143,6 +143,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
        - `open`
        - `allowlist` (default)
        - `disabled`
+       - `members` — verify all group members are in `groupAllowFrom` (cached 5 min, invalidated on join/leave)
 
     `groupAllowFrom` is used for group sender filtering. If not set, Telegram falls back to `allowFrom`.
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -26,11 +26,12 @@ All channels support DM policies and group policies:
 | `open`              | Allow all inbound DMs (requires `allowFrom: ["*"]`)             |
 | `disabled`          | Ignore all inbound DMs                                          |
 
-| Group policy          | Behavior                                               |
-| --------------------- | ------------------------------------------------------ |
-| `allowlist` (default) | Only groups matching the configured allowlist          |
-| `open`                | Bypass group allowlists (mention-gating still applies) |
-| `disabled`            | Block all group/room messages                          |
+| Group policy          | Behavior                                                                          |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `allowlist` (default) | Only groups matching the configured allowlist                                     |
+| `open`                | Bypass group allowlists (mention-gating still applies)                            |
+| `disabled`            | Block all group/room messages                                                     |
+| `members`             | Verify all group members are in the trusted `groupAllowFrom` list (Telegram only) |
 
 <Note>
 `channels.defaults.groupPolicy` sets the default when a provider's `groupPolicy` is unset.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -23,7 +23,7 @@ It flags common footguns (Gateway auth exposure, browser control exposure, eleva
 
 `--fix` applies safe guardrails:
 
-- Tighten `groupPolicy="open"` to `groupPolicy="allowlist"` (and per-account variants) for common channels.
+- Tighten `groupPolicy="open"` to `groupPolicy="allowlist"` or `"members"` (and per-account variants) for common channels.
 - Turn `logging.redactSensitive="off"` back to `"tools"`.
 - Tighten local perms (`~/.openclaw` → `700`, config file → `600`, plus common state files like `credentials/*.json`, `agents/*/agent/auth-profiles.json`, and `agents/*/sessions/sessions.json`).
 

--- a/src/channels/plugins/onboarding/channel-access.ts
+++ b/src/channels/plugins/onboarding/channel-access.ts
@@ -1,6 +1,6 @@
 import type { WizardPrompter } from "../../../wizard/prompts.js";
 
-export type ChannelAccessPolicy = "allowlist" | "open" | "disabled";
+export type ChannelAccessPolicy = "allowlist" | "open" | "disabled" | "members";
 
 export function parseAllowlistEntries(raw: string): string[] {
   return String(raw ?? "")

--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -57,7 +57,7 @@ async function noteDiscordTokenHelp(prompter: WizardPrompter): Promise<void> {
 function setDiscordGroupPolicy(
   cfg: OpenClawConfig,
   accountId: string,
-  groupPolicy: "open" | "allowlist" | "disabled",
+  groupPolicy: "open" | "allowlist" | "disabled" | "members",
 ): OpenClawConfig {
   if (accountId === DEFAULT_ACCOUNT_ID) {
     return {

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -127,7 +127,7 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
 function setSlackGroupPolicy(
   cfg: OpenClawConfig,
   accountId: string,
-  groupPolicy: "open" | "allowlist" | "disabled",
+  groupPolicy: "open" | "allowlist" | "disabled" | "members",
 ): OpenClawConfig {
   if (accountId === DEFAULT_ACCOUNT_ID) {
     return {

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -5,7 +5,7 @@ export type TypingMode = "never" | "instant" | "thinking" | "message";
 export type SessionScope = "per-sender" | "global";
 export type DmScope = "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
 export type ReplyToMode = "off" | "first" | "all";
-export type GroupPolicy = "open" | "disabled" | "allowlist";
+export type GroupPolicy = "open" | "disabled" | "allowlist" | "members";
 export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
 
 export type OutboundRetryConfig = {

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -20,6 +20,8 @@ export type ChannelHeartbeatVisibilityConfig = {
 
 export type ChannelDefaultsConfig = {
   groupPolicy?: GroupPolicy;
+  /** Default groupAllowFrom for all channels. Per-account groupAllowFrom overrides this. */
+  groupAllowFrom?: Array<string | number>;
   /** Default heartbeat visibility for all channels. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
 };

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -78,6 +78,8 @@ export type TelegramAccountConfig = {
    * - "open": groups bypass allowFrom, only mention-gating applies
    * - "disabled": block all group messages entirely
    * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+   * - "members": like "allowlist" sender check, plus verifies ALL group members are trusted
+   *   (calls Telegram API to confirm no untrusted members; cached 5 min, invalidated on join/leave)
    */
   groupPolicy?: GroupPolicy;
   /** Max group messages to keep as history context (0 disables). */

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -78,7 +78,7 @@ export type TelegramAccountConfig = {
    * - "open": groups bypass allowFrom, only mention-gating applies
    * - "disabled": block all group messages entirely
    * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
-   * - "members": like "allowlist" sender check, plus verifies ALL group members are trusted
+   * - "members": verifies ALL group members are in the trusted allowFrom list
    *   (calls Telegram API to confirm no untrusted members; cached 5 min, invalidated on join/leave)
    */
   groupPolicy?: GroupPolicy;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -124,7 +124,7 @@ export const ReplyToModeSchema = z.union([z.literal("off"), z.literal("first"), 
 // Used with .default("allowlist").optional() pattern:
 //   - .optional() allows field omission in input config
 //   - .default("allowlist") ensures runtime always resolves to "allowlist" if not provided
-export const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"]);
+export const GroupPolicySchema = z.enum(["open", "disabled", "allowlist", "members"]);
 
 export const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled"]);
 

--- a/src/config/zod-schema.providers.ts
+++ b/src/config/zod-schema.providers.ts
@@ -23,6 +23,7 @@ export const ChannelsSchema = z
     defaults: z
       .object({
         groupPolicy: GroupPolicySchema.optional(),
+        groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
         heartbeat: ChannelHeartbeatVisibilitySchema,
       })
       .strict()

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -428,7 +428,7 @@ export function isDiscordAutoThreadOwnedByBot(params: {
 }
 
 export function isDiscordGroupAllowedByPolicy(params: {
-  groupPolicy: "open" | "disabled" | "allowlist";
+  groupPolicy: "open" | "disabled" | "allowlist" | "members";
   guildAllowlisted: boolean;
   channelAllowlistConfigured: boolean;
   channelAllowed: boolean;

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -29,7 +29,7 @@ export type DiscordMessagePreflightContext = {
   textLimit: number;
   replyToMode: ReplyToMode;
   ackReactionScope: "all" | "direct" | "group-all" | "group-mentions";
-  groupPolicy: "open" | "disabled" | "allowlist";
+  groupPolicy: "open" | "disabled" | "allowlist" | "members";
 
   data: DiscordMessageEvent;
   client: Client;

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -174,9 +174,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const sentMessageCache = new SentMessageCache();
   const textLimit = resolveTextChunkLimit(cfg, "imessage", accountInfo.accountId);
   const allowFrom = normalizeAllowList(opts.allowFrom ?? imessageCfg.allowFrom);
+  const defaultGroupAllowFrom = cfg.channels?.defaults?.groupAllowFrom;
   const groupAllowFrom = normalizeAllowList(
     opts.groupAllowFrom ??
       imessageCfg.groupAllowFrom ??
+      defaultGroupAllowFrom ??
       (imessageCfg.allowFrom && imessageCfg.allowFrom.length > 0 ? imessageCfg.allowFrom : []),
   );
   const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -667,7 +667,7 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
       detail:
         `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
         "With tools.elevated enabled, a prompt injection in those rooms can become a high-impact incident.",
-      remediation: `Set groupPolicy="allowlist" and keep elevated allowlists extremely tight.`,
+      remediation: `Set groupPolicy="allowlist" or "members" and keep elevated allowlists extremely tight.`,
     });
   }
 

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -1,30 +1,1305 @@
-/**
- * Re-export barrel for security audit collector functions.
- *
- * Maintains backward compatibility with existing imports from audit-extra.
- * Implementation split into:
- * - audit-extra.sync.ts: Config-based checks (no I/O)
- * - audit-extra.async.ts: Filesystem/plugin checks (async I/O)
- */
+import JSON5 from "json5";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { SandboxToolPolicy } from "../agents/sandbox/types.js";
+import type { OpenClawConfig, ConfigFileSnapshot } from "../config/config.js";
+import type { AgentToolsConfig } from "../config/types.tools.js";
+import type { ExecFn } from "./windows-acl.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { isToolAllowedByPolicies } from "../agents/pi-tools.policy.js";
+import {
+  resolveSandboxConfigForAgent,
+  resolveSandboxToolPolicyForAgent,
+} from "../agents/sandbox.js";
+import { loadWorkspaceSkillEntries } from "../agents/skills.js";
+import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
+import { resolveBrowserConfig } from "../browser/config.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import { resolveNativeSkillsEnabled } from "../config/commands.js";
+import { createConfigIO } from "../config/config.js";
+import { INCLUDE_KEY, MAX_INCLUDE_DEPTH } from "../config/includes.js";
+import { resolveOAuthDir } from "../config/paths.js";
+import { resolveGatewayAuth } from "../gateway/auth.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import {
+  formatPermissionDetail,
+  formatPermissionRemediation,
+  inspectPathPermissions,
+  safeStat,
+} from "./audit-fs.js";
+import { scanDirectoryWithSummary, type SkillScanFinding } from "./skill-scanner.js";
 
-// Sync collectors
-export {
-  collectAttackSurfaceSummaryFindings,
-  collectExposureMatrixFindings,
-  collectHooksHardeningFindings,
-  collectModelHygieneFindings,
-  collectSecretsInConfigFindings,
-  collectSmallModelRiskFindings,
-  collectSyncedFolderFindings,
-  type SecurityAuditFinding,
-} from "./audit-extra.sync.js";
+export type SecurityAuditFinding = {
+  checkId: string;
+  severity: "info" | "warn" | "critical";
+  title: string;
+  detail: string;
+  remediation?: string;
+};
 
-// Async collectors
-export {
-  collectIncludeFilePermFindings,
-  collectInstalledSkillsCodeSafetyFindings,
-  collectPluginsCodeSafetyFindings,
-  collectPluginsTrustFindings,
-  collectStateDeepFilesystemFindings,
-  readConfigSnapshotForAudit,
-} from "./audit-extra.async.js";
+const SMALL_MODEL_PARAM_B_MAX = 300;
+
+function expandTilde(p: string, env: NodeJS.ProcessEnv): string | null {
+  if (!p.startsWith("~")) {
+    return p;
+  }
+  const home = typeof env.HOME === "string" && env.HOME.trim() ? env.HOME.trim() : null;
+  if (!home) {
+    return null;
+  }
+  if (p === "~") {
+    return home;
+  }
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return path.join(home, p.slice(2));
+  }
+  return null;
+}
+
+function summarizeGroupPolicy(cfg: OpenClawConfig): {
+  open: number;
+  allowlist: number;
+  other: number;
+} {
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  if (!channels || typeof channels !== "object") {
+    return { open: 0, allowlist: 0, other: 0 };
+  }
+  let open = 0;
+  let allowlist = 0;
+  let other = 0;
+  for (const value of Object.values(channels)) {
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+    const section = value as Record<string, unknown>;
+    const policy = section.groupPolicy;
+    if (policy === "open") {
+      open += 1;
+    } else if (policy === "allowlist") {
+      allowlist += 1;
+    } else {
+      other += 1;
+    }
+  }
+  return { open, allowlist, other };
+}
+
+export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const group = summarizeGroupPolicy(cfg);
+  const elevated = cfg.tools?.elevated?.enabled !== false;
+  const hooksEnabled = cfg.hooks?.enabled === true;
+  const browserEnabled = cfg.browser?.enabled ?? true;
+
+  const detail =
+    `groups: open=${group.open}, allowlist=${group.allowlist}` +
+    `\n` +
+    `tools.elevated: ${elevated ? "enabled" : "disabled"}` +
+    `\n` +
+    `hooks: ${hooksEnabled ? "enabled" : "disabled"}` +
+    `\n` +
+    `browser control: ${browserEnabled ? "enabled" : "disabled"}`;
+
+  return [
+    {
+      checkId: "summary.attack_surface",
+      severity: "info",
+      title: "Attack surface summary",
+      detail,
+    },
+  ];
+}
+
+function isProbablySyncedPath(p: string): boolean {
+  const s = p.toLowerCase();
+  return (
+    s.includes("icloud") ||
+    s.includes("dropbox") ||
+    s.includes("google drive") ||
+    s.includes("googledrive") ||
+    s.includes("onedrive")
+  );
+}
+
+export function collectSyncedFolderFindings(params: {
+  stateDir: string;
+  configPath: string;
+}): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  if (isProbablySyncedPath(params.stateDir) || isProbablySyncedPath(params.configPath)) {
+    findings.push({
+      checkId: "fs.synced_dir",
+      severity: "warn",
+      title: "State/config path looks like a synced folder",
+      detail: `stateDir=${params.stateDir}, configPath=${params.configPath}. Synced folders (iCloud/Dropbox/OneDrive/Google Drive) can leak tokens and transcripts onto other devices.`,
+      remediation: `Keep OPENCLAW_STATE_DIR on a local-only volume and re-run "${formatCliCommand("openclaw security audit --fix")}".`,
+    });
+  }
+  return findings;
+}
+
+function looksLikeEnvRef(value: string): boolean {
+  const v = value.trim();
+  return v.startsWith("${") && v.endsWith("}");
+}
+
+export function collectSecretsInConfigFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  const password =
+    typeof cfg.gateway?.auth?.password === "string" ? cfg.gateway.auth.password.trim() : "";
+  if (password && !looksLikeEnvRef(password)) {
+    findings.push({
+      checkId: "config.secrets.gateway_password_in_config",
+      severity: "warn",
+      title: "Gateway password is stored in config",
+      detail:
+        "gateway.auth.password is set in the config file; prefer environment variables for secrets when possible.",
+      remediation:
+        "Prefer OPENCLAW_GATEWAY_PASSWORD (env) and remove gateway.auth.password from disk.",
+    });
+  }
+
+  const hooksToken = typeof cfg.hooks?.token === "string" ? cfg.hooks.token.trim() : "";
+  if (cfg.hooks?.enabled === true && hooksToken && !looksLikeEnvRef(hooksToken)) {
+    findings.push({
+      checkId: "config.secrets.hooks_token_in_config",
+      severity: "info",
+      title: "Hooks token is stored in config",
+      detail:
+        "hooks.token is set in the config file; keep config perms tight and treat it like an API secret.",
+    });
+  }
+
+  return findings;
+}
+
+export function collectHooksHardeningFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  if (cfg.hooks?.enabled !== true) {
+    return findings;
+  }
+
+  const token = typeof cfg.hooks?.token === "string" ? cfg.hooks.token.trim() : "";
+  if (token && token.length < 24) {
+    findings.push({
+      checkId: "hooks.token_too_short",
+      severity: "warn",
+      title: "Hooks token looks short",
+      detail: `hooks.token is ${token.length} chars; prefer a long random token.`,
+    });
+  }
+
+  const gatewayAuth = resolveGatewayAuth({
+    authConfig: cfg.gateway?.auth,
+    tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
+  });
+  const gatewayToken =
+    gatewayAuth.mode === "token" &&
+    typeof gatewayAuth.token === "string" &&
+    gatewayAuth.token.trim()
+      ? gatewayAuth.token.trim()
+      : null;
+  if (token && gatewayToken && token === gatewayToken) {
+    findings.push({
+      checkId: "hooks.token_reuse_gateway_token",
+      severity: "warn",
+      title: "Hooks token reuses the Gateway token",
+      detail:
+        "hooks.token matches gateway.auth token; compromise of hooks expands blast radius to the Gateway API.",
+      remediation: "Use a separate hooks.token dedicated to hook ingress.",
+    });
+  }
+
+  const rawPath = typeof cfg.hooks?.path === "string" ? cfg.hooks.path.trim() : "";
+  if (rawPath === "/") {
+    findings.push({
+      checkId: "hooks.path_root",
+      severity: "critical",
+      title: "Hooks base path is '/'",
+      detail: "hooks.path='/' would shadow other HTTP endpoints and is unsafe.",
+      remediation: "Use a dedicated path like '/hooks'.",
+    });
+  }
+
+  return findings;
+}
+
+type ModelRef = { id: string; source: string };
+
+function addModel(models: ModelRef[], raw: unknown, source: string) {
+  if (typeof raw !== "string") {
+    return;
+  }
+  const id = raw.trim();
+  if (!id) {
+    return;
+  }
+  models.push({ id, source });
+}
+
+function collectModels(cfg: OpenClawConfig): ModelRef[] {
+  const out: ModelRef[] = [];
+  addModel(out, cfg.agents?.defaults?.model?.primary, "agents.defaults.model.primary");
+  for (const f of cfg.agents?.defaults?.model?.fallbacks ?? []) {
+    addModel(out, f, "agents.defaults.model.fallbacks");
+  }
+  addModel(out, cfg.agents?.defaults?.imageModel?.primary, "agents.defaults.imageModel.primary");
+  for (const f of cfg.agents?.defaults?.imageModel?.fallbacks ?? []) {
+    addModel(out, f, "agents.defaults.imageModel.fallbacks");
+  }
+
+  const list = Array.isArray(cfg.agents?.list) ? cfg.agents?.list : [];
+  for (const agent of list ?? []) {
+    if (!agent || typeof agent !== "object") {
+      continue;
+    }
+    const id =
+      typeof (agent as { id?: unknown }).id === "string" ? (agent as { id: string }).id : "";
+    const model = (agent as { model?: unknown }).model;
+    if (typeof model === "string") {
+      addModel(out, model, `agents.list.${id}.model`);
+    } else if (model && typeof model === "object") {
+      addModel(out, (model as { primary?: unknown }).primary, `agents.list.${id}.model.primary`);
+      const fallbacks = (model as { fallbacks?: unknown }).fallbacks;
+      if (Array.isArray(fallbacks)) {
+        for (const f of fallbacks) {
+          addModel(out, f, `agents.list.${id}.model.fallbacks`);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+const LEGACY_MODEL_PATTERNS: Array<{ id: string; re: RegExp; label: string }> = [
+  { id: "openai.gpt35", re: /\bgpt-3\.5\b/i, label: "GPT-3.5 family" },
+  { id: "anthropic.claude2", re: /\bclaude-(instant|2)\b/i, label: "Claude 2/Instant family" },
+  { id: "openai.gpt4_legacy", re: /\bgpt-4-(0314|0613)\b/i, label: "Legacy GPT-4 snapshots" },
+];
+
+const WEAK_TIER_MODEL_PATTERNS: Array<{ id: string; re: RegExp; label: string }> = [
+  { id: "anthropic.haiku", re: /\bhaiku\b/i, label: "Haiku tier (smaller model)" },
+];
+
+function inferParamBFromIdOrName(text: string): number | null {
+  const raw = text.toLowerCase();
+  const matches = raw.matchAll(/(?:^|[^a-z0-9])[a-z]?(\d+(?:\.\d+)?)b(?:[^a-z0-9]|$)/g);
+  let best: number | null = null;
+  for (const match of matches) {
+    const numRaw = match[1];
+    if (!numRaw) {
+      continue;
+    }
+    const value = Number(numRaw);
+    if (!Number.isFinite(value) || value <= 0) {
+      continue;
+    }
+    if (best === null || value > best) {
+      best = value;
+    }
+  }
+  return best;
+}
+
+function isGptModel(id: string): boolean {
+  return /\bgpt-/i.test(id);
+}
+
+function isGpt5OrHigher(id: string): boolean {
+  return /\bgpt-5(?:\b|[.-])/i.test(id);
+}
+
+function isClaudeModel(id: string): boolean {
+  return /\bclaude-/i.test(id);
+}
+
+function isClaude45OrHigher(id: string): boolean {
+  // Match claude-*-4-5+, claude-*-45+, claude-*4.5+, or future 5.x+ majors.
+  // Examples that should match:
+  //   claude-opus-4-5, claude-opus-4-6, claude-opus-45, claude-4.6, claude-sonnet-5
+  return /\bclaude-[^\s/]*?(?:-4-?(?:[5-9]|[1-9]\d)\b|4\.(?:[5-9]|[1-9]\d)\b|-[5-9](?:\b|[.-]))/i.test(
+    id,
+  );
+}
+
+export function collectModelHygieneFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  const models = collectModels(cfg);
+  if (models.length === 0) {
+    return findings;
+  }
+
+  const weakMatches = new Map<string, { model: string; source: string; reasons: string[] }>();
+  const addWeakMatch = (model: string, source: string, reason: string) => {
+    const key = `${model}@@${source}`;
+    const existing = weakMatches.get(key);
+    if (!existing) {
+      weakMatches.set(key, { model, source, reasons: [reason] });
+      return;
+    }
+    if (!existing.reasons.includes(reason)) {
+      existing.reasons.push(reason);
+    }
+  };
+
+  for (const entry of models) {
+    for (const pat of WEAK_TIER_MODEL_PATTERNS) {
+      if (pat.re.test(entry.id)) {
+        addWeakMatch(entry.id, entry.source, pat.label);
+        break;
+      }
+    }
+    if (isGptModel(entry.id) && !isGpt5OrHigher(entry.id)) {
+      addWeakMatch(entry.id, entry.source, "Below GPT-5 family");
+    }
+    if (isClaudeModel(entry.id) && !isClaude45OrHigher(entry.id)) {
+      addWeakMatch(entry.id, entry.source, "Below Claude 4.5");
+    }
+  }
+
+  const matches: Array<{ model: string; source: string; reason: string }> = [];
+  for (const entry of models) {
+    for (const pat of LEGACY_MODEL_PATTERNS) {
+      if (pat.re.test(entry.id)) {
+        matches.push({ model: entry.id, source: entry.source, reason: pat.label });
+        break;
+      }
+    }
+  }
+
+  if (matches.length > 0) {
+    const lines = matches
+      .slice(0, 12)
+      .map((m) => `- ${m.model} (${m.reason}) @ ${m.source}`)
+      .join("\n");
+    const more = matches.length > 12 ? `\n…${matches.length - 12} more` : "";
+    findings.push({
+      checkId: "models.legacy",
+      severity: "warn",
+      title: "Some configured models look legacy",
+      detail:
+        "Older/legacy models can be less robust against prompt injection and tool misuse.\n" +
+        lines +
+        more,
+      remediation: "Prefer modern, instruction-hardened models for any bot that can run tools.",
+    });
+  }
+
+  if (weakMatches.size > 0) {
+    const lines = Array.from(weakMatches.values())
+      .slice(0, 12)
+      .map((m) => `- ${m.model} (${m.reasons.join("; ")}) @ ${m.source}`)
+      .join("\n");
+    const more = weakMatches.size > 12 ? `\n…${weakMatches.size - 12} more` : "";
+    findings.push({
+      checkId: "models.weak_tier",
+      severity: "warn",
+      title: "Some configured models are below recommended tiers",
+      detail:
+        "Smaller/older models are generally more susceptible to prompt injection and tool misuse.\n" +
+        lines +
+        more,
+      remediation:
+        "Use the latest, top-tier model for any bot with tools or untrusted inboxes. Avoid Haiku tiers; prefer GPT-5+ and Claude 4.5+.",
+    });
+  }
+
+  return findings;
+}
+
+function extractAgentIdFromSource(source: string): string | null {
+  const match = source.match(/^agents\.list\.([^.]*)\./);
+  return match?.[1] ?? null;
+}
+
+function pickToolPolicy(config?: { allow?: string[]; deny?: string[] }): SandboxToolPolicy | null {
+  if (!config) {
+    return null;
+  }
+  const allow = Array.isArray(config.allow) ? config.allow : undefined;
+  const deny = Array.isArray(config.deny) ? config.deny : undefined;
+  if (!allow && !deny) {
+    return null;
+  }
+  return { allow, deny };
+}
+
+function resolveToolPolicies(params: {
+  cfg: OpenClawConfig;
+  agentTools?: AgentToolsConfig;
+  sandboxMode?: "off" | "non-main" | "all";
+  agentId?: string | null;
+}): SandboxToolPolicy[] {
+  const policies: SandboxToolPolicy[] = [];
+  const profile = params.agentTools?.profile ?? params.cfg.tools?.profile;
+  const profilePolicy = resolveToolProfilePolicy(profile);
+  if (profilePolicy) {
+    policies.push(profilePolicy);
+  }
+
+  const globalPolicy = pickToolPolicy(params.cfg.tools ?? undefined);
+  if (globalPolicy) {
+    policies.push(globalPolicy);
+  }
+
+  const agentPolicy = pickToolPolicy(params.agentTools);
+  if (agentPolicy) {
+    policies.push(agentPolicy);
+  }
+
+  if (params.sandboxMode === "all") {
+    const sandboxPolicy = resolveSandboxToolPolicyForAgent(params.cfg, params.agentId ?? undefined);
+    policies.push(sandboxPolicy);
+  }
+
+  return policies;
+}
+
+function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
+  const search = cfg.tools?.web?.search;
+  return Boolean(
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.OPENROUTER_API_KEY,
+  );
+}
+
+function isWebSearchEnabled(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
+  const enabled = cfg.tools?.web?.search?.enabled;
+  if (enabled === false) {
+    return false;
+  }
+  if (enabled === true) {
+    return true;
+  }
+  return hasWebSearchKey(cfg, env);
+}
+
+function isWebFetchEnabled(cfg: OpenClawConfig): boolean {
+  const enabled = cfg.tools?.web?.fetch?.enabled;
+  if (enabled === false) {
+    return false;
+  }
+  return true;
+}
+
+function isBrowserEnabled(cfg: OpenClawConfig): boolean {
+  try {
+    return resolveBrowserConfig(cfg.browser, cfg).enabled;
+  } catch {
+    return true;
+  }
+}
+
+export function collectSmallModelRiskFindings(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  const models = collectModels(params.cfg).filter((entry) => !entry.source.includes("imageModel"));
+  if (models.length === 0) {
+    return findings;
+  }
+
+  const smallModels = models
+    .map((entry) => {
+      const paramB = inferParamBFromIdOrName(entry.id);
+      if (!paramB || paramB > SMALL_MODEL_PARAM_B_MAX) {
+        return null;
+      }
+      return { ...entry, paramB };
+    })
+    .filter((entry): entry is { id: string; source: string; paramB: number } => Boolean(entry));
+
+  if (smallModels.length === 0) {
+    return findings;
+  }
+
+  let hasUnsafe = false;
+  const modelLines: string[] = [];
+  const exposureSet = new Set<string>();
+  for (const entry of smallModels) {
+    const agentId = extractAgentIdFromSource(entry.source);
+    const sandboxMode = resolveSandboxConfigForAgent(params.cfg, agentId ?? undefined).mode;
+    const agentTools =
+      agentId && params.cfg.agents?.list
+        ? params.cfg.agents.list.find((agent) => agent?.id === agentId)?.tools
+        : undefined;
+    const policies = resolveToolPolicies({
+      cfg: params.cfg,
+      agentTools,
+      sandboxMode,
+      agentId,
+    });
+    const exposed: string[] = [];
+    if (isWebSearchEnabled(params.cfg, params.env)) {
+      if (isToolAllowedByPolicies("web_search", policies)) {
+        exposed.push("web_search");
+      }
+    }
+    if (isWebFetchEnabled(params.cfg)) {
+      if (isToolAllowedByPolicies("web_fetch", policies)) {
+        exposed.push("web_fetch");
+      }
+    }
+    if (isBrowserEnabled(params.cfg)) {
+      if (isToolAllowedByPolicies("browser", policies)) {
+        exposed.push("browser");
+      }
+    }
+    for (const tool of exposed) {
+      exposureSet.add(tool);
+    }
+    const sandboxLabel = sandboxMode === "all" ? "sandbox=all" : `sandbox=${sandboxMode}`;
+    const exposureLabel = exposed.length > 0 ? ` web=[${exposed.join(", ")}]` : " web=[off]";
+    const safe = sandboxMode === "all" && exposed.length === 0;
+    if (!safe) {
+      hasUnsafe = true;
+    }
+    const statusLabel = safe ? "ok" : "unsafe";
+    modelLines.push(
+      `- ${entry.id} (${entry.paramB}B) @ ${entry.source} (${statusLabel}; ${sandboxLabel};${exposureLabel})`,
+    );
+  }
+
+  const exposureList = Array.from(exposureSet);
+  const exposureDetail =
+    exposureList.length > 0
+      ? `Uncontrolled input tools allowed: ${exposureList.join(", ")}.`
+      : "No web/browser tools detected for these models.";
+
+  findings.push({
+    checkId: "models.small_params",
+    severity: hasUnsafe ? "critical" : "info",
+    title: "Small models require sandboxing and web tools disabled",
+    detail:
+      `Small models (<=${SMALL_MODEL_PARAM_B_MAX}B params) detected:\n` +
+      modelLines.join("\n") +
+      `\n` +
+      exposureDetail +
+      `\n` +
+      "Small models are not recommended for untrusted inputs.",
+    remediation:
+      'If you must use small models, enable sandboxing for all sessions (agents.defaults.sandbox.mode="all") and disable web_search/web_fetch/browser (tools.deny=["group:web","browser"]).',
+  });
+
+  return findings;
+}
+
+export async function collectPluginsTrustFindings(params: {
+  cfg: OpenClawConfig;
+  stateDir: string;
+}): Promise<SecurityAuditFinding[]> {
+  const findings: SecurityAuditFinding[] = [];
+  const extensionsDir = path.join(params.stateDir, "extensions");
+  const st = await safeStat(extensionsDir);
+  if (!st.ok || !st.isDir) {
+    return findings;
+  }
+
+  const entries = await fs.readdir(extensionsDir, { withFileTypes: true }).catch(() => []);
+  const pluginDirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter(Boolean);
+  if (pluginDirs.length === 0) {
+    return findings;
+  }
+
+  const allow = params.cfg.plugins?.allow;
+  const allowConfigured = Array.isArray(allow) && allow.length > 0;
+  if (!allowConfigured) {
+    const hasString = (value: unknown) => typeof value === "string" && value.trim().length > 0;
+    const hasAccountStringKey = (account: unknown, key: string) =>
+      Boolean(
+        account &&
+        typeof account === "object" &&
+        hasString((account as Record<string, unknown>)[key]),
+      );
+
+    const discordConfigured =
+      hasString(params.cfg.channels?.discord?.token) ||
+      Boolean(
+        params.cfg.channels?.discord?.accounts &&
+        Object.values(params.cfg.channels.discord.accounts).some((a) =>
+          hasAccountStringKey(a, "token"),
+        ),
+      ) ||
+      hasString(process.env.DISCORD_BOT_TOKEN);
+
+    const telegramConfigured =
+      hasString(params.cfg.channels?.telegram?.botToken) ||
+      hasString(params.cfg.channels?.telegram?.tokenFile) ||
+      Boolean(
+        params.cfg.channels?.telegram?.accounts &&
+        Object.values(params.cfg.channels.telegram.accounts).some(
+          (a) => hasAccountStringKey(a, "botToken") || hasAccountStringKey(a, "tokenFile"),
+        ),
+      ) ||
+      hasString(process.env.TELEGRAM_BOT_TOKEN);
+
+    const slackConfigured =
+      hasString(params.cfg.channels?.slack?.botToken) ||
+      hasString(params.cfg.channels?.slack?.appToken) ||
+      Boolean(
+        params.cfg.channels?.slack?.accounts &&
+        Object.values(params.cfg.channels.slack.accounts).some(
+          (a) => hasAccountStringKey(a, "botToken") || hasAccountStringKey(a, "appToken"),
+        ),
+      ) ||
+      hasString(process.env.SLACK_BOT_TOKEN) ||
+      hasString(process.env.SLACK_APP_TOKEN);
+
+    const skillCommandsLikelyExposed =
+      (discordConfigured &&
+        resolveNativeSkillsEnabled({
+          providerId: "discord",
+          providerSetting: params.cfg.channels?.discord?.commands?.nativeSkills,
+          globalSetting: params.cfg.commands?.nativeSkills,
+        })) ||
+      (telegramConfigured &&
+        resolveNativeSkillsEnabled({
+          providerId: "telegram",
+          providerSetting: params.cfg.channels?.telegram?.commands?.nativeSkills,
+          globalSetting: params.cfg.commands?.nativeSkills,
+        })) ||
+      (slackConfigured &&
+        resolveNativeSkillsEnabled({
+          providerId: "slack",
+          providerSetting: params.cfg.channels?.slack?.commands?.nativeSkills,
+          globalSetting: params.cfg.commands?.nativeSkills,
+        }));
+
+    findings.push({
+      checkId: "plugins.extensions_no_allowlist",
+      severity: skillCommandsLikelyExposed ? "critical" : "warn",
+      title: "Extensions exist but plugins.allow is not set",
+      detail:
+        `Found ${pluginDirs.length} extension(s) under ${extensionsDir}. Without plugins.allow, any discovered plugin id may load (depending on config and plugin behavior).` +
+        (skillCommandsLikelyExposed
+          ? "\nNative skill commands are enabled on at least one configured chat surface; treat unpinned/unallowlisted extensions as high risk."
+          : ""),
+      remediation: "Set plugins.allow to an explicit list of plugin ids you trust.",
+    });
+  }
+
+  return findings;
+}
+
+function resolveIncludePath(baseConfigPath: string, includePath: string): string {
+  return path.normalize(
+    path.isAbsolute(includePath)
+      ? includePath
+      : path.resolve(path.dirname(baseConfigPath), includePath),
+  );
+}
+
+function listDirectIncludes(parsed: unknown): string[] {
+  const out: string[] = [];
+  const visit = (value: unknown) => {
+    if (!value) {
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
+      }
+      return;
+    }
+    if (typeof value !== "object") {
+      return;
+    }
+    const rec = value as Record<string, unknown>;
+    const includeVal = rec[INCLUDE_KEY];
+    if (typeof includeVal === "string") {
+      out.push(includeVal);
+    } else if (Array.isArray(includeVal)) {
+      for (const item of includeVal) {
+        if (typeof item === "string") {
+          out.push(item);
+        }
+      }
+    }
+    for (const v of Object.values(rec)) {
+      visit(v);
+    }
+  };
+  visit(parsed);
+  return out;
+}
+
+async function collectIncludePathsRecursive(params: {
+  configPath: string;
+  parsed: unknown;
+}): Promise<string[]> {
+  const visited = new Set<string>();
+  const result: string[] = [];
+
+  const walk = async (basePath: string, parsed: unknown, depth: number): Promise<void> => {
+    if (depth > MAX_INCLUDE_DEPTH) {
+      return;
+    }
+    for (const raw of listDirectIncludes(parsed)) {
+      const resolved = resolveIncludePath(basePath, raw);
+      if (visited.has(resolved)) {
+        continue;
+      }
+      visited.add(resolved);
+      result.push(resolved);
+      const rawText = await fs.readFile(resolved, "utf-8").catch(() => null);
+      if (!rawText) {
+        continue;
+      }
+      const nestedParsed = (() => {
+        try {
+          return JSON5.parse(rawText);
+        } catch {
+          return null;
+        }
+      })();
+      if (nestedParsed) {
+        // eslint-disable-next-line no-await-in-loop
+        await walk(resolved, nestedParsed, depth + 1);
+      }
+    }
+  };
+
+  await walk(params.configPath, params.parsed, 0);
+  return result;
+}
+
+export async function collectIncludeFilePermFindings(params: {
+  configSnapshot: ConfigFileSnapshot;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  execIcacls?: ExecFn;
+}): Promise<SecurityAuditFinding[]> {
+  const findings: SecurityAuditFinding[] = [];
+  if (!params.configSnapshot.exists) {
+    return findings;
+  }
+
+  const configPath = params.configSnapshot.path;
+  const includePaths = await collectIncludePathsRecursive({
+    configPath,
+    parsed: params.configSnapshot.parsed,
+  });
+  if (includePaths.length === 0) {
+    return findings;
+  }
+
+  for (const p of includePaths) {
+    // eslint-disable-next-line no-await-in-loop
+    const perms = await inspectPathPermissions(p, {
+      env: params.env,
+      platform: params.platform,
+      exec: params.execIcacls,
+    });
+    if (!perms.ok) {
+      continue;
+    }
+    if (perms.worldWritable || perms.groupWritable) {
+      findings.push({
+        checkId: "fs.config_include.perms_writable",
+        severity: "critical",
+        title: "Config include file is writable by others",
+        detail: `${formatPermissionDetail(p, perms)}; another user could influence your effective config.`,
+        remediation: formatPermissionRemediation({
+          targetPath: p,
+          perms,
+          isDir: false,
+          posixMode: 0o600,
+          env: params.env,
+        }),
+      });
+    } else if (perms.worldReadable) {
+      findings.push({
+        checkId: "fs.config_include.perms_world_readable",
+        severity: "critical",
+        title: "Config include file is world-readable",
+        detail: `${formatPermissionDetail(p, perms)}; include files can contain tokens and private settings.`,
+        remediation: formatPermissionRemediation({
+          targetPath: p,
+          perms,
+          isDir: false,
+          posixMode: 0o600,
+          env: params.env,
+        }),
+      });
+    } else if (perms.groupReadable) {
+      findings.push({
+        checkId: "fs.config_include.perms_group_readable",
+        severity: "warn",
+        title: "Config include file is group-readable",
+        detail: `${formatPermissionDetail(p, perms)}; include files can contain tokens and private settings.`,
+        remediation: formatPermissionRemediation({
+          targetPath: p,
+          perms,
+          isDir: false,
+          posixMode: 0o600,
+          env: params.env,
+        }),
+      });
+    }
+  }
+
+  return findings;
+}
+
+export async function collectStateDeepFilesystemFindings(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  stateDir: string;
+  platform?: NodeJS.Platform;
+  execIcacls?: ExecFn;
+}): Promise<SecurityAuditFinding[]> {
+  const findings: SecurityAuditFinding[] = [];
+  const oauthDir = resolveOAuthDir(params.env, params.stateDir);
+
+  const oauthPerms = await inspectPathPermissions(oauthDir, {
+    env: params.env,
+    platform: params.platform,
+    exec: params.execIcacls,
+  });
+  if (oauthPerms.ok && oauthPerms.isDir) {
+    if (oauthPerms.worldWritable || oauthPerms.groupWritable) {
+      findings.push({
+        checkId: "fs.credentials_dir.perms_writable",
+        severity: "critical",
+        title: "Credentials dir is writable by others",
+        detail: `${formatPermissionDetail(oauthDir, oauthPerms)}; another user could drop/modify credential files.`,
+        remediation: formatPermissionRemediation({
+          targetPath: oauthDir,
+          perms: oauthPerms,
+          isDir: true,
+          posixMode: 0o700,
+          env: params.env,
+        }),
+      });
+    } else if (oauthPerms.groupReadable || oauthPerms.worldReadable) {
+      findings.push({
+        checkId: "fs.credentials_dir.perms_readable",
+        severity: "warn",
+        title: "Credentials dir is readable by others",
+        detail: `${formatPermissionDetail(oauthDir, oauthPerms)}; credentials and allowlists can be sensitive.`,
+        remediation: formatPermissionRemediation({
+          targetPath: oauthDir,
+          perms: oauthPerms,
+          isDir: true,
+          posixMode: 0o700,
+          env: params.env,
+        }),
+      });
+    }
+  }
+
+  const agentIds = Array.isArray(params.cfg.agents?.list)
+    ? params.cfg.agents?.list
+        .map((a) => (a && typeof a === "object" && typeof a.id === "string" ? a.id.trim() : ""))
+        .filter(Boolean)
+    : [];
+  const defaultAgentId = resolveDefaultAgentId(params.cfg);
+  const ids = Array.from(new Set([defaultAgentId, ...agentIds])).map((id) => normalizeAgentId(id));
+
+  for (const agentId of ids) {
+    const agentDir = path.join(params.stateDir, "agents", agentId, "agent");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+    // eslint-disable-next-line no-await-in-loop
+    const authPerms = await inspectPathPermissions(authPath, {
+      env: params.env,
+      platform: params.platform,
+      exec: params.execIcacls,
+    });
+    if (authPerms.ok) {
+      if (authPerms.worldWritable || authPerms.groupWritable) {
+        findings.push({
+          checkId: "fs.auth_profiles.perms_writable",
+          severity: "critical",
+          title: "auth-profiles.json is writable by others",
+          detail: `${formatPermissionDetail(authPath, authPerms)}; another user could inject credentials.`,
+          remediation: formatPermissionRemediation({
+            targetPath: authPath,
+            perms: authPerms,
+            isDir: false,
+            posixMode: 0o600,
+            env: params.env,
+          }),
+        });
+      } else if (authPerms.worldReadable || authPerms.groupReadable) {
+        findings.push({
+          checkId: "fs.auth_profiles.perms_readable",
+          severity: "warn",
+          title: "auth-profiles.json is readable by others",
+          detail: `${formatPermissionDetail(authPath, authPerms)}; auth-profiles.json contains API keys and OAuth tokens.`,
+          remediation: formatPermissionRemediation({
+            targetPath: authPath,
+            perms: authPerms,
+            isDir: false,
+            posixMode: 0o600,
+            env: params.env,
+          }),
+        });
+      }
+    }
+
+    const storePath = path.join(params.stateDir, "agents", agentId, "sessions", "sessions.json");
+    // eslint-disable-next-line no-await-in-loop
+    const storePerms = await inspectPathPermissions(storePath, {
+      env: params.env,
+      platform: params.platform,
+      exec: params.execIcacls,
+    });
+    if (storePerms.ok) {
+      if (storePerms.worldReadable || storePerms.groupReadable) {
+        findings.push({
+          checkId: "fs.sessions_store.perms_readable",
+          severity: "warn",
+          title: "sessions.json is readable by others",
+          detail: `${formatPermissionDetail(storePath, storePerms)}; routing and transcript metadata can be sensitive.`,
+          remediation: formatPermissionRemediation({
+            targetPath: storePath,
+            perms: storePerms,
+            isDir: false,
+            posixMode: 0o600,
+            env: params.env,
+          }),
+        });
+      }
+    }
+  }
+
+  const logFile =
+    typeof params.cfg.logging?.file === "string" ? params.cfg.logging.file.trim() : "";
+  if (logFile) {
+    const expanded = logFile.startsWith("~") ? expandTilde(logFile, params.env) : logFile;
+    if (expanded) {
+      const logPath = path.resolve(expanded);
+      const logPerms = await inspectPathPermissions(logPath, {
+        env: params.env,
+        platform: params.platform,
+        exec: params.execIcacls,
+      });
+      if (logPerms.ok) {
+        if (logPerms.worldReadable || logPerms.groupReadable) {
+          findings.push({
+            checkId: "fs.log_file.perms_readable",
+            severity: "warn",
+            title: "Log file is readable by others",
+            detail: `${formatPermissionDetail(logPath, logPerms)}; logs can contain private messages and tool output.`,
+            remediation: formatPermissionRemediation({
+              targetPath: logPath,
+              perms: logPerms,
+              isDir: false,
+              posixMode: 0o600,
+              env: params.env,
+            }),
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+function listGroupPolicyOpen(cfg: OpenClawConfig): string[] {
+  const out: string[] = [];
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  if (!channels || typeof channels !== "object") {
+    return out;
+  }
+  for (const [channelId, value] of Object.entries(channels)) {
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+    const section = value as Record<string, unknown>;
+    if (section.groupPolicy === "open") {
+      out.push(`channels.${channelId}.groupPolicy`);
+    }
+    const accounts = section.accounts;
+    if (accounts && typeof accounts === "object") {
+      for (const [accountId, accountVal] of Object.entries(accounts)) {
+        if (!accountVal || typeof accountVal !== "object") {
+          continue;
+        }
+        const acc = accountVal as Record<string, unknown>;
+        if (acc.groupPolicy === "open") {
+          out.push(`channels.${channelId}.accounts.${accountId}.groupPolicy`);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  const openGroups = listGroupPolicyOpen(cfg);
+  if (openGroups.length === 0) {
+    return findings;
+  }
+
+  const elevatedEnabled = cfg.tools?.elevated?.enabled !== false;
+  if (elevatedEnabled) {
+    findings.push({
+      checkId: "security.exposure.open_groups_with_elevated",
+      severity: "critical",
+      title: "Open groupPolicy with elevated tools enabled",
+      detail:
+        `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
+        "With tools.elevated enabled, a prompt injection in those rooms can become a high-impact incident.",
+      remediation: `Set groupPolicy="allowlist" or "members" and keep elevated allowlists extremely tight.`,
+    });
+  }
+
+  return findings;
+}
+
+export async function readConfigSnapshotForAudit(params: {
+  env: NodeJS.ProcessEnv;
+  configPath: string;
+}): Promise<ConfigFileSnapshot> {
+  return await createConfigIO({
+    env: params.env,
+    configPath: params.configPath,
+  }).readConfigFileSnapshot();
+}
+
+function isPathInside(basePath: string, candidatePath: string): boolean {
+  const base = path.resolve(basePath);
+  const candidate = path.resolve(candidatePath);
+  const rel = path.relative(base, candidate);
+  return rel === "" || (!rel.startsWith(`..${path.sep}`) && rel !== ".." && !path.isAbsolute(rel));
+}
+
+function extensionUsesSkippedScannerPath(entry: string): boolean {
+  const segments = entry.split(/[\\/]+/).filter(Boolean);
+  return segments.some(
+    (segment) =>
+      segment === "node_modules" ||
+      (segment.startsWith(".") && segment !== "." && segment !== ".."),
+  );
+}
+
+async function readPluginManifestExtensions(pluginPath: string): Promise<string[]> {
+  const manifestPath = path.join(pluginPath, "package.json");
+  const raw = await fs.readFile(manifestPath, "utf-8").catch(() => "");
+  if (!raw.trim()) {
+    return [];
+  }
+
+  const parsed = JSON.parse(raw) as Partial<
+    Record<typeof MANIFEST_KEY, { extensions?: unknown }>
+  > | null;
+  const extensions = parsed?.[MANIFEST_KEY]?.extensions;
+  if (!Array.isArray(extensions)) {
+    return [];
+  }
+  return extensions.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean);
+}
+
+function listWorkspaceDirs(cfg: OpenClawConfig): string[] {
+  const dirs = new Set<string>();
+  const list = cfg.agents?.list;
+  if (Array.isArray(list)) {
+    for (const entry of list) {
+      if (entry && typeof entry === "object" && typeof entry.id === "string") {
+        dirs.add(resolveAgentWorkspaceDir(cfg, entry.id));
+      }
+    }
+  }
+  dirs.add(resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
+  return [...dirs];
+}
+
+function formatCodeSafetyDetails(findings: SkillScanFinding[], rootDir: string): string {
+  return findings
+    .map((finding) => {
+      const relPath = path.relative(rootDir, finding.file);
+      const filePath =
+        relPath && relPath !== "." && !relPath.startsWith("..")
+          ? relPath
+          : path.basename(finding.file);
+      const normalizedPath = filePath.replaceAll("\\", "/");
+      return `  - [${finding.ruleId}] ${finding.message} (${normalizedPath}:${finding.line})`;
+    })
+    .join("\n");
+}
+
+export async function collectPluginsCodeSafetyFindings(params: {
+  stateDir: string;
+}): Promise<SecurityAuditFinding[]> {
+  const findings: SecurityAuditFinding[] = [];
+  const extensionsDir = path.join(params.stateDir, "extensions");
+  const st = await safeStat(extensionsDir);
+  if (!st.ok || !st.isDir) {
+    return findings;
+  }
+
+  const entries = await fs.readdir(extensionsDir, { withFileTypes: true }).catch((err) => {
+    findings.push({
+      checkId: "plugins.code_safety.scan_failed",
+      severity: "warn",
+      title: "Plugin extensions directory scan failed",
+      detail: `Static code scan could not list extensions directory: ${String(err)}`,
+      remediation:
+        "Check file permissions and plugin layout, then rerun `openclaw security audit --deep`.",
+    });
+    return [];
+  });
+  const pluginDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+
+  for (const pluginName of pluginDirs) {
+    const pluginPath = path.join(extensionsDir, pluginName);
+    const extensionEntries = await readPluginManifestExtensions(pluginPath).catch(() => []);
+    const forcedScanEntries: string[] = [];
+    const escapedEntries: string[] = [];
+
+    for (const entry of extensionEntries) {
+      const resolvedEntry = path.resolve(pluginPath, entry);
+      if (!isPathInside(pluginPath, resolvedEntry)) {
+        escapedEntries.push(entry);
+        continue;
+      }
+      if (extensionUsesSkippedScannerPath(entry)) {
+        findings.push({
+          checkId: "plugins.code_safety.entry_path",
+          severity: "warn",
+          title: `Plugin "${pluginName}" entry path is hidden or node_modules`,
+          detail: `Extension entry "${entry}" points to a hidden or node_modules path. Deep code scan will cover this entry explicitly, but review this path choice carefully.`,
+          remediation: "Prefer extension entrypoints under normal source paths like dist/ or src/.",
+        });
+      }
+      forcedScanEntries.push(resolvedEntry);
+    }
+
+    if (escapedEntries.length > 0) {
+      findings.push({
+        checkId: "plugins.code_safety.entry_escape",
+        severity: "critical",
+        title: `Plugin "${pluginName}" has extension entry path traversal`,
+        detail: `Found extension entries that escape the plugin directory:\n${escapedEntries.map((entry) => `  - ${entry}`).join("\n")}`,
+        remediation:
+          "Update the plugin manifest so all openclaw.extensions entries stay inside the plugin directory.",
+      });
+    }
+
+    const summary = await scanDirectoryWithSummary(pluginPath, {
+      includeFiles: forcedScanEntries,
+    }).catch((err) => {
+      findings.push({
+        checkId: "plugins.code_safety.scan_failed",
+        severity: "warn",
+        title: `Plugin "${pluginName}" code scan failed`,
+        detail: `Static code scan could not complete: ${String(err)}`,
+        remediation:
+          "Check file permissions and plugin layout, then rerun `openclaw security audit --deep`.",
+      });
+      return null;
+    });
+    if (!summary) {
+      continue;
+    }
+
+    if (summary.critical > 0) {
+      const criticalFindings = summary.findings.filter((f) => f.severity === "critical");
+      const details = formatCodeSafetyDetails(criticalFindings, pluginPath);
+
+      findings.push({
+        checkId: "plugins.code_safety",
+        severity: "critical",
+        title: `Plugin "${pluginName}" contains dangerous code patterns`,
+        detail: `Found ${summary.critical} critical issue(s) in ${summary.scannedFiles} scanned file(s):\n${details}`,
+        remediation:
+          "Review the plugin source code carefully before use. If untrusted, remove the plugin from your OpenClaw extensions state directory.",
+      });
+    } else if (summary.warn > 0) {
+      const warnFindings = summary.findings.filter((f) => f.severity === "warn");
+      const details = formatCodeSafetyDetails(warnFindings, pluginPath);
+
+      findings.push({
+        checkId: "plugins.code_safety",
+        severity: "warn",
+        title: `Plugin "${pluginName}" contains suspicious code patterns`,
+        detail: `Found ${summary.warn} warning(s) in ${summary.scannedFiles} scanned file(s):\n${details}`,
+        remediation: `Review the flagged code to ensure it is intentional and safe.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export async function collectInstalledSkillsCodeSafetyFindings(params: {
+  cfg: OpenClawConfig;
+  stateDir: string;
+}): Promise<SecurityAuditFinding[]> {
+  const findings: SecurityAuditFinding[] = [];
+  const pluginExtensionsDir = path.join(params.stateDir, "extensions");
+  const scannedSkillDirs = new Set<string>();
+  const workspaceDirs = listWorkspaceDirs(params.cfg);
+
+  for (const workspaceDir of workspaceDirs) {
+    const entries = loadWorkspaceSkillEntries(workspaceDir, { config: params.cfg });
+    for (const entry of entries) {
+      if (entry.skill.source === "openclaw-bundled") {
+        continue;
+      }
+
+      const skillDir = path.resolve(entry.skill.baseDir);
+      if (isPathInside(pluginExtensionsDir, skillDir)) {
+        // Plugin code is already covered by plugins.code_safety checks.
+        continue;
+      }
+      if (scannedSkillDirs.has(skillDir)) {
+        continue;
+      }
+      scannedSkillDirs.add(skillDir);
+
+      const skillName = entry.skill.name;
+      const summary = await scanDirectoryWithSummary(skillDir).catch((err) => {
+        findings.push({
+          checkId: "skills.code_safety.scan_failed",
+          severity: "warn",
+          title: `Skill "${skillName}" code scan failed`,
+          detail: `Static code scan could not complete for ${skillDir}: ${String(err)}`,
+          remediation:
+            "Check file permissions and skill layout, then rerun `openclaw security audit --deep`.",
+        });
+        return null;
+      });
+      if (!summary) {
+        continue;
+      }
+
+      if (summary.critical > 0) {
+        const criticalFindings = summary.findings.filter(
+          (finding) => finding.severity === "critical",
+        );
+        const details = formatCodeSafetyDetails(criticalFindings, skillDir);
+        findings.push({
+          checkId: "skills.code_safety",
+          severity: "critical",
+          title: `Skill "${skillName}" contains dangerous code patterns`,
+          detail: `Found ${summary.critical} critical issue(s) in ${summary.scannedFiles} scanned file(s) under ${skillDir}:\n${details}`,
+          remediation: `Review the skill source code before use. If untrusted, remove "${skillDir}".`,
+        });
+      } else if (summary.warn > 0) {
+        const warnFindings = summary.findings.filter((finding) => finding.severity === "warn");
+        const details = formatCodeSafetyDetails(warnFindings, skillDir);
+        findings.push({
+          checkId: "skills.code_safety",
+          severity: "warn",
+          title: `Skill "${skillName}" contains suspicious code patterns`,
+          detail: `Found ${summary.warn} warning(s) in ${summary.scannedFiles} scanned file(s) under ${skillDir}:\n${details}`,
+          remediation: "Review flagged lines to ensure the behavior is intentional and safe.",
+        });
+      }
+    }
+  }
+
+  return findings;
+}

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -812,7 +812,8 @@ async function collectChannelSecurityFindings(params: {
       const groups = telegramCfg.groups as Record<string, unknown> | undefined;
       const groupsConfigured = Boolean(groups) && Object.keys(groups ?? {}).length > 0;
       const groupAccessPossible =
-        groupPolicy === "open" || (groupPolicy === "allowlist" && groupsConfigured);
+        groupPolicy === "open" ||
+        ((groupPolicy === "allowlist" || groupPolicy === "members") && groupsConfigured);
       if (!groupAccessPossible) {
         continue;
       }

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -820,9 +820,12 @@ async function collectChannelSecurityFindings(params: {
 
       const storeAllowFrom = await readChannelAllowFromStore("telegram").catch(() => []);
       const storeHasWildcard = storeAllowFrom.some((v) => String(v).trim() === "*");
+      const defaultGroupAllowFrom = params.cfg.channels?.defaults?.groupAllowFrom;
       const groupAllowFrom = Array.isArray(telegramCfg.groupAllowFrom)
         ? telegramCfg.groupAllowFrom
-        : [];
+        : Array.isArray(defaultGroupAllowFrom)
+          ? defaultGroupAllowFrom
+          : [];
       const groupAllowFromHasWildcard = groupAllowFrom.some((v) => String(v).trim() === "*");
       const anyGroupOverride = Boolean(
         groups &&

--- a/src/signal/identity.ts
+++ b/src/signal/identity.ts
@@ -117,7 +117,7 @@ export function isSignalSenderAllowed(sender: SignalSender, allowFrom: string[])
 }
 
 export function isSignalGroupAllowed(params: {
-  groupPolicy: "open" | "disabled" | "allowlist";
+  groupPolicy: "open" | "disabled" | "allowlist" | "members";
   allowFrom: string[];
   sender: SignalSender;
 }): boolean {

--- a/src/slack/monitor/policy.ts
+++ b/src/slack/monitor/policy.ts
@@ -1,5 +1,5 @@
 export function isSlackChannelAllowedByPolicy(params: {
-  groupPolicy: "open" | "disabled" | "allowlist";
+  groupPolicy: "open" | "disabled" | "allowlist" | "members";
   channelAllowlistConfigured: boolean;
   channelAllowed: boolean;
 }): boolean {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -30,6 +30,7 @@ import {
   buildTelegramParentPeer,
   resolveTelegramForumThreadId,
 } from "./bot/helpers.js";
+import { invalidateGroupMembership, verifyGroupMembership } from "./group-membership-cache.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import {
@@ -396,6 +397,34 @@ export const registerTelegramHandlers = ({
             return;
           }
         }
+        if (groupPolicy === "members") {
+          if (!senderId) {
+            logVerbose(`Blocked telegram group message (no sender ID, groupPolicy: members)`);
+            return;
+          }
+          if (
+            !isSenderAllowed({
+              allow: effectiveGroupAllow,
+              senderId,
+              senderUsername,
+            })
+          ) {
+            logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: members)`);
+            return;
+          }
+          const memberCheck = await verifyGroupMembership({
+            chatId,
+            api: ctx.api,
+            botId: ctx.me.id,
+            allowFrom: effectiveGroupAllow,
+          });
+          if (!memberCheck.trusted) {
+            logVerbose(
+              `Blocked telegram group ${chatId} (groupPolicy: members, ${memberCheck.reason})`,
+            );
+            return;
+          }
+        }
         const groupAllowlist = resolveGroupPolicy(chatId);
         if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
           logger.info(
@@ -674,6 +703,14 @@ export const registerTelegramHandlers = ({
     }
   });
 
+  // Invalidate group membership cache on member changes
+  bot.on("message:new_chat_members", (ctx) => {
+    invalidateGroupMembership(ctx.message.chat.id);
+  });
+  bot.on("message:left_chat_member", (ctx) => {
+    invalidateGroupMembership(ctx.message.chat.id);
+  });
+
   bot.on("message", async (ctx) => {
     try {
       const msg = ctx.message;
@@ -767,6 +804,36 @@ export const registerTelegramHandlers = ({
             })
           ) {
             logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: allowlist)`);
+            return;
+          }
+        }
+        if (groupPolicy === "members") {
+          const senderId = msg.from?.id;
+          if (senderId == null) {
+            logVerbose(`Blocked telegram group message (no sender ID, groupPolicy: members)`);
+            return;
+          }
+          const senderUsername = msg.from?.username ?? "";
+          if (
+            !isSenderAllowed({
+              allow: effectiveGroupAllow,
+              senderId: String(senderId),
+              senderUsername,
+            })
+          ) {
+            logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: members)`);
+            return;
+          }
+          const memberCheck = await verifyGroupMembership({
+            chatId,
+            api: ctx.api,
+            botId: ctx.me.id,
+            allowFrom: effectiveGroupAllow,
+          });
+          if (!memberCheck.trusted) {
+            logVerbose(
+              `Blocked telegram group ${chatId} (groupPolicy: members, ${memberCheck.reason})`,
+            );
             return;
           }
         }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -398,20 +398,6 @@ export const registerTelegramHandlers = ({
           }
         }
         if (groupPolicy === "members") {
-          if (!senderId) {
-            logVerbose(`Blocked telegram group message (no sender ID, groupPolicy: members)`);
-            return;
-          }
-          if (
-            !isSenderAllowed({
-              allow: effectiveGroupAllow,
-              senderId,
-              senderUsername,
-            })
-          ) {
-            logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: members)`);
-            return;
-          }
           const memberCheck = await verifyGroupMembership({
             chatId,
             api: ctx.api,
@@ -808,22 +794,6 @@ export const registerTelegramHandlers = ({
           }
         }
         if (groupPolicy === "members") {
-          const senderId = msg.from?.id;
-          if (senderId == null) {
-            logVerbose(`Blocked telegram group message (no sender ID, groupPolicy: members)`);
-            return;
-          }
-          const senderUsername = msg.from?.username ?? "";
-          if (
-            !isSenderAllowed({
-              allow: effectiveGroupAllow,
-              senderId: String(senderId),
-              senderUsername,
-            })
-          ) {
-            logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: members)`);
-            return;
-          }
           const memberCheck = await verifyGroupMembership({
             chatId,
             api: ctx.api,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -203,7 +203,13 @@ async function resolveTelegramCommandAuth(params: {
 
   if (isGroup && useAccessGroups) {
     const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-    const groupPolicy = telegramCfg.groupPolicy ?? defaultGroupPolicy ?? "open";
+    const groupPolicy =
+      firstDefined(
+        topicConfig?.groupPolicy,
+        groupConfig?.groupPolicy,
+        telegramCfg.groupPolicy,
+        defaultGroupPolicy,
+      ) ?? "open";
     if (groupPolicy === "disabled") {
       await withTelegramApiErrorLogging({
         operation: "sendMessage",

--- a/src/telegram/bot.create-telegram-bot.blocks-all-group-messages-grouppolicy-is.test.ts
+++ b/src/telegram/bot.create-telegram-bot.blocks-all-group-messages-grouppolicy-is.test.ts
@@ -450,10 +450,13 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 
-  it("blocks group messages from untrusted sender even when groupPolicy is 'members'", async () => {
+  it("blocks group messages via membership check when sender is not in trusted list", async () => {
     onSpy.mockReset();
     const replySpy = replyModule.__replySpy as unknown as ReturnType<typeof vi.fn>;
     replySpy.mockReset();
+    // 3 members in the group (trusted user + bot + untrusted sender) but only 2 trusted IDs
+    getChatMemberCountSpy.mockResolvedValue(3);
+    getChatMemberSpy.mockResolvedValue({ status: "member" });
     loadConfig.mockReturnValue({
       channels: {
         telegram: {
@@ -479,8 +482,8 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
-    // Should not even reach membership check
+    // Membership check should run and detect untrusted members
     expect(replySpy).not.toHaveBeenCalled();
-    expect(getChatMemberCountSpy).not.toHaveBeenCalled();
+    expect(getChatMemberCountSpy).toHaveBeenCalled();
   });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -233,9 +233,11 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   const textLimit = resolveTextChunkLimit(cfg, "telegram", account.accountId);
   const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
   const allowFrom = opts.allowFrom ?? telegramCfg.allowFrom;
+  const defaultGroupAllowFrom = cfg.channels?.defaults?.groupAllowFrom;
   const groupAllowFrom =
     opts.groupAllowFrom ??
     telegramCfg.groupAllowFrom ??
+    defaultGroupAllowFrom ??
     (telegramCfg.allowFrom && telegramCfg.allowFrom.length > 0
       ? telegramCfg.allowFrom
       : undefined) ??

--- a/src/telegram/group-membership-cache.test.ts
+++ b/src/telegram/group-membership-cache.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NormalizedAllowFrom } from "./bot-access.js";
+import {
+  clearGroupMembershipCache,
+  invalidateGroupMembership,
+  verifyGroupMembership,
+} from "./group-membership-cache.js";
+
+function makeAllowFrom(entries: string[], hasWildcard = false): NormalizedAllowFrom {
+  return {
+    entries,
+    entriesLower: entries.map((e) => e.toLowerCase()),
+    hasWildcard,
+    hasEntries: entries.length > 0 || hasWildcard,
+  };
+}
+
+function makeApi(opts: {
+  memberCount?: number;
+  members?: Record<number, string>; // userId -> status
+  countError?: boolean;
+  memberError?: boolean;
+}) {
+  return {
+    getChatMemberCount: vi.fn(async () => {
+      if (opts.countError) {
+        throw new Error("API error");
+      }
+      return opts.memberCount ?? 0;
+    }),
+    getChatMember: vi.fn(async (_chatId: number, userId: number) => {
+      if (opts.memberError) {
+        throw new Error("API error");
+      }
+      const status = opts.members?.[userId] ?? "left";
+      return { status };
+    }),
+  } as unknown as import("grammy").Api;
+}
+
+describe("group-membership-cache", () => {
+  afterEach(() => {
+    clearGroupMembershipCache();
+  });
+
+  it("returns trusted when all members are in allowlist + bot", async () => {
+    const api = makeApi({
+      memberCount: 3, // 2 trusted users + 1 bot
+      members: { 111: "member", 222: "member" },
+    });
+    const result = await verifyGroupMembership({
+      chatId: -100123,
+      api,
+      botId: 999,
+      allowFrom: makeAllowFrom(["111", "222"]),
+    });
+    expect(result.trusted).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it("returns untrusted when unknown members present (count mismatch)", async () => {
+    const api = makeApi({
+      memberCount: 5, // more than 2 trusted + 1 bot
+      members: { 111: "member", 222: "member" },
+    });
+    const result = await verifyGroupMembership({
+      chatId: -100456,
+      api,
+      botId: 999,
+      allowFrom: makeAllowFrom(["111", "222"]),
+    });
+    expect(result.trusted).toBe(false);
+    expect(result.reason).toContain("member-count-mismatch");
+  });
+
+  it("caches results (no API call on second check)", async () => {
+    const api = makeApi({
+      memberCount: 2,
+      members: { 111: "member" },
+    });
+    const allowFrom = makeAllowFrom(["111"]);
+
+    const r1 = await verifyGroupMembership({ chatId: -100789, api, botId: 999, allowFrom });
+    expect(r1.trusted).toBe(true);
+
+    const r2 = await verifyGroupMembership({ chatId: -100789, api, botId: 999, allowFrom });
+    expect(r2.trusted).toBe(true);
+
+    // getChatMemberCount should only be called once (first call), not on cached second call
+    expect((api.getChatMemberCount as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+
+  it("invalidateGroupMembership clears cache for that chat", async () => {
+    const api = makeApi({
+      memberCount: 2,
+      members: { 111: "member" },
+    });
+    const allowFrom = makeAllowFrom(["111"]);
+
+    await verifyGroupMembership({ chatId: -100111, api, botId: 999, allowFrom });
+    expect((api.getChatMemberCount as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+
+    invalidateGroupMembership(-100111);
+
+    await verifyGroupMembership({ chatId: -100111, api, botId: 999, allowFrom });
+    // Should have called API again after invalidation
+    expect((api.getChatMemberCount as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+  });
+
+  it("fails closed on API error (getChatMemberCount)", async () => {
+    const api = makeApi({ countError: true });
+    const result = await verifyGroupMembership({
+      chatId: -100222,
+      api,
+      botId: 999,
+      allowFrom: makeAllowFrom(["111"]),
+    });
+    expect(result.trusted).toBe(false);
+    expect(result.reason).toBe("api-error");
+  });
+
+  it("returns untrusted when no numeric entries in allowFrom", async () => {
+    const api = makeApi({ memberCount: 2 });
+    const result = await verifyGroupMembership({
+      chatId: -100333,
+      api,
+      botId: 999,
+      allowFrom: makeAllowFrom(["@alice", "@bob"]),
+    });
+    expect(result.trusted).toBe(false);
+    expect(result.reason).toBe("no-numeric-ids");
+    // Should not call API at all
+    expect((api.getChatMemberCount as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("returns trusted immediately if allowFrom has wildcard", async () => {
+    const api = makeApi({ memberCount: 100 });
+    const result = await verifyGroupMembership({
+      chatId: -100444,
+      api,
+      botId: 999,
+      allowFrom: makeAllowFrom([], true),
+    });
+    expect(result.trusted).toBe(true);
+    // Should not call API at all
+    expect((api.getChatMemberCount as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("handles members who left the group correctly", async () => {
+    const api = makeApi({
+      memberCount: 2, // 1 trusted user + 1 bot
+      members: { 111: "member", 222: "left" },
+    });
+    const result = await verifyGroupMembership({
+      chatId: -100555,
+      api,
+      botId: 999,
+      allowFrom: makeAllowFrom(["111", "222"]),
+    });
+    // 1 present + 1 bot = 2 total = trusted
+    expect(result.trusted).toBe(true);
+  });
+
+  it("returns untrusted when getChatMember fails for all users", async () => {
+    const api = makeApi({
+      memberCount: 2,
+      memberError: true,
+    });
+    const result = await verifyGroupMembership({
+      chatId: -100666,
+      api,
+      botId: 999,
+      allowFrom: makeAllowFrom(["111"]),
+    });
+    // 0 present + 1 bot = 1, but total is 2 → untrusted
+    expect(result.trusted).toBe(false);
+  });
+});

--- a/src/telegram/group-membership-cache.test.ts
+++ b/src/telegram/group-membership-cache.test.ts
@@ -46,7 +46,7 @@ describe("group-membership-cache", () => {
   it("returns trusted when all members are in allowlist + bot", async () => {
     const api = makeApi({
       memberCount: 3, // 2 trusted users + 1 bot
-      members: { 111: "member", 222: "member" },
+      members: { 111: "member", 222: "member", 999: "member" },
     });
     const result = await verifyGroupMembership({
       chatId: -100123,
@@ -76,7 +76,7 @@ describe("group-membership-cache", () => {
   it("caches results (no API call on second check)", async () => {
     const api = makeApi({
       memberCount: 2,
-      members: { 111: "member" },
+      members: { 111: "member", 999: "member" },
     });
     const allowFrom = makeAllowFrom(["111"]);
 
@@ -93,7 +93,7 @@ describe("group-membership-cache", () => {
   it("invalidateGroupMembership clears cache for that chat", async () => {
     const api = makeApi({
       memberCount: 2,
-      members: { 111: "member" },
+      members: { 111: "member", 999: "member" },
     });
     const allowFrom = makeAllowFrom(["111"]);
 
@@ -149,7 +149,7 @@ describe("group-membership-cache", () => {
   it("handles members who left the group correctly", async () => {
     const api = makeApi({
       memberCount: 2, // 1 trusted user + 1 bot
-      members: { 111: "member", 222: "left" },
+      members: { 111: "member", 222: "left", 999: "member" },
     });
     const result = await verifyGroupMembership({
       chatId: -100555,
@@ -157,7 +157,7 @@ describe("group-membership-cache", () => {
       botId: 999,
       allowFrom: makeAllowFrom(["111", "222"]),
     });
-    // 1 present + 1 bot = 2 total = trusted
+    // 2 present (111 + bot 999), 222 left → 2 present = 2 total = trusted
     expect(result.trusted).toBe(true);
   });
 
@@ -172,7 +172,7 @@ describe("group-membership-cache", () => {
       botId: 999,
       allowFrom: makeAllowFrom(["111"]),
     });
-    // 0 present + 1 bot = 1, but total is 2 → untrusted
+    // 0 present (all getChatMember calls fail), but total is 2 → untrusted
     expect(result.trusted).toBe(false);
   });
 });

--- a/src/telegram/group-membership-cache.ts
+++ b/src/telegram/group-membership-cache.ts
@@ -1,0 +1,127 @@
+/**
+ * In-memory cache for group membership verification.
+ * Used by groupPolicy "members" to ensure all group participants are trusted.
+ */
+
+import type { Api } from "grammy";
+import type { NormalizedAllowFrom } from "./bot-access.js";
+import { logVerbose, warn } from "../globals.js";
+
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+type MembershipResult = {
+  trusted: boolean;
+  reason?: string;
+};
+
+type CacheEntry = {
+  result: MembershipResult;
+  timestamp: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+function getChatKey(chatId: number | string): string {
+  return String(chatId);
+}
+
+/**
+ * Extract numeric user IDs from a NormalizedAllowFrom.
+ * Entries that look like integers are treated as user IDs;
+ * usernames (starting with @) and other strings are skipped.
+ */
+function extractNumericIds(allow: NormalizedAllowFrom): number[] {
+  return allow.entries.filter((e) => /^\d+$/.test(e)).map(Number);
+}
+
+export async function verifyGroupMembership(params: {
+  chatId: number | string;
+  api: Api;
+  botId: number;
+  allowFrom: NormalizedAllowFrom;
+}): Promise<MembershipResult> {
+  const { chatId, api, botId, allowFrom } = params;
+  const key = getChatKey(chatId);
+
+  // Check cache
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.timestamp < TTL_MS) {
+    return cached.result;
+  }
+
+  // Wildcard: everyone is trusted
+  if (allowFrom.hasWildcard) {
+    const result: MembershipResult = { trusted: true };
+    cache.set(key, { result, timestamp: Date.now() });
+    return result;
+  }
+
+  const numericIds = extractNumericIds(allowFrom);
+  if (numericIds.length === 0) {
+    logVerbose(
+      warn(
+        `[members] No numeric IDs in allowFrom for chat ${chatId}; cannot verify membership. Use numeric Telegram user IDs.`,
+      ),
+    );
+    const result: MembershipResult = { trusted: false, reason: "no-numeric-ids" };
+    cache.set(key, { result, timestamp: Date.now() });
+    return result;
+  }
+
+  try {
+    const totalCount = await api.getChatMemberCount(Number(chatId));
+
+    // Quick reject: if total members > allowed IDs + 1 (bot), there must be untrusted members
+    if (totalCount > numericIds.length + 1) {
+      const result: MembershipResult = {
+        trusted: false,
+        reason: `member-count-mismatch: ${totalCount} members but only ${numericIds.length} trusted IDs + bot`,
+      };
+      cache.set(key, { result, timestamp: Date.now() });
+      return result;
+    }
+
+    // Verify each trusted ID is actually a member
+    let presentCount = 0;
+    for (const userId of numericIds) {
+      try {
+        const member = await api.getChatMember(Number(chatId), userId);
+        const status = member.status;
+        if (status !== "left" && status !== "kicked") {
+          presentCount++;
+        }
+      } catch {
+        // User not in group or API error for this specific user — skip
+      }
+    }
+
+    // Trusted if: present allowed members + 1 bot == total count
+    const trusted = presentCount + 1 === totalCount;
+    const result: MembershipResult = trusted
+      ? { trusted: true }
+      : {
+          trusted: false,
+          reason: `untrusted-members: ${totalCount} total, ${presentCount} trusted + 1 bot = ${presentCount + 1}`,
+        };
+    cache.set(key, { result, timestamp: Date.now() });
+    return result;
+  } catch {
+    const result: MembershipResult = { trusted: false, reason: "api-error" };
+    cache.set(key, { result, timestamp: Date.now() });
+    return result;
+  }
+}
+
+/**
+ * Invalidate cached membership for a specific chat (e.g. on member join/leave).
+ */
+export function invalidateGroupMembership(chatId: number | string): void {
+  cache.delete(getChatKey(chatId));
+}
+
+/**
+ * Clear all cached entries (for testing).
+ */
+export function clearGroupMembershipCache(): void {
+  cache.clear();
+}

--- a/src/telegram/group-membership-cache.ts
+++ b/src/telegram/group-membership-cache.ts
@@ -40,7 +40,7 @@ export async function verifyGroupMembership(params: {
   botId: number;
   allowFrom: NormalizedAllowFrom;
 }): Promise<MembershipResult> {
-  const { chatId, api, botId, allowFrom } = params;
+  const { chatId, api, botId: _botId, allowFrom } = params;
   const key = getChatKey(chatId);
 
   // Check cache

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -73,8 +73,10 @@ async function resolveWhatsAppCommandAuthorized(params: {
   }
 
   const configuredAllowFrom = params.cfg.channels?.whatsapp?.allowFrom ?? [];
+  const defaultGroupAllowFrom = params.cfg.channels?.defaults?.groupAllowFrom;
   const configuredGroupAllowFrom =
     params.cfg.channels?.whatsapp?.groupAllowFrom ??
+    defaultGroupAllowFrom ??
     (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
 
   if (isGroup) {


### PR DESCRIPTION
## Problem

When using bots in Telegram groups, the existing `groupPolicy: "allowlist"` requires allowlisting each **group** by chat ID. This is painful when you want to freely create new groups (e.g., one per discussion topic) between yourself and a bot — every new group needs to be manually registered.

The new `"members"` policy flips the model: instead of allowlisting groups, you allowlist **users**. The bot replies in any group as long as every member is trusted (listed in `groupAllowFrom` or is the bot itself). Create as many groups as you want without touching the config.

## Summary

- Adds `groupPolicy: "members"` mode that verifies **all group participants** are in the trusted allowlist, not just the message sender
- Bot stops replying entirely if any unknown member is present in the group; resumes when they leave
- Adds `channels.defaults.groupAllowFrom` as a global default — per-account `groupAllowFrom` overrides it
- Results cached per chat (5-min TTL), invalidated on `new_chat_members`/`left_chat_member` events
- Fixes: DM allowlist no longer blocks group commands that already passed group-level auth
- Fails closed: API errors or username-only entries (no numeric IDs) block the message

## Test plan

- [x] `npm run build` passes
- [x] All 83 telegram tests pass
- [x] Manual: `/new` works in group with `groupPolicy: "members"`
- [x] Manual: adding an unknown user → bot stops replying
- [x] Manual: removing the unknown user → bot resumes
- [x] Manual: adding a trusted bot (ID in `groupAllowFrom`) → bot keeps replying
- [x] Manual: `channels.defaults.groupAllowFrom` inherited by accounts without per-account override

🤖 Generated with [Claude Code](https://claude.com/claude-code)