### PR TITLE
chore(changelog): note maxTokens clamp (#5516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Exec approvals: format forwarded command text as inline/fenced monospace for safer approval scanning across channels. (#11937)
+- Config: clamp `maxTokens` to `contextWindow` to prevent invalid model configs. (#5516) Thanks @lailoo.
 - Docs: fix language switcher ordering and Japanese locale flag in Mintlify nav. (#12023) Thanks @joshp123.
 - Paths: make internal path resolution respect `HOME`/`USERPROFILE` before `os.homedir()` across config, agents, sessions, pairing, cron, and CLI profiles. (#12091) Thanks @sebslight.
 - Thinking: allow xhigh for `github-copilot/gpt-5.2-codex` and `github-copilot/gpt-5.2`. (#11646) Thanks @seans-openclawbot.


### PR DESCRIPTION
Follow-up to #5516 (thanks @lailoo): add changelog entry.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a single changelog entry under `2026.2.6-4` → **Fixes** documenting the follow-up from #5516: clamping `maxTokens` to `contextWindow` to avoid invalid model configurations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line addition to CHANGELOG.md with no runtime or build impact; the entry follows the existing formatting and placement under the correct release section.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->