### PR TITLE
fix: wire streaming config field through resolveExtraParams to streamFn

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner.js";
 
@@ -38,6 +39,47 @@ describe("resolveExtraParams", () => {
       temperature: 0.7,
       maxTokens: 2048,
     });
+  });
+
+  it("includes streaming field when set in config", () => {
+    const result = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "ollama/llama2": {
+                streaming: false,
+              },
+            },
+          },
+        },
+      },
+      provider: "ollama",
+      modelId: "llama2",
+    });
+
+    expect(result).toEqual({ streaming: false });
+  });
+
+  it("merges streaming with params", () => {
+    const result = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-4": {
+                params: { temperature: 0.7 },
+                streaming: false,
+              },
+            },
+          },
+        },
+      },
+      provider: "openai",
+      modelId: "gpt-4",
+    });
+
+    expect(result).toEqual({ temperature: 0.7, streaming: false });
   });
 
   it("ignores unrelated model entries", () => {
@@ -128,6 +170,44 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls).toHaveLength(1);
     return calls[0]?.headers;
   }
+
+  it("passes streaming:false through to streamFn options", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return createAssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "ollama/llama2": {
+                streaming: false,
+              },
+            },
+          },
+        },
+      },
+      "ollama",
+      "llama2",
+    );
+
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "ollama/llama2",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, undefined);
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as Record<string, unknown>)?.streaming).toBe(false);
+  });
 
   it("adds OpenRouter attribution headers to stream options", () => {
     const { calls, agent } = createOptionsCaptureAgent();

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -29,7 +29,17 @@ export function resolveExtraParams(params: {
 }): Record<string, unknown> | undefined {
   const modelKey = `${params.provider}/${params.modelId}`;
   const modelConfig = params.cfg?.agents?.defaults?.models?.[modelKey];
-  return modelConfig?.params ? { ...modelConfig.params } : undefined;
+  if (!modelConfig) {
+    return undefined;
+  }
+  const result: Record<string, unknown> = {};
+  if (modelConfig.params) {
+    Object.assign(result, modelConfig.params);
+  }
+  if (typeof modelConfig.streaming === "boolean") {
+    result.streaming = modelConfig.streaming;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 type CacheRetention = "none" | "short" | "long";
@@ -84,12 +94,15 @@ function createStreamFnWithExtraParams(
     return undefined;
   }
 
-  const streamParams: CacheRetentionStreamOptions = {};
+  const streamParams: CacheRetentionStreamOptions & Record<string, unknown> = {};
   if (typeof extraParams.temperature === "number") {
     streamParams.temperature = extraParams.temperature;
   }
   if (typeof extraParams.maxTokens === "number") {
     streamParams.maxTokens = extraParams.maxTokens;
+  }
+  if (typeof extraParams.streaming === "boolean") {
+    streamParams.streaming = extraParams.streaming;
   }
   const cacheRetention = resolveCacheRetention(extraParams, provider);
   if (cacheRetention) {


### PR DESCRIPTION
## Summary

- Wire the `agents.defaults.models[key].streaming` config field through `resolveExtraParams()` so it reaches the stream function options
- Previously this field was declared in the Zod schema and TypeScript types but never consumed at runtime — `resolveExtraParams()` only read `modelConfig.params`, ignoring the top-level `streaming` boolean
- Now `resolveExtraParams()` merges `modelConfig.streaming` into the returned params object, and `createStreamFnWithExtraParams()` passes the `streaming` field through to the streamFn options
- This matches the existing Ollama workaround pattern (`params.streaming: false` in model discovery)

Fixes #12218

## Test plan

All 3 new tests fail before the fix, pass after:

- [x] `resolveExtraParams` includes `streaming` field when set in config (without `params`)
- [x] `resolveExtraParams` merges `streaming` with `params` when both are set
- [x] `applyExtraParamsToAgent` passes `streaming: false` through to streamFn options (end-to-end)
- [x] Existing 4 tests continue to pass
- [x] `pnpm build` passes
- [x] `pnpm check` passes (lint + format)

## Note on downstream provider consumption

The `streaming` field now flows correctly through the OpenClaw config resolution pipeline. However, whether a given pi-ai provider actually reads `options.streaming` to toggle HTTP-level streaming (`stream: true/false`) depends on the pi-ai library. Currently, providers like `openai-completions` hardcode `stream: true` in their `buildParams()` function. This is the same limitation that affects the existing Ollama workaround (`params.streaming: false`). When pi-ai adds per-request streaming control, this config path will "just work."

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a gap in the embedded runner’s config plumbing: the `agents.defaults.models["<provider>/<modelId>"].streaming` boolean was present in the config schema/types but wasn’t used at runtime.

Changes:
- `src/agents/pi-embedded-runner/extra-params.ts` now includes `modelConfig.streaming` in `resolveExtraParams()` output, and `createStreamFnWithExtraParams()` passes a boolean `streaming` value through into the streamFn option object.
- `src/agents/pi-embedded-runner-extraparams.test.ts` adds focused tests covering (a) `streaming`-only model config, (b) merge with `params`, and (c) end-to-end propagation into streamFn options.

This fits into the existing embedded runner pipeline in `src/agents/pi-embedded-runner/run/attempt.ts`, where `applyExtraParamsToAgent()` wraps the session’s `streamFn` to inject provider/model-specific stream options derived from the OpenClaw config.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and well-scoped: it extends existing extra-param resolution/wrapping to include a boolean `streaming` field, and adds tests to lock the behavior in. I didn’t find any breaking behavior changes beyond the intended config-to-options propagation.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->