### PR TITLE
feat: add Moonshot (Kimi K2.5) native video understanding provider

### DIFF
--- a/src/media-understanding/providers/index.ts
+++ b/src/media-understanding/providers/index.ts
@@ -5,6 +5,7 @@ import { deepgramProvider } from "./deepgram/index.js";
 import { googleProvider } from "./google/index.js";
 import { groqProvider } from "./groq/index.js";
 import { minimaxProvider } from "./minimax/index.js";
+import { moonshotProvider } from "./moonshot/index.js";
 import { openaiProvider } from "./openai/index.js";
 
 const PROVIDERS: MediaUnderstandingProvider[] = [
@@ -14,6 +15,7 @@ const PROVIDERS: MediaUnderstandingProvider[] = [
   anthropicProvider,
   minimaxProvider,
   deepgramProvider,
+  moonshotProvider,
 ];
 
 export function normalizeMediaProviderId(id: string): string {

--- a/src/media-understanding/providers/moonshot/index.ts
+++ b/src/media-understanding/providers/moonshot/index.ts
@@ -1,0 +1,10 @@
+import type { MediaUnderstandingProvider } from "../../types.js";
+import { describeImageWithModel } from "../image.js";
+import { describeMoonshotVideo } from "./video.js";
+
+export const moonshotProvider: MediaUnderstandingProvider = {
+  id: "moonshot",
+  capabilities: ["image", "video"],
+  describeImage: describeImageWithModel,
+  describeVideo: describeMoonshotVideo,
+};

--- a/src/media-understanding/providers/moonshot/video.ts
+++ b/src/media-understanding/providers/moonshot/video.ts
@@ -51,7 +51,7 @@ export async function describeMoonshotVideo(
         ],
       },
     ],
