### PR TITLE
fix: thinking toggle invisible in light mode

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -386,6 +386,12 @@
   color: var(--text);
 }
 
+:root[data-theme="light"] .btn--icon.active {
+  background: var(--accent-subtle);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .btn--icon svg {
   display: block;
   width: 18px;


### PR DESCRIPTION
Fixes #6541

## Problem
The thinking toggle button (and other icon buttons) in the chat toolbar have no visual distinction between active/inactive states in light mode. The `:root[data-theme="light"] .btn--icon` override sets `background: #ffffff` which has higher specificity than `.btn.active`, making the accent background invisible.

## Fix
Added a `:root[data-theme="light"] .btn--icon.active` rule that restores the accent styling (`--accent-subtle` background, `--accent` border and color) for active icon buttons in light mode. This matches the existing dark-mode behavior where `.btn.active` applies correctly.

## Changes
- `ui/src/styles/chat/layout.css`: +6 lines (one CSS rule)

## Testing
Visual check: active icon buttons in light mode now show red accent background/border consistent with the dark mode active state.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts chat toolbar icon button styling in light mode by adding a `:root[data-theme="light"] .btn--icon.active` rule in `ui/src/styles/chat/layout.css`. The new selector restores the same accent background/border/text colors used by the global `.btn.active` styles, but with higher specificity than the existing light-mode `.btn--icon` override, making active/inactive states visually distinct again in light theme.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted CSS specificity fix limited to light theme active icon buttons, and it aligns with existing `.btn.active` token usage (var(--accent*)), with no behavioral or runtime impact beyond intended styling.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->