### PR TITLE
refactor: consolidate duplicate utility functions

### DIFF
--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -6,6 +6,7 @@ import {
   type MSTeamsReplyStyle,
   type ReplyPayload,
   SILENT_REPLY_TOKEN,
+  sleep,
 } from "openclaw/plugin-sdk";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import type { StoredConversationReference } from "./conversation-store.js";
@@ -164,16 +165,6 @@ function clampMs(value: number, maxMs: number): number {
     return 0;
   }
   return Math.min(value, maxMs);
-}
-
-async function sleep(ms: number): Promise<void> {
-  const delay = Math.max(0, ms);
-  if (delay === 0) {
-    return;
-  }
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, delay);
-  });
 }
 
 function resolveRetryOptions(

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { sleep } from "openclaw/plugin-sdk";
 import type { VoiceCallConfig } from "./config.js";
 import type { VoiceCallRuntime } from "./runtime.js";
 import { resolveUserPath } from "./utils.js";
@@ -38,10 +39,6 @@ function resolveDefaultStorePath(config: VoiceCallConfig): string {
     }) ?? resolvedPreferred;
   const base = config.store?.trim() ? resolveUserPath(config.store) : existing;
   return path.join(base, "calls.jsonl");
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function registerVoiceCallCli(params: {

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -4,6 +4,7 @@ import {
   collectWhatsAppStatusIssues,
   createActionGate,
   DEFAULT_ACCOUNT_ID,
+  escapeRegExp,
   formatPairingApproveHint,
   getChatChannelMeta,
   isWhatsAppGroupJid,
@@ -32,8 +33,6 @@ import {
 import { getWhatsAppRuntime } from "./runtime.js";
 
 const meta = getChatChannelMeta("whatsapp");
-
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
   id: "whatsapp",

--- a/extensions/zalouser/src/zca.ts
+++ b/extensions/zalouser/src/zca.ts
@@ -1,4 +1,5 @@
 import { spawn, type SpawnOptions } from "node:child_process";
+import { stripAnsi } from "openclaw/plugin-sdk";
 import type { ZcaResult, ZcaRunOptions } from "./types.js";
 
 const ZCA_BINARY = "zca";
@@ -105,11 +106,6 @@ export function runZcaInteractive(args: string[], options?: ZcaRunOptions): Prom
       });
     });
   });
-}
-
-function stripAnsi(str: string): string {
-  // oxlint-disable-next-line no-control-regex
-  return str.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "");
 }
 
 export function parseJsonOutput<T>(stdout: string): T | null {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -43,7 +43,7 @@ import {
   buildDockerExecArgs,
   buildSandboxEnv,
   chunkString,
-  clampNumber,
+  clampWithDefault,
   coerceEnv,
   killSession,
   readEnvInt,
@@ -105,13 +105,13 @@ function validateHostEnv(env: Record<string, string>): void {
     }
   }
 }
