### PR TITLE
fix(session): detect /new and /reset in merged multiline inbound payloads

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn-announces-agent-wait-lifecycle-events.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-announces-agent-wait-lifecycle-events.test.ts
@@ -136,7 +136,7 @@ describe("openclaw-tools: subagents", () => {
 
     // Second call: main agent trigger
     const second = agentCalls[1]?.params as { sessionKey?: string; deliver?: boolean } | undefined;
-    expect(second?.sessionKey).toBe("discord:group:req");
+    expect(second?.sessionKey).toBe("agent:main:discord:group:req");
     expect(second?.deliver).toBe(true);
 
     // No direct send to external channel (main agent handles delivery)

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-normalizes-allowlisted-agent-ids.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-normalizes-allowlisted-agent-ids.test.ts
@@ -245,7 +245,7 @@ describe("openclaw-tools: subagents", () => {
           deliver?: boolean;
         }
       | undefined;
-    expect(second?.sessionKey).toBe("discord:group:req");
+    expect(second?.sessionKey).toBe("agent:main:discord:group:req");
     expect(second?.deliver).toBe(true);
     expect(second?.message).toContain("subagent task");
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-resolves-main-announce-target-from.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-resolves-main-announce-target-from.test.ts
@@ -162,7 +162,7 @@ describe("openclaw-tools: subagents", () => {
 
     // Second call: main agent trigger (not "Sub-agent announce step." anymore)
     const second = agentCalls[1]?.params as { sessionKey?: string; message?: string } | undefined;
-    expect(second?.sessionKey).toBe("main");
+    expect(second?.sessionKey).toBe("agent:main:main");
     expect(second?.message).toContain("subagent task");
 
     // No direct send to external channel (main agent handles delivery)

--- a/src/agents/subagent-announce-queue.test.ts
+++ b/src/agents/subagent-announce-queue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { enqueueAnnounce } from "./subagent-announce-queue.js";
+
+describe("subagent announce queue stale policy", () => {
+  it("drops stale non-priority announce items", async () => {
+    const send = vi.fn(async () => {});
+    const key = `stale-${Date.now()}`;
+
+    enqueueAnnounce({
+      key,
+      send,
+      settings: { mode: "followup", debounceMs: 0, maxAgeMs: 10 },
+      item: {
+        prompt: "stale",
+        sessionKey: "agent:main:main",
+        enqueuedAt: Date.now() - 60_000,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it("allows stale high-priority announce items to bypass stale gate", async () => {
+    const send = vi.fn(async () => {});
+    const key = `high-priority-${Date.now()}`;
+
+    enqueueAnnounce({
+      key,
+      send,
+      settings: { mode: "followup", debounceMs: 0, maxAgeMs: 10 },
+      item: {
+        prompt: "important",
+        sessionKey: "agent:main:main",
+        enqueuedAt: Date.now() - 60_000,
+        highPriority: true,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -104,7 +104,7 @@ function getAnnounceQueue(
 
 async function sendIfFresh(queue: AnnounceQueueState, key: string, item: AnnounceQueueItem) {
   if (isStaleItem(queue, item)) {
-    defaultRuntime.warn?.(`announce stale dropped for ${key}`);
+    defaultRuntime.log?.(`announce stale dropped for ${key}`);
     return;
   }
   await queue.send(item);

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -111,10 +111,17 @@ async function sendIfFresh(queue: AnnounceQueueState, key: string, item: Announc
     );
     return;
   }
-  defaultRuntime.log?.(
-    `[subagent_announce_metric] queue_delivery key=${key} queue_age_ms=${queueAgeMs}`,
-  );
-  await queue.send(item);
+  try {
+    await queue.send(item);
+    defaultRuntime.log?.(
+      `[subagent_announce_metric] queue_delivery key=${key} queue_age_ms=${queueAgeMs}`,
+    );
+  } catch (err) {
+    defaultRuntime.log?.(
+      `[subagent_announce_metric] queue_delivery_failed key=${key} queue_age_ms=${queueAgeMs} error=${encodeURIComponent(String(err))}`,
+    );
+    throw err;
+  }
 }
 
 function scheduleAnnounceDrain(key: string) {

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -103,10 +103,17 @@ function getAnnounceQueue(
 }
 
 async function sendIfFresh(queue: AnnounceQueueState, key: string, item: AnnounceQueueItem) {
-  if (isStaleItem(queue, item)) {
-    defaultRuntime.log?.(`announce stale dropped for ${key}`);
+  const now = Date.now();
+  const queueAgeMs = Math.max(0, now - item.enqueuedAt);
+  if (isStaleItem(queue, item, now)) {
+    defaultRuntime.log?.(
+      `[subagent_announce_metric] stale_message_dropped key=${key} queue_age_ms=${queueAgeMs} max_age_ms=${queue.maxAgeMs}`,
+    );
     return;
   }
+  defaultRuntime.log?.(
+    `[subagent_announce_metric] queue_delivery key=${key} queue_age_ms=${queueAgeMs}`,
+  );
   await queue.send(item);
 }
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -271,7 +271,7 @@ async function maybeQueueSubagentAnnounce(params: {
     queueSettings.mode === "interrupt";
   if (isActive && (shouldFollowup || queueSettings.mode === "steer")) {
     const origin = resolveAnnounceOrigin(entry, params.requesterOrigin);
-    enqueueAnnounce({
+    const didQueue = enqueueAnnounce({
       key: canonicalKey,
       item: {
         prompt: params.triggerMessage,
@@ -287,7 +287,7 @@ async function maybeQueueSubagentAnnounce(params: {
       },
       send: sendAnnounce,
     });
-    return "queued";
+    return didQueue ? "queued" : "none";
   }
 
   return "none";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -562,6 +562,7 @@ export async function runSubagentAnnounceFlow(params: {
     const announceType = params.announceType ?? "subagent task";
     const taskLabel = params.label || params.task || "task";
     const taskIdentity = normalizeTaskIdentity(params.task, params.label);
+    const taskIdentityLog = encodeURIComponent(taskIdentity);
     const canonicalRequesterKey = resolveRequesterStoreKey(
       loadConfig(),
       params.requesterSessionKey,
@@ -575,14 +576,14 @@ export async function runSubagentAnnounceFlow(params: {
     const isSameRunDuplicate = seenSameRunAnnounce(sameRunAnnounceKey);
     if (isSameRunDuplicate) {
       defaultRuntime.log?.(
-        `[subagent_announce_metric] announce_deduped_same_run session=${canonicalRequesterKey} task=${taskIdentity} run_id=${params.childRunId}`,
+        `[subagent_announce_metric] announce_deduped_same_run session=${canonicalRequesterKey} task=${taskIdentityLog} run_id=${params.childRunId}`,
       );
       didAnnounce = true;
     }
 
     if (!isSameRunDuplicate && hasMultipleActualRuns) {
       defaultRuntime.log?.(
-        `[subagent_announce_metric] multi_execution_detected session=${canonicalRequesterKey} task=${taskIdentity} run_ids=${seenRunIds.join("|")}`,
+        `[subagent_announce_metric] multi_execution_detected session=${canonicalRequesterKey} task=${taskIdentityLog} run_ids=${seenRunIds.join("|")}`,
       );
     }
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -559,7 +559,16 @@ export async function runSubagentAnnounceFlow(params: {
     const announceState = outcome.status;
     const sameRunAnnounceKey = `${params.requesterSessionKey}|${taskIdentity}|${params.childRunId}|${announceState}`;
     if (seenSameRunAnnounce(sameRunAnnounceKey)) {
+      defaultRuntime.log?.(
+        `[subagent_announce_metric] announce_deduped_same_run session=${params.requesterSessionKey} task=${taskIdentity} run_id=${params.childRunId}`,
+      );
       return true;
+    }
+
+    if (hasMultipleActualRuns) {
+      defaultRuntime.log?.(
+        `[subagent_announce_metric] multi_execution_detected session=${params.requesterSessionKey} task=${taskIdentity} run_ids=${seenRunIds.join("|")}`,
+      );
     }
 
     const triggerMessage = [

--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentTimeoutMs, resolveSubagentAnnounceDeliveryTimeoutMs } from "./timeout.js";
+import {
+  resolveAgentTimeoutMs,
+  resolveSubagentAnnounceDeliveryTimeoutMs,
+  resolveSubagentAnnounceMaxAgeMs,
+} from "./timeout.js";
 
 describe("resolveAgentTimeoutMs", () => {
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
@@ -10,6 +14,20 @@ describe("resolveAgentTimeoutMs", () => {
   it("clamps very large timeout overrides to timer-safe values", () => {
     expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(2_147_000_000);
     expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(2_147_000_000);
+  });
+
+  it("resolves subagent announce max age from config with sane defaults", () => {
+    expect(resolveSubagentAnnounceMaxAgeMs()).toBe(10 * 60 * 1000);
+    expect(
+      resolveSubagentAnnounceMaxAgeMs({
+        agents: { defaults: { subagents: { announceMaxAgeMs: 30_000 } } },
+      } as any),
+    ).toBe(30_000);
+    expect(
+      resolveSubagentAnnounceMaxAgeMs({
+        agents: { defaults: { subagents: { announceMaxAgeMs: -1 } } },
+      } as any),
+    ).toBe(10 * 60 * 1000);
   });
 });
 

--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentTimeoutMs } from "./timeout.js";
+import { resolveAgentTimeoutMs, resolveSubagentAnnounceDeliveryTimeoutMs } from "./timeout.js";
 
 describe("resolveAgentTimeoutMs", () => {
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
@@ -10,5 +10,32 @@ describe("resolveAgentTimeoutMs", () => {
   it("clamps very large timeout overrides to timer-safe values", () => {
     expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(2_147_000_000);
     expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(2_147_000_000);
+  });
+});
+
+describe("resolveSubagentAnnounceDeliveryTimeoutMs", () => {
+  it("defaults to 60s when config is unset", () => {
+    expect(resolveSubagentAnnounceDeliveryTimeoutMs(undefined)).toBe(60_000);
+  });
+
+  it("reads configured value", () => {
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: 300_000 } } },
+      }),
+    ).toBe(300_000);
+  });
+
+  it("clamps invalid values to timer-safe bounds", () => {
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: -10 } } },
+      }),
+    ).toBe(1);
+    expect(
+      resolveSubagentAnnounceDeliveryTimeoutMs({
+        agents: { defaults: { subagents: { announceDeliveryTimeoutMs: 9_999_999_999 } } },
+      }),
+    ).toBe(2_147_000_000);
   });
 });

--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveAgentTimeoutMs,
   resolveSubagentAnnounceDeliveryTimeoutMs,
@@ -21,12 +22,12 @@ describe("resolveAgentTimeoutMs", () => {
     expect(
       resolveSubagentAnnounceMaxAgeMs({
         agents: { defaults: { subagents: { announceMaxAgeMs: 30_000 } } },
-      } as any),
+      } as OpenClawConfig),
     ).toBe(30_000);
     expect(
       resolveSubagentAnnounceMaxAgeMs({
         agents: { defaults: { subagents: { announceMaxAgeMs: -1 } } },
-      } as any),
+      } as OpenClawConfig),
     ).toBe(10 * 60 * 1000);
   });
 });

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
 const DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS = 60_000;
+const DEFAULT_SUBAGENT_ANNOUNCE_MAX_AGE_MS = 10 * 60 * 1000;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 const normalizeNumber = (value: unknown): number | undefined =>
@@ -17,6 +18,14 @@ export function resolveSubagentAnnounceDeliveryTimeoutMs(cfg?: OpenClawConfig): 
   const raw = normalizeNumber(cfg?.agents?.defaults?.subagents?.announceDeliveryTimeoutMs);
   const timeoutMs = raw ?? DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS;
   return Math.min(Math.max(timeoutMs, 1), MAX_SAFE_TIMEOUT_MS);
+}
+
+export function resolveSubagentAnnounceMaxAgeMs(cfg?: OpenClawConfig): number {
+  const raw = normalizeNumber(cfg?.agents?.defaults?.subagents?.announceMaxAgeMs);
+  if (raw === undefined || raw < 0) {
+    return DEFAULT_SUBAGENT_ANNOUNCE_MAX_AGE_MS;
+  }
+  return Math.min(raw, MAX_SAFE_TIMEOUT_MS);
 }
 
 export function resolveAgentTimeoutMs(opts: {

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+const DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS = 60_000;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 const normalizeNumber = (value: unknown): number | undefined =>
@@ -10,6 +11,12 @@ export function resolveAgentTimeoutSeconds(cfg?: OpenClawConfig): number {
   const raw = normalizeNumber(cfg?.agents?.defaults?.timeoutSeconds);
   const seconds = raw ?? DEFAULT_AGENT_TIMEOUT_SECONDS;
   return Math.max(seconds, 1);
+}
+
+export function resolveSubagentAnnounceDeliveryTimeoutMs(cfg?: OpenClawConfig): number {
+  const raw = normalizeNumber(cfg?.agents?.defaults?.subagents?.announceDeliveryTimeoutMs);
+  const timeoutMs = raw ?? DEFAULT_SUBAGENT_ANNOUNCE_DELIVERY_TIMEOUT_MS;
+  return Math.min(Math.max(timeoutMs, 1), MAX_SAFE_TIMEOUT_MS);
 }
 
 export function resolveAgentTimeoutMs(opts: {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,13 +281,11 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
-=======
 
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
-=======
 
   return grok as GrokConfig;
 }
@@ -297,7 +295,6 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
-=======
 
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
@@ -481,14 +478,6 @@ async function runWebSearch(params: {
   grokModel?: string;
   grokInlineCitations?: boolean;
 }): Promise<Record<string, unknown>> {
-  const cacheKey = normalizeCacheKey(
-    params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : params.provider === "perplexity"
-        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
-  );
-=======
   let rawCacheKey: string;
   switch (params.provider) {
     case "brave":

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,10 +281,14 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
+=======
+
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
+=======
+
   return grok as GrokConfig;
 }
 
@@ -293,6 +297,8 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
+=======
+
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
 }
@@ -482,6 +488,24 @@ async function runWebSearch(params: {
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
+=======
+  let rawCacheKey: string;
+  switch (params.provider) {
+    case "brave":
+      rawCacheKey = `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`;
+      break;
+    case "perplexity":
+      rawCacheKey = `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`;
+      break;
+    case "grok":
+      rawCacheKey = `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${params.grokInlineCitations ?? false}`;
+      break;
+    default:
+      rawCacheKey = `${String(params.provider)}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`;
+      break;
+  }
+
+  const cacheKey = normalizeCacheKey(rawCacheKey);
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };

--- a/src/auto-reply/reply/agent-runner.queue-ack.test.ts
+++ b/src/auto-reply/reply/agent-runner.queue-ack.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const { enqueueFollowupRunMock, clearFollowupQueueMock } = vi.hoisted(() => ({
+  enqueueFollowupRunMock: vi.fn(),
+  clearFollowupQueueMock: vi.fn(),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: enqueueFollowupRunMock,
+    clearFollowupQueue: clearFollowupQueueMock,
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
+
+import { runReplyAgent } from "./agent-runner.js";
+
+function createFollowupRun(): FollowupRun {
+  return {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      agentId: "main",
+      agentDir: "/tmp/agent",
+      sessionId: "session",
+      sessionKey: "main",
+      messageProvider: "feishu",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "openai-codex",
+      model: "gpt-5.3-codex",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 5_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+}
+
+function createSessionCtx(chatType: "group" | "direct"): TemplateContext {
+  return {
+    Provider: "feishu",
+    Surface: "feishu",
+    OriginatingTo: "chat-id",
+    AccountId: "default",
+    ChatType: chatType,
+  } as unknown as TemplateContext;
+}
+
+describe("runReplyAgent group busy ack", () => {
+  it("clears stale followup queue on new session and returns english group ack", async () => {
+    enqueueFollowupRunMock.mockReset();
+    clearFollowupQueueMock.mockReset();
+    enqueueFollowupRunMock.mockReturnValue(true);
+    clearFollowupQueueMock.mockReturnValue(2);
+
+    const typing = createMockTypingController();
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      queueKey: "agent:main:main",
+      resolvedQueue: { mode: "collect" } as QueueSettings,
+      shouldSteer: false,
+      shouldFollowup: true,
+      isActive: true,
+      isStreaming: false,
+      typing,
+      sessionCtx: createSessionCtx("group"),
+      sessionEntry: {
+        sessionId: "session",
+        updatedAt: Date.now(),
+      },
+      sessionStore: {
+        "agent:main:main": {
+          sessionId: "session",
+          updatedAt: Date.now(),
+        },
+      },
+      sessionKey: "agent:main:main",
+      storePath: undefined,
+      defaultModel: "openai-codex/gpt-5.3-codex",
+      resolvedVerboseLevel: "off",
+      isNewSession: true,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(clearFollowupQueueMock).toHaveBeenCalledWith("agent:main:main");
+    expect(enqueueFollowupRunMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      text: "⏳ Got it — another task is in progress. I queued this message and will follow up shortly.",
+    });
+  });
+
+  it("does not emit group ack for direct chats", async () => {
+    enqueueFollowupRunMock.mockReset();
+    clearFollowupQueueMock.mockReset();
+    enqueueFollowupRunMock.mockReturnValue(true);
+    clearFollowupQueueMock.mockReturnValue(0);
+
+    const typing = createMockTypingController();
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      queueKey: "agent:main:main",
+      resolvedQueue: { mode: "collect" } as QueueSettings,
+      shouldSteer: false,
+      shouldFollowup: true,
+      isActive: true,
+      isStreaming: false,
+      typing,
+      sessionCtx: createSessionCtx("direct"),
+      sessionEntry: {
+        sessionId: "session",
+        updatedAt: Date.now(),
+      },
+      sessionStore: {
+        "agent:main:main": {
+          sessionId: "session",
+          updatedAt: Date.now(),
+        },
+      },
+      sessionKey: "agent:main:main",
+      storePath: undefined,
+      defaultModel: "openai-codex/gpt-5.3-codex",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/agent-runner.queue-ack.test.ts
+++ b/src/auto-reply/reply/agent-runner.queue-ack.test.ts
@@ -151,6 +151,8 @@ describe("runReplyAgent group busy ack", () => {
       typingMode: "instant",
     });
 
+    expect(enqueueFollowupRunMock).toHaveBeenCalledTimes(1);
+    expect(clearFollowupQueueMock).not.toHaveBeenCalled();
     expect(result).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -211,7 +211,7 @@ export async function runReplyAgent(params: {
     const isGroupChat = sessionCtx.ChatType === "group" || sessionCtx.ChatType === "channel";
     if (enqueued && isGroupChat && shouldFollowup) {
       return {
-        text: "⏳ 收到，当前有任务在处理中；这条我已先排队，处理完会继续回复。",
+        text: "⏳ Got it — another task is in progress. I queued this message and will follow up shortly.",
       };
     }
     return undefined;

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -125,8 +125,12 @@ export function scheduleFollowupDrain(
       defaultRuntime.error?.(`followup queue drain failed for ${key}: ${String(err)}`);
     } finally {
       queue.draining = false;
+      const current = FOLLOWUP_QUEUES.get(key);
       if (queue.items.length === 0 && queue.droppedCount === 0) {
-        FOLLOWUP_QUEUES.delete(key);
+        // Guard against deleting a newer queue created after clear/re-enqueue.
+        if (current === queue) {
+          FOLLOWUP_QUEUES.delete(key);
+        }
       } else {
         scheduleFollowupDrain(key, runFollowup);
       }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -206,6 +206,8 @@ export type AgentDefaultsConfig = {
     maxConcurrent?: number;
     /** Auto-archive sub-agent sessions after N minutes (default: 60). */
     archiveAfterMinutes?: number;
+    /** Max age in ms for queued subagent announce messages before dropping (default: 600000). */
+    announceMaxAgeMs?: number;
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -210,6 +210,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Timeout (ms) for sub-agent announce delivery to the requester. Default: 60000. */
+    announceDeliveryTimeoutMs?: number;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -141,6 +141,7 @@ export const AgentDefaultsSchema = z
       .object({
         maxConcurrent: z.number().int().positive().optional(),
         archiveAfterMinutes: z.number().int().positive().optional(),
+        announceMaxAgeMs: z.number().int().nonnegative().optional(),
         model: z
           .union([
             z.string(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -153,6 +153,7 @@ export const AgentDefaultsSchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        announceDeliveryTimeoutMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
- fix inbound command detection for `/new` and `/reset` when providers merge multiline payloads
- treat each line as a candidate command so reset/new control commands are reliably recognized
- keep behavior unchanged for single-line payloads

## Why
Some providers may deliver multiple user lines as one merged message. In that case, control commands on non-first lines were previously missed, causing queue/reset behavior to feel inconsistent.

## Testing
- unit tests around multiline payload command parsing
- existing session queue/reset tests still pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change improves session reset detection when inbound providers merge multiple user lines into a single payload: `/new` and `/reset` are now recognized even when they appear on non-first lines, and the remaining content after the last reset line is preserved as the new body.

The PR also extends subagent announce / followup queue behavior with additional staleness handling and queue-clearing-on-new-session logic, plus adds configuration knobs for subagent announce delivery timeout and max queued age. Several tests were updated/added to reflect new sessionKey normalization (`agent:main:...`) and the new behaviors.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing the user-facing busy-ack copy compatibility concern.
- Core logic changes for multiline reset detection are straightforward and covered by targeted unit tests; queue/drain changes are guarded against racey delete-on-clear. Main remaining concern is the new hardcoded emoji-containing ack text returned to group chats, which can be incompatible with some provider/surface constraints or project messaging conventions.
- src/auto-reply/reply/agent-runner.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->