### PR TITLE
feat(macos): add Granola-style meeting notes with live transcription

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1c9c9d251b760ed3234ecff741a88eb4bf42315ad6f50ac7392b187cf226c16c",
+  "originHash" : "67ef9c99a2af143ee96d6d382d84c3e0ff12a6b936f13d243266f63720f8270a",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -65,12 +65,39 @@
       }
     },
     {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-concurrency-extras",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
         "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
         "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
+        "version" : "2.3.1"
       }
     },
     {
@@ -110,6 +137,15 @@
       }
     },
     {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
+      "state" : {
+        "revision" : "573e5c9036c2f136b3a8a071da8e8907322403d0",
+        "version" : "1.1.6"
+      }
+    },
+    {
       "identity" : "swiftui-math",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/swiftui-math",
@@ -125,6 +161,15 @@
       "state" : {
         "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
         "version" : "0.3.1"
+      }
+    },
+    {
+      "identity" : "whisperkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/argmaxinc/WhisperKit.git",
+      "state" : {
+        "revision" : "664e1b5a65296cd957dfdf262cd120ca88f3b24b",
+        "version" : "0.15.0"
       }
     }
   ],

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .package(url: "https://github.com/steipete/Peekaboo.git", branch: "main"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../../Swabble"),
+        .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
     ],
     targets: [
         .target(
@@ -54,6 +55,7 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "PeekabooBridge", package: "Peekaboo"),
                 .product(name: "PeekabooAutomationKit", package: "Peekaboo"),
+                .product(name: "WhisperKit", package: "WhisperKit"),
             ],
             exclude: [
                 "Resources/Info.plist",

--- a/apps/macos/Sources/OpenClaw/CritterIconRenderer.swift
+++ b/apps/macos/Sources/OpenClaw/CritterIconRenderer.swift
@@ -110,7 +110,8 @@ enum CritterIconRenderer {
         earScale: CGFloat = 1,
         earHoles: Bool = false,
         eyesClosedLines: Bool = false,
-        badge: Badge? = nil) -> NSImage
+        badge: Badge? = nil,
+        recordingDot: Bool = false) -> NSImage
     {
         guard let rep = self.makeBitmapRep() else {
             return NSImage(size: self.size)
@@ -140,6 +141,10 @@ enum CritterIconRenderer {
 
         if let badge {
             self.drawBadge(badge, canvas: canvas)
+        }
+
+        if recordingDot {
+            self.drawRecordingDot(canvas: canvas)
         }
 
         let image = NSImage(size: size)
@@ -320,6 +325,33 @@ enum CritterIconRenderer {
         }
 
         canvas.context.fillPath()
+        canvas.context.restoreGState()
+    }
+
+    private static func drawRecordingDot(canvas: Canvas) {
+        let diameter = canvas.snapX(canvas.w * 0.34)
+        let margin = canvas.snapX(max(0.45, canvas.w * 0.03))
+        let rect = CGRect(
+            x: canvas.snapX(margin),
+            y: canvas.snapY(margin),
+            width: diameter,
+            height: diameter)
+
+        canvas.context.saveGState()
+        canvas.context.setShouldAntialias(true)
+
+        // Clear underlying pixels for readability.
+        canvas.context.saveGState()
+        canvas.context.setBlendMode(.clear)
+        canvas.context.addEllipse(in: rect.insetBy(dx: -1.0, dy: -1.0))
+        canvas.context.fillPath()
+        canvas.context.restoreGState()
+
+        // Solid filled circle.
+        canvas.context.setFillColor(NSColor.labelColor.cgColor)
+        canvas.context.addEllipse(in: rect)
+        canvas.context.fillPath()
+
         canvas.context.restoreGState()
     }
 

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
@@ -63,6 +63,7 @@ extension CritterStatusLabel {
                     .frame(width: 6, height: 6)
                     .padding(1)
             }
+
         }
         .frame(width: 18, height: 18)
     }
@@ -112,12 +113,14 @@ extension CritterStatusLabel {
             nil
         }
 
+        let recording = self.isMeetingRecording
+
         if self.isPaused {
-            return Image(nsImage: CritterIconRenderer.makeIcon(blink: 0, badge: nil))
+            return Image(nsImage: CritterIconRenderer.makeIcon(blink: 0, badge: nil, recordingDot: recording))
         }
 
         if self.isSleeping {
-            return Image(nsImage: CritterIconRenderer.makeIcon(blink: 1, eyesClosedLines: true, badge: nil))
+            return Image(nsImage: CritterIconRenderer.makeIcon(blink: 1, eyesClosedLines: true, badge: nil, recordingDot: recording))
         }
 
         return Image(nsImage: CritterIconRenderer.makeIcon(
@@ -126,7 +129,8 @@ extension CritterStatusLabel {
             earWiggle: self.earWiggle,
             earScale: self.earBoostActive ? 1.9 : 1.0,
             earHoles: self.earBoostActive,
-            badge: badge))
+            badge: badge,
+            recordingDot: recording))
     }
 
     private func resetMotion() {

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel.swift
@@ -10,6 +10,7 @@ struct CritterStatusLabel: View {
     var gatewayStatus: GatewayProcessManager.Status
     var animationsEnabled: Bool
     var iconState: IconState
+    var isMeetingRecording: Bool = false
 
     @State var blinkAmount: CGFloat = 0
     @State var nextBlink = Date().addingTimeInterval(Double.random(in: 3.5...8.5))

--- a/apps/macos/Sources/OpenClaw/MeetingDetector.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingDetector.swift
@@ -1,0 +1,276 @@
+import AVFoundation
+import EventKit
+import Foundation
+import Observation
+import OSLog
+import Speech
+
+@MainActor
+@Observable
+final class MeetingDetector {
+    static let shared = MeetingDetector()
+
+    private let logger = Logger(subsystem: "ai.openclaw", category: "meeting.detector")
+    private let eventStore = EKEventStore()
+    private let transcriber = MeetingTranscriber()
+
+    private(set) var currentSession: MeetingSession?
+    private(set) var upcomingMeetings: [EKEvent] = []
+    private(set) var calendarAccessGranted = false
+
+    var meetingDetectionEnabled: Bool = false {
+        didSet { UserDefaults.standard.set(self.meetingDetectionEnabled, forKey: "meetingDetectionEnabled") }
+    }
+
+    var adHocDetectionEnabled: Bool = true {
+        didSet { UserDefaults.standard.set(self.adHocDetectionEnabled, forKey: "meetingAdHocDetectionEnabled") }
+    }
+
+    private var calendarCheckTask: Task<Void, Never>?
+    private var silenceCheckTask: Task<Void, Never>?
+    private var lastMicActivity: Date?
+    private var micObserver: AudioInputDeviceObserver?
+    private var talkModeWasPaused = false
+
+    private init() {
+        self.meetingDetectionEnabled = UserDefaults.standard.bool(forKey: "meetingDetectionEnabled")
+        self.adHocDetectionEnabled = UserDefaults.standard.object(forKey: "meetingAdHocDetectionEnabled") as? Bool ?? true
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard self.meetingDetectionEnabled else { return }
+        self.logger.info("meeting detector starting")
+        self.startCalendarMonitor()
+        self.startMicMonitor()
+    }
+
+    func stop() {
+        self.logger.info("meeting detector stopping")
+        self.calendarCheckTask?.cancel()
+        self.calendarCheckTask = nil
+        self.silenceCheckTask?.cancel()
+        self.silenceCheckTask = nil
+        self.micObserver?.stop()
+        self.micObserver = nil
+        if self.currentSession != nil {
+            Task { await self.stopMeeting() }
+        }
+    }
+
+    // MARK: - Calendar monitoring
+
+    func requestCalendarAccess() async {
+        do {
+            let granted = try await self.eventStore.requestFullAccessToEvents()
+            self.calendarAccessGranted = granted
+            if granted {
+                self.logger.info("calendar access granted")
+                self.refreshUpcomingMeetings()
+            } else {
+                self.logger.warning("calendar access denied")
+            }
+        } catch {
+            self.logger.error("calendar access request failed: \(error.localizedDescription, privacy: .public)")
+            self.calendarAccessGranted = false
+        }
+    }
+
+    private func startCalendarMonitor() {
+        self.calendarCheckTask?.cancel()
+        self.calendarCheckTask = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                await self.checkCalendar()
+                try? await Task.sleep(nanoseconds: 30_000_000_000) // 30 seconds
+            }
+        }
+    }
+
+    private func checkCalendar() async {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        self.calendarAccessGranted = status == .fullAccess
+        guard self.calendarAccessGranted else { return }
+
+        self.refreshUpcomingMeetings()
+
+        // Check if any meeting is starting within 1 minute
+        let now = Date()
+        let oneMinute = now.addingTimeInterval(60)
+        for event in self.upcomingMeetings {
+            let hasMultipleAttendees = (event.attendees?.count ?? 0) >= 2
+            guard hasMultipleAttendees else { continue }
+            guard event.startDate <= oneMinute, event.startDate > now.addingTimeInterval(-60) else { continue }
+            guard self.currentSession == nil else { continue }
+
+            self.logger.info("upcoming meeting detected: \(event.title ?? "Untitled", privacy: .public)")
+            _ = await NotificationManager().send(
+                title: "Meeting Starting",
+                body: "\(event.title ?? "Meeting") — tap to start transcribing",
+                sound: nil,
+                priority: .active)
+        }
+    }
+
+    private func refreshUpcomingMeetings() {
+        let now = Date()
+        let endDate = now.addingTimeInterval(3600) // next hour
+        let calendars = self.eventStore.calendars(for: .event)
+        let predicate = self.eventStore.predicateForEvents(withStart: now, end: endDate, calendars: calendars)
+        let events = self.eventStore.events(matching: predicate)
+        self.upcomingMeetings = events
+            .filter { ($0.attendees?.count ?? 0) >= 2 }
+            .sorted { ($0.startDate ?? .distantPast) < ($1.startDate ?? .distantPast) }
+    }
+
+    // MARK: - Mic monitoring for ad-hoc calls
+
+    private func startMicMonitor() {
+        guard self.adHocDetectionEnabled else { return }
+        let observer = AudioInputDeviceObserver()
+        self.micObserver = observer
+        observer.start { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleMicChange()
+            }
+        }
+    }
+
+    private func handleMicChange() {
+        // Mic device change can indicate a meeting app activated the mic
+        guard self.adHocDetectionEnabled, self.currentSession == nil else { return }
+        self.lastMicActivity = Date()
+    }
+
+    // MARK: - Meeting control
+
+    func startMeeting(title: String? = nil, calendarEvent: EKEvent? = nil) async {
+        guard self.currentSession == nil else {
+            self.logger.warning("meeting already in progress")
+            return
+        }
+
+        // Request permissions before starting
+        let permsOk = await self.ensureTranscriptionPermissions()
+        if !permsOk {
+            self.logger.warning("meeting transcription permissions not granted")
+        }
+
+        let meetingTitle = title ?? calendarEvent?.title ?? "Meeting \(Self.shortTimestamp())"
+        let attendees = calendarEvent?.attendees?.compactMap(\.url.absoluteString) ?? []
+
+        // Pause TalkMode to free the single SFSpeechRecognitionTask slot
+        // Apple only allows one active recognition task per process
+        self.talkModeWasPaused = TalkModeController.shared.isPaused
+        if !self.talkModeWasPaused {
+            self.logger.info("meeting: pausing talk mode to free speech recognizer")
+            TalkModeController.shared.setPaused(true)
+            // Wait for TalkModeRuntime to actually stop its recognition task
+            await TalkModeRuntime.shared.setPaused(true)
+        }
+
+        let session = MeetingSession(
+            title: meetingTitle,
+            calendarEventId: calendarEvent?.eventIdentifier,
+            attendees: attendees)
+        session.start()
+        self.currentSession = session
+        self.logger.info("meeting started: \(meetingTitle, privacy: .public)")
+
+        // Start transcription
+        await self.transcriber.start { [weak session] speaker, text, isFinal in
+            guard let session, session.status == .recording else { return }
+            session.updateLastSegment(for: speaker, text: text, isFinal: isFinal)
+        }
+
+        self.startSilenceDetection()
+    }
+
+    // MARK: - Permission requests
+
+    private func ensureTranscriptionPermissions() async -> Bool {
+        let micStatus = await Self.requestMicPermission()
+        if !micStatus {
+            self.logger.warning("microphone permission denied")
+        }
+
+        let speechStatus = await Self.requestSpeechPermission()
+        if !speechStatus {
+            self.logger.warning("speech recognition permission denied")
+        }
+
+        return micStatus && speechStatus
+    }
+
+    /// Must be `nonisolated` so the completion handler doesn't inherit @MainActor isolation.
+    private nonisolated static func requestMicPermission() async -> Bool {
+        if #available(macOS 14, *) {
+            return await AVAudioApplication.requestRecordPermission()
+        } else {
+            return await withCheckedContinuation { cont in
+                AVCaptureDevice.requestAccess(for: .audio) { granted in
+                    cont.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    /// Must be `nonisolated` so the completion handler doesn't inherit @MainActor isolation.
+    private nonisolated static func requestSpeechPermission() async -> Bool {
+        await withCheckedContinuation { cont in
+            SFSpeechRecognizer.requestAuthorization { status in
+                cont.resume(returning: status == .authorized)
+            }
+        }
+    }
+
+    func stopMeeting() async {
+        guard let session = self.currentSession else { return }
+        session.stop()
+        await self.transcriber.stop()
+        self.silenceCheckTask?.cancel()
+        self.silenceCheckTask = nil
+
+        MeetingStore.shared.save(session: session)
+        self.logger.info(
+            "meeting ended: \(session.title, privacy: .public) " +
+                "segments=\(session.segments.filter(\.isFinal).count)")
+        self.currentSession = nil
+
+        // Resume TalkMode if it was active before the meeting
+        if !self.talkModeWasPaused {
+            self.logger.info("meeting: resuming talk mode")
+            TalkModeController.shared.setPaused(false)
+            await TalkModeRuntime.shared.setPaused(false)
+        }
+    }
+
+    // MARK: - Silence detection
+
+    private func startSilenceDetection() {
+        self.silenceCheckTask?.cancel()
+        self.silenceCheckTask = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 60_000_000_000) // check every 60s
+                await self.checkForSilence()
+            }
+        }
+    }
+
+    private func checkForSilence() async {
+        guard let session = self.currentSession, session.status == .recording else { return }
+        // Auto-stop after 15 minutes of no new final segments
+        let lastSegmentTime = session.segments.last(where: { $0.isFinal })?.timestamp ?? session.startedAt
+        let silenceDuration = Date().timeIntervalSince(lastSegmentTime)
+        if silenceDuration > 900 { // 15 minutes
+            self.logger.info("meeting auto-ending due to 15 min silence")
+            await self.stopMeeting()
+        }
+    }
+
+    private static func shortTimestamp() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: Date())
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MeetingMenuItems.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingMenuItems.swift
@@ -11,35 +11,49 @@ struct MeetingMenuItems: View {
                 Button {
                     Task { await self.detector.startMeeting() }
                 } label: {
-                    Label("Start Meeting Notes", systemImage: "text.badge.plus")
+                    HStack(spacing: 6) {
+                        Image(systemName: "record.circle")
+                        Text("Start Meeting Notes")
+                        Spacer()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .controlSize(.regular)
+            }
+
+            Button {
+                MeetingNotesWindowController.shared.show()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "list.bullet.rectangle")
+                    Text("Past Meetings")
                 }
             }
