### PR TITLE
Add Claude Code session-start hook and CLAUDE.md for fork setup

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,6 +6,9 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+# Run async so session starts immediately while deps install in background
+echo '{"async": true, "asyncTimeout": 300000}'
+
 cd "$CLAUDE_PROJECT_DIR"
 
 # Install pnpm if not available

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web/mobile) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install pnpm if not available
+if ! command -v pnpm &>/dev/null; then
+  npm install -g pnpm@10
+fi
+
+# Install dependencies (idempotent, uses cache on subsequent runs)
+pnpm install --frozen-lockfile=false
+
+# Build the project so linters with type-awareness work
+pnpm build

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,43 @@
-AGENTS.md
+# Fork-Specific Notes (alex-jadecli/openclaw)
+
+This is a personal fork. Never create PRs against the upstream `openclaw/openclaw` repository.
+All PRs should target this fork's `main` branch (`alex-jadecli/openclaw`).
+
+---
+
+# Repository Guidelines
+
+- Repo: https://github.com/openclaw/openclaw
+- GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or $'...') for real newlines; never embed "\\n".
+
+## Project Structure & Module Organization
+
+- Source code: `src/` (CLI wiring in `src/cli`, commands in `src/commands`, web provider in `src/provider-web.ts`, infra in `src/infra`, media pipeline in `src/media`).
+- Tests: colocated `*.test.ts`.
+- Docs: `docs/` (images, queue, Pi config). Built output lives in `dist/`.
+- Plugins/extensions: live under `extensions/*` (workspace packages). Keep plugin-only deps in the extension `package.json`; do not add them to the root `package.json` unless core uses them.
+- Plugins: install runs `npm install --omit=dev` in plugin dir; runtime deps must live in `dependencies`. Avoid `workspace:*` in `dependencies` (npm install breaks); put `openclaw` in `devDependencies` or `peerDependencies` instead (runtime resolves `openclaw/plugin-sdk` via jiti alias).
+- Messaging channels: always consider **all** built-in + extension channels when refactoring shared logic (routing, allowlists, pairing, command gating, onboarding, docs).
+
+## Build, Test, and Development Commands
+
+- Runtime baseline: Node **22+** (keep Node + Bun paths working).
+- Install deps: `pnpm install`
+- Build: `pnpm build`
+- Dev (auto-reload): `pnpm gateway:watch`
+- Type-check: `pnpm tsgo`
+- Lint/format: `pnpm check` (tsgo + lint + format)
+- Lint: `pnpm lint` (oxlint with type-awareness)
+- Lint fix: `pnpm lint:fix`
+- Format check: `pnpm format` (oxfmt)
+- Format fix: `pnpm format:fix`
+- Tests: `pnpm test` (vitest); single file: `npx vitest run path/to/file.test.ts`
+- Coverage: `pnpm test:coverage`
+- E2E: `pnpm test:e2e`
+
+## Coding Style & Naming Conventions
+
+- Language: TypeScript (ESM, ES2023). Prefer strict typing; avoid `any`.
+- Formatting/linting via Oxlint and Oxfmt; run `pnpm check` before commits.
+- Keep files under ~500 LOC when feasible.
+- Use oxlint/oxfmt conventions (no Prettier/ESLint).


### PR DESCRIPTION
- Add .claude/hooks/session-start.sh to install pnpm deps and build on Claude Code web/mobile sessions
- Add .claude/settings.json to register the SessionStart hook
- Replace CLAUDE.md symlink with standalone file containing fork guardrails and distilled build/test/lint commands

https://claude.ai/code/session_01WF3Lv4YhsSoKuQ9bfJNzqV