### PR TITLE
fix(daemon): detect and handle stale service entrypoints

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import type { DaemonInstallOptions } from "./types.js";
 import { buildGatewayInstallPlan } from "../../commands/daemon-install-helpers.js";
 import {
@@ -74,23 +75,41 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     fail(`Gateway service check failed: ${String(err)}`);
     return;
   }
-  if (loaded) {
-    if (!opts.force) {
-      emit({
-        ok: true,
-        result: "already-installed",
-        message: `Gateway service already ${service.loadedText}.`,
-        service: buildDaemonServiceSnapshot(service, loaded),
-        warnings: warnings.length ? warnings : undefined,
-      });
-      if (!json) {
-        defaultRuntime.log(`Gateway service already ${service.loadedText}.`);
-        defaultRuntime.log(
-          `Reinstall with: ${formatCliCommand("openclaw gateway install --force")}`,
-        );
+  if (loaded && !opts.force) {
+    // Validate that the currently configured entrypoint actually exists.
+    // This catches stale LaunchAgent/systemd configs pointing to removed npm installs,
+    // moved git checkouts, or outdated pnpm store paths.
+    const currentConfig = await service.readCommand(process.env);
+    if (currentConfig?.programArguments && currentConfig.programArguments.length >= 2) {
+      const entrypoint = currentConfig.programArguments[1];
+      try {
+        await fs.access(entrypoint);
+      } catch {
+        // Entrypoint doesn't exist - service config is stale, force reinstall
+        const msg = `Configured entrypoint ${entrypoint} not found; reinstalling...`;
+        if (json) {
+          warnings.push(msg);
+        } else {
+          defaultRuntime.log(msg);
+        }
+        loaded = false;
       }
-      return;
     }
+  }
+
+  if (loaded && !opts.force) {
+    emit({
+      ok: true,
+      result: "already-installed",
+      message: `Gateway service already ${service.loadedText}.`,
+      service: buildDaemonServiceSnapshot(service, loaded),
+      warnings: warnings.length ? warnings : undefined,
+    });
+    if (!json) {
+      defaultRuntime.log(`Gateway service already ${service.loadedText}.`);
+      defaultRuntime.log(`Reinstall with: ${formatCliCommand("openclaw gateway install --force")}`);
+    }
+    return;
   }
 
   const { programArguments, workingDirectory, environment } = await buildGatewayInstallPlan({

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -145,7 +145,15 @@ export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
 
   // Validate that the configured entrypoint exists before attempting to start.
   // This provides a clear error instead of letting the service crash repeatedly.
-  const currentConfig = await service.readCommand(process.env);
+  let currentConfig: Awaited<ReturnType<typeof service.readCommand>> | undefined;
+  try {
+    currentConfig = await service.readCommand(process.env);
+  } catch {
+    // Can't read service config - suggest reinstall
+    const hints = [`Run: openclaw gateway install --force`];
+    fail(`Gateway service config unreadable. Reinstall the service.`, hints);
+    return;
+  }
   if (currentConfig?.programArguments && currentConfig.programArguments.length >= 2) {
     const entrypoint = currentConfig.programArguments[1];
     try {

--- a/src/cli/daemon-cli/register.ts
+++ b/src/cli/daemon-cli/register.ts
@@ -46,7 +46,7 @@ export function registerDaemonCli(program: Command) {
     .option("--port <port>", "Gateway port")
     .option("--runtime <runtime>", "Daemon runtime (node|bun). Default: node")
     .option("--token <token>", "Gateway token (token auth)")
-    .option("--force", "Reinstall/overwrite if already installed", false)
+    .option("--force", "Reinstall/overwrite if already installed")
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runDaemonInstall(opts);

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -430,6 +430,9 @@ export async function installLaunchAgent({
   });
   await fs.writeFile(plistPath, plist, "utf8");
 
+  // Bootout by label first (catches services loaded from different paths, e.g., old npm installs).
+  // Then bootout by plist path as fallback. Both are best-effort; bootstrap will fail if still loaded.
+  await execLaunchctl(["bootout", `${domain}/${label}`]);
   await execLaunchctl(["bootout", domain, plistPath]);
   await execLaunchctl(["unload", plistPath]);
   // launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.


### PR DESCRIPTION
## Summary

**macOS LaunchAgent issue:** When switching between install methods (e.g., npm global → git checkout, or vice versa), the LaunchAgent service config can become stale and point to a non-existent file. This causes:
- `gateway install` to return 'already installed' for a broken service
- `gateway start` to silently fail with MODULE_NOT_FOUND errors  
- The service to crash-loop thousands of times

Note: Regular pnpm/npm updates should NOT trigger this issue - the code already prefers symlinked paths that stay stable across version updates.

## Context 

I've been running into this several times on multiple Macs. In one case, I broke my local install somehow, and tasked Opus in VS Code with fixing it. Of course, that installed the pnpm package and ignored my git checkout copy. I switched back, but then ran into this.

I ran into it again last night (`openclaw update` tried to install the pnpm version) and finally figured out what was going wrong.

## Steps to Reproduce

1. Install OpenClaw via npm: `npm install -g openclaw`
2. Run `openclaw gateway install` - creates LaunchAgent pointing to `/opt/homebrew/lib/node_modules/openclaw/dist/index.js`
3. Switch to git install (different path entirely)
4. Run `openclaw gateway install` again
5. Observe: returns "already installed" because the LaunchAgent label is still registered
6. Run `openclaw gateway start` 
7. Observe: service crashes repeatedly with `MODULE_NOT_FOUND`

**Symptoms:**
- `launchctl print gui/$UID/ai.openclaw.gateway` shows `last exit code = 1` and very high `runs` count (thousands!)
- Error logs show: `Error: Cannot find module '/opt/homebrew/lib/node_modules/openclaw/dist/index.js'`
- Confusingly, `openclaw gateway` (foreground) works fine - only the LaunchAgent service fails

## Root Cause

Two issues combine:

1. **"Already installed" check doesn't validate entrypoint** - `isLaunchAgentLoaded()` only checks if `launchctl print` succeeds, not whether the configured binary path exists

2. **`installLaunchAgent` bootout uses plist path, not label** - When the service was loaded from a different plist path (old npm location), booting out by the new plist path doesn't unload it

3. **Pre-existing bug: `--force` option conflict** - Both parent `gateway` and child `gateway install` define `--force`. Commander's option inheritance caused the parent's `false` default to override the child's parsed `true` value, so `--force` was silently ignored

## Changes

1. **Install: Validate entrypoint exists before 'already installed'**
   If the configured entrypoint doesn't exist, auto-reinstall instead of returning early.

2. **Start: Validate entrypoint exists before attempting to start**
   Provides a clear error message with hint to reinstall the service.

3. **LaunchAgent: Bootout by label before plist path**
   When reinstalling, bootout by service label first (catches services loaded from different paths).

4. **Fix --force option conflict**
   Fixed by not applying run-specific options to parent gateway command, making `gateway run` the default subcommand.

Fixes #3419
Related to #11324

---

🤖 **AI-assisted:** This fix was developed with Opus 4.5 via OpenClaw.

Prompts were mostly troubleshooting based - "`openclaw gateway start` isn't working, but `openclaw gateway` does, why?" The issue was pretty quick to identify, then the rest was searching issues and PRs, as well as testing the fixes.

I have personally reviewed the code and understand it. I think the Commander.js changes look good and fix the conflict, but I'm not too familiar with how the option inheritance actually works.

**Testing:** 
- [x] Tested on my live system experiencing the bug, and it resolved the behavior
- [x] Unit tests pass (849 passed, 1 unrelated flaky failure in warning-filter.test.ts)
- [x] Lint + format pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves Gateway daemon service robustness, primarily for macOS LaunchAgents:

- `gateway install`: when the service is already loaded, it now reads the existing service command and verifies the configured entrypoint exists; if it doesn’t, it proceeds with reinstall instead of returning `already-installed`.
- `gateway start`: validates the configured entrypoint exists before trying to restart the service, and emits a clearer error with reinstall hints when it’s stale.
- `launchd` installer: tries to `bootout` by label first (to catch cases where the same label was bootstrapped from a different plist path), then `bootout`/`unload` by plist path.
- CLI wiring: changes the `gateway` command structure so `gateway run` is the default subcommand and `gateway install` no longer conflicts with `gateway run --force` option parsing.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing a couple of unhandled-error paths.
- The changes are localized and align with the stated macOS LaunchAgent failure mode, but both new entrypoint-validation paths call `service.readCommand` without guarding against exceptions, which can cause unhandled CLI failures in error states that the rest of the code handles via `fail(...)`. Fixing those would make behavior consistent and predictable.
- src/cli/daemon-cli/install.ts, src/cli/daemon-cli/lifecycle.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->