+
         }
     }
 
     @ViewBuilder
     private func activeMeetingSection(session: MeetingSession) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Label {
-                HStack {
-                    Text(session.title)
-                        .lineLimit(1)
-                    Spacer()
-                    Text(session.formattedDuration)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            } icon: {
-                Image(systemName: "record.circle")
-                    .foregroundStyle(.red)
-            }
+        HStack(spacing: 6) {
+            Image(systemName: "record.circle.fill")
+                .foregroundStyle(.red)
+            Text(session.title)
+                .lineLimit(1)
         }
-        .disabled(true)
 
         Button {
             Task { await self.detector.stopMeeting() }
         } label: {
-            Label("Stop Meeting Notes", systemImage: "stop.circle")
+            HStack(spacing: 6) {
+                Image(systemName: "stop.circle.fill")
+                Text("Stop Meeting Notes")
+                Spacer()
+            }
         }
+        .buttonStyle(.borderedProminent)
+        .tint(.orange)
+        .controlSize(.regular)
     }
 }

--- a/apps/macos/Sources/OpenClaw/MeetingMenuItems.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingMenuItems.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct MeetingMenuItems: View {
+    @Bindable private var detector = MeetingDetector.shared
+
+    var body: some View {
+        if self.detector.meetingDetectionEnabled {
+            if let session = self.detector.currentSession {
+                self.activeMeetingSection(session: session)
+            } else {
+                Button {
+                    Task { await self.detector.startMeeting() }
+                } label: {
+                    Label("Start Meeting Notes", systemImage: "text.badge.plus")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func activeMeetingSection(session: MeetingSession) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Label {
+                HStack {
+                    Text(session.title)
+                        .lineLimit(1)
+                    Spacer()
+                    Text(session.formattedDuration)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } icon: {
+                Image(systemName: "record.circle")
+                    .foregroundStyle(.red)
+            }
+        }
+        .disabled(true)
+
+        Button {
+            Task { await self.detector.stopMeeting() }
+        } label: {
+            Label("Stop Meeting Notes", systemImage: "stop.circle")
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MeetingNotesWindow.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingNotesWindow.swift
@@ -1,0 +1,216 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class MeetingNotesWindowController {
+    static let shared = MeetingNotesWindowController()
+    private var window: NSWindow?
+
+    func show() {
+        if let window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let hosting = NSHostingController(rootView: MeetingNotesView())
+        let window = NSWindow(contentViewController: hosting)
+        window.title = "Meeting Notes"
+        window.setContentSize(NSSize(width: 900, height: 600))
+        window.styleMask = [.titled, .closable, .resizable, .miniaturizable]
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        self.window = window
+    }
+}
+
+struct MeetingNotesView: View {
+    @Bindable private var store = MeetingStore.shared
+    @State private var selectedMeetingIds: Set<UUID> = []
+    @State private var selectedMeeting: StoredMeeting?
+    @AppStorage("meetingGoogleDriveSyncEnabled") private var syncEnabled = false
+
+    var body: some View {
+        Group {
+            if self.store.summaries.isEmpty {
+                VStack {
+                    Spacer()
+                    Text("No meetings recorded yet.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+            } else {
+                HSplitView {
+                    self.meetingsList
+                        .frame(minWidth: 260, maxWidth: 320)
+
+                    self.transcriptDetail
+                        .frame(minWidth: 300, maxWidth: .infinity)
+                }
+            }
+        }
+        .frame(minWidth: 700, minHeight: 400)
+        .onAppear {
+            self.store.loadAll()
+        }
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Text("\(self.store.summaries.count) meetings")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    self.deleteSelected()
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+                .keyboardShortcut(.delete, modifiers: [])
+                .disabled(self.selectedMeetingIds.isEmpty)
+            }
+        }
+    }
+
+    private var meetingsList: some View {
+        List(self.store.summaries, selection: self.$selectedMeetingIds) { summary in
+            HStack(spacing: 6) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(summary.title)
+                        .font(.callout.weight(.medium))
+                        .lineLimit(1)
+                    HStack(spacing: 8) {
+                        Text(summary.formattedDate)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(summary.formattedDuration)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("\(summary.segmentCount) segments")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+
+                self.syncStatusIcon(for: summary.id)
+            }
+            .padding(.vertical, 4)
+            .contextMenu {
+                if self.store.gogAvailable, self.syncEnabled {
+                    Button("Sync to Google Drive") {
+                        self.store.retrySyncToGoogleDrive(id: summary.id)
+                    }
+                    Divider()
+                }
+                let count = self.selectedMeetingIds.contains(summary.id) ? self.selectedMeetingIds.count : 1
+                Button("Delete\(count > 1 ? " \(count) Meetings" : "")", role: .destructive) {
+                    if self.selectedMeetingIds.contains(summary.id) {
+                        self.deleteSelected()
+                    } else {
+                        self.store.delete(id: summary.id)
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .onChange(of: self.selectedMeetingIds) { _, newIds in
+            if newIds.count == 1, let id = newIds.first {
+                self.selectedMeeting = self.store.load(id: id)
+            } else {
+                self.selectedMeeting = nil
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func syncStatusIcon(for meetingId: UUID) -> some View {
+        if let status = self.store.syncStatuses[meetingId] {
+            switch status {
+            case .syncing:
+                ProgressView()
+                    .controlSize(.small)
+            case .synced:
+                Image(systemName: "checkmark.icloud.fill")
+                    .foregroundStyle(.green)
+                    .font(.caption)
+            case .failed:
+                Image(systemName: "exclamationmark.icloud.fill")
+                    .foregroundStyle(.red)
+                    .font(.caption)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var transcriptDetail: some View {
+        if let meeting = self.selectedMeeting {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(meeting.title)
+                        .font(.title3.weight(.semibold))
+                        .padding(.bottom, 4)
+
+                    if !meeting.attendees.isEmpty {
+                        Text("Attendees: \(meeting.attendees.joined(separator: ", "))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.bottom, 8)
+                    }
+
+                    ForEach(Array(meeting.transcript.enumerated()), id: \.offset) { _, segment in
+                        HStack(alignment: .top, spacing: 8) {
+                            Text(segment.speaker == .me ? "You" : "Other")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(segment.speaker == .me ? .blue : .green)
+                                .frame(width: 40, alignment: .trailing)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(segment.text)
+                                    .font(.callout)
+                                    .textSelection(.enabled)
+                                Text(Self.timeFormatter.string(from: segment.timestamp))
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+                .padding()
+            }
+        } else if self.selectedMeetingIds.count > 1 {
+            VStack {
+                Spacer()
+                Text("\(self.selectedMeetingIds.count) meetings selected")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+        } else {
+            VStack {
+                Spacer()
+                Text("Select a meeting to view its transcript")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+        }
+    }
+
+    private func deleteSelected() {
+        let ids = self.selectedMeetingIds
+        guard !ids.isEmpty else { return }
+        self.selectedMeetingIds = []
+        self.selectedMeeting = nil
+        for id in ids {
+            self.store.delete(id: id)
+        }
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .medium
+        return f
+    }()
+}

--- a/apps/macos/Sources/OpenClaw/MeetingRecordingStatusItem.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingRecordingStatusItem.swift
@@ -1,0 +1,85 @@
+import AppKit
+import Observation
+
+@MainActor
+final class MeetingRecordingStatusItem {
+    static let shared = MeetingRecordingStatusItem()
+
+    private var statusItem: NSStatusItem?
+    private var timer: Timer?
+    private var observationTask: Task<Void, Never>?
+
+    func start() {
+        self.observationTask = Task { [weak self] in
+            let detector = MeetingDetector.shared
+            var wasRecording = false
+            while !Task.isCancelled {
+                let isRecording = detector.currentSession != nil
+                if isRecording != wasRecording {
+                    wasRecording = isRecording
+                    if isRecording {
+                        self?.show()
+                    } else {
+                        self?.hide()
+                    }
+                }
+                try? await Task.sleep(nanoseconds: 500_000_000)
+            }
+        }
+    }
+
+    private func show() {
+        guard self.statusItem == nil else { return }
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        item.button?.action = #selector(self.clicked(_:))
+        item.button?.target = self
+        self.statusItem = item
+        self.updateTitle()
+        self.timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateTitle()
+            }
+        }
+    }
+
+    private func hide() {
+        self.timer?.invalidate()
+        self.timer = nil
+        if let item = self.statusItem {
+            NSStatusBar.system.removeStatusItem(item)
+            self.statusItem = nil
+        }
+    }
+
+    private func updateTitle() {
+        guard let session = MeetingDetector.shared.currentSession,
+              let button = self.statusItem?.button else { return }
+
+        let duration = session.formattedDuration
+        let attributed = NSMutableAttributedString()
+
+        // Red dot
+        let dot = NSAttributedString(
+            string: "\u{25CF} ",
+            attributes: [
+                .foregroundColor: NSColor.systemRed,
+                .font: NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular),
+            ])
+        attributed.append(dot)
+
+        // Timer text
+        let text = NSAttributedString(
+            string: duration,
+            attributes: [
+                .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .medium),
+            ])
+        attributed.append(text)
+
+        button.attributedTitle = attributed
+    }
+
+    @objc private func clicked(_ sender: Any?) {
+        // Stop the meeting when clicking the timer
+        Task { await MeetingDetector.shared.stopMeeting() }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MeetingRecordingStatusItem.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingRecordingStatusItem.swift
@@ -2,7 +2,7 @@ import AppKit
 import Observation
 
 @MainActor
-final class MeetingRecordingStatusItem {
+final class MeetingRecordingStatusItem: NSObject {
     static let shared = MeetingRecordingStatusItem()
 
     private var statusItem: NSStatusItem?
@@ -31,8 +31,19 @@ final class MeetingRecordingStatusItem {
     private func show() {
         guard self.statusItem == nil else { return }
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        item.button?.action = #selector(self.clicked(_:))
-        item.button?.target = self
+
+        let menu = NSMenu()
+        let stopItem = NSMenuItem(title: "Stop Meeting Notes", action: #selector(self.stopClicked(_:)), keyEquivalent: "")
+        stopItem.target = self
+        stopItem.image = NSImage(systemSymbolName: "stop.circle.fill", accessibilityDescription: "Stop")
+        menu.addItem(stopItem)
+
+        let openItem = NSMenuItem(title: "Open Meeting Notes", action: #selector(self.openClicked(_:)), keyEquivalent: "")
+        openItem.target = self
+        openItem.image = NSImage(systemSymbolName: "list.bullet.rectangle", accessibilityDescription: "Open")
+        menu.addItem(openItem)
+
+        item.menu = menu
         self.statusItem = item
         self.updateTitle()
         self.timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
@@ -78,8 +89,11 @@ final class MeetingRecordingStatusItem {
         button.attributedTitle = attributed
     }
 
-    @objc private func clicked(_ sender: Any?) {
-        // Stop the meeting when clicking the timer
+    @objc private func stopClicked(_ sender: Any?) {
         Task { await MeetingDetector.shared.stopMeeting() }
+    }
+
+    @objc private func openClicked(_ sender: Any?) {
+        MeetingNotesWindowController.shared.show()
     }
 }

--- a/apps/macos/Sources/OpenClaw/MeetingSession.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingSession.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Observation
+
+enum Speaker: String, Codable, Sendable {
+    case me
+    case other
+    case unknown
+}
+
+enum SessionStatus: String, Sendable {
+    case idle
+    case recording
+    case paused
+    case ended
+}
+
+struct TranscriptSegment: Codable, Identifiable, Sendable {
+    let id: UUID
+    let speaker: Speaker
+    var text: String
+    let timestamp: Date
+    var isFinal: Bool
+
+    init(speaker: Speaker, text: String, timestamp: Date = Date(), isFinal: Bool = false) {
+        self.id = UUID()
+        self.speaker = speaker
+        self.text = text
+        self.timestamp = timestamp
+        self.isFinal = isFinal
+    }
+}
+
+@MainActor
+@Observable
+final class MeetingSession: Identifiable {
+    let id: UUID
+    var title: String
+    let startedAt: Date
+    var endedAt: Date?
+    var calendarEventId: String?
+    var attendees: [String]
+    private(set) var segments: [TranscriptSegment] = []
+    var status: SessionStatus = .idle
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        startedAt: Date = Date(),
+        calendarEventId: String? = nil,
+        attendees: [String] = [])
+    {
+        self.id = id
+        self.title = title
+        self.startedAt = startedAt
+        self.calendarEventId = calendarEventId
+        self.attendees = attendees
+    }
+
+    var duration: TimeInterval {
+        let end = self.endedAt ?? Date()
+        return end.timeIntervalSince(self.startedAt)
+    }
+
+    var formattedDuration: String {
+        let total = Int(self.duration)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let seconds = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    func start() {
+        self.status = .recording
+    }
+
+    func stop() {
+        self.status = .ended
+        self.endedAt = Date()
+        // Mark all remaining non-final segments as final so they get saved
+        for i in self.segments.indices where !self.segments[i].isFinal {
+            self.segments[i].isFinal = true
+        }
+    }
+
+    func appendSegment(_ segment: TranscriptSegment) {
+        self.segments.append(segment)
+    }
+
+    func updateLastSegment(for speaker: Speaker, text: String, isFinal: Bool) {
+        // Apple's SFSpeechRecognizer sends one cumulative stream of partial results.
+        // Update the last non-final segment regardless of speaker, since it's all
+        // part of the same recognition stream.
+        if let lastIndex = self.segments.lastIndex(where: { !$0.isFinal }) {
+            self.segments[lastIndex].text = text
+            self.segments[lastIndex].isFinal = isFinal
+        } else {
+            self.appendSegment(TranscriptSegment(speaker: speaker, text: text, isFinal: isFinal))
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MeetingSettings.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingSettings.swift
@@ -12,6 +12,8 @@ struct MeetingSettings: View {
         VStack(alignment: .leading, spacing: 16) {
             self.togglesSection
             Divider()
+            self.engineSection
+            Divider()
             self.syncSection
             Divider()
             self.meetingListSection
@@ -68,6 +70,166 @@ struct MeetingSettings: View {
                         .font(.caption)
                         .foregroundStyle(.green)
                 }
+            }
+        }
+    }
+
+    // MARK: - Transcription Engine
+
+    @ViewBuilder
+    private var engineSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Transcription Engine")
+                .font(.headline)
+
+            Picker("Engine:", selection: self.$detector.transcriptionEngine) {
+                ForEach(TranscriptionEngine.allCases) { engine in
+                    Text(engine.displayName).tag(engine)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 300)
+
+            if self.detector.transcriptionEngine == .whisper {
+                self.whisperOptions
+            }
+        }
+    }
+
+    @AppStorage("whisperModelSize") private var whisperModelSize = "openai_whisper-base.en"
+    @State private var downloadedModels: Set<String> = WhisperTranscriber.scanDownloadedModels().0
+    @State private var downloadStarted = false
+
+    private var whisperModels: [String] { WhisperTranscriber.supportedModels }
+
+    /// Show a short display name: "openai_whisper-base.en" → "base.en"
+    private func modelDisplayName(_ model: String) -> String {
+        if let range = model.range(of: "whisper-") {
+            return String(model[range.upperBound...])
+        }
+        return model
+    }
+
+    @ViewBuilder
+    private var whisperOptions: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                Picker("Model:", selection: self.$whisperModelSize) {
+                    ForEach(self.whisperModels, id: \.self) { model in
+                        HStack {
+                            Text(self.modelDisplayName(model))
+                            if self.downloadedModels.contains(model) {
+                                Image(systemName: "arrow.down.circle.fill")
+                                    .foregroundStyle(.green)
+                                    .font(.caption2)
+                            }
+                        }
+                        .tag(model)
+                    }
+                }
+                .frame(maxWidth: 300)
+
+                self.modelStatusView
+            }
+            .onChange(of: self.whisperModelSize) { _, newModel in
+                self.downloadStarted = false
+                if self.downloadedModels.contains(newModel) {
+                    Task { await self.detector.whisperTranscriber.downloadModel(named: newModel) }
+                } else {
+                    Task { await self.detector.whisperTranscriber.resetState() }
+                }
+            }
+
+            Text("Whisper runs locally on your device. Larger models are more accurate but use more memory.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var selectedModelIsDownloaded: Bool {
+        self.downloadedModels.contains(self.whisperModelSize)
+    }
+
+    private func rescanDownloadedModels() {
+        self.downloadedModels = WhisperTranscriber.scanDownloadedModels().0
+    }
+
+    /// Whether the actor's modelState refers to the currently selected model.
+    private var stateIsForCurrentModel: Bool {
+        self.detector.whisperTranscriber.currentModelName == self.whisperModelSize
+    }
+
+    /// The effective state for the currently selected model in the picker.
+    private var effectiveModelState: WhisperModelState {
+        if self.stateIsForCurrentModel {
+            return self.detector.whisperModelState
+        }
+        // Actor hasn't caught up yet — show downloading(0) if user already clicked
+        if self.downloadStarted {
+            return .downloading(0)
+        }
+        return .idle
+    }
+
+    @ViewBuilder
+    private var modelStatusView: some View {
+        switch self.effectiveModelState {
+        case .idle where self.selectedModelIsDownloaded:
+            // Already on disk but not loaded yet — auto-load
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading model...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .onAppear {
+                Task { await self.detector.whisperTranscriber.downloadModel(named: self.whisperModelSize) }
+            }
+        case .idle:
+            Button("Download Model") {
+                self.downloadStarted = true
+                Task {
+                    await self.detector.whisperTranscriber.downloadModel(named: self.whisperModelSize)
+                    self.rescanDownloadedModels()
+                    self.downloadStarted = false
+                }
+            }
+        case .downloading(let progress):
+            HStack(spacing: 6) {
+                ProgressView(value: progress)
+                    .progressViewStyle(.linear)
+                    .frame(width: 80)
+                Text("\(Int(progress * 100))%")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+        case .loading:
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading model...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        case .ready:
+            Label("Ready", systemImage: "checkmark.circle.fill")
+                .font(.caption)
+                .foregroundStyle(.green)
+        case .error(let message):
+            HStack(spacing: 6) {
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(1)
+                Button("Retry") {
+                    Task {
+                        await self.detector.whisperTranscriber.downloadModel(named: self.whisperModelSize)
+                        self.rescanDownloadedModels()
+                    }
+                }
+                .controlSize(.small)
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/MeetingSettings.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingSettings.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+struct MeetingSettings: View {
+    @Bindable private var detector = MeetingDetector.shared
+    @Bindable private var store = MeetingStore.shared
+    @State private var selectedMeetingId: UUID?
+    @State private var selectedMeeting: StoredMeeting?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            self.togglesSection
+            Divider()
+            self.meetingListSection
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear {
+            self.store.loadAll()
+        }
+    }
+
+    // MARK: - Toggles
+
+    @ViewBuilder
+    private var togglesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Meeting Notes")
+                .font(.headline)
+
+            Toggle(isOn: self.$detector.meetingDetectionEnabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Enable meeting detection")
+                    Text("Automatically detect meetings via calendar events and microphone activity.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .onChange(of: self.detector.meetingDetectionEnabled) { _, enabled in
+                if enabled {
+                    self.detector.start()
+                } else {
+                    self.detector.stop()
+                }
+            }
+
+            Toggle(isOn: self.$detector.adHocDetectionEnabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Auto-detect ad-hoc calls")
+                    Text("Prompt to transcribe when microphone activates outside a scheduled meeting.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .disabled(!self.detector.meetingDetectionEnabled)
+
+            HStack(spacing: 12) {
+                Button("Grant Calendar Access") {
+                    Task { await self.detector.requestCalendarAccess() }
+                }
+                .disabled(self.detector.calendarAccessGranted)
+
+                if self.detector.calendarAccessGranted {
+                    Label("Calendar access granted", systemImage: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+            }
+        }
+    }
+
+    // MARK: - Meeting list
+
+    @ViewBuilder
+    private var meetingListSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Past Meetings")
+                    .font(.headline)
+                Spacer()
+                Text("\(self.store.summaries.count) meetings")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if self.store.summaries.isEmpty {
+                Text("No meetings recorded yet.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 12)
+            } else {
+                HSplitView {
+                    self.meetingsList
+                        .frame(minWidth: 260, maxWidth: 320)
+
+                    self.transcriptDetail
+                        .frame(minWidth: 300, maxWidth: .infinity)
+                }
+                .frame(minHeight: 350)
+            }
+        }
+    }
+
+    private var meetingsList: some View {
+        List(self.store.summaries, selection: self.$selectedMeetingId) { summary in
+            VStack(alignment: .leading, spacing: 4) {
+                Text(summary.title)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+                HStack(spacing: 8) {
+                    Text(summary.formattedDate)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(summary.formattedDuration)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(summary.segmentCount) segments")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.vertical, 4)
+            .contextMenu {
+                Button("Delete", role: .destructive) {
+                    self.store.delete(id: summary.id)
+                    if self.selectedMeetingId == summary.id {
+                        self.selectedMeetingId = nil
+                        self.selectedMeeting = nil
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .onChange(of: self.selectedMeetingId) { _, newId in
+            if let newId {
+                self.selectedMeeting = self.store.load(id: newId)
+            } else {
+                self.selectedMeeting = nil
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var transcriptDetail: some View {
+        if let meeting = self.selectedMeeting {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(meeting.title)
+                        .font(.title3.weight(.semibold))
+                        .padding(.bottom, 4)
+
+                    if !meeting.attendees.isEmpty {
+                        Text("Attendees: \(meeting.attendees.joined(separator: ", "))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.bottom, 8)
+                    }
+
+                    ForEach(Array(meeting.transcript.enumerated()), id: \.offset) { _, segment in
+                        HStack(alignment: .top, spacing: 8) {
+                            Text(segment.speaker == .me ? "You" : "Other")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(segment.speaker == .me ? .blue : .green)
+                                .frame(width: 40, alignment: .trailing)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(segment.text)
+                                    .font(.callout)
+                                    .textSelection(.enabled)
+                                Text(Self.timeFormatter.string(from: segment.timestamp))
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+                .padding()
+            }
+        } else {
+            VStack {
+                Spacer()
+                Text("Select a meeting to view its transcript")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+        }
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .medium
+        return f
+    }()
+}

--- a/apps/macos/Sources/OpenClaw/MeetingStore.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingStore.swift
@@ -54,19 +54,32 @@ struct StoredMeeting: Codable {
     }
 }
 
+enum SyncStatus: Sendable {
+    case syncing
+    case synced
+    case failed(String)
+}
+
 @MainActor
 @Observable
 final class MeetingStore {
     static let shared = MeetingStore()
     private let logger = Logger(subsystem: "ai.openclaw", category: "meeting.store")
     private(set) var summaries: [MeetingSummary] = []
+    private(set) var gogAvailable = false
+    var syncStatuses: [UUID: SyncStatus] = [:]
 
     private var meetingsDir: URL {
+        OpenClawPaths.workspaceURL.appendingPathComponent("meetings", isDirectory: true)
+    }
+
+    private var legacyMeetingsDir: URL {
         OpenClawPaths.stateDirURL.appendingPathComponent("meetings", isDirectory: true)
     }
 
     init() {
         self.ensureDirectory()
+        self.checkGogAvailability()
     }
 
     private func ensureDirectory() {
@@ -79,6 +92,8 @@ final class MeetingStore {
             }
         }
     }
+
+    // MARK: - Save / Load / Delete
 
     func save(session: MeetingSession) {
         self.ensureDirectory()
@@ -93,38 +108,34 @@ final class MeetingStore {
                 StoredMeeting.StoredSegment(speaker: $0.speaker, text: $0.text, timestamp: $0.timestamp)
             })
 
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-
         do {
-            let data = try encoder.encode(stored)
+            let markdown = Self.renderMarkdown(from: stored)
             let fileName = self.fileName(for: session)
             let fileURL = self.meetingsDir.appendingPathComponent(fileName)
-            try data.write(to: fileURL, options: .atomic)
+            try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
             self.logger.info("saved meeting \(session.id) to \(fileName, privacy: .public)")
             self.loadAll()
+            self.syncToGoogleDrive(fileURL: fileURL, meetingId: session.id)
         } catch {
             self.logger.error("failed to save meeting: \(error.localizedDescription, privacy: .public)")
         }
     }
 
     func loadAll() {
+        self.migrateJsonIfNeeded()
         self.ensureDirectory()
         let fm = FileManager.default
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
 
         do {
             let files = try fm.contentsOfDirectory(at: self.meetingsDir, includingPropertiesForKeys: [.contentModificationDateKey])
-                .filter { $0.pathExtension == "json" }
+                .filter { $0.pathExtension == "md" }
                 .sorted { $0.lastPathComponent > $1.lastPathComponent }
 
             var loaded: [MeetingSummary] = []
             for file in files {
                 do {
-                    let data = try Data(contentsOf: file)
-                    let stored = try decoder.decode(StoredMeeting.self, from: data)
+                    let content = try String(contentsOf: file, encoding: .utf8)
+                    let stored = try Self.parseMarkdown(from: content, fileName: file.lastPathComponent)
                     loaded.append(MeetingSummary(
                         id: stored.id,
                         title: stored.title,
@@ -133,7 +144,7 @@ final class MeetingStore {
                         segmentCount: stored.transcript.count,
                         fileName: file.lastPathComponent))
                 } catch {
-                    self.logger.warning("skipping malformed meeting file \(file.lastPathComponent, privacy: .public)")
+                    self.logger.warning("skipping malformed meeting file \(file.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 }
             }
             self.summaries = loaded
@@ -146,11 +157,9 @@ final class MeetingStore {
     func load(id: UUID) -> StoredMeeting? {
         guard let summary = self.summaries.first(where: { $0.id == id }) else { return nil }
         let fileURL = self.meetingsDir.appendingPathComponent(summary.fileName)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
         do {
-            let data = try Data(contentsOf: fileURL)
-            return try decoder.decode(StoredMeeting.self, from: data)
+            let content = try String(contentsOf: fileURL, encoding: .utf8)
+            return try Self.parseMarkdown(from: content, fileName: summary.fileName)
         } catch {
             self.logger.error("failed to load meeting \(id): \(error.localizedDescription, privacy: .public)")
             return nil
@@ -169,12 +178,376 @@ final class MeetingStore {
         }
     }
 
+    // MARK: - Markdown Rendering
+
+    static func renderMarkdown(from meeting: StoredMeeting) -> String {
+        var lines: [String] = []
+
+        // YAML frontmatter
+        lines.append("---")
+        lines.append("id: \(meeting.id.uuidString)")
+        lines.append("title: \(meeting.title)")
+        lines.append("date: \(iso8601String(from: meeting.startedAt))")
+        if let endedAt = meeting.endedAt {
+            lines.append("endedAt: \(iso8601String(from: endedAt))")
+        }
+        if let duration = meeting.endedAt.map({ $0.timeIntervalSince(meeting.startedAt) }) {
+            lines.append("duration: \(compactDuration(duration))")
+        }
+        if !meeting.attendees.isEmpty {
+            lines.append("attendees:")
+            for attendee in meeting.attendees {
+                lines.append("  - \(attendee)")
+            }
+        }
+        lines.append("---")
+        lines.append("")
+
+        // Title heading
+        lines.append("# \(meeting.title)")
+
+        // Date range subtitle
+        let dateRange = formatDateRange(start: meeting.startedAt, end: meeting.endedAt)
+        lines.append("*\(dateRange)*")
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+        // Transcript segments
+        for segment in meeting.transcript {
+            let speakerName = segment.speaker == .me ? "You" : "Other"
+            let timeStr = formatTimeOnly(segment.timestamp)
+            lines.append("**\(speakerName)** *(\(timeStr))*")
+            lines.append(segment.text)
+            lines.append("")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Markdown Parsing
+
+    enum ParseError: Error, LocalizedError {
+        case missingFrontmatter
+        case missingRequiredField(String)
+        case invalidDate(String)
+        case invalidUUID(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingFrontmatter: return "Missing YAML frontmatter"
+            case .missingRequiredField(let f): return "Missing required field: \(f)"
+            case .invalidDate(let d): return "Invalid date: \(d)"
+            case .invalidUUID(let u): return "Invalid UUID: \(u)"
+            }
+        }
+    }
+
+    static func parseMarkdown(from content: String, fileName: String) throws -> StoredMeeting {
+        let (frontmatter, body) = try extractFrontmatter(from: content)
+        let fields = parseFrontmatterFields(frontmatter)
+
+        guard let idStr = fields["id"] else { throw ParseError.missingRequiredField("id") }
+        guard let id = UUID(uuidString: idStr) else { throw ParseError.invalidUUID(idStr) }
+        guard let title = fields["title"] else { throw ParseError.missingRequiredField("title") }
+        guard let dateStr = fields["date"] else { throw ParseError.missingRequiredField("date") }
+        guard let startedAt = parseISO8601(dateStr) else { throw ParseError.invalidDate(dateStr) }
+
+        let endedAt: Date? = fields["endedAt"].flatMap { parseISO8601($0) }
+        let attendees = parseAttendeeList(from: frontmatter)
+        let transcript = parseTranscriptSegments(from: body, baseDate: startedAt)
+
+        return StoredMeeting(
+            id: id,
+            title: title,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            calendarEventId: nil,
+            attendees: attendees,
+            transcript: transcript)
+    }
+
+    private static func extractFrontmatter(from content: String) throws -> (frontmatter: String, body: String) {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("---") else { throw ParseError.missingFrontmatter }
+
+        let afterFirst = trimmed.dropFirst(3).drop(while: { $0.isNewline })
+        guard let endRange = afterFirst.range(of: "\n---") else { throw ParseError.missingFrontmatter }
+
+        let frontmatter = String(afterFirst[afterFirst.startIndex..<endRange.lowerBound])
+        let body = String(afterFirst[endRange.upperBound...]).trimmingCharacters(in: .newlines)
+        return (frontmatter, body)
+    }
+
+    private static func parseFrontmatterFields(_ frontmatter: String) -> [String: String] {
+        var fields: [String: String] = [:]
+        for line in frontmatter.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // Skip list items and empty lines
+            if trimmed.hasPrefix("- ") || trimmed.isEmpty { continue }
+            guard let colonIndex = trimmed.firstIndex(of: ":") else { continue }
+            let key = String(trimmed[trimmed.startIndex..<colonIndex]).trimmingCharacters(in: .whitespaces)
+            let value = String(trimmed[trimmed.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
+            if !value.isEmpty {
+                fields[key] = value
+            }
+        }
+        return fields
+    }
+
+    private static func parseAttendeeList(from frontmatter: String) -> [String] {
+        var attendees: [String] = []
+        var inAttendees = false
+        for line in frontmatter.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("attendees:") {
+                inAttendees = true
+                continue
+            }
+            if inAttendees {
+                if trimmed.hasPrefix("- ") {
+                    let value = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                    if !value.isEmpty {
+                        attendees.append(value)
+                    }
+                } else if !trimmed.isEmpty {
+                    break
+                }
+            }
+        }
+        return attendees
+    }
+
+    private static func parseTranscriptSegments(from body: String, baseDate: Date) -> [StoredMeeting.StoredSegment] {
+        var segments: [StoredMeeting.StoredSegment] = []
+        let lines = body.components(separatedBy: "\n")
+        var i = 0
+
+        while i < lines.count {
+            let line = lines[i]
+
+            // Match **Speaker** *(time)*
+            if line.hasPrefix("**"),
+               let speakerEnd = line.range(of: "**", range: line.index(line.startIndex, offsetBy: 2)..<line.endIndex),
+               let timeStart = line.range(of: "*("),
+               let timeEnd = line.range(of: ")*")
+            {
+                let speakerStr = String(line[line.index(line.startIndex, offsetBy: 2)..<speakerEnd.lowerBound])
+                let speaker: Speaker = speakerStr == "You" ? .me : .other
+
+                let timeStr = String(line[timeStart.upperBound..<timeEnd.lowerBound])
+                let timestamp = parseTimeOnly(timeStr, baseDate: baseDate) ?? baseDate
+
+                // Collect text lines until next speaker or end
+                i += 1
+                var textLines: [String] = []
+                while i < lines.count {
+                    let nextLine = lines[i]
+                    if nextLine.hasPrefix("**") && nextLine.contains("*(") {
+                        break
+                    }
+                    let trimmedNext = nextLine.trimmingCharacters(in: .whitespaces)
+                    if !trimmedNext.isEmpty {
+                        textLines.append(trimmedNext)
+                    }
+                    i += 1
+                }
+
+                if !textLines.isEmpty {
+                    segments.append(StoredMeeting.StoredSegment(
+                        speaker: speaker,
+                        text: textLines.joined(separator: "\n"),
+                        timestamp: timestamp))
+                }
+            } else {
+                i += 1
+            }
+        }
+
+        return segments
+    }
+
+    // MARK: - Date Formatting Helpers
+
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func iso8601String(from date: Date) -> String {
+        iso8601Formatter.string(from: date)
+    }
+
+    private static func parseISO8601(_ string: String) -> Date? {
+        iso8601Formatter.date(from: string)
+    }
+
+    private static let timeOnlyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "h:mm a"
+        return f
+    }()
+
+    private static func formatTimeOnly(_ date: Date) -> String {
+        timeOnlyFormatter.string(from: date)
+    }
+
+    private static func parseTimeOnly(_ string: String, baseDate: Date) -> Date? {
+        let f = DateFormatter()
+        f.dateFormat = "h:mm a"
+        guard let timeParsed = f.date(from: string) else { return nil }
+
+        let calendar = Calendar.current
+        let baseComponents = calendar.dateComponents([.year, .month, .day], from: baseDate)
+        let timeComponents = calendar.dateComponents([.hour, .minute], from: timeParsed)
+
+        var merged = DateComponents()
+        merged.year = baseComponents.year
+        merged.month = baseComponents.month
+        merged.day = baseComponents.day
+        merged.hour = timeComponents.hour
+        merged.minute = timeComponents.minute
+        return calendar.date(from: merged)
+    }
+
+    private static let dateRangeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d, yyyy"
+        return f
+    }()
+
+    private static func formatDateRange(start: Date, end: Date?) -> String {
+        let datePart = dateRangeFormatter.string(from: start)
+        let startTime = formatTimeOnly(start)
+        guard let end else {
+            return "\(datePart), \(startTime)"
+        }
+        let endTime = formatTimeOnly(end)
+        let duration = compactDuration(end.timeIntervalSince(start))
+        return "\(datePart), \(startTime) – \(endTime) (\(duration))"
+    }
+
+    private static func compactDuration(_ interval: TimeInterval) -> String {
+        let total = Int(interval)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    // MARK: - Legacy JSON Migration
+
+    private func migrateJsonIfNeeded() {
+        let fm = FileManager.default
+        let sentinel = self.meetingsDir.appendingPathComponent(".migrated-from-json")
+
+        guard fm.fileExists(atPath: self.legacyMeetingsDir.path),
+              !fm.fileExists(atPath: sentinel.path) else { return }
+
+        self.ensureDirectory()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        do {
+            let files = try fm.contentsOfDirectory(at: self.legacyMeetingsDir, includingPropertiesForKeys: nil)
+                .filter { $0.pathExtension == "json" }
+
+            guard !files.isEmpty else {
+                // Write sentinel even if no files to avoid re-checking
+                try "".write(to: sentinel, atomically: true, encoding: .utf8)
+                return
+            }
+
+            var migrated = 0
+            for file in files {
+                do {
+                    let data = try Data(contentsOf: file)
+                    let stored = try decoder.decode(StoredMeeting.self, from: data)
+                    let markdown = Self.renderMarkdown(from: stored)
+                    let mdFileName = file.deletingPathExtension().lastPathComponent + ".md"
+                    let destURL = self.meetingsDir.appendingPathComponent(mdFileName)
+                    if !fm.fileExists(atPath: destURL.path) {
+                        try markdown.write(to: destURL, atomically: true, encoding: .utf8)
+                        migrated += 1
+                    }
+                } catch {
+                    self.logger.warning("migration: skipping \(file.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
+            }
+
+            try "".write(to: sentinel, atomically: true, encoding: .utf8)
+            self.logger.info("migrated \(migrated) meetings from JSON to Markdown")
+        } catch {
+            self.logger.error("migration failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Google Drive Sync (gog CLI)
+
+    private static let gogSearchPaths = [
+        "/opt/homebrew/bin/gog",
+        "/usr/local/bin/gog",
+        "/usr/bin/gog",
+    ]
+
+    private(set) var gogPath: String?
+
+    private func checkGogAvailability() {
+        for path in Self.gogSearchPaths {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                self.gogPath = path
+                self.gogAvailable = true
+                return
+            }
+        }
+        self.gogAvailable = false
+    }
+
+    func syncToGoogleDrive(fileURL: URL, meetingId: UUID) {
+        let enabled = UserDefaults.standard.bool(forKey: "meetingGoogleDriveSyncEnabled")
+        guard enabled, self.gogAvailable else { return }
+        guard let folderId = UserDefaults.standard.string(forKey: "meetingGoogleDriveFolderId"),
+              !folderId.isEmpty else { return }
+
+        self.syncStatuses[meetingId] = .syncing
+        let gog = self.gogPath ?? "gog"
+        Task.detached { [logger] in
+            let result = await ShellExecutor.runDetailed(
+                command: [gog, "drive", "upload", fileURL.path, "--parent", folderId],
+                cwd: nil,
+                env: nil,
+                timeout: 30)
+
+            await MainActor.run {
+                if result.success {
+                    self.syncStatuses[meetingId] = .synced
+                    logger.info("synced meeting \(meetingId) to Google Drive")
+                } else {
+                    let msg = result.errorMessage ?? result.stderr
+                    self.syncStatuses[meetingId] = .failed(msg)
+                    logger.warning("Google Drive sync failed for \(meetingId): \(msg, privacy: .public)")
+                }
+            }
+        }
+    }
+
+    func retrySyncToGoogleDrive(id: UUID) {
+        guard let summary = self.summaries.first(where: { $0.id == id }) else { return }
+        let fileURL = self.meetingsDir.appendingPathComponent(summary.fileName)
+        self.syncToGoogleDrive(fileURL: fileURL, meetingId: id)
+    }
+
+    // MARK: - Helpers
+
     private func fileName(for session: MeetingSession) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd_HH-mm"
         let dateStr = formatter.string(from: session.startedAt)
         let slug = Self.slugify(session.title)
-        return "\(dateStr)_\(slug).json"
+        return "\(dateStr)_\(slug).md"
     }
 
     private static func slugify(_ title: String) -> String {

--- a/apps/macos/Sources/OpenClaw/MeetingStore.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingStore.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Observation
+import OSLog
+
+struct MeetingSummary: Identifiable, Codable {
+    let id: UUID
+    let title: String
+    let startedAt: Date
+    let endedAt: Date?
+    let segmentCount: Int
+    let fileName: String
+
+    var duration: TimeInterval? {
+        guard let endedAt else { return nil }
+        return endedAt.timeIntervalSince(self.startedAt)
+    }
+
+    var formattedDuration: String {
+        guard let duration else { return "–" }
+        let total = Int(duration)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    var formattedDate: String {
+        Self.dateFormatter.string(from: self.startedAt)
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f
+    }()
+}
+
+struct StoredMeeting: Codable {
+    let id: UUID
+    let title: String
+    let startedAt: Date
+    let endedAt: Date?
+    let calendarEventId: String?
+    let attendees: [String]
+    let transcript: [StoredSegment]
+
+    struct StoredSegment: Codable {
+        let speaker: Speaker
+        let text: String
+        let timestamp: Date
+    }
+}
+
+@MainActor
+@Observable
+final class MeetingStore {
+    static let shared = MeetingStore()
+    private let logger = Logger(subsystem: "ai.openclaw", category: "meeting.store")
+    private(set) var summaries: [MeetingSummary] = []
+
+    private var meetingsDir: URL {
+        OpenClawPaths.stateDirURL.appendingPathComponent("meetings", isDirectory: true)
+    }
+
+    init() {
+        self.ensureDirectory()
+    }
+
+    private func ensureDirectory() {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: self.meetingsDir.path) {
+            do {
+                try fm.createDirectory(at: self.meetingsDir, withIntermediateDirectories: true)
+            } catch {
+                self.logger.error("failed to create meetings dir: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    func save(session: MeetingSession) {
+        self.ensureDirectory()
+        let stored = StoredMeeting(
+            id: session.id,
+            title: session.title,
+            startedAt: session.startedAt,
+            endedAt: session.endedAt,
+            calendarEventId: session.calendarEventId,
+            attendees: session.attendees,
+            transcript: session.segments.filter(\.isFinal).map {
+                StoredMeeting.StoredSegment(speaker: $0.speaker, text: $0.text, timestamp: $0.timestamp)
+            })
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        do {
+            let data = try encoder.encode(stored)
+            let fileName = self.fileName(for: session)
+            let fileURL = self.meetingsDir.appendingPathComponent(fileName)
+            try data.write(to: fileURL, options: .atomic)
+            self.logger.info("saved meeting \(session.id) to \(fileName, privacy: .public)")
+            self.loadAll()
+        } catch {
+            self.logger.error("failed to save meeting: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func loadAll() {
+        self.ensureDirectory()
+        let fm = FileManager.default
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        do {
+            let files = try fm.contentsOfDirectory(at: self.meetingsDir, includingPropertiesForKeys: [.contentModificationDateKey])
+                .filter { $0.pathExtension == "json" }
+                .sorted { $0.lastPathComponent > $1.lastPathComponent }
+
+            var loaded: [MeetingSummary] = []
+            for file in files {
+                do {
+                    let data = try Data(contentsOf: file)
+                    let stored = try decoder.decode(StoredMeeting.self, from: data)
+                    loaded.append(MeetingSummary(
+                        id: stored.id,
+                        title: stored.title,
+                        startedAt: stored.startedAt,
+                        endedAt: stored.endedAt,
+                        segmentCount: stored.transcript.count,
+                        fileName: file.lastPathComponent))
+                } catch {
+                    self.logger.warning("skipping malformed meeting file \(file.lastPathComponent, privacy: .public)")
+                }
+            }
+            self.summaries = loaded
+        } catch {
+            self.logger.error("failed to list meetings dir: \(error.localizedDescription, privacy: .public)")
+            self.summaries = []
+        }
+    }
+
+    func load(id: UUID) -> StoredMeeting? {
+        guard let summary = self.summaries.first(where: { $0.id == id }) else { return nil }
+        let fileURL = self.meetingsDir.appendingPathComponent(summary.fileName)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            let data = try Data(contentsOf: fileURL)
+            return try decoder.decode(StoredMeeting.self, from: data)
+        } catch {
+            self.logger.error("failed to load meeting \(id): \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    func delete(id: UUID) {
+        guard let summary = self.summaries.first(where: { $0.id == id }) else { return }
+        let fileURL = self.meetingsDir.appendingPathComponent(summary.fileName)
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+            self.logger.info("deleted meeting \(id)")
+            self.loadAll()
+        } catch {
+            self.logger.error("failed to delete meeting \(id): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func fileName(for session: MeetingSession) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm"
+        let dateStr = formatter.string(from: session.startedAt)
+        let slug = Self.slugify(session.title)
+        return "\(dateStr)_\(slug).json"
+    }
+
+    private static func slugify(_ title: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-"))
+        let slug = title
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "-")
+            .unicodeScalars
+            .filter { allowed.contains($0) }
+            .map { Character($0) }
+        let result = String(slug)
+        if result.isEmpty { return "meeting" }
+        return String(result.prefix(50))
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MeetingTranscriber.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingTranscriber.swift
@@ -167,6 +167,22 @@ actor MeetingTranscriber {
         self.micEngine = nil
     }
 
+    /// Temporarily stop the mic engine so external code can probe whether
+    /// another app is still using the hardware microphone.
+    func pauseMic() {
+        self.micEngine?.stop()
+    }
+
+    /// Re-start the mic engine after a `pauseMic()` probe.
+    func resumeMic() {
+        guard let engine = self.micEngine else { return }
+        do {
+            try engine.start()
+        } catch {
+            self.logger.error("meeting: mic resume failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     // MARK: - System audio (ScreenCaptureKit)
 
     private func startSystemAudioStream(request: SFSpeechAudioBufferRecognitionRequest) async {

--- a/apps/macos/Sources/OpenClaw/MeetingTranscriber.swift
+++ b/apps/macos/Sources/OpenClaw/MeetingTranscriber.swift
@@ -1,0 +1,276 @@
+import AVFoundation
+import Foundation
+import OSLog
+@preconcurrency import ScreenCaptureKit
+import Speech
+
+/// Captures mic audio, feeds it to a single SFSpeechRecognizer, and optionally captures
+/// system audio via ScreenCaptureKit.
+///
+/// Apple's SFSpeechRecognizer only supports **one active recognition task per process**,
+/// so we use a single recognizer for mic input. System audio is captured separately via
+/// ScreenCaptureKit and mixed into the same recognition request so both sides of the
+/// conversation are transcribed together.
+actor MeetingTranscriber {
+    private let logger = Logger(subsystem: "ai.openclaw", category: "meeting.transcriber")
+
+    // Single recognizer + request (Apple only allows one active task per process)
+    private var recognizer: SFSpeechRecognizer?
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    // Mic capture
+    private var micEngine: AVAudioEngine?
+
+    // System audio capture (ScreenCaptureKit)
+    private var systemStream: SCStream?
+    private var systemStreamOutput: SystemAudioStreamOutput?
+
+    // Mic RMS tracking for speaker attribution (accessed from audio tap callback)
+    private nonisolated(unsafe) var micIsSpeaking = false
+    private let micRMSThreshold: Float = -40.0 // dBFS
+
+    private var isRunning = false
+    private var generation: Int = 0
+    private var onSegment: (@MainActor (Speaker, String, Bool) -> Void)?
+
+    func start(onSegment: @MainActor @escaping (Speaker, String, Bool) -> Void) async {
+        guard !self.isRunning else { return }
+        self.isRunning = true
+        self.generation &+= 1
+        self.onSegment = onSegment
+
+        await self.startCapture()
+    }
+
+    func stop() async {
+        self.isRunning = false
+        self.generation &+= 1
+        self.onSegment = nil
+
+        await self.stopCapture()
+    }
+
+    // MARK: - Combined capture
+
+    private func startCapture() async {
+        let gen = self.generation
+
+        let recognizer = SFSpeechRecognizer(locale: Locale.current)
+        guard let recognizer, recognizer.isAvailable else {
+            self.logger.error("meeting recognizer unavailable (locale=\(Locale.current.identifier, privacy: .public))")
+            return
+        }
+        self.recognizer = recognizer
+
+        // Check if on-device recognition is available
+        let supportsOnDevice = recognizer.supportsOnDeviceRecognition
+        self.logger.info("meeting recognizer: locale=\(Locale.current.identifier, privacy: .public) onDevice=\(supportsOnDevice, privacy: .public)")
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        // Don't force on-device — let the system choose
+        self.request = request
+
+        // Start mic audio engine FIRST, before creating the recognition task
+        let micStarted = self.startMicEngine(request: request)
+        if !micStarted {
+            self.logger.error("meeting mic engine failed to start")
+            return
+        }
+
+        // Create recognition task IMMEDIATELY after mic engine starts
+        // (before system audio setup which requires async/await and could delay things)
+        let currentSpeaker = { [weak self] () -> Speaker in
+            guard let self else { return .unknown }
+            // Heuristic: if mic RMS is above threshold, it's you speaking
+            return self.micIsSpeaking ? .me : .other
+        }
+
+        let onSegment = self.onSegment
+        self.logger.info("meeting creating recognition task...")
+        self.task = recognizer.recognitionTask(with: request) { [weak self, gen] result, error in
+            guard let self else { return }
+            if let error {
+                self.logger.warning("meeting recognition error: \(error.localizedDescription, privacy: .public)")
+            }
+            let transcript = result?.bestTranscription.formattedString
+            let isFinal = result?.isFinal ?? false
+            guard let transcript, !transcript.isEmpty else { return }
+            let speaker = currentSpeaker()
+            Task { @MainActor in
+                onSegment?(speaker, transcript, isFinal)
+            }
+            if isFinal {
+                Task { await self.restartRecognitionIfNeeded(gen) }
+            }
+        }
+        self.logger.info("meeting capture started (mic=\(micStarted, privacy: .public))")
+
+        // System audio capture (optional — requires screen recording permission)
+        await self.startSystemAudioStream(request: request)
+    }
+
+    private func restartRecognitionIfNeeded(_ gen: Int) async {
+        guard self.isRunning, gen == self.generation else { return }
+        // Stop and restart everything for a fresh recognition task
+        await self.stopCapture()
+        await self.startCapture()
+    }
+
+    private func stopCapture() async {
+        self.task?.cancel()
+        self.task = nil
+        self.request?.endAudio()
+        self.request = nil
+        self.recognizer = nil
+
+        self.stopMicEngine()
+        await self.stopSystemAudioStream()
+    }
+
+    // MARK: - Mic engine
+
+    private func startMicEngine(request: SFSpeechAudioBufferRecognitionRequest) -> Bool {
+        let engine = AVAudioEngine()
+        self.micEngine = engine
+
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        guard format.channelCount > 0, format.sampleRate > 0 else {
+            self.logger.error("meeting mic: no audio input available (channels=\(format.channelCount) rate=\(format.sampleRate))")
+            return false
+        }
+
+        input.removeTap(onBus: 0)
+        input.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self, weak request] buffer, _ in
+            request?.append(buffer)
+            if let rms = Self.rmsLevel(buffer: buffer) {
+                self?.micIsSpeaking = rms > (self?.micRMSThreshold ?? -40.0)
+            }
+        }
+
+        engine.prepare()
+        do {
+            try engine.start()
+            self.logger.info("meeting mic engine started (format: \(format.sampleRate)Hz \(format.channelCount)ch)")
+            return true
+        } catch {
+            self.logger.error("meeting mic engine start failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    private func stopMicEngine() {
+        self.micEngine?.inputNode.removeTap(onBus: 0)
+        self.micEngine?.stop()
+        self.micEngine = nil
+    }
+
+    // MARK: - System audio (ScreenCaptureKit)
+
+    private func startSystemAudioStream(request: SFSpeechAudioBufferRecognitionRequest) async {
+        do {
+            let content = try await SCShareableContent.current
+            guard let display = content.displays.first else {
+                self.logger.warning("meeting system audio: no displays available")
+                return
+            }
+
+            let filter = SCContentFilter(display: display, excludingWindows: [])
+            let config = SCStreamConfiguration()
+            config.capturesAudio = true
+            config.excludesCurrentProcessAudio = true
+            config.width = 2
+            config.height = 2
+
+            let output = SystemAudioStreamOutput(request: request, logger: self.logger)
+            self.systemStreamOutput = output
+
+            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+            try stream.addStreamOutput(output, type: .audio, sampleHandlerQueue: output.queue)
+            self.systemStream = stream
+
+            try await stream.startCapture()
+            self.logger.info("meeting system audio capture started")
+        } catch {
+            self.logger.warning("meeting system audio unavailable: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func stopSystemAudioStream() async {
+        if let stream = self.systemStream {
+            try? await stream.stopCapture()
+        }
+        self.systemStream = nil
+        self.systemStreamOutput = nil
+    }
+
+    // MARK: - Helpers
+
+    private static func rmsLevel(buffer: AVAudioPCMBuffer) -> Float? {
+        guard let channelData = buffer.floatChannelData else { return nil }
+        let channelDataValue = channelData.pointee
+        let count = Int(buffer.frameLength)
+        guard count > 0 else { return nil }
+        var sum: Float = 0
+        for i in 0..<count {
+            let sample = channelDataValue[i]
+            sum += sample * sample
+        }
+        let rms = sqrt(sum / Float(count))
+        let db = 20 * log10(max(rms, 1e-10))
+        return db
+    }
+}
+
+private final class SystemAudioStreamOutput: NSObject, SCStreamOutput, @unchecked Sendable {
+    let queue = DispatchQueue(label: "ai.openclaw.meeting.systemAudio")
+    private let request: SFSpeechAudioBufferRecognitionRequest
+    private let logger: Logger
+
+    init(request: SFSpeechAudioBufferRecognitionRequest, logger: Logger) {
+        self.request = request
+        self.logger = logger
+        super.init()
+    }
+
+    func stream(
+        _ stream: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of type: SCStreamOutputType)
+    {
+        guard type == .audio, CMSampleBufferDataIsReady(sampleBuffer) else { return }
+
+        guard let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc)
+        else { return }
+
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: asbd.pointee.mSampleRate,
+            channels: AVAudioChannelCount(asbd.pointee.mChannelsPerFrame),
+            interleaved: false)
+        guard let format else { return }
+
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return }
+        let frameCount = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard frameCount > 0 else { return }
+
+        guard let pcmBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount))
+        else { return }
+        pcmBuffer.frameLength = AVAudioFrameCount(frameCount)
+
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        var totalLength: Int = 0
+        let status = CMBlockBufferGetDataPointer(blockBuffer, atOffset: 0, lengthAtOffsetOut: nil, totalLengthOut: &totalLength, dataPointerOut: &dataPointer)
+        guard status == kCMBlockBufferNoErr, let dataPointer else { return }
+
+        if let channelData = pcmBuffer.floatChannelData {
+            let byteCount = min(totalLength, Int(pcmBuffer.frameLength) * MemoryLayout<Float>.size * Int(format.channelCount))
+            memcpy(channelData[0], dataPointer, byteCount)
+        }
+
+        self.request.append(pcmBuffer)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -16,6 +16,7 @@ struct OpenClawApp: App {
     private let controlChannel = ControlChannel.shared
     private let activityStore = WorkActivityStore.shared
     private let connectivityCoordinator = GatewayConnectivityCoordinator.shared
+    @Bindable private var meetingDetector = MeetingDetector.shared
     @State private var statusItem: NSStatusItem?
     @State private var isMenuPresented = false
     @State private var isPanelVisible = false
@@ -48,7 +49,8 @@ struct OpenClawApp: App {
                 sendCelebrationTick: self.state.sendCelebrationTick,
                 gatewayStatus: self.gatewayManager.status,
                 animationsEnabled: self.state.iconAnimationsEnabled && !self.isGatewaySleeping,
-                iconState: self.effectiveIconState)
+                iconState: self.effectiveIconState,
+                isMeetingRecording: self.meetingDetector.currentSession != nil)
         }
         .menuBarExtraStyle(.menu)
         .menuBarExtraAccess(isPresented: self.$isMenuPresented) { item in
@@ -286,6 +288,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { await PortGuardian.shared.sweep(mode: AppStateStore.shared.connectionMode) }
         Task { await PeekabooBridgeHostCoordinator.shared.setEnabled(AppStateStore.shared.peekabooBridgeEnabled) }
         MeetingDetector.shared.start()
+        MeetingRecordingStatusItem.shared.start()
         self.scheduleFirstRunOnboardingIfNeeded()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             CLIInstallPrompter.shared.checkAndPromptIfNeeded(reason: "launch")

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -285,6 +285,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { await HealthStore.shared.refresh(onDemand: true) }
         Task { await PortGuardian.shared.sweep(mode: AppStateStore.shared.connectionMode) }
         Task { await PeekabooBridgeHostCoordinator.shared.setEnabled(AppStateStore.shared.peekabooBridgeEnabled) }
+        MeetingDetector.shared.start()
         self.scheduleFirstRunOnboardingIfNeeded()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             CLIInstallPrompter.shared.checkAndPromptIfNeeded(reason: "launch")
@@ -301,6 +302,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        MeetingDetector.shared.stop()
         PresenceReporter.shared.stop()
         NodePairingApprovalPrompter.shared.stop()
         DevicePairingApprovalPrompter.shared.stop()

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -62,7 +62,11 @@ struct MenuContent: View {
             }
             .disabled(self.state.connectionMode == .unconfigured)
 
-            Divider()
+            if MeetingDetector.shared.meetingDetectionEnabled {
+                Divider()
+                MeetingMenuItems()
+                Divider()
+            }
             Toggle(isOn: self.heartbeatsBinding) {
                 HStack(spacing: 8) {
                     Label("Send Heartbeats", systemImage: "waveform.path.ecg")
@@ -145,7 +149,6 @@ struct MenuContent: View {
             }
             .disabled(!voiceWakeSupported)
             .opacity(voiceWakeSupported ? 1 : 0.5)
-            MeetingMenuItems()
             Divider()
             Button("Settings…") { self.open(tab: .general) }
                 .keyboardShortcut(",", modifiers: [.command])

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -145,6 +145,7 @@ struct MenuContent: View {
             }
             .disabled(!voiceWakeSupported)
             .opacity(voiceWakeSupported ? 1 : 0.5)
+            MeetingMenuItems()
             Divider()
             Button("Settings…") { self.open(tab: .general) }
                 .keyboardShortcut(",", modifiers: [.command])

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -4,6 +4,7 @@ import AVFoundation
 import OpenClawIPC
 import CoreGraphics
 import CoreLocation
+import EventKit
 import Foundation
 import Observation
 import Speech
@@ -48,6 +49,8 @@ enum PermissionManager {
             await self.ensureCamera(interactive: interactive)
         case .location:
             await self.ensureLocation(interactive: interactive)
+        case .calendar:
+            await self.ensureCalendar(interactive: interactive)
         }
     }
 
@@ -174,6 +177,28 @@ enum PermissionManager {
         }
     }
 
+    private static func ensureCalendar(interactive: Bool) async -> Bool {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        switch status {
+        case .fullAccess:
+            return true
+        case .notDetermined:
+            guard interactive else { return false }
+            do {
+                return try await EKEventStore().requestFullAccessToEvents()
+            } catch {
+                return false
+            }
+        case .denied, .restricted, .writeOnly:
+            if interactive {
+                CalendarPermissionHelper.openSettings()
+            }
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
     static func voiceWakePermissionsGranted() -> Bool {
         let mic = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         let speech = SFSpeechRecognizer.authorizationStatus() == .authorized
@@ -221,6 +246,10 @@ enum PermissionManager {
                 let status = CLLocationManager().authorizationStatus
                 results[cap] = CLLocationManager.locationServicesEnabled()
                     && self.isLocationAuthorized(status: status, requireAlways: false)
+
+            case .calendar:
+                let status = EKEventStore.authorizationStatus(for: .event)
+                results[cap] = status == .fullAccess
             }
         }
         return results
@@ -261,6 +290,21 @@ enum CameraPermissionHelper {
     static func openSettings() {
         let candidates = [
             "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera",
+            "x-apple.systempreferences:com.apple.preference.security",
+        ]
+
+        for candidate in candidates {
+            if let url = URL(string: candidate), NSWorkspace.shared.open(url) {
+                return
+            }
+        }
+    }
+}
+
+enum CalendarPermissionHelper {
+    static func openSettings() {
+        let candidates = [
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars",
             "x-apple.systempreferences:com.apple.preference.security",
         ]
 

--- a/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
@@ -176,6 +176,7 @@ struct PermissionRow: View {
         case .speechRecognition: "Speech Recognition"
         case .camera: "Camera"
         case .location: "Location"
+        case .calendar: "Calendar"
         }
     }
 
@@ -190,6 +191,7 @@ struct PermissionRow: View {
         case .speechRecognition: "Transcribe Voice Wake trigger phrases on-device"
         case .camera: "Capture photos and video from the camera"
         case .location: "Share location when requested by the agent"
+        case .calendar: "Read calendar events for meeting detection"
         }
     }
 
@@ -203,6 +205,7 @@ struct PermissionRow: View {
         case .speechRecognition: "waveform"
         case .camera: "camera"
         case .location: "location"
+        case .calendar: "calendar"
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/Resources/Info.plist
+++ b/apps/macos/Sources/OpenClaw/Resources/Info.plist
@@ -57,6 +57,8 @@
 	<string>OpenClaw needs the mic for Voice Wake tests and agent audio capture.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>OpenClaw uses speech recognition to detect your Voice Wake trigger phrase.</string>
+    <key>NSCalendarsUsageDescription</key>
+    <string>OpenClaw reads your calendar to detect upcoming meetings for live transcription.</string>
     <key>NSAppleEventsUsageDescription</key>
     <string>OpenClaw needs Automation (AppleScript) permission to drive Terminal and other apps for agent actions.</string>
 

--- a/apps/macos/Sources/OpenClaw/SettingsRootView.swift
+++ b/apps/macos/Sources/OpenClaw/SettingsRootView.swift
@@ -55,6 +55,10 @@ struct SettingsRootView: View {
                     .tabItem { Label("Skills", systemImage: "sparkles") }
                     .tag(SettingsTab.skills)
 
+                MeetingSettings()
+                    .tabItem { Label("Meetings", systemImage: "text.bubble") }
+                    .tag(SettingsTab.meetings)
+
                 PermissionsSettings(
                     status: self.permissionMonitor.status,
                     refresh: self.refreshPerms,
@@ -176,7 +180,7 @@ struct SettingsRootView: View {
 }
 
 enum SettingsTab: CaseIterable {
-    case general, channels, skills, sessions, cron, config, instances, voiceWake, permissions, debug, about
+    case general, channels, skills, sessions, cron, config, instances, voiceWake, meetings, permissions, debug, about
     static let windowWidth: CGFloat = 824 // wider
     static let windowHeight: CGFloat = 790 // +10% (more room)
     var title: String {
@@ -189,6 +193,7 @@ enum SettingsTab: CaseIterable {
         case .config: "Config"
         case .instances: "Instances"
         case .voiceWake: "Voice Wake"
+        case .meetings: "Meetings"
         case .permissions: "Permissions"
         case .debug: "Debug"
         case .about: "About"
@@ -205,6 +210,7 @@ enum SettingsTab: CaseIterable {
         case .config: "slider.horizontal.3"
         case .instances: "network"
         case .voiceWake: "waveform.circle"
+        case .meetings: "text.bubble"
         case .permissions: "lock.shield"
         case .debug: "ant"
         case .about: "info.circle"

--- a/apps/macos/Sources/OpenClaw/WhisperTranscriber.swift
+++ b/apps/macos/Sources/OpenClaw/WhisperTranscriber.swift
@@ -1,0 +1,439 @@
+import AVFoundation
+import Foundation
+import OSLog
+@preconcurrency import ScreenCaptureKit
+import WhisperKit
+
+enum TranscriptionEngine: String, CaseIterable, Identifiable {
+    case whisper = "whisper"
+    case apple = "apple"
+
+    var id: String { self.rawValue }
+
+    var displayName: String {
+        switch self {
+        case .whisper: "Whisper (Local)"
+        case .apple: "Apple Speech"
+        }
+    }
+}
+
+enum WhisperModelState: Sendable {
+    case idle
+    case downloading(Double) // 0.0–1.0
+    case loading
+    case ready
+    case error(String)
+}
+
+/// Captures mic + system audio and transcribes using WhisperKit in ~5-second chunks.
+actor WhisperTranscriber {
+    private let logger = Logger(subsystem: "ai.openclaw", category: "meeting.whisper")
+
+    // WhisperKit isn't Sendable but we only use it within the actor's serialized context.
+    // The `transcribe` call is async, which triggers a sending diagnostic — suppress it here.
+    nonisolated(unsafe) private var whisperKit: WhisperKit?
+    private var micEngine: AVAudioEngine?
+    private var systemStream: SCStream?
+    private var systemStreamOutput: WhisperSystemAudioOutput?
+
+    // Audio buffer accumulation
+    private var audioBuffer: [Float] = []
+    private var sampleRate: Double = 16000
+    private let chunkInterval: TimeInterval = 5.0
+    private var chunkTimer: Task<Void, Never>?
+
+    // Mic RMS tracking for speaker attribution
+    private nonisolated(unsafe) var micIsSpeaking = false
+    private let micRMSThreshold: Float = -40.0 // dBFS
+
+    private var isRunning = false
+    private var onSegment: (@MainActor (Speaker, String, Bool) -> Void)?
+
+    // Observable state (read from MainActor via nonisolated)
+    nonisolated(unsafe) private(set) var modelState: WhisperModelState = .idle
+    nonisolated(unsafe) private(set) var currentModelName: String = ""
+    nonisolated(unsafe) private(set) var downloadedModels: Set<String> = []
+    private var downloadedModelPaths: [String: URL] = [:]
+
+    static let supportedModels = [
+        "openai_whisper-tiny.en",
+        "openai_whisper-base.en",
+        "openai_whisper-small.en",
+        "openai_whisper-medium.en",
+        "openai_whisper-large-v3",
+    ]
+
+    private static let downloadBase: URL = OpenClawPaths.stateDirURL
+        .appendingPathComponent("whisper-models", isDirectory: true)
+
+    func start(onSegment: @MainActor @escaping (Speaker, String, Bool) -> Void) async {
+        guard !self.isRunning else { return }
+        self.isRunning = true
+        self.onSegment = onSegment
+
+        let modelName = UserDefaults.standard.string(forKey: "whisperModelSize") ?? "openai_whisper-base.en"
+        await self.ensureModelLoaded(modelName: modelName)
+
+        guard self.whisperKit != nil else {
+            self.logger.error("whisper: model not loaded, cannot start")
+            return
+        }
+
+        await self.startCapture()
+        self.startChunkTimer()
+    }
+
+    func stop() async {
+        self.isRunning = false
+        self.chunkTimer?.cancel()
+        self.chunkTimer = nil
+        self.onSegment = nil
+
+        // Transcribe any remaining audio
+        await self.transcribeCurrentChunk()
+
+        await self.stopCapture()
+        self.audioBuffer.removeAll()
+    }
+
+    // MARK: - Model management
+
+    /// Scan the download directory to find which models are already on disk.
+    func refreshDownloadedModels() {
+        let (found, paths) = Self.scanDownloadedModels()
+        self.downloadedModels = found
+        self.downloadedModelPaths = paths
+    }
+
+    /// Synchronous scan — can be called from any isolation context.
+    nonisolated static func scanDownloadedModels() -> (Set<String>, [String: URL]) {
+        let fm = FileManager.default
+        let modelsDir = downloadBase.appendingPathComponent("models", isDirectory: true)
+        guard let enumerator = fm.enumerator(
+            at: modelsDir, includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]) else {
+            return ([], [:])
+        }
+        var found = Set<String>()
+        var paths = [String: URL]()
+        for case let url as URL in enumerator {
+            let melSpec = url.appendingPathComponent("MelSpectrogram.mlmodelc")
+            if fm.fileExists(atPath: melSpec.path) {
+                let name = url.lastPathComponent
+                found.insert(name)
+                paths[name] = url
+            }
+        }
+        return (found, paths)
+    }
+
+    /// Reset model state (e.g. when switching to a model that isn't downloaded yet).
+    func resetState() {
+        self.modelState = .idle
+        self.whisperKit = nil
+        self.currentModelName = ""
+    }
+
+    /// Download and load a model proactively (e.g. from settings UI).
+    func downloadModel(named modelName: String) async {
+        await self.ensureModelLoaded(modelName: modelName)
+    }
+
+    private func ensureModelLoaded(modelName: String) async {
+        if self.whisperKit != nil, self.currentModelName == modelName {
+            return
+        }
+
+        self.currentModelName = modelName
+        self.logger.info("whisper: preparing model \(modelName, privacy: .public)")
+
+        // Check if already downloaded on disk
+        self.refreshDownloadedModels()
+        let modelFolder: URL
+
+        if let existingPath = self.downloadedModelPaths[modelName] {
+            self.logger.info("whisper: model \(modelName, privacy: .public) found on disk")
+            modelFolder = existingPath
+        } else {
+            // Download with progress
+            self.modelState = .downloading(0)
+            do {
+                modelFolder = try await WhisperKit.download(
+                    variant: modelName,
+                    downloadBase: Self.downloadBase
+                ) { [weak self] progress in
+                    self?.modelState = .downloading(progress.fractionCompleted)
+                }
+            } catch {
+                self.modelState = .error(error.localizedDescription)
+                self.logger.error("whisper: download failed: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+            self.refreshDownloadedModels()
+        }
+
+        // Load model into WhisperKit
+        self.modelState = .loading
+        do {
+            let kit = try await WhisperKit(
+                modelFolder: modelFolder.path,
+                download: false
+            )
+            self.whisperKit = kit
+            self.modelState = .ready
+            self.logger.info("whisper: model \(modelName, privacy: .public) ready")
+        } catch {
+            self.modelState = .error(error.localizedDescription)
+            self.logger.error("whisper: model load failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Audio capture
+
+    private func startCapture() async {
+        let micStarted = self.startMicEngine()
+        self.logger.info("whisper: mic capture started=\(micStarted, privacy: .public)")
+
+        await self.startSystemAudioCapture()
+    }
+
+    private func stopCapture() async {
+        self.stopMicEngine()
+        await self.stopSystemAudioCapture()
+    }
+
+    private func startMicEngine() -> Bool {
+        let engine = AVAudioEngine()
+        self.micEngine = engine
+
+        let input = engine.inputNode
+        let nativeFormat = input.outputFormat(forBus: 0)
+        guard nativeFormat.channelCount > 0, nativeFormat.sampleRate > 0 else {
+            self.logger.error("whisper: no audio input available")
+            return false
+        }
+
+        self.sampleRate = nativeFormat.sampleRate
+
+        // Target format: mono Float32 at native sample rate (WhisperKit resamples internally)
+        let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: nativeFormat.sampleRate,
+            channels: 1,
+            interleaved: false)!
+
+        input.removeTap(onBus: 0)
+        input.installTap(onBus: 0, bufferSize: 4096, format: targetFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+            // RMS for speaker attribution
+            if let rms = Self.rmsLevel(buffer: buffer) {
+                self.micIsSpeaking = rms > self.micRMSThreshold
+            }
+            // Append samples to buffer
+            if let channelData = buffer.floatChannelData {
+                let count = Int(buffer.frameLength)
+                let samples = Array(UnsafeBufferPointer(start: channelData[0], count: count))
+                Task { await self.appendSamples(samples) }
+            }
+        }
+
+        engine.prepare()
+        do {
+            try engine.start()
+            return true
+        } catch {
+            self.logger.error("whisper: mic engine start failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    private func stopMicEngine() {
+        self.micEngine?.inputNode.removeTap(onBus: 0)
+        self.micEngine?.stop()
+        self.micEngine = nil
+    }
+
+    private func appendSamples(_ samples: [Float]) {
+        guard self.isRunning else { return }
+        self.audioBuffer.append(contentsOf: samples)
+    }
+
+    // MARK: - System audio (ScreenCaptureKit)
+
+    private func startSystemAudioCapture() async {
+        do {
+            let content = try await SCShareableContent.current
+            guard let display = content.displays.first else {
+                self.logger.warning("whisper: no displays for system audio")
+                return
+            }
+
+            let filter = SCContentFilter(display: display, excludingWindows: [])
+            let config = SCStreamConfiguration()
+            config.capturesAudio = true
+            config.excludesCurrentProcessAudio = true
+            config.width = 2
+            config.height = 2
+
+            let output = WhisperSystemAudioOutput { [weak self] samples in
+                Task { await self?.appendSamples(samples) }
+            }
+            self.systemStreamOutput = output
+
+            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+            try stream.addStreamOutput(output, type: .audio, sampleHandlerQueue: output.queue)
+            self.systemStream = stream
+
+            try await stream.startCapture()
+            self.logger.info("whisper: system audio capture started")
+        } catch {
+            self.logger.warning("whisper: system audio unavailable: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func stopSystemAudioCapture() async {
+        if let stream = self.systemStream {
+            try? await stream.stopCapture()
+        }
+        self.systemStream = nil
+        self.systemStreamOutput = nil
+    }
+
+    // MARK: - Chunked transcription
+
+    private func startChunkTimer() {
+        self.chunkTimer?.cancel()
+        self.chunkTimer = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(self.chunkInterval * 1_000_000_000))
+                guard !Task.isCancelled else { break }
+                await self.transcribeCurrentChunk()
+            }
+        }
+    }
+
+    private func transcribeCurrentChunk() async {
+        guard let whisperKit = self.whisperKit else { return }
+
+        let samples = self.audioBuffer
+        self.audioBuffer.removeAll(keepingCapacity: true)
+
+        // Need at least 0.5 seconds of audio
+        let minSamples = Int(self.sampleRate * 0.5)
+        guard samples.count >= minSamples else { return }
+
+        // Resample to 16kHz if needed (WhisperKit expects 16kHz)
+        let audio: [Float]
+        if abs(self.sampleRate - 16000) > 1 {
+            audio = Self.resample(samples, from: self.sampleRate, to: 16000)
+        } else {
+            audio = samples
+        }
+
+        let speaker: Speaker = self.micIsSpeaking ? .me : .other
+
+        do {
+            let results = try await whisperKit.transcribe(audioArray: audio)
+            for result in results {
+                let text = result.text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+                guard !text.isEmpty else { continue }
+                let onSegment = self.onSegment
+                Task { @MainActor in
+                    onSegment?(speaker, text, true)
+                }
+            }
+        } catch {
+            self.logger.warning("whisper: transcription error: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func rmsLevel(buffer: AVAudioPCMBuffer) -> Float? {
+        guard let channelData = buffer.floatChannelData else { return nil }
+        let channelDataValue = channelData.pointee
+        let count = Int(buffer.frameLength)
+        guard count > 0 else { return nil }
+        var sum: Float = 0
+        for i in 0..<count {
+            let sample = channelDataValue[i]
+            sum += sample * sample
+        }
+        let rms = sqrt(sum / Float(count))
+        let db = 20 * log10(max(rms, 1e-10))
+        return db
+    }
+
+    /// Simple linear resampling from one sample rate to another.
+    private static func resample(_ samples: [Float], from sourceSR: Double, to targetSR: Double) -> [Float] {
+        let ratio = targetSR / sourceSR
+        let outputCount = Int(Double(samples.count) * ratio)
+        guard outputCount > 0 else { return [] }
+        var output = [Float](repeating: 0, count: outputCount)
+        for i in 0..<outputCount {
+            let srcIndex = Double(i) / ratio
+            let low = Int(srcIndex)
+            let high = min(low + 1, samples.count - 1)
+            let frac = Float(srcIndex - Double(low))
+            output[i] = samples[low] * (1 - frac) + samples[high] * frac
+        }
+        return output
+    }
+}
+
+// MARK: - System audio stream output for WhisperKit
+
+private final class WhisperSystemAudioOutput: NSObject, SCStreamOutput, @unchecked Sendable {
+    let queue = DispatchQueue(label: "ai.openclaw.meeting.whisper.systemAudio")
+    private let onSamples: @Sendable ([Float]) -> Void
+
+    init(onSamples: @escaping @Sendable ([Float]) -> Void) {
+        self.onSamples = onSamples
+        super.init()
+    }
+
+    func stream(
+        _ stream: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of type: SCStreamOutputType)
+    {
+        guard type == .audio, CMSampleBufferDataIsReady(sampleBuffer) else { return }
+
+        guard let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc)
+        else { return }
+
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return }
+        let frameCount = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard frameCount > 0 else { return }
+
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        var totalLength: Int = 0
+        let status = CMBlockBufferGetDataPointer(
+            blockBuffer, atOffset: 0, lengthAtOffsetOut: nil,
+            totalLengthOut: &totalLength, dataPointerOut: &dataPointer)
+        guard status == kCMBlockBufferNoErr, let dataPointer else { return }
+
+        let channelCount = Int(asbd.pointee.mChannelsPerFrame)
+        let sampleCount = frameCount * channelCount
+        let floatPointer = UnsafeRawPointer(dataPointer).bindMemory(to: Float.self, capacity: sampleCount)
+        let floatBuffer = UnsafeBufferPointer(start: floatPointer, count: sampleCount)
+
+        // Mix to mono if multi-channel
+        var mono = [Float](repeating: 0, count: frameCount)
+        if channelCount == 1 {
+            mono = Array(floatBuffer)
+        } else {
+            for i in 0..<frameCount {
+                var sum: Float = 0
+                for ch in 0..<channelCount {
+                    sum += floatBuffer[i * channelCount + ch]
+                }
+                mono[i] = sum / Float(channelCount)
+            }
+        }
+
+        self.onSamples(mono)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/WhisperTranscriber.swift
+++ b/apps/macos/Sources/OpenClaw/WhisperTranscriber.swift
@@ -254,6 +254,22 @@ actor WhisperTranscriber {
         self.micEngine = nil
     }
 
+    /// Temporarily stop the mic engine so external code can probe whether
+    /// another app is still using the hardware microphone.
+    func pauseMic() {
+        self.micEngine?.stop()
+    }
+
+    /// Re-start the mic engine after a `pauseMic()` probe.
+    func resumeMic() {
+        guard let engine = self.micEngine else { return }
+        do {
+            try engine.start()
+        } catch {
+            self.logger.error("whisper: mic resume failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     private func appendSamples(_ samples: [Float]) {
         guard self.isRunning else { return }
         self.audioBuffer.append(contentsOf: samples)

--- a/apps/macos/Sources/OpenClawIPC/IPC.swift
+++ b/apps/macos/Sources/OpenClawIPC/IPC.swift
@@ -13,6 +13,7 @@ public enum Capability: String, Codable, CaseIterable, Sendable {
     case speechRecognition
     case camera
     case location
+    case calendar
 }
 
 public enum CameraFacing: String, Codable, Sendable {

--- a/apps/macos/Tests/OpenClawIPCTests/MeetingDetectorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MeetingDetectorTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct MeetingDetectorTests {
+    @Test func sharedInstanceExists() {
+        let detector = MeetingDetector.shared
+        #expect(detector.currentSession == nil)
+    }
+
+    @Test func defaultSettingsState() {
+        let detector = MeetingDetector.shared
+        // Detector should not have an active session by default
+        #expect(detector.currentSession == nil)
+        #expect(detector.upcomingMeetings.isEmpty)
+    }
+
+    @Test func meetingDetectionTogglePersists() {
+        let detector = MeetingDetector.shared
+        let original = detector.meetingDetectionEnabled
+
+        detector.meetingDetectionEnabled = true
+        #expect(detector.meetingDetectionEnabled == true)
+
+        detector.meetingDetectionEnabled = false
+        #expect(detector.meetingDetectionEnabled == false)
+
+        // Restore
+        detector.meetingDetectionEnabled = original
+    }
+
+    @Test func adHocDetectionTogglePersists() {
+        let detector = MeetingDetector.shared
+        let original = detector.adHocDetectionEnabled
+
+        detector.adHocDetectionEnabled = false
+        #expect(detector.adHocDetectionEnabled == false)
+
+        detector.adHocDetectionEnabled = true
+        #expect(detector.adHocDetectionEnabled == true)
+
+        // Restore
+        detector.adHocDetectionEnabled = original
+    }
+
+    @Test func startMeetingCreatesSession() async {
+        let detector = MeetingDetector.shared
+        // Ensure no session is active
+        if detector.currentSession != nil {
+            await detector.stopMeeting()
+        }
+
+        await detector.startMeeting(title: "Test Meeting")
+        #expect(detector.currentSession != nil)
+        #expect(detector.currentSession?.title == "Test Meeting")
+        #expect(detector.currentSession?.status == .recording)
+
+        // Clean up
+        await detector.stopMeeting()
+        #expect(detector.currentSession == nil)
+    }
+
+    @Test func startMeetingWhileActiveLogs() async {
+        let detector = MeetingDetector.shared
+        if detector.currentSession != nil {
+            await detector.stopMeeting()
+        }
+
+        await detector.startMeeting(title: "First")
+        #expect(detector.currentSession?.title == "First")
+
+        // Starting another should not replace the existing one
+        await detector.startMeeting(title: "Second")
+        #expect(detector.currentSession?.title == "First")
+
+        await detector.stopMeeting()
+    }
+
+    @Test func stopMeetingSavesToStore() async {
+        let detector = MeetingDetector.shared
+        if detector.currentSession != nil {
+            await detector.stopMeeting()
+        }
+
+        await detector.startMeeting(title: "Save Test \(UUID().uuidString.prefix(8))")
+        let sessionId = detector.currentSession?.id
+        #expect(sessionId != nil)
+
+        await detector.stopMeeting()
+        #expect(detector.currentSession == nil)
+
+        // Verify it was saved
+        if let sessionId {
+            let store = MeetingStore.shared
+            #expect(store.summaries.contains { $0.id == sessionId })
+            // Clean up
+            store.delete(id: sessionId)
+        }
+    }
+
+    @Test func stopWithNoSessionIsNoOp() async {
+        let detector = MeetingDetector.shared
+        if detector.currentSession != nil {
+            await detector.stopMeeting()
+        }
+
+        // Should not crash
+        await detector.stopMeeting()
+        #expect(detector.currentSession == nil)
+    }
+
+    @Test func startAndStopLifecycleDoesNotCrash() {
+        let detector = MeetingDetector.shared
+        let original = detector.meetingDetectionEnabled
+
+        detector.meetingDetectionEnabled = true
+        detector.start()
+        detector.stop()
+
+        detector.meetingDetectionEnabled = original
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/MeetingSessionTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MeetingSessionTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct MeetingSessionTests {
+    @Test func sessionInitializesWithDefaults() {
+        let session = MeetingSession(title: "Standup")
+        #expect(session.title == "Standup")
+        #expect(session.status == .idle)
+        #expect(session.segments.isEmpty)
+        #expect(session.endedAt == nil)
+        #expect(session.calendarEventId == nil)
+        #expect(session.attendees.isEmpty)
+    }
+
+    @Test func sessionInitializesWithAllProperties() {
+        let date = Date()
+        let session = MeetingSession(
+            title: "Design Review",
+            startedAt: date,
+            calendarEventId: "cal-123",
+            attendees: ["alice@example.com", "bob@example.com"])
+        #expect(session.title == "Design Review")
+        #expect(session.startedAt == date)
+        #expect(session.calendarEventId == "cal-123")
+        #expect(session.attendees.count == 2)
+    }
+
+    @Test func startSetsStatusToRecording() {
+        let session = MeetingSession(title: "Test")
+        session.start()
+        #expect(session.status == .recording)
+    }
+
+    @Test func stopSetsStatusToEndedAndSetsEndDate() {
+        let session = MeetingSession(title: "Test")
+        session.start()
+        session.stop()
+        #expect(session.status == .ended)
+        #expect(session.endedAt != nil)
+    }
+
+    @Test func appendSegmentAddsToList() {
+        let session = MeetingSession(title: "Test")
+        let segment = TranscriptSegment(speaker: .me, text: "Hello", isFinal: true)
+        session.appendSegment(segment)
+        #expect(session.segments.count == 1)
+        #expect(session.segments.first?.text == "Hello")
+        #expect(session.segments.first?.speaker == .me)
+    }
+
+    @Test func appendMultipleSegments() {
+        let session = MeetingSession(title: "Test")
+        session.appendSegment(TranscriptSegment(speaker: .me, text: "Hello", isFinal: true))
+        session.appendSegment(TranscriptSegment(speaker: .other, text: "Hi there", isFinal: true))
+        session.appendSegment(TranscriptSegment(speaker: .me, text: "How are you?", isFinal: true))
+        #expect(session.segments.count == 3)
+    }
+
+    @Test func updateLastSegmentUpdatesExistingNonFinal() {
+        let session = MeetingSession(title: "Test")
+        session.updateLastSegment(for: .me, text: "Hel", isFinal: false)
+        #expect(session.segments.count == 1)
+        #expect(session.segments.first?.text == "Hel")
+        #expect(session.segments.first?.isFinal == false)
+
+        session.updateLastSegment(for: .me, text: "Hello world", isFinal: false)
+        #expect(session.segments.count == 1)
+        #expect(session.segments.first?.text == "Hello world")
+
+        session.updateLastSegment(for: .me, text: "Hello world!", isFinal: true)
+        #expect(session.segments.count == 1)
+        #expect(session.segments.first?.text == "Hello world!")
+        #expect(session.segments.first?.isFinal == true)
+    }
+
+    @Test func updateLastSegmentCreatesNewAfterFinal() {
+        let session = MeetingSession(title: "Test")
+        session.updateLastSegment(for: .me, text: "First sentence", isFinal: true)
+        #expect(session.segments.count == 1)
+
+        session.updateLastSegment(for: .me, text: "Second", isFinal: false)
+        #expect(session.segments.count == 2)
+        #expect(session.segments.last?.text == "Second")
+    }
+
+    @Test func updateLastSegmentTracksSpeakersSeparately() {
+        let session = MeetingSession(title: "Test")
+        session.updateLastSegment(for: .me, text: "Me partial", isFinal: false)
+        session.updateLastSegment(for: .other, text: "Other partial", isFinal: false)
+        #expect(session.segments.count == 2)
+
+        session.updateLastSegment(for: .me, text: "Me updated", isFinal: false)
+        #expect(session.segments.count == 2)
+        #expect(session.segments.first?.text == "Me updated")
+    }
+
+    @Test func durationCalculatesCorrectly() {
+        let start = Date(timeIntervalSinceNow: -120) // 2 minutes ago
+        let session = MeetingSession(title: "Test", startedAt: start)
+        #expect(session.duration >= 119)
+        #expect(session.duration <= 121)
+    }
+
+    @Test func durationUsesEndDateWhenEnded() {
+        let start = Date(timeIntervalSinceNow: -300) // 5 minutes ago
+        let session = MeetingSession(title: "Test", startedAt: start)
+        session.stop()
+        let duration = session.duration
+        // Should be approximately 300s, not growing
+        #expect(duration >= 299)
+        #expect(duration <= 301)
+    }
+
+    @Test func formattedDurationShowsMinutesAndSeconds() {
+        let start = Date(timeIntervalSinceNow: -90) // 1:30
+        let session = MeetingSession(title: "Test", startedAt: start)
+        let formatted = session.formattedDuration
+        #expect(formatted.contains(":"))
+    }
+
+    @Test func formattedDurationShowsHoursWhenNeeded() {
+        let start = Date(timeIntervalSinceNow: -3700) // > 1 hour
+        let session = MeetingSession(title: "Test", startedAt: start)
+        let formatted = session.formattedDuration
+        // Should have format like "1:01:40"
+        let colonCount = formatted.filter { $0 == ":" }.count
+        #expect(colonCount == 2)
+    }
+}
+
+@Suite
+struct TranscriptSegmentTests {
+    @Test func segmentHasUniqueId() {
+        let seg1 = TranscriptSegment(speaker: .me, text: "Hello")
+        let seg2 = TranscriptSegment(speaker: .me, text: "Hello")
+        #expect(seg1.id != seg2.id)
+    }
+
+    @Test func segmentDefaultsToCurrentTimestamp() {
+        let before = Date()
+        let segment = TranscriptSegment(speaker: .other, text: "Test")
+        let after = Date()
+        #expect(segment.timestamp >= before)
+        #expect(segment.timestamp <= after)
+    }
+
+    @Test func segmentDefaultsToNotFinal() {
+        let segment = TranscriptSegment(speaker: .me, text: "Test")
+        #expect(segment.isFinal == false)
+    }
+
+    @Test func speakerCodableRoundTrip() throws {
+        let cases: [Speaker] = [.me, .other, .unknown]
+        for speaker in cases {
+            let data = try JSONEncoder().encode(speaker)
+            let decoded = try JSONDecoder().decode(Speaker.self, from: data)
+            #expect(decoded == speaker)
+        }
+    }
+
+    @Test func segmentCodableRoundTrip() throws {
+        let segment = TranscriptSegment(speaker: .me, text: "Hello world", timestamp: Date(), isFinal: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let data = try encoder.encode(segment)
+        let decoded = try decoder.decode(TranscriptSegment.self, from: data)
+        #expect(decoded.id == segment.id)
+        #expect(decoded.speaker == segment.speaker)
+        #expect(decoded.text == segment.text)
+        #expect(decoded.isFinal == segment.isFinal)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/MeetingStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MeetingStoreTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct MeetingStoreTests {
+    /// Creates a temp directory and swaps the meetings dir for testing.
+    private func withTempMeetingsDir(_ body: (MeetingStore) throws -> Void) throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-meeting-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // We test the store via its public API, writing to the real meetings dir.
+        // Instead, we test the data roundtrip directly.
+        let store = MeetingStore.shared
+        try body(store)
+    }
+
+    @Test func storedMeetingCodableRoundTrip() throws {
+        let meeting = StoredMeeting(
+            id: UUID(),
+            title: "Weekly Standup",
+            startedAt: Date(),
+            endedAt: Date().addingTimeInterval(1800),
+            calendarEventId: "cal-abc",
+            attendees: ["alice@example.com", "bob@example.com"],
+            transcript: [
+                StoredMeeting.StoredSegment(speaker: .me, text: "Hello everyone", timestamp: Date()),
+                StoredMeeting.StoredSegment(speaker: .other, text: "Hi there", timestamp: Date()),
+                StoredMeeting.StoredSegment(speaker: .me, text: "Let's get started", timestamp: Date()),
+            ])
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(meeting)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(StoredMeeting.self, from: data)
+
+        #expect(decoded.id == meeting.id)
+        #expect(decoded.title == meeting.title)
+        #expect(decoded.calendarEventId == meeting.calendarEventId)
+        #expect(decoded.attendees.count == 2)
+        #expect(decoded.transcript.count == 3)
+        #expect(decoded.transcript[0].speaker == .me)
+        #expect(decoded.transcript[0].text == "Hello everyone")
+        #expect(decoded.transcript[1].speaker == .other)
+    }
+
+    @Test func storedMeetingWithNilOptionals() throws {
+        let meeting = StoredMeeting(
+            id: UUID(),
+            title: "Ad-hoc Call",
+            startedAt: Date(),
+            endedAt: nil,
+            calendarEventId: nil,
+            attendees: [],
+            transcript: [])
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(meeting)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(StoredMeeting.self, from: data)
+
+        #expect(decoded.title == "Ad-hoc Call")
+        #expect(decoded.endedAt == nil)
+        #expect(decoded.calendarEventId == nil)
+        #expect(decoded.attendees.isEmpty)
+        #expect(decoded.transcript.isEmpty)
+    }
+
+    @Test func meetingSummaryFormattedDuration() {
+        let summary = MeetingSummary(
+            id: UUID(),
+            title: "Test",
+            startedAt: Date(),
+            endedAt: Date().addingTimeInterval(5400), // 1.5 hours
+            segmentCount: 10,
+            fileName: "test.json")
+        #expect(summary.formattedDuration == "1h 30m")
+    }
+
+    @Test func meetingSummaryFormattedDurationShort() {
+        let summary = MeetingSummary(
+            id: UUID(),
+            title: "Quick",
+            startedAt: Date(),
+            endedAt: Date().addingTimeInterval(300), // 5 min
+            segmentCount: 3,
+            fileName: "quick.json")
+        #expect(summary.formattedDuration == "5m")
+    }
+
+    @Test func meetingSummaryFormattedDurationNoEndDate() {
+        let summary = MeetingSummary(
+            id: UUID(),
+            title: "Ongoing",
+            startedAt: Date(),
+            endedAt: nil,
+            segmentCount: 0,
+            fileName: "ongoing.json")
+        #expect(summary.formattedDuration == "–")
+    }
+
+    @Test func meetingSummaryFormattedDate() {
+        let summary = MeetingSummary(
+            id: UUID(),
+            title: "Test",
+            startedAt: Date(),
+            endedAt: nil,
+            segmentCount: 0,
+            fileName: "test.json")
+        #expect(!summary.formattedDate.isEmpty)
+    }
+
+    @Test func meetingSummaryDuration() {
+        let summary = MeetingSummary(
+            id: UUID(),
+            title: "Test",
+            startedAt: Date(),
+            endedAt: Date().addingTimeInterval(600),
+            segmentCount: 5,
+            fileName: "test.json")
+        #expect(summary.duration == 600)
+    }
+
+    @Test func saveAndLoadRoundTrip() throws {
+        let store = MeetingStore.shared
+        let session = MeetingSession(title: "Test Save Load")
+        session.start()
+        session.appendSegment(TranscriptSegment(speaker: .me, text: "Hello", isFinal: true))
+        session.appendSegment(TranscriptSegment(speaker: .other, text: "Hi", isFinal: true))
+        session.stop()
+
+        store.save(session: session)
+
+        // Verify it shows up in summaries
+        #expect(store.summaries.contains { $0.id == session.id })
+
+        // Verify we can load the full meeting
+        let loaded = store.load(id: session.id)
+        #expect(loaded != nil)
+        #expect(loaded?.title == "Test Save Load")
+        #expect(loaded?.transcript.count == 2)
+        #expect(loaded?.transcript[0].text == "Hello")
+        #expect(loaded?.transcript[1].text == "Hi")
+
+        // Clean up
+        store.delete(id: session.id)
+        #expect(!store.summaries.contains { $0.id == session.id })
+    }
+
+    @Test func saveFilterOutNonFinalSegments() {
+        let store = MeetingStore.shared
+        let session = MeetingSession(title: "Test Non-Final Filter")
+        session.start()
+        session.appendSegment(TranscriptSegment(speaker: .me, text: "Final text", isFinal: true))
+        session.appendSegment(TranscriptSegment(speaker: .other, text: "Partial", isFinal: false))
+        session.stop()
+
+        store.save(session: session)
+        let loaded = store.load(id: session.id)
+        // Only the final segment should be stored
+        #expect(loaded?.transcript.count == 1)
+        #expect(loaded?.transcript[0].text == "Final text")
+
+        store.delete(id: session.id)
+    }
+
+    @Test func deleteNonExistentIdIsNoOp() {
+        let store = MeetingStore.shared
+        let before = store.summaries.count
+        store.delete(id: UUID())
+        #expect(store.summaries.count == before)
+    }
+
+    @Test func loadNonExistentIdReturnsNil() {
+        let store = MeetingStore.shared
+        let result = store.load(id: UUID())
+        #expect(result == nil)
+    }
+
+    @Test func loadAllPopulatesSummaries() {
+        let store = MeetingStore.shared
+        store.loadAll()
+        // Just verify it doesn't crash and returns an array
+        #expect(store.summaries.count >= 0)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/MeetingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MeetingViewSmokeTests.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct MeetingViewSmokeTests {
+    @Test func meetingSettingsBuildsBody() {
+        let view = MeetingSettings()
+        _ = view.body
+    }
+
+    @Test func meetingMenuItemsBuildsBodyWithNoSession() {
+        MeetingDetector.shared.meetingDetectionEnabled = false
+        let view = MeetingMenuItems()
+        _ = view.body
+    }
+
+    @Test func meetingMenuItemsBuildsBodyWhenEnabled() {
+        MeetingDetector.shared.meetingDetectionEnabled = true
+        let view = MeetingMenuItems()
+        _ = view.body
+        // Reset
+        MeetingDetector.shared.meetingDetectionEnabled = false
+    }
+
+    @Test func settingsRootViewIncludesMeetingsTab() {
+        let state = AppState(preview: true)
+        let view = SettingsRootView(state: state, updater: nil, initialTab: .meetings)
+        _ = view.body
+    }
+
+    @Test func settingsTabEnumHasMeetings() {
+        #expect(SettingsTab.allCases.contains(.meetings))
+        #expect(SettingsTab.meetings.title == "Meetings")
+        #expect(SettingsTab.meetings.systemImage == "text.bubble")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/WideAreaGatewayDiscoveryTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WideAreaGatewayDiscoveryTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Testing
 @testable import OpenClawDiscovery
 


### PR DESCRIPTION
## Summary

Adds a full meeting notes feature to the macOS menu bar app, inspired by [Granola](https://granola.so):

- **Live transcription** during meetings using WhisperKit (local, on-device) or Apple Speech
- **Auto-start/stop** meeting notes when joining/leaving calls (mic activity detection via CoreAudio polling)
- **Calendar integration** — auto-start for scheduled meetings with 2+ attendees
- **Markdown storage** with optional Google Drive sync
- **Standalone Meeting Notes window** for browsing past meetings (extracted from Settings)
- **Menu bar recording indicator** — red dot on critter icon + separate timer status item with stop/open controls
- **Ad-hoc detection** — polls `kAudioDevicePropertyDeviceIsRunningSomewhere` across all input devices; uses pause-probe to distinguish own transcriber from meeting app mic usage

### Key files
| File | Purpose |
|------|---------|
| `MeetingDetector.swift` | Calendar monitoring, mic polling, auto-start/stop logic |
| `MeetingSession.swift` | Session model with segments, duration, speaker attribution |
| `MeetingStore.swift` | Markdown persistence + Google Drive sync |
| `MeetingTranscriber.swift` | Apple Speech engine (SFSpeechRecognizer + ScreenCaptureKit) |
| `WhisperTranscriber.swift` | WhisperKit local engine with model management |
| `MeetingSettings.swift` | Settings tab for engine selection, model downloads, sync config |
| `MeetingNotesWindow.swift` | Standalone past-meetings browser (HSplitView) |
| `MeetingMenuItems.swift` | Menu bar start/stop/past-meetings buttons |
| `MeetingRecordingStatusItem.swift` | Live timer NSStatusItem with stop/open menu |

## AI-assisted

- [x] AI-assisted (Claude Code)
- [x] Lightly tested — verified on macOS with Google Meet calls
- [x] I understand what the code does

## Test plan

- [x] Enable "Meeting Notes" in Settings → Meetings
- [x] Join a Google Meet / Zoom / FaceTime call — meeting notes should auto-start within ~2s
- [x] Verify live transcription appears (WhisperKit processes 5s chunks)
- [x] Leave the call — recording should auto-stop within ~20s (2 consecutive idle probes)
- [x] Check menu bar: red dot on critter icon during recording, timer status item with stop/open
- [x] Open "Past Meetings" from menu bar or Settings — standalone window with transcript browser
- [x] Delete meetings via multi-select + Delete key
- [x] Switch transcription engine in Settings (Whisper ↔ Apple Speech)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a macOS “Meeting Notes” feature: calendar + microphone-based meeting detection, live transcription via WhisperKit or Apple Speech, markdown persistence with optional Google Drive sync, a standalone past-meetings browser window, and new menu bar/status-item UI to control/indicate recording.

Key new components include `MeetingDetector` (auto start/stop orchestration), `MeetingSession` (segment model), `MeetingStore` (markdown save/load + sync), `MeetingTranscriber`/`WhisperTranscriber` (engines), and associated settings/menu/window/status-item views. Existing UI is updated to show a recording indicator on the critter icon and to surface meeting controls when enabled.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has correctness issues that should be fixed before merge.
- Score reduced due to a failing/incorrect unit test expectation, and meeting persistence issues where metadata can be silently lost or misparsed from frontmatter (titles containing ':'). There is also a lifecycle issue where the status-item watcher can spawn duplicate polling tasks if started multiple times.
- apps/macos/Sources/OpenClaw/MeetingStore.swift, apps/macos/Tests/OpenClawIPCTests/MeetingSessionTests.swift, apps/macos/Sources/OpenClaw/MeetingRecordingStatusItem.swift

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->