### PR TITLE
Code Quality: Add Strict Oxlint Configuration

### DIFF
--- a/.oxlintrc
+++ b/.oxlintrc
@@ -1,11 +1,2 @@
-{
-  "rules": {
-    "no-unused-vars": "error",
-    "strict-null-checks": true,
-    "no-explicit-any": "warn",
-    "prefer-const": "error",
-    "no-var-keyword": "error",
-    "no-duplicate-imports": "error",
-    "no-empty": "warn"
-  }
-}
+{"rules":{"no-unused-vars":"error","strict-null-checks":true,"no-explicit-any":"warn","prefer-const":"error","no-var-keyword":"error","no-duplicate-imports":"error","no-empty":"warn"}}
+

--- a/.oxlintrc
+++ b/.oxlintrc
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "no-unused-vars": "error",
+    "strict-null-checks": true,
+    "no-explicit-any": "warn",
+    "prefer-const": "error",
+    "no-var-keyword": "error",
+    "no-duplicate-imports": "error",
+    "no-empty": "warn"
+  }
+}

--- a/test/auto-reply.retry.test.ts
+++ b/test/auto-reply.retry.test.ts
@@ -86,4 +86,48 @@ describe("deliverWebReply retry", () => {
 
     expect(msg.sendMedia).toHaveBeenCalledTimes(2);
   });
+
+  it("logs retry attempts", async () => {
+    const msg = makeMsg();
+    const warnLogger = {
+      warn: vi.fn(),
+    };
+    msg.reply.mockRejectedValueOnce(new Error("timeout"));
+    msg.reply.mockResolvedValueOnce(undefined);
+
+    await expect(
+      deliverWebReply({
+        replyResult: { text: "hi" },
+        msg,
+        maxMediaBytes: 5_000_000,
+        replyLogger: warnLogger,
+        runtime: defaultRuntime,
+        skipLog: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(warnLogger.warn).toHaveBeenCalledWith("Retrying transient error: timeout", {
+      attempt: 1,
+      maxAttempts: 3,
+    });
+  });
+
+  it("stops retrying after max attempts", async () => {
+    const msg = makeMsg();
+    msg.reply.mockRejectedValue(new Error("permanent failure"));
+
+    await expect(
+      deliverWebReply({
+        replyResult: { text: "hi" },
+        msg,
+        maxMediaBytes: 5_000_000,
+        replyLogger: noopLogger,
+        runtime: defaultRuntime,
+        skipLog: true,
+        maxRetries: 2,
+      }),
+    ).rejects.toThrow("permanent failure");
+
+    expect(msg.reply).toHaveBeenCalledTimes(3);
+  });
 });

--- a/test/auto-reply.retry.test.ts
+++ b/test/auto-reply.retry.test.ts
@@ -56,6 +56,7 @@ describe("deliverWebReply retry", () => {
         replyResult: { text: "hi" },
         msg,
         maxMediaBytes: 5_000_000,
+        textLimit: 2000,
         replyLogger: noopLogger,
         runtime: defaultRuntime,
         skipLog: true,
@@ -78,6 +79,7 @@ describe("deliverWebReply retry", () => {
         },
         msg,
         maxMediaBytes: 5_000_000,
+        textLimit: 2000,
         replyLogger: noopLogger,
         runtime: defaultRuntime,
         skipLog: true,
@@ -85,49 +87,5 @@ describe("deliverWebReply retry", () => {
     ).resolves.toBeUndefined();
 
     expect(msg.sendMedia).toHaveBeenCalledTimes(2);
-  });
-
-  it("logs retry attempts", async () => {
-    const msg = makeMsg();
-    const warnLogger = {
-      warn: vi.fn(),
-    };
-    msg.reply.mockRejectedValueOnce(new Error("timeout"));
-    msg.reply.mockResolvedValueOnce(undefined);
-
-    await expect(
-      deliverWebReply({
-        replyResult: { text: "hi" },
-        msg,
-        maxMediaBytes: 5_000_000,
-        replyLogger: warnLogger,
-        runtime: defaultRuntime,
-        skipLog: false,
-      }),
-    ).resolves.toBeUndefined();
-
-    expect(warnLogger.warn).toHaveBeenCalledWith("Retrying transient error: timeout", {
-      attempt: 1,
-      maxAttempts: 3,
-    });
-  });
-
-  it("stops retrying after max attempts", async () => {
-    const msg = makeMsg();
-    msg.reply.mockRejectedValue(new Error("permanent failure"));
-
-    await expect(
-      deliverWebReply({
-        replyResult: { text: "hi" },
-        msg,
-        maxMediaBytes: 5_000_000,
-        replyLogger: noopLogger,
-        runtime: defaultRuntime,
-        skipLog: true,
-        maxRetries: 2,
-      }),
-    ).rejects.toThrow("permanent failure");
-
-    expect(msg.reply).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
Added strict oxlint configuration to enforce:
- No unused variables
- Strict null checks
- No explicit any types
- Prefer const over let
- No var keyword
- No duplicate imports

Ensures better code quality and type safety moving forward

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `.oxlintrc` to enable stricter Oxlint rules (unused vars, const preference, duplicate imports, etc.) and extends `test/auto-reply.retry.test.ts` with cases intended to validate retry logging and max-attempt behavior for `deliverWebReply`.

The retry-related tests currently don’t align with the `deliverWebReply` API/behavior in `src/web/auto-reply/deliver-reply.ts`: they omit a required `textLimit` param, pass an unsupported `maxRetries` param, and assert on `replyLogger.warn` for retries even though retries are logged via `logVerbose` instead.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the newly added retry tests don’t match the current `deliverWebReply` API/behavior and should fail CI.
- Confidence is reduced due to concrete test/API mismatches (missing required `textLimit`, unsupported `maxRetries`, and an assertion expecting retry warnings via `replyLogger.warn` that the implementation never emits). The Oxlint config itself is small, but the missing newline could also trip formatting checks.
- test/auto-reply.retry.test.ts, .oxlintrc

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->