### PR TITLE
fix(compaction): add fallback for undefined ctx.model (#12016)

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -170,7 +170,27 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const toolFailureSection = formatToolFailuresSection(toolFailures);
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
-    const model = ctx.model;
+    let model = ctx.model;
+    
+    // Fallback: Try to get model from runtime if ctx.model is undefined
+    if (!model) {
+      const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+      if (runtime?.model) {
+        model = runtime.model;
+        console.warn(
+          'Compaction safeguard: ctx.model was undefined, using model from runtime:',
+          model,
+        );
+      } else {
+        // Log diagnostic info to help debug why model is missing
+        console.error('Compaction safeguard: No model available', {
+          'ctx.model': ctx.model,
+          'ctx keys': Object.keys(ctx),
+          'hasSessionManager': !!ctx.sessionManager,
+          'runtime.model': runtime?.model,
+        });
+      }
+    }
     if (!model) {
       return {
         compaction: {


### PR DESCRIPTION
## Problem
Compaction safeguard fails when `ctx.model` is undefined, causing exit code 1 and falling back to generic summary instead of generating AI-powered summary.

## Solution
- Changed `const model` to `let model` to allow reassignment
- Added fallback logic to retrieve model from `getCompactionSafeguardRuntime()`
- Added comprehensive diagnostic logging for debugging

## Benefits
- Prevents compaction failures when model context is missing
- Provides detailed error logs for troubleshooting
- Maintains backward compatibility with existing code

Fixes #12016

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the compaction safeguard extension to be more resilient when `ctx.model` is missing. It introduces a fallback to read the model from the compaction safeguard runtime (via `getCompactionSafeguardRuntime(ctx.sessionManager)`), and adds additional warning/error logging to aid diagnosis. This keeps the existing behavior of returning a generic fallback summary when no model/API key is available, but avoids failing compaction purely due to an undefined model in the compaction context.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one logging/data-exposure concern to address.
- The functional change is small and contained (model fallback), and preserves the existing fallback-summary behavior when no model/API key is available. The main remaining risk is the new diagnostic logging potentially emitting sensitive internal context details into logs when `ctx.model` is absent.
- src/agents/pi-extensions/compaction-safeguard.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->