### PR TITLE
feat(security): add Privacy Shield for PII masking in model context

### DIFF
--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -22,6 +22,7 @@ import type {
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
+import type { SecurityConfig } from "./types.security.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
@@ -75,6 +76,7 @@ export type OpenClawConfig = {
       avatar?: string;
     };
   };
+  security?: SecurityConfig;
   skills?: SkillsConfig;
   plugins?: PluginsConfig;
   models?: ModelsConfig;

--- a/src/config/types.security.ts
+++ b/src/config/types.security.ts
@@ -1,0 +1,16 @@
+export type PrivacyConfig = {
+  /**
+   * PII scrubbing mode (off|on). When on, common PII (phone, email, credit cards)
+   * is masked before being sent to LLMs.
+   */
+  piiScrubbing?: "off" | "on";
+  /**
+   * Custom patterns for PII scrubbing (regex strings).
+   */
+  piiPatterns?: string[];
+};
+
+export type SecurityConfig = {
+  /** Privacy protection settings. */
+  privacy?: PrivacyConfig;
+};

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -22,6 +22,7 @@ export * from "./types.msteams.js";
 export * from "./types.plugins.js";
 export * from "./types.queue.js";
 export * from "./types.sandbox.js";
+export * from "./types.security.js";
 export * from "./types.signal.js";
 export * from "./types.skills.js";
 export * from "./types.slack.js";

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -32,6 +32,21 @@ const NodeHostSchema = z
   .strict()
   .optional();
 
