### PR TITLE
fix(gateway): use timing-safe comparison for hook token authentication

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1,5 +1,6 @@
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
+import { timingSafeEqual } from "node:crypto";
 import {
   createServer as createHttpServer,
   type Server as HttpServer,
@@ -157,7 +158,11 @@ export function createHooksRequestHandler(
     }
 
     const token = extractHookToken(req);
-    if (!token || token !== hooksConfig.token) {
+    if (
+      !token ||
+      token.length !== hooksConfig.token.length ||
+      !timingSafeEqual(Buffer.from(token), Buffer.from(hooksConfig.token))
+    ) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");


### PR DESCRIPTION
## Summary

- The hook endpoint in `server-http.ts` compared tokens using JavaScript strict equality (`!==`), which is susceptible to timing attacks
- The gateway auth system (`auth.ts:35-40`) already uses `crypto.timingSafeEqual` for token and password comparisons, but the hooks handler bypassed this
- Switches to `timingSafeEqual` with a length pre-check, consistent with the rest of the gateway auth layer

## Test plan

- [ ] Verify hook endpoint still rejects invalid tokens (401)
- [ ] Verify hook endpoint still accepts valid tokens
- [ ] Confirm no behavioral change beyond timing-safe comparison

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the hooks HTTP handler in `src/gateway/server-http.ts` to authenticate the hook token using `crypto.timingSafeEqual` instead of strict string equality, aligning hook auth with the gateway’s timing-safe comparisons used elsewhere.

The main area to double-check is the new length pre-check vs the actual bytes passed to `timingSafeEqual`, to avoid runtime exceptions and unintended 500 responses for certain token values.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a concrete edge-case that can cause 500 responses during hook auth.
- The change is small and improves security, but the current length pre-check is on JS string length while `timingSafeEqual` operates on byte buffers; for non-ASCII tokens this can throw at runtime and change behavior from 401 to 500.
- src/gateway/server-http.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->