### PR TITLE
chore: Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,11 @@ node_modules
 .env
 docker-compose.extra.yml
 dist
-*.bun-build
 pnpm-lock.yaml
 bun.lock
 bun.lockb
 coverage
+.tsbuildinfo
 .pnpm-store
 .worktrees/
 .DS_Store
@@ -15,6 +15,11 @@ coverage
 ui/src/ui/__screenshots__/
 ui/playwright-report/
 ui/test-results/
+
+# Android build artifacts
+apps/android/.gradle/
+apps/android/app/build/
+apps/android/.cxx/
 
 # Bun build artifacts
 *.bun-build
@@ -52,7 +57,6 @@ apps/ios/fastlane/screenshots/
 apps/ios/fastlane/test_output/
 apps/ios/fastlane/logs/
 apps/ios/fastlane/.env
-apps/ios/fastlane/report.xml
 
 # fastlane build artifacts (local)
 apps/ios/*.ipa
@@ -60,7 +64,6 @@ apps/ios/*.dSYM.zip
 
 # provisioning profiles (local)
 apps/ios/*.mobileprovision
-.env
 
 # Local untracked files
 .local/


### PR DESCRIPTION
Review and update the gitignore
Added:
.tsbuildinfo - TypeScript build info cache
Android build artifacts:
apps/android/.gradle/
apps/android/app/build/
apps/android/.cxx/

Removed (duplicates):
Duplicate .env entry
Duplicate apps/ios/fastlane/report.xml

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `.gitignore` to better exclude build/cache artifacts: adds TypeScript `.tsbuildinfo` cache files and Android build directories (`apps/android/.gradle/`, `apps/android/app/build/`, `apps/android/.cxx/`), while removing duplicate ignore entries for `.env` and `apps/ios/fastlane/report.xml`. This keeps generated artifacts out of version control and avoids redundant patterns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to `.gitignore` housekeeping and does not affect runtime behavior, build output, or application logic. Added patterns are standard for TypeScript/Android, and duplicate removals reduce noise without changing intent.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->