### PR TITLE
fix: prevent cron jobs from getting stuck when next-run time is in the past

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -28,6 +28,19 @@ describe("cron schedule", () => {
     expect(next).toBe(now + 30_000);
   });
 
+  it("returns nowMs for cron expression when croner next-run is in the past (#12025)", () => {
+    // After a gateway restart, croner may compute a next-run that has already
+    // passed. The scheduler should return nowMs (fire immediately) instead of
+    // undefined, which would permanently strand the job.
+    const nowMs = Date.parse("2026-02-09T12:00:00.000Z");
+    // Daily at 09:00 UTC — next occurrence is tomorrow, but the 1ms lookback
+    // trick might return today's 09:00 which is in the past.  In any case,
+    // the result must be a valid number, never undefined.
+    const next = computeNextRunAtMs({ kind: "cron", expr: "0 9 * * *", tz: "UTC" }, nowMs);
+    expect(next).toBeTypeOf("number");
+    expect(next).toBeGreaterThanOrEqual(nowMs);
+  });
+
   it("advances when now matches anchor for every schedule", () => {
     const anchor = Date.parse("2025-12-13T00:00:00.000Z");
     const next = computeNextRunAtMs({ kind: "every", everyMs: 30_000, anchorMs: anchor }, anchor);

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -57,5 +57,11 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
     return undefined;
   }
   const nextMs = next.getTime();
-  return Number.isFinite(nextMs) && nextMs >= nowMs ? nextMs : undefined;
+  if (!Number.isFinite(nextMs)) {
+    return undefined;
+  }
+  // For cron schedules, if croner returns a past time (e.g. after a gateway
+  // restart or clock skew), return nowMs so the job fires on the next tick
+  // instead of getting stuck with nextRunAtMs=undefined forever (#12025).
+  return nextMs >= nowMs ? nextMs : nowMs;
 }


### PR DESCRIPTION
## Summary

- When `croner.nextRun()` returns a past time for `kind: 'cron'` schedules, return `nowMs` instead of `undefined`
- This prevents recurring cron jobs from being permanently stranded after gateway restarts or clock skew

## Root Cause

In `schedule.ts` line 60, `computeNextRunAtMs()` returned `undefined` when `nextMs < nowMs`:

```typescript
// Before:
return Number.isFinite(nextMs) && nextMs >= nowMs ? nextMs : undefined;
```

This `undefined` propagated through:
1. `recomputeNextRuns()` sets `job.state.nextRunAtMs = undefined`
2. `findDueJobs()` requires `typeof next === "number" && now >= next` — `undefined` never matches
3. Job is never found as "due" and never executes
4. Next tick: `recomputeNextRuns()` sees `nextRunAtMs === undefined`, calls `computeNextRunAtMs()` which returns `undefined` again
5. Infinite loop — job is permanently stranded

This affects both `kind: 'cron'` (expr-based) and indirectly any recurring schedule that might compute a past time after gateway restart.

## Fix

```typescript
// After:
if (!Number.isFinite(nextMs)) {
  return undefined;
}
return nextMs >= nowMs ? nextMs : nowMs;
```

When croner returns a past time, return `nowMs` so the job fires on the next timer tick. After execution, `applyJobResult()` correctly computes the next future run time.

Note: `kind: 'every'` was already correct — its arithmetic always produces a future time. `kind: 'at'` (one-shot) correctly returns `undefined` for past times since expired one-shots should not re-fire.

## Test plan

- [x] `schedule.test.ts` — 5 tests pass (including new regression test for #12025)
- [x] All 89 cron tests pass (`src/cron/` — 20 test files)

Closes #12025

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `computeNextRunAtMs()` for `kind: "cron"` schedules so that if `croner.nextRun()` yields a timestamp earlier than `nowMs`, the scheduler returns `nowMs` (fire on next tick) instead of `undefined`. This prevents a persisted `nextRunAtMs=undefined` state from causing recurring cron jobs to become permanently undiscoverable by `findDueJobs()` after restarts/clock skew. A regression test was added in `src/cron/schedule.test.ts` to assert cron schedules never return `undefined` and never return a time earlier than `nowMs` for this scenario.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to cron next-run computation and directly address an observed stranded-job state by ensuring `nextRunAtMs` remains numeric for recurring cron schedules. The new behavior preserves existing semantics for one-shot (`at`) schedules and keeps `undefined` only for invalid/unschedulable cron expressions. The change is self-contained and covered by an added regression test.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->