### PR TITLE
docs(examples): Linux browser-use reliability improvements for dynamic pages

### DIFF
--- a/docs/linux-stable-cdp.md
+++ b/docs/linux-stable-cdp.md
@@ -1,0 +1,61 @@
+# Stable Chrome CDP Setup (Linux + systemd)
+
+This guide covers Linux with systemd. For macOS/Windows, see platform-specific examples.
+
+## Why this setup
+Common failure modes on Linux:
+- CDP endpoint unstable or unreachable
+- display/X authority issues
+- extension relay mismatch when direct CDP is intended
+- dynamic page refs changing between snapshot and click/type
+
+## 1) Create dedicated automation profile
+Use a dedicated Chrome user-data-dir instead of your daily profile directly.
+
+Example destination:
+- `$HOME/chrome-profiles/main-openclaw`
+
+You can sync from default profile with `sync-main-profile-to-openclaw.sh`.
+
+## 2) Start Xvfb and Chrome CDP with user services
+Use templates:
+- `templates/systemd/openclaw-xvfb.service`
+- `templates/systemd/openclaw-chrome-main.service`
+
+Install (example):
+```bash
+mkdir -p ~/.config/systemd/user
+cp openclaw-xvfb.service ~/.config/systemd/user/
+cp openclaw-chrome-main.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now openclaw-xvfb.service
+systemctl --user enable --now openclaw-chrome-main.service
+```
+
+## 3) Point OpenClaw browser profile to CDP
+Set OpenClaw browser profile CDP URL to loopback endpoint (example `127.0.0.1:18804`) and make it default if needed.
+
+## 4) Validate
+```bash
+openclaw browser status --json
+openclaw browser open https://x.com/compose/post --json
+openclaw browser snapshot --json --efficient --limit 200
+```
+
+## 5) Dynamic pages: stale-ref-safe actions
+Do not reuse old refs on dynamic pages.
+
+Recommended loop:
+1. snapshot
+2. resolve ref by semantic attributes (role/name)
+3. action (type/click)
+4. if error: wait + fresh snapshot + retry
+
+Example helper:
+- `templates/scripts/openclaw-browser-safe-action.sh` (generic action engine)
+- `templates/scripts/openclaw-x-post.sh` (X-specific wrapper on top)
+
+## Troubleshooting
+- If service starts but CDP is down, verify port binding and process args.
+- If snapshot works but click fails, refresh refs before each action.
+- If you use strict network policies, ensure local loopback CDP is still reachable.

--- a/docs/linux-stable-cdp.md
+++ b/docs/linux-stable-cdp.md
@@ -3,26 +3,33 @@
 This guide covers Linux with systemd. For macOS/Windows, see platform-specific examples.
 
 ## Why this setup
+
 Common failure modes on Linux:
+
 - CDP endpoint unstable or unreachable
 - display/X authority issues
 - extension relay mismatch when direct CDP is intended
 - dynamic page refs changing between snapshot and click/type
 
 ## 1) Create dedicated automation profile
+
 Use a dedicated Chrome user-data-dir instead of your daily profile directly.
 
 Example destination:
+
 - `$HOME/chrome-profiles/main-openclaw`
 
 You can sync from default profile with `sync-main-profile-to-openclaw.sh`.
 
 ## 2) Start Xvfb and Chrome CDP with user services
+
 Use templates:
+
 - `templates/systemd/openclaw-xvfb.service`
 - `templates/systemd/openclaw-chrome-main.service`
 
 Install (example):
+
 ```bash
 mkdir -p ~/.config/systemd/user
 cp openclaw-xvfb.service ~/.config/systemd/user/
@@ -33,9 +40,11 @@ systemctl --user enable --now openclaw-chrome-main.service
 ```
 
 ## 3) Point OpenClaw browser profile to CDP
+
 Set OpenClaw browser profile CDP URL to loopback endpoint (example `127.0.0.1:18804`) and make it default if needed.
 
 ## 4) Validate
+
 ```bash
 openclaw browser status --json
 openclaw browser open https://x.com/compose/post --json
@@ -43,19 +52,23 @@ openclaw browser snapshot --json --efficient --limit 200
 ```
 
 ## 5) Dynamic pages: stale-ref-safe actions
+
 Do not reuse old refs on dynamic pages.
 
 Recommended loop:
+
 1. snapshot
 2. resolve ref by semantic attributes (role/name)
 3. action (type/click)
 4. if error: wait + fresh snapshot + retry
 
 Example helper:
