### PR TITLE
gateway: incident tracking, recover command, and ciao ERR_SERVER_CLOSED hardening

### DIFF
--- a/docs/incident-hardening.md
+++ b/docs/incident-hardening.md
@@ -1,0 +1,88 @@
+# Gateway incident hardening
+
+This document describes the **native incident tracking + recovery** primitives added to the OpenClaw gateway.
+
+## Goals
+
+- Capture actionable evidence about gateway restarts/crashes (especially fast crash→recover cycles).
+- Reduce restart loops caused by non-fatal mDNS (Bonjour) lifecycle errors.
+- Provide a first-party recovery command that can replace ad-hoc watchdog scripts.
+
+## New commands
+
+### `openclaw gateway incidents`
+
+Show recent gateway incidents recorded on this machine.
+
+```bash
+openclaw gateway incidents --limit 100
+openclaw gateway incidents --json
+```
+
+Data source (default):
+
+- `~/.openclaw/state/gateway-incidents.jsonl`
+- `~/.openclaw/state/gateway-incidents-state.json`
+
+### `openclaw gateway recover`
+
+Best-effort recovery helper with an anti-loop cooldown.
+
+```bash
+# default: only acts if gateway health probe fails
+openclaw gateway recover
+
+# override cooldown + force attempt
+openclaw gateway recover --force --cooldown-ms 0
+
+# JSON output for automation
+openclaw gateway recover --json
+```
+
+Behavior (intentionally conservative):
+
+- If the gateway is reachable (RPC `health` succeeds), it **does nothing**.
+- If unreachable, it attempts a **service restart** via the platform service manager.
+- It does **not** auto-install/uninstall the service.
+- It records recovery attempts to the incident log.
+
+## mDNS hardening: suppress `ERR_SERVER_CLOSED`
+
+Some environments trigger a `@homebridge/ciao` timer callback after the mDNS socket has closed (send-after-close), producing:
+
+```
+ERR_SERVER_CLOSED: Cannot send packets on a closed mdns server!
+```
+
+This error is treated as **non-fatal** for OpenClaw:
+
+- It is logged as a warning.
+- The process is not terminated.
+
+This reduces crash/restart loops during shutdown and interface churn.
+
+## Incident log model (high level)
+
+Incidents are written as JSONL entries, with a small state file for quick summary:
+
+- `kind=start` (records restartCount)
+- `kind=signal` (SIGTERM/SIGINT/SIGUSR1)
+- `kind=crash` (uncaught exceptions)
+- `kind=recover` (recover attempts)
+
+See `docs/incident-model.md` for field-level details.
+
+## Migration notes (from external watchdog scripts)
+
+If you currently run a shell-script watchdog that probes the gateway and restarts it:
+
+1. Replace the custom logic with `openclaw gateway recover --json`.
+2. Schedule it via:
+   - launchd/systemd timer
+   - cron
+   - your existing job runner
+
+The incident log provides evidence for both:
+
+- **Down + recovery failed** (recover command exits non-zero and records an entry)
+- **Crashed but recovered** (crash entries can be correlated with the next `start` entry)

--- a/docs/incident-model.md
+++ b/docs/incident-model.md
@@ -1,0 +1,71 @@
+# Gateway incident model
+
+This document specifies the on-disk incident log used by the OpenClaw gateway.
+
+## Files
+
+- **Incident log (append-only):** `~/.openclaw/state/gateway-incidents.jsonl`
+- **Incident summary state:** `~/.openclaw/state/gateway-incidents-state.json`
+
+`OPENCLAW_STATE_DIR` overrides the base directory.
+
+## JSONL entry schema
+
+Each line in `gateway-incidents.jsonl` is a JSON object:
+
+```ts
+type GatewayIncidentKind = "start" | "signal" | "crash" | "recover";
+
+type GatewayIncidentEntry = {
+  ts: number; // epoch millis
+  kind: GatewayIncidentKind;
+  pid?: number;
+  restartCount?: number;
+
+  // kind=signal
+  signal?: string;
+
+  // kind=crash
+  exitCode?: number | null;
+  errorName?: string;
+  errorMessage?: string;
+  errorStack?: string;
+  errorCode?: string;
+
+  // kind=recover
+  status?: "ok" | "error";
+  detail?: string;
+};
+```
+
+Notes:
+
+- `errorMessage` / `errorStack` are tailed (size-limited) to reduce log bloat.
+- The log is pruned opportunistically (size/line limits) to avoid unbounded growth.
+
+## Summary state schema
+
+`gateway-incidents-state.json` is a small JSON document used to quickly surface:
+
+- last crash time
+- last signal
+- restartCount
+
+```ts
+type GatewayIncidentState = {
+  version: 1;
+  restartCount: number;
+  lastStartAtMs?: number;
+  lastSignalAtMs?: number;
+  lastSignal?: string;
+  lastCrashAtMs?: number;
+  lastCrashSummary?: string;
+  lastRecoverAttemptAtMs?: number;
+};
+```
+
+## Design constraints
+
+- **Best-effort:** incident writes must never throw in a way that crashes the gateway.
+- **Low overhead:** append-only JSONL with small prune routine.
+- **Automation-friendly:** CLI exposes `--json` output and stable fields.

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -243,7 +243,7 @@ export function registerGatewayCli(program: Command) {
           colorize(
             rich,
             theme.muted,
-            `restartCount=${state.restartCount}${state.lastCrashAtMs ? ` · lastCrash=${new Date(state.lastCrashAtMs).toISOString()}` : ""}`,
+            `restartCount=${state.restartCount}${state.lastRestartReason ? ` · lastRestartReason=${state.lastRestartReason}` : ""}${state.lastCrashAtMs ? ` · lastCrash=${new Date(state.lastCrashAtMs).toISOString()}` : ""}`,
           ),
         );
 
