### PR TITLE
feat: add commands.allowFrom config for separate command authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Added
 
+- Commands: add `commands.allowFrom` config for separate command authorization, allowing operators to restrict slash commands to specific users while keeping chat open to others. (#12430) Thanks @thewilloftheshadow.
 - iOS: alpha node app + setup-code onboarding. (#11756) Thanks @mbelinky.
 - Channels: comprehensive BlueBubbles and channel cleanup. (#11093) Thanks @tyler6204.
 - Plugins: device pairing + phone control plugins (Telegram `/pair`, iOS/Android node controls). (#11755) Thanks @mbelinky.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -990,6 +990,10 @@ Controls how chat commands are enabled across connectors.
     config: false, // allow /config (writes to disk)
     debug: false, // allow /debug (runtime-only overrides)
     restart: false, // allow /restart + gateway restart tool
+    allowFrom: {
+      "*": ["user1"], // optional per-provider command allowlist
+      discord: ["user:123"],
+    },
     useAccessGroups: true, // enforce access-group allowlists/policies for commands
   },
 }
@@ -1008,9 +1012,14 @@ Notes:
 - `channels.<provider>.configWrites` gates config mutations initiated by that channel (default: true). This applies to `/config set|unset` plus provider-specific auto-migrations (Telegram supergroup ID changes, Slack channel ID changes).
 - `commands.debug: true` enables `/debug` (runtime-only overrides).
 - `commands.restart: true` enables `/restart` and the gateway tool restart action.
-- `commands.useAccessGroups: false` allows commands to bypass access-group allowlists/policies.
-- Slash commands and directives are only honored for **authorized senders**. Authorization is derived from
-  channel allowlists/pairing plus `commands.useAccessGroups`.
+- `commands.allowFrom` sets a per-provider allowlist for command execution. When configured, it is the **only**
+  authorization source for commands and directives (channel allowlists/pairing and `commands.useAccessGroups` are ignored).
+  Use `"*"` for a global default; provider-specific keys (for example `discord`) override it.
+- `commands.useAccessGroups: false` allows commands to bypass access-group allowlists/policies when `commands.allowFrom`
+  is not set.
+- Slash commands and directives are only honored for **authorized senders**. If `commands.allowFrom` is set,
+  authorization comes solely from that list; otherwise it is derived from channel allowlists/pairing plus
+  `commands.useAccessGroups`.
 
 ### `web` (WhatsApp web channel runtime)
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -18,7 +18,8 @@ There are two related systems:
   - Directives are stripped from the message before the model sees it.
   - In normal chat messages (not directive-only), they are treated as “inline hints” and do **not** persist session settings.
   - In directive-only messages (the message contains only directives), they persist to the session and reply with an acknowledgement.
-  - Directives are only applied for **authorized senders** (channel allowlists/pairing plus `commands.useAccessGroups`).
+  - Directives are only applied for **authorized senders**. If `commands.allowFrom` is set, it is the only
+    allowlist used; otherwise authorization comes from channel allowlists/pairing plus `commands.useAccessGroups`.
     Unauthorized senders see directives treated as plain text.
 
 There are also a few **inline shortcuts** (allowlisted/authorized senders only): `/help`, `/commands`, `/status`, `/whoami` (`/id`).
@@ -37,6 +38,10 @@ They run immediately, are stripped before the model sees the message, and the re
     config: false,
     debug: false,
     restart: false,
+    allowFrom: {
+      "*": ["user1"],
+      discord: ["user:123"],
+    },
     useAccessGroups: true,
   },
 }
@@ -55,7 +60,10 @@ They run immediately, are stripped before the model sees the message, and the re
 - `commands.bashForegroundMs` (default `2000`) controls how long bash waits before switching to background mode (`0` backgrounds immediately).
 - `commands.config` (default `false`) enables `/config` (reads/writes `openclaw.json`).
 - `commands.debug` (default `false`) enables `/debug` (runtime-only overrides).
