### PR TITLE
fix: prevent cron list/status from silently skipping due jobs

### DIFF
--- a/src/cron/service/jobs.test.ts
+++ b/src/cron/service/jobs.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import type { CronServiceState } from "./state.js";
+import { recomputeNextRuns } from "./jobs.js";
+
+function makeJob(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: "job-1",
+    name: "test",
+    enabled: true,
+    createdAtMs: 1000,
+    updatedAtMs: 1000,
+    schedule: { kind: "every", everyMs: 60_000, anchorMs: 0 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "ping" },
+    state: {},
+    ...overrides,
+  };
+}
+
+const noopLog = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function makeState(jobs: CronJob[], nowMs: number): CronServiceState {
+  return {
+    deps: {
+      nowMs: () => nowMs,
+      log: noopLog,
+      storePath: "/tmp/cron.json",
+      cronEnabled: true,
+      enqueueSystemEvent: () => {},
+      requestHeartbeatNow: () => {},
+      runIsolatedAgentJob: async () => ({ status: "ok" }),
+    },
+    store: { version: 1, jobs },
+    timer: null,
+    running: false,
+    op: Promise.resolve(),
+    warnedDisabled: false,
+    storeLoadedAtMs: null,
+    storeFileMtimeMs: null,
+  };
+}
+
+describe("recomputeNextRuns", () => {
+  it("advances past-due jobs by default", () => {
+    const job = makeJob({ state: { nextRunAtMs: 5000 } });
+    const state = makeState([job], 10_000);
+
+    recomputeNextRuns(state);
+
+    // nextRunAtMs should have been advanced past now (10_000)
+    expect(job.state.nextRunAtMs).toBeGreaterThan(10_000);
+  });
+
+  it("preserves past-due jobs when preserveDue is true", () => {
+    const job = makeJob({ state: { nextRunAtMs: 5000 } });
+    const state = makeState([job], 10_000);
+
+    const changed = recomputeNextRuns(state, { preserveDue: true });
+
+    // nextRunAtMs must NOT be advanced — the timer should fire it first
+    expect(job.state.nextRunAtMs).toBe(5000);
+    expect(changed).toBe(false);
+  });
+
+  it("still fills in missing nextRunAtMs when preserveDue is true", () => {
+    const job = makeJob({ state: {} });
+    const state = makeState([job], 10_000);
+
+    const changed = recomputeNextRuns(state, { preserveDue: true });
+
+    // Missing nextRunAtMs should still be computed
+    expect(job.state.nextRunAtMs).toBeTypeOf("number");
+    expect(changed).toBe(true);
+  });
+});

--- a/src/cron/service/jobs.test.ts
+++ b/src/cron/service/jobs.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { CronJob } from "../types.js";
 import type { CronServiceState } from "./state.js";
@@ -31,7 +33,11 @@ function makeState(jobs: CronJob[], nowMs: number): CronServiceState {
     deps: {
       nowMs: () => nowMs,
       log: noopLog,
-      storePath: "/tmp/cron.json",
+      // Use a temp path that is unique per test run to avoid cross-test interference.
+      storePath: path.join(
+        os.tmpdir(),
+        `cron-test-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+      ),
       cronEnabled: true,
       enqueueSystemEvent: () => {},
       requestHeartbeatNow: () => {},

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -53,7 +53,7 @@ export async function status(state: CronServiceState) {
   return await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     if (state.store) {
-      const changed = recomputeNextRuns(state);
+      const changed = recomputeNextRuns(state, { preserveDue: true });
       if (changed) {
         await persist(state);
       }
@@ -71,7 +71,7 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
   return await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     if (state.store) {
-      const changed = recomputeNextRuns(state);
+      const changed = recomputeNextRuns(state, { preserveDue: true });
       if (changed) {
         await persist(state);
       }


### PR DESCRIPTION
## Summary

Fixes #12440

When `cron list` or `cron status` is called after a job's scheduled time but before the 60-second timer fires, `recomputeNextRuns()` advances `nextRunAtMs` to the next cycle — effectively skipping the due run without executing it.

**Root cause:** `recomputeNextRuns()` treats past-due jobs (`now >= nextRunAtMs`) the same as jobs with missing `nextRunAtMs` — it recomputes both. For `start()` this is correct because `runMissedJobs()` runs first, but `list()` and `status()` never execute missed jobs before calling `recomputeNextRuns()`.

**Fix:** Add a `preserveDue` option to `recomputeNextRuns()` that skips past-due jobs so the timer can still pick them up. `list()` and `status()` pass `{ preserveDue: true }` while `start()`, `onTimer()`, and `add()` retain the default behaviour.

### Changed files

- `src/cron/service/jobs.ts` — `recomputeNextRuns()` accepts optional `{ preserveDue: true }` to leave past-due `nextRunAtMs` untouched
- `src/cron/service/ops.ts` — `status()` and `list()` pass `{ preserveDue: true }`
- `src/cron/service/jobs.test.ts` — regression tests covering the new behaviour

## Test plan

- [x] New unit tests: `recomputeNextRuns` with `preserveDue: true` leaves past-due jobs untouched
- [x] New unit tests: `recomputeNextRuns` without `preserveDue` advances past-due jobs (existing behaviour)
- [x] New unit tests: `preserveDue: true` still fills in missing `nextRunAtMs`
- [x] Full test suite passes (975/975, 1 pre-existing failure unrelated to cron)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes cron’s `recomputeNextRuns()` to accept an optional `preserveDue` flag. When set, past-due jobs (`now >= nextRunAtMs`) are left untouched rather than being recomputed forward, preventing `cron list` / `cron status` from accidentally “skipping” a due run before the timer fires. `status()` and `list()` now call `recomputeNextRuns(state, { preserveDue: true })`, while the scheduler paths (`start`, timer, add) keep the default behavior.

A new unit test file (`src/cron/service/jobs.test.ts`) was added to cover both behaviors (default recompute advances past-due jobs; `preserveDue` keeps them due; `preserveDue` still fills missing `nextRunAtMs`).

<h3>Confidence Score: 3/5</h3>

- Behavioral change looks correct, but the added tests likely won’t compile as written without completing CronServiceState deps stubs.
- The core logic change is small and targeted (only gates recomputation when due + preserveDue), and the call sites are appropriate (list/status). The main merge-blocker risk is build/test failure from the new test helper constructing an incomplete CronServiceState (and secondarily, using a fixed /tmp path that could become an FS write if a codepath changes).
- src/cron/service/jobs.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->