### PR TITLE
fix(cron): recover flat params when LLM omits job wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Docs: https://docs.openclaw.ai
 - Gateway: stabilize chat routing by canonicalizing node session keys for node-originated chat methods. (#11755) Thanks @mbelinky.
 - Web UI: make chat refresh smoothly scroll to the latest messages and suppress new-messages badge flash during manual refresh.
 - Cron: route text-only isolated agent announces through the shared subagent announce flow; add exponential backoff for repeated errors; preserve future `nextRunAtMs` on restart; include current-boundary schedule matches; prevent stale threadId reuse across targets; and add per-job execution timeout. (#11641) Thanks @tyler6204.
+- Cron tool: recover flat params when LLM omits the `job` wrapper for add requests. (#11310, #12124) Thanks @tyler6204.
+- Cron scheduler: fix `nextRun` skipping the current occurrence when computed mid-second. (#12124) Thanks @tyler6204.
 - Subagents: stabilize announce timing, preserve compaction metrics across retries, clamp overflow-prone long timeouts, and cap impossible context usage token totals. (#11551) Thanks @tyler6204.
 - Agents: recover from context overflow caused by oversized tool results (pre-emptive capping + fallback truncation). (#11579) Thanks @tyler6204.
 - Gateway: no more post-compaction amnesia; injected transcript writes now preserve Pi session `parentId` chain so agents can remember again. Thanks @Takhoffman 🦞.

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -321,6 +321,109 @@ describe("cron tool", () => {
     });
   });
 
+  // ── Flat-params recovery (issue #11310) ──────────────────────────────
+
+  it("recovers flat params when job is missing", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool();
+    await tool.execute("call-flat", {
+      action: "add",
+      name: "flat-job",
+      schedule: { kind: "at", at: new Date(123).toISOString() },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "do stuff" },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: { name?: string; sessionTarget?: string; payload?: { kind?: string } };
+    };
+    expect(call.method).toBe("cron.add");
+    expect(call.params?.name).toBe("flat-job");
+    expect(call.params?.sessionTarget).toBe("isolated");
+    expect(call.params?.payload?.kind).toBe("agentTurn");
+  });
+
+  it("recovers flat params when job is empty object", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool();
+    await tool.execute("call-empty-job", {
+      action: "add",
+      job: {},
+      name: "empty-job",
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "main",
+      payload: { kind: "systemEvent", text: "wake up" },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: { name?: string; sessionTarget?: string; payload?: { text?: string } };
+    };
+    expect(call.method).toBe("cron.add");
+    expect(call.params?.name).toBe("empty-job");
+    expect(call.params?.sessionTarget).toBe("main");
+    expect(call.params?.payload?.text).toBe("wake up");
+  });
+
+  it("recovers flat message shorthand as agentTurn payload", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool();
+    await tool.execute("call-msg-shorthand", {
+      action: "add",
+      schedule: { kind: "at", at: new Date(456).toISOString() },
+      message: "do stuff",
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: { payload?: { kind?: string; message?: string }; sessionTarget?: string };
+    };
+    expect(call.method).toBe("cron.add");
+    // normalizeCronJobCreate infers agentTurn from message and isolated from agentTurn
+    expect(call.params?.payload?.kind).toBe("agentTurn");
+    expect(call.params?.payload?.message).toBe("do stuff");
+    expect(call.params?.sessionTarget).toBe("isolated");
+  });
+
+  it("does not recover flat params when no meaningful job field is present", async () => {
+    const tool = createCronTool();
+    await expect(
+      tool.execute("call-no-signal", {
+        action: "add",
+        name: "orphan-name",
+        enabled: true,
+      }),
+    ).rejects.toThrow("job required");
+  });
+
+  it("prefers existing non-empty job over flat params", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool();
+    await tool.execute("call-nested-wins", {
+      action: "add",
+      job: {
+        name: "nested-job",
+        schedule: { kind: "at", at: new Date(123).toISOString() },
+        payload: { kind: "systemEvent", text: "from nested" },
+      },
+      name: "flat-name-should-be-ignored",
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { name?: string; payload?: { text?: string } };
+    };
+    expect(call?.params?.name).toBe("nested-job");
+    expect(call?.params?.payload?.text).toBe("from nested");
+  });
+
   it("does not infer delivery when mode is none", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -301,6 +301,57 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             }),
           );
         case "add": {
+          // Flat-params recovery: non-frontier models (e.g. Grok) sometimes flatten
+          // job properties to the top level alongside `action` instead of nesting
+          // them inside `job`. When `params.job` is missing or empty, reconstruct
+          // a synthetic job object from any recognised top-level job fields.
+          // See: https://github.com/openclaw/openclaw/issues/11310
+          if (
+            !params.job ||
+            (typeof params.job === "object" &&
+              params.job !== null &&
+              Object.keys(params.job as Record<string, unknown>).length === 0)
+          ) {
+            const JOB_KEYS: ReadonlySet<string> = new Set([
+              "name",
+              "schedule",
+              "sessionTarget",
+              "wakeMode",
+              "payload",
+              "delivery",
+              "enabled",
+              "description",
+              "deleteAfterRun",
+              "agentId",
+              "message",
+              "text",
+              "model",
+              "thinking",
+              "timeoutSeconds",
+              "allowUnsafeExternalContent",
+            ]);
+            const synthetic: Record<string, unknown> = {};
+            let found = false;
+            for (const key of Object.keys(params)) {
+              if (JOB_KEYS.has(key) && params[key] !== undefined) {
+                synthetic[key] = params[key];
+                found = true;
+              }
+            }
+            // Only use the synthetic job if at least one meaningful field is present
+            // (schedule, payload, message, or text are the minimum signals that the
+            // LLM intended to create a job).
+            if (
+              found &&
+              (synthetic.schedule !== undefined ||
+                synthetic.payload !== undefined ||
+                synthetic.message !== undefined ||
+                synthetic.text !== undefined)
+            ) {
+              params.job = synthetic;
+            }
+          }
+
           if (!params.job || typeof params.job !== "object") {
             throw new Error("job required");
           }

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -49,13 +49,17 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
     timezone: resolveCronTimezone(schedule.tz),
     catch: false,
   });
