### PR TITLE
fix: add synchronous config fallback to lookupContextTokens

### DIFF
--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+describe("lookupContextTokens", () => {
+  let lookupContextTokens: (modelId?: string) => number | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    // Mock the async model discovery so it never populates MODEL_CACHE.
+    vi.mock("./pi-model-discovery.js", () => {
+      throw new Error("not available in test");
+    });
+    // Mock loadConfig to return a known provider config.
+    vi.mock("../config/config.js", () => ({
+      loadConfig: () => ({
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                { id: "claude-opus-4-6", contextWindow: 1_000_000, maxTokens: 32768 },
+                { id: "claude-haiku-4-5", contextWindow: 200_000, maxTokens: 8192 },
+              ],
+            },
+          },
+        },
+      }),
+    }));
+    const mod = await import("./context.js");
+    lookupContextTokens = mod.lookupContextTokens;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns contextWindow from config when async cache is empty", () => {
+    expect(lookupContextTokens("claude-opus-4-6")).toBe(1_000_000);
+  });
+
+  it("returns contextWindow for another model", () => {
+    expect(lookupContextTokens("claude-haiku-4-5")).toBe(200_000);
+  });
+
+  it("returns undefined for unknown model", () => {
+    expect(lookupContextTokens("unknown-model")).toBeUndefined();
+  });
+
+  it("returns undefined for empty modelId", () => {
+    expect(lookupContextTokens("")).toBeUndefined();
+    expect(lookupContextTokens(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `lookupContextTokens()` uses an async IIFE to populate `MODEL_CACHE` via model discovery, but the lookup is synchronous — on first call the cache is empty and callers fall back to `DEFAULT_CONTEXT_TOKENS` (200K)
- Add a synchronous fallback that reads `contextWindow` from `loadConfig().models.providers` when the async cache miss occurs
- This ensures cron sessions, status display, and session store updates use the correct context window from the start

Closes #12158

## Test plan

- [x] New unit tests verify config fallback returns correct contextWindow when async cache is empty
- [x] Tests verify unknown and empty model IDs return undefined
- [x] `npx vitest run src/agents/context.test.ts` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `lookupContextTokens()` to avoid returning an incorrect default context window on first call.

- `src/agents/context.ts` now falls back synchronously to `loadConfig().models.providers[*].models[*].contextWindow` when the async model-discovery cache hasn’t populated yet.
- `src/agents/context.test.ts` adds unit coverage for the config-based fallback behavior, plus unknown/empty modelId handling.

This fits into the existing flow where multiple session/status/cron paths call `lookupContextTokens(model)` and previously could see `undefined` (and then fall back to `DEFAULT_CONTEXT_TOKENS`) before the async cache filled.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and maintain the existing best-effort async behavior while adding a defensive synchronous config fallback. The fallback logic is wrapped in a try/catch and only activates on cache miss, and new unit tests cover the intended behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->