-const DEFAULT_MAX_OUTPUT = clampNumber(
+const DEFAULT_MAX_OUTPUT = clampWithDefault(
   readEnvInt("PI_BASH_MAX_OUTPUT_CHARS"),
   200_000,
   1_000,
   200_000,
 );
-const DEFAULT_PENDING_MAX_OUTPUT = clampNumber(
+const DEFAULT_PENDING_MAX_OUTPUT = clampWithDefault(
   readEnvInt("OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS"),
   200_000,
   1_000,
@@ -801,7 +801,7 @@ export function createExecTool(
   defaults?: ExecToolDefaults,
   // oxlint-disable-next-line typescript/no-explicit-any
 ): AgentTool<any, ExecToolDetails> {
-  const defaultBackgroundMs = clampNumber(
+  const defaultBackgroundMs = clampWithDefault(
     defaults?.backgroundMs ?? readEnvInt("PI_BASH_YIELD_MS"),
     10_000,
     10,
@@ -860,7 +860,12 @@ export function createExecTool(
       const yieldWindow = allowBackground
         ? backgroundRequested
           ? 0
-          : clampNumber(params.yieldMs ?? defaultBackgroundMs, defaultBackgroundMs, 10, 120_000)
+          : clampWithDefault(
+              params.yieldMs ?? defaultBackgroundMs,
+              defaultBackgroundMs,
+              10,
+              120_000,
+            )
         : null;
       const elevatedDefaults = defaults?.elevated;
       const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -146,7 +146,10 @@ function safeCwd() {
   }
 }
 
-export function clampNumber(
+/**
+ * Clamp a number within min/max bounds, using defaultValue if undefined or NaN.
+ */
+export function clampWithDefault(
   value: number | undefined,
   defaultValue: number,
   min: number,

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -10,16 +10,13 @@ import type { CliBackendConfig } from "../../config/types.js";
 import type { EmbeddedContextFile } from "../pi-embedded-helpers.js";
 import { runExec } from "../../process/exec.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
+import { escapeRegExp } from "../../utils.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
 import { detectRuntimeShell } from "../shell-utils.js";
 import { buildSystemPromptParams } from "../system-prompt-params.js";
 import { buildAgentSystemPrompt } from "../system-prompt.js";
 
 const CLI_RUN_QUEUE = new Map<string, Promise<unknown>>();
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 export async function cleanupResumeProcesses(
   backend: CliBackendConfig,
@@ -43,7 +40,7 @@ export async function cleanupResumeProcesses(
   const resumeTokens = resumeArgs.map((arg) => arg.replaceAll("{sessionId}", sessionId));
   const pattern = [commandToken, ...resumeTokens]
     .filter(Boolean)
-    .map((token) => escapeRegex(token))
+    .map((token) => escapeRegExp(token))
     .join(".*");
   if (!pattern) {
     return;
@@ -95,9 +92,9 @@ function buildSessionMatchers(backend: CliBackendConfig): RegExp[] {
 
 function tokenToRegex(token: string): string {
   if (!token.includes("{sessionId}")) {
-    return escapeRegex(token);
+    return escapeRegExp(token);
   }
-  const parts = token.split("{sessionId}").map((part) => escapeRegex(part));
+  const parts = token.split("{sessionId}").map((part) => escapeRegExp(part));
   return parts.join("\\S+");
 }
 

--- a/src/agents/pty-keys.ts
+++ b/src/agents/pty-keys.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from "../utils.js";
+
 const ESC = "\x1b";
 const CR = "\r";
 const TAB = "\t";
@@ -11,10 +13,6 @@ type Modifiers = {
   alt: boolean;
   shift: boolean;
 };
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 const namedKeyMap = new Map<string, string>([
   ["enter", CR],

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -14,6 +14,7 @@ import type {
 } from "./commands-registry.types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
+import { escapeRegExp } from "../utils.js";
 import { getChatCommands, getNativeCommandSurfaces } from "./commands-registry.data.js";
 
 export type {
@@ -66,10 +67,6 @@ function getTextAliasMap(): Map<string, TextAliasSpec> {
   cachedTextAliasMap = map;
   cachedTextAliasCommands = commands;
   return map;
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function buildSkillCommandDefinitions(skillCommands?: SkillCommandSpec[]): ChatCommandDefinition[] {

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -1,6 +1,4 @@
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+import { escapeRegExp } from "../utils.js";
 
 export function extractModelDirective(
   body?: string,

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -1,4 +1,5 @@
 import type { NoticeLevel, ReasoningLevel } from "../thinking.js";
+import { escapeRegExp } from "../../utils.js";
 import {
   type ElevatedLevel,
   normalizeElevatedLevel,
@@ -16,8 +17,6 @@ type ExtractedLevel<T> = {
   rawLevel?: string;
   hasDirective: boolean;
 };
-
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const matchLevelDirective = (
   body: string,

--- a/src/auto-reply/reply/inbound-sender-meta.ts
+++ b/src/auto-reply/reply/inbound-sender-meta.ts
@@ -1,6 +1,7 @@
 import type { MsgContext } from "../templating.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { listSenderLabelCandidates, resolveSenderLabel } from "../../channels/sender-label.js";
+import { escapeRegExp } from "../../utils.js";
 
 export function formatInboundBodyWithSenderMeta(params: { body: string; ctx: MsgContext }): string {
   const body = params.body;
@@ -50,8 +51,4 @@ function hasSenderMetaLine(body: string, ctx: MsgContext): boolean {
     const pattern = new RegExp(`(^|\\n|\\]\\s*)${escaped}:\\s`, "i");
     return pattern.test(body);
   });
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -3,10 +3,7 @@ import type { MsgContext } from "../templating.js";
 import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import { getChannelDock } from "../../channels/dock.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
-
-function escapeRegExp(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+import { escapeRegExp } from "../../utils.js";
 
 function deriveMentionPatterns(identity?: { name?: string; emoji?: string }) {
   const patterns: string[] = [];

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,9 +1,7 @@
+import { escapeRegExp } from "../utils.js";
+
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 export function isSilentReplyText(
   text: string | undefined,

--- a/src/browser/routes/dispatcher.ts
+++ b/src/browser/routes/dispatcher.ts
@@ -1,5 +1,6 @@
 import type { BrowserRouteContext } from "../server-context.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
+import { escapeRegExp } from "../../utils.js";
 import { registerBrowserRoutes } from "./index.js";
 
 type BrowserDispatchRequest = {
@@ -22,10 +23,6 @@ type RouteEntry = {
   handler: (req: BrowserRequest, res: BrowserResponse) => void | Promise<void>;
 };
 
-function escapeRegex(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function compileRoute(path: string): { regex: RegExp; paramNames: string[] } {
   const paramNames: string[] = [];
   const parts = path.split("/").map((part) => {
@@ -34,7 +31,7 @@ function compileRoute(path: string): { regex: RegExp; paramNames: string[] } {
       paramNames.push(name);
       return "([^/]+)";
     }
-    return escapeRegex(part);
+    return escapeRegExp(part);
   });
   return { regex: new RegExp(`^${parts.join("/")}$`), paramNames };
 }

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -18,7 +18,7 @@ import { resolveSignalAccount } from "../signal/accounts.js";
 import { resolveSlackAccount, resolveSlackReplyToMode } from "../slack/accounts.js";
 import { buildSlackThreadingToolContext } from "../slack/threading-tool-context.js";
 import { resolveTelegramAccount } from "../telegram/accounts.js";
-import { normalizeE164 } from "../utils.js";
+import { escapeRegExp, normalizeE164 } from "../utils.js";
 import { resolveWhatsAppAccount } from "../web/accounts.js";
 import { normalizeWhatsAppTarget } from "../whatsapp/normalize.js";
 import {
@@ -75,8 +75,6 @@ const formatLower = (allowFrom: Array<string | number>) =>
     .map((entry) => String(entry).trim())
     .filter(Boolean)
     .map((entry) => entry.toLowerCase());
-
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 // Channel docks: lightweight channel metadata/behavior for shared code paths.
 //

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -1,13 +1,12 @@
 import type { Command } from "commander";
+import { formatErrorMessage } from "../infra/errors.js";
+
+export { formatErrorMessage };
 
 export type ManagerLookupResult<T> = {
   manager: T | null;
   error?: string;
 };
-
-export function formatErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
 
 export async function withManager<T>(params: {
   getManager: () => Promise<ManagerLookupResult<T>>;

--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { stripAnsi } from "../terminal/ansi.js";
 import { formatHealthCheckFailure } from "./health-format.js";
-
-const ansiEscape = String.fromCharCode(27);
-const ansiRegex = new RegExp(`${ansiEscape}\\[[0-9;]*m`, "g");
-const stripAnsi = (input: string) => input.replace(ansiRegex, "");
 
 describe("formatHealthCheckFailure", () => {
   it("keeps non-rich output stable", () => {

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { SystemPresence } from "../infra/system-presence.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 
@@ -25,13 +26,6 @@ export type GatewayProbeResult = {
   presence: SystemPresence[] | null;
   configSnapshot: unknown;
 };
-
-function formatError(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return String(err);
-}
 
 export async function probeGateway(opts: {
   url: string;
@@ -65,7 +59,7 @@ export async function probeGateway(opts: {
       mode: GATEWAY_CLIENT_MODES.PROBE,
       instanceId,
       onConnectError: (err) => {
-        connectError = formatError(err);
+        connectError = formatErrorMessage(err);
       },
       onClose: (code, reason) => {
         close = { code, reason };
@@ -93,7 +87,7 @@ export async function probeGateway(opts: {
           settle({
             ok: false,
             connectLatencyMs,
-            error: formatError(err),
+            error: formatErrorMessage(err),
             close,
             health: null,
             status: null,

--- a/src/gateway/server-methods/logs.ts
+++ b/src/gateway/server-methods/logs.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { GatewayRequestHandlers } from "./types.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
+import { clamp } from "../../utils.js";
 import {
   ErrorCodes,
   errorShape,
@@ -14,10 +15,6 @@ const DEFAULT_MAX_BYTES = 250_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
 const ROLLING_LOG_RE = /^openclaw-\d{4}-\d{2}-\d{2}\.log$/;
-
-function clamp(value: number, min: number, max: number) {
-  return Math.max(min, Math.min(max, value));
-}
 
 function isRollingLogFile(file: string): boolean {
   return ROLLING_LOG_RE.test(path.basename(file));

--- a/src/infra/env-file.ts
+++ b/src/infra/env-file.ts
@@ -1,10 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveConfigDir } from "../utils.js";
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+import { escapeRegExp, resolveConfigDir } from "../utils.js";
 
 export function upsertSharedEnvVar(params: {
   key: string;

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -1,6 +1,7 @@
 import type { Llama, LlamaEmbeddingContext, LlamaModel } from "node-llama-cpp";
 import fsSync from "node:fs";
 import type { OpenClawConfig } from "../config/config.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { resolveUserPath } from "../utils.js";
 import { createGeminiEmbeddingProvider, type GeminiEmbeddingClient } from "./embeddings-gemini.js";
 import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./embeddings-openai.js";
@@ -73,7 +74,7 @@ function canAutoSelectLocal(options: EmbeddingProviderOptions): boolean {
 }
 
 function isMissingApiKeyError(err: unknown): boolean {
-  const message = formatError(err);
+  const message = formatErrorMessage(err);
   return message.includes("No API key found for provider");
 }
 
@@ -149,7 +150,7 @@ export async function createEmbeddingProvider(
   };
 
   const formatPrimaryError = (err: unknown, provider: "openai" | "local" | "gemini" | "voyage") =>
-    provider === "local" ? formatLocalSetupError(err) : formatError(err);
+    provider === "local" ? formatLocalSetupError(err) : formatErrorMessage(err);
 
   if (requestedProvider === "auto") {
     const missingKeyErrors: string[] = [];
@@ -202,20 +203,13 @@ export async function createEmbeddingProvider(
       } catch (fallbackErr) {
         // oxlint-disable-next-line preserve-caught-error
         throw new Error(
-          `${reason}\n\nFallback to ${fallback} failed: ${formatError(fallbackErr)}`,
+          `${reason}\n\nFallback to ${fallback} failed: ${formatErrorMessage(fallbackErr)}`,
           { cause: fallbackErr },
         );
       }
     }
     throw new Error(reason, { cause: primaryErr });
   }
-}
-
-function formatError(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return String(err);
 }
 
 function isNodeLlamaCppMissing(err: unknown): boolean {
@@ -230,7 +224,7 @@ function isNodeLlamaCppMissing(err: unknown): boolean {
 }
 
 function formatLocalSetupError(err: unknown): string {
-  const detail = formatError(err);
+  const detail = formatErrorMessage(err);
   const missing = isNodeLlamaCppMissing(err);
   return [
     "Local embeddings unavailable.",

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -229,7 +229,7 @@ export {
 } from "../agents/tools/common.js";
 export { formatDocsLink } from "../terminal/links.js";
 export type { HookEntry } from "../hooks/types.js";
-export { normalizeE164 } from "../utils.js";
+export { escapeRegExp, normalizeE164 } from "../utils.js";
 export { missingTargetError } from "../infra/outbound/target-errors.js";
 export { registerLogTransport } from "../logging/logger.js";
 export type { LogTransport, LogTransportRecord } from "../logging/logger.js";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -229,7 +229,8 @@ export {
 } from "../agents/tools/common.js";
 export { formatDocsLink } from "../terminal/links.js";
 export type { HookEntry } from "../hooks/types.js";
-export { escapeRegExp, normalizeE164 } from "../utils.js";
+export { clamp, escapeRegExp, normalizeE164, sleep } from "../utils.js";
+export { stripAnsi } from "../terminal/ansi.js";
 export { missingTargetError } from "../infra/outbound/target-errors.js";
 export { registerLogTransport } from "../logging/logger.js";
 export type { LogTransport, LogTransportRecord } from "../logging/logger.js";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,13 @@ export function clampInt(value: number, min: number, max: number): number {
   return clampNumber(Math.floor(value), min, max);
 }
 
+/**
+ * Escapes special regex characters in a string so it can be used in a RegExp constructor.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export type WebChannel = "web";
 
 export function assertWebChannel(input: string): asserts input is WebChannel {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,9 @@ export function clampInt(value: number, min: number, max: number): number {
   return clampNumber(Math.floor(value), min, max);
 }
 
+/** Alias for clampNumber (shorter, more common name) */
+export const clamp = clampNumber;
+
 /**
  * Escapes special regex characters in a string so it can be used in a RegExp constructor.
  */

--- a/src/web/reconnect.ts
+++ b/src/web/reconnect.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "../config/config.js";
 import type { BackoffPolicy } from "../infra/backoff.js";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
+import { clamp } from "../utils.js";
 
 export type ReconnectPolicy = BackoffPolicy & {
   maxAttempts: number;
@@ -15,8 +16,6 @@ export const DEFAULT_RECONNECT_POLICY: ReconnectPolicy = {
   jitter: 0.25,
   maxAttempts: 12,
 };
-
-const clamp = (val: number, min: number, max: number) => Math.max(min, Math.min(max, val));
 
 export function resolveHeartbeatSeconds(cfg: OpenClawConfig, overrideSeconds?: number): number {
   const candidate = overrideSeconds ?? cfg.web?.heartbeatSeconds;

--- a/test/gateway.multi.e2e.test.ts
+++ b/test/gateway.multi.e2e.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import { GatewayClient } from "../src/gateway/client.js";
 import { loadOrCreateDeviceIdentity } from "../src/infra/device-identity.js";
+import { sleep } from "../src/utils.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../src/utils/message-channel.js";
 
 type GatewayInstance = {
@@ -31,8 +32,6 @@ type HealthPayload = { ok?: boolean };
 
 const GATEWAY_START_TIMEOUT_MS = 45_000;
 const E2E_TIMEOUT_MS = 120_000;
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const getFreePort = async () => {
   const srv = net.createServer();

--- a/test/helpers/envelope-timestamp.ts
+++ b/test/helpers/envelope-timestamp.ts
@@ -3,6 +3,8 @@ import {
   formatZonedTimestamp,
 } from "../../src/infra/format-time/format-datetime.js";
 
+export { escapeRegExp } from "../../src/utils.js";
+
 type EnvelopeTimestampZone = string;
 
 export function formatEnvelopeTimestamp(date: Date, zone: EnvelopeTimestampZone = "utc"): string {
@@ -35,8 +37,4 @@ export function formatEnvelopeTimestamp(date: Date, zone: EnvelopeTimestampZone 
 
 export function formatLocalEnvelopeTimestamp(date: Date): string {
   return formatEnvelopeTimestamp(date, "local");
-}
-
-export function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/test/helpers/normalize-text.ts
+++ b/test/helpers/normalize-text.ts
@@ -1,32 +1,4 @@
-function stripAnsi(input: string): string {
-  let out = "";
-  for (let i = 0; i < input.length; i++) {
-    const code = input.charCodeAt(i);
-    if (code !== 27) {
-      out += input[i];
-      continue;
-    }
-
-    const next = input[i + 1];
-    if (next !== "[") {
-      continue;
-    }
-    i += 1;
-
-    while (i + 1 < input.length) {
-      i += 1;
-      const c = input[i];
-      if (!c) {
-        break;
-      }
-      const isLetter = (c >= "A" && c <= "Z") || (c >= "a" && c <= "z") || c === "~";
-      if (isLetter) {
-        break;
-      }
-    }
-  }
-  return out;
-}
+import { stripAnsi } from "../../src/terminal/ansi.js";
 
 export function normalizeTestText(input: string): string {
   return stripAnsi(input)

--- a/test/helpers/poll.ts
+++ b/test/helpers/poll.ts
@@ -1,11 +1,9 @@
+import { sleep } from "../../src/utils.js";
+
 export type PollOptions = {
   timeoutMs?: number;
   intervalMs?: number;
 };
-
-function sleep(ms: number) {
-  return new Promise<void>((resolve) => setTimeout(resolve, ms));
-}
 
 export async function pollUntil<T>(
   fn: () => Promise<T | null | undefined>,


### PR DESCRIPTION
Consolidates duplicate utility function definitions across the codebase.

## Changes

- **escapeRegExp**: Centralized to `src/utils.ts` (was in 13 files)
- **sleep**: Centralized to `src/utils.ts` (was in 4 files)  
- **stripAnsi**: Centralized to `src/terminal/ansi.ts` (was in 4 files)
- **clamp**: Added alias in `utils.ts` for `clampNumber` (was in 3 files)
- **clampNumber** (bash-tools): Renamed to `clampWithDefault` (4-param variant with defaultValue)

## Plugin SDK exports

Added to `src/plugin-sdk/index.ts` for extension use:
- `clamp` - numeric clamping
- `escapeRegExp` - regex special character escaping
- `sleep` - promise-based delay
- `stripAnsi` - ANSI escape code stripping

## Testing
- `pnpm check` passes
- Related tests pass