-  // Use a tiny lookback (1ms) so croner doesn't skip the current second
-  // boundary. Without this, a job updated at exactly its cron time would
-  // be scheduled for the *next* matching time (e.g. 24h later for daily).
-  const next = cron.nextRun(new Date(nowMs - 1));
+  // Cron operates at second granularity, so floor nowMs to the start of the
+  // current second.  This prevents the lookback from landing inside a matching
+  // second — if nowMs is e.g. 12:00:00.500 and the pattern fires at second 0,
+  // a 1ms lookback (12:00:00.499) is still *within* that second, causing
+  // croner to skip ahead to the next occurrence (e.g. the following day).
+  // Flooring first ensures the lookback always falls in the *previous* second.
+  const nowSecondMs = Math.floor(nowMs / 1000) * 1000;
+  const next = cron.nextRun(new Date(nowSecondMs - 1));
   if (!next) {
     return undefined;
   }
   const nextMs = next.getTime();
-  return Number.isFinite(nextMs) && nextMs >= nowMs ? nextMs : undefined;
+  return Number.isFinite(nextMs) && nextMs >= nowSecondMs ? nextMs : undefined;
 }

--- a/src/infra/warning-filter.test.ts
+++ b/src/infra/warning-filter.test.ts
@@ -56,7 +56,7 @@ describe("warning filter", () => {
   });
 
   it("installs once and suppresses known warnings at emit time", async () => {
-    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const baseEmitSpy = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
 
     installProcessWarningFilter();
     installProcessWarningFilter();
@@ -74,10 +74,10 @@ describe("warning filter", () => {
       code: "DEP0060",
     });
     await new Promise((resolve) => setImmediate(resolve));
-    expect(writeSpy).not.toHaveBeenCalled();
+    expect(baseEmitSpy).not.toHaveBeenCalled();
 
     emitWarning("Visible warning", { type: "Warning", code: "OPENCLAW_TEST_WARNING" });
     await new Promise((resolve) => setImmediate(resolve));
-    expect(writeSpy).toHaveBeenCalled();
+    expect(baseEmitSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Problem

Closes #11310.

Non-frontier models (e.g. Grok) flatten job properties to the top level alongside `action` instead of nesting them inside the `job` parameter. The cron tool's `add` handler schema uses an opaque `Type.Object({}, { additionalProperties: true })` for `job`, giving these models no structural hint — so they place `name`, `schedule`, `payload`, `sessionTarget`, etc. as siblings of `action`.

This causes either:
- `Error('job required')` when `params.job` is `undefined`
- Gateway validation failure (4 missing required properties) when `params.job` is `{}` and the actual fields are ignored at the top level

## Fix

Added a **flat-params recovery step** at the top of the `case 'add':` handler in `src/agents/tools/cron-tool.ts`:

1. When `params.job` is missing or an empty object, scan `params` for recognised job property names (`name`, `schedule`, `payload`, `sessionTarget`, `enabled`, `message`, `text`, `model`, `thinking`, etc.)
2. If at least one meaningful signal field is found (`schedule`, `payload`, `message`, or `text`), construct a synthetic `job` object from those fields
3. The synthetic job then flows into the existing `normalizeCronJobCreate` path which handles kind inference, defaults, and validation

If `params.job` already contains properties, the existing behavior is completely unchanged.

## Tests

Added 5 test cases covering:
- Flat params with no `job` wrapper → recovered successfully
- Empty `job: {}` + flat params → recovered successfully
- Message shorthand at top level → inferred as `agentTurn` payload
- No meaningful fields present → still throws `'job required'`
- Non-empty `job` takes precedence over flat params

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the cron tool’s `add` handler to recover from “flat” LLM tool params where job fields (e.g. `name`, `schedule`, `payload`) are provided at the top level instead of under `job`. When `params.job` is missing or `{}`, it reconstructs a synthetic `job` from recognized keys (only if there’s a clear signal like `schedule`/`payload`/`message`/`text`) and then proceeds through the existing `normalizeCronJobCreate` path. The change is covered by 5 new tests validating recovery, shorthand message inference, the “no signal” error path, and that a non-empty nested `job` continues to take precedence.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to the cron tool `add` path, gated to only run when `params.job` is missing or empty, and further gated on strong intent signals (`schedule`/`payload`/`message`/`text`). Existing behavior for non-empty `job` is preserved, and new unit tests cover the main recovery and precedence cases. No broader code paths or schemas are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->