### PR TITLE
fix: include deliveryContext in restart sentinel for config.patch/apply/update [AI-assisted]

### DIFF
--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -1,6 +1,15 @@
 import { Type } from "@sinclair/typebox";
 import { NonEmptyString } from "./primitives.js";
 
+/** Delivery context for routing post-restart wake messages back to the correct channel. */
+const DeliveryContextSchema = Type.Optional(
+  Type.Object({
+    channel: Type.Optional(Type.String()),
+    to: Type.Optional(Type.String()),
+    accountId: Type.Optional(Type.String()),
+  }),
+);
+
 export const ConfigGetParamsSchema = Type.Object({}, { additionalProperties: false });
 
 export const ConfigSetParamsSchema = Type.Object(
@@ -18,6 +27,8 @@ export const ConfigApplyParamsSchema = Type.Object(
     sessionKey: Type.Optional(Type.String()),
     note: Type.Optional(Type.String()),
     restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    deliveryContext: DeliveryContextSchema,
+    threadId: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -29,6 +40,8 @@ export const ConfigPatchParamsSchema = Type.Object(
     sessionKey: Type.Optional(Type.String()),
     note: Type.Optional(Type.String()),
     restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    deliveryContext: DeliveryContextSchema,
+    threadId: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -41,6 +54,8 @@ export const UpdateRunParamsSchema = Type.Object(
     note: Type.Optional(Type.String()),
     restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+    deliveryContext: DeliveryContextSchema,
+    threadId: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -74,11 +74,29 @@ export const updateHandlers: GatewayRequestHandlers = {
       };
     }
 
+    // Extract delivery context passed from agent-side gateway tool
+    const rawDc = (params as { deliveryContext?: unknown }).deliveryContext;
+    let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
+    if (rawDc && typeof rawDc === "object") {
+      const dc = rawDc as Record<string, unknown>;
+      const channel = typeof dc.channel === "string" ? dc.channel.trim() || undefined : undefined;
+      const to = typeof dc.to === "string" ? dc.to.trim() || undefined : undefined;
+      const accountId =
+        typeof dc.accountId === "string" ? dc.accountId.trim() || undefined : undefined;
+      if (channel || to || accountId) {
+        deliveryContext = { channel, to, accountId };
+      }
+    }
+    const threadIdRaw = (params as { threadId?: unknown }).threadId;
+    const threadId = typeof threadIdRaw === "string" ? threadIdRaw.trim() || undefined : undefined;
+
     const payload: RestartSentinelPayload = {
       kind: "update",
       status: result.status,
       ts: Date.now(),
       sessionKey,
+      deliveryContext,
+      threadId,
       message: note ?? null,
       doctorHint: formatDoctorNonInteractiveHint(),
       stats: {


### PR DESCRIPTION
## What

Restart sentinel written by `config.patch`, `config.apply`, and `update.run` now includes `deliveryContext` and `threadId` fields, matching the existing behavior of the `restart` action.

## Why

When the agent triggers a gateway restart via config changes, the sentinel was missing channel routing info (`deliveryContext`). Post-restart, `scheduleRestartSentinelWake()` couldn't resolve `channel`/`to` and fell back to `enqueueSystemEvent()` — which only fires on the next user message, not proactively. This made the agent appear unresponsive after any config-triggered restart until the user manually sent a message.

The `restart` action already had this logic; `config.patch`, `config.apply`, and `update.run` simply didn't.

## How

- Extracted shared `resolveDeliveryContextForSession()` helper in `gateway-tool.ts` (was previously inline in the `restart` action only)
- Agent-side now passes `deliveryContext` + `threadId` to server-side RPC for `config.patch`, `config.apply`, and `update.run`
- Server-side handlers (`config.ts`, `update.ts`) read and include these fields in the sentinel payload

## Testing

- `pnpm build && pnpm check && pnpm test` all pass
- 855 unit tests pass (1 pre-existing flaky failure in `warning-filter.test.ts`, unrelated)
- Added unit test verifying `deliveryContext` roundtrip through sentinel write/read
- Root cause confirmed by source tracing

## AI Disclosure

- [x] AI-assisted (OpenClaw agent running Claude Opus 4.6)
- [x] Fully tested (`build` + `check` + `test`)
- [x] Prompt context: agent discovered the bug while investigating why it became unresponsive after self-triggered `config.patch` restarts. Traced through `gateway-tool.ts` → `server-methods/config.ts` → `restart-sentinel.ts` → `server-restart-sentinel.ts` to identify the missing `deliveryContext` in the sentinel payload.
- [x] I understand what the code does: the `restart` action already captured `deliveryContext` from the session store before writing the sentinel; `config.patch`, `config.apply`, and `update.run` did not. This fix applies the same pattern to all restart-triggering code paths so that `scheduleRestartSentinelWake()` can route the wake message through the channel instead of falling back to `enqueueSystemEvent()`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads channel routing information (`deliveryContext`) and `threadId` through the restart-sentinel written by `config.apply`, `config.patch`, and `update.run`, matching the existing `restart` action behavior. It adds a shared helper in `src/agents/tools/gateway-tool.ts` to resolve delivery context from the session store, extends the gateway RPC schemas to accept these fields, and updates the server-side handlers to persist them into the sentinel. A unit test was added to ensure `deliveryContext`/`threadId` roundtrip through sentinel write/consume.

Key integration point: the gateway restart flow depends on `scheduleRestartSentinelWake()` being able to route the wake message to the right channel after a restart; persisting `deliveryContext` in the sentinel closes the gap for config/update-triggered restarts.

Issues to address before merge are mostly around consistency/typing: the agent tool JSON schema doesn’t declare the new fields, and `config.patch` currently writes `kind: "config-apply"` (because the sentinel `kind` union doesn’t include a patch kind), which can break downstream consumers that rely on `payload.kind`.

<h3>Confidence Score: 3/5</h3>

- This PR is close but has a couple of correctness/consistency issues that should be fixed before merge.
- Main functionality (persisting deliveryContext/threadId through RPC into restart sentinel) is straightforward, but there are two concrete inconsistencies: the agent tool schema doesn’t declare the new fields it now uses, and `config.patch` is currently forced to emit `kind: "config-apply"` due to the sentinel kind union, which can confuse downstream logic. Fixing these should make the change low-risk.
- src/agents/tools/gateway-tool.ts, src/gateway/server-methods/config.ts, src/infra/restart-sentinel.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->