### PR TITLE
feat: Add DuckDuckGo as free web search provider

### DIFF
--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -21,4 +21,19 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts duckduckgo provider without api key", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "duckduckgo",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -475,8 +475,9 @@ const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
-  "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", or "duckduckgo").',
+  "tools.web.search.apiKey":
+    "Brave Search API key (fallback: BRAVE_API_KEY env var; not needed for DuckDuckGo).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
   "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -171,7 +171,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("duckduckgo")])
+      .optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
Add DuckDuckGo search provider for users who want a free, no-API-key-required search option alongside Brave and Perplexity.

## Changes
- Added 'duckduckgo' to SEARCH_PROVIDERS constant
- Implemented runDuckDuckGoSearch() function using DuckDuckGo HTML endpoint
- Added proper URL resolution and result parsing
- Updated config validation to accept 'duckduckgo' provider
- Added tests for DuckDuckGo provider configuration

## Usage
Users can now set:

tools.web.search.provider: 'duckduckgo'

Without needing an API key.

## Testing
- Config validation accepts 'duckduckgo' provider
- Search functionality works without API key

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the web_search tool to support DuckDuckGo as an additional provider (alongside Brave and Perplexity), including provider resolution, a new HTML-scraping search implementation, and config/runtime schema updates. It also adds a config validation test to ensure `duckduckgo` is accepted without an API key.

The change fits into the existing `src/agents/tools/web-search.ts` provider switch in `runWebSearch`, and updates the Zod runtime schema so config validation allows the new provider value.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; main remaining issue is a small but user-visible config help text inconsistency.
- Core changes are localized (provider enum expansion + new provider branch in runWebSearch + schema updates) and the added test covers the intended config validation. I found one definite user-facing inconsistency in config help text; the DuckDuckGo HTML parsing approach may be brittle long-term but isn’t a definite regression introduced by this diff.
- src/config/schema.ts (FIELD_HELP strings); src/agents/tools/web-search.ts (DuckDuckGo HTML parsing robustness)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->