### PR TITLE
feat(context): preemptive exec result cap near context limit

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -38,6 +38,7 @@ Environment overrides:
 - `PI_BASH_YIELD_MS`: default yield (ms)
 - `PI_BASH_MAX_OUTPUT_CHARS`: in‑memory output cap (chars)
 - `OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS`: pending stdout/stderr cap per stream (chars)
+- `OPENCLAW_EXEC_RESULT_MAX_CHARS`: max chars from exec output included in tool results sent to the model (hard clamp 1000–50000)
 - `PI_BASH_JOB_TTL_MS`: TTL for finished sessions (ms, bounded to 1m–3h)
 
 Config (preferred):

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2050,6 +2050,7 @@ of `every`, keep `HEARTBEAT.md` tiny, and/or choose a cheaper `model`.
 - `timeoutSec`: auto-kill after this runtime (seconds, default 1800)
 - `cleanupMs`: how long to keep finished sessions in memory (ms, default 1800000)
 - `notifyOnExit`: enqueue a system event + request heartbeat when backgrounded exec exits (default true)
+- `resultMaxChars`: max exec output chars included in tool results sent to the model (default 20000; hard clamp 1000–50000). This does **not** change `process log` in-memory aggregation caps.
 - `applyPatch.enabled`: enable experimental `apply_patch` (OpenAI/OpenAI Codex only; default false)
 - `applyPatch.allowModels`: optional allowlist of model ids (e.g. `gpt-5.2` or `openai/gpt-5.2`)
   Note: `applyPatch` is only under `tools.exec`.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2048,6 +2048,7 @@ of `every`, keep `HEARTBEAT.md` tiny, and/or choose a cheaper `model`.
 
 - `backgroundMs`: time before auto-background (ms, default 10000)
 - `timeoutSec`: auto-kill after this runtime (seconds, default 1800)
+- `resultMaxChars`: max output chars included in tool results sent to the model (does not affect process log cache; default 20000)
 - `cleanupMs`: how long to keep finished sessions in memory (ms, default 1800000)
 - `notifyOnExit`: enqueue a system event + request heartbeat when backgrounded exec exits (default true)
 - `resultMaxChars`: max exec output chars included in tool results sent to the model (default 20000; hard clamp 1000–50000). This does **not** change `process log` in-memory aggregation caps.

