### PR TITLE
fix: treat HTTP 5xx server errors as failover-worthy

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -38,6 +38,7 @@ export type AuthProfileFailureReason =
   | "rate_limit"
   | "billing"
   | "timeout"
+  | "server_error"
   | "unknown";
 
 /** Per-profile usage statistics for round-robin and cooldown tracking */

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -50,6 +50,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 408;
     case "format":
       return 400;
+    case "server_error":
+      return 503;
     default:
       return undefined;
   }
@@ -162,6 +164,9 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
   if (status === 400) {
     return "format";
+  }
+  if (status !== undefined && status >= 500) {
+    return "server_error";
   }
 
   const code = (getErrorCode(err) ?? "").toUpperCase();

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -26,6 +26,7 @@ export {
   isImageDimensionErrorMessage,
   isImageSizeError,
   isOverloadedErrorMessage,
+  isServerErrorMessage,
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -498,6 +498,16 @@ const ERROR_PATTERNS = {
     "messages.1.content.1.tool_use.id",
     "invalid request format",
   ],
+  serverError: [
+    /\b500\b.*(?:internal server error|api_error)/,
+    /\b502\b/,
+    /\b503\b/,
+    /\b529\b/,
+    "internal server error",
+    "bad gateway",
+    "service unavailable",
+    "no capacity available",
+  ],
 } as const;
 
 const TOOL_CALL_INPUT_MISSING_RE =
@@ -565,6 +575,10 @@ export function isAuthErrorMessage(raw: string): boolean {
 
 export function isOverloadedErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
+}
+
+export function isServerErrorMessage(raw: string): boolean {
+  return matchesErrorPatterns(raw, ERROR_PATTERNS.serverError);
 }
 
 export function parseImageDimensionError(raw: string): {
@@ -654,6 +668,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isAuthErrorMessage(raw)) {
     return "auth";
+  }
+  if (isServerErrorMessage(raw)) {
+    return "server_error";
   }
   return null;
 }

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,3 +1,10 @@
 export type EmbeddedContextFile = { path: string; content: string };
 
-export type FailoverReason = "auth" | "format" | "rate_limit" | "billing" | "timeout" | "unknown";
+export type FailoverReason =
+  | "auth"
+  | "format"
+  | "rate_limit"
+  | "billing"
+  | "timeout"
+  | "server_error"
+  | "unknown";


### PR DESCRIPTION
## Summary

When a provider returns an HTTP 5xx server error (e.g., Anthropic returning `503 No capacity available`), `classifyFailoverReason()` returns `null`, so the error is **not treated as failover-worthy**. Configured model fallbacks are never attempted — users see raw error messages or silent failures instead of automatic failover.

This PR adds `"server_error"` as a new `FailoverReason` and detects 5xx errors through both:
- **HTTP status code**: any `status >= 500` → `"server_error"`
- **Error message patterns**: `internal server error`, `bad gateway`, `service unavailable`, `no capacity available`, and status code patterns (`500`, `502`, `503`, `529`)

## Changes

| File | Change |
|------|--------|
| `pi-embedded-helpers/types.ts` | Add `"server_error"` to `FailoverReason` union |
| `pi-embedded-helpers/errors.ts` | Add `serverError` patterns + `isServerErrorMessage()` + update `classifyFailoverReason()` |
| `pi-embedded-helpers.ts` | Export `isServerErrorMessage` |
| `failover-error.ts` | Handle `status >= 500` in `resolveFailoverReasonFromError()` + map `server_error` → 503 in `resolveFailoverStatus()` |
| `failover-error.test.ts` | Add tests for 5xx status codes, error messages, and coercion |

## Test plan

- [x] All existing tests pass (`vitest run src/agents/failover-error.test.ts` — 8 tests)
- [x] New tests cover: HTTP 500/502/503/529 status codes, "no capacity available" message, "service unavailable" message, coercion with provider metadata
- [x] TypeScript compiles without errors in changed files
- [ ] Manual: configure a primary model + fallback, simulate 503 → verify fallback triggers

Fixes #8112

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends failover classification so HTTP 5xx responses are treated as failover-worthy via a new `server_error` reason, detected by status codes (`status >= 500`) and message patterns (e.g. “service unavailable”, “no capacity available”). It updates the failover error coercion/status mapping and adds unit tests to cover these cases.

The PR also adjusts embedded Pi subscription handling to detect native thinking blocks and relax `<final>` tag enforcement when native thinking is present.

Separately, `src/gateway/server-methods/chat.ts` was refactored to use the response-prefix template context plumbing and to register agent run context for routing; this refactor currently removes a few fields/behaviors that appear relied upon by gateway clients (see comments).

<h3>Confidence Score: 3/5</h3>

- This PR is close, but gateway chat API regressions should be fixed before merging.
- Failover classification changes look straightforward and are covered by tests, but the unrelated `chat.ts` refactor removes/changes response fields and tool-event routing behavior in ways that can break gateway/webchat clients.
- src/gateway/server-methods/chat.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->