@@ -262,7 +262,7 @@ export function registerGatewayCli(program: Command) {
                 ? `status=${entry.status ?? "?"}${entry.detail ? ` · ${entry.detail}` : ""}`
                 : kind === "crash"
                   ? `${entry.errorName ?? "Error"}${entry.errorMessage ? `: ${entry.errorMessage}` : ""}`
-                  : `pid=${entry.pid ?? "?"}`;
+                  : `pid=${entry.pid ?? "?"}${entry.restartReason ? ` · reason=${entry.restartReason}` : ""}`;
           defaultRuntime.log(`${ts}  ${kind.padEnd(7)}  ${detail}`);
         }
       }, "gateway incidents failed");

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -4,7 +4,16 @@ import type { GatewayDiscoverOpts } from "./discover.js";
 import { gatewayStatusCommand } from "../../commands/gateway-status.js";
 import { formatHealthChannelLines, type HealthSummary } from "../../commands/health.js";
 import { loadConfig } from "../../config/config.js";
+import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
+import { resolveGatewayService } from "../../daemon/service.js";
 import { discoverGatewayBeacons } from "../../infra/bonjour-discovery.js";
+import {
+  readGatewayIncidentEntries,
+  readGatewayIncidentState,
+  recordGatewayRecoverAttempt,
+  resolveGatewayIncidentsPath,
+} from "../../infra/gateway-incidents.js";
+import { writeRestartSentinel } from "../../infra/restart-sentinel.js";
 import { resolveWideAreaDiscoveryDomain } from "../../infra/widearea-dns.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
