### PR TITLE
feat: Add DuckDuckGo as free web search provider

### DIFF
--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -21,4 +21,19 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts duckduckgo provider without api key", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "duckduckgo",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -471,8 +471,9 @@ const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
-  "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", or "duckduckgo").',
+  "tools.web.search.apiKey":
+    "Brave Search API key (fallback: BRAVE_API_KEY env var; not needed for DuckDuckGo).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
   "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -171,7 +171,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("duckduckgo")])
+      .optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
Add DuckDuckGo search provider for users who want a free, no-API-key-required search option alongside Brave and Perplexity.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `duckduckgo` as a third `web_search` provider alongside Brave and Perplexity. The tool implementation (`src/agents/tools/web-search.ts`) routes requests to DuckDuckGo’s HTML endpoint, parses result titles/URLs/snippets, wraps returned text via `wrapWebContent`, and skips API-key enforcement for the DuckDuckGo provider. Config validation and UI hints are updated to allow `provider: "duckduckgo"`, and a new test asserts configs can enable DuckDuckGo without an API key.

The change fits into the existing provider-selection pattern: `resolveSearchProvider()` now recognizes `duckduckgo` (and `ddg` alias), `runWebSearch()` branches by provider, and runtime config schemas are extended to accept the new provider value.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; one user-facing config hint is inconsistent with the new no-key DuckDuckGo provider.
- Core routing and schema updates for the new provider are straightforward and self-contained, and the added test covers the no-API-key config case. The remaining issue is a misleading UI/help hint that will incorrectly tell users an API key is always required for web_search.
- src/config/schema.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->