### PR TITLE
fix(voice-call): pass stream auth token via Twilio <Parameter> element

### DIFF
--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -89,7 +89,8 @@ export class MediaStreamHandler {
    */
   private async handleConnection(ws: WebSocket, _request: IncomingMessage): Promise<void> {
     let session: StreamSession | null = null;
-    const streamToken = this.getStreamToken(_request);
+    // Try to get token from URL query params (fallback)
+    const urlToken = this.getStreamToken(_request);
 
     ws.on("message", async (data: Buffer) => {
       try {
@@ -100,9 +101,13 @@ export class MediaStreamHandler {
             console.log("[MediaStream] Twilio connected");
             break;
 
-          case "start":
+          case "start": {
+            // Prefer token from Twilio's customParameters (set via <Parameter> in TwiML),
+            // fall back to URL query params for backwards compatibility
+            const streamToken = message.start?.customParameters?.token ?? urlToken;
             session = await this.handleStart(ws, message, streamToken);
             break;
+          }
 
           case "media":
             if (session && message.media?.payload) {
@@ -393,6 +398,7 @@ interface TwilioMediaMessage {
     accountSid: string;
     callSid: string;
     tracks: string[];
+    customParameters?: Record<string, string>;
     mediaFormat: {
       encoding: string;
       sampleRate: number;

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -421,7 +421,11 @@ export class TwilioProvider implements VoiceCallProvider {
       return null;
     }
     const token = this.getStreamAuthToken(callSid);
-    return { url: baseUrl, token };
+    // Include token in URL as well for backwards compatibility
+    // (media-stream.ts falls back to reading from URL query params)
+    const url = new URL(baseUrl);
+    url.searchParams.set("token", token);
+    return { url: url.toString(), token };
   }
 
   /**

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -351,8 +351,8 @@ export class TwilioProvider implements VoiceCallProvider {
 
       // Conversation mode: return streaming TwiML immediately for outbound calls.
       if (isOutbound) {
-        const streamUrl = callSid ? this.getStreamUrlForCall(callSid) : null;
-        return streamUrl ? this.getStreamConnectXml(streamUrl) : TwilioProvider.PAUSE_TWIML;
+        const stream = callSid ? this.getStreamUrlForCall(callSid) : null;
+        return stream ? this.getStreamConnectXml(stream.url, stream.token) : TwilioProvider.PAUSE_TWIML;
       }
     }
 
@@ -364,8 +364,8 @@ export class TwilioProvider implements VoiceCallProvider {
     // Handle subsequent webhook requests (status callbacks, etc.)
     // For inbound calls, answer immediately with stream
     if (direction === "inbound") {
-      const streamUrl = callSid ? this.getStreamUrlForCall(callSid) : null;
-      return streamUrl ? this.getStreamConnectXml(streamUrl) : TwilioProvider.PAUSE_TWIML;
+      const stream = callSid ? this.getStreamUrlForCall(callSid) : null;
+      return stream ? this.getStreamConnectXml(stream.url, stream.token) : TwilioProvider.PAUSE_TWIML;
     }
 
     // For outbound calls, only connect to stream when call is in-progress
@@ -373,8 +373,8 @@ export class TwilioProvider implements VoiceCallProvider {
       return TwilioProvider.EMPTY_TWIML;
     }
 
-    const streamUrl = callSid ? this.getStreamUrlForCall(callSid) : null;
-    return streamUrl ? this.getStreamConnectXml(streamUrl) : TwilioProvider.PAUSE_TWIML;
+    const stream = callSid ? this.getStreamUrlForCall(callSid) : null;
+    return stream ? this.getStreamConnectXml(stream.url, stream.token) : TwilioProvider.PAUSE_TWIML;
   }
 
   /**
@@ -411,28 +411,35 @@ export class TwilioProvider implements VoiceCallProvider {
     return token;
   }
 
-  private getStreamUrlForCall(callSid: string): string | null {
+  private getStreamUrlForCall(callSid: string): { url: string; token: string } | null {
     const baseUrl = this.getStreamUrl();
     if (!baseUrl) {
       return null;
     }
     const token = this.getStreamAuthToken(callSid);
-    const url = new URL(baseUrl);
-    url.searchParams.set("token", token);
-    return url.toString();
+    return { url: baseUrl, token };
   }
 
   /**
    * Generate TwiML to connect a call to a WebSocket media stream.
    * This enables bidirectional audio streaming for real-time STT/TTS.
    *
+   * Uses Twilio's <Parameter> element to pass the auth token, which arrives
+   * in the stream start event's customParameters. URL query params are NOT
+   * forwarded by Twilio's <Stream> element to the WebSocket connection.
+   *
    * @param streamUrl - WebSocket URL (wss://...) for the media stream
+   * @param token - Auth token to pass via <Parameter> for stream validation
    */
-  getStreamConnectXml(streamUrl: string): string {
+  getStreamConnectXml(streamUrl: string, token?: string): string {
+    const parameterTag = token
+      ? `\n      <Parameter name="token" value="${escapeXml(token)}" />`
+      : "";
     return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
-    <Stream url="${escapeXml(streamUrl)}" />
+    <Stream url="${escapeXml(streamUrl)}">${parameterTag}
+    </Stream>
   </Connect>
 </Response>`;
   }

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -352,7 +352,9 @@ export class TwilioProvider implements VoiceCallProvider {
       // Conversation mode: return streaming TwiML immediately for outbound calls.
       if (isOutbound) {
         const stream = callSid ? this.getStreamUrlForCall(callSid) : null;
-        return stream ? this.getStreamConnectXml(stream.url, stream.token) : TwilioProvider.PAUSE_TWIML;
+        return stream
+          ? this.getStreamConnectXml(stream.url, stream.token)
+          : TwilioProvider.PAUSE_TWIML;
       }
     }
 
@@ -365,7 +367,9 @@ export class TwilioProvider implements VoiceCallProvider {
     // For inbound calls, answer immediately with stream
     if (direction === "inbound") {
       const stream = callSid ? this.getStreamUrlForCall(callSid) : null;
-      return stream ? this.getStreamConnectXml(stream.url, stream.token) : TwilioProvider.PAUSE_TWIML;
+      return stream
+        ? this.getStreamConnectXml(stream.url, stream.token)
+        : TwilioProvider.PAUSE_TWIML;
     }
 
     // For outbound calls, only connect to stream when call is in-progress


### PR DESCRIPTION
## Problem

Conversation mode (two-way voice calls) always fails with `Rejecting media stream: invalid token`. The stream auth token is placed in the WebSocket URL as a query parameter, but **Twilio's `<Stream>` element does not forward URL query parameters to the WebSocket connection**. The token always arrives as `NONE`.

```
[MediaStream] Stream started: MZ... (call: CA..., token: NONE)
[twilio] isValidStreamToken: hasExpected=true, hasToken=false
[voice-call] Rejecting media stream: invalid token for CA...
```

## Fix

Pass the auth token using Twilio's [`<Parameter>`](https://www.twilio.com/docs/voice/twiml/stream#parameter) child element inside `<Stream>`, which delivers it via the start event's `customParameters` field. The URL query param approach is kept as a fallback for backwards compatibility.

### Changes

**`providers/twilio.ts`**
- `getStreamUrlForCall()` now returns `{ url, token }` instead of baking the token into the URL
- `getStreamConnectXml()` accepts an optional `token` param and emits `<Parameter name="token" value="..." />` inside `<Stream>`

**`media-stream.ts`**
- Token extraction: prefer `message.start.customParameters.token` (from `<Parameter>`), fall back to URL query params
- Added `customParameters` to `TwilioMediaMessage.start` type definition

## Testing

Tested with Twilio + ngrok tunnel. Before fix: all conversation-mode calls rejected immediately. After fix: full two-way conversation working (STT → agent response → TTS → caller).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Twilio Media Streams authentication for conversation mode by passing the per-call stream auth token via TwiML `<Parameter>` inside `<Stream>`, and updating the WebSocket handler to prefer `start.customParameters.token` on the Twilio `start` event.

`TwilioProvider` now returns `{ url, token }` for stream connection and emits the `<Parameter>` child element, while `MediaStreamHandler` extracts the token from `customParameters` and only falls back to URL query parsing.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but token back-compat handling is inconsistent and should be resolved before merging.
- Core change (using TwiML `<Parameter>` and reading `start.customParameters`) is straightforward and localized. However, the code/comments claim a URL-query fallback path that is no longer actually exercised by the Twilio provider after this change, which can lead to confusion and broken expectations for compatibility.
- extensions/voice-call/src/providers/twilio.ts; extensions/voice-call/src/media-stream.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->