### PR TITLE
fix(whatsapp): handle native group @mentions with requireMention

### DIFF
--- a/src/web/auto-reply.web-auto-reply.supports-always-group-activation-silent-token-preserves.test.ts
+++ b/src/web/auto-reply.web-auto-reply.supports-always-group-activation-silent-token-preserves.test.ts
@@ -193,7 +193,7 @@ describe("web auto-reply", () => {
     await cleanup();
     resetLoadConfigMock();
   });
-  it("ignores JID mentions in self-chat mode (group chats)", async () => {
+  it("detects JID mentions in self-chat mode when sender is not owner", async () => {
     const sendMedia = vi.fn();
     const reply = vi.fn().mockResolvedValue(undefined);
     const sendComposing = vi.fn();
@@ -227,7 +227,7 @@ describe("web auto-reply", () => {
     await monitorWebChannel(false, listenerFactory, false, resolver);
     expect(capturedOnMessage).toBeDefined();
 
-    // WhatsApp @mention of the owner should NOT trigger the bot in self-chat mode.
+    // WhatsApp @mention from another user (Alice) should trigger the bot even in self-chat mode.
     await capturedOnMessage?.({
       body: "@owner ping",
       from: "123@g.us",
@@ -246,7 +246,7 @@ describe("web auto-reply", () => {
       sendMedia,
     });
 
-    expect(resolver).not.toHaveBeenCalled();
+    expect(resolver).toHaveBeenCalledTimes(1);
 
     // Text-based mentionPatterns still work (user can type "openclaw" explicitly).
     await capturedOnMessage?.({
@@ -266,7 +266,7 @@ describe("web auto-reply", () => {
       sendMedia,
     });
 
-    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(resolver).toHaveBeenCalledTimes(2);
 
     resetLoadConfigMock();
   });

--- a/src/web/auto-reply/mentions.test.ts
+++ b/src/web/auto-reply/mentions.test.ts
@@ -52,4 +52,47 @@ describe("isBotMentionedFromTargets", () => {
     const targets = resolveMentionTargets(msg);
     expect(isBotMentionedFromTargets(msg, mentionCfg, targets)).toBe(true);
   });
+
+  describe("self-chat mode", () => {
+    const selfChatMentionCfg = {
+      mentionRegexes: [/\bopenclaw\b/i],
+      allowFrom: ["+15551234567"],
+    };
+
+    it("blocks owner's messages with auto-included JID (prevents false positives)", () => {
+      const msg = makeMsg({
+        body: "Hello everyone",
+        mentionedJids: ["15551234567@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+        senderE164: "+15551234567",
+      });
+      const targets = resolveMentionTargets(msg);
+      expect(isBotMentionedFromTargets(msg, selfChatMentionCfg, targets)).toBe(false);
+    });
+
+    it("triggers when non-owner @mentions the bot", () => {
+      const msg = makeMsg({
+        body: "@bot please help",
+        mentionedJids: ["15551234567@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+        senderE164: "+19998887777",
+      });
+      const targets = resolveMentionTargets(msg);
+      expect(isBotMentionedFromTargets(msg, selfChatMentionCfg, targets)).toBe(true);
+    });
+
+    it("blocks text patterns when JID mentions present (no fallback in self-chat)", () => {
+      const msg = makeMsg({
+        body: "openclaw help", 
+        mentionedJids: ["19998887777@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+        senderE164: "+19998887777",
+      });
+      const targets = resolveMentionTargets(msg);
+      expect(isBotMentionedFromTargets(msg, selfChatMentionCfg, targets)).toBe(false);
+    });
+  });
 });

--- a/src/web/auto-reply/mentions.test.ts
+++ b/src/web/auto-reply/mentions.test.ts
@@ -85,7 +85,7 @@ describe("isBotMentionedFromTargets", () => {
 
     it("blocks text patterns when JID mentions present (no fallback in self-chat)", () => {
       const msg = makeMsg({
-        body: "openclaw help", 
+        body: "openclaw help",
         mentionedJids: ["19998887777@s.whatsapp.net"],
         selfE164: "+15551234567",
         selfJid: "15551234567@s.whatsapp.net",
@@ -93,6 +93,32 @@ describe("isBotMentionedFromTargets", () => {
       });
       const targets = resolveMentionTargets(msg);
       expect(isBotMentionedFromTargets(msg, selfChatMentionCfg, targets)).toBe(false);
+    });
+
+    it("blocks owner's messages when senderE164 is missing but senderJid matches (fallback)", () => {
+      const msg = makeMsg({
+        body: "Hello team",
+        mentionedJids: ["15551234567@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+        senderJid: "15551234567@s.whatsapp.net",
+        // senderE164 is intentionally undefined (edge case)
+      });
+      const targets = resolveMentionTargets(msg);
+      expect(isBotMentionedFromTargets(msg, selfChatMentionCfg, targets)).toBe(false);
+    });
+
+    it("triggers when non-owner mentions bot and senderE164 is missing (uses senderJid)", () => {
+      const msg = makeMsg({
+        body: "@bot help",
+        mentionedJids: ["15551234567@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+        senderJid: "19998887777@s.whatsapp.net",
+        // senderE164 is intentionally undefined (edge case)
+      });
+      const targets = resolveMentionTargets(msg);
+      expect(isBotMentionedFromTargets(msg, selfChatMentionCfg, targets)).toBe(true);
     });
   });
 });

--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -54,8 +54,14 @@ export function isBotMentionedFromTargets(
     // Self-chat mode: suppress mentions only when the sender IS the owner (WhatsApp auto-includes
     // the owner's JID in mentionedJids). When someone else mentions the bot via JID or LID,
     // normalizedMentions correctly resolves to E164 — honour that.
-    const senderIsOwner =
-      msg.senderE164 && targets.selfE164 && normalizeE164(msg.senderE164) === targets.selfE164;
+    let senderIsOwner = false;
+    if (msg.senderE164 && targets.selfE164) {
+      senderIsOwner = normalizeE164(msg.senderE164) === targets.selfE164;
+    } else if (msg.senderJid && targets.selfJid) {
+      // Fallback: compare JIDs when senderE164 is missing
+      const normalizeSenderJid = msg.senderJid.replace(/:\d+/, "");
+      senderIsOwner = normalizeSenderJid === targets.selfJid;
+    }
     if (!senderIsOwner) {
       if (targets.selfE164 && targets.normalizedMentions.includes(targets.selfE164)) {
         return true;


### PR DESCRIPTION
## Issue
Fixes #11758

WhatsApp native `@mention` detection fails in group chats when
`requireMention: true` is enabled and the owner number is included
in `allowFrom` (owner/self messages).

## Root Cause

When `requireMention` is enabled, native WhatsApp mentions using LID
identifiers (e.g. `181891881787642@lid`) were not correctly recognized,
causing valid group mentions to be ignored.

Two issues contributed to this:

1. Owner JID comparison was performed between incompatible formats
   (bare JID vs E164), which could never match.
2. WhatsApp automatically includes the owner’s JID in `mentionedJids`
   even when no explicit `@mention` is made, leading to false positives.

## Fix

- Removed the incorrect JID format comparison
- Added explicit owner/self-sender detection:
  - If the sender **is the owner**, suppress auto-included JID mentions
  - If the sender **is not the owner**, validate native `@mention`s
- Ensured explicit `false` return to prevent fallback to text-based
  mention detection when JID mentions are present

## Tests

- Added unit tests in `mentions.test.ts` covering owner/self message cases
- Updated integration expectations in
  `supports-always-group-activation-silent-token-preserves.test.ts`
- All mention unit tests pass
- All group mention integration tests pass
- Full web provider test suite passes (157/157)
- Linting and formatting checks pass

## 🤖 AI / Vibe-coded PR disclosure

- [x] **AI-assisted:** Yes — used AI tools for debugging, reasoning about edge
  cases, and reviewing the solution. All code was written, verified, and
  understood by me.
- [x] **Testing level:** Fully tested.
  - Unit tests added/updated
  - Integration tests updated
  - Full web provider test suite passes (157/157)
- [x] **Prompts / session logs:** No production session logs included.
  Debugging and reasoning were based on local reproduction and tests.
- [x] **Author understanding:** I understand what the code does and why these
  changes are required, and I’m confident the fix preserves existing behavior.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts WhatsApp group @mention detection when `requireMention: true` is enabled in “self-chat mode” (where `allowFrom` contains the owner/self number). The mention logic in `src/web/auto-reply/mentions.ts` now:

- Treats any presence of `mentionedJids` as authoritative (no regex fallback) for non-self-chat mode.
- In self-chat mode, ignores auto-included self mentions only when the sender is the owner, while still honoring explicit JID/LID mentions from other senders.

Tests were updated/added to cover self/owner message suppression, non-owner native mentions, and adjusted integration expectations for group activation behavior.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a self-chat false-positive edge case if senderE164 is missing.
- The core logic change is small and tests cover the intended scenarios, but the new owner/self detection depends on `msg.senderE164` being present. If it’s absent on some inbound messages, owner messages with auto-included self JIDs can incorrectly trigger the bot in self-chat mode.
- src/web/auto-reply/mentions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->