+const PrivacySchema = z
+  .object({
+    piiScrubbing: z.union([z.literal("on"), z.literal("off")]).optional(),
+    piiPatterns: z.array(z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
+const SecuritySchema = z
+  .object({
+    privacy: PrivacySchema,
+  })
+  .strict()
+  .optional();
+
 const MemoryQmdPathSchema = z
   .object({
     path: z.string(),
@@ -243,6 +258,7 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    security: SecuritySchema,
     auth: z
       .object({
         profiles: z

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -17,6 +17,7 @@ import {
 import { resolveChannelMediaMaxBytes } from "../../channels/plugins/media-limits.js";
 import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
+import { scrubPIIWithConfig } from "../privacy.js";
 import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
@@ -314,8 +315,9 @@ export async function deliverOutboundPayloads(params: {
   };
   const normalizedPayloads = normalizeReplyPayloadsForDelivery(payloads);
   for (const payload of normalizedPayloads) {
+    const scrubbedText = scrubPIIWithConfig(payload.text ?? \"\");
     const payloadSummary: NormalizedOutboundPayload = {
-      text: payload.text ?? "",
+      text: scrubbedText,
       mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
       channelData: payload.channelData,
     };

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -17,13 +17,13 @@ import {
 import { resolveChannelMediaMaxBytes } from "../../channels/plugins/media-limits.js";
 import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
-import { scrubPIIWithConfig } from "../privacy.js";
 import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
 import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
 import { sendMessageSignal } from "../../signal/send.js";
+import { scrubPIIWithConfig } from "../privacy.js";
 import { throwIfAborted } from "./abort.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -315,7 +315,7 @@ export async function deliverOutboundPayloads(params: {
   };
   const normalizedPayloads = normalizeReplyPayloadsForDelivery(payloads);
   for (const payload of normalizedPayloads) {
-    const scrubbedText = scrubPIIWithConfig(payload.text ?? \"\");
+    const scrubbedText = scrubPIIWithConfig(payload.text ?? "");
     const payloadSummary: NormalizedOutboundPayload = {
       text: scrubbedText,
       mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),

--- a/src/infra/privacy.ts
+++ b/src/infra/privacy.ts
@@ -102,14 +102,15 @@ export function scrubPIIInMessages<T>(messages: T[]): T[] {
         return msg;
       }
 
-      const next = { ...(msg as any) };
+      const next = { ...(msg as Record<string, unknown>) };
       if (typeof next.content === "string") {
         next.content = scrubPII(next.content, patterns);
       } else if (Array.isArray(next.content)) {
-        next.content = next.content.map((block: any) => {
+        next.content = next.content.map((block: unknown) => {
           if (block && typeof block === "object") {
-            if (block.type === "text" && typeof block.text === "string") {
-              return { ...block, text: scrubPII(block.text, patterns) };
+            const b = block as Record<string, unknown>;
+            if (b.type === "text" && typeof b.text === "string") {
+              return { ...b, text: scrubPII(b.text, patterns) };
             }
           }
           return block;

--- a/src/infra/privacy.ts
+++ b/src/infra/privacy.ts
@@ -1,0 +1,124 @@
+/**
+ * Privacy Shield - Scans and redacts PII (Personally Identifiable Information)
+ * from agent context before sending it to LLMs.
+ */
+
+import { loadConfig } from "../config/config.js";
+
+export interface PiiRedactor {
+  name: string;
+  pattern: RegExp;
+  replace: string;
+}
+
+const DEFAULT_PII_RED_LIST: PiiRedactor[] = [
+  {
+    name: "Email",
+    pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g,
+    replace: "[EMAIL_REDACTED]",
+  },
+  {
+    name: "Phone",
+    // Matches common phone formats: +1-202-555-0123, (202) 555-0123, 13812345678, etc.
+    pattern: /(\+?\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4,6}/g,
+    replace: "[PHONE_REDACTED]",
+  },
+  {
+    name: "Credit Card",
+    pattern: /\b(?:\d[ -]*?){13,16}\b/g,
+    replace: "[CREDIT_CARD_REDACTED]",
+  },
+  {
+    name: "IPv4",
+    pattern: /\b(?:\d{1,3}\.){3}\d{1,3}\b/g,
+    replace: "[IP_REDACTED]",
+  },
+];
+
+/**
+ * Scrub PII from a string.
+ */
+export function scrubPII(text: string, customPatterns?: string[]): string {
+  if (!text) {
+    return text;
+  }
+
+  let scrubbed = text;
+
+  // Apply default patterns
+  for (const redactor of DEFAULT_PII_RED_LIST) {
+    scrubbed = scrubbed.replace(redactor.pattern, redactor.replace);
+  }
+
+  // Apply custom patterns from config
+  if (customPatterns) {
+    for (const patternStr of customPatterns) {
+      try {
+        const re = new RegExp(patternStr, "gi");
+        scrubbed = scrubbed.replace(re, "[REDACTED]");
+      } catch {
+        // ignore invalid regex
+      }
+    }
+  }
+
+  return scrubbed;
+}
+
+/**
+ * Enhanced scrubbing that checks config.
+ */
+export function scrubPIIWithConfig(text: string): string {
+  try {
+    const config = loadConfig();
+    const privacy = config.security?.privacy;
+
+    if (privacy?.piiScrubbing === "on") {
+      return scrubPII(text, privacy.piiPatterns);
+    }
+  } catch {
+    // Fallback if config can't be loaded
+  }
+
+  return text;
+}
+
+/**
+ * Scrub PII in a list of agent messages.
+ */
+export function scrubPIIInMessages(messages: unknown[]): unknown[] {
+  try {
+    const config = loadConfig();
+    const privacy = config.security?.privacy;
+
+    if (privacy?.piiScrubbing !== "on") {
+      return messages;
+    }
+
+    const patterns = privacy.piiPatterns;
+
+    return messages.map((msg) => {
+      if (!msg || typeof msg !== "object") {
+        return msg;
+      }
+
+      const next = { ...(msg as Record<string, unknown>) };
+      if (typeof next.content === "string") {
+        next.content = scrubPII(next.content, patterns);
+      } else if (Array.isArray(next.content)) {
+        next.content = next.content.map((block: unknown) => {
+          if (block && typeof block === "object") {
+            const b = block as Record<string, unknown>;
+            if (b.type === "text" && typeof b.text === "string") {
+              return { ...b, text: scrubPII(b.text, patterns) };
+            }
+          }
+          return block;
+        });
+      }
+      return next;
+    });
+  } catch {
+    return messages;
+  }
+}

--- a/src/infra/privacy.ts
+++ b/src/infra/privacy.ts
@@ -86,7 +86,7 @@ export function scrubPIIWithConfig(text: string): string {
 /**
  * Scrub PII in a list of agent messages.
  */
-export function scrubPIIInMessages(messages: unknown[]): unknown[] {
+export function scrubPIIInMessages<T extends { content?: unknown }>(messages: T[]): T[] {
   try {
     const config = loadConfig();
     const privacy = config.security?.privacy;
@@ -116,7 +116,7 @@ export function scrubPIIInMessages(messages: unknown[]): unknown[] {
           return block;
         });
       }
-      return next;
+      return next as T;
     });
   } catch {
     return messages;


### PR DESCRIPTION
## Summary

Add a Privacy Shield layer that scans and redacts PII (Personally Identifiable Information) from the agent's **outbound responses** before they are sent to chat channels.

## Motivation

This is specifically designed to combat **Prompt Injection attacks**. While the model needs access to sensitive info in its context to be helpful, we want to prevent that info from being "leaked" to external chat channels if the model is tricked or "hallucinates" private data into its output.

## Features

- **Output Interception**: Intercepts messages at the final delivery stage (e.g., Telegram, Discord).
- **Preserves Model Intelligence**: Input context remains unscrubbed so the model stays smart.
- **Default PII Redaction**: Automatically masks Emails, Phone numbers, Credit Card numbers, and IPv4 addresses.
- **Configurable**: Users can enable/disable this feature via `security.privacy.piiScrubbing`.
- **Custom Patterns**: Users can provide their own regex patterns for additional redaction.

## Configuration Example

```json
{
  "security": {
    "privacy": {
      "piiScrubbing": "on",
      "piiPatterns": ["\\bsecret-project-code\\b"]
    }
  }
}
```

## Behavior Changes

| Context (What Model Sees) | Output (What is Sent to User) |
|---------------------------|-------------------------------|
| "Call my boss at 123-456-7890" | "Calling [PHONE_REDACTED]..." |
| "The secret code is XYZ-123" | "The secret code is [REDACTED]" |

## Files Changed

- `src/infra/privacy.ts`: Core PII scrubbing logic.
- `src/infra/outbound/deliver.ts`: Integration into the outbound delivery pipeline.
- `src/config/types.security.ts`: New security configuration types.
- `src/config/zod-schema.ts`: Configuration schema validation.

## AI-Assisted Contribution 🤖

- [x] AI-assisted (Claude)
- [x] Focused on Prompt Injection defense
- [x] Tested output scrubbing locally

lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a “Privacy Shield” that redacts PII from agent context before sending it to LLMs. It adds a new `security.privacy` config section (types + Zod schema), implements PII scrubbing utilities in `src/infra/privacy.ts`, and integrates scrubbing into the embedded runner by applying it to the generated system prompt and to the limited message history before calling `replaceMessages()`.

Key integration points are in `src/agents/pi-embedded-runner/run/attempt.ts`, where the system prompt override is scrubbed and the session history is scrubbed after validation/limiting.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but there is a type-safety regression at a core integration point that should be fixed before merging.
- The config/type additions and integration look straightforward, but `scrubPIIInMessages()` returns `unknown[]` and is fed into `replaceMessages()`, which is intended to operate on `AgentMessage[]`. That’s either a TS compile break or a loss of guarantees in the message pipeline. Once the scrubber is typed to preserve `AgentMessage` shapes, the remaining changes appear low-risk.
- src/agents/pi-embedded-runner/run/attempt.ts, src/infra/privacy.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->