### PR TITLE
fix(session): circuit-breaker on repeated context overflow

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,13 +281,11 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
-=======
 
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
-=======
 
   return grok as GrokConfig;
 }
@@ -297,7 +295,6 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
-=======
 
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
@@ -481,14 +478,6 @@ async function runWebSearch(params: {
   grokModel?: string;
   grokInlineCitations?: boolean;
 }): Promise<Record<string, unknown>> {
-  const cacheKey = normalizeCacheKey(
-    params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : params.provider === "perplexity"
-        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
-  );
-=======
   let rawCacheKey: string;
   switch (params.provider) {
     case "brave":

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,10 +281,14 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
+=======
+
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
+=======
+
   return grok as GrokConfig;
 }
 
@@ -293,6 +297,8 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
+=======
+
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
 }
@@ -482,6 +488,24 @@ async function runWebSearch(params: {
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
+=======
+  let rawCacheKey: string;
+  switch (params.provider) {
+    case "brave":
+      rawCacheKey = `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`;
+      break;
+    case "perplexity":
+      rawCacheKey = `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`;
+      break;
+    case "grok":
+      rawCacheKey = `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${params.grokInlineCitations ?? false}`;
+      break;
+    default:
+      rawCacheKey = `${String(params.provider)}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`;
+      break;
+  }
+
+  const cacheKey = normalizeCacheKey(rawCacheKey);
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };

--- a/src/auto-reply/reply/body.ts
+++ b/src/auto-reply/reply/body.ts
@@ -41,6 +41,38 @@ export async function applySessionHints(params: {
     }
   }
 
+  const recovered = params.sessionEntry?.recoveredFromUnhealthy;
+  const recoveredReason = params.sessionEntry?.recoveredFromUnhealthyReason;
+  if (recovered) {
+    const hint =
+      "Note: The previous session became unhealthy (likely context overflow). " +
+      "A fresh session was started automatically; you may need to re-run the last request.";
+    const reasonHint = recoveredReason ? ` (reason: ${recoveredReason})` : "";
+    prefixedBodyBase = `${hint}${reasonHint}\n\n${prefixedBodyBase}`;
+
+    if (params.sessionEntry && params.sessionStore && params.sessionKey) {
+      params.sessionEntry.recoveredFromUnhealthy = false;
+      params.sessionEntry.recoveredFromUnhealthyReason = undefined;
+      params.sessionEntry.updatedAt = Date.now();
+      params.sessionStore[params.sessionKey] = params.sessionEntry;
+      if (params.storePath) {
+        const sessionKey = params.sessionKey;
+        await updateSessionStore(params.storePath, (store) => {
+          const entry = store[sessionKey] ?? params.sessionEntry;
+          if (!entry) {
+            return;
+          }
+          store[sessionKey] = {
+            ...entry,
+            recoveredFromUnhealthy: false,
+            recoveredFromUnhealthyReason: undefined,
+            updatedAt: Date.now(),
+          };
+        });
+      }
+    }
+  }
+
   const messageIdHint = params.messageId?.trim() ? `[message_id: ${params.messageId.trim()}]` : "";
   if (messageIdHint) {
     prefixedBodyBase = `${prefixedBodyBase}\n${messageIdHint}`;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -76,6 +76,19 @@ export type SessionEntry = {
   compactionCount?: number;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
+
+  /** Session marked temporarily unhealthy (e.g. repeated context overflow). */
+  unhealthyUntil?: number;
+  /** Short machine-friendly reason for unhealthy state. */
+  unhealthyReason?: string;
+  /** Consecutive overflow-like failures within a time window. */
+  overflowErrorStreak?: number;
+  /** Timestamp (ms) of last overflow-like failure used for streak accounting. */
+  overflowErrorAt?: number;
+
+  /** One-shot flag: this session was auto-reset due to unhealthy state; used to show a hint once. */
+  recoveredFromUnhealthy?: boolean;
+  recoveredFromUnhealthyReason?: string;
   cliSessionIds?: Record<string, string>;
   claudeCliSessionId?: string;
   label?: string;


### PR DESCRIPTION
## Summary
Adds a simple session circuit-breaker for repeated context overflow:
- Track overflow-like failures (`context_overflow`, `compaction_failure`) in `sessions.json` with a short streak window.
- After 2 such failures within 10 minutes, mark the session unhealthy for 30 minutes.
- On the next inbound message, auto-start a fresh session (so we don't keep routing user messages into a dead session).
- Show a one-time hint that a fresh session was created due to overflow.

## Why
When a session hits context overflow and auto-compaction/pruning can't recover, subsequent turns can appear to "work" but actually make no progress. This makes the failure mode explicit and self-healing.

## Details
- Stored fields: `overflowErrorStreak`, `overflowErrorAt`, `unhealthyUntil`, `unhealthyReason`, plus one-shot `recoveredFromUnhealthy*` hint.
- Trigger signal is the embedded runner `meta.error.kind`.

## Validation
- `pnpm -s vitest run src/auto-reply/reply/session.test.ts src/auto-reply/reply/followup-runner.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change introduces a session “unhealthy” circuit breaker for repeated context-overflow-like failures. It adds new per-session fields in `sessions.json` to track overflow streaks and an `unhealthyUntil` cooldown, sets those fields based on the embedded runner’s `meta.error.kind` in the followup runner, and updates session initialization to auto-start a fresh session when the prior one is marked unhealthy. A one-shot `recoveredFromUnhealthy*` flag is also added so the inbound prompt builder can show a single hint explaining why a fresh session was started.

These changes integrate with the existing session store plumbing (`loadSessionStore`/`updateSessionStore`) and the inbound message pipeline (`initSessionState` → `applySessionHints` → agent run).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The circuit-breaker logic is localized, uses existing session store update patterns, and the new behavior is covered by a targeted unit test. No clear runtime errors or regressions were identified in the changed code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->