@@ -196,6 +205,200 @@ export function registerGatewayCli(program: Command) {
     .action(async (opts) => {
       await runDaemonRestart(opts);
     });
+
+  gateway
+    .command("incidents")
+    .description("Show recent gateway incidents (signals, crashes, recoveries)")
+    .option("--limit <n>", "Max entries", "50")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runGatewayCommand(async () => {
+        const limitRaw = typeof opts.limit === "string" ? opts.limit : "50";
+        const limit = Math.max(1, Math.min(5000, Number.parseInt(limitRaw, 10) || 50));
+        const filePath = resolveGatewayIncidentsPath(process.env);
+        const [state, entries] = await Promise.all([
+          readGatewayIncidentState(process.env),
+          readGatewayIncidentEntries(filePath, { limit }),
+        ]);
+
+        if (opts.json) {
+          defaultRuntime.log(
+            JSON.stringify(
+              {
+                filePath,
+                state,
+                entries,
+              },
+              null,
+              2,
+            ),
+          );
+          return;
+        }
+
+        const rich = isRich();
+        defaultRuntime.log(colorize(rich, theme.heading, "Gateway Incidents"));
+        defaultRuntime.log(colorize(rich, theme.muted, `log: ${filePath}`));
+        defaultRuntime.log(
+          colorize(
+            rich,
+            theme.muted,
+            `restartCount=${state.restartCount}${state.lastCrashAtMs ? ` · lastCrash=${new Date(state.lastCrashAtMs).toISOString()}` : ""}`,
+          ),
+        );
+
+        if (entries.length === 0) {
+          defaultRuntime.log("(no incidents recorded)");
+          return;
+        }
+
+        for (const entry of entries) {
+          const ts = new Date(entry.ts).toISOString();
+          const kind = entry.kind;
+          const detail =
+            kind === "signal"
+              ? `signal=${entry.signal ?? "?"}`
+              : kind === "recover"
+                ? `status=${entry.status ?? "?"}${entry.detail ? ` · ${entry.detail}` : ""}`
+                : kind === "crash"
+                  ? `${entry.errorName ?? "Error"}${entry.errorMessage ? `: ${entry.errorMessage}` : ""}`
+                  : `pid=${entry.pid ?? "?"}`;
+          defaultRuntime.log(`${ts}  ${kind.padEnd(7)}  ${detail}`);
+        }
+      }, "gateway incidents failed");
+    });
+
+  gatewayCallOpts(
+    gateway
+      .command("recover")
+      .description("Attempt to recover a stuck gateway (best effort; avoids reinstall by default)")
+      .option("--force", "Attempt recovery even if gateway is reachable", false)
+      .option("--cooldown-ms <ms>", "Minimum time between recovery attempts (anti-loop)", "60000")
+      .action(async (opts) => {
+        await runGatewayCommand(async () => {
+          const now = Date.now();
+          const cooldownMsRaw = typeof opts.cooldownMs === "string" ? opts.cooldownMs : "60000";
+          const cooldownMs = Math.max(0, Number.parseInt(cooldownMsRaw, 10) || 60_000);
+          const force = Boolean(opts.force);
+          const sessionKey = resolveMainSessionKeyFromConfig();
+          const writeSentinel = async (status: "ok" | "error", message: string) => {
+            try {
+              await writeRestartSentinel({
+                kind: "recover",
+                status,
+                ts: Date.now(),
+                sessionKey,
+                message,
+              });
+            } catch {
+              // ignore
+            }
+          };
+
+          const state = await readGatewayIncidentState(process.env);
+          const lastAttempt = state.lastRecoverAttemptAtMs ?? 0;
+          if (!force && lastAttempt > 0 && now - lastAttempt < cooldownMs) {
+            const remainingMs = cooldownMs - (now - lastAttempt);
+            const message = `recovery suppressed (cooldown active; retry in ${Math.ceil(remainingMs / 1000)}s or pass --force)`;
+            await recordGatewayRecoverAttempt({ status: "ok", detail: message, env: process.env });
+            await writeSentinel("ok", message);
+            if (opts.json) {
+              defaultRuntime.log(JSON.stringify({ ok: true, skipped: true, message }, null, 2));
+            } else {
+              defaultRuntime.log(message);
+            }
+            return;
+          }
+
+          const probeOk = await callGatewayCli("health", opts).then(
+            () => true,
+            () => false,
+          );
+
+          if (probeOk && !force) {
+            const message = "gateway is reachable; no recovery needed";
+            await recordGatewayRecoverAttempt({ status: "ok", detail: message, env: process.env });
+            await writeSentinel("ok", message);
+            if (opts.json) {
+              defaultRuntime.log(JSON.stringify({ ok: true, skipped: true, message }, null, 2));
+            } else {
+              defaultRuntime.log(message);
+            }
+            return;
+          }
+
+          const service = resolveGatewayService();
+          const loaded = await service.isLoaded({ env: process.env }).catch(() => false);
+          const action = loaded ? "restart" : "start";
+
+          if (!loaded) {
+            const message = `gateway service ${service.notLoadedText}; recovery cannot proceed (install required)`;
+            await recordGatewayRecoverAttempt({
+              status: "error",
+              detail: message,
+              env: process.env,
+            });
+            await writeSentinel("error", message);
+            if (opts.json) {
+              defaultRuntime.log(JSON.stringify({ ok: false, message }, null, 2));
+            } else {
+              defaultRuntime.error(message);
+            }
+            defaultRuntime.exit(1);
+            return;
+          }
+
+          try {
+            await service.restart({ env: process.env, stdout: process.stdout });
+          } catch (err) {
+            const message = `gateway ${action} failed: ${String(err)}`;
+            await recordGatewayRecoverAttempt({
+              status: "error",
+              detail: message,
+              env: process.env,
+            });
+            await writeSentinel("error", message);
+            if (opts.json) {
+              defaultRuntime.log(JSON.stringify({ ok: false, message }, null, 2));
+            } else {
+              defaultRuntime.error(message);
+            }
+            defaultRuntime.exit(1);
+            return;
+          }
+
+          // Give the service a moment to come up.
+          await new Promise((r) => setTimeout(r, 1500));
+
+          const recovered = await callGatewayCli("health", opts).then(
+            () => true,
+            () => false,
+          );
+
+          if (recovered) {
+            const message = "gateway recovery succeeded";
+            await recordGatewayRecoverAttempt({ status: "ok", detail: message, env: process.env });
+            await writeSentinel("ok", message);
+            if (opts.json) {
+              defaultRuntime.log(JSON.stringify({ ok: true, message }, null, 2));
+            } else {
+              defaultRuntime.log(message);
+            }
+            return;
+          }
+
+          const message = "gateway still unreachable after recovery attempt";
+          await recordGatewayRecoverAttempt({ status: "error", detail: message, env: process.env });
+          await writeSentinel("error", message);
+          if (opts.json) {
+            defaultRuntime.log(JSON.stringify({ ok: false, message }, null, 2));
+          } else {
+            defaultRuntime.error(message);
+          }
+          defaultRuntime.exit(1);
+        }, "gateway recover failed");
+      }),
+  );
 
   gatewayCallOpts(
     gateway

--- a/src/cli/gateway.sigterm.test.ts
+++ b/src/cli/gateway.sigterm.test.ts
@@ -156,5 +156,17 @@ describe("gateway SIGTERM", () => {
       return;
     }
     expect(result.signal).toBeNull();
+
+    // Incident tracking should record a start + signal.
+    const incidentsPath = path.join(stateDir, "state", "gateway-incidents.jsonl");
+    const rawIncidents = fs.readFileSync(incidentsPath, "utf8");
+    const lines = rawIncidents
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+    expect(lines.length).toBeGreaterThan(0);
+    const parsed = lines.map((l) => JSON.parse(l) as { kind?: string; signal?: string });
+    expect(parsed.some((e) => e.kind === "start")).toBe(true);
+    expect(parsed.some((e) => e.kind === "signal" && e.signal === "SIGTERM")).toBe(true);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,15 @@ import {
   loadSessionStore,
   resolveSessionKey,
   resolveStorePath,
+  resolveMainSessionKeyFromConfig,
   saveSessionStore,
 } from "./config/sessions.js";
 import { ensureBinary } from "./infra/binaries.js";
+import { isCiaoMdnsServerClosedError } from "./infra/bonjour-uncaught.js";
 import { loadDotEnv } from "./infra/dotenv.js";
 import { normalizeEnv } from "./infra/env.js";
 import { formatUncaughtError } from "./infra/errors.js";
+import { recordGatewayCrashSync } from "./infra/gateway-incidents.js";
 import { isMainModule } from "./infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "./infra/path-env.js";
 import {
@@ -27,7 +30,12 @@ import {
   handlePortError,
   PortInUseError,
 } from "./infra/ports.js";
+import {
+  formatDoctorNonInteractiveHint,
+  writeRestartSentinelSync,
+} from "./infra/restart-sentinel.js";
 import { assertSupportedRuntime } from "./infra/runtime-guard.js";
+import { isShutdownInProgress } from "./infra/shutdown-state.js";
 import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "./logging.js";
 import { runCommandWithTimeout, runExec } from "./process/exec.js";
@@ -82,6 +90,39 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    const isGateway =
+      process.env.OPENCLAW_SERVICE_KIND === "gateway" ||
+      process.argv.includes("gateway") ||
+      process.argv.includes("daemon");
+
+    // @homebridge/ciao occasionally throws ERR_SERVER_CLOSED from a timer callback during
+    // shutdown/teardown (send-after-close). This is non-fatal for OpenClaw; suppress it
+    // to avoid crash/restart loops.
+    if (isCiaoMdnsServerClosedError(error)) {
+      if (isGateway) {
+        recordGatewayCrashSync({ error, exitCode: null });
+      }
+      const suffix = isShutdownInProgress() ? " (during shutdown)" : "";
+      console.warn(
+        `[openclaw] Suppressed ERR_SERVER_CLOSED from ciao${suffix}:`,
+        formatUncaughtError(error),
+      );
+      return;
+    }
+
+    if (isGateway) {
+      recordGatewayCrashSync({ error, exitCode: 1 });
+      const sessionKey = resolveMainSessionKeyFromConfig();
+      writeRestartSentinelSync({
+        kind: "crash",
+        status: "error",
+        ts: Date.now(),
+        sessionKey,
+        message: `Uncaught exception: ${formatUncaughtError(error)}`,
+        doctorHint: formatDoctorNonInteractiveHint(),
+      });
+    }
+
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/infra/bonjour-uncaught.test.ts
+++ b/src/infra/bonjour-uncaught.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isCiaoMdnsServerClosedError } from "./bonjour-uncaught.js";
+
+describe("isCiaoMdnsServerClosedError", () => {
+  it("matches by code", () => {
+    const err = Object.assign(new Error("x"), { code: "ERR_SERVER_CLOSED" });
+    expect(isCiaoMdnsServerClosedError(err)).toBe(true);
+  });
+
+  it("matches by message", () => {
+    const err = new Error("Cannot send packets on a closed mdns server!");
+    expect(isCiaoMdnsServerClosedError(err)).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isCiaoMdnsServerClosedError(new Error("nope"))).toBe(false);
+  });
+});

--- a/src/infra/bonjour-uncaught.ts
+++ b/src/infra/bonjour-uncaught.ts
@@ -1,0 +1,17 @@
+import { extractErrorCode, formatErrorMessage } from "./errors.js";
+
+export function isCiaoMdnsServerClosedError(err: unknown): boolean {
+  const code = extractErrorCode(err);
+  if (code === "ERR_SERVER_CLOSED") {
+    return true;
+  }
+
+  const msg = formatErrorMessage(err).toLowerCase();
+  if (!msg) {
+    return false;
+  }
+  if (msg.includes("cannot send packets on a closed mdns server")) {
+    return true;
+  }
+  return false;
+}

--- a/src/infra/gateway-incidents.test.ts
+++ b/src/infra/gateway-incidents.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  readGatewayIncidentEntries,
+  readGatewayIncidentState,
+  recordGatewayRecoverAttempt,
+  recordGatewaySignal,
+  recordGatewayStart,
+  recordGatewayCrashSync,
+  resolveGatewayIncidentsPath,
+  resolveGatewayIncidentStatePath,
+} from "./gateway-incidents.js";
+
+function makeEnv(tmpRoot: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    OPENCLAW_STATE_DIR: tmpRoot,
+  };
+}
+
+describe("gateway-incidents", () => {
+  it("records start/signal/recover and persists restartCount", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-incidents-"));
+    const env = makeEnv(tmpRoot);
+
+    const s1 = await recordGatewayStart(env);
+    expect(s1.restartCount).toBe(1);
+
+    await recordGatewaySignal("SIGTERM", env);
+    await recordGatewayRecoverAttempt({ status: "ok", detail: "noop", env });
+
+    const statePath = resolveGatewayIncidentStatePath(env);
+    const logPath = resolveGatewayIncidentsPath(env);
+
+    // Verify files exist.
+    await expect(fs.stat(statePath)).resolves.toBeTruthy();
+    await expect(fs.stat(logPath)).resolves.toBeTruthy();
+
+    const state = await readGatewayIncidentState(env);
+    expect(state.restartCount).toBe(1);
+    expect(state.lastSignal).toBe("SIGTERM");
+
+    const entries = await readGatewayIncidentEntries(logPath, { limit: 50 });
+    expect(entries.some((e) => e.kind === "start")).toBe(true);
+    expect(entries.some((e) => e.kind === "signal" && e.signal === "SIGTERM")).toBe(true);
+    expect(entries.some((e) => e.kind === "recover" && e.status === "ok")).toBe(true);
+  });
+
+  it("records crash sync", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-incidents-"));
+    const env = makeEnv(tmpRoot);
+
+    recordGatewayCrashSync({
+      env,
+      error: Object.assign(new Error("boom"), { code: "ERR_TEST" }),
+      exitCode: 1,
+    });
+
+    const logPath = resolveGatewayIncidentsPath(env);
+    const entries = await readGatewayIncidentEntries(logPath, { limit: 10 });
+    const crash = entries.find((e) => e.kind === "crash");
+    expect(crash).toBeTruthy();
+    expect(crash?.errorMessage).toContain("boom");
+    expect(crash?.errorCode).toBe("ERR_TEST");
+
+    const state = await readGatewayIncidentState(env);
+    expect(typeof state.lastCrashAtMs).toBe("number");
+    expect(state.lastCrashSummary).toContain("boom");
+  });
+});

