### PR TITLE
fix(bluebubbles): add staleness check to drop replayed webhooks after restart

### DIFF
--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -41,6 +41,7 @@ const bluebubblesAccountSchema = z.object({
   chunkMode: z.enum(["length", "newline"]).optional(),
   mediaMaxMb: z.number().int().positive().optional(),
   sendReadReceipts: z.boolean().optional(),
+  maxMessageAgeMs: z.number().int().min(0).optional(),
   blockStreaming: z.boolean().optional(),
   groups: z.object({}).catchall(bluebubblesGroupConfigSchema).optional(),
 });

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -39,6 +39,7 @@ export type BlueBubblesMonitorOptions = {
 
 const DEFAULT_WEBHOOK_PATH = "/bluebubbles-webhook";
 const DEFAULT_TEXT_LIMIT = 4000;
+const DEFAULT_MAX_MESSAGE_AGE_MS = 5 * 60 * 1000;
 const invalidAckReactions = new Set<string>();
 
 const REPLY_CACHE_MAX = 2000;
@@ -1640,6 +1641,17 @@ async function processMessage(
     // Cache from-me messages so reply context can resolve sender/body.
     cacheInboundMessage();
     return;
+  }
+
+  const maxMessageAgeMs = account.config.maxMessageAgeMs ?? DEFAULT_MAX_MESSAGE_AGE_MS;
+  if (typeof message.timestamp === "number" && maxMessageAgeMs > 0) {
+    const ageMs = Date.now() - message.timestamp;
+    if (ageMs < 0 || ageMs > maxMessageAgeMs) {
+      runtime.log?.(
+        `[bluebubbles] drop stale message: age=${Math.round(ageMs / 1000)}s limit=${Math.round(maxMessageAgeMs / 1000)}s sender=${message.senderId} id=${message.messageId ?? ""}`,
+      );
+      return;
+    }
   }
 
   if (!rawBody) {

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -46,6 +46,8 @@ export type BlueBubblesAccountConfig = {
   mediaMaxMb?: number;
   /** Send read receipts for incoming messages (default: true). */
   sendReadReceipts?: boolean;
+  /** Max age (ms) of inbound messages before they are dropped as stale (default: 300000 = 5 min). */
+  maxMessageAgeMs?: number;
   /** Per-group configuration keyed by chat GUID or identifier. */
   groups?: Record<string, BlueBubblesGroupConfig>;
 };


### PR DESCRIPTION
## Summary

Fixes #12053

When the BlueBubbles server re-delivers webhook messages after a restart, the in-memory dedup cache (`shouldSkipDuplicateInbound`) is empty, so all replayed messages get processed as new. This PR adds a **timestamp-based staleness check** in `processMessage()` that drops inbound messages older than a configurable threshold (default: 5 minutes).

- Adds `DEFAULT_MAX_MESSAGE_AGE_MS` (5 min) constant and staleness guard in `processMessage()`
- Adds `maxMessageAgeMs` to `BlueBubblesAccountConfig` type and `bluebubblesAccountSchema` (Zod config schema)
- Messages with no timestamp are passed through (no false positives)
- Configurable per-account via `channels.bluebubbles.maxMessageAgeMs` or per-account override

## Test plan

- [x] Add 4 new tests in `describe("staleness protection")`:
  - Drops inbound messages with a stale timestamp (17h old)
  - Processes messages with a recent timestamp (10s old)
  - Processes messages with no timestamp (graceful pass-through)
  - Respects configurable `maxMessageAgeMs` (custom 2s threshold)
- [x] All 4 tests fail before implementation, pass after (TDD)
- [x] Full test suite: all 55 BlueBubbles monitor tests pass
- [x] `pnpm build` passes
- [x] `pnpm check` (lint) passes — 0 warnings, 0 errors
- [x] `codex review --base main` passes clean (2 rounds — first caught missing schema field, fixed and re-verified)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds timestamp-based staleness protection to the BlueBubbles webhook monitor so replayed webhook deliveries after a BlueBubbles server restart are dropped instead of re-processed. It introduces a default `maxMessageAgeMs` (5 minutes), wires the new per-account config through the Zod schema and types, and adds a dedicated test suite covering stale, fresh, missing-timestamp, custom-threshold, and future-dated timestamp cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to inbound webhook processing, use an existing normalized `timestamp` field (with ms/sec normalization already in place), add the config field to both types and Zod schema, and include targeted tests for stale, fresh, missing timestamp, custom thresholds, and future timestamps. No additional issues were found beyond the already-addressed future-timestamp bypass.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->