### PR TITLE
[AI-assisted] Discord: fix bare guild ID misrouted as channel ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Sessions/Agents: pass `agentId` when resolving existing transcript paths in reply runs so non-default agents and heartbeat/chat handlers no longer fail with `Session file path must be within sessions directory`. (#15141) Thanks @Goldenmonstew.
 - Sessions/Agents: pass `agentId` through status and usage transcript-resolution paths (auto-reply, gateway usage APIs, and session cost/log loaders) so non-default agents can resolve absolute session files without path-validation failures. (#15103) Thanks @jalehman.
 - Signal/Install: auto-install `signal-cli` via Homebrew on non-x64 Linux architectures, avoiding x86_64 native binary `Exec format error` failures on arm64/arm hosts. (#15443) Thanks @jogvan-k.
+- Discord: avoid misrouting numeric guild allowlist entries to `/channels/<guildId>` by prefixing guild-only inputs with `guild:` during resolution. (#12326) Thanks @headswim.
 - Web tools/web_fetch: prefer `text/markdown` responses for Cloudflare Markdown for Agents, add `cf-markdown` extraction for markdown bodies, and redact fetched URLs in `x-markdown-tokens` debug logs to avoid leaking raw paths/query params. (#15376) Thanks @Yaxuan42.
 - Config: keep legacy audio transcription migration strict by rejecting non-string/unsafe command tokens while still migrating valid custom script executables. (#5042) Thanks @shayan919293.
 


### PR DESCRIPTION
#### Summary

Due to regex ordering in `parseDiscordChannelInput`, bare numeric guild IDs were matched as channel IDs. This caused the resolver to call Discord's `/channels/<guildId>` endpoint, which 404s, and the entire channel resolution would fall back to raw config entries.

Prefixing guild-only entries with `guild:` ensures the parser skips the channel regex and routes them correctly.

#### Repro Steps

1. Configure `channels.discord.guilds` with a numeric guild ID and no specific channel keys
2. Start the Discord monitor
3. Observe: `discord channel resolve failed; using config entries. Discord API /channels/<guildId> failed (404): Unknown Channel`

#### Root Cause

In `resolve-channels.ts`, two regexes both match bare numeric strings:
- `^(?:channel:|discord:)?(\d+)$` (channel — fires first)
- `^(?:guild:|server:)?(\d+)$` (guild — never reached for bare numbers)

Because of the ordering of the regex parsing on the Discord config, bare guild IDs hit the channel path. Prefixing with `guild:` makes it skip the channel regex (which doesn't recognize `guild:` as a valid prefix) and land on the correct guild regex.

#### Behavior Changes

- Guild-only entries now prefixed with `guild:` at both call sites (monitor provider + onboarding wizard)
- No change to the parser itself — the `guild:` prefix was already supported

#### Tests

- Lightly tested — new regression tests added, all existing tests pass
- `pnpm build && pnpm check && pnpm test` — all green

#### AI-Assisted

- Built with Cursor (Claude)
- Bug initially identified via gateway logs (`discord channel resolve failed; using config entries. Discord API /channels/<guildId> failed (404): Unknown Channel`)
- Root-caused by tracing the guild ID through `provider.ts` into `parseDiscordChannelInput` and seeing the regex ordering issue
- Second instance found in onboarding wizard (`onboarding/discord.ts`) with the same pattern
- Confirmed understanding of the parser, fix, and both call sites
- 🦞

**Sign-Off**

- Models used: Claude Opus4.6 (Cursor+ Claude Code)
- Submitter effort: identified bug from logs, guided fix and testing
- Agent notes: one-line fix at two call sites, regression tests confirm the parser ambiguity, submitter's first pull request on oss

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change prefixes guild-only Discord allowlist entries with `guild:` at the two call sites that generate inputs for `resolveDiscordChannelAllowlist()` (the Discord monitor provider and the onboarding wizard). This avoids an ambiguity in `parseDiscordChannelInput()` where bare numeric strings match the channel-id regex before the guild-id regex, causing numeric guild IDs to be treated as channel IDs.

A couple regression tests were added in `src/discord/resolve-channels.test.ts` to cover `guild:`-prefixed resolution and to document the bare-numeric ambiguity.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but one new regression test does not accurately model the reported failure mode.
- The runtime behavior change is minimal and localized (string prefixing at two call sites) and aligns with the existing parser behavior. The main remaining concern is test coverage: the added bare-numeric regression test currently makes the misrouting path succeed by returning a 200 for `/channels/<id>`, so it doesn’t protect against the real 404-driven fallback described in the PR.
- src/discord/resolve-channels.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->