### PR TITLE
fix(zalo): support photo_url field for inbound images

### DIFF
--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -162,7 +162,7 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount> = {
         if (!trimmed) {
           return false;
         }
-        return /^\d{3,}$/.test(trimmed);
+        return /^[a-f0-9]{3,}$/i.test(trimmed);
       },
       hint: "<chatId>",
     },

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -294,10 +294,6 @@ async function processUpdate(
   fetcher?: ZaloFetch,
 ): Promise<void> {
   const { event_name, message } = update;
-  console.log(
-    `[${account.accountId}] Zalo event: ${event_name}`,
-    JSON.stringify(update).slice(0, 500),
-  );
   if (!message) {
     return;
   }

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -294,6 +294,10 @@ async function processUpdate(
   fetcher?: ZaloFetch,
 ): Promise<void> {
   const { event_name, message } = update;
+  console.log(
+    `[${account.accountId}] Zalo event: ${event_name}`,
+    JSON.stringify(update).slice(0, 500),
+  );
   if (!message) {
     return;
   }
@@ -367,15 +371,16 @@ async function handleImageMessage(
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void,
   fetcher?: ZaloFetch,
 ): Promise<void> {
-  const { photo, caption } = message;
+  const { photo, photo_url, caption } = message;
+  const photoSrc = photo || photo_url;
 
   let mediaPath: string | undefined;
   let mediaType: string | undefined;
 
-  if (photo) {
+  if (photoSrc) {
     try {
       const maxBytes = mediaMaxMb * 1024 * 1024;
-      const fetched = await core.channel.media.fetchRemoteMedia({ url: photo });
+      const fetched = await core.channel.media.fetchRemoteMedia({ url: photoSrc });
       const saved = await core.channel.media.saveMediaBuffer(
         fetched.buffer,
         fetched.contentType,


### PR DESCRIPTION
Zalo API returns image URL in 'photo_url' field, but plugin only read 'photo'. Also fix chat ID validation regex to support hex IDs (Zalo user IDs).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Zalo channel integration to (1) accept hex-like chat/user IDs in the target resolver, and (2) treat `photo_url` as an alternative to `photo` when processing inbound image messages so images can be downloaded and attached to the pipeline.

The change is localized to the Zalo extension (`extensions/zalo`) and affects inbound message handling and CLI/chat-id validation for the Zalo channel.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but includes an unconditional debug log that should be removed or gated before merging.
- The functional changes (accepting `photo_url` and allowing hex-like IDs) are small and straightforward. However, the newly added unconditional `console.log(JSON.stringify(update))` in the hot path will reliably cause noisy logging and may expose message metadata in production environments, so it should be addressed first.
- extensions/zalo/src/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->