### PR TITLE
Auto-reply: include weekday in envelope timestamps

### DIFF
--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -23,7 +23,7 @@ describe("formatAgentEnvelope", () => {
 
     process.env.TZ = originalTz;
 
-    expect(body).toBe("[WebChat user1 mac-mini 10.0.0.5 2025-01-02T03:04Z] hello");
+    expect(body).toBe("[WebChat user1 mac-mini 10.0.0.5 Thu 2025-01-02T03:04Z] hello");
   });
 
   it("formats timestamps in local timezone by default", () => {
@@ -39,7 +39,7 @@ describe("formatAgentEnvelope", () => {
 
     process.env.TZ = originalTz;
 
-    expect(body).toMatch(/\[WebChat 2025-01-01 19:04 [^\]]+\] hello/);
+    expect(body).toMatch(/\[WebChat Wed 2025-01-01 19:04 [^\]]+\] hello/);
   });
 
   it("formats timestamps in UTC when configured", () => {
@@ -56,7 +56,7 @@ describe("formatAgentEnvelope", () => {
 
     process.env.TZ = originalTz;
 
-    expect(body).toBe("[WebChat 2025-01-02T03:04Z] hello");
+    expect(body).toBe("[WebChat Thu 2025-01-02T03:04Z] hello");
   });
 
   it("formats timestamps in user timezone when configured", () => {
@@ -68,7 +68,7 @@ describe("formatAgentEnvelope", () => {
       body: "hello",
     });
 
-    expect(body).toMatch(/\[WebChat 2025-01-02 04:04 [^\]]+\] hello/);
+    expect(body).toMatch(/\[WebChat Thu 2025-01-02 04:04 [^\]]+\] hello/);
   });
 
   it("omits timestamps when configured", () => {

--- a/test/helpers/envelope-timestamp.ts
+++ b/test/helpers/envelope-timestamp.ts
@@ -7,13 +7,30 @@ type EnvelopeTimestampZone = string;
 
 export function formatEnvelopeTimestamp(date: Date, zone: EnvelopeTimestampZone = "utc"): string {
   const normalized = zone.trim().toLowerCase();
+  const weekday = (() => {
+    try {
+      if (normalized === "utc" || normalized === "gmt") {
+        return new Intl.DateTimeFormat("en-US", { timeZone: "UTC", weekday: "short" }).format(date);
+      }
+      if (normalized === "local" || normalized === "host") {
+        return new Intl.DateTimeFormat("en-US", { weekday: "short" }).format(date);
+      }
+      return new Intl.DateTimeFormat("en-US", { timeZone: zone, weekday: "short" }).format(date);
+    } catch {
+      return undefined;
+    }
+  })();
+
   if (normalized === "utc" || normalized === "gmt") {
-    return formatUtcTimestamp(date);
+    const ts = formatUtcTimestamp(date);
+    return weekday ? `${weekday} ${ts}` : ts;
   }
   if (normalized === "local" || normalized === "host") {
-    return formatZonedTimestamp(date) ?? formatUtcTimestamp(date);
+    const ts = formatZonedTimestamp(date) ?? formatUtcTimestamp(date);
+    return weekday ? `${weekday} ${ts}` : ts;
   }
-  return formatZonedTimestamp(date, { timeZone: zone }) ?? formatUtcTimestamp(date);
+  const ts = formatZonedTimestamp(date, { timeZone: zone }) ?? formatUtcTimestamp(date);
+  return weekday ? `${weekday} ${ts}` : ts;
 }
 
 export function formatLocalEnvelopeTimestamp(date: Date): string {


### PR DESCRIPTION
Problem
- Some models miscompute day-of-week from an absolute date (e.g. interpreting 2026-02-09 as Sunday), causing "today/tonight" confusion when the system prompt omits current date/time by design.

Fix
- Prefix channel envelope timestamps with a short weekday (Mon/Tue/...) in the same timezone used for the envelope timestamp.
- Updated test helper + unit tests accordingly.

Testing
- pnpm test src/auto-reply/envelope.test.ts src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
- pnpm test src/auto-reply/inbound.test.ts src/auto-reply/reply/session-resets.test.ts src/gateway/server-methods/agent-timestamp.test.ts
- pnpm check

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes auto-reply envelope timestamp formatting to prefix absolute timestamps with a short weekday (Mon/Tue/…) in the same timezone as the existing timestamp, so models don’t need to derive day-of-week from the date. It updates unit tests and the test timestamp helper to match the new envelope format.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a concrete crash case in the updated timestamp test helper when given whitespace-padded timezones.
- Core production change in src/auto-reply/envelope.ts is straightforward and covered by updated unit tests. However, the modified test helper can throw a RangeError for padded IANA timezone strings because it reuses the untrimmed `zone` when calling Intl/formatZonedTimestamp despite trimming for normalization.
- test/helpers/envelope-timestamp.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->