### PR TITLE
fix(security): use timing-safe comparison for hook token authentication

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { timingSafeEqual } from "node:crypto";
 import {
   createReplyPrefixOptions,
   logAckFailure,
@@ -1530,7 +1531,9 @@ export async function handleBlueBubblesWebhookRequest(
       req.headers["x-bluebubbles-guid"] ??
       req.headers["authorization"];
     const guid = (Array.isArray(headerToken) ? headerToken[0] : headerToken) ?? guidParam ?? "";
-    if (guid && guid.trim() === token) {
+    const guidBuf = Buffer.from(guid.trim());
+    const tokenBuf = Buffer.from(token);
+    if (guid && guidBuf.length === tokenBuf.length && timingSafeEqual(guidBuf, tokenBuf)) {
       return true;
     }
     const remote = req.socket?.remoteAddress ?? "";

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1,5 +1,6 @@
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
+import { timingSafeEqual } from "node:crypto";
 import {
   createServer as createHttpServer,
   type Server as HttpServer,
@@ -157,7 +158,11 @@ export function createHooksRequestHandler(
     }
 
     const token = extractHookToken(req);
-    if (!token || token !== hooksConfig.token) {
+    if (
+      !token ||
+      token.length !== hooksConfig.token.length ||
+      !timingSafeEqual(Buffer.from(token), Buffer.from(hooksConfig.token))
+    ) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -158,10 +158,12 @@ export function createHooksRequestHandler(
     }
 
     const token = extractHookToken(req);
+    const tokenBuf = Buffer.from(token ?? "");
+    const expectedBuf = Buffer.from(hooksConfig.token);
     if (
       !token ||
-      token.length !== hooksConfig.token.length ||
-      !timingSafeEqual(Buffer.from(token), Buffer.from(hooksConfig.token))
+      tokenBuf.length !== expectedBuf.length ||
+      !timingSafeEqual(tokenBuf, expectedBuf)
     ) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");


### PR DESCRIPTION
## Summary
- Replace plain `!==` string comparison with `crypto.timingSafeEqual` for hook token authentication, preventing timing side-channel attacks
- Extend the same timing-safe pattern to the BlueBubbles webhook token check

## Key Changes
- **`src/gateway/server-http.ts`**: Hook token comparison now uses `Buffer.from()` + `timingSafeEqual` with buffer-length pre-check (handles non-ASCII tokens correctly)
- **`extensions/bluebubbles/src/monitor.ts`**: BlueBubbles webhook `guid === token` comparison replaced with the same `timingSafeEqual` pattern

## How It Works
The existing `auth.ts` already uses `timingSafeEqual` via a `safeEqual` helper (not exported). This PR applies the same approach to two additional token comparison sites that were using plain `===`/`!==`, which leak timing information proportional to the length of the matching prefix.

## Files Changed
| File | Change |
|---|---|
| `src/gateway/server-http.ts` | `token !== hooksConfig.token` → buffer-based `timingSafeEqual` |
| `extensions/bluebubbles/src/monitor.ts` | `guid.trim() === token` → buffer-based `timingSafeEqual` + added `node:crypto` import |

## Testing
- Type check (`pnpm tsgo`): passes clean
- Linter: passes clean
- CodeRabbit review: all actionable feedback addressed

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens token-based webhook authentication by replacing direct string equality checks with `crypto.timingSafeEqual`.

- In `src/gateway/server-http.ts`, the hooks request handler now compares the presented hook token and configured token using a buffer-length pre-check plus `timingSafeEqual`, preventing timing side-channels.
- In `extensions/bluebubbles/src/monitor.ts`, the BlueBubbles webhook GUID/token check is updated to the same timing-safe comparison pattern.

These changes align the hook/webhook authentication paths with the existing timing-safe comparison approach already used for gateway auth in `src/gateway/auth.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to authentication comparisons, follow a proven pattern (length pre-check + timingSafeEqual), and avoid the common timingSafeEqual length-mismatch exception. No functional regressions were identified in the updated call sites.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->