### PR TITLE
feat(browser): session-aware context isolation for multi-agent browser use

### DIFF
--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -235,11 +235,16 @@ export async function handleDiscordMessagingAction(
       const replyTo = readStringParam(params, "replyTo");
       const embeds =
         Array.isArray(params.embeds) && params.embeds.length > 0 ? params.embeds : undefined;
+      const components =
+        Array.isArray(params.components) && params.components.length > 0
+          ? params.components
+          : undefined;
       const result = await sendMessageDiscord(to, content, {
         ...(accountId ? { accountId } : {}),
         mediaUrl,
         replyTo,
         embeds,
+        components,
       });
       return jsonResult({ ok: true, result });
     }

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -288,10 +288,9 @@ export async function handleDiscordMessagingAction(
       const messageId = readStringParam(params, "messageId");
       // Optional initial content (required for forum posts).
       const content = readStringParam(params, "content") ?? undefined;
-      // Optional applied tag ids (forum posts).
-      const appliedTagIds = Array.isArray(params.appliedTagIds)
-        ? params.appliedTagIds.filter((x) => typeof x === "string" && x.trim())
-        : undefined;
+      // Optional applied tag ids (forum posts). Supports native arrays, JSON array strings,
+      // and comma-separated strings via readStringArrayParam.
+      const appliedTagIds = readStringArrayParam(params, "appliedTagIds");
       const autoArchiveMinutesRaw = params.autoArchiveMinutes;
       const autoArchiveMinutes =
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -281,18 +281,31 @@ export async function handleDiscordMessagingAction(
       const channelId = resolveChannelId();
       const name = readStringParam(params, "name", { required: true });
       const messageId = readStringParam(params, "messageId");
+      // Optional initial content (required for forum posts).
+      const content = readStringParam(params, "content") ?? undefined;
+      // Optional applied tag ids (forum posts).
+      const appliedTagIds = Array.isArray(params.appliedTagIds)
+        ? params.appliedTagIds.filter((x) => typeof x === "string" && x.trim())
+        : undefined;
       const autoArchiveMinutesRaw = params.autoArchiveMinutes;
       const autoArchiveMinutes =
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)
           ? autoArchiveMinutesRaw
           : undefined;
+
       const thread = accountId
         ? await createThreadDiscord(
             channelId,
-            { name, messageId, autoArchiveMinutes },
+            { name, messageId, autoArchiveMinutes, content, appliedTagIds },
             { accountId },
           )
-        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes });
+        : await createThreadDiscord(channelId, {
+            name,
+            messageId,
+            autoArchiveMinutes,
+            content,
+            appliedTagIds,
+          });
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -197,6 +197,13 @@ function buildThreadSchema() {
   return {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
+    appliedTagIds: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Tag IDs to apply to forum posts. For forum channels, the 'message' field " +
+          "is used as the initial post content.",
+      }),
+    ),
   };
 }
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -100,6 +100,30 @@ function buildSendSchema(options: { includeButtons: boolean; includeCards: boole
         },
       ),
     ),
