### PR TITLE
fix(exec): cap tool-result output separately from process cache

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -38,6 +38,7 @@ Environment overrides:
 - `PI_BASH_YIELD_MS`: default yield (ms)
 - `PI_BASH_MAX_OUTPUT_CHARS`: in‑memory output cap (chars)
 - `OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS`: pending stdout/stderr cap per stream (chars)
+- `OPENCLAW_EXEC_RESULT_MAX_CHARS`: max chars from exec output included in tool results sent to the model (hard clamp 1000–50000)
 - `PI_BASH_JOB_TTL_MS`: TTL for finished sessions (ms, bounded to 1m–3h)
 
 Config (preferred):

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2050,6 +2050,7 @@ of `every`, keep `HEARTBEAT.md` tiny, and/or choose a cheaper `model`.
 - `timeoutSec`: auto-kill after this runtime (seconds, default 1800)
 - `cleanupMs`: how long to keep finished sessions in memory (ms, default 1800000)
 - `notifyOnExit`: enqueue a system event + request heartbeat when backgrounded exec exits (default true)
+- `resultMaxChars`: max exec output chars included in tool results sent to the model (default 20000; hard clamp 1000–50000). This does **not** change `process log` in-memory aggregation caps.
 - `applyPatch.enabled`: enable experimental `apply_patch` (OpenAI/OpenAI Codex only; default false)
 - `applyPatch.allowModels`: optional allowlist of model ids (e.g. `gpt-5.2` or `openai/gpt-5.2`)
   Note: `applyPatch` is only under `tools.exec`.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2048,6 +2048,7 @@ of `every`, keep `HEARTBEAT.md` tiny, and/or choose a cheaper `model`.
 
 - `backgroundMs`: time before auto-background (ms, default 10000)
 - `timeoutSec`: auto-kill after this runtime (seconds, default 1800)
+- `resultMaxChars`: max output chars included in tool results sent to the model (does not affect process log cache; default 20000)
 - `cleanupMs`: how long to keep finished sessions in memory (ms, default 1800000)
 - `notifyOnExit`: enqueue a system event + request heartbeat when backgrounded exec exits (default true)
 - `resultMaxChars`: max exec output chars included in tool results sent to the model (default 20000; hard clamp 1000–50000). This does **not** change `process log` in-memory aggregation caps.

