### PR TITLE
fix(gateway): return 404 for missing static assets instead of SPA fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Control UI: return 404 for missing static-asset paths instead of serving SPA fallback HTML, while preserving client-route fallback behavior for extensionless and non-asset dotted paths. (#12060) thanks @mcaxtr.
 - Gateway/Pairing: prevent device-token rotate scope escalation by enforcing an approved-scope baseline, preserving approved scopes across metadata updates, and rejecting rotate requests that exceed approved role scope implications. (#20703) thanks @coygeek.
 - Gateway/Security: require secure context and paired-device checks for Control UI auth even when `gateway.controlUi.allowInsecureAuth` is set, and align audit messaging with the hardened behavior. (#20684) thanks @coygeek.
 - macOS/Build: default release packaging to `BUNDLE_ID=ai.openclaw.mac` in `scripts/package-mac-dist.sh`, so Sparkle feed URL is retained and auto-update no longer fails with an empty appcast feed. (#19750) thanks @loganprit.


### PR DESCRIPTION
Fixes #11556

## Summary

The webchat SPA catch-all route in `handleControlUiHttpRequest()` serves `index.html` for **all** unmatched paths — including requests for static assets like `/webchat/favicon.svg`. This causes the logo to appear broken in the webchat UI because the browser receives HTML (with `Content-Type: text/html`) instead of the actual SVG file.

## Root Cause

In `src/gateway/control-ui.ts`, the SPA fallback (lines 355-364) fires whenever a requested file doesn't exist on disk. It doesn't distinguish between:
- **Navigation requests** (extensionless paths like `/webchat/chat`) → should get `index.html` for client-side routing
- **Asset requests** (paths with file extensions like `/webchat/favicon.svg`) → should get 404 if the file is missing

## Fix

Before the SPA fallback, check `path.extname(fileRel)`. If the requested path has a file extension and the file doesn't exist, return 404 instead of serving `index.html`. Extensionless paths continue to get the SPA fallback as before.

## Test Plan

- [x] New test: missing static asset path (`/webchat/favicon.svg`) returns 404
- [x] New test: extensionless SPA path (`/webchat/chat`) still gets `index.html` fallback (200)
- [x] Existing test: security headers still applied
- [x] All 2 new tests fail before fix, pass after (TDD)
- [x] Full suite: 251 tests pass, 0 failures
- [x] `pnpm build` passes
- [x] `pnpm check` passes (lint + format)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes tighten the Control UI (webchat SPA) fallback behavior so that requests for *missing static assets* (e.g. `.svg`, `.js`, `.css`, etc.) return `404 Not Found` instead of incorrectly serving `index.html`. This prevents browsers from receiving HTML for asset URLs (fixing broken favicon/logo scenarios) while preserving SPA routing for extensionless routes and dotted path segments.

Implementation-wise, `src/gateway/control-ui.ts` introduces a `STATIC_ASSET_EXTENSIONS` allowlist and checks it after the on-disk file lookup but before the SPA `index.html` fallback. Tests in `src/gateway/control-ui.test.ts` cover missing-asset 404s (GET/HEAD), extensionless SPA fallback, dotted-route fallback, and `.html`-suffixed route fallback.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (a single allowlist check before SPA fallback) and is covered by targeted tests for the previously broken behavior (missing assets returning `index.html`) plus regressions (dotted SPA routes and `.html` routes). No additional functional issues were found in the modified code paths beyond the already-discussed prior threads.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->