--- a/src/agents/bash-tools.exec.result-cap.test.ts
+++ b/src/agents/bash-tools.exec.result-cap.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+const isWin = process.platform === "win32";
+
+describe("exec tool result cap", () => {
+  it("truncates foreground gateway exec output before returning tool result", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      resultMaxChars: 1000,
+    });
+
+    const result = await tool.execute("call1", {
+      command: "node -e \"process.stdout.write('a'.repeat(6000))\"",
+      timeout: 30,
+    });
+
+    const text = result.content.find((entry) => entry.type === "text")?.text ?? "";
+    expect(text).toContain("[TRUNCATED originalChars=");
+    expect(result.details?.status).toBe("completed");
+    if (
+      result.details &&
+      (result.details.status === "completed" || result.details.status === "failed")
+    ) {
+      expect(result.details.truncated).toBe(true);
+      expect(typeof result.details.originalChars).toBe("number");
+      expect(typeof result.details.keptChars).toBe("number");
+      expect(result.details.originalChars).toBeGreaterThan(result.details.keptChars ?? 0);
+      expect(result.details.aggregated).toContain("[TRUNCATED originalChars=");
+    }
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -29,6 +29,7 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import { logInfo, logWarn } from "../logger.js";
 import { formatSpawnError, spawnWithFallback } from "../process/spawn-utils.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { clampNumber } from "../utils.js";
 import {
   type ProcessSession,
   type SessionStdin,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -119,7 +119,7 @@ const DEFAULT_PENDING_MAX_OUTPUT = clampWithDefault(
   200_000,
 );
 
-const DEFAULT_RESULT_MAX_OUTPUT = clampNumber(
+const DEFAULT_RESULT_MAX_OUTPUT = clampWithDefault(
   readEnvInt("OPENCLAW_EXEC_RESULT_MAX_CHARS"),
   20_000,
   1_000,
@@ -889,7 +889,7 @@ export function createExecTool(
 
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
-      const resultMaxChars = clampNumber(
+      const resultMaxChars = clampWithDefault(
         defaults?.resultMaxChars,
         DEFAULT_RESULT_MAX_OUTPUT,
         1_000,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -29,7 +29,6 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import { logInfo, logWarn } from "../logger.js";
 import { formatSpawnError, spawnWithFallback } from "../process/spawn-utils.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
-import { clampNumber } from "../utils.js";
 import {
   type ProcessSession,
   type SessionStdin,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -73,7 +73,7 @@ export type RunEmbeddedPiAgentParams = {
   verboseLevel?: VerboseLevel;
   reasoningLevel?: ReasoningLevel;
   toolResultFormat?: ToolResultFormat;
-  execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
+  execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node" | "resultMaxChars">;
   bashElevated?: ExecElevatedDefaults;
   timeoutMs: number;
   runId: string;

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -59,7 +59,7 @@ export type EmbeddedRunAttemptParams = {
   verboseLevel?: VerboseLevel;
   reasoningLevel?: ReasoningLevel;
   toolResultFormat?: ToolResultFormat;
-  execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
+  execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node" | "resultMaxChars">;
   bashElevated?: ExecElevatedDefaults;
   timeoutMs: number;
   runId: string;

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -97,6 +97,7 @@ function resolveExecConfig(cfg: OpenClawConfig | undefined) {
     safeBins: globalExec?.safeBins,
     backgroundMs: globalExec?.backgroundMs,
     timeoutSec: globalExec?.timeoutSec,
+    resultMaxChars: globalExec?.resultMaxChars,
     approvalRunningNoticeMs: globalExec?.approvalRunningNoticeMs,
     cleanupMs: globalExec?.cleanupMs,
     notifyOnExit: globalExec?.notifyOnExit,
@@ -290,6 +291,7 @@ export function createOpenClawCodingTools(options?: {
     timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
     approvalRunningNoticeMs:
       options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
+    resultMaxChars: options?.exec?.resultMaxChars ?? execConfig.resultMaxChars,
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     sandbox: sandbox
       ? {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,13 +281,11 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
-=======
 
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
-=======
 
   return grok as GrokConfig;
 }
@@ -297,7 +295,6 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
-=======
 
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
@@ -481,14 +478,6 @@ async function runWebSearch(params: {
   grokModel?: string;
   grokInlineCitations?: boolean;
 }): Promise<Record<string, unknown>> {
-  const cacheKey = normalizeCacheKey(
-    params.provider === "brave"
-      ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : params.provider === "perplexity"
-        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
-  );
-=======
   let rawCacheKey: string;
   switch (params.provider) {
     case "brave":

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -281,10 +281,14 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
   }
+=======
+
   const grok = "grok" in search ? search.grok : undefined;
   if (!grok || typeof grok !== "object") {
     return {};
   }
+=======
+
   return grok as GrokConfig;
 }
 
@@ -293,6 +297,8 @@ function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   if (fromConfig) {
     return fromConfig;
   }
+=======
+
   const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
   return fromEnv || undefined;
 }
@@ -482,6 +488,24 @@ async function runWebSearch(params: {
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
+=======
+  let rawCacheKey: string;
+  switch (params.provider) {
+    case "brave":
+      rawCacheKey = `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`;
+      break;
+    case "perplexity":
+      rawCacheKey = `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`;
+      break;
+    case "grok":
+      rawCacheKey = `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${params.grokInlineCitations ?? false}`;
+      break;
+    default:
+      rawCacheKey = `${String(params.provider)}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`;
+      break;
+  }
+
+  const cacheKey = normalizeCacheKey(rawCacheKey);
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -60,6 +60,46 @@ const baseQueuedRun = (messageProvider = "whatsapp"): FollowupRun =>
     },
   }) as FollowupRun;
 
+describe("createFollowupRunner preemptive exec result cap", () => {
+  it("reduces exec resultMaxChars when session is near the context window", async () => {
+    const storePath = path.join(
+      await fs.mkdtemp(path.join(tmpdir(), "openclaw-waterline-")),
+      "sessions.json",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      // Near 95%: trigger the 4k cap.
+      totalTokens: 95_000,
+      contextTokens: 100_000,
+    };
+    const sessionStore: Record<string, SessionEntry> = { main: sessionEntry };
+    await saveSessionStore(storePath, sessionStore);
+
+    runEmbeddedPiAgentMock.mockReset();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({ payloads: [{ text: "ok" }], meta: {} });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply: vi.fn(async () => {}) },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    const queued = baseQueuedRun();
+    queued.run.sessionKey = "main";
+
+    await runner(queued);
+
+    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as any;
+    expect(call.execOverrides?.resultMaxChars).toBe(4000);
+  });
+});
+
 describe("createFollowupRunner compaction", () => {
   it("adds verbose auto-compaction notice and tracks count", async () => {
     const storePath = path.join(

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -95,7 +95,9 @@ describe("createFollowupRunner preemptive exec result cap", () => {
 
     await runner(queued);
 
-    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as any;
+    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as unknown as {
+      execOverrides?: { resultMaxChars?: number };
+    };
     expect(call.execOverrides?.resultMaxChars).toBe(4000);
   });
 });

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -67,7 +67,7 @@ export type FollowupRun = {
     verboseLevel?: VerboseLevel;
     reasoningLevel?: ReasoningLevel;
     elevatedLevel?: ElevatedLevel;
-    execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
+    execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node" | "resultMaxChars">;
     bashElevated?: {
       enabled: boolean;
       allowed: boolean;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -177,6 +177,8 @@ export type ExecToolConfig = {
   backgroundMs?: number;
   /** Default timeout (seconds) before auto-killing exec commands. */
   timeoutSec?: number;
+  /** Max characters from exec output to include in tool results sent to the model (does not affect process log cache). */
+  resultMaxChars?: number;
   /** Emit a running notice (ms) when approval-backed exec runs long (default: 10000, 0 = off). */
   approvalRunningNoticeMs?: number;
   /** How long to keep finished sessions in memory (ms). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -283,6 +283,7 @@ export const AgentToolsSchema = z
         safeBins: z.array(z.string()).optional(),
         backgroundMs: z.number().int().positive().optional(),
         timeoutSec: z.number().int().positive().optional(),
+        resultMaxChars: z.number().int().positive().optional(),
         approvalRunningNoticeMs: z.number().int().nonnegative().optional(),
         cleanupMs: z.number().int().positive().optional(),
         notifyOnExit: z.boolean().optional(),
@@ -535,6 +536,7 @@ export const ToolsSchema = z
         safeBins: z.array(z.string()).optional(),
         backgroundMs: z.number().int().positive().optional(),
         timeoutSec: z.number().int().positive().optional(),
+        resultMaxChars: z.number().int().positive().optional(),
         cleanupMs: z.number().int().positive().optional(),
         notifyOnExit: z.boolean().optional(),
         applyPatch: z


### PR DESCRIPTION
## Summary
Preemptive waterline guard (tools-layer): when a session is near its context window limit, reduce how much `exec` output is injected back into the model.

- If `totalTokens/contextTokens >= 0.85` → cap `exec` tool result to 10k chars.
- If `>= 0.95` → cap to 4k chars.
- Works by passing `execOverrides.resultMaxChars` into the embedded runner call.

## Why
Even with per-tool truncation and overflow recovery, sessions near the limit are fragile. This reduces the chance of hitting context overflow by automatically shrinking the highest-risk tool output before the request is retried.

## Notes
- This PR is intentionally small and self-contained.
- It stacks on #12349 (adds `tools.exec.resultMaxChars` / `ExecToolDefaults.resultMaxChars`).

## Validation
- `pnpm -s vitest run src/auto-reply/reply/followup-runner.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a configurable cap (`resultMaxChars`) on how much `tools.exec` output is included in tool results sent back to the model, including an env-var default (`OPENCLAW_EXEC_RESULT_MAX_CHARS`) and wiring through embedded runner `execOverrides`. It also adds a “context waterline” guard in `createFollowupRunner` that automatically lowers `execOverrides.resultMaxChars` when a session’s `totalTokens/contextTokens` ratio is high (>=0.85 => 10k, >=0.95 => 4k), plus tests and docs updates.

The changes fit into the existing tools layer by truncating only the model-facing tool result string (leaving process-log aggregation caps unchanged) and by passing overrides through the embedded runner call path so higher-level orchestration can adjust exec output size under pressure.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge once the docs issue is fixed.
- Core logic is straightforward (plumbing a capped exec result size and applying it based on token waterlines) and includes targeted tests. The main blocking issue found is a duplicated/contradictory documentation bullet for `tools.exec.resultMaxChars`. Tooling/tests could not be executed in this environment due to missing node/pnpm, so confidence is slightly reduced.
- docs/gateway/configuration.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->