### PR TITLE
docs: Add security hardening guide for OpenClaw configurations

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,6 +4,7 @@
 
 ## Documents
 
+- [Hardening Guide](./hardening-guide.md) - Practical security checklist for OpenClaw configurations
 - [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
 - [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,9 +4,9 @@
 
 ## Documents
 
-- [Hardening Guide](./hardening-guide.md) - Practical security checklist for OpenClaw configurations
-- [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
-- [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
+- [Hardening Guide](/security/hardening-guide) - Practical security checklist for OpenClaw configurations
+- [Threat Model](/security/threat-model-atlas) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
+- [Contributing to the Threat Model](/security/contributing-threat-model) - How to add threats, mitigations, and attack chains
 
 ## Reporting Vulnerabilities
 

--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -1,0 +1,239 @@
+# Security Hardening Guide
+
+A practical guide to securing your OpenClaw configuration. These recommendations are based on real-world analysis of publicly committed OpenClaw configurations on GitHub.
+
+## Quick Check
+
+Run a security audit of your configuration in under 1 second:
+
+```bash
+npx clawhatch scan
+```
+
+This checks 128 security issues across 10 categories, entirely locally — nothing leaves your machine.
+
+---
+
+## 1. Never Commit Credentials
+
+**Risk:** Hardcoded API keys, bot tokens, and passwords in `openclaw.json` are the most common security issue we see in public repositories.
+
+**Fix:** Use environment variable references instead of plaintext values:
+
+```json
+// ❌ Bad — credentials in plaintext
+{
+  "providers": {
+    "anthropic": {
+      "apiKey": "sk-ant-api03-actual-key-here"
+    }
+  }
+}
+
+// ✅ Good — environment variable reference
+{
+  "providers": {
+    "anthropic": {
+      "apiKey": "${ANTHROPIC_API_KEY}"
+    }
+  }
+}
+```
+
+Store the actual values in a `.env` file:
+
+```bash
+# .env (add to .gitignore!)
+ANTHROPIC_API_KEY=sk-ant-api03-...
+OPENAI_API_KEY=sk-proj-...
+TELEGRAM_BOT_TOKEN=123456:ABC-...
+```
+
+### Add to .gitignore
+
+```gitignore
+# OpenClaw security
+openclaw.json
+.env
+.env.*
+*.jsonl
+sessions/
+```
+
+> **⚠️ Known Issue ([#9627](https://github.com/openclaw/openclaw/issues/9627)):** Running `openclaw update`, `openclaw doctor`, or `openclaw configure` may resolve `${...}` environment variable references and write the actual values back to `openclaw.json`. Check your config file after running these commands and restore `${...}` syntax if needed.
+
+---
+
+## 2. Enable Sandbox Isolation
+
+**Risk:** Without sandbox configuration, the AI agent executes commands with the same permissions as the user who launched OpenClaw — unrestricted shell, file, and network access.
+
+**Fix:** Set sandbox mode in your config:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "sandbox": {
+        "mode": "non-main"
+      }
+    }
+  }
+}
+```
+
+Available modes:
+- `"non-main"` — Sandbox all sessions except the main session (recommended minimum)
+- `"always"` — Sandbox all sessions including main (maximum isolation)
+
+---
+
+## 3. Configure DM Allowlists
+
+**Risk:** Without a DM allowlist, anyone who can message your bot on Telegram, Discord, or WhatsApp can potentially issue commands to it.
+
+**Fix:** Restrict who can send direct messages to your agent:
+
+```json
+{
+  "identity": {
+    "ownerNumbers": ["+15555551234"],
+    "dmAllowlist": [
+      "your-telegram-user-id",
+      "your-discord-user-id",
+      "+15555551234"
+    ]
+  }
+}
+```
+
+Without an allowlist, you're relying on the agent's prompt engineering to reject malicious requests. That is not a security boundary.
+
+---
+
+## 4. Bind Gateway to Localhost
+
+**Risk:** Binding the gateway to `0.0.0.0` exposes the agent's control API to your entire local network (or the internet, if port-forwarded).
+
+**Fix:**
+
+```json
+{
+  "gateway": {
+    "bind": "127.0.0.1:18789"
+  }
+}
+```
+
+If you need remote access, use SSH tunneling or a reverse proxy with authentication rather than exposing the gateway directly.
+
+---
+
+## 5. Use Strong Auth Tokens
+
+**Risk:** Weak, default, or missing gateway auth tokens allow anyone with network access to control your agent.
+
+**Fix:** Generate a cryptographically random token:
+
+```bash
+# Generate a 32-byte random hex token
+openssl rand -hex 32
+```
+
+```json
+{
+  "gateway": {
+    "authToken": "your-64-character-random-hex-token"
+  }
+}
+```
+
+Avoid common tokens like `test`, `password`, `changeme`, or short tokens that can be brute-forced.
+
+---
+
+## 6. Review Tool Permissions
+
+**Risk:** Agents with elevated tool access (browser control, node pairing, file system access) have a larger attack surface.
+
+**Fix:** Only enable the tools your agent actually needs. Review `agents.defaults.sandbox` settings:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "sandbox": {
+        "mode": "non-main",
+        "browser": {
+          "allowHostControl": false
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## 7. Check Your Git History
+
+Even if your current config is clean, Git preserves everything:
+
+```bash
+# Check if openclaw.json was ever committed
+git log --all --full-history -- openclaw.json
+
+# View a specific commit's version
+git show <commit-hash>:openclaw.json
+```
+
+If credentials appear in your history:
+
+1. **Rotate all exposed credentials immediately**
+2. Use [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or `git filter-branch` to remove secrets from history
+3. Force push the cleaned history
+4. Consider any credentials that were ever committed as compromised
+
+---
+
+## Security Checklist
+
+| Check | Status |
+|-------|--------|
+| No plaintext credentials in config | ☐ |
+| Using `${ENV_VAR}` references for all secrets | ☐ |
+| `openclaw.json` in `.gitignore` | ☐ |
+| `.env` in `.gitignore` | ☐ |
+| Sandbox mode set to `non-main` or `always` | ☐ |
+| DM allowlist configured | ☐ |
+| Gateway bound to `127.0.0.1` | ☐ |
+| Strong auth token set | ☐ |
+| Git history clean of credentials | ☐ |
+| No unnecessary elevated tool permissions | ☐ |
+
+---
+
+## Automated Scanning
+
+For automated security auditing, [Clawhatch](https://clawhatch.com) provides a comprehensive scanner:
+
+```bash
+# Run a full security audit
+npx clawhatch scan
+
+# Auto-fix safe issues
+npx clawhatch scan --fix
+
+# Share anonymized results with the community threat feed
+npx clawhatch scan --share
+```
+
+128 checks across 10 categories: secrets, identity & access, network exposure, sandbox configuration, data protection, model security, tool permissions, skills & plugins, operational security, and cloud sync.
+
+---
+
+## Further Reading
+
+- [OpenClaw Threat Model](./THREAT-MODEL-ATLAS.md)
+- [Trust & Vulnerability Reporting](https://trust.openclaw.ai)
+- [State of AI Agent Security 2026](https://clawhatch.com/blog/state-of-ai-agent-security-2026) — Public audit of GitHub-hosted OpenClaw configurations

--- a/docs/security/hardening-guide.md
+++ b/docs/security/hardening-guide.md
@@ -234,6 +234,6 @@ npx clawhatch scan --share
 
 ## Further Reading
 
-- [OpenClaw Threat Model](./THREAT-MODEL-ATLAS.md)
+- [OpenClaw Threat Model](/security/threat-model-atlas)
 - [Trust & Vulnerability Reporting](https://trust.openclaw.ai)
 - [State of AI Agent Security 2026](https://clawhatch.com/blog/state-of-ai-agent-security-2026) — Public audit of GitHub-hosted OpenClaw configurations


### PR DESCRIPTION
## Summary

Adds a practical security hardening guide to the docs covering the most common misconfigurations found in publicly committed OpenClaw configs.

## What's included

- **Credential management** — using ${ENV_VAR} references, .gitignore best practices, and a note about #9627 (env var resolution during config writes)
- **Sandbox isolation** — enabling 
on-main or lways mode
- **DM allowlists** — restricting who can message your agent
- **Gateway binding** — localhost-only binding to prevent network exposure
- **Auth tokens** — generating and configuring strong tokens
- **Tool permissions** — reviewing elevated access
- **Git history hygiene** — checking for and cleaning committed credentials
- **Security checklist** — quick reference table
- **Automated scanning** — mention of community tools for config auditing

## Motivation

While researching AI agent security, I audited publicly committed OpenClaw configurations on GitHub (5,700+ repos). Every config I found had at least one security issue — hardcoded credentials, missing sandboxes, exposed gateways, or no access controls.

The existing security docs cover the threat model well, but there's no practical 'how to harden your config' guide. This PR fills that gap.

## Details

- Written for the docs site (Markdown, consistent with existing style)
- Updated docs/security/README.md to link to the new guide
- All recommendations are actionable with specific config snippets
- No breaking changes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new security hardening guide under `docs/security/` with concrete configuration recommendations (secrets via env vars, sandbox modes, DM allowlists, localhost gateway binding, strong auth tokens, tool permission review, and git history cleanup), and links to it from `docs/security/README.md`.

Main integration point is the security docs index (`docs/security/README.md`) so readers can discover the new guide alongside the existing threat model documents.

<h3>Confidence Score: 4/5</h3>

- Low-risk docs-only PR, but internal doc links likely won’t work on the Mintlify site as written.
- Changes are limited to documentation, but multiple links use relative paths with `.md` extensions, which conflicts with the repo’s stated Mintlify linking convention for `docs/**/*.md` and will break navigation on docs.openclaw.ai unless corrected.
- docs/security/hardening-guide.md; docs/security/README.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->