### PR TITLE
fix: exclude owner-only context files (USER.md, MEMORY.md) for non-owner senders

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -4,6 +4,7 @@ import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import { buildBootstrapContextFiles, resolveBootstrapMaxChars } from "./pi-embedded-helpers.js";
 import {
   filterBootstrapFilesForSession,
+  filterOwnerOnlyBootstrapFiles,
   loadWorkspaceBootstrapFiles,
   type WorkspaceBootstrapFile,
 } from "./workspace.js";
@@ -24,12 +25,14 @@ export async function resolveBootstrapFilesForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  senderIsOwner?: boolean;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
-  const bootstrapFiles = filterBootstrapFilesForSession(
+  let bootstrapFiles = filterBootstrapFilesForSession(
     await loadWorkspaceBootstrapFiles(params.workspaceDir),
     sessionKey,
   );
+  bootstrapFiles = filterOwnerOnlyBootstrapFiles(bootstrapFiles, params.senderIsOwner);
   return applyBootstrapHookOverrides({
     files: bootstrapFiles,
     workspaceDir: params.workspaceDir,
@@ -46,6 +49,7 @@ export async function resolveBootstrapContextForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  senderIsOwner?: boolean;
   warn?: (message: string) => void;
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -213,6 +213,7 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
+      senderIsOwner: params.senderIsOwner,
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
     });
     const runAbortController = new AbortController();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -193,6 +193,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        senderIsOwner: params.senderIsOwner,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
       });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -301,3 +301,30 @@ export function filterBootstrapFilesForSession(
   }
   return files.filter((file) => SUBAGENT_BOOTSTRAP_ALLOWLIST.has(file.name));
 }
+
+/**
+ * Files that contain private owner information and should NOT be injected
+ * into the system prompt for non-owner senders.  Without this filter, any
+ * stranger who messages the agent over a public channel receives responses
+ * informed by the owner's name, email, personal notes, and memory.
+ */
+const OWNER_ONLY_BOOTSTRAP_FILES: ReadonlySet<string> = new Set([
+  DEFAULT_USER_FILENAME,
+  DEFAULT_MEMORY_FILENAME,
+  DEFAULT_MEMORY_ALT_FILENAME,
+]);
+
+/**
+ * Strip owner-only bootstrap files from the list when the sender is not the
+ * owner.  This prevents private context (USER.md, MEMORY.md) from leaking
+ * into conversations with non-owner senders on public-facing channels.
+ */
+export function filterOwnerOnlyBootstrapFiles(
+  files: WorkspaceBootstrapFile[],
+  senderIsOwner?: boolean,
+): WorkspaceBootstrapFile[] {
+  if (senderIsOwner !== false) {
+    return files;
+  }
+  return files.filter((file) => !OWNER_ONLY_BOOTSTRAP_FILES.has(file.name));
+}

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -64,6 +64,7 @@ async function resolveContextReport(
     config: params.cfg,
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
+    senderIsOwner: params.command.senderIsOwner,
   });
   const skillsSnapshot = (() => {
     try {


### PR DESCRIPTION
## Summary

When a non-owner sends a message via a public-facing channel (`dmPolicy: "open"` or equivalent), the agent's full bootstrap context — including `USER.md` (name, email, personal info) and `MEMORY.md` (accumulated observations) — is injected into the system prompt. The existing `senderIsOwner` flag only gates **tool access** (e.g. `whatsapp_login`), not **information visibility**.

This means any external sender who DMs an agent receives responses informed by the owner's private context, which is a data privacy issue.

This PR threads `senderIsOwner` through the bootstrap context resolution pipeline and filters out owner-only files when the sender is not the owner:

| File | Change |
|------|--------|
| `src/agents/workspace.ts` | Define `OWNER_ONLY_BOOTSTRAP_FILES` set (`USER.md`, `MEMORY.md`, `memory.md`) and `filterOwnerOnlyBootstrapFiles()` |
| `src/agents/bootstrap-files.ts` | Accept `senderIsOwner` in `resolveBootstrapFilesForRun` and `resolveBootstrapContextForRun`; apply the filter after session filtering |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Pass `params.senderIsOwner` to `resolveBootstrapContextForRun` |
| `src/agents/pi-embedded-runner/compact.ts` | Pass `params.senderIsOwner` to `resolveBootstrapContextForRun` |
| `src/auto-reply/reply/commands-context-report.ts` | Pass `params.command.senderIsOwner` to `resolveBootstrapContextForRun` |

The filter is a no-op when `senderIsOwner` is `true` or `undefined`, preserving backward compatibility for owner sessions, CLI usage, and any callers that don't pass the parameter.

**Files classified as owner-only:**
- `USER.md` — personal information about the owner
- `MEMORY.md` / `memory.md` — accumulated memory and observations

**Files that remain accessible to all senders:**
- `SOUL.md`, `AGENTS.md`, `TOOLS.md`, `IDENTITY.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`

## Test plan

- Existing unit tests pass (workspace + bootstrap-files: 5/5)
- When `senderIsOwner` is `false`, `USER.md` and `MEMORY.md` are excluded from the bootstrap file list
- When `senderIsOwner` is `true` or omitted, all files are included (backward compatible)
- `SOUL.md`, `AGENTS.md`, `TOOLS.md`, `IDENTITY.md` remain accessible to non-owner senders so agent behavior stays consistent

Fixes #11900

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a `senderIsOwner` flag into bootstrap context resolution so that owner-only workspace context files are excluded from the system prompt for non-owner senders (e.g. public DMs). Concretely, it adds an owner-only bootstrap file filter (`USER.md`, `MEMORY.md`/`memory.md`) in `src/agents/workspace.ts`, applies that filter during bootstrap file resolution in `src/agents/bootstrap-files.ts`, and passes `senderIsOwner` through the embedded runner (run + compaction) and the `/context` report path so context reports match what will actually be injected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to bootstrap context selection and only take effect when `senderIsOwner === false`. Call sites in the embedded runner and context report path were updated accordingly, and behavior remains unchanged for owner sessions and callers that omit the flag.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->