--- a/src/agents/bash-tools.exec.result-cap.test.ts
+++ b/src/agents/bash-tools.exec.result-cap.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+const isWin = process.platform === "win32";
+
+describe("exec tool result cap", () => {
+  it("truncates foreground gateway exec output before returning tool result", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      resultMaxChars: 1000,
+    });
+
+    const result = await tool.execute("call1", {
+      command: "node -e \"process.stdout.write('a'.repeat(6000))\"",
+      timeout: 30,
+    });
+
+    const text = result.content.find((entry) => entry.type === "text")?.text ?? "";
+    expect(text).toContain("[TRUNCATED originalChars=");
+    expect(result.details?.status).toBe("completed");
+    if (
+      result.details &&
+      (result.details.status === "completed" || result.details.status === "failed")
+    ) {
+      expect(result.details.truncated).toBe(true);
+      expect(typeof result.details.originalChars).toBe("number");
+      expect(typeof result.details.keptChars).toBe("number");
+      expect(result.details.originalChars).toBeGreaterThan(result.details.keptChars ?? 0);
+      expect(result.details.aggregated).toContain("[TRUNCATED originalChars=");
+    }
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -29,6 +29,7 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import { logInfo, logWarn } from "../logger.js";
 import { formatSpawnError, spawnWithFallback } from "../process/spawn-utils.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { clampNumber } from "../utils.js";
 import {
   type ProcessSession,
   type SessionStdin,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -119,7 +119,7 @@ const DEFAULT_PENDING_MAX_OUTPUT = clampWithDefault(
   200_000,
 );
 
-const DEFAULT_RESULT_MAX_OUTPUT = clampNumber(
+const DEFAULT_RESULT_MAX_OUTPUT = clampWithDefault(
   readEnvInt("OPENCLAW_EXEC_RESULT_MAX_CHARS"),
   20_000,
   1_000,
@@ -889,7 +889,7 @@ export function createExecTool(
 
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
-      const resultMaxChars = clampNumber(
+      const resultMaxChars = clampWithDefault(
         defaults?.resultMaxChars,
         DEFAULT_RESULT_MAX_OUTPUT,
         1_000,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -29,7 +29,6 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import { logInfo, logWarn } from "../logger.js";
 import { formatSpawnError, spawnWithFallback } from "../process/spawn-utils.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
-import { clampNumber } from "../utils.js";
 import {
   type ProcessSession,
   type SessionStdin,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -97,6 +97,7 @@ function resolveExecConfig(cfg: OpenClawConfig | undefined) {
     safeBins: globalExec?.safeBins,
     backgroundMs: globalExec?.backgroundMs,
     timeoutSec: globalExec?.timeoutSec,
+    resultMaxChars: globalExec?.resultMaxChars,
     approvalRunningNoticeMs: globalExec?.approvalRunningNoticeMs,
     cleanupMs: globalExec?.cleanupMs,
     notifyOnExit: globalExec?.notifyOnExit,
@@ -290,6 +291,7 @@ export function createOpenClawCodingTools(options?: {
     timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
     approvalRunningNoticeMs:
       options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
+    resultMaxChars: options?.exec?.resultMaxChars ?? execConfig.resultMaxChars,
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     sandbox: sandbox
       ? {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,13 +281,11 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
-=======
 
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
-=======
 
   return grok as GrokConfig;
 }
@@ -297,7 +295,6 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
-=======
 
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
@@ -481,14 +478,6 @@ async function runWebSearch(params: {
   grokModel?: string;
   grokInlineCitations?: boolean;
 }): Promise<Record<string, unknown>> {
-  const cacheKey = normalizeCacheKey(
-    params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : params.provider === "perplexity"
-        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
-  );
-=======
   let rawCacheKey: string;
   switch (params.provider) {
     case "brave":

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,10 +281,14 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
+=======
+
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
+=======
+
   return grok as GrokConfig;
 }
 
@@ -293,6 +297,8 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
+=======
+
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
 }
@@ -482,6 +488,24 @@ async function runWebSearch(params: {
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
+=======
+  let rawCacheKey: string;
+  switch (params.provider) {
+    case "brave":
+      rawCacheKey = `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`;
+      break;
+    case "perplexity":
+      rawCacheKey = `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`;
+      break;
+    case "grok":
+      rawCacheKey = `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${params.grokInlineCitations ?? false}`;
+      break;
+    default:
+      rawCacheKey = `${String(params.provider)}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`;
+      break;
+  }
+
+  const cacheKey = normalizeCacheKey(rawCacheKey);
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -177,6 +177,8 @@ export type ExecToolConfig = {
   backgroundMs?: number;
   /** Default timeout (seconds) before auto-killing exec commands. */
   timeoutSec?: number;
+  /** Max characters from exec output to include in tool results sent to the model (does not affect process log cache). */
+  resultMaxChars?: number;
   /** Emit a running notice (ms) when approval-backed exec runs long (default: 10000, 0 = off). */
   approvalRunningNoticeMs?: number;
   /** How long to keep finished sessions in memory (ms). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -283,6 +283,7 @@ export const AgentToolsSchema = z
         safeBins: z.array(z.string()).optional(),
         backgroundMs: z.number().int().positive().optional(),
         timeoutSec: z.number().int().positive().optional(),
+        resultMaxChars: z.number().int().positive().optional(),
         approvalRunningNoticeMs: z.number().int().nonnegative().optional(),
         cleanupMs: z.number().int().positive().optional(),
         notifyOnExit: z.boolean().optional(),
@@ -535,6 +536,7 @@ export const ToolsSchema = z
         safeBins: z.array(z.string()).optional(),
         backgroundMs: z.number().int().positive().optional(),
         timeoutSec: z.number().int().positive().optional(),
+        resultMaxChars: z.number().int().positive().optional(),
         cleanupMs: z.number().int().positive().optional(),
         notifyOnExit: z.boolean().optional(),
         applyPatch: z


### PR DESCRIPTION
## Summary
- add `tools.exec.resultMaxChars` config (and env override `OPENCLAW_EXEC_RESULT_MAX_CHARS`) to cap exec output that is **returned to the model**
- keep existing process/session aggregation caps unchanged (`PI_BASH_MAX_OUTPUT_CHARS`, pending cap), so `process log` observability remains intact
- apply truncation to both gateway exec and node exec return paths, with explicit marker:
  - `[TRUNCATED originalChars=... keptChars=... capChars=...]`
- include truncation metadata in exec tool details (`truncated`, `originalChars`, `keptChars`)
- add regression test: `bash-tools.exec.result-cap.test.ts`
- document the new knob in gateway docs

## Why
Large single-turn tool results can still blow model context before pruning/compaction kicks in.
This separates:
- **cache budget** (for debugging/process log)
- **model-injection budget** (for prompt safety)

## Base decision (PRFLOW)
Based on `upstream/main` directly (not stacked), because this change is orthogonal to current `/new` queue/session PR chain and should stay reviewable in isolation.

## Validation
- `pnpm -s vitest run src/agents/bash-tools.exec*.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a separate output cap for `exec` tool results sent back to the model (`tools.exec.resultMaxChars`, env override `OPENCLAW_EXEC_RESULT_MAX_CHARS`) while keeping the existing process/session aggregation caps unchanged for `process log` observability. The implementation adds a head/tail truncation helper that appends a `[TRUNCATED ...]` marker and attaches truncation metadata to `ExecToolDetails`. Both gateway and node exec return paths are updated to apply this truncation, and a regression test plus docs updates are included.

In the codebase, this hooks into the existing `createExecTool` implementation (`src/agents/bash-tools.exec.ts`) and is wired through tool config resolution (`src/agents/pi-tools.ts`) and the runtime config schemas (`src/config/types.tools.ts`, `src/config/zod-schema.agent-runtime.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but there are a couple of inconsistencies in how the cap is applied and how warnings/aggregated output are returned.
- Core truncation logic is straightforward and applied in multiple return paths, but (1) the warnings prefix can cause the final returned text to exceed the configured cap in the sandbox/gateway foreground path, and (2) the host=node gateway-return path drops warnings entirely. Both are user-visible/model-visible behavior changes that should be corrected before merging.
- src/agents/bash-tools.exec.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->