### PR TITLE
fix(agents): add path containment check in apply_patch for non-sandboxed mode

### DIFF
--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -229,6 +229,11 @@ async function resolvePatchPath(
   }
 
   const resolved = resolvePathFromCwd(filePath, options.cwd);
+  const cwdResolved = path.resolve(options.cwd);
+  const relative = path.relative(cwdResolved, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Path escapes workspace root: ${filePath}`);
+  }
   return {
     resolved,
     display: toDisplayPath(resolved, options.cwd),


### PR DESCRIPTION
## Fix Summary

Add a workspace root containment check in `resolvePatchPath()` for the non-sandboxed code path. When `sandboxRoot` is `undefined`, the function now verifies that the resolved path stays within `cwd` (the workspace root), rejecting `../` traversal and absolute paths with a clear error message.

## Issue Linkage

Fixes #12173

## Security Snapshot

- CVSS v3.1: 8.5 (High)
- CVSS v4.0: 8.4 (High)

## Implementation Details

### Files Changed
- `src/agents/apply-patch.test.ts` (+37/-0)
- `src/agents/apply-patch.ts` (+5/-0)

### Technical Analysis
- Added 4-line containment check in `resolvePatchPath()` (`src/agents/apply-patch.ts:231-234`)
- Mirrors the existing `resolveSandboxPath` pattern from `sandbox-paths.ts`
- Computes `path.relative(cwd, resolved)` and rejects if it starts with `..` or is absolute

## Validation Evidence

- Command: `pnpm build`
- Status: passed

## Risk and Compatibility

- **Blast radius:** Minimal — only affects the non-sandboxed `apply_patch` code path
- **Backward compatible:** Yes — only rejects paths that were already outside the intended workspace
- **No behavioral change** for legitimate use (relative paths within workspace)

Fixes #12173

## AI-Assisted Disclosure

🤖 Generated with [Claude Code](https://claude.ai/code)

This fix was generated with AI assistance (Claude Opus 4.6).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens `apply_patch` when running without a sandbox root by adding a workspace-root containment check in `resolvePatchPath()`. It rejects absolute paths and `../`-style traversal in the non-sandboxed code path and adds tests covering traversal rejection, absolute path rejection, and an allowed in-workspace relative path.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the new containment check can incorrectly reject some valid in-workspace paths.
- The change is small and well-targeted, but the use of `relative.startsWith("..")` will block legitimate filenames/directories beginning with `..` (e.g. `..foo/`), which is a functional regression for those cases and should be corrected before merging.
- src/agents/apply-patch.ts (workspace containment logic); src/agents/apply-patch.test.ts (add coverage for '..foo' case)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
