### PR TITLE
chore(git): Update the .gitignore file to refine the ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,10 @@ node_modules
 .env
 docker-compose.extra.yml
 dist
-*.bun-build
-pnpm-lock.yaml
 bun.lock
 bun.lockb
 coverage
+.tsbuildinfo
 .pnpm-store
 .worktrees/
 .DS_Store
@@ -15,6 +14,11 @@ coverage
 ui/src/ui/__screenshots__/
 ui/playwright-report/
 ui/test-results/
+
+# Android build artifacts
+apps/android/.gradle/
+apps/android/app/build/
+apps/android/.cxx/
 
 # Bun build artifacts
 *.bun-build
@@ -52,7 +56,6 @@ apps/ios/fastlane/screenshots/
 apps/ios/fastlane/test_output/
 apps/ios/fastlane/logs/
 apps/ios/fastlane/.env
-apps/ios/fastlane/report.xml
 
 # fastlane build artifacts (local)
 apps/ios/*.ipa
@@ -60,7 +63,6 @@ apps/ios/*.dSYM.zip
 
 # provisioning profiles (local)
 apps/ios/*.mobileprovision
-.env
 
 # Local untracked files
 .local/


### PR DESCRIPTION
Review and adjust the gitignore

Added:
.tsbuildinfo - TypeScript build info cache
Android build artifacts:
apps/android/.gradle/
apps/android/app/build/
apps/android/.cxx/

Removed (duplicates/redundant):
pnpm-lock.yaml (keeping .pnpm-store)
Duplicate .env entry
Duplicate apps/ios/fastlane/report.xml

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `.gitignore` to refine ignored artifacts: it adds TypeScript build cache (`.tsbuildinfo`) and Android build output directories under `apps/android/`, and removes some duplicate/redundant entries.

The changes fit into the repo’s existing ignore strategy for build outputs and local environment files, but the removal of `pnpm-lock.yaml` from ignores also changes whether the lockfile will be picked up by git going forward.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but confirm intended lockfile tracking behavior.
- The PR is a narrow `.gitignore` update. The only material risk is the behavior change from unignoring `pnpm-lock.yaml`, which can introduce unexpected diffs/CI drift if not intentional or if the lockfile isn’t committed consistently.
- .gitignore

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->