### PR TITLE
Tests: trim timezone in envelope timestamp helper

### DIFF
--- a/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
+++ b/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
@@ -106,6 +106,11 @@ describe("web auto-reply", () => {
     vi.useRealTimers();
   });
 
+  it("handles helper envelope timestamps with trimmed timezones (regression)", () => {
+    const d = new Date("2025-01-01T00:00:00.000Z");
+    expect(() => formatEnvelopeTimestamp(d, " America/Los_Angeles ")).not.toThrow();
+  });
+
   it("reconnects after a connection close", async () => {
     const closeResolvers: Array<() => void> = [];
     const sleep = vi.fn(async () => {});

--- a/test/helpers/envelope-timestamp.ts
+++ b/test/helpers/envelope-timestamp.ts
@@ -6,7 +6,8 @@ import {
 type EnvelopeTimestampZone = string;
 
 export function formatEnvelopeTimestamp(date: Date, zone: EnvelopeTimestampZone = "utc"): string {
-  const normalized = zone.trim().toLowerCase();
+  const trimmedZone = zone.trim();
+  const normalized = trimmedZone.toLowerCase();
   const weekday = (() => {
     try {
       if (normalized === "utc" || normalized === "gmt") {
@@ -15,7 +16,9 @@ export function formatEnvelopeTimestamp(date: Date, zone: EnvelopeTimestampZone 
       if (normalized === "local" || normalized === "host") {
         return new Intl.DateTimeFormat("en-US", { weekday: "short" }).format(date);
       }
-      return new Intl.DateTimeFormat("en-US", { timeZone: zone, weekday: "short" }).format(date);
+      return new Intl.DateTimeFormat("en-US", { timeZone: trimmedZone, weekday: "short" }).format(
+        date,
+      );
     } catch {
       return undefined;
     }
@@ -29,7 +32,7 @@ export function formatEnvelopeTimestamp(date: Date, zone: EnvelopeTimestampZone 
     const ts = formatZonedTimestamp(date) ?? formatUtcTimestamp(date);
     return weekday ? `${weekday} ${ts}` : ts;
   }
-  const ts = formatZonedTimestamp(date, { timeZone: zone }) ?? formatUtcTimestamp(date);
+  const ts = formatZonedTimestamp(date, { timeZone: trimmedZone }) ?? formatUtcTimestamp(date);
   return weekday ? `${weekday} ${ts}` : ts;
 }
 


### PR DESCRIPTION
Fix
- Trim the timezone string before passing it to Intl/formatZonedTimestamp in the envelope timestamp test helper.
- Add a regression assertion in an existing src test (since the test runner does not include test/helpers/*.test.ts).

Why
- Prevents RangeError for inputs like " America/Los_Angeles ".

Testing
- pnpm test src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
- pnpm check

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `formatEnvelopeTimestamp` test helper to `trim()` the provided timezone string before passing it into `Intl.DateTimeFormat` and `formatZonedTimestamp`, preventing `RangeError` on inputs like `" America/Los_Angeles "`. It also adds a small regression assertion in an existing `src/web` test file to ensure the helper no longer throws when given whitespace-padded IANA timezones (since `test/helpers/*.test.ts` isn’t picked up by the runner).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized to a test helper and a regression assertion, and they directly address a concrete runtime failure (whitespace-padded timezone identifiers causing `Intl` to throw). The updated helper now consistently uses the trimmed zone for both weekday and timestamp formatting, avoiding the prior inconsistency. No production code paths are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->