### PR TITLE
fix(gateway): include ui helper in npm package with source guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "openclaw.mjs",
     "README-header.png",
     "README.md",
+    "scripts/ui.js",
     "skills/"
   ],
   "type": "module",

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -9,6 +9,13 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 const uiDir = path.join(repoRoot, "ui");
 
+if (!fs.existsSync(uiDir)) {
+  process.stderr.write(
+    "Control UI source directory (ui/) not found. This command is only available in source installs.\n",
+  );
+  process.exit(1);
+}
+
 function usage() {
   // keep this tiny; it's invoked from npm scripts too
   process.stderr.write("Usage: node scripts/ui.js <install|dev|build|test> [...args]\n");


### PR DESCRIPTION
# Problem
The `scripts/ui.js` helper, which is essential for certain build and development workflows, was previously excluded from the published npm package. This caused failures for users attempting to run UI-related commands from an installed package environment. However, since the script relies on the presence of the `ui/` source directory (which is typically not included in the distribution), running it without proper guards led to confusing errors.

# Changes
- **Packaging Manifest**: Updated `package.json` to include `scripts/ui.js` in the `files` list, ensuring it is available in the npm distribution.
- **Runtime Guard**: Added an explicit check in `scripts/ui.js` to verify the existence of the `ui/` source directory. If the directory is missing, the script now exits gracefully with an informative message explaining that UI commands require a full source checkout.
- **Error Messaging**: Improved the developer experience by providing clear feedback when environment requirements are not met, preventing cryptic Node.js file system errors.

# Validation
- **Package Audit**: Verified that `scripts/ui.js` is present in the generated pack list.
- **Guard Testing**: Confirmed that the script correctly identifies the absence of the `ui/` folder in a simulated npm install environment and provides the expected warning message.
- **Linting**: Passed `pnpm lint`.