### PR TITLE
test: normalize paths in OPENCLAW_HOME tests for cross-platform support

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -208,22 +208,21 @@ describe("resolveAgentConfig", () => {
     expect(result?.workspace).toBe("~/openclaw");
   });
 
-  // Unix-style paths behave differently on Windows; skip there
-  it.skipIf(process.platform === "win32")("uses OPENCLAW_HOME for default agent workspace", () => {
-    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+  it("uses OPENCLAW_HOME for default agent workspace", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
 
     const workspace = resolveAgentWorkspaceDir({} as OpenClawConfig, "main");
-    expect(workspace).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
+    expect(workspace).toBe(path.join(home, ".openclaw", "workspace"));
   });
 
-  // Unix-style paths behave differently on Windows; skip there
-  it.skipIf(process.platform === "win32")("uses OPENCLAW_HOME for default agentDir", () => {
-    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+  it("uses OPENCLAW_HOME for default agentDir", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    // Clear state dir so it falls back to OPENCLAW_HOME
     vi.stubEnv("OPENCLAW_STATE_DIR", "");
 
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");
-    expect(agentDir).toBe(
-      path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "agents", "main", "agent"),
-    );
+    expect(agentDir).toBe(path.join(home, ".openclaw", "agents", "main", "agent"));
   });
 });

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -213,7 +213,7 @@ describe("resolveAgentConfig", () => {
     vi.stubEnv("OPENCLAW_HOME", home);
 
     const workspace = resolveAgentWorkspaceDir({} as OpenClawConfig, "main");
-    expect(workspace).toBe(path.join(home, ".openclaw", "workspace"));
+    expect(workspace).toBe(path.join(path.resolve(home), ".openclaw", "workspace"));
   });
 
   it("uses OPENCLAW_HOME for default agentDir", () => {
@@ -223,6 +223,6 @@ describe("resolveAgentConfig", () => {
     vi.stubEnv("OPENCLAW_STATE_DIR", "");
 
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");
-    expect(agentDir).toBe(path.join(home, ".openclaw", "agents", "main", "agent"));
+    expect(agentDir).toBe(path.join(path.resolve(home), ".openclaw", "agents", "main", "agent"));
   });
 });