+    embeds: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Provider-specific embed objects (Discord embeds, etc.). Passed through to the channel adapter when supported.",
+          },
+        ),
+      ),
+    ),
+    components: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Provider-specific message components (Discord buttons/selects, etc.). Passed through when supported.",
+          },
+        ),
+      ),
+    ),
   };
   if (!options.includeButtons) {
     delete props.buttons;

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -198,9 +198,10 @@ function buildThreadSchema() {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
     appliedTagIds: Type.Optional(
-      Type.Array(Type.String(), {
+      Type.Union([Type.String(), Type.Array(Type.String())], {
         description:
-          "Tag IDs to apply to forum posts. For forum channels, the 'message' field " +
+          "Tag IDs to apply to forum posts. Accepts a JSON array string, comma-separated string, " +
+          "or an array of strings. For forum channels, the 'message' field " +
           "is used as the initial post content.",
       }),
     ),

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -41,6 +41,7 @@ export async function handleDiscordMessageAction(
     const mediaUrl = readStringParam(params, "media", { trim: false });
     const replyTo = readStringParam(params, "replyTo");
     const embeds = Array.isArray(params.embeds) ? params.embeds : undefined;
+    const components = Array.isArray(params.components) ? params.components : undefined;
     return await handleDiscordAction(
       {
         action: "sendMessage",
@@ -50,6 +51,7 @@ export async function handleDiscordMessageAction(
         mediaUrl: mediaUrl ?? undefined,
         replyTo: replyTo ?? undefined,
         embeds,
+        components,
       },
       cfg,
     );

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -184,6 +184,10 @@ export async function handleDiscordMessageAction(
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
+    // Optional initial post content (required for forum post creation).
+    const content = readStringParam(params, "message");
+    // Optional forum tag ids.
+    const appliedTagIds = readStringArrayParam(params, "appliedTagIds");
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
@@ -194,6 +198,8 @@ export async function handleDiscordMessageAction(
         channelId: resolveChannelId(),
         name,
         messageId,
+        content,
+        appliedTagIds,
         autoArchiveMinutes,
       },
       cfg,

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -108,8 +108,8 @@ export async function createThreadDiscord(
   }
 
   // Forum posts (channel type 15) require an initial message payload.
-  // If content is provided, create the thread with an initial post.
-  if (payload.content) {
+  // If content is provided (even empty string), create the thread with an initial post.
+  if (payload.content !== undefined) {
     body.message = { content: payload.content };
     if (Array.isArray(payload.appliedTagIds) && payload.appliedTagIds.length) {
       body.applied_tags = payload.appliedTagIds;
@@ -123,9 +123,16 @@ export async function createThreadDiscord(
 
   // Regular threads: create from an existing message when messageId is provided,
   // otherwise create a standard thread in the channel.
-  const route = payload.messageId
-    ? Routes.threads(channelId, payload.messageId)
-    : `/channels/${channelId}/threads`;
+  // NOTE: Forum channels (type 15) require content for the initial post; attempting
+  // to create a thread without content or messageId will fail at Discord's API.
+  // Provide a clear error here instead of relying on Discord's generic validation.
+  if (!payload.messageId) {
+    throw new Error(
+      "Forum channel threads require initial post content. Provide 'content' (message field) " +
+        "for forum posts, or 'messageId' to create a thread from an existing message.",
+    );
+  }
+  const route = Routes.threads(channelId, payload.messageId);
   return await rest.post(route, { body });
 }
 

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -123,16 +123,14 @@ export async function createThreadDiscord(
 
   // Regular threads: create from an existing message when messageId is provided,
   // otherwise create a standard thread in the channel.
-  // NOTE: Forum channels (type 15) require content for the initial post; attempting
-  // to create a thread without content or messageId will fail at Discord's API.
-  // Provide a clear error here instead of relying on Discord's generic validation.
-  if (!payload.messageId) {
-    throw new Error(
-      "Forum channel threads require initial post content. Provide 'content' (message field) " +
-        "for forum posts, or 'messageId' to create a thread from an existing message.",
-    );
+  if (payload.messageId) {
+    const route = Routes.threads(channelId, payload.messageId);
+    return await rest.post(route, { body });
   }
-  const route = Routes.threads(channelId, payload.messageId);
+
+  // No content and no messageId — create a plain thread (works for text channels).
+  // Forum channels (type 15) would fail here at Discord's API level, which is fine.
+  const route = `/channels/${channelId}/threads`;
   return await rest.post(route, { body });
 }
 

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -29,6 +29,7 @@ type DiscordSendOpts = {
   replyTo?: string;
   retry?: RetryConfig;
   embeds?: unknown[];
+  components?: unknown[];
 };
 
 export async function sendMessageDiscord(
@@ -63,6 +64,7 @@ export async function sendMessageDiscord(
         request,
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
+        opts.components,
         chunkMode,
       );
     } else {
@@ -74,6 +76,7 @@ export async function sendMessageDiscord(
         request,
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
+        opts.components,
         chunkMode,
       );
     }

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -286,6 +286,7 @@ async function sendDiscordText(
   request: DiscordRequest,
   maxLinesPerMessage?: number,
   embeds?: unknown[],
+  components?: unknown[],
   chunkMode?: ChunkMode,
 ) {
   if (!text.trim()) {
@@ -308,6 +309,7 @@ async function sendDiscordText(
             content: chunks[0],
             message_reference: messageReference,
             ...(embeds?.length ? { embeds } : {}),
+            ...(components?.length ? { components } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -324,6 +326,7 @@ async function sendDiscordText(
             content: chunk,
             message_reference: isFirst ? messageReference : undefined,
             ...(isFirst && embeds?.length ? { embeds } : {}),
+            ...(isFirst && components?.length ? { components } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -345,6 +348,7 @@ async function sendDiscordMedia(
   request: DiscordRequest,
   maxLinesPerMessage?: number,
   embeds?: unknown[],
+  components?: unknown[],
   chunkMode?: ChunkMode,
 ) {
   const media = await loadWebMedia(mediaUrl);
@@ -367,6 +371,7 @@ async function sendDiscordMedia(
           content: caption || undefined,
           message_reference: messageReference,
           ...(embeds?.length ? { embeds } : {}),
+          ...(components?.length ? { components } : {}),
           files: [
             {
               data: media.buffer,
@@ -388,6 +393,7 @@ async function sendDiscordMedia(
       undefined,
       request,
       maxLinesPerMessage,
+      undefined,
       undefined,
       chunkMode,
     );

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -68,9 +68,16 @@ export type DiscordMessageEdit = {
 };
 
 export type DiscordThreadCreate = {
+  /** Optional message id to start a thread from (for classic threads). */
   messageId?: string;
+  /** Thread / forum post title. */
   name: string;
+  /** Auto-archive duration in minutes. */
   autoArchiveMinutes?: number;
+  /** Optional initial post content (required for forum post creation). */
+  content?: string;
+  /** Optional forum tag ids (applied tags). */
+  appliedTagIds?: string[];
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary

Add browser session isolation so multiple sessions/sub-agents can use the browser simultaneously without tab/state conflicts, while sharing login state (cookies) from the main context.

## Problem

Currently, the browser module uses a global singleton for role-ref caching and page state. When multiple agents/sessions operate tabs concurrently, they overwrite each other's cached refs, leading to stale references and "element not found" errors (#3605, #8157).

## Solution

Introduce a **Session-aware Context Registry** pattern — lightweight session isolation that scopes role-ref caches per caller while sharing the underlying CDP connection and browser contexts.

### Phase 1 — Session Context Registry (`pw-session.ts`)
- `SessionContext` type with `roleRefsByTarget`, `pageStateOverrides`, `cookies`
- Auto-cleanup: 30min expiry, max 100 sessions
- Default session `__default__` for backward compatibility

### Phase 2 — Session-aware Role Refs (`pw-tools-core.snapshot.ts`)
- All snapshot functions accept optional `sessionId`
- Dual cache strategy: session-scoped + global fallback
- `restoreRoleRefsForTarget` prioritizes session cache, falls back to global

### Phase 3 — Cookie Inheritance (`pw-session.ts`)
- `captureCookiesFromBrowser` / `applyCookiesToBrowser` for state transfer
- `inheritCookiesFromDefault` lets sub-agents share login state
- `cloneSessionContext` / `copyCookiesBetweenSessions` utilities

### Phase 4 — Full Route Integration
- `BrowserRequest` type extended with `sessionId` field
- `getSessionId()` helper: extracts sessionId from body, query, or header
- All `pw-tools-core.*.ts` functions accept `sessionId`
- `agent.act.ts` and `agent.snapshot.ts` routes pass `sessionId` through

## Backward Compatibility

All `sessionId` parameters are **optional**. Existing callers that don't pass a sessionId automatically use the `__default__` session, preserving identical behavior.

## Design Choices

- **Not full BrowserContext isolation**: CDP `connect()` gets existing contexts; `newContext()` creates new windows. Full isolation would require re-login for each session.
- **Dual cache**: Refs stored in both session-scoped and global cache. Session takes priority on read, global serves as fallback for non-session-aware callers.
- **Cleanup**: Stale sessions (>30min inactive) are garbage-collected automatically, with a hard cap of 100 concurrent sessions.

## Testing

- TypeScript strict-mode compilation passes (`tsc --noEmit`)
- Full `pnpm build` succeeds
- All changes are additive; no existing function signatures changed

Addresses: #3605, #8157
Related: #4663

## Files Changed (13)

| File | Changes |
|------|---------|
| `pw-session.ts` | +358 (registry + cookies) |
| `pw-tools-core.snapshot.ts` | +37 (session-aware refs) |
| `pw-tools-core.interactions.ts` | +39 (sessionId passthrough) |
| `routes/agent.act.ts` | +29 (route integration) |
| `routes/agent.shared.ts` | +28 (getSessionId helper) |
| `routes/agent.snapshot.ts` | +13 |
| `routes/types.ts` | +2 |
| Other pw-tools-core files | +1-8 each |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Discord messaging/thread tooling to support richer outbound payloads and forum-thread creation:

- Adds passthrough `embeds` and `components` fields to message send flows (tool schema → action handler → Discord send helpers).
- Enhances `readStringArrayParam` to accept JSON-array strings and comma-separated strings in addition to native arrays.
- Extends thread-create flows to optionally include initial post `content` and `appliedTagIds` (intended for forum posts).

Main integration points are the agent tool schemas (`src/agents/tools/message-tool.ts`), the Discord action handlers (`src/agents/tools/discord-actions-messaging.ts`, `src/channels/plugins/actions/discord/handle-action.ts`), and the Discord REST wrappers (`src/discord/send.*.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a functional issue that can break thread creation in some Discord channel types.
- Most changes are additive and plumb optional fields through safely, but `createThreadDiscord` currently throws whenever `content` is omitted and `messageId` is absent, which can block valid non-forum thread creation paths.
- src/discord/send.messages.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->