+
 - `templates/scripts/openclaw-browser-safe-action.sh` (generic action engine)
 - `templates/scripts/openclaw-x-post.sh` (X-specific wrapper on top)
 
 ## Troubleshooting
+
 - If service starts but CDP is down, verify port binding and process args.
 - If snapshot works but click fails, refresh refs before each action.
 - If you use strict network policies, ensure local loopback CDP is still reachable.

--- a/docs/linux-stable-cdp.md
+++ b/docs/linux-stable-cdp.md
@@ -25,15 +25,15 @@ You can sync from default profile with `sync-main-profile-to-openclaw.sh`.
 
 Use templates:
 
-- `templates/systemd/openclaw-xvfb.service`
-- `templates/systemd/openclaw-chrome-main.service`
+- `examples/systemd/openclaw-xvfb.service`
+- `examples/systemd/openclaw-chrome-main.service`
 
 Install (example):
 
 ```bash
 mkdir -p ~/.config/systemd/user
-cp openclaw-xvfb.service ~/.config/systemd/user/
-cp openclaw-chrome-main.service ~/.config/systemd/user/
+cp examples/systemd/openclaw-xvfb.service ~/.config/systemd/user/
+cp examples/systemd/openclaw-chrome-main.service ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now openclaw-xvfb.service
 systemctl --user enable --now openclaw-chrome-main.service
@@ -62,10 +62,17 @@ Recommended loop:
 3. action (type/click)
 4. if error: wait + fresh snapshot + retry
 
+Production hints from current CDP usage:
+
+- **Lock by targetId** once you open/reuse a tab, and pass `--target-id` on every command.
+- Take a **fresh snapshot before each action** (`type`, `click`, upload steps), especially on React/Vue pages.
+- Treat failed actions as potentially stale refs and run a **stale-ref retry loop** (small wait + fresh snapshot + ref re-resolve).
+- Prefer semantic matching (`role` + name regex) over positional assumptions.
+
 Example helper:
 
-- `templates/scripts/openclaw-browser-safe-action.sh` (generic action engine)
-- `templates/scripts/openclaw-x-post.sh` (X-specific wrapper on top)
+- `examples/scripts/openclaw-browser-safe-action.sh` (generic action engine)
+- `examples/scripts/openclaw-x-post.sh` (X-specific wrapper on top)
 
 ## Troubleshooting
 

--- a/examples/policies/chrome-managed-hardening.json
+++ b/examples/policies/chrome-managed-hardening.json
@@ -1,0 +1,6 @@
+{
+  "EnableMediaRouter": false,
+  "MediaRouterCastAllowAllIPs": false,
+  "AccessCodeCastEnabled": false,
+  "LocalDiscoveryEnabled": false
+}

--- a/examples/scripts/openclaw-browser-safe-action.sh
+++ b/examples/scripts/openclaw-browser-safe-action.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="${OPENCLAW_PROFILE:-main}"
+TARGET_ID=""
+URL=""
+REUSE_URL_REGEX=""
+ACTION=""
+ROLE=""
+NAME_REGEX=""
+TEXT_VALUE=""
+MAX_RETRIES="${OPENCLAW_RETRIES:-6}"
+WAIT_MS="${OPENCLAW_WAIT_MS:-1200}"
+SNAPSHOT_LIMIT="${OPENCLAW_SNAPSHOT_LIMIT:-500}"
+CMD_RETRIES="${OPENCLAW_CMD_RETRIES:-4}"
+CMD_RETRY_SLEEP_SEC="${OPENCLAW_CMD_RETRY_SLEEP_SEC:-2}"
+LOCK_WAIT_SEC="${OPENCLAW_SAFE_LOCK_WAIT_SEC:-30}"
+REQUIRE_ENABLED=1
+FALLBACK_FN=""
+OUTPUT_JSON=0
+FORCE_OPEN=0
+DRY_RUN=0
+
+usage() {
+  cat <<USAGE
+Usage:
+  $(basename "$0") --action <click|type> --role <role> --name-regex <regex> [options]
+
+Options:
+  --profile <name>
+  --target-id <id>
+  --url <url>
+  --reuse-url-regex <regex>   Try reusing an existing page tab before opening a new one
+  --force-open                Force opening a new tab for --url
+  --text <value>              Required for --action type
+  --max-retries <n>
+  --wait-ms <ms>
+  --snapshot-limit <n>
+  --no-require-enabled        Allow clicking disabled-looking refs
+  --fallback-fn <js-fn>       JS function passed to evaluate when retries fail
+  --dry-run                   Resolve ref and validate readiness, skip actual action
+  --json
+
+Examples:
+  $(basename "$0") --action click --role button --name-regex 'Post|Publish' --url 'https://x.com/compose/post'
+  $(basename "$0") --action type --role textbox --name-regex 'Post text' --text 'hello' --target-id ABC123
+USAGE
+}
+
+log() {
+  printf '[openclaw-safe] %s\n' "$*" >&2
+}
+
+die() {
+  printf '[openclaw-safe] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+is_transient_openclaw_error() {
+  local msg="$1"
+  printf '%s\n' "$msg" | grep -Eq \
+    'Port [0-9]+ is in use for profile|ECONNREFUSED|connect ECONN|EADDRINUSE|uv_interface_addresses|CDP|websocket|Timed out'
+}
+
+oc_raw() {
+  openclaw browser --browser-profile "$PROFILE" "$@"
+}
+
+oc_json() {
+  local out
+  local rc=0
+  local attempt=1
+  local max_attempts="$CMD_RETRIES"
+
+  while (( attempt <= max_attempts )); do
+    rc=0
+    out="$(oc_raw "$@" 2>&1)" || rc=$?
+    if (( rc == 0 )); then
+      printf '%s\n' "$out" | sed -n '/^{/,$p'
+      return 0
+    fi
+
+    if is_transient_openclaw_error "$out" && (( attempt < max_attempts )); then
+      log "Transient openclaw error (attempt ${attempt}/${max_attempts}); retrying in ${CMD_RETRY_SLEEP_SEC}s"
+      sleep "$CMD_RETRY_SLEEP_SEC"
+      rc=0
+      ((attempt++))
+      continue
+    fi
+
+    printf '%s\n' "$out" >&2
+    return "${rc:-1}"
+  done
+
+  printf '%s\n' "$out" >&2
+  return 1
+}
+
+with_target_args() {
+  local cmd="$1"
+  shift
+  local args=("$cmd" "$@")
+  if [[ -n "$TARGET_ID" ]]; then
+    args+=(--target-id "$TARGET_ID")
+  fi
+  printf '%s\0' "${args[@]}"
+}
+
+oc_json_targeted() {
+  local cmd="$1"
+  shift
+  local -a args=()
+  while IFS= read -r -d '' item; do
+    args+=("$item")
+  done < <(with_target_args "$cmd" "$@")
+  oc_json "${args[@]}" --json
+}
+
+oc_wait_small() {
+  local -a args=(wait --time "$WAIT_MS")
+  if [[ -n "$TARGET_ID" ]]; then
+    args+=(--target-id "$TARGET_ID")
+  fi
+  oc_raw "${args[@]}" >/dev/null 2>&1 || true
+}
+
+snapshot_json() {
+  local -a args=(snapshot --json --efficient --limit "$SNAPSHOT_LIMIT")
+  if [[ -n "$TARGET_ID" ]]; then
+    args+=(--target-id "$TARGET_ID")
+  fi
+  oc_json "${args[@]}"
+}
+
+find_ref() {
+  local snap_json="$1"
+  local role="$2"
+  local name_regex="$3"
+
+  printf '%s\n' "$snap_json" |
+    jq -r --arg role "$role" --arg rx "$name_regex" '
+      .refs
+      | to_entries
+      | map(select((.value.role // "") == $role and ((.value.name // "") | test($rx; "i"))))
+      | .[0].key // empty
+    '
+}
+
+is_ref_disabled() {
+  local snap_json="$1"
+  local ref="$2"
+  local line
+
+  line="$({
+    printf '%s\n' "$snap_json" |
+      jq -r --arg ref "$ref" '
+        .snapshot
+        | split("\\n")
+        | map(select(test("\\\\[ref=" + $ref + "\\\\]")))
+        | .[0] // ""
+      '
+  })"
+
+  [[ "$line" == *"[disabled]"* ]]
+}
+
+resolve_target_from_tabs() {
+  local tabs_json
+  tabs_json="$(oc_json tabs --json)" || return 1
+
+  TARGET_ID="$(
+    printf '%s\n' "$tabs_json" |
+      jq -r --arg rx "$REUSE_URL_REGEX" '
+        .tabs
+        | map(select(.type == "page" and ((.url // "") | test($rx; "i"))))
+        | .[-1].targetId // empty
+      '
+  )"
+
+  [[ -n "$TARGET_ID" ]]
+}
+
+open_or_navigate() {
+  if [[ -n "$REUSE_URL_REGEX" && -z "$TARGET_ID" ]]; then
+    resolve_target_from_tabs || true
+    if [[ -n "$TARGET_ID" ]]; then
+      log "Reusing existing tab targetId=$TARGET_ID"
+    fi
+  fi
+
+  if [[ -z "$URL" ]]; then
+    return 0
+  fi
+
+  if [[ -n "$TARGET_ID" && "$FORCE_OPEN" -eq 0 ]]; then
+    log "Navigating existing targetId=$TARGET_ID to URL"
+    oc_json_targeted navigate "$URL" >/dev/null || return 1
+    return 0
+  fi
+
+  log "Opening URL in a new tab"
+  local open_json
+  open_json="$(oc_json open "$URL" --json)" || return 1
+  TARGET_ID="$(printf '%s\n' "$open_json" | jq -r '.targetId // empty')"
+  [[ -n "$TARGET_ID" ]] || return 1
+}
+
+emit_success() {
+  local ref="$1"
+  if [[ "$OUTPUT_JSON" -eq 1 ]]; then
+    jq -n \
+      --arg action "$ACTION" \
+      --arg ref "$ref" \
+      --arg targetId "$TARGET_ID" \
+      '{ok:true, action:$action, ref:$ref, targetId:$targetId}'
+  else
+    log "Success action=$ACTION ref=$ref targetId=$TARGET_ID"
+  fi
+}
+
+while (($#)); do
+  case "$1" in
+    --profile)
+      shift
+      (($#)) || die "--profile requires a value"
+      PROFILE="$1"
+      ;;
+    --target-id)
+      shift
+      (($#)) || die "--target-id requires a value"
+      TARGET_ID="$1"
+      ;;
+    --url)
+      shift
+      (($#)) || die "--url requires a value"
+      URL="$1"
+      ;;
+    --reuse-url-regex)
+      shift
+      (($#)) || die "--reuse-url-regex requires a value"
+      REUSE_URL_REGEX="$1"
+      ;;
+    --force-open)
+      FORCE_OPEN=1
+      ;;
+    --action)
+      shift
+      (($#)) || die "--action requires a value"
+      ACTION="$1"
+      ;;
+    --role)
+      shift
+      (($#)) || die "--role requires a value"
+      ROLE="$1"
+      ;;
+    --name-regex)
+      shift
+      (($#)) || die "--name-regex requires a value"
+      NAME_REGEX="$1"
+      ;;
+    --text)
+      shift
+      (($#)) || die "--text requires a value"
+      TEXT_VALUE="$1"
+      ;;
+    --max-retries)
+      shift
+      (($#)) || die "--max-retries requires a value"
+      MAX_RETRIES="$1"
+      ;;
+    --wait-ms)
+      shift
+      (($#)) || die "--wait-ms requires a value"
+      WAIT_MS="$1"
+      ;;
+    --snapshot-limit)
+      shift
+      (($#)) || die "--snapshot-limit requires a value"
+      SNAPSHOT_LIMIT="$1"
+      ;;
+    --no-require-enabled)
+      REQUIRE_ENABLED=0
+      ;;
+    --fallback-fn)
+      shift
+      (($#)) || die "--fallback-fn requires a value"
+      FALLBACK_FN="$1"
+      ;;
+    --json)
+      OUTPUT_JSON=1
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+  shift || true
+done
+
+require_cmd openclaw
+require_cmd jq
+
+[[ "$ACTION" == "click" || "$ACTION" == "type" ]] || die "--action must be click or type"
+[[ -n "$ROLE" ]] || die "--role is required"
+[[ -n "$NAME_REGEX" ]] || die "--name-regex is required"
+if [[ "$ACTION" == "type" ]]; then
+  [[ -n "$TEXT_VALUE" ]] || die "--text is required for type"
+fi
+
+if command -v flock >/dev/null 2>&1; then
+  LOCK_FILE="${OPENCLAW_SAFE_LOCK_FILE:-/tmp/openclaw-safe-${PROFILE}.lock}"
+  exec 9>"$LOCK_FILE"
+  if ! flock -w "$LOCK_WAIT_SEC" 9; then
+    log "Lock busy ($LOCK_FILE); continuing without lock"
+  fi
+fi
+
+open_or_navigate || die "Failed to establish target page"
+
+if [[ -n "$URL" ]]; then
+  local_wait_args=(wait --url '**' --timeout-ms 30000)
+  if [[ -n "$TARGET_ID" ]]; then
+    local_wait_args+=(--target-id "$TARGET_ID")
+  fi
+  oc_raw "${local_wait_args[@]}" >/dev/null 2>&1 || true
+fi
+
+for ((attempt=1; attempt<=MAX_RETRIES; attempt++)); do
+  log "Attempt ${attempt}/${MAX_RETRIES}"
+
+  snap="$(snapshot_json)" || {
+    oc_wait_small
+    continue
+  }
+
+  ref="$(find_ref "$snap" "$ROLE" "$NAME_REGEX")"
+  if [[ -z "$ref" ]]; then
+    oc_wait_small
+    continue
+  fi
+
+  if [[ "$ACTION" == "click" && "$REQUIRE_ENABLED" -eq 1 ]]; then
+    if is_ref_disabled "$snap" "$ref"; then
+      oc_wait_small
+      continue
+    fi
+  fi
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    emit_success "$ref"
+    exit 0
+  fi
+
+  case "$ACTION" in
+    click)
+      if oc_json_targeted click "$ref" >/dev/null; then
+        emit_success "$ref"
+        exit 0
+      fi
+      ;;
+    type)
+      if oc_json_targeted type "$ref" "$TEXT_VALUE" >/dev/null; then
+        emit_success "$ref"
+        exit 0
+      fi
+      ;;
+  esac
+
+  oc_wait_small
+done
+
+if [[ -n "$FALLBACK_FN" ]]; then
+  log "Running fallback evaluate"
+  fb_json="$(oc_json_targeted evaluate --fn "$FALLBACK_FN" 2>/dev/null || true)"
+  if [[ -n "$fb_json" ]]; then
+    if printf '%s\n' "$fb_json" | jq -e '(.ok == true) and ((.result.ok // false) or (.result == true) or (.result.success // false))' >/dev/null 2>&1; then
+      emit_success "evaluate-fallback"
+      exit 0
+    fi
+  fi
+fi
+
+die "Failed after ${MAX_RETRIES} attempts"

--- a/examples/scripts/openclaw-browser-safe-action.sh
+++ b/examples/scripts/openclaw-browser-safe-action.sh
@@ -113,7 +113,8 @@ with_target_args() {
 oc_json_targeted() {
   local cmd="$1"
   shift
-  local -a args=()
+  local -a args
+  args=()
   while IFS= read -r -d '' item; do
     args+=("$item")
   done < <(with_target_args "$cmd" "$@")
@@ -121,7 +122,8 @@ oc_json_targeted() {
 }
 
 oc_wait_small() {
-  local -a args=(wait --time "$WAIT_MS")
+  local -a args
+  args=(wait --time "$WAIT_MS")
   if [[ -n "$TARGET_ID" ]]; then
     args+=(--target-id "$TARGET_ID")
   fi
@@ -129,7 +131,8 @@ oc_wait_small() {
 }
 
 snapshot_json() {
-  local -a args=(snapshot --json --efficient --limit "$SNAPSHOT_LIMIT")
+  local -a args
+  args=(snapshot --json --efficient --limit "$SNAPSHOT_LIMIT")
   if [[ -n "$TARGET_ID" ]]; then
     args+=(--target-id "$TARGET_ID")
   fi
@@ -328,13 +331,15 @@ fi
 open_or_navigate || die "Failed to establish target page"
 
 if [[ -n "$URL" ]]; then
-  local_wait_args=(wait --url '**' --timeout-ms 30000)
+  declare -a wait_args=(wait --url '**' --timeout-ms 30000)
   if [[ -n "$TARGET_ID" ]]; then
-    local_wait_args+=(--target-id "$TARGET_ID")
+    wait_args+=(--target-id "$TARGET_ID")
   fi
-  oc_raw "${local_wait_args[@]}" >/dev/null 2>&1 || true
+  oc_raw "${wait_args[@]}" >/dev/null 2>&1 || true
 fi
 
+snap=""
+ref=""
 for ((attempt=1; attempt<=MAX_RETRIES; attempt++)); do
   log "Attempt ${attempt}/${MAX_RETRIES}"
 

--- a/examples/scripts/openclaw-x-post.sh
+++ b/examples/scripts/openclaw-x-post.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="${OPENCLAW_PROFILE:-main}"
+URL="${OPENCLAW_X_COMPOSE_URL:-https://x.com/compose/post}"
+MAX_RETRIES="${OPENCLAW_RETRIES:-6}"
+WAIT_MS="${OPENCLAW_WAIT_MS:-1200}"
+SNAPSHOT_LIMIT="${OPENCLAW_SNAPSHOT_LIMIT:-500}"
+LOCK_WAIT_SEC="${OPENCLAW_X_LOCK_WAIT_SEC:-45}"
+MIN_INTERVAL_SEC="${OPENCLAW_X_MIN_INTERVAL_SEC:-2}"
+TARGET_ID=""
+PUBLISH=0
+FORCE_OPEN=0
+REUSE_COMPOSE_TAB=1
+
+TEXTBOX_REGEX="${OPENCLAW_X_TEXTBOX_REGEX:-Metni gönderi olarak yayınla|Post text|What.?s happening|What is happening}"
+PUBLISH_REGEX="${OPENCLAW_X_PUBLISH_REGEX:-Gönderi yayınla|Post|Publish|Yayınla}"
+TWEET_BUTTON_SELECTOR="${OPENCLAW_X_TWEET_BUTTON_SELECTOR:-[data-testid=\"tweetButtonInline\"], [data-testid=\"tweetButton\"]}"
+SAFE_ACTION_SCRIPT="${OPENCLAW_SAFE_ACTION_SCRIPT:-openclaw-browser-safe-action}"
+
+usage() {
+  cat <<USAGE
+Usage:
+  $(basename "$0") [options] "post text"
+
+Options:
+  --profile <name>
+  --target-id <id>
+  --publish
+  --force-open
+  --no-reuse-compose-tab
+  --url <compose-url>
+  --textbox-regex <regex>
+  --publish-regex <regex>
+  --tweet-button-selector <css>
+  --max-retries <n>
+  --wait-ms <ms>
+  --snapshot-limit <n>
+
+Examples:
+  $(basename "$0") "Dry run text"
+  $(basename "$0") --publish "Real post text"
+USAGE
+}
+
+log() {
+  printf '[openclaw-x-post] %s\n' "$*"
+}
+
+die() {
+  printf '[openclaw-x-post] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+build_fallback_fn() {
+  local selector_json
+  selector_json="$(jq -Rn --arg s "$TWEET_BUTTON_SELECTOR" '$s')"
+
+  cat <<JS
+() => {
+  const selector = ${selector_json};
+  const el = document.querySelector(selector);
+  if (!el) return { ok: false, reason: 'not-found' };
+  const disabled = !!el.disabled || el.getAttribute('aria-disabled') === 'true';
+  if (disabled) return { ok: false, reason: 'disabled' };
+  el.click();
+  return { ok: true };
+}
+JS
+}
+
+run_safe_action() {
+  local include_url=1
+  if [[ "${1:-}" == "--no-url" ]]; then
+    include_url=0
+    shift
+  fi
+
+  local action="$1"
+  shift
+  local -a args=("$SAFE_ACTION_SCRIPT" --json --profile "$PROFILE" --action "$action")
+
+  if [[ -n "$TARGET_ID" ]]; then
+    args+=(--target-id "$TARGET_ID")
+  fi
+
+  if [[ "$include_url" -eq 1 ]]; then
+    args+=(--url "$URL")
+
+    if [[ "$REUSE_COMPOSE_TAB" -eq 1 ]]; then
+      args+=(--reuse-url-regex 'https://x\.com/compose/post')
+    fi
+
+    if [[ "$FORCE_OPEN" -eq 1 ]]; then
+      args+=(--force-open)
+    fi
+  fi
+
+  args+=(--max-retries "$MAX_RETRIES" --wait-ms "$WAIT_MS" --snapshot-limit "$SNAPSHOT_LIMIT")
+  args+=("$@")
+
+  "${args[@]}"
+}
+
+POST_TEXT=""
+while (($#)); do
+  case "$1" in
+    --profile)
+      shift
+      (($#)) || die "--profile requires a value"
+      PROFILE="$1"
+      ;;
+    --target-id)
+      shift
+      (($#)) || die "--target-id requires a value"
+      TARGET_ID="$1"
+      ;;
+    --publish)
+      PUBLISH=1
+      ;;
+    --force-open)
+      FORCE_OPEN=1
+      ;;
+    --no-reuse-compose-tab)
+      REUSE_COMPOSE_TAB=0
+      ;;
+    --url)
+      shift
+      (($#)) || die "--url requires a value"
+      URL="$1"
+      ;;
+    --textbox-regex)
+      shift
+      (($#)) || die "--textbox-regex requires a value"
+      TEXTBOX_REGEX="$1"
+      ;;
+    --publish-regex)
+      shift
+      (($#)) || die "--publish-regex requires a value"
+      PUBLISH_REGEX="$1"
+      ;;
+    --tweet-button-selector)
+      shift
+      (($#)) || die "--tweet-button-selector requires a value"
+      TWEET_BUTTON_SELECTOR="$1"
+      ;;
+    --max-retries)
+      shift
+      (($#)) || die "--max-retries requires a value"
+      MAX_RETRIES="$1"
+      ;;
+    --wait-ms)
+      shift
+      (($#)) || die "--wait-ms requires a value"
+      WAIT_MS="$1"
+      ;;
+    --snapshot-limit)
+      shift
+      (($#)) || die "--snapshot-limit requires a value"
+      SNAPSHOT_LIMIT="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -z "$POST_TEXT" ]]; then
+        POST_TEXT="$1"
+      else
+        POST_TEXT+=" $1"
+      fi
+      ;;
+  esac
+  shift || true
+done
+
+[[ -n "$POST_TEXT" ]] || {
+  usage
+  exit 1
+}
+
+require_cmd openclaw
+require_cmd jq
+require_cmd "$SAFE_ACTION_SCRIPT"
+
+if command -v flock >/dev/null 2>&1; then
+  LOCK_FILE="${OPENCLAW_X_LOCK_FILE:-/tmp/openclaw-x-post-${PROFILE}.lock}"
+  exec 8>"$LOCK_FILE"
+  flock -w "$LOCK_WAIT_SEC" 8 || die "Failed to acquire lock: $LOCK_FILE"
+fi
+
+STAMP_FILE="${OPENCLAW_X_STAMP_FILE:-/tmp/openclaw-x-post-${PROFILE}.last}"
+now="$(date +%s)"
+if [[ -f "$STAMP_FILE" ]]; then
+  last="$(cat "$STAMP_FILE" 2>/dev/null || echo 0)"
+  if [[ "$last" =~ ^[0-9]+$ ]]; then
+    gap=$((now - last))
+    if (( gap < MIN_INTERVAL_SEC )); then
+      sleep $((MIN_INTERVAL_SEC - gap))
+    fi
+  fi
+fi
+printf '%s\n' "$(date +%s)" > "$STAMP_FILE"
+
+log "Typing into compose box with target lock + retry"
+type_json="$(run_safe_action type --role textbox --name-regex "$TEXTBOX_REGEX" --text "$POST_TEXT")" || die "Failed to type post text"
+TARGET_ID="$(printf '%s\n' "$type_json" | jq -r '.targetId // empty')"
+[[ -n "$TARGET_ID" ]] || die "No targetId returned from type action"
+
+if [[ "$PUBLISH" -eq 0 ]]; then
+  log "Dry run: validating publish button state"
+  run_safe_action --no-url click --role button --name-regex "$PUBLISH_REGEX" --dry-run >/dev/null || die "Publish button not ready"
+  log "Ready: publish button is resolvable and enabled (targetId=$TARGET_ID)"
+  log "Use --publish to click the publish button"
+  exit 0
+fi
+
+log "Publishing with retry + JS fallback"
+FALLBACK_FN="$(build_fallback_fn)"
+run_safe_action --no-url click --role button --name-regex "$PUBLISH_REGEX" --fallback-fn "$FALLBACK_FN" >/dev/null || die "Failed to publish"
+
+log "Publish action sent successfully (targetId=$TARGET_ID)"

--- a/examples/scripts/sync-main-profile-to-openclaw.sh
+++ b/examples/scripts/sync-main-profile-to-openclaw.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_PROFILE_DIR="${SOURCE_PROFILE_DIR:-$HOME/.config/google-chrome}"
+TARGET_PROFILE_DIR="${TARGET_PROFILE_DIR:-$HOME/chrome-profiles/main-openclaw}"
+CHROME_SERVICE="${CHROME_SERVICE:-openclaw-chrome-main.service}"
+
+if [[ ! -d "${SOURCE_PROFILE_DIR}" ]]; then
+  echo "Source profile not found: ${SOURCE_PROFILE_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "${TARGET_PROFILE_DIR}"
+
+if [[ -S "/run/user/$(id -u)/bus" ]]; then
+  export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+  export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+  systemctl --user stop "${CHROME_SERVICE}" >/dev/null 2>&1 || true
+fi
+
+rsync -a --delete \
+  --exclude='Singleton*' \
+  --exclude='*.lock' \
+  --exclude='DevToolsActivePort' \
+  --exclude='BrowserMetrics*' \
+  --exclude='CrashpadMetrics*' \
+  --exclude='Safe Browsing' \
+  --exclude='component_crx_cache' \
+  --exclude='GrShaderCache' \
+  --exclude='ShaderCache' \
+  "${SOURCE_PROFILE_DIR}/" "${TARGET_PROFILE_DIR}/"
+
+if [[ -S "/run/user/$(id -u)/bus" ]]; then
+  systemctl --user start "${CHROME_SERVICE}" >/dev/null 2>&1 || true
+fi
+
+echo "Profile sync complete: ${SOURCE_PROFILE_DIR} -> ${TARGET_PROFILE_DIR}"

--- a/examples/systemd/openclaw-chrome-main.service
+++ b/examples/systemd/openclaw-chrome-main.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=OpenClaw Chrome Main CDP (port 18804)
+After=network-online.target openclaw-xvfb.service
+Wants=network-online.target
+Requires=openclaw-xvfb.service
+
+[Service]
+Type=simple
+Environment=DISPLAY=:100
+Environment=HOME=%h
+Environment=XDG_RUNTIME_DIR=/run/user/%U
+ExecStart=/usr/bin/google-chrome-stable \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port=18804 \
+  --user-data-dir=%h/chrome-profiles/main-openclaw \
+  --profile-directory=Default \
+  --no-first-run \
+  --no-default-browser-check \
+  --disable-background-networking \
+  --disable-sync \
+  --disable-features=Translate,MediaRouter,DialMediaRouteProvider,CastMediaRouteProvider,GlobalMediaControlsCastStartStop \
+  --disable-component-extensions-with-background-pages \
+  --disable-zeroconf \
+  --disable-extensions \
+  --disable-component-update \
+  --window-size=1365,1024 \
+  https://x.com/home
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/examples/systemd/openclaw-xvfb.service
+++ b/examples/systemd/openclaw-xvfb.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenClaw virtual display :100 for browser automation
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/Xvfb :100 -screen 0 1920x1080x24 -nolisten tcp -ac
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Related to #10994

## Summary
This PR documents a Linux-first browser automation setup that keeps OpenClaw stable with Chrome CDP and dynamic pages:

- user-level `systemd` units for `Xvfb` and Chrome CDP
- dedicated automation profile sync script (copy default profile into isolated profile dir)
- stale-ref-resistant browser workflow example (`snapshot -> ref lookup -> action -> retry`)

The goal is to improve reliability on Linux where users often hit:
- CDP endpoint flakiness
- display/auth issues
- dynamic DOM ref invalidation between snapshot and action

## What's Included
- docs: Linux stable CDP setup and troubleshooting
- service templates: user-level Xvfb and Chrome main CDP
- example scripts:
  - profile sync script
  - X post helper with fresh-snapshot + retry logic

## Platform Support
- Core scripts (`openclaw-browser-safe-action.sh`, `openclaw-x-post.sh`) are **cross-platform** (Linux/macOS/WSL) - dependencies: bash, flock, jq
- Service templates (`openclaw-xvfb.service`, `openclaw-chrome-main.service`) are **Linux-specific** (systemd)
- macOS (launchd) and Windows (Task Scheduler) adapters can be added in follow-up PRs

## Why
On dynamic pages, element refs from snapshot can change before action. A retry loop that always refreshes snapshot and resolves ref by semantic attributes (role/name) is significantly more stable than static ref reuse.

## Notes
- This PR intentionally avoids machine-specific values.
- Paths and service names are template-based and configurable.
- No user data, credentials, or local config files are included.

## Test Steps
1. Start user services (`openclaw-xvfb`, `openclaw-chrome-main`).
2. Verify CDP endpoint responds on loopback.
3. Run example script in dry-run mode.
4. Confirm retry logic handles ref invalidation without failing hard.

## Follow-ups (Optional)
- add first-class docs link from browser CLI help
- provide official retry helper in OpenClaw examples
- add platform-specific adapters/docs for macOS (launchd) and Windows (Task Scheduler)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Linux-focused documentation and examples intended to improve browser automation reliability on dynamic pages: a systemd user-service setup for Xvfb + Chrome CDP, a Chrome managed-policy hardening example, and bash scripts for syncing a Chrome profile and performing “stale-ref-safe” snapshot→ref-resolve→action retries.

Key integration points are the new `examples/scripts/*` helpers which wrap `openclaw browser` commands (snapshot/click/type/evaluate) and the `examples/systemd/*` units which run a loopback-only CDP Chrome under a dedicated user-data-dir.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of issues that will break the documented workflow and one script at runtime.
- The added docs reference paths that don’t exist in the repo, and `openclaw-browser-safe-action.sh` contains a top-level array assignment using `local` under `set -u`, which will cause the script to exit when `--url` is used. Other changes are additive examples/services and don’t appear to affect existing code paths.
- examples/scripts/openclaw-browser-safe-action.sh, docs/linux-stable-cdp.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->
