### PR TITLE
fix: trim leading/trailing whitespace from outbound messages

### DIFF
--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -103,7 +103,7 @@ export async function sendMessageIMessage(
   }
 
   const params: Record<string, unknown> = {
-    text: message,
+    text: typeof message === "string" ? message.trim() : message,
     service: service || "auto",
     region,
   };


### PR DESCRIPTION
## Problem

`sanitizeUserFacingText` computes a trimmed version of outbound text for validation checks, but returns the untrimmed result from `collapseConsecutiveDuplicateBlocks(stripped)`. This causes leading/trailing newlines to appear in delivered messages.

This is especially visible on platforms like iMessage that don't collapse whitespace — messages arrive with blank lines before or after the actual content.

## Fix

Added `.trim()` to the final return of `sanitizeUserFacingText` so outbound text is always clean.

## Test

Added test cases for leading, trailing, and surrounding whitespace in the existing test suite.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes `sanitizeUserFacingText` so it returns trimmed outbound text after collapsing consecutive duplicate blocks, preventing delivered messages from having leading/trailing blank lines or spaces (notably on clients like iMessage that preserve whitespace). The PR also adds unit tests to cover leading, trailing, and surrounding whitespace cases.

The updated logic lives in `src/agents/pi-embedded-helpers/errors.ts` and is exercised by the colocated Vitest suite in `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (a final `.trim()` on sanitized outbound text) and is covered by new unit tests for the regressions described in the PR. No API surface changes or complex logic modifications were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->