### PR TITLE
fix(skills): apply agents.list skill filter in embedded runner paths

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -22,7 +22,7 @@ import { resolveUserPath } from "../../../utils.js";
 import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
-import { resolveSessionAgentIds } from "../../agent-scope.js";
+import { resolveAgentSkillsFilter, resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
@@ -249,21 +249,33 @@ export async function runEmbeddedAttempt(
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
+    const skillFilter = params.config
+      ? resolveAgentSkillsFilter(
+          params.config,
+          resolveSessionAgentIds({ sessionKey: params.sessionKey, config: params.config })
+            .sessionAgentId,
+        )
+      : undefined;
+    const filteredSkillEntries =
+      skillFilter !== undefined
+        ? skillEntries.filter((entry) => skillFilter.includes(entry.skill.name))
+        : skillEntries;
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
         })
       : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
+          skills: filteredSkillEntries,
           config: params.config,
         });
 
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      entries: shouldLoadSkillEntries ? filteredSkillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      skillFilter,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/skills.resolveskillspromptforrun.e2e.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.e2e.test.ts
@@ -29,4 +29,51 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
   });
+  it("applies skillFilter when snapshot is absent", () => {
+    const alpha: SkillEntry = {
+      skill: {
+        name: "alpha",
+        description: "Alpha skill",
+        filePath: "/app/skills/alpha/SKILL.md",
+        baseDir: "/app/skills/alpha",
+        source: "openclaw-bundled",
+      },
+      frontmatter: {},
+    };
+    const beta: SkillEntry = {
+      skill: {
+        name: "beta",
+        description: "Beta skill",
+        filePath: "/app/skills/beta/SKILL.md",
+        baseDir: "/app/skills/beta",
+        source: "openclaw-bundled",
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      entries: [alpha, beta],
+      workspaceDir: "/tmp/openclaw",
+      skillFilter: ["alpha"],
+    });
+    expect(prompt).toContain("alpha");
+    expect(prompt).not.toContain("beta");
+  });
+  it("returns empty when skillFilter is an empty array", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/app/skills/demo-skill/SKILL.md",
+        baseDir: "/app/skills/demo-skill",
+        source: "openclaw-bundled",
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      entries: [entry],
+      workspaceDir: "/tmp/openclaw",
+      skillFilter: [],
+    });
+    expect(prompt).toBe("");
+  });
 });

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -515,6 +515,7 @@ export function resolveSkillsPromptForRun(params: {
   entries?: SkillEntry[];
   config?: OpenClawConfig;
   workspaceDir: string;
+  skillFilter?: string[];
 }): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
   if (snapshotPrompt) {
@@ -524,6 +525,7 @@ export function resolveSkillsPromptForRun(params: {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
       entries: params.entries,
       config: params.config,
+      skillFilter: params.skillFilter,
     });
     return prompt.trim() ? prompt : "";
   }


### PR DESCRIPTION
## Summary

Fixes #10546

When `agents.list[].skills` is configured to restrict which skills an agent can use, the filter was **not applied** in the embedded runner's non-snapshot code path. This meant that if no pre-built `skillsSnapshot` was available (or it lacked `resolvedSkills`), `resolveSkillsPromptForRun()` would rebuild the prompt via `buildWorkspaceSkillsPrompt()` **without passing the agent's skill filter**, causing all eligible skills to appear in the prompt. Additionally, excluded skills could still inject environment variables via `applySkillEnvOverrides`.

### Root cause

`resolveSkillsPromptForRun()` did not accept a `skillFilter` parameter, so its callers in `attempt.ts` and `compact.ts` had no way to thread the per-agent allowlist through. The skill entries were also passed unfiltered to `applySkillEnvOverrides`.

### Changes

- **`src/agents/skills/workspace.ts`** — Added `skillFilter?: string[]` to `resolveSkillsPromptForRun()` params and forwarded it to `buildWorkspaceSkillsPrompt()`.
- **`src/agents/pi-embedded-runner/run/attempt.ts`** — Resolve the agent's skill filter from config + session key via `resolveAgentSkillsFilter()`, filter entries before `applySkillEnvOverrides`, and pass filter to `resolveSkillsPromptForRun()`.
- **`src/agents/pi-embedded-runner/compact.ts`** — Same wiring as `attempt.ts`.
- **`src/agents/skills.resolveskillspromptforrun.test.ts`** — Added 2 tests verifying that `skillFilter` is respected when the snapshot path is bypassed.

## Test plan

- [x] TDD: both new tests fail before the fix, pass after
- [x] Existing `resolveSkillsPromptForRun` tests still pass (4/4)
- [x] Related skills test suites pass (syncs, snapshot, env/config filters)
- [x] `pi-embedded-runner.test.ts` suite passes
- [x] `run.overflow-compaction.test.ts` suite passes (8/8)
- [x] `pnpm build && pnpm check` passes (build, types, lint, format)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads the per-agent `agents.list[].skills` allowlist into the embedded runner’s non-snapshot path.

Concretely:
- `resolveSkillsPromptForRun()` now accepts an optional `skillFilter` and forwards it to `buildWorkspaceSkillsPrompt()` (`src/agents/skills/workspace.ts`).
- The embedded run/compaction entry points resolve the current agent id from the session key, compute the agent’s skill filter, and apply it both to env overrides (`applySkillEnvOverrides`) and to the prompt-building path (`resolveSkillsPromptForRun`) (`src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/compact.ts`).
- Tests were added to ensure the filter is respected when a snapshot is not used (`src/agents/skills.resolveskillspromptforrun.test.ts`).

This closes the gap where the embedded runner could include (and apply env overrides for) skills outside the configured allowlist when it had to rebuild the skills prompt from workspace entries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped: they only thread an existing agent skill allowlist into previously-unfiltered embedded-runner code paths and add tests covering the new behavior. The wiring matches existing filtering semantics (explicit empty allowlist disables all skills), and no unrelated logic was modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->