### PR TITLE
fix(daemon): use execFileSync instead of execSync to prevent shell injection

### DIFF
--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -148,10 +148,10 @@ async function resolveNodePath(): Promise<string> {
 }
 
 async function resolveBinaryPath(binary: string): Promise<string> {
-  const { execSync } = await import("node:child_process");
+  const { execFileSync } = await import("node:child_process");
   const cmd = process.platform === "win32" ? "where" : "which";
   try {
-    const output = execSync(`${cmd} ${binary}`, { encoding: "utf8" }).trim();
+    const output = execFileSync(cmd, [binary], { encoding: "utf8" }).trim();
     const resolved = output.split(/\r?\n/)[0]?.trim();
     if (!resolved) {
       throw new Error("empty");


### PR DESCRIPTION
## Summary
- Replace `execSync` with `execFileSync` in `resolveBinaryPath()` to eliminate shell injection vector
- The `binary` parameter was interpolated into a shell command string; `execFileSync` passes it as an argv array instead

## Key Changes
- **`src/daemon/program-args.ts`**: `execSync(\`${cmd} ${binary}\`)` → `execFileSync(cmd, [binary], ...)`

## How It Works
`resolveBinaryPath()` locates `node` or `bun` executables using `which`/`where`. Previously it used `execSync` with string interpolation, which passes through a shell and is vulnerable to injection if the `binary` parameter ever contains shell metacharacters. `execFileSync` bypasses the shell entirely by passing arguments as an array.

## Files Changed
| File | Change |
|---|---|
| `src/daemon/program-args.ts` | `execSync` → `execFileSync`, string interpolation → argv array |

## Testing
- Type check (`pnpm tsgo`): passes clean
- Linter: passes clean
- CodeRabbit review: no actionable feedback on our change

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens `resolveBinaryPath()` in `src/daemon/program-args.ts` by replacing `execSync` (shell string interpolation) with `execFileSync(cmd, [binary])`, ensuring the `binary` value is passed as an argv entry instead of being interpreted by a shell. The rest of the daemon argument resolution logic is unchanged: it still uses `which`/`where`, trims output, selects the first match, and validates the resolved path exists before returning it.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to replacing shell-invoking execSync with execFileSync while keeping the same command (`which`/`where`) and output parsing/validation logic. This eliminates the injection vector without altering the expected resolved-path behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->