### PR TITLE
fix: prevent chunker from truncating messages that fit within limit

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -239,10 +239,13 @@ export async function deliverOutboundPayloads(params: {
       results.push(await handler.sendText(text));
       return;
     }
-    // Safety: if text fits within limit, send directly without chunking.
-    // This prevents the chunker from splitting messages that don't need it,
-    // which was causing mid-sentence truncation on Signal/TUI. (#12064)
-    if (text.length <= textLimit) {
+    // Safety: if text fits within limit AND we're in length mode (default),
+    // send directly without chunking. This prevents the chunker from splitting
+    // messages that don't need it, which was causing mid-sentence truncation
+    // on Signal/TUI. (#12064)
+    // Note: newline mode is intentionally allowed to chunk even when text fits,
+    // for readability (paragraph boundaries).
+    if (text.length <= textLimit && chunkMode === "length") {
       results.push(await handler.sendText(text));
       return;
     }

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -241,7 +241,7 @@ export async function deliverOutboundPayloads(params: {
     }
     // Safety: if text fits within limit, send directly without chunking.
     // This prevents the chunker from splitting messages that don't need it,
-    // which was causing mid-sentence truncation on Signal/TUI. (#XXXX)
+    // which was causing mid-sentence truncation on Signal/TUI. (#12064)
     if (text.length <= textLimit) {
       results.push(await handler.sendText(text));
       return;


### PR DESCRIPTION
## Bug

The message chunker introduced in 191da1feb unpredictably truncates messages mid-sentence on Signal, TUI, and other channels — even when the text fits within the channel's textChunkLimit.

## Root Cause

`sendTextChunks()` in `deliver.ts` always passes text through the chunker pipeline regardless of whether splitting is needed. The chunker can return partial/empty results for text that doesn't need chunking.

## Fix

1. **Skip chunking when text fits:** If `text.length <= textLimit`, send directly without invoking the chunker.
2. **Guard empty chunker output:** If chunker returns an empty array, send the original text intact instead of silently dropping it.

## Reproduction

Send any multi-paragraph message via Signal or TUI on v2026.2.6-3. Messages are randomly cut mid-sentence.

## Workaround

Add `"chunker": null` to each channel in openclaw.json.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Change is localized to `src/infra/outbound/deliver.ts` and adjusts outbound text delivery to avoid invoking the channel chunker when the text already fits within `textChunkLimit`, and to fall back to sending the original text if the chunker returns an empty array. This targets a regression where some chunkers could return partial/empty output and truncate messages even when no splitting was required.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk once the small cleanup is addressed.
- The change is narrow and preserves existing behavior except for skipping chunking when unnecessary and guarding empty chunker output. No new external dependencies or complex logic were introduced; the only actionable issue found is an unresolved placeholder reference in a new comment.
- src/infra/outbound/deliver.ts (comment cleanup)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->