--- a/src/infra/gateway-incidents.ts
+++ b/src/infra/gateway-incidents.ts
@@ -1,0 +1,414 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+export type GatewayIncidentKind = "start" | "signal" | "crash" | "recover";
+
+export type GatewayIncidentEntry = {
+  ts: number;
+  kind: GatewayIncidentKind;
+  pid?: number;
+  /** Restart count at time of incident (best-effort). */
+  restartCount?: number;
+
+  /** Signals (kind=signal). */
+  signal?: string;
+
+  /** Crashes (kind=crash). */
+  exitCode?: number | null;
+  errorName?: string;
+  errorMessage?: string;
+  errorStack?: string;
+  errorCode?: string;
+
+  /** Recovery attempts (kind=recover). */
+  status?: "ok" | "error";
+  detail?: string;
+};
+
+export type GatewayIncidentState = {
+  version: 1;
+  restartCount: number;
+  lastStartAtMs?: number;
+  lastSignalAtMs?: number;
+  lastSignal?: string;
+  lastCrashAtMs?: number;
+  lastCrashSummary?: string;
+  lastRecoverAttemptAtMs?: number;
+};
+
+const INCIDENTS_FILENAME = "gateway-incidents.jsonl";
+const STATE_FILENAME = "gateway-incidents-state.json";
+
+export function resolveGatewayIncidentsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), "state", INCIDENTS_FILENAME);
+}
+
+export function resolveGatewayIncidentStatePath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), "state", STATE_FILENAME);
+}
+
+function trimTail(input?: string | null, maxChars = 8000): string | undefined {
+  if (!input) {
+    return undefined;
+  }
+  const text = input.trimEnd();
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `…${text.slice(text.length - maxChars)}`;
+}
+
+const writesByPath = new Map<string, Promise<void>>();
+
+async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLines: number }) {
+  const stat = await fsp.stat(filePath).catch(() => null);
+  if (!stat || stat.size <= opts.maxBytes) {
+    return;
+  }
+
+  const raw = await fsp.readFile(filePath, "utf-8").catch(() => "");
+  const lines = raw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
+  const tmp = `${filePath}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`;
+  await fsp.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fsp.rename(tmp, filePath);
+}
+
+export async function appendGatewayIncident(
+  filePath: string,
+  entry: GatewayIncidentEntry,
+  opts?: { maxBytes?: number; keepLines?: number },
+) {
+  const resolved = path.resolve(filePath);
+  const prev = writesByPath.get(resolved) ?? Promise.resolve();
+  const next = prev
+    .catch(() => undefined)
+    .then(async () => {
+      await fsp.mkdir(path.dirname(resolved), { recursive: true });
+      await fsp.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await pruneIfNeeded(resolved, {
+        maxBytes: opts?.maxBytes ?? 2_000_000,
+        keepLines: opts?.keepLines ?? 2_000,
+      });
+    });
+  writesByPath.set(resolved, next);
+  await next;
+}
+
+export function appendGatewayIncidentSync(filePath: string, entry: GatewayIncidentEntry) {
+  try {
+    const resolved = path.resolve(filePath);
+    fs.mkdirSync(path.dirname(resolved), { recursive: true });
+    fs.appendFileSync(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+  } catch {
+    // ignore
+  }
+}
+
+export async function readGatewayIncidentState(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<GatewayIncidentState> {
+  const p = resolveGatewayIncidentStatePath(env);
+  try {
+    const raw = await fsp.readFile(p, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<GatewayIncidentState> | null;
+    if (!parsed || typeof parsed !== "object" || parsed.version !== 1) {
+      throw new Error("invalid incident state");
+    }
+    const restartCount =
+      typeof parsed.restartCount === "number" && Number.isFinite(parsed.restartCount)
+        ? Math.max(0, Math.floor(parsed.restartCount))
+        : 0;
+    return {
+      version: 1,
+      restartCount,
+      lastStartAtMs: typeof parsed.lastStartAtMs === "number" ? parsed.lastStartAtMs : undefined,
+      lastSignalAtMs: typeof parsed.lastSignalAtMs === "number" ? parsed.lastSignalAtMs : undefined,
+      lastSignal: typeof parsed.lastSignal === "string" ? parsed.lastSignal : undefined,
+      lastCrashAtMs: typeof parsed.lastCrashAtMs === "number" ? parsed.lastCrashAtMs : undefined,
+      lastCrashSummary:
+        typeof parsed.lastCrashSummary === "string" ? parsed.lastCrashSummary : undefined,
+      lastRecoverAttemptAtMs:
+        typeof parsed.lastRecoverAttemptAtMs === "number"
+          ? parsed.lastRecoverAttemptAtMs
+          : undefined,
+    };
+  } catch {
+    return { version: 1, restartCount: 0 };
+  }
+}
+
+export async function writeGatewayIncidentState(
+  state: GatewayIncidentState,
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  const p = resolveGatewayIncidentStatePath(env);
+  await fsp.mkdir(path.dirname(p), { recursive: true });
+  await fsp.writeFile(p, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+}
+
+export async function readGatewayIncidentEntries(
+  filePath: string,
+  opts?: { limit?: number },
+): Promise<GatewayIncidentEntry[]> {
+  const limit = Math.max(1, Math.min(5000, Math.floor(opts?.limit ?? 50)));
+  const raw = await fsp.readFile(path.resolve(filePath), "utf-8").catch(() => "");
+  if (!raw.trim()) {
+    return [];
+  }
+  const out: GatewayIncidentEntry[] = [];
+  const lines = raw.split("\n");
+  for (let i = lines.length - 1; i >= 0 && out.length < limit; i--) {
+    const line = lines[i]?.trim();
+    if (!line) {
+      continue;
+    }
+    try {
+      const obj = JSON.parse(line) as Partial<GatewayIncidentEntry> | null;
+      if (!obj || typeof obj !== "object") {
+        continue;
+      }
+      if (typeof obj.ts !== "number" || !Number.isFinite(obj.ts)) {
+        continue;
+      }
+      if (
+        obj.kind !== "start" &&
+        obj.kind !== "signal" &&
+        obj.kind !== "crash" &&
+        obj.kind !== "recover"
+      ) {
+        continue;
+      }
+      out.push(obj as GatewayIncidentEntry);
+    } catch {
+      // ignore invalid lines
+    }
+  }
+  return out.toReversed();
+}
+
+export async function recordGatewayStart(env: NodeJS.ProcessEnv = process.env) {
+  const filePath = resolveGatewayIncidentsPath(env);
+  const state = await readGatewayIncidentState(env);
+  const restartCount = (state.restartCount ?? 0) + 1;
+  const now = Date.now();
+  const nextState: GatewayIncidentState = {
+    ...state,
+    version: 1,
+    restartCount,
+    lastStartAtMs: now,
+  };
+  await writeGatewayIncidentState(nextState, env);
+  await appendGatewayIncident(filePath, {
+    ts: now,
+    kind: "start",
+    pid: process.pid,
+    restartCount,
+  });
+  return nextState;
+}
+
+/**
+ * Synchronous best-effort start recorder (used during fast shutdown paths).
+ * Must never throw.
+ */
+export function recordGatewayStartSync(env: NodeJS.ProcessEnv = process.env) {
+  try {
+    const filePath = resolveGatewayIncidentsPath(env);
+    const statePath = resolveGatewayIncidentStatePath(env);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+
+    let state: GatewayIncidentState = { version: 1, restartCount: 0 };
+    try {
+      const raw = fs.readFileSync(statePath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<GatewayIncidentState> | null;
+      if (parsed && typeof parsed === "object" && parsed.version === 1) {
+        const restartCount =
+          typeof parsed.restartCount === "number" && Number.isFinite(parsed.restartCount)
+            ? Math.max(0, Math.floor(parsed.restartCount))
+            : 0;
+        state = { ...state, ...parsed, restartCount };
+      }
+    } catch {
+      // ignore
+    }
+
+    const now = Date.now();
+    const restartCount = (state.restartCount ?? 0) + 1;
+    const nextState: GatewayIncidentState = {
+      ...state,
+      version: 1,
+      restartCount,
+      lastStartAtMs: now,
+    };
+
+    fs.writeFileSync(statePath, `${JSON.stringify(nextState, null, 2)}\n`, "utf-8");
+    appendGatewayIncidentSync(filePath, {
+      ts: now,
+      kind: "start",
+      pid: process.pid,
+      restartCount,
+    });
+
+    return nextState;
+  } catch {
+    return null;
+  }
+}
+
+export async function recordGatewaySignal(signal: string, env: NodeJS.ProcessEnv = process.env) {
+  const filePath = resolveGatewayIncidentsPath(env);
+  const state = await readGatewayIncidentState(env);
+  const now = Date.now();
+  const nextState: GatewayIncidentState = {
+    ...state,
+    version: 1,
+    lastSignalAtMs: now,
+    lastSignal: signal,
+  };
+  await writeGatewayIncidentState(nextState, env);
+  await appendGatewayIncident(filePath, {
+    ts: now,
+    kind: "signal",
+    pid: process.pid,
+    restartCount: state.restartCount,
+    signal,
+  });
+  return nextState;
+}
+
+/** Synchronous best-effort signal recorder (for fast shutdown paths). */
+export function recordGatewaySignalSync(signal: string, env: NodeJS.ProcessEnv = process.env) {
+  try {
+    const filePath = resolveGatewayIncidentsPath(env);
+    const statePath = resolveGatewayIncidentStatePath(env);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+
+    let state: GatewayIncidentState = { version: 1, restartCount: 0 };
+    try {
+      const raw = fs.readFileSync(statePath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<GatewayIncidentState> | null;
+      if (parsed && typeof parsed === "object" && parsed.version === 1) {
+        const restartCount =
+          typeof parsed.restartCount === "number" && Number.isFinite(parsed.restartCount)
+            ? Math.max(0, Math.floor(parsed.restartCount))
+            : 0;
+        state = { ...state, ...parsed, restartCount };
+      }
+    } catch {
+      // ignore
+    }
+
+    const now = Date.now();
+    const nextState: GatewayIncidentState = {
+      ...state,
+      version: 1,
+      lastSignalAtMs: now,
+      lastSignal: signal,
+    };
+
+    fs.writeFileSync(statePath, `${JSON.stringify(nextState, null, 2)}\n`, "utf-8");
+    appendGatewayIncidentSync(filePath, {
+      ts: now,
+      kind: "signal",
+      pid: process.pid,
+      restartCount: state.restartCount,
+      signal,
+    });
+
+    return nextState;
+  } catch {
+    return null;
+  }
+}
+
+export function recordGatewayCrashSync(params: {
+  error: unknown;
+  exitCode?: number | null;
+  env?: NodeJS.ProcessEnv;
+}) {
+  const env = params.env ?? process.env;
+  const filePath = resolveGatewayIncidentsPath(env);
+  const now = Date.now();
+  const err = params.error;
+  const errorName = err instanceof Error ? err.name : undefined;
+  const errorMessage =
+    err instanceof Error ? err.message : typeof err === "string" ? err : undefined;
+  const errorStack = err instanceof Error ? err.stack : undefined;
+  const errorCode =
+    err && typeof err === "object" && "code" in err
+      ? String((err as { code?: unknown }).code)
+      : undefined;
+
+  appendGatewayIncidentSync(filePath, {
+    ts: now,
+    kind: "crash",
+    pid: process.pid,
+    exitCode: params.exitCode ?? null,
+    errorName,
+    errorMessage: trimTail(errorMessage),
+    errorStack: trimTail(errorStack),
+    errorCode,
+  });
+
+  // Best-effort state update (sync).
+  try {
+    const statePath = resolveGatewayIncidentStatePath(env);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    let state: GatewayIncidentState = { version: 1, restartCount: 0 };
+    try {
+      const raw = fs.readFileSync(statePath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<GatewayIncidentState> | null;
+      if (parsed && typeof parsed === "object" && parsed.version === 1) {
+        const restartCount =
+          typeof parsed.restartCount === "number" && Number.isFinite(parsed.restartCount)
+            ? Math.max(0, Math.floor(parsed.restartCount))
+            : 0;
+        state = { ...state, ...parsed, restartCount };
+      }
+    } catch {
+      // ignore
+    }
+    const summary = `${errorName ?? "Error"}${errorMessage ? `: ${errorMessage}` : ""}`.trim();
+    const nextState: GatewayIncidentState = {
+      ...state,
+      version: 1,
+      lastCrashAtMs: now,
+      lastCrashSummary: trimTail(summary, 512),
+    };
+    fs.writeFileSync(statePath, `${JSON.stringify(nextState, null, 2)}\n`, "utf-8");
+  } catch {
+    // ignore
+  }
+}
+
+export async function recordGatewayRecoverAttempt(params: {
+  status: "ok" | "error";
+  detail?: string;
+  env?: NodeJS.ProcessEnv;
+}) {
+  const env = params.env ?? process.env;
+  const filePath = resolveGatewayIncidentsPath(env);
+  const now = Date.now();
+  const state = await readGatewayIncidentState(env);
+  const nextState: GatewayIncidentState = {
+    ...state,
+    version: 1,
+    lastRecoverAttemptAtMs: now,
+  };
+  await writeGatewayIncidentState(nextState, env);
+  await appendGatewayIncident(filePath, {
+    ts: now,
+    kind: "recover",
+    pid: process.pid,
+    restartCount: state.restartCount,
+    status: params.status,
+    detail: params.detail ? trimTail(params.detail, 2000) : undefined,
+  });
+  return nextState;
+}

--- a/src/infra/shutdown-state.ts
+++ b/src/infra/shutdown-state.ts
@@ -1,0 +1,30 @@
+let shutdownStartedAtMs: number | null = null;
+let shutdownReason: string | null = null;
+
+export function markShutdownInProgress(reason?: string) {
+  if (shutdownStartedAtMs != null) {
+    return;
+  }
+  shutdownStartedAtMs = Date.now();
+  shutdownReason = reason?.trim() || null;
+}
+
+export function isShutdownInProgress() {
+  return shutdownStartedAtMs != null;
+}
+
+export function getShutdownState() {
+  return {
+    startedAtMs: shutdownStartedAtMs,
+    reason: shutdownReason,
+  };
+}
+
+export function clearShutdownInProgress() {
+  shutdownStartedAtMs = null;
+  shutdownReason = null;
+}
+
+export function resetShutdownStateForTest() {
+  clearShutdownInProgress();
+}


### PR DESCRIPTION
## Problem

On supervised setups (launchd/systemd), the gateway can enter fast restart churn (SIGTERM restarts, crash→recover cycles). Two gaps show up operationally:

1) **No durable incident trail** for signals/crashes/recovery attempts (hard to correlate with cron/config activity).
2) `@homebridge/ciao` can throw an **uncaught** error during teardown:

```
ERR_SERVER_CLOSED: Cannot send packets on a closed mdns server!
```

…which turns a graceful stop into a crash/restart loop.

## Changes

### 1) Native gateway incident tracking (JSONL + summary state)
- Append-only incident log: `~/.openclaw/state/gateway-incidents.jsonl`
- Summary state: `~/.openclaw/state/gateway-incidents-state.json`
- Records: `start`, `signal`, `crash`, `recover`

### 2) New CLI surfaces
- `openclaw gateway incidents` (human + `--json`)
- `openclaw gateway recover` (best-effort, non-destructive by default)
  - includes cooldown (`--cooldown-ms`) to avoid restart loops
  - records recovery attempts to the incident log

### 3) mDNS hardening
- Suppress ciao `ERR_SERVER_CLOSED` as a non-fatal uncaught exception (warn + continue)
  - prevents crash/restart loops during shutdown/interface churn

### 4) Cron UX
- `openclaw cron list` prints a note when disabled jobs are hidden (use `--all`)

### 5) Alert plumbing (minimal)
- Extend restart sentinel kinds with `crash` + `recover` and add a sync writer for crash paths
  - enables post-restart wake/notification flows to include crash/recover events

## Tests

Ran locally:

```bash
pnpm vitest run \
  src/infra/gateway-incidents.test.ts \
  src/infra/bonjour-uncaught.test.ts \
  src/cli/gateway.sigterm.test.ts
```

## Docs

- `docs/incident-hardening.md`
- `docs/incident-model.md`

## Notes / compatibility

- New files/fields are additive; no protocol changes required.
- `ERR_SERVER_CLOSED` suppression is narrowly targeted (code/message match).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a durable gateway incident trail (JSONL log + summary state under the state dir), wires synchronous incident recording into the gateway run loop (start/signal/crash), and adds two new CLI commands: `openclaw gateway incidents` (reads and prints the log) and `openclaw gateway recover` (best-effort service restart with cooldown and sentinel/incident recording). It also hardens shutdown by suppressing a specific `@homebridge/ciao` `ERR_SERVER_CLOSED` uncaught exception and adds tests covering the new incident logging and suppression behavior.

Key integration points are the global `process.on("uncaughtException")` handler in `src/index.ts`, the gateway lifecycle hooks in `src/cli/gateway-cli/run-loop.ts`, and the new persistence layer in `src/infra/gateway-incidents.ts`.


<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a few correctness/runtime issues to address before merging.
- Core design looks consistent and tests cover the new incident primitives, but there are (1) a definite bug in `gateway recover` always calling `restart`, (2) a likely runtime-compat issue using `toReversed()`, and (3) the uncaught-exception gateway detection is broad enough to misclassify CLI crashes as gateway crashes, impacting incident/sentinel outputs.
- src/cli/gateway-cli/register.ts, src/infra/gateway-incidents.ts, src/index.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->