### PR TITLE
fix: .gitignore `.tgz` → `*.tgz` glob pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ apps/ios/*.mobileprovision
 .local/
 IDENTITY.md
 USER.md
-.tgz
+*.tgz
 
 # local tooling
 .serena/


### PR DESCRIPTION
## Summary

`.tgz` in `.gitignore` (line 69) only matches a file literally named `.tgz`. It does not match tarball files generated by `npm pack` (e.g. `openclaw-2026.2.6-3.tgz`).

Changed to `*.tgz` so all tarballs are properly ignored.

## Steps to reproduce

```bash
npm pack
git status
# openclaw-2026.2.6-3.tgz shows as untracked
```

## Environment

- OpenClaw version: 2026.2.6-3
- OS: Linux (Docker container)

✍️ **Author**: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the root `.gitignore` entry for tarball artifacts from `.tgz` (which only matches a file literally named `.tgz`) to `*.tgz`, ensuring `npm pack`-generated archives like `openclaw-<version>.tgz` are ignored. This change only affects Git ignore behavior for untracked tarball files and does not impact build/runtime code paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line `.gitignore` glob fix; change is correct and scoped to ignoring untracked npm pack tarballs, with no effect on shipped code or tooling behavior beyond Git status noise reduction.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->