### PR TITLE
fix(message): add threadId parameter to fetch schema for Slack thread reading

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -130,6 +130,7 @@ function buildFetchSchema() {
     before: Type.Optional(Type.String()),
     after: Type.Optional(Type.String()),
     around: Type.Optional(Type.String()),
+    threadId: Type.Optional(Type.String()),
     fromMe: Type.Optional(Type.Boolean()),
     includeArchived: Type.Optional(Type.Boolean()),
   };


### PR DESCRIPTION
## Problem
The message tool could send messages to Slack threads but couldn't read thread replies.

When calling:
```javascript
message(action='read', channel='slack', target='<channel>', threadId='<ts>', limit=10)
```

The tool would return channel messages instead of thread replies.

## Root Cause
The `threadId` parameter was only defined in `buildSendSchema()` (for sending to threads) but not in `buildFetchSchema()` (for reading messages).

The backend Slack implementation (`src/slack/actions.ts`) has always supported thread reading via the `conversations.replies` API - the parameter just wasn't exposed in the tool schema.

## Solution
Added `threadId: Type.Optional(Type.String())` to `buildFetchSchema()` in `src/agents/tools/message-tool.ts`.

## Testing
Direct API verification confirmed the backend implementation works correctly when the parameter is provided.

## Files Changed
- `src/agents/tools/message-tool.ts` - Added threadId to buildFetchSchema()

## Impact
- Enables full thread reading for Slack
- Matches existing thread sending capability
- No breaking changes - parameter is optional
- Works with existing backend implementation

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an optional `threadId` parameter to the message tool’s fetch/read schema (`src/agents/tools/message-tool.ts`) so callers can request Slack thread replies when using the existing backend support for `conversations.replies`.

This change aligns the read schema with the already-supported send-to-thread behavior, without altering runtime execution logic (only schema exposure).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow schema-only addition (`threadId` optional) that matches existing send schema and does not affect execution flow; no conflicting properties or type issues were introduced in the modified file.
- src/agents/tools/message-tool.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->