### PR TITLE
feat(cli): add --stream-json flag for live NDJSON streaming

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -109,10 +109,9 @@ export function handleMessageUpdate(
     }
   }
 
-  if (ctx.state.streamReasoning) {
-    // Handle partial <think> tags: stream whatever reasoning is visible so far.
-    ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
-  }
+  // Extract <think>-tagged reasoning and emit for all consumers (NDJSON/SSE, TUI).
+  // The emitReasoningStream function handles dedup and delta computation internally.
+  ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
 
   const next = ctx
     .stripBlockTags(ctx.state.deltaBuffer, {

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -41,6 +41,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     )
     .option("--deliver", "Send the agent's reply back to the selected channel", false)
     .option("--json", "Output result as JSON", false)
+    .option("--stream-json", "Stream NDJSON events to stdout", false)
     .option(
       "--timeout <seconds>",
       "Override agent command timeout (seconds, default 600 or config value)",
@@ -73,10 +74,17 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .action(async (opts) => {
       const verboseLevel = typeof opts.verbose === "string" ? opts.verbose.toLowerCase() : "";
       setVerbose(verboseLevel === "on");
+      if (opts.json && opts.streamJson) {
+        throw new Error("Choose either --json or --stream-json, not both.");
+      }
       // Build default deps (keeps parity with other commands; future-proofing).
       const deps = createDefaultDeps();
       await runCommandWithRuntime(defaultRuntime, async () => {
-        await agentCliCommand(opts, defaultRuntime, deps);
+        await agentCliCommand(
+          { ...opts, streamJson: Boolean(opts.streamJson) },
+          defaultRuntime,
+          deps,
+        );
       });
     });
 

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -15,7 +15,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import * as configModule from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
-import { agentCliCommand } from "./agent-via-gateway.js";
+import { agentCliCommand, emitNdjsonLine } from "./agent-via-gateway.js";
 import { agentCommand } from "./agent.js";
 
 const runtime: RuntimeEnv = {
@@ -120,6 +120,104 @@ describe("agentCliCommand", () => {
       expect(runtime.log).toHaveBeenCalledWith("local");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("routes to streaming gateway path when --stream-json is set", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-cli-"));
+    const store = path.join(dir, "sessions.json");
+    mockConfig(store);
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    // callGateway should receive an onEvent callback when streaming
+    vi.mocked(callGateway).mockImplementation(async (opts) => {
+      // Simulate a couple of gateway events via the onEvent callback
+      const onEvent = (opts as { onEvent?: (evt: unknown) => void }).onEvent;
+      if (onEvent) {
+        onEvent({
+          event: "chat",
+          payload: { runId: "r1", state: "delta", message: { text: "he" } },
+          seq: 1,
+        });
+        onEvent({
+          event: "chat",
+          payload: { runId: "r1", state: "final", message: { text: "hello" } },
+          seq: 2,
+        });
+      }
+      return { runId: "r1", status: "ok", result: { payloads: [{ text: "hello" }] } };
+    });
+
+    try {
+      await agentCliCommand({ message: "hi", to: "+1555", streamJson: true }, runtime);
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      // Verify onEvent was passed to callGateway
+      const callOpts = vi.mocked(callGateway).mock.calls[0][0] as Record<string, unknown>;
+      expect(typeof callOpts.onEvent).toBe("function");
+
+      // Verify NDJSON lines were written to stdout (2 events + 1 result)
+      const writes = stdoutSpy.mock.calls.map(([data]) => String(data));
+      expect(writes).toHaveLength(3);
+      for (const line of writes) {
+        // Each line should be valid JSON followed by a newline
+        expect(line.endsWith("\n")).toBe(true);
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+
+      // The last line should be the result event
+      const lastLine = JSON.parse(writes[2]);
+      expect(lastLine.event).toBe("result");
+      expect(lastLine.status).toBe("ok");
+
+      // Normal log output should NOT be called (NDJSON-only)
+      expect(runtime.log).not.toHaveBeenCalled();
+    } finally {
+      stdoutSpy.mockRestore();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes --stream-json through to embedded agent when --local is set", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-cli-"));
+    const store = path.join(dir, "sessions.json");
+    mockConfig(store);
+
+    vi.mocked(agentCommand).mockResolvedValueOnce(undefined);
+
+    try {
+      await agentCliCommand({ message: "hi", to: "+1555", local: true, streamJson: true }, runtime);
+
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      const passedOpts = vi.mocked(agentCommand).mock.calls[0][0] as Record<string, unknown>;
+      expect(passedOpts.streamJson).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("emitNdjsonLine", () => {
+  it("writes valid JSON followed by a newline", () => {
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      emitNdjsonLine({
+        event: "agent",
+        runId: "r1",
+        stream: "lifecycle",
+        data: { phase: "start" },
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      const output = String(spy.mock.calls[0][0]);
+      expect(output.endsWith("\n")).toBe(true);
+      const parsed = JSON.parse(output);
+      expect(parsed.event).toBe("agent");
+      expect(parsed.runId).toBe("r1");
+      expect(parsed.data).toEqual({ phase: "start" });
+    } finally {
+      spy.mockRestore();
     }
   });
 });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -15,6 +15,11 @@ import {
 import { agentCommand } from "./agent.js";
 import { resolveSessionKeyForRequest } from "./agent/session.js";
 
+/** Write a single NDJSON line to stdout. */
+export function emitNdjsonLine(obj: Record<string, unknown>): void {
+  process.stdout.write(`${JSON.stringify(obj)}\n`);
+}
+
 type AgentGatewayResult = {
   payloads?: Array<{
     text?: string;
@@ -39,6 +44,8 @@ export type AgentCliOpts = {
   thinking?: string;
   verbose?: string;
   json?: boolean;
+  /** Stream NDJSON events to stdout during the agent run. */
+  streamJson?: boolean;
   timeout?: string;
   deliver?: boolean;
   channel?: string;
@@ -172,6 +179,78 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   return response;
 }
 
+/**
+ * Gateway agent call with live NDJSON event streaming to stdout.
+ * Reuses callGateway with an onEvent callback to emit each gateway event as an NDJSON line.
+ */
+async function agentViaGatewayStreamJson(opts: AgentCliOpts, _runtime: RuntimeEnv) {
+  const body = (opts.message ?? "").trim();
+  if (!body) {
+    throw new Error("Message (--message) is required");
+  }
+  if (!opts.to && !opts.sessionId && !opts.agent) {
+    throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
+  }
+
+  const cfg = loadConfig();
+  const agentIdRaw = opts.agent?.trim();
+  const agentId = agentIdRaw ? normalizeAgentId(agentIdRaw) : undefined;
+  if (agentId) {
+    const knownAgents = listAgentIds(cfg);
+    if (!knownAgents.includes(agentId)) {
+      throw new Error(
+        `Unknown agent id "${agentIdRaw}". Use "${formatCliCommand("openclaw agents list")}" to see configured agents.`,
+      );
+    }
+  }
+  const timeoutSeconds = parseTimeoutSeconds({ cfg, timeout: opts.timeout });
+  const gatewayTimeoutMs = Math.max(10_000, (timeoutSeconds + 30) * 1000);
+
+  const sessionKey = resolveSessionKeyForRequest({
+    cfg,
+    agentId,
+    to: opts.to,
+    sessionId: opts.sessionId,
+  }).sessionKey;
+
+  const channel = normalizeMessageChannel(opts.channel) ?? DEFAULT_CHAT_CHANNEL;
+  const idempotencyKey = opts.runId?.trim() || randomIdempotencyKey();
+
+  const response = await callGateway<GatewayAgentResponse>({
+    method: "agent",
+    params: {
+      message: body,
+      agentId,
+      to: opts.to,
+      replyTo: opts.replyTo,
+      sessionId: opts.sessionId,
+      sessionKey,
+      thinking: opts.thinking,
+      deliver: Boolean(opts.deliver),
+      channel,
+      replyChannel: opts.replyChannel,
+      replyAccountId: opts.replyAccount,
+      timeout: timeoutSeconds,
+      lane: opts.lane,
+      extraSystemPrompt: opts.extraSystemPrompt,
+      idempotencyKey,
+    },
+    expectFinal: true,
+    timeoutMs: gatewayTimeoutMs,
+    clientName: GATEWAY_CLIENT_NAMES.CLI,
+    mode: GATEWAY_CLIENT_MODES.CLI,
+    onEvent: (evt) => {
+      // Emit each gateway event as an NDJSON line (chat deltas, agent tool/lifecycle events).
+      emitNdjsonLine({ event: evt.event, ...(evt.payload as Record<string, unknown>) });
+    },
+  });
+
+  // Emit the final result as the last NDJSON line.
+  emitNdjsonLine({ event: "result", ...response });
+
+  return response;
+}
+
 export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, deps?: CliDeps) {
   const localOpts = {
     ...opts,
@@ -180,6 +259,11 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
   };
   if (opts.local === true) {
     return await agentCommand(localOpts, runtime, deps);
+  }
+
+  // Stream NDJSON via the gateway (no embedded fallback — streaming should fail loud).
+  if (opts.streamJson) {
+    return await agentViaGatewayStreamJson(opts, runtime);
   }
 
   try {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -47,6 +47,7 @@ import {
 import {
   clearAgentRunContext,
   emitAgentEvent,
+  onAgentEvent,
   registerAgentRunContext,
 } from "../infra/agent-events.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
@@ -56,6 +57,7 @@ import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
+import { emitNdjsonLine } from "./agent-via-gateway.js";
 import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
@@ -156,6 +158,24 @@ export async function agentCommand(
   } = sessionResolution;
   let sessionEntry = resolvedSessionEntry;
   const runId = opts.runId?.trim() || sessionId;
+
+  // Subscribe to agent events for NDJSON streaming when --stream-json is active.
+  const unsubNdjson = opts.streamJson
+    ? onAgentEvent((evt) => {
+        if (evt.runId !== runId) {
+          return;
+        }
+        emitNdjsonLine({
+          event: "agent",
+          runId: evt.runId,
+          seq: evt.seq,
+          stream: evt.stream,
+          ts: evt.ts,
+          data: evt.data,
+          ...(evt.sessionKey ? { sessionKey: evt.sessionKey } : {}),
+        });
+      })
+    : undefined;
 
   try {
     if (opts.deliver === true) {
@@ -516,6 +536,16 @@ export async function agentCommand(
       });
     }
 
+    // Emit the final result as NDJSON when streaming.
+    if (opts.streamJson) {
+      emitNdjsonLine({
+        event: "result",
+        runId,
+        status: "ok",
+        payloads: result.payloads ?? [],
+      });
+    }
+
     const payloads = result.payloads ?? [];
     return await deliverAgentCommandResult({
       cfg,
@@ -527,6 +557,7 @@ export async function agentCommand(
       payloads,
     });
   } finally {
+    unsubNdjson?.();
     clearAgentRunContext(runId);
   }
 }

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -41,6 +41,8 @@ export type AgentCommandOpts = {
   thinkingOnce?: string;
   verbose?: string;
   json?: boolean;
+  /** Stream NDJSON events to stdout during the agent run. */
+  streamJson?: boolean;
   timeout?: string;
   deliver?: boolean;
   /** Override delivery target (separate from session routing). */

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -42,6 +42,8 @@ export type CallGatewayOptions = {
    * Does not affect config loading; callers still control auth via opts.token/password/env/config.
    */
   configPath?: string;
+  /** Optional callback for gateway events received while the request is in flight. */
+  onEvent?: (evt: { event: string; payload?: unknown; seq?: number }) => void;
 };
 
 export type GatewayConnectionDetails = {
@@ -273,6 +275,9 @@ export async function callGateway<T = Record<string, unknown>>(
       deviceIdentity: loadOrCreateDeviceIdentity(),
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
+      onEvent: opts.onEvent
+        ? (evt) => opts.onEvent!({ event: evt.event, payload: evt.payload, seq: evt.seq })
+        : undefined,
       onHelloOk: async () => {
         try {
           const result = await client.request<T>(opts.method, opts.params, {


### PR DESCRIPTION
## Summary

Add a `--stream-json` flag to `openclaw agent --agent <id> --message <text>` that streams NDJSON events to stdout in real time during an agent run.

This enables external frontends to consume live agent events (text deltas, tool calls, thinking/reasoning, lifecycle phases) without polling — particularly useful for **AI SDK's `useChat()` capability** and similar streaming interfaces.

Many frontends would want to consume live agent events from within a sandbox, where only way to receive live events out would be the live terminal output stream. This helps with exactly that.

For a working example of a Next.js frontend consuming `--stream-json` via AI SDK's `useChat()`, see:
https://github.com/kumarabhirup/openclaw-ai-sdk/tree/main/apps/web

### What it does

```bash
openclaw agent --agent main --message "Hello" --stream-json
```

Outputs one JSON object per line (NDJSON) as the agent runs:
```jsonl
{"event":"agent","runId":"...","stream":"lifecycle","data":{"phase":"start"}}
{"event":"agent","runId":"...","stream":"thinking","data":{"delta":"Let me..."}}
{"event":"agent","runId":"...","stream":"assistant","data":{"delta":"Hello!"}}
{"event":"result","runId":"...","status":"ok","payloads":[{"text":"Hello!"}]}
```

### Changes

- **CLI**: register `--stream-json` option (mutually exclusive with `--json`)
- **Gateway path**: new `agentViaGatewayStreamJson()` uses `callGateway`'s new `onEvent` callback to relay each gateway event as an NDJSON line
- **Embedded path**: subscribe to `onAgentEvent` bus and emit matching events as NDJSON when `--stream-json` is active
- **Reasoning/thinking**: emit reasoning deltas as agent events unconditionally so NDJSON/SSE consumers receive thinking content
- **`callGateway`**: add `onEvent` callback option, wired through to `GatewayClient`'s existing event handler
- **Tests**: 3 new tests covering gateway streaming, embedded passthrough, and NDJSON line format

## Test plan

- [x] `pnpm test -- src/commands/agent-via-gateway.test.ts` — all 6 tests pass (3 existing + 3 new)
- [x] `pnpm tsgo` — no type errors
- [x] Lint clean — no new warnings

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `--stream-json` flag to `openclaw agent` to stream live NDJSON events to stdout during an agent run. It does this by (1) adding an `onEvent` callback to `callGateway` so gateway events can be relayed as NDJSON, and (2) subscribing to the embedded agent event bus (`onAgentEvent`) to emit matching NDJSON lines locally. It also changes embedded message handling to emit `<think>` reasoning deltas as agent events unconditionally so streaming consumers can receive them.

Main integration points are `src/cli/program/register.agent.ts` (flag registration + `--json` exclusivity), `src/commands/agent-via-gateway.ts` (new streaming gateway path + NDJSON writer), `src/commands/agent.ts` (embedded NDJSON subscription), and `src/gateway/call.ts` (wiring `onEvent` into the gateway client request).

<h3>Confidence Score: 2/5</h3>

- This PR likely needs fixes before merge due to at least one test-suite breaking issue and stream correctness concerns.
- Score is reduced because the modified test file appears to have mismatched closing braces/describe blocks that would break tests, and because the NDJSON streaming path can be corrupted by any other stdout output (especially on errors), which would break downstream consumers relying on valid NDJSON.
- src/commands/agent-via-gateway.test.ts, src/commands/agent-via-gateway.ts, src/commands/agent.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->