### PR TITLE
fix(ios): operator connection auth loop + dual gateway architecture

### DIFF
--- a/apps/ios/Sources/Chat/ChatSheet.swift
+++ b/apps/ios/Sources/Chat/ChatSheet.swift
@@ -8,7 +8,7 @@ struct ChatSheet: View {
     private let userAccent: Color?
 
     init(gateway: GatewayNodeSession, sessionKey: String, userAccent: Color? = nil) {
-        let transport = IOSGatewayChatTransport(gateway: gateway)
+        let transport = IOSGatewayChatTransport(gateway: gateway, supportsChatSubscribe: false)
         self._viewModel = State(
             initialValue: OpenClawChatViewModel(
                 sessionKey: sessionKey,

--- a/apps/ios/Sources/Chat/ChatSheet.swift
+++ b/apps/ios/Sources/Chat/ChatSheet.swift
@@ -7,8 +7,8 @@ struct ChatSheet: View {
     @State private var viewModel: OpenClawChatViewModel
     private let userAccent: Color?
 
-    init(gateway: GatewayNodeSession, sessionKey: String, userAccent: Color? = nil) {
-        let transport = IOSGatewayChatTransport(gateway: gateway, supportsChatSubscribe: false)
+    init(gateway: GatewayNodeSession, sessionKey: String, supportsChatSubscribe: Bool = true, userAccent: Color? = nil) {
+        let transport = IOSGatewayChatTransport(gateway: gateway, supportsChatSubscribe: supportsChatSubscribe)
         self._viewModel = State(
             initialValue: OpenClawChatViewModel(
                 sessionKey: sessionKey,

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -5,9 +5,11 @@ import Foundation
 
 struct IOSGatewayChatTransport: OpenClawChatTransport, Sendable {
     private let gateway: GatewayNodeSession
+    private let supportsChatSubscribe: Bool
 
-    init(gateway: GatewayNodeSession) {
+    init(gateway: GatewayNodeSession, supportsChatSubscribe: Bool = true) {
         self.gateway = gateway
+        self.supportsChatSubscribe = supportsChatSubscribe
     }
 
     func abortRun(sessionKey: String, runId: String) async throws {
@@ -33,6 +35,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport, Sendable {
     }
 
     func setActiveSessionKey(_ sessionKey: String) async throws {
+        guard self.supportsChatSubscribe else { return }
         struct Subscribe: Codable { var sessionKey: String }
         let data = try JSONEncoder().encode(Subscribe(sessionKey: sessionKey))
         let json = String(data: data, encoding: .utf8)

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -205,7 +205,8 @@ final class GatewayConnectionController {
         password: String?)
     {
         guard let appModel else { return }
-        let connectOptions = self.makeConnectOptions()
+        let nodeConnectOptions = self.makeNodeConnectOptions()
+        let operatorConnectOptions = self.makeOperatorConnectOptions()
 
         Task { [weak self] in
             guard let self else { return }
@@ -218,7 +219,8 @@ final class GatewayConnectionController {
                 tls: tls,
                 token: token,
                 password: password,
-                connectOptions: connectOptions)
+                nodeConnectOptions: nodeConnectOptions,
+                operatorConnectOptions: operatorConnectOptions)
         }
     }
 
@@ -273,7 +275,7 @@ final class GatewayConnectionController {
         "manual|\(host.lowercased())|\(port)"
     }
 
-    private func makeConnectOptions() -> GatewayConnectOptions {
+    private func makeNodeConnectOptions() -> GatewayConnectOptions {
         let defaults = UserDefaults.standard
         let displayName = self.resolvedDisplayName(defaults: defaults)
 
@@ -286,6 +288,22 @@ final class GatewayConnectionController {
             clientId: "openclaw-ios",
             clientMode: "node",
             clientDisplayName: displayName)
+    }
+
+    private func makeOperatorConnectOptions() -> GatewayConnectOptions {
+        let defaults = UserDefaults.standard
+        let displayName = self.resolvedDisplayName(defaults: defaults)
+
+        return GatewayConnectOptions(
+            role: "operator",
+            scopes: [],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios",
+            clientMode: "ui",
+            clientDisplayName: displayName,
+            skipDeviceAuth: true)
     }
 
     private func resolvedDisplayName(defaults: UserDefaults) -> String {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -261,8 +261,10 @@ final class NodeAppModel {
                                     message: "UNAVAILABLE: operator connection does not handle invokes"))
                         })
                     if Task.isCancelled { break }
-                    attempt = 0
-                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    // Backoff after disconnect to avoid tight reconnect loop (battery drain)
+                    attempt += 1
+                    let reconnectDelay = min(8.0, 0.5 * pow(1.7, Double(attempt)))
+                    try? await Task.sleep(nanoseconds: UInt64(reconnectDelay * 1_000_000_000))
                 } catch {
                     if Task.isCancelled { break }
                     attempt += 1

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -52,7 +52,7 @@ struct RootCanvas: View {
                 SettingsTab()
             case .chat:
                 ChatSheet(
-                    gateway: self.appModel.gatewaySession,
+                    gateway: self.appModel.operatorGatewaySession,
                     sessionKey: self.appModel.mainSessionKey,
                     userAccent: self.appModel.seamColor)
             }

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -54,6 +54,7 @@ struct RootCanvas: View {
                 ChatSheet(
                     gateway: self.appModel.operatorGatewaySession,
                     sessionKey: self.appModel.mainSessionKey,
+                    supportsChatSubscribe: false,
                     userAccent: self.appModel.seamColor)
             }
         }

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -67,6 +67,7 @@ struct SettingsTab: View {
                 Section("Gateway") {
                     LabeledContent("Discovery", value: self.gatewayController.discoveryStatusText)
                     LabeledContent("Status", value: self.appModel.gatewayStatusText)
+                    LabeledContent("Operator Status", value: self.appModel.operatorGatewayStatusText)
                     if let serverName = self.appModel.gatewayServerName {
                         LabeledContent("Server", value: serverName)
                         if let addr = self.appModel.gatewayRemoteAddress {

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -44,14 +44,16 @@ final class TalkModeManager: NSObject {
     var mp3Player: StreamingAudioPlaying = StreamingAudioPlayer.shared
 
     private var gateway: GatewayNodeSession?
+    private var supportsChatSubscribe: Bool = true
     private let silenceWindow: TimeInterval = 0.7
 
     private var chatSubscribedSessionKeys = Set<String>()
 
     private let logger = Logger(subsystem: "bot.molt", category: "TalkMode")
 
-    func attachGateway(_ gateway: GatewayNodeSession) {
+    func attachGateway(_ gateway: GatewayNodeSession, supportsChatSubscribe: Bool = true) {
         self.gateway = gateway
+        self.supportsChatSubscribe = supportsChatSubscribe
     }
 
     func updateMainSessionKey(_ sessionKey: String?) {
@@ -296,6 +298,7 @@ final class TalkModeManager: NSObject {
     }
 
     private func subscribeChatIfNeeded(sessionKey: String) async {
+        guard self.supportsChatSubscribe else { return }
         let key = sessionKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !key.isEmpty else { return }
         guard let gateway else { return }
@@ -308,6 +311,7 @@ final class TalkModeManager: NSObject {
     }
 
     private func unsubscribeAllChats() async {
+        guard self.supportsChatSubscribe else { return }
         guard let gateway else { return }
         let keys = self.chatSubscribedSessionKeys
         self.chatSubscribedSessionKeys.removeAll()


### PR DESCRIPTION
## Problem

The iOS app was experiencing a critical connection issue when operating as an operator/node:

### Infinite Reconnection Loop
- WebSocket would connect successfully
- Immediately rejected with "pairing required" error
- Automatic reconnection triggered
- Cycle repeats endlessly

### Battery Drain
- This reconnection loop caused **99% battery usage**
- Made the app unusable for operator connections
- Required immediate fix for production use

## Root Cause

Operator connections were attempting device authentication (pairing), but the gateway was rejecting them because operators should not require device pairing. The app had no mechanism to distinguish between:
- **Node connections** (require device pairing)
- **Operator connections** (should bypass device pairing)

## Solution

### Dual Gateway Architecture
Implemented separate WebSocket sessions for different connection roles:

1. **Node Gateway** - For device capabilities (camera, screen, location, etc.)
   - Requires full device authentication
   - Uses device pairing flow
   
2. **Operator Gateway** - For chat/operator UI
   - Bypasses device authentication with `skipDeviceAuth` flag
   - No pairing required
   - Dedicated connection for operator-only features

### Key Changes

**`skipDeviceAuth` flag** (`GatewayChannel.swift`, `GatewayConnectionController.swift`)
- Added to `GatewayConnectOptions`
- When `true`, skips device identity signing and pairing
- Allows operator connections to succeed without device auth

**Separate connection options**
- `makeNodeConnectOptions()` - Standard node connection with device auth
- `makeOperatorConnectOptions()` - Operator connection with `skipDeviceAuth: true`

**Dual gateway sessions** (`NodeAppModel.swift`)
- `gatewaySession` - Node operations
- `operatorGatewaySession` - Chat/operator UI
- Independent connection lifecycle for each

**Chat subscribe optimization** (`IOSGatewayChatTransport.swift`, `TalkModeManager.swift`)
- Added `supportsChatSubscribe` flag
- Prevents unnecessary `chat.subscribe` calls on operator connections
- Cleaner connection handling

**UI integration** (`RootCanvas.swift`, `ChatSheet.swift`, `SettingsTab.swift`)
- Chat UI now uses operator gateway
- Settings show status for both gateways
- Better visibility into connection health

## Testing

- ✅ Operator connection no longer loops
- ✅ Battery usage back to normal levels
- ✅ Chat functionality works without device pairing
- ✅ Node capabilities still require proper device auth
- ✅ Clean reconnection handling for both gateway types

## Related

- Fixes battery drain issue
- Enables operator mode functionality
- Maintains security for device operations

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a dual-gateway connection model for iOS: a node session (device capabilities, full device auth) and an operator/UI session (chat/UI, `skipDeviceAuth`). It threads separate connect options through `GatewayConnectionController` → `NodeAppModel`, adds a second `GatewayNodeSession` + reconnect loop, routes the chat UI to the operator gateway, and adds a `supportsChatSubscribe` switch to avoid issuing `chat.subscribe` in some contexts. Settings additionally displays operator gateway status.

Main thing to verify before merge is that chat session switching/subscribe semantics still work as intended with the new transport flag, and that the operator reconnect loop can’t regress into a tight reconnect/battery-drain cycle under common failure modes.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has a couple of behavior regressions that should be fixed before merge.
- The dual-session split and `skipDeviceAuth` gating look consistent, but (1) chat subscribe is now disabled unconditionally in `ChatSheet`, which can break session switching/subscription, and (2) the operator gateway reconnect loop doesn’t clearly inherit the node loop’s backoff behavior on common disconnect/reject paths, risking a reconnect/battery loop regression under certain gateway responses.
- apps/ios/Sources/Chat/ChatSheet.swift, apps/ios/Sources/Model/NodeAppModel.swift

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->