### PR TITLE
docs(heartbeat): clarify behavior when HEARTBEAT.md is missing

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -299,7 +299,15 @@ safe to include every 30 minutes.
 
 If `HEARTBEAT.md` exists but is effectively empty (only blank lines and markdown
 headers like `# Heading`), OpenClaw skips the heartbeat run to save API calls.
-If the file is missing, the heartbeat still runs and the model decides what to do.
+
+If the file is missing, OpenClaw may create an empty `HEARTBEAT.md` during
+workspace bootstrap (see `agents.defaults.skipBootstrap`). In that case, the
+heartbeat is skipped for the same “empty file” reason. If you want the heartbeat
+to run without a file-driven checklist, either:
+
+- create a non-empty `HEARTBEAT.md`, or
+- set a custom heartbeat `prompt` that doesn’t depend on `HEARTBEAT.md`, or
+- disable bootstrap file creation (`agents.defaults.skipBootstrap: true`).
 
 Keep it tiny (short checklist or reminders) to avoid prompt bloat.
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -298,14 +298,22 @@ agent to read it. Think of it as your “heartbeat checklist”: small, stable, 
 safe to include every 30 minutes.
 
 If `HEARTBEAT.md` exists but is effectively empty (only blank lines and markdown
-headers like `# Heading`), OpenClaw skips the heartbeat run to save API calls.
+headers like `# Heading`), OpenClaw **currently skips** the heartbeat run to save
+API calls.
 
-If the file is missing, OpenClaw may create an empty `HEARTBEAT.md` during
-workspace bootstrap (see `agents.defaults.skipBootstrap`). In that case, the
-heartbeat is skipped for the same “empty file” reason. If you want the heartbeat
-to run without a file-driven checklist, either:
+If the file is **missing**, OpenClaw may create an empty `HEARTBEAT.md` during
+workspace bootstrap (see `agents.defaults.skipBootstrap`). In practice, this can
+lead to heartbeats being skipped for the same “empty file” reason.
 
-- create a non-empty `HEARTBEAT.md`, or
+Note: this “empty or missing `HEARTBEAT.md` → skip” behavior is the subject of
+bug reports (see #11766). In particular, an empty/missing heartbeat file can
+also interfere with some manual wakes (e.g. cron jobs that rely on heartbeat to
+wake the agent).
+
+**Workarounds (until the behavior is changed):**
+
+- Put at least **one non-comment, non-heading line** in `HEARTBEAT.md` (e.g.
+  `- noop`), or
 - set a custom heartbeat `prompt` that doesn’t depend on `HEARTBEAT.md`, or
 - disable bootstrap file creation (`agents.defaults.skipBootstrap: true`).
 


### PR DESCRIPTION
Fixes #11766.

## Why
Docs previously implied that if `HEARTBEAT.md` is missing, heartbeats still run.
In practice, workspace bootstrap may create an empty `HEARTBEAT.md`, and the existing “empty file = skip” rule then prevents heartbeat API calls.

## What changed
- Clarified that **missing/empty** `HEARTBEAT.md` can result in **skip** due to bootstrap creating an empty file.
- Added explicit workarounds:
  - `agents.defaults.skipBootstrap` to prevent bootstrap from creating the file
  - heartbeat `prompt` override options

## Repro (current behavior)
1. Remove `HEARTBEAT.md`
2. Run a heartbeat poll
3. If bootstrap creates an empty `HEARTBEAT.md`, the heartbeat will be skipped under the documented “empty = skip” rule

Docs-only change (no code).