-    max_tokens: 4096,
+    max_tokens: 8192,
   };
 
   const { response: res, release } = await fetchWithTimeoutGuarded(
@@ -75,11 +75,14 @@ export async function describeMoonshotVideo(
 
     const payload = (await res.json()) as {
       choices?: Array<{
-        message?: { content?: string };
+        message?: { content?: string; reasoning_content?: string };
       }>;
     };
 
-    const text = payload.choices?.[0]?.message?.content?.trim();
+    const msg = payload.choices?.[0]?.message;
+    // K2.5 defaults to thinking mode: main reply in content, reasoning in reasoning_content.
+    // If content is empty but reasoning_content exists, use reasoning as fallback.
+    const text = msg?.content?.trim() || msg?.reasoning_content?.trim();
     if (!text) {
       throw new Error("Moonshot video description response missing content");
     }

--- a/src/media-understanding/providers/moonshot/video.ts
+++ b/src/media-understanding/providers/moonshot/video.ts
@@ -22,7 +22,6 @@ export async function describeMoonshotVideo(
 ): Promise<VideoDescriptionResult> {
   const fetchFn = params.fetchFn ?? fetch;
   const baseUrl = normalizeBaseUrl(params.baseUrl, DEFAULT_MOONSHOT_VIDEO_BASE_URL);
-  const allowPrivate = Boolean(params.baseUrl?.trim());
   const model = resolveModel(params.model);
   const url = `${baseUrl}/chat/completions`;
 
@@ -63,7 +62,7 @@ export async function describeMoonshotVideo(
     },
     params.timeoutMs,
     fetchFn,
-    allowPrivate ? { ssrfPolicy: { allowPrivateNetwork: true } } : undefined,
+    undefined,
   );
 
   try {

--- a/src/media-understanding/providers/moonshot/video.ts
+++ b/src/media-understanding/providers/moonshot/video.ts
@@ -1,7 +1,7 @@
 import type { VideoDescriptionRequest, VideoDescriptionResult } from "../../types.js";
 import { fetchWithTimeoutGuarded, normalizeBaseUrl, readErrorResponse } from "../shared.js";
 
-export const DEFAULT_MOONSHOT_VIDEO_BASE_URL = "https://api.moonshot.cn/v1";
+export const DEFAULT_MOONSHOT_VIDEO_BASE_URL = "https://api.moonshot.ai/v1";
 const DEFAULT_MOONSHOT_VIDEO_MODEL = "kimi-k2.5";
 const DEFAULT_MOONSHOT_VIDEO_PROMPT = "Describe the video in detail.";
 

--- a/src/media-understanding/providers/moonshot/video.ts
+++ b/src/media-understanding/providers/moonshot/video.ts
@@ -1,0 +1,90 @@
+import type { VideoDescriptionRequest, VideoDescriptionResult } from "../../types.js";
+import { fetchWithTimeoutGuarded, normalizeBaseUrl, readErrorResponse } from "../shared.js";
+
+export const DEFAULT_MOONSHOT_VIDEO_BASE_URL = "https://api.moonshot.cn/v1";
+const DEFAULT_MOONSHOT_VIDEO_MODEL = "kimi-k2.5";
+const DEFAULT_MOONSHOT_VIDEO_PROMPT = "Describe the video in detail.";
+
+function resolveModel(model?: string): string {
+  return model?.trim() || DEFAULT_MOONSHOT_VIDEO_MODEL;
+}
+
+function resolvePrompt(prompt?: string): string {
+  return prompt?.trim() || DEFAULT_MOONSHOT_VIDEO_PROMPT;
+}
+
+/**
+ * Describe a video using Moonshot (Kimi K2.5) OpenAI-compatible API.
+ * Uses the `video_url` content type with base64 data URI.
+ */
+export async function describeMoonshotVideo(
+  params: VideoDescriptionRequest,
+): Promise<VideoDescriptionResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const baseUrl = normalizeBaseUrl(params.baseUrl, DEFAULT_MOONSHOT_VIDEO_BASE_URL);
+  const allowPrivate = Boolean(params.baseUrl?.trim());
+  const model = resolveModel(params.model);
+  const url = `${baseUrl}/chat/completions`;
+
+  const mime = params.mime ?? "video/mp4";
+  const videoBase64 = params.buffer.toString("base64");
+
+  const headers = new Headers(params.headers);
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+  if (!headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${params.apiKey}`);
+  }
+
+  const body = {
+    model,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: resolvePrompt(params.prompt) },
+          {
+            type: "video_url",
+            video_url: { url: `data:${mime};base64,${videoBase64}` },
+          },
+        ],
+      },
+    ],
+    max_tokens: 4096,
+  };
+
+  const { response: res, release } = await fetchWithTimeoutGuarded(
+    url,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    },
+    params.timeoutMs,
+    fetchFn,
+    allowPrivate ? { ssrfPolicy: { allowPrivateNetwork: true } } : undefined,
+  );
+
+  try {
+    if (!res.ok) {
+      const detail = await readErrorResponse(res);
+      const suffix = detail ? `: ${detail}` : "";
+      throw new Error(`Moonshot video description failed (HTTP ${res.status})${suffix}`);
+    }
+
+    const payload = (await res.json()) as {
+      choices?: Array<{
+        message?: { content?: string };
+      }>;
+    };
+
+    const text = payload.choices?.[0]?.message?.content?.trim();
+    if (!text) {
+      throw new Error("Moonshot video description response missing content");
+    }
+    return { text, model };
+  } finally {
+    await release();
+  }
+}

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -50,7 +50,7 @@ import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
 const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google"] as const;
 const AUTO_IMAGE_KEY_PROVIDERS = ["openai", "anthropic", "google", "minimax"] as const;
-const AUTO_VIDEO_KEY_PROVIDERS = ["google"] as const;
+const AUTO_VIDEO_KEY_PROVIDERS = ["google", "moonshot"] as const;
 const DEFAULT_IMAGE_MODELS: Record<string, string> = {
   openai: "gpt-5-mini",
   anthropic: "claude-opus-4-6",

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -974,8 +974,11 @@ async function runProviderEntry(params: {
     fileName: media.fileName,
     mime: media.mime,
     apiKey,
-    baseUrl: providerConfig?.baseUrl,
-    headers: providerConfig?.headers,
+    baseUrl: entry.baseUrl ?? providerConfig?.baseUrl,
+    headers: {
+      ...providerConfig?.headers,
+      ...entry.headers,
+    },
     model: entry.model,
     prompt,
     timeoutMs,


### PR DESCRIPTION
## Summary

Add Moonshot AI (Kimi K2.5) as a native video understanding provider for media-understanding.

K2.5 uses **MoonViT** — a native multimodal vision encoder trained on video tokens, providing true video understanding rather than frame extraction.

## Changes

- **New provider**: `src/media-understanding/providers/moonshot/` (index + video)
- **Registration**: Added to provider registry in `providers/index.ts`
- **Auto-detection**: Added `moonshot` to `AUTO_VIDEO_KEY_PROVIDERS` in `runner.ts`

## How it works

- Uses OpenAI-compatible API at `https://api.moonshot.ai/v1`
- Sends video as base64 data URI via `video_url` content type
- Handles K2.5's thinking mode (`reasoning_content` fallback)
- Auto-detects via `MOONSHOT_API_KEY` environment variable
- Model: `kimi-k2.5` (1T params, 32B activated, 256K context)

## Testing

- Verified with demo video (264KB mp4 → 20K tokens)
- K2.5 correctly identified video content using native vision
- API authentication and response parsing working correctly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires in a new `moonshot` media-understanding provider with image+video capabilities. It registers the provider in the media provider registry, adds a Moonshot video implementation that calls an OpenAI-compatible `/chat/completions` endpoint with `video_url` as a base64 data URI, and extends auto-detection so video can be resolved via `MOONSHOT_API_KEY`.

Key integration points are `src/media-understanding/providers/index.ts` (registry) and `src/media-understanding/runner.ts` (auto video provider list + provider invocation).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of behavioral/security issues that should be fixed first.
- Score reduced due to (1) video provider config (baseUrl/headers) being ignored, which will break intended configuration like Moonshot CN endpoint, and (2) SSRF policy being widened to allow private-network access based solely on providing a custom baseUrl.
- src/media-understanding/runner.ts; src/media-understanding/providers/moonshot/video.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->