-- `commands.useAccessGroups` (default `true`) enforces allowlists/policies for commands.
+- `commands.allowFrom` (optional) sets a per-provider allowlist for command authorization. When configured, it is the
+  only authorization source for commands and directives (channel allowlists/pairing and `commands.useAccessGroups`
+  are ignored). Use `"*"` for a global default; provider-specific keys override it.
+- `commands.useAccessGroups` (default `true`) enforces allowlists/policies for commands when `commands.allowFrom` is not set.
 
 ## Command list
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -306,6 +306,7 @@ const FIELD_LABELS: Record<string, string> = {
   "commands.restart": "Allow Restart",
   "commands.useAccessGroups": "Use Access Groups",
   "commands.ownerAllowFrom": "Command Owners",
+  "commands.allowFrom": "Command Access Allowlist",
   "ui.seamColor": "Accent Color",
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
@@ -675,6 +676,8 @@ const FIELD_HELP: Record<string, string> = {
   "commands.useAccessGroups": "Enforce access-group allowlists/policies for commands.",
   "commands.ownerAllowFrom":
     "Explicit owner allowlist for owner-only tools/commands. Use channel-native IDs (optionally prefixed like \"whatsapp:+15551234567\"). '*' is ignored.",
+  "commands.allowFrom":
+    'Per-provider allowlist restricting who can use slash commands. If set, overrides the channel\'s allowFrom for command authorization. Use \'*\' key for global default; provider-specific keys (e.g. \'discord\') override the global. Example: { "*": ["user1"], "discord": ["user:123"] }.',
   "session.dmScope":
     'DM session scoping: "main" keeps continuity; "per-peer", "per-channel-peer", or "per-account-channel-peer" isolates DM history (recommended for shared inboxes/multi-account).',
   "session.identityLinks":

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -88,6 +88,13 @@ export type MessagesConfig = {
 
 export type NativeCommandsSetting = boolean | "auto";
 
+/**
+ * Per-provider allowlist for command authorization.
+ * Keys are channel IDs (e.g., "discord", "whatsapp") or "*" for global default.
+ * Values are arrays of sender IDs allowed to use commands on that channel.
+ */
+export type CommandAllowFrom = Record<string, Array<string | number>>;
+
 export type CommandsConfig = {
   /** Enable native command registration when supported (default: "auto"). */
   native?: NativeCommandsSetting;
@@ -109,6 +116,13 @@ export type CommandsConfig = {
   useAccessGroups?: boolean;
   /** Explicit owner allowlist for owner-only tools/commands (channel-native IDs). */
   ownerAllowFrom?: Array<string | number>;
+  /**
+   * Per-provider allowlist restricting who can use slash commands.
+   * If set, overrides the channel's allowFrom for command authorization.
+   * Use "*" key for global default, provider-specific keys override the global.
+   * Example: { "*": ["user1"], discord: ["user:123"] }
+   */
+  allowFrom?: CommandAllowFrom;
 };
 
 export type ProviderCommandsConfig = {

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { parseByteSize } from "../cli/parse-bytes.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
+import { ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
 import {
   GroupChatSchema,
   InboundDebounceSchema,
@@ -158,6 +159,7 @@ export const CommandsSchema = z
     restart: z.boolean().optional(),
     useAccessGroups: z.boolean().optional(),
     ownerAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowFrom: ElevatedAllowFromSchema.optional(),
   })
   .strict()
   .optional()


### PR DESCRIPTION
## Summary

Add a `commands.allowFrom` config option that restricts who can use slash commands (like /approve, /exec, /new) separately from who can chat with the bot.

## Motivation

Currently, the same `allowFrom` list is used both for who can chat with the bot and who can use commands. This change allows operators to have a more open chat policy while restricting command access to specific users.

## Implementation

When `commands.allowFrom` is set, it overrides the channel's `allowFrom` for command authorization only. The pattern follows `tools.elevated.allowFrom`:

- Use `*` key for global default
- Provider-specific keys (e.g. `discord`, `whatsapp`) override the global

### Example config:
```yaml
commands:
  allowFrom:
    "*": ["user1", "user2"]  # Global default  
    discord: ["user:123"]        # Discord-specific override
```

If `commands.allowFrom` is not configured, falls back to existing behavior (using the channel's `allowFrom`).

## Changes

- Added `allowFrom` field to `CommandsConfig` type
- Added schema validation in `zod-schema.session.ts`
- Added UI labels/descriptions in `schema.ts`
- Modified `resolveCommandAuthorization` to check `commands.allowFrom` first
- Added tests for the new functionality

## Testing

Added test cases covering:
- Global allowlist usage
- Provider-specific override behavior
- Fallback to channel allowFrom
- Wildcard support

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `commands.allowFrom` config intended to decouple slash-command authorization from the channel-level `allowFrom` (chat access). It wires the new config through types/schema/UI hints, updates `resolveCommandAuthorization` to consult `commands.allowFrom` first, and adds unit tests covering global (`"*"`) and provider-specific overrides plus fallback behavior.

The new logic lives in `src/auto-reply/command-auth.ts` and is consumed wherever command context is built (e.g. `src/auto-reply/reply/commands-context.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a couple of behavior/schema issues that should be fixed before merging.
- Core functionality is implemented and tests were added, but (1) the new authorization branch appears to bypass the existing `commandAuthorized` gate, and (2) the zod schema change likely makes `commands.allowFrom` required due to missing `.optional()`, which would break existing configs.
- src/auto-reply/command-auth.ts, src/config/zod-schema.session.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->