### PR TITLE
fix: harden resolveUserPath and compact against undefined workspaceDir

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -19,7 +19,6 @@ import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
-import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
@@ -59,6 +58,7 @@ import {
   type SkillSnapshot,
 } from "../skills.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
+import { resolveRunWorkspaceDir } from "../workspace-run.js";
 import {
   compactWithSafetyTimeout,
   EMBEDDED_COMPACTION_TIMEOUT_MS,
@@ -253,7 +253,12 @@ export async function compactEmbeddedPiSessionDirect(
   const attempt = params.attempt ?? 1;
   const maxAttempts = params.maxAttempts ?? 1;
   const runId = params.runId ?? params.sessionId;
-  const resolvedWorkspace = resolveUserPath(params.workspaceDir);
+  const workspaceResolution = resolveRunWorkspaceDir({
+    workspaceDir: params.workspaceDir,
+    sessionKey: params.sessionKey,
+    config: params.config,
+  });
+  const resolvedWorkspace = workspaceResolution.workspaceDir;
   const prevCwd = process.cwd();
 
   const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
@@ -551,7 +556,7 @@ export async function compactEmbeddedPiSessionDirect(
       });
 
       const { session } = await createAgentSession({
-        cwd: resolvedWorkspace,
+        cwd: effectiveWorkspace,
         agentDir,
         authStorage,
         modelRegistry,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -576,7 +576,7 @@ export async function runEmbeddedAttempt(
       const allCustomTools = [...customTools, ...clientToolDefs];
 
       ({ session } = await createAgentSession({
-        cwd: resolvedWorkspace,
+        cwd: effectiveWorkspace,
         agentDir,
         authStorage: params.authStorage,
         modelRegistry: params.modelRegistry,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -222,4 +222,10 @@ describe("resolveUserPath", () => {
     expect(resolveUserPath("")).toBe("");
     expect(resolveUserPath("   ")).toBe("");
   });
+
+  it("returns empty string for undefined/null input instead of crashing", () => {
+    // This should not throw "Cannot read properties of undefined (reading 'trim')"
+    expect(resolveUserPath(undefined as unknown as string)).toBe("");
+    expect(resolveUserPath(null as unknown as string)).toBe("");
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -293,6 +293,9 @@ export function truncateUtf16Safe(input: string, maxLen: number): string {
 }
 
 export function resolveUserPath(input: string): string {
+  if (!input) {
+    return "";
+  }
   const trimmed = input.trim();
   if (!trimmed) {
     return trimmed;


### PR DESCRIPTION
## Summary

- Guard `resolveUserPath()` against `undefined`/`null` input — previously crashed with `Cannot read properties of undefined (reading 'trim')`
- Update `compactEmbeddedPiSessionDirect()` to use `resolveRunWorkspaceDir()` instead of calling `resolveUserPath()` directly with a potentially undefined `params.workspaceDir`

## Root cause

Sub-agent compaction passes `params.workspaceDir` to `resolveUserPath()`, but `workspaceDir` can be `undefined` when the session was created without an explicit workspace. The `.trim()` call on line 241 of `utils.ts` crashes on `undefined`.

## Changes

- `src/utils.ts`: Early return `""` for falsy input in `resolveUserPath()`
- `src/agents/pi-embedded-runner/compact.ts`: Use `resolveRunWorkspaceDir()` for proper workspace resolution (consistent with `runEmbeddedAttempt`)
- `src/utils.test.ts`: Test covering `undefined` and `null` inputs

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test src/utils.test.ts` — 26 tests pass, including new undefined/null guard test
- [x] Rebased on latest `main`, no conflicts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens path/workspace handling in two places:

- `resolveUserPath()` now returns an empty string for falsy inputs (preventing `.trim()` crashes on `undefined`/`null`).
- Embedded PI session compaction now resolves the workspace via `resolveRunWorkspaceDir()` instead of calling `resolveUserPath(params.workspaceDir)` directly, aligning compaction’s workspace resolution with the runner.
- Adds a regression test in `src/utils.test.ts` covering `undefined`/`null` inputs to `resolveUserPath`.

Overall, this fits into the codebase’s existing workspace resolution flow by centralizing fallback behavior in `resolveRunWorkspaceDir()` and making `resolveUserPath()` safer at the boundary where user/config values can be missing.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is one likely sandbox-related cwd mismatch that can break compaction in sandboxed runs.
- Changes are small and well-scoped with a regression test added; the main concern is `createAgentSession` being instantiated with `cwd: resolvedWorkspace` while the rest of the compaction path uses `effectiveWorkspace` (post-sandbox), which can diverge when sandboxing is enabled.
- src/agents/pi-embedded-runner/compact.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->