### PR TITLE
feat(tts): add stripMarkdown config option to clean text before synthesis

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1374,7 +1374,7 @@ Notes:
 
 ### Why do I need a token on localhost now
 
-The wizard generates a gateway token by default (even on loopback) so **local WS clients must authenticate**. This blocks other local processes from calling the Gateway. Paste the token into the Control UI settings (or your client config) to connect.
+The wizard generates a gateway token by default (even on loopback) so **local WS clients must authenticate**. This blocks other local processes from calling the Gateway. Paste the token into the Overview → Gateway Access (or your client config) to connect.
 
 If you **really** want open loopback, remove `gateway.auth` from your config. Doctor can generate a token for you any time: `openclaw doctor --generate-gateway-token`.
 
@@ -2409,7 +2409,7 @@ Fix:
 - If you don't have a token yet: `openclaw doctor --generate-gateway-token`.
 - If remote, tunnel first: `ssh -N -L 18789:127.0.0.1:18789 user@host` then open `http://127.0.0.1:18789/`.
 - Set `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`) on the gateway host.
-- In the Control UI settings, paste the same token.
+- In the Overview → Gateway Access, paste the same token (or refresh with a one-time `?token=...` link).
 - Still stuck? Run `openclaw status --all` and follow [Troubleshooting](/gateway/troubleshooting). See [Dashboard](/web/dashboard) for auth details.
 
 ### I set gatewaybind tailnet but it cant bind nothing listens

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -139,4 +139,4 @@ Note: Moonshot and Kimi Coding are separate providers. Keys are not interchangea
 - Override pricing and context metadata in `models.providers` if needed.
 - If Moonshot publishes different context limits for a model, adjust
   `contextWindow` accordingly.
-- Use `https://api.moonshot.ai/v1` for the international endpoint, and `https://api.moonshot.cn/v1` for the China endpoint.
+- Use `https://api.moonshot.cn/v1` if you need the China endpoint.

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -9,6 +9,11 @@
   "peerDependencies": {
     "openclaw": ">=2026.1.26"
   },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -9,6 +9,7 @@ export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
