### PR TITLE
fix: cap Discord gateway reconnect at 50 attempts to prevent infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: harden quote parsing; preserve quote context; avoid QUOTE_TEXT_INVALID; avoid nested reply quote misclassification. (#12156) Thanks @rybnikov.
 - Telegram: recover proactive sends when stale topic thread IDs are used by retrying without `message_thread_id`. (#11620)
 - Discord: auto-create forum/media thread posts on send, with chunked follow-up replies and media handling for forum sends. (#12380) Thanks @magendary, @thewilloftheshadow.
+- Discord: cap gateway reconnect attempts to avoid infinite retry loops. (#12230) Thanks @Yida-Dev.
 - Telegram: render markdown spoilers with `<tg-spoiler>` HTML tags. (#11543) Thanks @ezhikkk.
 - Telegram: truncate command registration to 100 entries to avoid `BOT_COMMANDS_TOO_MUCH` failures on startup. (#12356) Thanks @arosstale.
 - Telegram: match DM `allowFrom` against sender user id (fallback to chat id) and clarify pairing logs. (#12779) Thanks @liuxiaopai-ai.

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -504,7 +504,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     [
       new GatewayPlugin({
         reconnect: {
-          maxAttempts: Number.POSITIVE_INFINITY,
+          maxAttempts: 50,
         },
         intents: resolveDiscordGatewayIntents(discordCfg.intents),
         autoInteractions: true,


### PR DESCRIPTION
## Summary
- Discord `GatewayPlugin` was configured with `maxAttempts: Number.POSITIVE_INFINITY`, allowing unbounded reconnection loops
- When the Discord gateway enters a persistent failure state (e.g. WebSocket close code 1005 with stalled HELLO), the provider reconnects every ~30 seconds indefinitely
- User reported 2,483 reconnection attempts in one log file, starving the event loop and blocking cron, heartbeat, and other channels
- Changed `maxAttempts` from `Infinity` to `50`, providing ~25 minutes of retry time before cleanly exiting via the existing `shouldStopOnError` handler that checks for "Max reconnect attempts"

## Test plan
- [x] All 176 Discord tests pass (23 test files)
- [x] The existing `shouldStopOnError` handler (line 659) already handles the "Max reconnect attempts" error message that Carbon emits when the limit is reached

Closes #11836

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Discord `GatewayPlugin` reconnect configuration in `src/discord/monitor/provider.ts` by capping `reconnect.maxAttempts` from `Number.POSITIVE_INFINITY` to `50`. The intent is to prevent unbounded reconnect loops when the Discord gateway is in a persistent failure/zombie state, letting the existing `shouldStopOnError` handler (which stops on the "Max reconnect attempts" error message) terminate the monitor cleanly after a finite retry window.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, localized config adjustment (Infinity -> 50) that prevents an infinite reconnect loop without altering control flow elsewhere, and it leverages existing stop-on-error handling already present in the provider. No additional code paths or interfaces are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->