### PR TITLE
fix: immediate wake on exec completion

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -388,11 +388,12 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   const output = normalizeNotifyOutput(
     tail(session.tail || session.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
   );
-  const summary = output
-    ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
-    : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
-  enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+  const id = session.id.slice(0, 8);
+  const statusLabel = status === "failed" ? ", failed" : "";
+  const text = output
+    ? `Exec finished (id=${id}, ${exitLabel}${statusLabel})\n${output}`
+    : `Exec finished (id=${id}, ${exitLabel}${statusLabel})`;
+  emitExecSystemEvent(text, { sessionKey });
 }
 
 function createApprovalSlug(id: string) {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -289,16 +289,17 @@ describe("exec notifyOnExit", () => {
 
     const prefix = sessionId.slice(0, 8);
     let finished = getFinishedSession(sessionId);
-    let hasEvent = peekSystemEvents("agent:main:main").some((event) => event.includes(prefix));
+    let matchingEvent = peekSystemEvents("agent:main:main").find((event) => event.includes(prefix));
     const deadline = Date.now() + (isWin ? 12_000 : 5_000);
-    while ((!finished || !hasEvent) && Date.now() < deadline) {
+    while ((!finished || !matchingEvent) && Date.now() < deadline) {
       await sleep(20);
       finished = getFinishedSession(sessionId);
-      hasEvent = peekSystemEvents("agent:main:main").some((event) => event.includes(prefix));
+      matchingEvent = peekSystemEvents("agent:main:main").find((event) => event.includes(prefix));
     }
 
     expect(finished).toBeTruthy();
-    expect(hasEvent).toBe(true);
+    expect(matchingEvent).toBeTruthy();
+    expect(matchingEvent).toContain("Exec finished");
   });
 });
 


### PR DESCRIPTION
## What
Fix background `exec` notifyOnExit so completion reliably triggers an immediate heartbeat wake (no polling) and the agent relays the command output.

## Why
The heartbeat runner treats exec completions specially only when:
- wake reason is `exec-event`, and
- a pending system event contains `Exec finished`

The notifyOnExit path previously emitted a different reason/text, so async background exec completion could be missed until manual polling or the next scheduled heartbeat.

## Changes
- Align notifyOnExit completion system event text to `Exec finished ...` and wake using `reason: "exec-event"`.
- Tighten regression coverage for notifyOnExit.

## Testing
- `pnpm test src/agents/bash-tools.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR aligns background `exec` notifyOnExit completion events with the heartbeat runner’s exec-event detection by emitting system events that include `"Exec finished"` and waking the heartbeat with `reason: "exec-event"`. The notifyOnExit test was updated to look for an event containing the session id prefix and to assert the standardized completion text.

This fits into the existing heartbeat runner behavior in `src/infra/heartbeat-runner.ts`, which selects a specialized exec-event prompt only when both the wake reason is `exec-event` and pending system events include `"Exec finished"`.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with a couple correctness gaps to address.
- The core behavior change (standardizing exec completion events + exec-event wake reason) matches the heartbeat runner’s detection logic and is localized. Remaining concerns are around notifyOnExit reliability if event emission fails (exitNotified is set before enqueue), and the regression test not asserting that output is actually relayed in the event text.
- src/agents/bash-tools.exec.ts, src/agents/bash-tools.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->