### PR TITLE
Test Improvements: Add Retry Logging and Max Attempts Handling

### DIFF
--- a/test/auto-reply.retry.test.ts
+++ b/test/auto-reply.retry.test.ts
@@ -86,4 +86,48 @@ describe("deliverWebReply retry", () => {
 
     expect(msg.sendMedia).toHaveBeenCalledTimes(2);
   });
+
+  it("logs retry attempts", async () => {
+    const msg = makeMsg();
+    const warnLogger = {
+      warn: vi.fn(),
+    };
+    msg.reply.mockRejectedValueOnce(new Error("timeout"));
+    msg.reply.mockResolvedValueOnce(undefined);
+
+    await expect(
+      deliverWebReply({
+        replyResult: { text: "hi" },
+        msg,
+        maxMediaBytes: 5_000_000,
+        replyLogger: warnLogger,
+        runtime: defaultRuntime,
+        skipLog: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(warnLogger.warn).toHaveBeenCalledWith("Retrying transient error: timeout", {
+      attempt: 1,
+      maxAttempts: 3,
+    });
+  });
+
+  it("stops retrying after max attempts", async () => {
+    const msg = makeMsg();
+    msg.reply.mockRejectedValue(new Error("permanent failure"));
+
+    await expect(
+      deliverWebReply({
+        replyResult: { text: "hi" },
+        msg,
+        maxMediaBytes: 5_000_000,
+        replyLogger: noopLogger,
+        runtime: defaultRuntime,
+        skipLog: true,
+        maxRetries: 2,
+      }),
+    ).rejects.toThrow("permanent failure");
+
+    expect(msg.reply).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
Enhanced test coverage for auto-reply retry logic by adding:
- Test case for retry logging
- Test case for max retry attempts enforcement
- Improved error handling validation

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds two new Vitest cases to cover the web auto-reply retry behavior: one asserts that retry attempts are logged, and another asserts that the retry loop stops after the configured maximum attempts. This complements existing tests that already cover transient retry behavior for text and media sends.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the new tests assert behavior that doesn’t match the current `deliverWebReply` API/implementation.
- The added tests depend on (1) a retry logging call that isn’t made by `deliverWebReply` (retries log via `logVerbose`, not `replyLogger.warn`), and (2) a `maxRetries` parameter that isn’t part of `deliverWebReply`’s signature (retry max attempts are currently fixed at 3). These are definitive mismatches that will cause failing tests or type errors depending on the build settings.
- test/auto-reply.retry.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->