+  ignorePaths: string[];
   provider: "openai" | "local" | "gemini" | "voyage" | "auto";
   remote?: {
     baseUrl?: string;
@@ -181,6 +182,26 @@ function mergeConfig(
     .map((value) => value.trim())
     .filter(Boolean);
   const extraPaths = Array.from(new Set(rawPaths));
+  // Default ignore patterns for common non-document directories
+  const defaultIgnorePaths = [
+    "**/node_modules/**",
+    "**/.git/**",
+    "**/.venv/**",
+    "**/venv/**",
+    "**/.env/**",
+    "**/__pycache__/**",
+    "**/.tox/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.nuxt/**",
+    "**/target/**",
+    "**/.cargo/**",
+  ];
+  const userIgnorePaths = [...(defaults?.ignorePaths ?? []), ...(overrides?.ignorePaths ?? [])]
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const ignorePaths = Array.from(new Set([...defaultIgnorePaths, ...userIgnorePaths]));
   const vector = {
     enabled: overrides?.store?.vector?.enabled ?? defaults?.store?.vector?.enabled ?? true,
     extensionPath:
@@ -256,6 +277,7 @@ function mergeConfig(
     enabled,
     sources,
     extraPaths,
+    ignorePaths,
     provider,
     remote,
     experimental: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -25,7 +25,7 @@ type ModelCandidate = {
   model: string;
 };
 
-type FallbackAttempt = {
+export type FallbackAttempt = {
   provider: string;
   model: string;
   error: string;

--- a/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
+++ b/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
@@ -55,3 +55,18 @@ describe("isContextOverflowError", () => {
     expect(isContextOverflowError("Something is causing context overflow messages")).toBe(false);
   });
 });
+
+describe("isContextOverflowError - Anthropic extended thinking", () => {
+  it("matches Anthropic 'exceed context limit' error from extended thinking", () => {
+    // When using extended thinking with large contexts, Anthropic returns this error:
+    // "input length and max_tokens exceed context limit: 156321 + 48384 > 200000"
+    const samples = [
+      "input length and max_tokens exceed context limit: 156321 + 48384 > 200000",
+      '{"type":"error","error":{"type":"invalid_request_error","message":"input length and max_tokens exceed context limit: 100000 + 16000 > 100000"}}',
+      "exceed context limit: 50000 + 10000 > 50000",
+    ];
+    for (const sample of samples) {
+      expect(isContextOverflowError(sample)).toBe(true);
+    }
+  });
+});

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -25,7 +25,8 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("exceeds model context window") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
     lower.includes("context overflow:") ||
-    (lower.includes("413") && lower.includes("too large"))
+    (lower.includes("413") && lower.includes("too large")) ||
+    lower.includes("exceed context limit")
   );
 }
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -164,7 +164,14 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
-  const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
+  let model = modelRegistry.find(provider, modelId) as Model<Api> | null;
+
+  // Fallback: OpenRouter's "auto" model is stored with full id "openrouter/auto"
+  // but parseModelRef splits it into provider="openrouter", modelId="auto"
+  if (!model && provider === "openrouter" && modelId === "auto") {
+    model = modelRegistry.find(provider, "openrouter/auto") as Model<Api> | null;
+  }
+
   if (!model) {
     const providers = cfg?.models?.providers ?? {};
     const inlineModels = buildInlineProviderModels(providers);

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -32,7 +32,6 @@ import {
   classifyFailoverReason,
   formatAssistantErrorText,
   isAuthAssistantError,
-  isBillingAssistantError,
   isCompactionFailureError,
   isContextOverflowError,
   isFailoverAssistantError,
@@ -706,7 +705,6 @@ export async function runEmbeddedPiAgent(
 
           const authFailure = isAuthAssistantError(lastAssistant);
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          const billingFailure = isBillingAssistantError(lastAssistant);
           const failoverFailure = isFailoverAssistantError(lastAssistant);
           const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -186,7 +186,11 @@ export async function runEmbeddedPiAgent(
         params.config,
       );
       if (!model) {
-        throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
+        throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
+          reason: "unknown",
+          provider,
+          model: modelId,
+        });
       }
 
       const ctxInfo = resolveContextWindowInfo({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -32,6 +32,7 @@ import {
   classifyFailoverReason,
   formatAssistantErrorText,
   isAuthAssistantError,
+  isBillingAssistantError,
   isCompactionFailureError,
   isContextOverflowError,
   isFailoverAssistantError,
@@ -709,6 +710,7 @@ export async function runEmbeddedPiAgent(
 
           const authFailure = isAuthAssistantError(lastAssistant);
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
+          const billingFailure = isBillingAssistantError(lastAssistant);
           const failoverFailure = isFailoverAssistantError(lastAssistant);
           const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -821,6 +821,18 @@ export async function runEmbeddedAttempt(
             });
           }
 
+          // Diagnostic: log context sizes before prompt to help debug early overflow errors.
+          {
+            const msgCount = activeSession.messages.length;
+            const systemLen = systemPromptText?.length ?? 0;
+            const promptLen = effectivePrompt.length;
+            log.info(
+              `[context-diag] pre-prompt: sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                `messages=${msgCount} systemPromptChars=${systemLen} promptChars=${promptLen} ` +
+                `provider=${params.provider}/${params.modelId} sessionFile=${params.sessionFile}`,
+            );
+          }
+
           // Only pass images option if there are actually images to pass
           // This avoids potential issues with models that don't expect the images parameter
           if (imageResult.images.length > 0) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -602,7 +602,8 @@ export async function runEmbeddedAttempt(
         } else {
           runAbortController.abort(reason);
         }
-        void activeSession.abort();
+        // Catch AbortError from in-flight requests - expected during timeout aborts
+        activeSession.abort().catch(() => {});
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> => {
         const signal = runAbortController.signal;

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -19,6 +19,8 @@ const TURN_PREFIX_INSTRUCTIONS =
   " early progress, and any details needed to understand the retained suffix.";
 const MAX_TOOL_FAILURES = 8;
 const MAX_TOOL_FAILURE_CHARS = 240;
+const FALLBACK_RECENT_MESSAGES = 10;
+const MAX_MESSAGE_PREVIEW_CHARS = 500;
 
 type ToolFailure = {
   toolCallId: string;
@@ -158,6 +160,54 @@ function formatFileOperations(readFiles: string[], modifiedFiles: string[]): str
   return `\n\n${sections.join("\n\n")}`;
 }
 
+function extractMessageText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const rec = block as { type?: unknown; text?: unknown };
+    if (rec.type === "text" && typeof rec.text === "string") {
+      parts.push(rec.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function formatRecentMessagesSection(messages: AgentMessage[]): string {
+  if (messages.length === 0) {
+    return "";
+  }
+  const recent = messages.slice(-FALLBACK_RECENT_MESSAGES);
+  const lines: string[] = [];
+  for (const message of recent) {
+    const role = (message as { role?: unknown }).role;
+    if (role !== "user" && role !== "assistant") {
+      continue;
+    }
+    const content = (message as { content?: unknown }).content;
+    let text = extractMessageText(content);
+    if (!text.trim()) {
+      continue;
+    }
+    if (text.length > MAX_MESSAGE_PREVIEW_CHARS) {
+      text = `${text.slice(0, MAX_MESSAGE_PREVIEW_CHARS)}...`;
+    }
+    const label = role === "user" ? "**User**" : "**Assistant**";
+    lines.push(`${label}: ${text.replace(/\n/g, " ").trim()}`);
+  }
+  if (lines.length === 0) {
+    return "";
+  }
+  return `\n\n## Recent Messages (fallback context)\n${lines.join("\n\n")}`;
+}
+
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const { preparation, customInstructions, signal } = event;
@@ -168,7 +218,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       ...preparation.turnPrefixMessages,
     ]);
     const toolFailureSection = formatToolFailuresSection(toolFailures);
-    const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
+    const recentMessagesSection = formatRecentMessagesSection(preparation.messagesToSummarize);
+    const fallbackSummary = `${FALLBACK_SUMMARY}${recentMessagesSection}${toolFailureSection}${fileOpsSummary}`;
 
     const model = ctx.model;
     if (!model) {

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -33,10 +33,8 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.venv([\\/]|$)/,
   /(^|[\\/])venv([\\/]|$)/,
   /(^|[\\/])__pycache__([\\/]|$)/,
-  /(^|[\\/])\.mypy_cache([\\/]|$)/,
   /(^|[\\/])\.pytest_cache([\\/]|$)/,
-  // Build artifacts and caches
-  /(^|[\\/])build([\\/]|$)/,
+  // General caches
   /(^|[\\/])\.cache([\\/]|$)/,
 ];
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -397,8 +397,10 @@ export async function runSubagentAnnounceFlow(params: {
   let shouldDeleteChildSession = params.cleanup === "delete";
   try {
     // Check if announcements are suppressed (per-spawn or global config).
+    // Return true (not false) so callers treat suppression as success for cleanup bookkeeping —
+    // returning false would cause finalizeSubagentCleanup to retry on every wake/restart.
     if (shouldSuppressAnnounce({ silent: params.silent })) {
-      return false;
+      return true;
     }
     const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
     const childSessionId = (() => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -364,6 +364,16 @@ export type SubagentRunOutcome = {
 
 export type SubagentAnnounceType = "subagent task" | "cron job";
 
+function shouldSuppressAnnounce(params: { silent?: boolean }): boolean {
+  // Per-spawn override takes precedence.
+  if (typeof params.silent === "boolean") {
+    return params.silent;
+  }
+  // Fall back to global config.
+  const cfg = loadConfig();
+  return cfg.agents?.defaults?.subagents?.suppressAnnounce === true;
+}
+
 export async function runSubagentAnnounceFlow(params: {
   childSessionKey: string;
   childRunId: string;
@@ -380,10 +390,16 @@ export async function runSubagentAnnounceFlow(params: {
   label?: string;
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
+  /** Per-spawn override: when true, skip the announcement entirely. */
+  silent?: boolean;
 }): Promise<boolean> {
   let didAnnounce = false;
   let shouldDeleteChildSession = params.cleanup === "delete";
   try {
+    // Check if announcements are suppressed (per-spawn or global config).
+    if (shouldSuppressAnnounce({ silent: params.silent })) {
+      return false;
+    }
     const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
     const childSessionId = (() => {
       const entry = loadSessionEntryByKey(params.childSessionKey);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -18,6 +18,8 @@ export type SubagentRunRecord = {
   task: string;
   cleanup: "delete" | "keep";
   label?: string;
+  /** When true, suppress the completion announcement to the parent session. */
+  silent?: boolean;
   createdAt: number;
   startedAt?: number;
   endedAt?: number;
@@ -76,6 +78,7 @@ function resumeSubagentRun(runId: string) {
       endedAt: entry.endedAt,
       label: entry.label,
       outcome: entry.outcome,
+      silent: entry.silent,
     }).then((didAnnounce) => {
       finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
     });
@@ -239,6 +242,7 @@ function ensureListener() {
       endedAt: entry.endedAt,
       label: entry.label,
       outcome: entry.outcome,
+      silent: entry.silent,
     }).then((didAnnounce) => {
       finalizeSubagentCleanup(evt.runId, entry.cleanup, didAnnounce);
     });
@@ -291,6 +295,7 @@ export function registerSubagentRun(params: {
   cleanup: "delete" | "keep";
   label?: string;
   runTimeoutSeconds?: number;
+  silent?: boolean;
 }) {
   const now = Date.now();
   const cfg = loadConfig();
@@ -307,6 +312,7 @@ export function registerSubagentRun(params: {
     task: params.task,
     cleanup: params.cleanup,
     label: params.label,
+    silent: params.silent,
     createdAt: now,
     startedAt: now,
     archiveAtMs,
@@ -387,6 +393,7 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       endedAt: entry.endedAt,
       label: entry.label,
       outcome: entry.outcome,
+      silent: entry.silent,
     }).then((didAnnounce) => {
       finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
     });

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -145,7 +145,6 @@ async function resizeImageBase64IfNeeded(params: {
     }
   }
 
-  const bestBase64 = smallest?.base64 ?? params.base64;
   const bestSize = smallest?.size ?? base64Length;
   const maxMb = (params.maxBytes / (1024 * 1024)).toFixed(0);
   const gotMb = (bestSize / (1024 * 1024)).toFixed(2);

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -33,6 +33,7 @@ const SessionsSpawnToolSchema = Type.Object({
   // Back-compat alias. Prefer runTimeoutSeconds.
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
+  silent: Type.Optional(Type.Boolean()),
 });
 
 function splitModelRef(ref?: string) {
@@ -93,6 +94,7 @@ export function createSessionsSpawnTool(opts?: {
       const thinkingOverrideRaw = readStringParam(params, "thinking");
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
+      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
       const requesterOrigin = normalizeDeliveryContext({
         channel: opts?.agentChannel,
         accountId: opts?.agentAccountId,
@@ -293,6 +295,7 @@ export function createSessionsSpawnTool(opts?: {
         cleanup,
         label: label || undefined,
         runTimeoutSeconds,
+        silent,
       });
 
       return jsonResult({

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -23,6 +23,12 @@ function resolveProviderFromContext(ctx: MsgContext, cfg: OpenClawConfig): Chann
   if (direct) {
     return direct;
   }
+  // For internal channels (webchat, tui), don't fallback to configured messaging channels.
+  // These channels are always trusted and should not inherit allowFrom restrictions.
+  const provider = (ctx.Provider ?? ctx.Surface ?? "").trim().toLowerCase();
+  if (provider === "webchat" || provider === "tui") {
+    return undefined;
+  }
   const candidates = [ctx.From, ctx.To]
     .filter((value): value is string => Boolean(value?.trim()))
     .flatMap((value) => value.split(":").map((part) => part.trim()));

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -8,7 +8,7 @@ import type { TypingSignaler } from "./typing-mode.js";
 import { resolveAgentModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { runWithModelFallback, type FallbackAttempt } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
   isCompactionFailureError,
@@ -44,6 +44,7 @@ export type AgentRunLoopResult =
       runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
       fallbackProvider?: string;
       fallbackModel?: string;
+      fallbackAttempts: FallbackAttempt[];
       didLogHeartbeatStrip: boolean;
       autoCompactionCompleted: boolean;
       /** Payload keys sent directly (not via pipeline) during tool flush. */
@@ -96,6 +97,7 @@ export async function runAgentTurnWithFallback(params: {
   let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
   let fallbackProvider = params.followupRun.run.provider;
   let fallbackModel = params.followupRun.run.model;
+  let fallbackAttempts: FallbackAttempt[] = [];
   let didResetAfterCompactionFailure = false;
 
   while (true) {
@@ -469,6 +471,7 @@ export async function runAgentTurnWithFallback(params: {
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
+      fallbackAttempts = fallbackResult.attempts;
 
       // Some embedded runs surface context overflow as an error payload instead of throwing.
       // Treat those as a session-level failure and auto-recover by starting a fresh session.
@@ -599,6 +602,7 @@ export async function runAgentTurnWithFallback(params: {
     runResult,
     fallbackProvider,
     fallbackModel,
+    fallbackAttempts,
     didLogHeartbeatStrip,
     autoCompactionCompleted,
     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,

--- a/src/auto-reply/reply/fallback-notify.test.ts
+++ b/src/auto-reply/reply/fallback-notify.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { checkFallbackNotification } from "./fallback-notify.js";
+
+describe("checkFallbackNotification", () => {
+  it("returns undefined when no attempts (primary succeeded)", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-1",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns a notification when fallback model is used", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-2",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "rate limited",
+          reason: "rate_limit",
+        },
+      ],
+    });
+    expect(result).toBeDefined();
+    expect(result).toContain("anthropic/claude-haiku-3-5");
+    expect(result).toContain("openai/gpt-4.1-mini");
+    expect(result).toContain("rate_limit");
+  });
+
+  it("suppresses duplicate notifications for the same fallback", () => {
+    const sessionKey = "test-session-3";
+    const params = {
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "rate limited",
+          reason: "rate_limit" as const,
+        },
+      ],
+    };
+
+    // First call should notify
+    const first = checkFallbackNotification(params);
+    expect(first).toBeDefined();
+
+    // Second call with same fallback should be suppressed
+    const second = checkFallbackNotification(params);
+    expect(second).toBeUndefined();
+  });
+
+  it("clears tracker when primary succeeds again", () => {
+    const sessionKey = "test-session-4";
+
+    // Fallback used — should notify
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+
+    // Primary recovers — clears tracker
+    checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [],
+    });
+
+    // Fallback again — should notify again (new failover event)
+    const third = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(third).toBeDefined();
+  });
+
+  it("notifies again when fallback model changes", () => {
+    const sessionKey = "test-session-5";
+
+    // First fallback
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+    expect(first).toContain("claude-haiku-3-5");
+
+    // Different fallback model — should notify again
+    const second = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "google",
+      usedModel: "gemini-2.5-flash",
+      attempts: [
+        { provider: "openai", model: "gpt-4.1-mini", error: "rate limited" },
+        { provider: "anthropic", model: "claude-haiku-3-5", error: "also rate limited" },
+      ],
+    });
+    expect(second).toBeDefined();
+    expect(second).toContain("gemini-2.5-flash");
+  });
+
+  it("returns undefined when used model matches original despite attempts", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-6",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "transient error" }],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("works without a session key", () => {
+    const result = checkFallbackNotification({
+      sessionKey: undefined,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(result).toBeDefined();
+  });
+
+  it("includes reason from the primary attempt when available", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-7",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "billing error",
+          reason: "billing",
+        },
+      ],
+    });
+    expect(result).toContain("billing");
+  });
+
+  it("omits reason when not available on primary attempt", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-8",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "unknown error" }],
+    });
+    expect(result).toBeDefined();
+    expect(result).not.toContain("(undefined)");
+  });
+});

--- a/src/auto-reply/reply/fallback-notify.ts
+++ b/src/auto-reply/reply/fallback-notify.ts
@@ -1,0 +1,62 @@
+import type { FallbackAttempt } from "../../agents/model-fallback.js";
+
+/**
+ * In-memory tracker for fallback model notifications.
+ *
+ * Ensures the user is notified only ONCE per failover event —
+ * i.e., when the fallback model changes or the primary recovers
+ * and then fails again.
+ */
+const lastNotifiedFallback = new Map<string, string>();
+
+/**
+ * Determine whether a fallback notification should be shown to the user.
+ *
+ * Returns a notification message when:
+ * 1. The primary model failed and a different fallback model was used
+ * 2. We haven't already notified about this specific fallback for this session
+ *
+ * Clears the tracker when the primary model succeeds (no attempts).
+ */
+export function checkFallbackNotification(params: {
+  sessionKey: string | undefined;
+  originalProvider: string;
+  originalModel: string;
+  usedProvider: string;
+  usedModel: string;
+  attempts: FallbackAttempt[];
+}): string | undefined {
+  const { sessionKey, originalProvider, originalModel, usedProvider, usedModel, attempts } = params;
+
+  // No failed attempts — primary model succeeded
+  if (attempts.length === 0) {
+    if (sessionKey) {
+      lastNotifiedFallback.delete(sessionKey);
+    }
+    return undefined;
+  }
+
+  // Fallback was used — check if it's actually a different model
+  const usedKey = `${usedProvider}/${usedModel}`;
+  const primaryKey = `${originalProvider}/${originalModel}`;
+
+  if (usedKey === primaryKey) {
+    return undefined;
+  }
+
+  // Already notified about this exact fallback for this session
+  if (sessionKey && lastNotifiedFallback.get(sessionKey) === usedKey) {
+    return undefined;
+  }
+
+  // Record notification
+  if (sessionKey) {
+    lastNotifiedFallback.set(sessionKey, usedKey);
+  }
+
+  // Build a concise reason from the first failed attempt
+  const primaryAttempt = attempts[0];
+  const reason = primaryAttempt?.reason ? ` (${primaryAttempt.reason})` : "";
+
+  return `⚡ Using fallback model \`${usedProvider}/${usedModel}\` — primary \`${primaryKey}\` is unavailable${reason}`;
+}

--- a/src/auto-reply/reply/fallback-notify.ts
+++ b/src/auto-reply/reply/fallback-notify.ts
@@ -1,13 +1,51 @@
 import type { FallbackAttempt } from "../../agents/model-fallback.js";
 
+/** Maximum number of sessions tracked before evicting the oldest entries. */
+const MAX_TRACKED_SESSIONS = 1000;
+
+/** Time-to-live for each entry (1 hour). */
+const ENTRY_TTL_MS = 60 * 60 * 1000;
+
+interface TrackedFallback {
+  model: string;
+  ts: number;
+}
+
 /**
  * In-memory tracker for fallback model notifications.
  *
  * Ensures the user is notified only ONCE per failover event —
  * i.e., when the fallback model changes or the primary recovers
  * and then fails again.
+ *
+ * Entries are capped at {@link MAX_TRACKED_SESSIONS} and expire
+ * after {@link ENTRY_TTL_MS} to prevent unbounded memory growth.
  */
-const lastNotifiedFallback = new Map<string, string>();
+const lastNotifiedFallback = new Map<string, TrackedFallback>();
+
+/** Evict entries older than {@link ENTRY_TTL_MS}. */
+function evictStale(now: number): void {
+  for (const [key, entry] of lastNotifiedFallback) {
+    if (now - entry.ts > ENTRY_TTL_MS) {
+      lastNotifiedFallback.delete(key);
+    } else {
+      // Map iterates in insertion order; once we hit a fresh entry the rest are newer.
+      break;
+    }
+  }
+}
+
+/** Evict oldest entries until the map is within the size cap. */
+function evictOldest(): void {
+  while (lastNotifiedFallback.size > MAX_TRACKED_SESSIONS) {
+    const oldest = lastNotifiedFallback.keys().next().value;
+    if (oldest !== undefined) {
+      lastNotifiedFallback.delete(oldest);
+    } else {
+      break;
+    }
+  }
+}
 
 /**
  * Determine whether a fallback notification should be shown to the user.
@@ -28,6 +66,9 @@ export function checkFallbackNotification(params: {
 }): string | undefined {
   const { sessionKey, originalProvider, originalModel, usedProvider, usedModel, attempts } = params;
 
+  const now = Date.now();
+  evictStale(now);
+
   // No failed attempts — primary model succeeded
   if (attempts.length === 0) {
     if (sessionKey) {
@@ -45,13 +86,19 @@ export function checkFallbackNotification(params: {
   }
 
   // Already notified about this exact fallback for this session
-  if (sessionKey && lastNotifiedFallback.get(sessionKey) === usedKey) {
-    return undefined;
+  if (sessionKey) {
+    const existing = lastNotifiedFallback.get(sessionKey);
+    if (existing && existing.model === usedKey) {
+      return undefined;
+    }
   }
 
   // Record notification
   if (sessionKey) {
-    lastNotifiedFallback.set(sessionKey, usedKey);
+    // Delete first so re-insertion moves the key to the end (freshest).
+    lastNotifiedFallback.delete(sessionKey);
+    lastNotifiedFallback.set(sessionKey, { model: usedKey, ts: now });
+    evictOldest();
   }
 
   // Build a concise reason from the first failed attempt

--- a/src/commands/chutes-oauth.test.ts
+++ b/src/commands/chutes-oauth.test.ts
@@ -48,6 +48,7 @@ describe("loginChutes", () => {
         expect(state).toBeTruthy();
         // Use the actual bound port (reported via onListening) instead of
         // the placeholder port 0 from the redirect URI.
+        expect(boundPort).toBeGreaterThan(0);
         await fetch(`http://127.0.0.1:${boundPort}/oauth-callback?code=code_local&state=${state}`);
       },
       onPrompt,

--- a/src/commands/chutes-oauth.ts
+++ b/src/commands/chutes-oauth.ts
@@ -168,10 +168,7 @@ export async function loginChutes(params: {
     }
     codeAndState = parsed;
   } else {
-    let resolveReady!: () => void;
-    const readyPromise = new Promise<void>((resolve) => {
-      resolveReady = resolve;
-    });
+    const { promise: readyPromise, resolve: resolveReady } = Promise.withResolvers<void>();
 
     const callback = waitForLocalCallback({
       redirectUri: params.app.redirectUri,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -210,6 +210,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Suppress sub-agent completion announcements to the parent session (default: false). */
+    suppressAnnounce?: boolean;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -23,6 +23,12 @@ export type TelegramActionConfig = {
 export type TelegramNetworkConfig = {
   /** Override Node's autoSelectFamily behavior (true = enable, false = disable). */
   autoSelectFamily?: boolean;
+  /**
+   * DNS result order for network requests ("ipv4first" | "verbatim").
+   * Set to "ipv4first" to prioritize IPv4 addresses and work around IPv6 issues.
+   * Default: "ipv4first" on Node 22+ to avoid common fetch failures.
+   */
+  dnsResultOrder?: "ipv4first" | "verbatim";
 };
 
 export type TelegramInlineButtonsScope = "off" | "dm" | "group" | "all" | "allowlist";

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -228,6 +228,8 @@ export type MemorySearchConfig = {
   sources?: Array<"memory" | "sessions">;
   /** Extra paths to include in memory search (directories or .md files). */
   extraPaths?: string[];
+  /** Glob patterns to ignore when watching extraPaths (merged with defaults like node_modules, .git, .venv). */
+  ignorePaths?: string[];
   /** Experimental memory search settings. */
   experimental?: {
     /** Enable session transcript indexing (experimental, default: false). */

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -32,6 +32,8 @@ export type TtsConfig = {
   mode?: TtsMode;
   /** Primary TTS provider (fallbacks are automatic). */
   provider?: TtsProvider;
+  /** Strip markdown formatting from text before sending to TTS provider. */
+  stripMarkdown?: boolean;
   /** Optional model override for TTS auto-summary (provider/model or alias). */
   summaryModel?: string;
   /** Allow the model to override TTS parameters. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -153,6 +153,7 @@ export const AgentDefaultsSchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        suppressAnnounce: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -320,6 +320,8 @@ export const MemorySearchSchema = z
     enabled: z.boolean().optional(),
     sources: z.array(z.union([z.literal("memory"), z.literal("sessions")])).optional(),
     extraPaths: z.array(z.string()).optional(),
+    /** Glob patterns to ignore when watching extraPaths (merged with defaults). */
+    ignorePaths: z.array(z.string()).optional(),
     experimental: z
       .object({
         sessionMemory: z.boolean().optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -164,6 +164,7 @@ export const TtsConfigSchema = z
     enabled: z.boolean().optional(),
     mode: TtsModeSchema.optional(),
     provider: TtsProviderSchema.optional(),
+    stripMarkdown: z.boolean().optional(),
     summaryModel: z.string().optional(),
     modelOverrides: z
       .object({

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -119,6 +119,7 @@ export const TelegramAccountSchemaBase = z
     network: z
       .object({
         autoSelectFamily: z.boolean().optional(),
+        dnsResultOrder: z.enum(["ipv4first", "verbatim"]).optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -47,6 +47,7 @@ const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
 const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
   { prefix: "gateway.reload", kind: "none" },
+  { prefix: "meta", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
   {

--- a/src/gateway/control-ui.test.ts
+++ b/src/gateway/control-ui.test.ts
@@ -2,7 +2,12 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  buildControlUiAvatarUrl,
+  normalizeControlUiBasePath,
+  resolveAssistantAvatarUrl,
+} from "./control-ui-shared.js";
 import { handleControlUiHttpRequest } from "./control-ui.js";
 
 const makeResponse = (): {
@@ -40,5 +45,99 @@ describe("handleControlUiHttpRequest", () => {
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleControlUiHttpRequest – SPA fallback vs /api/* routes
+// ---------------------------------------------------------------------------
+
+function mockReq(method: string, url: string): IncomingMessage {
+  return { method, url, headers: {} } as unknown as IncomingMessage;
+}
+
+function mockRes(): ServerResponse & {
+  _status: number;
+  _headers: Record<string, string>;
+  _body: string;
+} {
+  const res = {
+    _status: 200,
+    _headers: {} as Record<string, string>,
+    _body: "",
+    set statusCode(v: number) {
+      this._status = v;
+    },
+    get statusCode() {
+      return this._status;
+    },
+    setHeader(k: string, v: string) {
+      this._headers[k.toLowerCase()] = v;
+    },
+    end(body?: string | Buffer) {
+      if (body != null) this._body = typeof body === "string" ? body : body.toString("utf8");
+    },
+  } as unknown as ServerResponse & {
+    _status: number;
+    _headers: Record<string, string>;
+    _body: string;
+  };
+  return res;
+}
+
+describe("handleControlUiHttpRequest – /api/ exclusion", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cui-test-"));
+    fs.writeFileSync(path.join(tmpDir, "index.html"), "<html><body>SPA</body></html>", "utf8");
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const rootState = () => ({ kind: "resolved" as const, path: tmpDir });
+
+  it("serves SPA fallback for normal unknown routes", () => {
+    const req = mockReq("GET", "/some/page");
+    const res = mockRes();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+    expect(res._headers["content-type"]).toContain("text/html");
+    expect(res._body).toContain("SPA");
+  });
+
+  it("returns JSON 404 for /api/ routes instead of SPA fallback", () => {
+    const req = mockReq("GET", "/api/some-endpoint");
+    const res = mockRes();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(res._headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
+  });
+
+  it("returns JSON 404 for /api (no trailing slash)", () => {
+    const req = mockReq("GET", "/api");
+    const res = mockRes();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
+  });
+
+  it("returns JSON 404 for /api/ routes under a basePath", () => {
+    const req = mockReq("GET", "/ui/api/foo");
+    const res = mockRes();
+    const handled = handleControlUiHttpRequest(req, res, {
+      basePath: "/ui",
+      root: rootState(),
+    });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(res._headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
   });
 });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -355,9 +355,7 @@ export function handleControlUiHttpRequest(
   // API routes should never fall through to the SPA fallback – return a proper
   // JSON 404 so callers don't receive HTML when they expect JSON.
   if (uiPath === "/api" || uiPath.startsWith("/api/")) {
-    res.statusCode = 404;
-    res.setHeader("Content-Type", "application/json; charset=utf-8");
-    res.end(JSON.stringify({ error: "Not found" }));
+    sendJson(res, 404, { error: "Not found" });
     return true;
   }
 

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -352,6 +352,15 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
+  // API routes should never fall through to the SPA fallback – return a proper
+  // JSON 404 so callers don't receive HTML when they expect JSON.
+  if (uiPath === "/api" || uiPath.startsWith("/api/")) {
+    res.statusCode = 404;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(JSON.stringify({ error: "Not found" }));
+    return true;
+  }
+
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
   if (fs.existsSync(indexPath)) {

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -92,6 +92,7 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
         sessionKey,
         to: resolved.to,
         channel,
+        accountId: origin?.accountId,
         deliver: true,
         bestEffortDeliver: true,
         messageChannel: channel,

--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -417,7 +417,7 @@ describe("gateway server auth/connect", () => {
         },
       });
       expect(res.ok).toBe(false);
-      expect(res.error?.message ?? "").toContain("Control UI settings");
+      expect(res.error?.message ?? "").toContain("Overview → Gateway Access");
       ws.close();
     });
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -85,7 +85,7 @@ function formatGatewayAuthFailureMessage(params: {
   const isCli = isGatewayCliClient(client);
   const isControlUi = client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
   const isWebchat = isWebchatClient(client);
-  const uiHint = "open the dashboard URL and paste the token in Control UI settings";
+  const uiHint = "open a tokenized dashboard URL or paste token in Overview → Gateway Access";
   const tokenHint = isCli
     ? "set gateway.remote.token to match gateway.auth.token"
     : isControlUi || isWebchat
@@ -94,7 +94,7 @@ function formatGatewayAuthFailureMessage(params: {
   const passwordHint = isCli
     ? "set gateway.remote.password to match gateway.auth.password"
     : isControlUi || isWebchat
-      ? "enter the password in Control UI settings"
+      ? "enter the password in Overview → Gateway Access"
       : "provide gateway auth password";
   switch (reason) {
     case "token_missing":

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -41,7 +41,7 @@ describe("applyMediaUnderstanding", () => {
     mockedResolveApiKey.mockClear();
     mockedFetchRemoteMedia.mockReset();
     mockedFetchRemoteMedia.mockResolvedValue({
-      buffer: Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+      buffer: Buffer.alloc(2048),
       contentType: "audio/ogg",
       fileName: "note.ogg",
     });
@@ -51,7 +51,7 @@ describe("applyMediaUnderstanding", () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
     const audioPath = path.join(dir, "note.ogg");
-    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8]));
+    await fs.writeFile(audioPath, Buffer.alloc(2048));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
@@ -94,7 +94,7 @@ describe("applyMediaUnderstanding", () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
     const audioPath = path.join(dir, "data.mp3");
-    await fs.writeFile(audioPath, '"a","b"\n"1","2"');
+    await fs.writeFile(audioPath, '"a","b"\n"1","2"' + "\n".repeat(1100));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
@@ -134,7 +134,7 @@ describe("applyMediaUnderstanding", () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
     const audioPath = path.join(dir, "note.ogg");
-    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8]));
+    await fs.writeFile(audioPath, Buffer.alloc(2048));
 
     const ctx: MsgContext = {
       Body: "<media:audio> /capture status",
@@ -251,7 +251,7 @@ describe("applyMediaUnderstanding", () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
     const audioPath = path.join(dir, "note.ogg");
-    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8]));
+    await fs.writeFile(audioPath, Buffer.alloc(2048));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
@@ -392,7 +392,7 @@ describe("applyMediaUnderstanding", () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
     const audioPath = path.join(dir, "fallback.ogg");
-    await fs.writeFile(audioPath, Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6]));
+    await fs.writeFile(audioPath, Buffer.alloc(2048));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
@@ -430,8 +430,8 @@ describe("applyMediaUnderstanding", () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
     const audioPathA = path.join(dir, "note-a.ogg");
     const audioPathB = path.join(dir, "note-b.ogg");
-    await fs.writeFile(audioPathA, Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]));
-    await fs.writeFile(audioPathB, Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]));
+    await fs.writeFile(audioPathA, Buffer.alloc(2048));
+    await fs.writeFile(audioPathB, Buffer.alloc(2048));
 
     const ctx: MsgContext = {
       Body: "<media:audio>",
@@ -475,7 +475,7 @@ describe("applyMediaUnderstanding", () => {
     const audioPath = path.join(dir, "note.ogg");
     const videoPath = path.join(dir, "clip.mp4");
     await fs.writeFile(imagePath, "image-bytes");
-    await fs.writeFile(audioPath, Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]));
+    await fs.writeFile(audioPath, Buffer.alloc(2048));
     await fs.writeFile(videoPath, "video-bytes");
 
     const ctx: MsgContext = {

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -212,6 +212,50 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Audio]\nTranscript:\nremote transcript");
   });
 
+  it("skips URL-only audio when remote file is too small", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    // Override the default mock to return a tiny buffer (below MIN_AUDIO_FILE_BYTES)
+    mockedFetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.alloc(100),
+      contentType: "audio/ogg",
+      fileName: "tiny.ogg",
+    });
+
+    const ctx: MsgContext = {
+      Body: "<media:audio>",
+      MediaUrl: "https://example.com/tiny.ogg",
+      MediaType: "audio/ogg",
+      ChatType: "dm",
+    };
+    const transcribeAudio = vi.fn(async () => ({ text: "should-not-run" }));
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            enabled: true,
+            maxBytes: 1024 * 1024,
+            scope: {
+              default: "deny",
+              rules: [{ action: "allow", match: { chatType: "direct" } }],
+            },
+            models: [{ provider: "groq" }],
+          },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      providers: {
+        groq: { id: "groq", transcribeAudio },
+      },
+    });
+
+    expect(transcribeAudio).not.toHaveBeenCalled();
+    expect(result.appliedAudio).toBe(false);
+  });
+
   it("skips audio transcription when attachment exceeds maxBytes", async () => {
     const { applyMediaUnderstanding } = await loadApply();
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -51,3 +51,10 @@ export const DEFAULT_IMAGE_MODELS: Record<string, string> = {
 };
 export const CLI_OUTPUT_MAX_BUFFER = 5 * MB;
 export const DEFAULT_MEDIA_CONCURRENCY = 2;
+
+/**
+ * Minimum audio file size in bytes below which transcription is skipped.
+ * Files smaller than this threshold are almost certainly empty or corrupt
+ * and would cause unhelpful API errors from Whisper/transcription providers.
+ */
+export const MIN_AUDIO_FILE_BYTES = 1024;

--- a/src/media-understanding/errors.ts
+++ b/src/media-understanding/errors.ts
@@ -1,4 +1,9 @@
-export type MediaUnderstandingSkipReason = "maxBytes" | "timeout" | "unsupported" | "empty";
+export type MediaUnderstandingSkipReason =
+  | "maxBytes"
+  | "timeout"
+  | "unsupported"
+  | "empty"
+  | "tooSmall";
 
 export class MediaUnderstandingSkipError extends Error {
   readonly reason: MediaUnderstandingSkipReason;

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -16,7 +16,7 @@ describe("runCapability auto audio entries", () => {
     const originalPath = process.env.PATH;
     process.env.PATH = "/usr/bin:/bin";
     const tmpPath = path.join(os.tmpdir(), `openclaw-auto-audio-${Date.now()}.wav`);
-    await fs.writeFile(tmpPath, Buffer.from("RIFF"));
+    await fs.writeFile(tmpPath, Buffer.alloc(2048));
     const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
     const media = normalizeMediaAttachments(ctx);
     const cache = createMediaAttachmentCache(media);
@@ -67,7 +67,7 @@ describe("runCapability auto audio entries", () => {
     const originalPath = process.env.PATH;
     process.env.PATH = "/usr/bin:/bin";
     const tmpPath = path.join(os.tmpdir(), `openclaw-auto-audio-${Date.now()}.wav`);
-    await fs.writeFile(tmpPath, Buffer.from("RIFF"));
+    await fs.writeFile(tmpPath, Buffer.alloc(2048));
     const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
     const media = normalizeMediaAttachments(ctx);
     const cache = createMediaAttachmentCache(media);

--- a/src/media-understanding/runner.deepgram.test.ts
+++ b/src/media-understanding/runner.deepgram.test.ts
@@ -14,7 +14,7 @@ import {
 describe("runCapability deepgram provider options", () => {
   it("merges provider options, headers, and baseUrl overrides", async () => {
     const tmpPath = path.join(os.tmpdir(), `openclaw-deepgram-${Date.now()}.wav`);
-    await fs.writeFile(tmpPath, Buffer.from("RIFF"));
+    await fs.writeFile(tmpPath, Buffer.alloc(2048));
     const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
     const media = normalizeMediaAttachments(ctx);
     const cache = createMediaAttachmentCache(media);

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    // Case-insensitive replacement
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
+
+describe("normalizePlaceholders", () => {
+  it("should convert {file} to {{MediaPath}}", () => {
+    expect(normalizePlaceholders("{file}")).toBe("{{MediaPath}}");
+  });
+
+  it("should convert {FILE} case-insensitively", () => {
+    expect(normalizePlaceholders("{FILE}")).toBe("{{MediaPath}}");
+  });
+
+  it("should convert {File} mixed case", () => {
+    expect(normalizePlaceholders("{File}")).toBe("{{MediaPath}}");
+  });
+
+  it("should handle {input} as MediaPath alias", () => {
+    expect(normalizePlaceholders("{input}")).toBe("{{MediaPath}}");
+  });
+
+  it("should handle {output} as OutputDir alias", () => {
+    expect(normalizePlaceholders("{output}")).toBe("{{OutputDir}}");
+  });
+
+  it("should handle {output_dir} as OutputDir alias", () => {
+    expect(normalizePlaceholders("{output_dir}")).toBe("{{OutputDir}}");
+  });
+
+  it("should handle {prompt} as Prompt alias", () => {
+    expect(normalizePlaceholders("{prompt}")).toBe("{{Prompt}}");
+  });
+
+  it("should preserve already-correct {{MediaPath}} format", () => {
+    expect(normalizePlaceholders("{{MediaPath}}")).toBe("{{MediaPath}}");
+  });
+
+  it("should work with mixed content", () => {
+    const input = "--input {file} --output {output}";
+    const expected = "--input {{MediaPath}} --output {{OutputDir}}";
+    expect(normalizePlaceholders(input)).toBe(expected);
+  });
+
+  it("should handle real whisper CLI args", () => {
+    const args = ["{file}", "--model", "large-v3-turbo", "--output_dir", "/tmp"];
+    const normalized = args.map(normalizePlaceholders);
+    expect(normalized[0]).toBe("{{MediaPath}}");
+    expect(normalized[1]).toBe("--model");
+    expect(normalized[2]).toBe("large-v3-turbo");
+  });
+
+  it("should not modify unrelated content", () => {
+    expect(normalizePlaceholders("--model turbo")).toBe("--model turbo");
+    expect(normalizePlaceholders("/path/to/file.txt")).toBe("/path/to/file.txt");
+  });
+});

--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { MIN_AUDIO_FILE_BYTES } from "./defaults.js";
+import {
+  buildProviderRegistry,
+  createMediaAttachmentCache,
+  normalizeMediaAttachments,
+  runCapability,
+} from "./runner.js";
+
+describe("runCapability skips tiny audio files", () => {
+  it("skips audio transcription when file is smaller than MIN_AUDIO_FILE_BYTES", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    // Create a tiny audio file (well below the 1KB threshold)
+    const tmpPath = path.join(os.tmpdir(), `openclaw-tiny-audio-${Date.now()}.wav`);
+    const tinyBuffer = Buffer.alloc(100); // 100 bytes, way below 1024
+    await fs.writeFile(tmpPath, tinyBuffer);
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async (req) => {
+          transcribeCalled = true;
+          return { text: "should not happen", model: req.model };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      // The provider should never be called
+      expect(transcribeCalled).toBe(false);
+
+      // The result should indicate the attachment was skipped
+      expect(result.outputs).toHaveLength(0);
+      expect(result.decision.outcome).toBe("skipped");
+      expect(result.decision.attachments[0]?.attempts[0]?.outcome).toBe("skipped");
+      expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain("tooSmall");
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+
+  it("skips audio transcription for empty (0-byte) files", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    const tmpPath = path.join(os.tmpdir(), `openclaw-empty-audio-${Date.now()}.ogg`);
+    await fs.writeFile(tmpPath, Buffer.alloc(0));
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/ogg" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async () => {
+          transcribeCalled = true;
+          return { text: "nope", model: "whisper-1" };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      expect(transcribeCalled).toBe(false);
+      expect(result.outputs).toHaveLength(0);
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+
+  it("proceeds with transcription when file meets minimum size", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    const tmpPath = path.join(os.tmpdir(), `openclaw-ok-audio-${Date.now()}.wav`);
+    const okBuffer = Buffer.alloc(MIN_AUDIO_FILE_BYTES + 100);
+    await fs.writeFile(tmpPath, okBuffer);
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async (req) => {
+          transcribeCalled = true;
+          return { text: "hello world", model: req.model };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      expect(transcribeCalled).toBe(true);
+      expect(result.outputs).toHaveLength(1);
+      expect(result.outputs[0]?.text).toBe("hello world");
+      expect(result.decision.outcome).toBe("success");
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+});

--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -65,8 +65,10 @@ describe("runCapability skips tiny audio files", () => {
       // The result should indicate the attachment was skipped
       expect(result.outputs).toHaveLength(0);
       expect(result.decision.outcome).toBe("skipped");
-      expect(result.decision.attachments[0]?.attempts[0]?.outcome).toBe("skipped");
-      expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain("tooSmall");
+      expect(result.decision.attachments).toHaveLength(1);
+      expect(result.decision.attachments[0].attempts).toHaveLength(1);
+      expect(result.decision.attachments[0].attempts[0].outcome).toBe("skipped");
+      expect(result.decision.attachments[0].attempts[0].reason).toContain("tooSmall");
     } finally {
       process.env.PATH = originalPath;
       await cache.cleanup();

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_AUDIO_MODELS,
   DEFAULT_IMAGE_MODELS,
   DEFAULT_TIMEOUT_SECONDS,
+  MIN_AUDIO_FILE_BYTES,
 } from "./defaults.js";
 import { isMediaUnderstandingSkipError, MediaUnderstandingSkipError } from "./errors.js";
 import { describeImageWithModel } from "./providers/image.js";
@@ -894,6 +895,12 @@ async function runProviderEntry(params: {
       maxBytes,
       timeoutMs,
     });
+    if (media.size < MIN_AUDIO_FILE_BYTES) {
+      throw new MediaUnderstandingSkipError(
+        "tooSmall",
+        `Audio attachment ${params.attachmentIndex + 1} is too small (${media.size} bytes, minimum ${MIN_AUDIO_FILE_BYTES})`,
+      );
+    }
     const auth = await resolveApiKeyForProvider({
       provider: providerId,
       cfg,
@@ -1016,6 +1023,15 @@ async function runCliEntry(params: {
     maxBytes,
     timeoutMs,
   });
+  if (capability === "audio") {
+    const stat = await fs.stat(pathResult.path);
+    if (stat.size < MIN_AUDIO_FILE_BYTES) {
+      throw new MediaUnderstandingSkipError(
+        "tooSmall",
+        `Audio attachment ${params.attachmentIndex + 1} is too small (${stat.size} bytes, minimum ${MIN_AUDIO_FILE_BYTES})`,
+      );
+    }
+  }
   const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-cli-"));
   const mediaPath = pathResult.path;
   const outputBase = path.join(outputDir, path.parse(mediaPath).name);

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -4,6 +4,39 @@ import os from "node:os";
 import path from "node:path";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { applyTemplate } from "../auto-reply/templating.js";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { runExec } from "../process/exec.js";
+
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    // Case-insensitive replacement
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
 import type {
   MediaUnderstandingConfig,
   MediaUnderstandingModelConfig,
@@ -16,15 +49,11 @@ import type {
   MediaUnderstandingOutput,
   MediaUnderstandingProvider,
 } from "./types.js";
-import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import {
   findModelInCatalog,
   loadModelCatalog,
   modelSupportsVision,
 } from "../agents/model-catalog.js";
-import { applyTemplate } from "../auto-reply/templating.js";
-import { logVerbose, shouldLogVerbose } from "../globals.js";
-import { runExec } from "../process/exec.js";
 import { MediaAttachmentCache, normalizeAttachments, selectAttachments } from "./attachments.js";
 import {
   AUTO_AUDIO_KEY_PROVIDERS,
@@ -1046,7 +1075,7 @@ async function runCliEntry(params: {
     MaxChars: maxChars,
   };
   const argv = [command, ...args].map((part, index) =>
-    index === 0 ? part : applyTemplate(part, templCtx),
+    index === 0 ? part : applyTemplate(normalizePlaceholders(part), templCtx),
   );
   try {
     if (shouldLogVerbose()) {

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -114,6 +114,30 @@ describe("listMemoryFiles", () => {
       expect(files.some((file) => file.endsWith("nested.md"))).toBe(false);
     }
   });
+
+  it("respects ignorePaths glob patterns", async () => {
+    await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Default memory");
+    const extraDir = path.join(tmpDir, "extra");
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "note.md"), "# Note");
+
+    // Create node_modules with a .md file inside
+    const nodeModules = path.join(extraDir, "node_modules");
+    await fs.mkdir(nodeModules, { recursive: true });
+    await fs.writeFile(path.join(nodeModules, "readme.md"), "# Should be ignored");
+
+    // Create .venv with a .md file inside
+    const venv = path.join(extraDir, ".venv");
+    await fs.mkdir(venv, { recursive: true });
+    await fs.writeFile(path.join(venv, "docs.md"), "# Should also be ignored");
+
+    const files = await listMemoryFiles(tmpDir, [extraDir], ["**/node_modules/**", "**/.venv/**"]);
+    expect(files).toHaveLength(2); // MEMORY.md + note.md
+    expect(files.some((file) => file.endsWith("MEMORY.md"))).toBe(true);
+    expect(files.some((file) => file.endsWith("note.md"))).toBe(true);
+    expect(files.some((file) => file.includes("node_modules"))).toBe(false);
+    expect(files.some((file) => file.includes(".venv"))).toBe(false);
+  });
 });
 
 describe("chunkMarkdown", () => {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -831,6 +831,7 @@ export class MemoryIndexManager implements MemorySearchManager {
     ]);
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
+      ignored: this.settings.ignorePaths,
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,
@@ -1071,7 +1072,11 @@ export class MemoryIndexManager implements MemorySearchManager {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    const files = await listMemoryFiles(this.workspaceDir, this.settings.extraPaths);
+    const files = await listMemoryFiles(
+      this.workspaceDir,
+      this.settings.extraPaths,
+      this.settings.ignorePaths,
+    );
     const fileEntries = await Promise.all(
       files.map(async (file) => buildFileEntry(file, this.workspaceDir)),
     );

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,28 +1,49 @@
+import * as dns from "node:dns";
 import * as net from "node:net";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { resolveTelegramAutoSelectFamilyDecision } from "./network-config.js";
+import {
+  resolveTelegramAutoSelectFamilyDecision,
+  resolveTelegramDnsResultOrderDecision,
+} from "./network-config.js";
 
 let appliedAutoSelectFamily: boolean | null = null;
+let appliedDnsResultOrder: string | null = null;
 const log = createSubsystemLogger("telegram/network");
 
 // Node 22 workaround: disable autoSelectFamily to avoid Happy Eyeballs timeouts.
 // See: https://github.com/nodejs/node/issues/54359
 function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void {
-  const decision = resolveTelegramAutoSelectFamilyDecision({ network });
-  if (decision.value === null || decision.value === appliedAutoSelectFamily) {
-    return;
+  // Apply autoSelectFamily workaround
+  const autoSelectDecision = resolveTelegramAutoSelectFamilyDecision({ network });
+  if (autoSelectDecision.value !== null && autoSelectDecision.value !== appliedAutoSelectFamily) {
+    appliedAutoSelectFamily = autoSelectDecision.value;
+    if (typeof net.setDefaultAutoSelectFamily === "function") {
+      try {
+        net.setDefaultAutoSelectFamily(autoSelectDecision.value);
+        const label = autoSelectDecision.source ? ` (${autoSelectDecision.source})` : "";
+        log.info(`autoSelectFamily=${autoSelectDecision.value}${label}`);
+      } catch {
+        // ignore if unsupported by the runtime
+      }
+    }
   }
-  appliedAutoSelectFamily = decision.value;
 
-  if (typeof net.setDefaultAutoSelectFamily === "function") {
-    try {
-      net.setDefaultAutoSelectFamily(decision.value);
-      const label = decision.source ? ` (${decision.source})` : "";
-      log.info(`telegram: autoSelectFamily=${decision.value}${label}`);
-    } catch {
-      // ignore if unsupported by the runtime
+  // Apply DNS result order workaround for IPv4/IPv6 issues.
+  // Some APIs (including Telegram) may fail with IPv6 on certain networks.
+  // See: https://github.com/openclaw/openclaw/issues/5311
+  const dnsDecision = resolveTelegramDnsResultOrderDecision({ network });
+  if (dnsDecision.value !== null && dnsDecision.value !== appliedDnsResultOrder) {
+    appliedDnsResultOrder = dnsDecision.value;
+    if (typeof dns.setDefaultResultOrder === "function") {
+      try {
+        dns.setDefaultResultOrder(dnsDecision.value as "ipv4first" | "verbatim");
+        const label = dnsDecision.source ? ` (${dnsDecision.source})` : "";
+        log.info(`dnsResultOrder=${dnsDecision.value}${label}`);
+      } catch {
+        // ignore if unsupported by the runtime
+      }
     }
   }
 }

--- a/src/telegram/network-config.ts
+++ b/src/telegram/network-config.ts
@@ -5,9 +5,15 @@ import { isTruthyEnvValue } from "../infra/env.js";
 export const TELEGRAM_DISABLE_AUTO_SELECT_FAMILY_ENV =
   "OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY";
 export const TELEGRAM_ENABLE_AUTO_SELECT_FAMILY_ENV = "OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY";
+export const TELEGRAM_DNS_RESULT_ORDER_ENV = "OPENCLAW_TELEGRAM_DNS_RESULT_ORDER";
 
 export type TelegramAutoSelectFamilyDecision = {
   value: boolean | null;
+  source?: string;
+};
+
+export type TelegramDnsResultOrderDecision = {
+  value: string | null;
   source?: string;
 };
 
@@ -34,5 +40,48 @@ export function resolveTelegramAutoSelectFamilyDecision(params?: {
   if (Number.isFinite(nodeMajor) && nodeMajor >= 22) {
     return { value: false, source: "default-node22" };
   }
+  return { value: null };
+}
+
+/**
+ * Resolve DNS result order setting for Telegram network requests.
+ * Some networks/ISPs have issues with IPv6 causing fetch failures.
+ * Setting "ipv4first" prioritizes IPv4 addresses in DNS resolution.
+ *
+ * Priority:
+ * 1. Environment variable OPENCLAW_TELEGRAM_DNS_RESULT_ORDER
+ * 2. Config: channels.telegram.network.dnsResultOrder
+ * 3. Default: "ipv4first" on Node 22+ (to work around common IPv6 issues)
+ */
+export function resolveTelegramDnsResultOrderDecision(params?: {
+  network?: TelegramNetworkConfig;
+  env?: NodeJS.ProcessEnv;
+  nodeMajor?: number;
+}): TelegramDnsResultOrderDecision {
+  const env = params?.env ?? process.env;
+  const nodeMajor =
+    typeof params?.nodeMajor === "number"
+      ? params.nodeMajor
+      : Number(process.versions.node.split(".")[0]);
+
+  // Check environment variable
+  const envValue = env[TELEGRAM_DNS_RESULT_ORDER_ENV]?.trim().toLowerCase();
+  if (envValue === "ipv4first" || envValue === "verbatim") {
+    return { value: envValue, source: `env:${TELEGRAM_DNS_RESULT_ORDER_ENV}` };
+  }
+
+  // Check config
+  const configValue = (params?.network as { dnsResultOrder?: string } | undefined)?.dnsResultOrder
+    ?.trim()
+    .toLowerCase();
+  if (configValue === "ipv4first" || configValue === "verbatim") {
+    return { value: configValue, source: "config" };
+  }
+
+  // Default to ipv4first on Node 22+ to avoid IPv6 issues
+  if (Number.isFinite(nodeMajor) && nodeMajor >= 22) {
+    return { value: "ipv4first", source: "default-node22" };
+  }
+
   return { value: null };
 }

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ChatLog } from "./chat-log.js";
+
+describe("ChatLog", () => {
+  describe("finalizeAssistant", () => {
+    it("does not add a component when text is NO_REPLY and no streaming entry exists", () => {
+      const log = new ChatLog();
+      const childrenBefore = log.children.length;
+
+      log.finalizeAssistant("NO_REPLY", "run-1");
+
+      // No child should have been added
+      expect(log.children.length).toBe(childrenBefore);
+    });
+
+    it("removes streaming entry when text is NO_REPLY and a streaming entry exists", () => {
+      const log = new ChatLog();
+      log.startAssistant("thinking...", "run-2");
+      const childrenAfterStart = log.children.length;
+      expect(childrenAfterStart).toBeGreaterThan(0);
+
+      log.finalizeAssistant("NO_REPLY", "run-2");
+
+      // The streaming component should have been removed
+      expect(log.children.length).toBe(childrenAfterStart - 1);
+    });
+
+    it("adds a component for normal (non-silent) text without a streaming entry", () => {
+      const log = new ChatLog();
+      const childrenBefore = log.children.length;
+
+      log.finalizeAssistant("Hello there!", "run-3");
+
+      expect(log.children.length).toBe(childrenBefore + 1);
+    });
+
+    it("updates the existing streaming entry for normal text", () => {
+      const log = new ChatLog();
+      log.startAssistant("partial...", "run-4");
+      const childrenAfterStart = log.children.length;
+
+      log.finalizeAssistant("Full response here.", "run-4");
+
+      // Same number of children — existing component was updated, not removed or duplicated
+      expect(log.children.length).toBe(childrenAfterStart);
+    });
+  });
+});

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -45,6 +45,15 @@ export class ChatLog extends Container {
     existing.setText(text);
   }
 
+  dropAssistant(runId?: string) {
+    const effectiveRunId = this.resolveRunId(runId);
+    const existing = this.streamingRuns.get(effectiveRunId);
+    if (existing) {
+      this.removeChild(existing);
+      this.streamingRuns.delete(effectiveRunId);
+    }
+  }
+
   finalizeAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -1,4 +1,5 @@
 import { Container, Spacer, Text } from "@mariozechner/pi-tui";
+import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import { theme } from "../theme/theme.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
@@ -55,6 +56,10 @@ export class ChatLog extends Container {
   }
 
   finalizeAssistant(text: string, runId?: string) {
+    if (isSilentReplyText(text)) {
+      this.dropAssistant(runId);
+      return;
+    }
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (existing) {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -6,7 +6,7 @@ import { createEventHandlers } from "./tui-event-handlers.js";
 
 type MockChatLog = Pick<
   ChatLog,
-  "startTool" | "updateToolResult" | "addSystem" | "updateAssistant" | "finalizeAssistant"
+  "startTool" | "updateToolResult" | "addSystem" | "updateAssistant" | "finalizeAssistant" | "dropAssistant"
 >;
 type MockTui = Pick<TUI, "requestRender">;
 
@@ -41,6 +41,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       addSystem: vi.fn(),
       updateAssistant: vi.fn(),
       finalizeAssistant: vi.fn(),
+      dropAssistant: vi.fn(),
     };
     const tui: MockTui = { requestRender: vi.fn() };
     const setActivityStatus = vi.fn();
@@ -356,5 +357,53 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses display when final message is NO_REPLY", () => {
+    const state = makeState({ activeChatRunId: null });
+    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { handleChatEvent } = createEventHandlers({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      chatLog: chatLog as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    handleChatEvent({
+      runId: "run-silent",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: "NO_REPLY" },
+    });
+
+    expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBeNull();
+  });
+
+  it("displays normal messages that are not NO_REPLY", () => {
+    const state = makeState({ activeChatRunId: null });
+    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { handleChatEvent } = createEventHandlers({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      chatLog: chatLog as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    handleChatEvent({
+      runId: "run-normal",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: "Hello, how can I help?" },
+    });
+
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+    expect(chatLog.finalizeAssistant).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Add messages.tts.stripMarkdown config option that preprocesses TTS text by removing markdown formatting characters before sending to providers.

Closes #12232

## Changes (3 files, +17/-9 lines)

- types.tts.ts: Add stripMarkdown?: boolean to TtsConfig
- zod-schema.core.ts: Add stripMarkdown to Zod validation  
- tts.ts: Apply stripping in textToSpeech() and textToSpeechTelephony()

## Code Review (Sonnet agent)

All findings addressed: Zod schema added, directive order verified correct, null/empty checks not needed (upstream guards).

## Tests: 71/71 passing. Build clean.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `messages.tts.stripMarkdown` configuration option, wires it into `TtsConfig` typing and Zod validation, and applies markdown stripping before sending text to TTS providers in `textToSpeech()` and `textToSpeechTelephony()`.

Most of the change is localized to the TTS pipeline (`src/tts/tts.ts`) and config schemas (`src/config/types.tts.ts`, `src/config/zod-schema.core.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but there is a likely runtime import-path issue in the new markdown stripping integration.
- Config typing and Zod validation changes are straightforward, but `src/tts/tts.ts` imports `../line/markdown-to-line.js` while the repo source is `markdown-to-line.ts`. If the compiled JS file is not emitted/available at that path, TTS will crash at runtime when stripMarkdown is enabled (or possibly on module load).
- src/tts/tts.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->