### PR TITLE
Update the browser URL support to include WebSocket protocols

### DIFF
--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -5,12 +5,12 @@ import {
 } from "./control-service.js";
 import { createBrowserRouteDispatcher } from "./routes/dispatcher.js";
 
-function isAbsoluteHttp(url: string): boolean {
-  return /^https?:\/\//i.test(url.trim());
+function isAbsoluteUrl(url: string): boolean {
+  return /^(https?|wss?):\/\//i.test(url.trim());
 }
 
 function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number): Error {
-  const hint = isAbsoluteHttp(url)
+  const hint = isAbsoluteUrl(url)
     ? "If this is a sandboxed session, ensure the sandbox browser is running and try again."
     : `Start (or restart) the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`) and try again.`;
   const msg = String(err);
@@ -54,7 +54,7 @@ export async function fetchBrowserJson<T>(
 ): Promise<T> {
   const timeoutMs = init?.timeoutMs ?? 5000;
   try {
-    if (isAbsoluteHttp(url)) {
+    if (isAbsoluteUrl(url)) {
       return await fetchHttpJson<T>(url, { ...init, timeoutMs });
     }
     const started = await startBrowserControlServiceFromConfig();

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -5,12 +5,12 @@ import {
 } from "./control-service.js";
 import { createBrowserRouteDispatcher } from "./routes/dispatcher.js";
 
-function isAbsoluteUrl(url: string): boolean {
-  return /^(https?|wss?):\/\//i.test(url.trim());
+function isAbsoluteHttp(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim());
 }
 
 function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number): Error {
-  const hint = isAbsoluteUrl(url)
+  const hint = isAbsoluteHttp(url)
     ? "If this is a sandboxed session, ensure the sandbox browser is running and try again."
     : `Start (or restart) the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`) and try again.`;
   const msg = String(err);
@@ -54,7 +54,7 @@ export async function fetchBrowserJson<T>(
 ): Promise<T> {
   const timeoutMs = init?.timeoutMs ?? 5000;
   try {
-    if (isAbsoluteUrl(url)) {
+    if (isAbsoluteHttp(url)) {
       return await fetchHttpJson<T>(url, { ...init, timeoutMs });
     }
     const started = await startBrowserControlServiceFromConfig();

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -139,12 +139,17 @@ function parseBaseUrl(raw: string): {
   baseUrl: string;
 } {
   const parsed = new URL(raw.trim().replace(/\/$/, ""));
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`extension relay cdpUrl must be http(s), got ${parsed.protocol}`);
+  if (
+    parsed.protocol !== "http:" &&
+    parsed.protocol !== "https:" &&
+    parsed.protocol !== "ws:" &&
+    parsed.protocol !== "wss:"
+  ) {
+    throw new Error(`extension relay cdpUrl must be http(s) or ws(s), got ${parsed.protocol}`);
   }
   const host = parsed.hostname;
-  const port =
-    parsed.port?.trim() !== "" ? Number(parsed.port) : parsed.protocol === "https:" ? 443 : 80;
+  const isSecure = parsed.protocol === "https:" || parsed.protocol === "wss:";
+  const port = parsed.port?.trim() !== "" ? Number(parsed.port) : isSecure ? 443 : 80;
   if (!Number.isFinite(port) || port <= 0 || port > 65535) {
     throw new Error(`extension relay cdpUrl has invalid port: ${parsed.port || "(empty)"}`);
   }

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -153,7 +153,9 @@ function parseBaseUrl(raw: string): {
   if (!Number.isFinite(port) || port <= 0 || port > 65535) {
     throw new Error(`extension relay cdpUrl has invalid port: ${parsed.port || "(empty)"}`);
   }
-  return { host, port, baseUrl: parsed.toString().replace(/\/$/, "") };
+  const httpProtocol = isSecure ? "https:" : "http:";
+  const baseUrl = `${httpProtocol}//${host}:${port}`;
+  return { host, port, baseUrl };
 }
 
 function text(res: Duplex, status: number, bodyText: string) {


### PR DESCRIPTION
Enable the browser to work with WebSocket endpoints, which is useful for connecting to WebSocket-based services like Chrome DevTools Protocol (CDP) endpoints that often use WebSocket URLs.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change broadens `parseBaseUrl()` in `src/browser/extension-relay.ts` to accept `ws://` and `wss://` inputs (in addition to `http(s)`), and adjusts default port selection to treat `wss/https` as secure.

Within the extension relay server, the returned `baseUrl` is used as the URL base for HTTP request parsing and for constructing the relay’s advertised endpoints. Allowing `ws(s)` schemes introduces a mismatch: the relay is an HTTP server (for `/json/*`), while websocket is only for the `/cdp` upgrade path.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after fixing a scheme normalization bug in the relay base URL handling.
- The change is small and localized, but permitting `ws(s)` in `parseBaseUrl()` leaks into `baseUrl` construction used for HTTP URL parsing, which can break request routing and produces inconsistent advertised endpoints when a websocket URL is provided as input.
- src/browser/extension-relay.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->