### PR TITLE
cron: pass agentDir to embedded runner for isolated sessions

### DIFF
--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -141,6 +141,7 @@ export function createFollowupRunner(params: {
               sessionId: queued.run.sessionId,
               sessionKey: queued.run.sessionKey,
               agentId: queued.run.agentId,
+              agentDir: queued.run.agentDir,
               messageProvider: queued.run.messageProvider,
               agentAccountId: queued.run.agentAccountId,
               messageTo: queued.originatingTo,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -405,6 +405,7 @@ export async function runCronIsolatedAgentTurn(params: {
           sessionId: cronSession.sessionEntry.sessionId,
           sessionKey: agentSessionKey,
           agentId,
+          agentDir,
           messageChannel,
           agentAccountId: resolvedDelivery.accountId,
           sessionFile,


### PR DESCRIPTION
#### Summary

Cron isolated sessions (`sessionTarget: "isolated"`) with a non-default `agentId` fail auth resolution because `agentDir` is not passed to `runEmbeddedPiAgent()`. The runner falls back to `resolveOpenClawAgentDir()` which hardcodes the `"main"` agent directory, causing "No API key found" errors for any custom agent.

#### Repro Steps

1. Create a custom agent: `openclaw agents add myagent`
2. Configure auth for the custom agent
3. Create a cron job with `sessionTarget: "isolated"` and `agentId: "myagent"`
4. Wait for cron trigger → auth error referencing `agents/main/agent/auth-profiles.json`

#### Root Cause

`runCronIsolatedAgentTurn()` correctly resolves `agentDir` for the custom agent (line 154), and passes it to `runWithModelFallback()` (line 383), but the `run` callback omits `agentDir` when calling `runEmbeddedPiAgent()` (line 404).

Without an explicit `agentDir`, `runEmbeddedPiAgent` falls back to `resolveOpenClawAgentDir()` (`src/agents/agent-paths.ts:12`) which returns the hardcoded `agents/main/agent` path.

Same issue exists in `followup-runner.ts` where `queued.run.agentDir` is available but not forwarded.

#### Behavior Changes

- Cron isolated sessions now correctly use the agent-specific auth store instead of always falling back to `agents/main/agent/`
- No change for users with only the default `"main"` agent

#### Codebase and GitHub Search

- Searched all `runEmbeddedPiAgent()` call sites (38 matches in 13 files) — other callers (`agent-runner-execution.ts`, `agent-runner-memory.ts`, `agent.ts`, `llm-slug-generator.ts`, `voice-call`) already pass `agentDir` correctly
- Only `cron/isolated-agent/run.ts` and `followup-runner.ts` were missing it

#### Tests

- `pnpm test -- --run src/cron` → 87/87 passed
- `pnpm test -- --run src/auto-reply/reply/followup` → 5/5 passed
- `pnpm test -- --run src/agents/pi-embedded-runner` → 158/158 passed
- `pnpm lint` → 0 warnings, 0 errors
- `pnpm tsgo` → clean

lobster-biscuit

**Sign-Off**

- Models used: claude-opus-4-6-thinking
- Submitter effort: code trace + manual verification on live system
- Agent notes: Bug discovered while debugging cron auth failures on a multi-agent setup. Two-line fix, both adding the already-resolved `agentDir` to existing call sites.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes auth resolution for cron isolated sessions (and followup runs) when using a non-default `agentId` by forwarding the already-resolved `agentDir` into `runEmbeddedPiAgent()`.

Concretely:
- `src/cron/isolated-agent/run.ts` now passes the `agentDir` resolved via `resolveAgentDir(cfg, agentId)` into the embedded PI runner.
- `src/auto-reply/reply/followup-runner.ts` now forwards `queued.run.agentDir` into the embedded PI runner.

This prevents the embedded runner from falling back to `resolveOpenClawAgentDir()` (defaulting to `agents/main/agent`) and therefore stops “No API key found” errors for custom agents whose auth profiles live under their own agent directory.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (two call sites) and aligns with existing runner behavior: `runEmbeddedPiAgent` already accepts an optional `agentDir` and otherwise falls back to the default agent directory. Forwarding the pre-resolved `agentDir` fixes an incorrect fallback without changing logic for the default agent. No other behavior paths are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->