### PR TITLE
test(heartbeat): don't skip empty HEARTBEAT.md for cron wake events

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -299,7 +299,15 @@ safe to include every 30 minutes.
 
 If `HEARTBEAT.md` exists but is effectively empty (only blank lines and markdown
 headers like `# Heading`), OpenClaw skips the heartbeat run to save API calls.
-If the file is missing, the heartbeat still runs and the model decides what to do.
+
+If the file is missing, OpenClaw may create an empty `HEARTBEAT.md` during
+workspace bootstrap (see `agents.defaults.skipBootstrap`). In that case, the
+heartbeat is skipped for the same “empty file” reason. If you want the heartbeat
+to run without a file-driven checklist, either:
+
+- create a non-empty `HEARTBEAT.md`, or
+- set a custom heartbeat `prompt` that doesn’t depend on `HEARTBEAT.md`, or
+- disable bootstrap file creation (`agents.defaults.skipBootstrap: true`).
 
 Keep it tiny (short checklist or reminders) to avoid prompt bloat.
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -298,14 +298,22 @@ agent to read it. Think of it as your “heartbeat checklist”: small, stable, 
 safe to include every 30 minutes.
 
 If `HEARTBEAT.md` exists but is effectively empty (only blank lines and markdown
-headers like `# Heading`), OpenClaw skips the heartbeat run to save API calls.
+headers like `# Heading`), OpenClaw **currently skips** the heartbeat run to save
+API calls.
 
-If the file is missing, OpenClaw may create an empty `HEARTBEAT.md` during
-workspace bootstrap (see `agents.defaults.skipBootstrap`). In that case, the
-heartbeat is skipped for the same “empty file” reason. If you want the heartbeat
-to run without a file-driven checklist, either:
+If the file is **missing**, OpenClaw may create an empty `HEARTBEAT.md` during
+workspace bootstrap (see `agents.defaults.skipBootstrap`). In practice, this can
+lead to heartbeats being skipped for the same “empty file” reason.
 
-- create a non-empty `HEARTBEAT.md`, or
+Note: this “empty or missing `HEARTBEAT.md` → skip” behavior is the subject of
+bug reports (see #11766). In particular, an empty/missing heartbeat file can
+also interfere with some manual wakes (e.g. cron jobs that rely on heartbeat to
+wake the agent).
+
+**Workarounds (until the behavior is changed):**
+
+- Put at least **one non-comment, non-heading line** in `HEARTBEAT.md` (e.g.
+  `- noop`), or
 - set a custom heartbeat `prompt` that doesn’t depend on `HEARTBEAT.md`, or
 - disable bootstrap file creation (`agents.defaults.skipBootstrap: true`).
 

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -943,6 +943,76 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("does not skip empty HEARTBEAT.md for cron wake events", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+    const workspaceDir = path.join(tmpDir, "workspace");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      // Create effectively empty HEARTBEAT.md (only header and comments)
+      await fs.writeFile(
+        path.join(workspaceDir, "HEARTBEAT.md"),
+        "# HEARTBEAT.md\n\n## Tasks\n\n",
+        "utf-8",
+      );
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            [sessionKey]: {
+              sessionId: "sid",
+              updatedAt: Date.now(),
+              lastChannel: "whatsapp",
+              lastTo: "+1555",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      replySpy.mockResolvedValue({ text: "Cron wake processed" });
+      const sendWhatsApp = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        toJid: "jid",
+      });
+
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "cron:unit-test",
+        deps: {
+          sendWhatsApp,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+          webAuthExists: async () => true,
+          hasActiveWebListener: () => true,
+        },
+      });
+
+      expect(res.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalled();
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    } finally {
+      replySpy.mockRestore();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("runs heartbeat when HEARTBEAT.md has actionable content", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-"));
     const storePath = path.join(tmpDir, "sessions.json");


### PR DESCRIPTION
Adds regression test to ensure cron wake events (reason=cron:*) are not skipped by the empty-HEARTBEAT.md optimization.\n\nContext: #11766

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the heartbeat documentation to clarify that an empty `HEARTBEAT.md` currently causes heartbeat runs to be skipped, and notes common scenarios (e.g., bootstrap creating an empty file) and workarounds.

It also adds a regression test in `src/infra/heartbeat-runner.returns-default-unset.test.ts` to assert that when the wake reason is `cron:*`, `runHeartbeatOnce` should not apply the “empty HEARTBEAT.md” optimization and should still run the heartbeat (including calling `getReplyFromConfig` and sending the configured outbound message).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to a documentation clarification and a targeted regression test. The new test matches the current `runHeartbeatOnce` behavior (cron reasons bypass the empty-HEARTBEAT skip) and does not introduce production code changes.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->