### PR TITLE
fix(googlechat): detect bot @mention by user.type fallback

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -387,7 +387,16 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
     if (botTargets.has(userName)) {
       return true;
     }
-    return normalizeUserId(userName) === "app";
+    if (normalizeUserId(userName) === "app") {
+      return true;
+    }
+    // Webhook events send the bot's numeric user ID (e.g. "users/112..."),
+    // not "users/app". When botUser is not configured, fall back to
+    // checking the user.type field provided by the Google Chat API.
+    if (entry.userMention?.user?.type?.toUpperCase() === "BOT") {
+      return true;
+    }
+    return false;
   });
   return { hasAnyMention, wasMentioned };
 }


### PR DESCRIPTION
## Summary

Fixes #12323

Google Chat webhook events send the bot's **numeric user ID** (e.g. `users/112...`) in annotation data instead of the documented `users/app`. When `botUser` is not explicitly configured, `extractMentionInfo()` fails to match the bot mention, causing the bot to silently ignore @mentions.

### Root Cause

The current logic in `extractMentionInfo()` only checks:
1. Whether the mentioned user name is in `botTargets` (which requires explicit `botUser` config)
2. Whether `normalizeUserId(userName)` equals `"app"`

Neither check matches numeric user IDs like `users/112345678901234567890`.

### Fix

Add a fallback that checks `entry.userMention.user.type === "BOT"` — the Google Chat API includes a `type` field on user objects that reliably identifies bot users regardless of the user ID format.

### Changes

- `extensions/googlechat/src/monitor.ts`: Added BOT type fallback check in `extractMentionInfo()`

### Test Plan

- [x] Verified the `GoogleChatUser` type already includes `type?: string` field
- [x] Confirmed no existing tests break (`extractMentionInfo` is not exported, tested via integration)
- [x] Reviewed Google Chat API docs confirming `type: "BOT"` for bot users

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Google Chat mention detection in `extensions/googlechat/src/monitor.ts` by adding a fallback path for webhook annotations that mention the bot using a numeric `users/<id>` identifier rather than `users/app`. The new logic treats a `USER_MENTION` whose mentioned user has `user.type === "BOT"` as a bot mention, intended to keep `requireMention` gating working when `botUser` isn’t configured.

This change sits in the inbound webhook processing path and directly affects whether group messages are accepted or dropped based on mention-gating.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but changes mention-gating behavior in a way that can cause incorrect replies in multi-bot spaces.
- The change is small and localized, but the new BOT-type fallback will deterministically misclassify mentions of other bots as mentions of this bot when `botUser` isn’t configured, altering gating semantics in group chats. Fixing the fallback condition should make this safe.
- extensions/googlechat/src/monitor.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->