### PR TITLE
fix: scope error-detection heuristics to error source in sanitizeUserFacingText

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -38,3 +38,61 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
 });
+
+describe('sanitizeUserFacingText with { source: "assistant" }', () => {
+  const assistant = { source: "assistant" as const };
+
+  it("does not rewrite billing-related keywords in assistant text", () => {
+    expect(sanitizeUserFacingText("Your credit balance is $42.00", assistant)).toBe(
+      "Your credit balance is $42.00",
+    );
+    expect(sanitizeUserFacingText("billing: please upgrade your plan", assistant)).toBe(
+      "billing: please upgrade your plan",
+    );
+    expect(sanitizeUserFacingText("insufficient credits for this operation", assistant)).toBe(
+      "insufficient credits for this operation",
+    );
+  });
+
+  it("does not rewrite HTTP status codes in assistant text", () => {
+    expect(sanitizeUserFacingText("500 Internal Server Error", assistant)).toBe(
+      "500 Internal Server Error",
+    );
+    expect(sanitizeUserFacingText("402 Payment Required", assistant)).toBe("402 Payment Required");
+  });
+
+  it("does not rewrite error-prefixed text in assistant text", () => {
+    expect(sanitizeUserFacingText("Error: something went wrong in the build", assistant)).toBe(
+      "Error: something went wrong in the build",
+    );
+    expect(sanitizeUserFacingText("Failed: deployment step 3", assistant)).toBe(
+      "Failed: deployment step 3",
+    );
+  });
+
+  it("does not rewrite raw JSON error payloads in assistant text", () => {
+    const raw = '{"type":"error","error":{"message":"Something exploded","type":"server_error"}}';
+    expect(sanitizeUserFacingText(raw, assistant)).toBe(raw);
+  });
+
+  it("still strips <final> tags for assistant text", () => {
+    expect(sanitizeUserFacingText("<final>Hello</final>", assistant)).toBe("Hello");
+    expect(sanitizeUserFacingText("Hi <final>there</final>!", assistant)).toBe("Hi there!");
+  });
+
+  it("still collapses consecutive duplicate paragraphs for assistant text", () => {
+    const text = "Hello there!\n\nHello there!";
+    expect(sanitizeUserFacingText(text, assistant)).toBe("Hello there!");
+  });
+
+  it("does not collapse distinct paragraphs for assistant text", () => {
+    const text = "Hello there!\n\nDifferent line.";
+    expect(sanitizeUserFacingText(text, assistant)).toBe(text);
+  });
+
+  it("passes through normal assistant content unchanged", () => {
+    const response =
+      "Here are your Linear issues:\n1. Show Credit Balance - Task #1234\n2. 402 API endpoint - Task #5678";
+    expect(sanitizeUserFacingText(response, assistant)).toBe(response);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -15,6 +15,7 @@ export {
   isBillingAssistantError,
   parseApiErrorInfo,
   sanitizeUserFacingText,
+  type SanitizeTextSource,
   isBillingErrorMessage,
   isCloudCodeAssistFormatError,
   isCompactionFailureError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -379,7 +379,27 @@ export function formatAssistantErrorText(
   return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
 }
 
-export function sanitizeUserFacingText(text: string): string {
+/**
+ * Source of the text being sanitized.
+ *
+ * - `"assistant"` — normal assistant response content.  Only safe transforms
+ *   are applied (tag stripping, duplicate collapse).  Error-detection
+ *   heuristics are skipped to avoid false positives when the response happens
+ *   to mention billing keywords, HTTP status codes, etc.
+ *
+ * - `"error"` — an API / provider error message.  Full error-detection and
+ *   rewriting logic is applied (HTTP status formatting, rate-limit /
+ *   overloaded detection, etc.).
+ *
+ * For backward compatibility the parameter is optional; when omitted the
+ * function behaves as before (applies all checks).
+ */
+export type SanitizeTextSource = "assistant" | "error";
+
+export function sanitizeUserFacingText(
+  text: string,
+  options?: { source?: SanitizeTextSource },
+): string {
   if (!text) {
     return text;
   }
@@ -387,6 +407,13 @@ export function sanitizeUserFacingText(text: string): string {
   const trimmed = stripped.trim();
   if (!trimmed) {
     return stripped;
+  }
+
+  // When the text is known to be a normal assistant response, skip the
+  // error-detection heuristics that can false-positive on legitimate content
+  // containing billing keywords, HTTP status codes, or error-like prefixes.
+  if (options?.source === "assistant") {
+    return collapseConsecutiveDuplicateBlocks(stripped);
   }
 
   if (/incorrect role information|roles must alternate/i.test(trimmed)) {

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -218,7 +218,7 @@ export function extractAssistantText(msg: AssistantMessage): string {
         .filter(Boolean)
     : [];
   const extracted = blocks.join("\n").trim();
-  return sanitizeUserFacingText(extracted);
+  return sanitizeUserFacingText(extracted, { source: "assistant" });
 }
 
 export function extractAssistantThinking(msg: AssistantMessage): string {

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -389,5 +389,5 @@ export function extractAssistantText(message: unknown): string | undefined {
     }
   }
   const joined = chunks.join("").trim();
-  return joined ? sanitizeUserFacingText(joined) : undefined;
+  return joined ? sanitizeUserFacingText(joined, { source: "assistant" }) : undefined;
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -127,7 +127,7 @@ export async function runAgentTurnWithFallback(params: {
         if (!text) {
           return { skip: true };
         }
-        const sanitized = sanitizeUserFacingText(text);
+        const sanitized = sanitizeUserFacingText(text, { source: "assistant" });
         if (!sanitized.trim()) {
           return { skip: true };
         }

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -62,7 +62,7 @@ export function normalizeReplyPayload(
   }
 
   if (text) {
-    text = sanitizeUserFacingText(text);
+    text = sanitizeUserFacingText(text, { source: "assistant" });
   }
   if (!text?.trim() && !hasMedia && !hasChannelData) {
     opts.onSkip?.("empty");


### PR DESCRIPTION
## Summary

`sanitizeUserFacingText()` applies error-detection heuristics (HTTP status matching, error-prefix detection, rate-limit rewriting) to **all** outbound text, including normal assistant responses. This causes false positives when the assistant's reply contains billing keywords (`"credit balance"`, `"402"`), HTTP-status-like prefixes, or error-related phrases — the entire response gets replaced with a generic error message.

This PR adds an optional `source` parameter (`"assistant"` | `"error"`) so callers can indicate the origin of the text:

- **`"assistant"`** — skips the error-detection heuristics; only applies safe transforms (tag stripping, duplicate block collapse)
- **`"error"`** — applies the full error-detection and rewriting logic (current behavior)
- **omitted** — backward-compatible, behaves as before

All callers that process normal assistant content now pass `{ source: "assistant" }`:

| File | Role |
|------|------|
| `src/auto-reply/reply/normalize-reply.ts` | Outbound reply normalization for all channels |
| `src/auto-reply/reply/agent-runner-execution.ts` | Streaming text normalization during model execution |
| `src/agents/pi-embedded-utils.ts` | Assistant text extraction from message blocks |
| `src/agents/tools/sessions-helpers.ts` | Session transcript text extraction |

Error-path callers (e.g. `formatAssistantErrorText`) continue to use the default behavior and apply full error detection.

## Test plan

- Existing unit tests pass (18/18 across `sanitizeUserFacingText`, `isBillingErrorMessage`, `formatAssistantErrorText`, and `classifyFailoverReason` suites)
- Verified that assistant responses containing "credit balance", "402", "billing upgrade" are no longer mangled when delivered through the outbound reply pipeline
- Error messages (actual API failures) continue to be formatted correctly

Fixes #12022

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR scopes `sanitizeUserFacingText()`’s error-detection/rewriting heuristics (HTTP status formatting, error-prefix detection, rate-limit/overload rewriting, billing keyword detection) to text that is known to originate from an error source.

It introduces an optional `source` option (`"assistant" | "error"`, defaulting to the previous behavior when omitted) and updates outbound/assistant-text call sites (`normalize-reply`, streaming normalization, transcript extraction) to pass `{ source: "assistant" }` so normal assistant replies don’t get replaced by generic error messages when they contain billing keywords (e.g. “credit balance”) or status-code-like text.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge, with the main remaining risk being insufficient test coverage for the new `{ source: "assistant" }` behavior.
- Behavioral change is narrowly scoped and call sites are consistently updated to pass `source: "assistant"` for normal assistant output while keeping backward-compatible defaults for error paths. The primary concern is that the test suite doesn’t exercise the new code path, so the intended prevention of false positives (billing keywords/status-like text) and preservation of safe transforms in assistant mode aren’t locked in by tests.
- src/agents/pi-embedded-helpers/errors.ts (add/adjust unit tests to cover `source: "assistant"` and optionally `source: "error"`)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->