### PR TITLE
fix: wrap waitForCompactionRetry with abort signal to prevent session lock leak

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -830,7 +830,7 @@ export async function runEmbeddedAttempt(
         }
 
         try {
-          await waitForCompactionRetry();
+          await abortable(waitForCompactionRetry());
         } catch (err) {
           if (isAbortError(err)) {
             if (!promptError) {


### PR DESCRIPTION
## Summary
- After an embedded run is aborted (timeout or external abort), `waitForCompactionRetry()` hangs indefinitely because it waits for compaction events that never arrive post-abort
- This prevents the `finally` block from executing, so `clearActiveEmbeddedRun()` and `sessionLock.release()` are never called
- The session stays in `ACTIVE_EMBEDDED_RUNS` and the `.lock` file remains — the agent becomes permanently unresponsive until gateway restart
- Fix: wrap `waitForCompactionRetry()` with the existing `abortable()` helper, matching the pattern already used for `activeSession.prompt()` on lines 820-822

## Test plan
- [x] Existing compaction retry tests pass (5 tests)
- [x] The fix follows the exact same `abortable()` pattern used 2 lines above for `activeSession.prompt()`

Closes #12085

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change wraps the `waitForCompactionRetry()` await in the existing `abortable()` helper inside `runEmbeddedAttempt()`. That ensures an external abort/timeout can break out of the post-prompt compaction wait and allow the surrounding `finally` blocks to run, preventing embedded session state (including the session write lock) from being left behind in a stuck state after an aborted run.

The implementation matches the established pattern already used for `activeSession.prompt()` in the same function, so behavior stays consistent across the two long-running awaits in the embedded run lifecycle.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff is a single-line change using an already-present `abortable()` helper, localized to the embedded run attempt flow. It aligns with the existing abort handling pattern used for `activeSession.prompt()` and directly addresses a hang that could prevent the cleanup `finally` blocks from releasing session state and locks.
- src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->