### PR TITLE
fix: remove billing error false-positive from sanitizeUserFacingText

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -60,4 +60,17 @@ describe("sanitizeUserFacingText", () => {
     const text = "Hello there!\n\nDifferent line.";
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
+
+  it("does not false-positive on billing-related words in normal AI responses", () => {
+    const samples = [
+      "Check your billing plan for details.",
+      "The credit balance on the account is sufficient.",
+      "Please update your payment method in the billing portal.",
+      "Here's a summary of your billing and payment history.",
+      "Error 402 is a payment required status code in HTTP.",
+    ];
+    for (const sample of samples) {
+      expect(sanitizeUserFacingText(sample)).toBe(sample);
+    }
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -424,10 +424,6 @@ export function sanitizeUserFacingText(text: string): string {
     );
   }
 
-  if (isBillingErrorMessage(trimmed)) {
-    return BILLING_ERROR_USER_MESSAGE;
-  }
-
   if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {
     return formatRawAssistantErrorForUi(trimmed);
   }


### PR DESCRIPTION
## Summary
- `sanitizeUserFacingText()` runs on **all** outgoing messages (Telegram, Slack, etc.) and calls `isBillingErrorMessage()` which false-positive matches common words like "billing plan", "credit balance", "payment" in normal AI responses
- When triggered, the entire AI response is replaced with the billing error banner — users reported this as a persistent issue on Telegram (#11359)
- Real billing errors are already caught by `formatAssistantErrorText()` which correctly gates on `stopReason === "error"` before checking billing patterns (line 331 + 388)
- The `isBillingErrorMessage()` check in `sanitizeUserFacingText()` is redundant and harmful — removed it
- User @afiffattouh confirmed the root cause analysis and verified the patch works

## Test plan
- [x] Added regression test with 5 false-positive samples ("billing plan", "credit balance", "payment method", etc.)
- [x] All 11 sanitize tests pass
- [x] Billing error detection tests still pass (isBillingErrorMessage unchanged)
- [x] `formatAssistantErrorText` still catches real billing errors via `stopReason === "error"` gate

Closes #11359

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change removes the `isBillingErrorMessage(trimmed)` branch from `sanitizeUserFacingText()` so that normal assistant responses mentioning billing-related terms (e.g., “billing plan”, “credit balance”, “payment method”) are no longer replaced with the generic billing banner.

Billing error detection remains in `formatAssistantErrorText()`, which is only used for assistant messages where `stopReason === "error"` (or an explicit `errorMessage`), keeping the billing banner behavior scoped to real provider failures. A regression test was added to ensure billing-related words in normal responses are preserved.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped: removing a redundant billing-error rewrite from sanitizeUserFacingText and adding a regression test. Billing banner behavior remains enforced via formatAssistantErrorText for stopReason==='error'. No behavioral issues found in the modified logic beyond the intended fix.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->