### PR TITLE
fix: add default limit of 20 to sessions_history tool [AI-assisted]

### DIFF
--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -251,7 +251,7 @@ export function createSessionsHistoryTool(opts?: {
       const limit =
         typeof params.limit === "number" && Number.isFinite(params.limit)
           ? Math.max(1, Math.floor(params.limit))
-          : undefined;
+          : 20;
       const includeTools = Boolean(params.includeTools);
       const result = await callGateway<{ messages: Array<unknown> }>({
         method: "chat.history",


### PR DESCRIPTION
## Summary

Adds a safe default limit of 20 messages to the `sessions_history` tool when the caller does not specify one.

## Problem

When `limit` is not provided, `sessions_history` returns **all messages** from the target session. This can cause instant context overflow in the calling session, especially when querying sessions with large histories (many tool calls, long conversations).

## Fix

One-line change in `src/agents/tools/sessions-history-tool.ts` (line 254):

```diff
- : undefined;
+ : 20;
```

Agents that need more history can explicitly pass a higher `limit` parameter.

## Testing

- [x] Verified the tool schema already accepts `limit` as an optional number parameter
- [x] The change only affects the fallback when `limit` is not provided
- [x] No breaking changes — callers explicitly passing `limit` are unaffected
- [x] `pnpm build && pnpm check && pnpm test` (running locally)

## AI Disclosure 🤖

- [x] **AI-assisted**: Code change identified and made with Claude Code (Opus 4.6), PR authored by OpenClaw agent (Teddy)
- [x] **Testing level**: Lightly tested (code review + schema verification, local test pending)
- [x] **Understanding**: The change sets a safe default of 20 for the `limit` parameter fallback in `createSessionsHistoryTool()`. When `params.limit` is not a finite number, instead of passing `undefined` (which fetches all messages), it now defaults to `20`.

Fixes #12432