--- a/src/agents/pi-embedded-runner.test.ts
+++ b/src/agents/pi-embedded-runner.test.ts
@@ -173,7 +173,6 @@ const readSessionMessages = async (sessionFile: string) => {
 };
 
 describe("runEmbeddedPiAgent", () => {
-  const itIfNotWin32 = process.platform === "win32" ? it.skip : it;
   it("writes models.json into the provided agentDir", async () => {
     const sessionFile = nextSessionFile();
 
@@ -288,39 +287,35 @@ describe("runEmbeddedPiAgent", () => {
     ).rejects.toThrow("Malformed agent session key");
   });
 
-  itIfNotWin32(
-    "persists the first user message before assistant output",
-    { timeout: 120_000 },
-    async () => {
-      const sessionFile = nextSessionFile();
-      const cfg = makeOpenAiConfig(["mock-1"]);
-      await ensureModels(cfg);
+  it("persists the first user message before assistant output", { timeout: 120_000 }, async () => {
+    const sessionFile = nextSessionFile();
+    const cfg = makeOpenAiConfig(["mock-1"]);
+    await ensureModels(cfg);
 
-      await runEmbeddedPiAgent({
-        sessionId: "session:test",
-        sessionKey: testSessionKey,
-        sessionFile,
-        workspaceDir,
-        config: cfg,
-        prompt: "hello",
-        provider: "openai",
-        model: "mock-1",
-        timeoutMs: 5_000,
-        agentDir,
-        enqueue: immediateEnqueue,
-      });
+    await runEmbeddedPiAgent({
+      sessionId: "session:test",
+      sessionKey: testSessionKey,
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      provider: "openai",
+      model: "mock-1",
+      timeoutMs: 5_000,
+      agentDir,
+      enqueue: immediateEnqueue,
+    });
 
-      const messages = await readSessionMessages(sessionFile);
-      const firstUserIndex = messages.findIndex(
-        (message) => message?.role === "user" && textFromContent(message.content) === "hello",
-      );
-      const firstAssistantIndex = messages.findIndex((message) => message?.role === "assistant");
-      expect(firstUserIndex).toBeGreaterThanOrEqual(0);
-      if (firstAssistantIndex !== -1) {
-        expect(firstUserIndex).toBeLessThan(firstAssistantIndex);
-      }
-    },
-  );
+    const messages = await readSessionMessages(sessionFile);
+    const firstUserIndex = messages.findIndex(
+      (message) => message?.role === "user" && textFromContent(message.content) === "hello",
+    );
+    const firstAssistantIndex = messages.findIndex((message) => message?.role === "assistant");
+    expect(firstUserIndex).toBeGreaterThanOrEqual(0);
+    if (firstAssistantIndex !== -1) {
+      expect(firstUserIndex).toBeLessThan(firstAssistantIndex);
+    }
+  });
 
   it("persists the user message when prompt fails before assistant output", async () => {
     const sessionFile = nextSessionFile();

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -7,15 +7,13 @@ afterEach(() => {
 });
 
 describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
-  // Unix-style paths behave differently on Windows; skip there
-  it.skipIf(process.platform === "win32")("uses OPENCLAW_HOME at module import time", async () => {
-    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
-    vi.stubEnv("HOME", "/home/other");
+  it("uses OPENCLAW_HOME at module import time", async () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    vi.stubEnv("HOME", path.join(path.sep, "home", "other"));
     vi.resetModules();
 
     const mod = await import("./workspace.js");
-    expect(mod.DEFAULT_AGENT_WORKSPACE_DIR).toBe(
-      path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"),
-    );
+    expect(mod.DEFAULT_AGENT_WORKSPACE_DIR).toBe(path.join(home, ".openclaw", "workspace"));
   });
 });

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -14,6 +14,8 @@ describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
     vi.resetModules();
 
     const mod = await import("./workspace.js");
-    expect(mod.DEFAULT_AGENT_WORKSPACE_DIR).toBe(path.join(home, ".openclaw", "workspace"));
+    expect(mod.DEFAULT_AGENT_WORKSPACE_DIR).toBe(
+      path.join(path.resolve(home), ".openclaw", "workspace"),
+    );
   });
 });

--- a/src/config/config.nix-integration-u3-u5-u9.test.ts
+++ b/src/config/config.nix-integration-u3-u5-u9.test.ts
@@ -49,37 +49,31 @@ describe("Nix integration (U3, U5, U9)", () => {
       });
     });
 
-    // Skip on Windows: these tests use Unix-style paths that only make sense on Nix/Unix
-    it.skipIf(process.platform === "win32")(
-      "STATE_DIR respects OPENCLAW_HOME when state override is unset",
-      async () => {
-        await withEnvOverride(
-          { OPENCLAW_HOME: "/custom/home", OPENCLAW_STATE_DIR: undefined },
-          async () => {
-            const { STATE_DIR } = await import("./config.js");
-            expect(STATE_DIR).toBe(path.resolve("/custom/home/.openclaw"));
-          },
-        );
-      },
-    );
+    it("STATE_DIR respects OPENCLAW_HOME when state override is unset", async () => {
+      const customHome = path.join(path.sep, "custom", "home");
+      await withEnvOverride(
+        { OPENCLAW_HOME: customHome, OPENCLAW_STATE_DIR: undefined },
+        async () => {
+          const { STATE_DIR } = await import("./config.js");
+          expect(STATE_DIR).toBe(path.join(customHome, ".openclaw"));
+        },
+      );
+    });
 
