### PR TITLE
fix(mattermost): preserve newlines in inbound messages during mention removal

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -68,6 +68,12 @@ describe("mattermostPlugin", () => {
       const result = normalizeMention(input, "bot");
       expect(result).toBe("# Heading\n> quote\n- item");
     });
+
+    it("preserves CRLF newlines with mention", () => {
+      const input = "@bot line1\r\nline2\r\nline3";
+      const result = normalizeMention(input, "bot");
+      expect(result).toBe("line1\r\nline2\r\nline3");
+    });
   });
 
   describe("config", () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -102,7 +102,7 @@ export function normalizeMention(text: string, mention: string | undefined): str
   const re = new RegExp(`@${escaped}\\b`, "gi");
   return text
     .replace(re, " ")
-    .replace(/[^\S\n]+/g, " ")
+    .replace(/[^\S\r\n]+/g, " ")
     .trim();
 }
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -94,13 +94,16 @@ function resolveRuntime(opts: MonitorMattermostOpts): RuntimeEnv {
   );
 }
 
-function normalizeMention(text: string, mention: string | undefined): string {
+export function normalizeMention(text: string, mention: string | undefined): string {
   if (!mention) {
     return text.trim();
   }
   const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(`@${escaped}\\b`, "gi");
-  return text.replace(re, " ").replace(/\s+/g, " ").trim();
+  return text
+    .replace(re, " ")
+    .replace(/[^\S\n]+/g, " ")
+    .trim();
 }
 
 function resolveOncharPrefixes(prefixes: string[] | undefined): string[] {


### PR DESCRIPTION
## Summary

Fixes #12247

The `normalizeMention()` function in the Mattermost plugin was collapsing **all whitespace** (including newlines) into single spaces when removing `@bot` mentions from inbound messages. This caused multi-line messages to arrive flattened into a single line, breaking Markdown block structure (headings, quotes, lists).

**Root cause:** The regex `/\s+/g` matches all whitespace characters including `\n`. Changed to `/[^\S\n]+/g` which only collapses horizontal whitespace (spaces, tabs) while preserving newlines.

- **Before:** `"@bot line1\nline2\nline3"` → `"line1 line2 line3"`
- **After:** `"@bot line1\nline2\nline3"` → `"line1\nline2\nline3"`

## Changes

- `extensions/mattermost/src/mattermost/monitor.ts`: Changed `/\s+/g` → `/[^\S\n]+/g` in `normalizeMention()` and exported the function for testability
- `extensions/mattermost/src/channel.test.ts`: Added 5 new tests for `normalizeMention()` covering newline preservation, horizontal space collapsing, mention removal, and Markdown structure preservation

## Test plan

- [x] All 5 new tests fail before the fix, pass after (TDD)
- [x] All 5 existing tests continue to pass (no regressions)
- [x] `pnpm build` passes
- [x] `pnpm check` passes (lint + format clean)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Mattermost extension’s inbound mention normalization so that removing an `@bot` mention no longer collapses line breaks. `normalizeMention()` is now exported for testability and switches from `\s+` collapsing to a horizontal-whitespace-only regex that preserves both `\n` and Windows `\r\n`. Adds unit tests in `extensions/mattermost/src/channel.test.ts` to cover newline/CRLF preservation, horizontal space collapsing, mention removal, and Markdown block structure retention.

<h3>Confidence Score: 5/5</h3>

- This PR looks safe to merge with minimal risk.
- Change is narrowly scoped to mention normalization, preserves both LF and CRLF line breaks as intended, and is covered by targeted unit tests. No other call sites appear affected beyond improved formatting behavior for inbound messages.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->