### PR TITLE
fix: prevent billing error false positive on bare '402' in chat content

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -28,4 +28,9 @@ describe("isBillingErrorMessage", () => {
     expect(isBillingErrorMessage("invalid api key")).toBe(false);
     expect(isBillingErrorMessage("context length exceeded")).toBe(false);
   });
+  it("does not false-positive on chat content mentioning '402'", () => {
+    expect(isBillingErrorMessage("the x402 protocol uses HTTP 402 status codes")).toBe(false);
+    expect(isBillingErrorMessage("error code 402 returned from the endpoint")).toBe(false);
+    expect(isBillingErrorMessage("402 results found")).toBe(false);
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -466,7 +466,7 @@ const ERROR_PATTERNS = {
   overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
   timeout: ["timeout", "timed out", "deadline exceeded", "context deadline exceeded"],
   billing: [
-    /\b402\b/,
+    /\b402\s+payment/i,
     "payment required",
     "insufficient credits",
     "credit balance",


### PR DESCRIPTION
## Summary

- `ERROR_PATTERNS.billing` included `/\b402\b/` which matches any text containing the bare number '402'
- Since `sanitizeUserFacingText()` runs on all outbound assistant text, normal chat content mentioning '402' (e.g. discussing x402 protocol, HTTP status codes) triggers a spurious billing warning
- Replace `/\b402\b/` with `/\b402\s+payment/i` so the pattern only fires on actual '402 Payment Required' error responses
- The existing `"payment required"` string pattern already covers the full error message

Closes #12192

## Test plan

- [x] Existing tests for `isBillingErrorMessage` still pass (positive matches: "HTTP 402 Payment Required", "insufficient credits", etc.)
- [x] New test verifies no false positive on chat content mentioning '402'
- [x] `sanitizeUserFacingText` regression tests pass (10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR narrows the billing-error detection regex in `src/agents/pi-embedded-helpers/errors.ts` to avoid false positives when assistant output contains the bare number `402` (since `sanitizeUserFacingText()` runs over normal assistant chat content).

It updates `ERROR_PATTERNS.billing` from `/\b402\b/` to `/\b402\s+payment/i`, relying on explicit “Payment Required” wording (and the existing `"payment required"` string pattern) to identify true billing failures. A new unit test in `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` asserts that general chat text mentioning `402` no longer triggers billing warnings.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped (one regex tweak) with a matching unit test addition to prevent regression; it reduces known false positives without affecting other billing indicators (e.g., "payment required", "insufficient credits"). No behavioral changes outside billing-error classification paths were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->