### PR TITLE
fix: update DEFAULT_CONTEXT_TOKENS from 200K to 1M for Opus 4.6

### DIFF
--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -2,5 +2,6 @@
 // Model id uses pi-ai's built-in Anthropic catalog.
 export const DEFAULT_PROVIDER = "anthropic";
 export const DEFAULT_MODEL = "claude-opus-4-6";
-// Conservative fallback used when model metadata is unavailable.
-export const DEFAULT_CONTEXT_TOKENS = 200_000;
+// Fallback used when model metadata is unavailable.
+// Must stay in sync with DEFAULT_MODEL — currently claude-opus-4-6 (1M context).
+export const DEFAULT_CONTEXT_TOKENS = 1_000_000;


### PR DESCRIPTION
## Summary
- `DEFAULT_CONTEXT_TOKENS` is the fallback when model metadata is unavailable (cold start, cron sessions, status display)
- It was still `200_000` (matching Opus 4.5), but the default model was changed to `claude-opus-4-6` in v2026.2.4 (#9853)
- Opus 4.6 has a 1M context window (consistent with `MODEL_CONTEXT_WINDOWS` in `opencode-zen-models.ts`)
- This caused sessions to compact ~5x more often than necessary, and `/status` to show `Xk/200k` instead of `Xk/1000k`
- Updated to `1_000_000` to match the default model

## Test plan
- [x] All opencode-zen-models tests pass (11 tests)
- [x] Config identity defaults tests pass (9 tests)
- [x] Overflow compaction tests pass (8 tests)

Closes #12126

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the agent metadata fallback `DEFAULT_CONTEXT_TOKENS` in `src/agents/defaults.ts` from `200_000` to `1_000_000`, aligning the cold-start / missing-metadata fallback with the repo’s default model (`claude-opus-4-6`) which is expected to have a 1M context window.

The change is localized to the defaults constant and affects only scenarios where upstream model metadata isn’t available (e.g., cold start, cron sessions, status display fallback), reducing unnecessary compaction and correcting `/status`’s displayed total context size.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a single constant update plus comment clarification, and it aligns an internal fallback with the already-selected default model; no behavioral changes occur when model metadata is present.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->