### PR TITLE
fix(reply): honor /v off for group tool summaries

### DIFF
--- a/src/auto-reply/reply/agent-runner-helpers.test.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createShouldEmitToolResult } from "./agent-runner-helpers.js";
+
+describe("createShouldEmitToolResult", () => {
+  it("defaults to emitting tool results for group sessions", () => {
+    const shouldEmit = createShouldEmitToolResult({
+      sessionKey: "agent:main:telegram:group:-100123",
+      resolvedVerboseLevel: "off",
+    });
+    expect(shouldEmit()).toBe(true);
+  });
+
+  it("honors explicit verbose off in group session store", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-verbose-"));
+    const storePath = path.join(dir, "sessions.json");
+    const sessionKey = "agent:main:telegram:group:-100123";
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ [sessionKey]: { verboseLevel: "off", updatedAt: Date.now() } }),
+      "utf-8",
+    );
+
+    const shouldEmit = createShouldEmitToolResult({
+      sessionKey,
+      storePath,
+      resolvedVerboseLevel: "on",
+    });
+
+    expect(shouldEmit()).toBe(false);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("inherits verbose off from parent group session for topic/thread keys", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-verbose-parent-"));
+    const storePath = path.join(dir, "sessions.json");
+    const parentKey = "agent:main:telegram:group:-100123";
+    const topicKey = "agent:main:telegram:group:-100123:topic:777";
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ [parentKey]: { verboseLevel: "off", updatedAt: Date.now() } }),
+      "utf-8",
+    );
+
+    const shouldEmit = createShouldEmitToolResult({
+      sessionKey: topicKey,
+      storePath,
+      resolvedVerboseLevel: "on",
+    });
+
+    expect(shouldEmit()).toBe(false);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("respects verbose off for non-group sessions", () => {
+    const shouldEmit = createShouldEmitToolResult({
+      sessionKey: "agent:main:main",
+      resolvedVerboseLevel: "off",
+    });
+    expect(shouldEmit()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- make group/channel verbose default-on behavior respect explicit `verbose=off`
- apply session-key parent resolution for threaded/topic sessions
- add dispatch-layer guard so tool-result summaries are suppressed when verbose is off

## Root Cause
Group chats defaulted to verbose output and some paths ignored the session-level override, so `/v off` did not consistently suppress tool-result chatter.

## Changes
- `src/auto-reply/reply/agent-runner-helpers.ts`
  - resolve parent session verbose state for topic/thread keys
  - preserve group default-on only when no explicit off override exists
- `src/auto-reply/reply/dispatch-from-config.ts`
  - add `resolveSessionVerbose(...)` guard before emitting tool-result summaries
- tests:
  - `src/auto-reply/reply/agent-runner-helpers.test.ts`
  - `src/auto-reply/reply/dispatch-from-config.test.ts`

## Validation
- `pnpm -s vitest src/auto-reply/reply/agent-runner-helpers.test.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- all targeted tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates how verbose mode is resolved for group/channel sessions (including topic/thread session keys) so an explicit `/v off` disables tool-result summaries even when groups default to verbose-on. It adds a dispatch-layer guard to omit `onToolResult` for group-like chats when the resolved session verbose level is `off`, and adds tests covering group defaults, explicit off overrides, and parent session inheritance for topic keys.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but has a likely session-store lookup bug that can cause verbose-off to be ignored in some cases.
- Core behavior change is small and tests cover several group/topic scenarios, but `createShouldEmitToolResult` does not mirror the store key normalization used elsewhere (lowercasing), so explicit verbose settings may be missed and tool summaries could still emit when `/v off` was set for sessions whose keys are stored normalized.
- src/auto-reply/reply/agent-runner-helpers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->