-    // Skip on Windows: these tests use Unix-style paths that only make sense on Nix/Unix
-    it.skipIf(process.platform === "win32")(
-      "CONFIG_PATH defaults to OPENCLAW_HOME/.openclaw/openclaw.json",
-      async () => {
-        await withEnvOverride(
-          {
-            OPENCLAW_HOME: "/custom/home",
-            OPENCLAW_CONFIG_PATH: undefined,
-            OPENCLAW_STATE_DIR: undefined,
-          },
-          async () => {
-            const { CONFIG_PATH } = await import("./config.js");
-            expect(CONFIG_PATH).toBe(path.resolve("/custom/home/.openclaw/openclaw.json"));
-          },
-        );
-      },
-    );
+    it("CONFIG_PATH defaults to OPENCLAW_HOME/.openclaw/openclaw.json", async () => {
+      const customHome = path.join(path.sep, "custom", "home");
+      await withEnvOverride(
+        {
+          OPENCLAW_HOME: customHome,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          const { CONFIG_PATH } = await import("./config.js");
+          expect(CONFIG_PATH).toBe(path.join(customHome, ".openclaw", "openclaw.json"));
+        },
+      );
+    });
 
     it("CONFIG_PATH defaults to ~/.openclaw/openclaw.json when env not set", async () => {
       await withEnvOverride(

--- a/src/config/config.nix-integration-u3-u5-u9.test.ts
+++ b/src/config/config.nix-integration-u3-u5-u9.test.ts
@@ -55,7 +55,7 @@ describe("Nix integration (U3, U5, U9)", () => {
         { OPENCLAW_HOME: customHome, OPENCLAW_STATE_DIR: undefined },
         async () => {
           const { STATE_DIR } = await import("./config.js");
-          expect(STATE_DIR).toBe(path.join(customHome, ".openclaw"));
+          expect(STATE_DIR).toBe(path.join(path.resolve(customHome), ".openclaw"));
         },
       );
     });
@@ -70,7 +70,9 @@ describe("Nix integration (U3, U5, U9)", () => {
         },
         async () => {
           const { CONFIG_PATH } = await import("./config.js");
-          expect(CONFIG_PATH).toBe(path.join(customHome, ".openclaw", "openclaw.json"));
+          expect(CONFIG_PATH).toBe(
+            path.join(path.resolve(customHome), ".openclaw", "openclaw.json"),
+          );
         },
       );
     });


### PR DESCRIPTION
Fix Windows CI test failures caused by Unix-style path literals (e.g., `/srv/openclaw-home`) in tests. Instead of skipping tests on Windows, normalize paths using `path.join(path.sep, ...)` for cross-platform compatibility.

Tests now also account for `path.resolve()` behavior from #12125.

## Changes

### `src/agents/agent-scope.test.ts`
- Replace hardcoded `/srv/openclaw-home` paths with `path.join(path.sep, "srv", "openclaw-home")` 
- Clear `OPENCLAW_STATE_DIR` to ensure `OPENCLAW_HOME` fallback is properly tested
- Use `path.resolve(home)` in expectations for cross-platform compatibility

### `src/agents/workspace.defaults.test.ts`
- Same path normalization approach with `path.resolve()`

### `src/config/config.nix-integration-u3-u5-u9.test.ts`
- Normalize `/custom/home` paths to use `path.join(path.sep, ...)`
- Use `path.resolve()` in expectations to match production behavior

### `src/agents/pi-embedded-runner.test.ts`
- Remove unnecessary `itIfNotWin32` skip - test runs fine on Windows

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- `pnpm vitest run src/agents/agent-scope.test.ts` - all 10 tests pass
- `pnpm vitest run src/agents/workspace.defaults.test.ts` - all 1 test passes  
- `pnpm vitest run src/config/config.nix-integration-u3-u5-u9.test.ts` - all 19 tests pass
- `pnpm vitest run src/agents/pi-embedded-runner.test.ts` - all 9 tests pass
- `pnpm check` passes

Fixes Windows CI failures from #11881.