### PR TITLE
test: skip unix-path OPENCLAW_HOME tests on Windows

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -207,14 +207,16 @@ describe("resolveAgentConfig", () => {
     expect(result?.workspace).toBe("~/openclaw");
   });
 
-  it("uses OPENCLAW_HOME for default agent workspace", () => {
+  // Unix-style paths behave differently on Windows; skip there
+  it.skipIf(process.platform === "win32")("uses OPENCLAW_HOME for default agent workspace", () => {
     vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
 
     const workspace = resolveAgentWorkspaceDir({} as OpenClawConfig, "main");
     expect(workspace).toBe("/srv/openclaw-home/.openclaw/workspace");
   });
 
-  it("uses OPENCLAW_HOME for default agentDir", () => {
+  // Unix-style paths behave differently on Windows; skip there
+  it.skipIf(process.platform === "win32")("uses OPENCLAW_HOME for default agentDir", () => {
     vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
 
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -6,7 +6,8 @@ afterEach(() => {
 });
 
 describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
-  it("uses OPENCLAW_HOME at module import time", async () => {
+  // Unix-style paths behave differently on Windows; skip there
+  it.skipIf(process.platform === "win32")("uses OPENCLAW_HOME at module import time", async () => {
     vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
     vi.stubEnv("HOME", "/home/other");
     vi.resetModules();


### PR DESCRIPTION
Fixes Windows CI failures introduced by #11881.

Tests that set `OPENCLAW_HOME` to Unix-style paths like `/srv/openclaw-home` behave differently on Windows (path separators, drive letters). These tests are skipped on Windows since they're testing Unix-specific behavior.

## Changes
- Skip `agent-scope.test.ts` tests for `OPENCLAW_HOME` on Windows
- Skip `workspace.defaults.test.ts` test for `OPENCLAW_HOME` on Windows

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts a small set of unit tests that hard-code Unix-style `OPENCLAW_HOME` values (e.g. `/srv/openclaw-home`) to be skipped on Windows (`process.platform === "win32"`). This avoids Windows CI failures where path parsing/normalization behaves differently (drive letters and path separators), while preserving the Unix/Nix coverage of these env-driven defaults.

Changes are localized to the `src/agents/*` test suite and follow an existing repo pattern (`it.skipIf(process.platform === "win32")`) already used in other configuration tests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is limited to test gating on Windows and uses an existing, already-used Vitest pattern in this repository (`it.skipIf(process.platform === "win32")`), so it should not introduce runtime or build changes outside the test suite.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->