### PR TITLE
fix(cron): correct nextRunAtMs calculation and prevent timer stall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ USER.md
 
 # local tooling
 .serena/
+.cursor/
 
 # Agent credentials and memory (NEVER COMMIT)
 /memory/

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -33,4 +33,65 @@ describe("cron schedule", () => {
     const next = computeNextRunAtMs({ kind: "every", everyMs: 30_000, anchorMs: anchor }, anchor);
     expect(next).toBe(anchor + 30_000);
   });
+
+  // --- #12278 regression: hourly cron with timezone ---
+
+  it("hourly cron returns next hour, not next day (#12278)", () => {
+    // Feb 8, 2026 6:45 PM PST = Feb 9, 2026 02:45:00 UTC
+    const nowMs = Date.parse("2026-02-09T02:45:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 * * * *", tz: "America/Vancouver" },
+      nowMs,
+    );
+    // Next hour at :00 = 7:00 PM PST = 03:00 UTC, ~15 min later (not 24h)
+    expect(next).toBe(Date.parse("2026-02-09T03:00:00.000Z"));
+  });
+
+  it("hourly cron at exact boundary returns current match, not next (#12278)", () => {
+    // Exactly 7:00 PM PST = Feb 9, 2026 03:00:00.000 UTC
+    const nowMs = Date.parse("2026-02-09T03:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 * * * *", tz: "America/Vancouver" },
+      nowMs,
+    );
+    // Should return 7:00 PM (current match) or 8:00 PM, but NOT 24h later
+    expect(next).toBeDefined();
+    // Must be within the next hour
+    expect(next! - nowMs).toBeLessThanOrEqual(60 * 60 * 1000);
+  });
+
+  it("daily cron at exact boundary returns current match, not tomorrow (#12278)", () => {
+    // Exactly 8:00 PM PST = Feb 9, 2026 04:00:00.000 UTC
+    const nowMs = Date.parse("2026-02-09T04:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 20 * * *", tz: "America/Vancouver" },
+      nowMs,
+    );
+    // At exact boundary: should return today's 8PM or tomorrow's 8PM
+    expect(next).toBeDefined();
+    // Must be within the next 24 hours
+    expect(next! - nowMs).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+  });
+
+  it("hourly cron 1ms after boundary returns next hour (#12278)", () => {
+    // 1ms after 7:00 PM PST
+    const nowMs = Date.parse("2026-02-09T03:00:00.001Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 * * * *", tz: "America/Vancouver" },
+      nowMs,
+    );
+    // Should be 8:00 PM PST = 04:00 UTC, exactly 1 hour minus 1ms later
+    expect(next).toBe(Date.parse("2026-02-09T04:00:00.000Z"));
+  });
+
+  it("cron with 30-min interval returns next 30-min slot (#12278)", () => {
+    // Feb 8, 2026 6:15 PM PST = Feb 9, 2026 02:15:00 UTC
+    const nowMs = Date.parse("2026-02-09T02:15:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0,30 * * * *", tz: "America/Vancouver" },
+      nowMs,
+    );
+    // Next :30 = 6:30 PM PST = 02:30 UTC, 15 min later
+    expect(next).toBe(Date.parse("2026-02-09T02:30:00.000Z"));
+  });
 });

--- a/src/cron/service/locked.ts
+++ b/src/cron/service/locked.ts
@@ -8,10 +8,29 @@ const resolveChain = (promise: Promise<unknown>) =>
     () => undefined,
   );
 
+/**
+ * Timestamp (from state.deps.nowMs) when the current locked operation
+ * started, or null if no operation is in progress. Checked by onTimer
+ * to detect and log potentially stuck operations without using
+ * setTimeout (which interferes with fake timers in tests).
+ */
+export let lockAcquiredAtMs: number | null = null;
+
+/** Threshold after which the lock is considered potentially stuck. */
+export const LOCK_WARN_MS = 2 * 60_000; // 2 minutes
+
 export async function locked<T>(state: CronServiceState, fn: () => Promise<T>): Promise<T> {
   const storePath = state.deps.storePath;
   const storeOp = storeLocks.get(storePath) ?? Promise.resolve();
-  const next = Promise.all([resolveChain(state.op), resolveChain(storeOp)]).then(fn);
+
+  const trackedFn = () => {
+    lockAcquiredAtMs = state.deps.nowMs();
+    return fn().finally(() => {
+      lockAcquiredAtMs = null;
+    });
+  };
+
+  const next = Promise.all([resolveChain(state.op), resolveChain(storeOp)]).then(trackedFn);
 
   // Keep the chain alive even when the operation fails.
   const keepAlive = resolveChain(next);


### PR DESCRIPTION
## Summary

Fixes the recurring cron jobs `nextRunAtMs` miscalculation that caused jobs to never fire on schedule.

**Root causes identified and fixed:**

1. **`computeNextRunAtMs` boundary handling** (`schedule.ts`): The 1ms lookback (`nowMs - 1`) was insufficient because croner compares at second granularity. A call at exactly HH:00:00.000 would still land in the same second, causing croner to skip the current match and return the next occurrence (e.g., +24h for daily crons). Changed to a 1-second lookback with a fallback to strict `nextRun(nowMs)` when the lookback returns a past match.

2. **Timer death on `state.running` guard** (`timer.ts`): When `onTimer` was called while a previous execution was still running (triggered by external `armTimer` calls from add/update/remove operations), it returned early **without re-arming the timer**. This caused the cron scheduler to silently stall until the running job finished. If the running job took longer than expected, subsequent timer ticks would be lost entirely. Now re-arms with `MAX_TIMER_DELAY_MS` (60s) to prevent both hot-looping and permanent timer death.

3. **Added debug logging** at `onTimer` entry and at the `state.running` early-return path so silent stalls are detectable in logs.

Fixes #12278. Related: #12263, #12276.

## Test plan

- [x] 5 new regression tests for hourly, daily, and 30-min cron expressions with timezones
- [x] Tests for exact-boundary and 1ms-after-boundary edge cases
- [x] Updated timer re-arm test to verify safe-delay behavior
- [x] Full cron test suite passes (93/93 tests across 20 files)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the cron scheduler in two places:

- `src/cron/schedule.ts` changes `computeNextRunAtMs` to use a 1-second lookback (instead of 1ms) when calling Croner’s `nextRun`, and falls back to a strict `nextRun(now)` if the lookback result would be in the past. This addresses exact-boundary scheduling where Croner compares at second granularity.
- `src/cron/service/timer.ts` fixes a scheduler stall when `onTimer` is invoked while another `onTimer` execution is still running: the early-return path now re-arms the timer with a safe delay (`MAX_TIMER_DELAY_MS`, 60s) so the scheduler can recover.

The PR also adds regression tests for boundary/timezone cron expressions and adjusts an existing timer overlap regression test to assert the new re-arm behavior. `.gitignore` is updated to ignore `.cursor/`.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to cron scheduling and timer re-arming, and are covered by targeted regression tests for the boundary/timezone cases and the timer stall scenario. No correctness issues were found in the updated logic paths during review of the modified files and their call sites.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->