### PR TITLE
fix(cron): ensure computeNextRunAtMs is deterministic

### DIFF
--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -49,10 +49,7 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
     timezone: resolveCronTimezone(schedule.tz),
     catch: false,
   });
-  // Use a tiny lookback (1ms) so croner doesn't skip the current second
-  // boundary. Without this, a job updated at exactly its cron time would
-  // be scheduled for the *next* matching time (e.g. 24h later for daily).
-  const next = cron.nextRun(new Date(nowMs - 1));
+  const next = cron.nextRun(new Date(nowMs));
   if (!next) {
     return undefined;
   }


### PR DESCRIPTION
Addresses Greptile review for #11824 by using explicit nowMs baseline.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `computeNextRunAtMs` to call `croner.nextRun()` using an explicit `nowMs` baseline (instead of a 1ms lookback) to make next-run computation deterministic.

The function is the central place where OpenClaw converts stored cron/interval/absolute schedules into a concrete `nextRunAtMs` timestamp used by the scheduler.

<h3>Confidence Score: 3/5</h3>

- This PR is relatively small, but it changes cron boundary semantics in a way that can skip runs at exact scheduled times.
- Only one line changed, but it removes an explicit 1ms lookback that was guarding against a known boundary condition; if `croner.nextRun()` treats equality as ‘passed’, jobs recomputed exactly at their scheduled time could be delayed by a full interval.
- src/cron/schedule.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->