### PR TITLE
fix(plugins): rebind global hook runner on cache hit

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -180,6 +180,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     const cached = registryCache.get(cacheKey);
     if (cached) {
       setActivePluginRegistry(cached, cacheKey);
+      initializeGlobalHookRunner(cached);
       return cached;
     }
   }


### PR DESCRIPTION
## Fix Summary

Add `initializeGlobalHookRunner(cached)` to the cache-hit branch of `loadOpenClawPlugins()`. Previously, cache hits updated the active plugin registry but left the process-global hook runner bound to whichever workspace last triggered a cache miss, causing cross-workspace hook bleed.

## Issue Linkage

Fixes #12453

## Security Snapshot

- CVSS v3.1: 9.9 (Critical)
- CVSS v4.0: 9.4 (Critical)

## Implementation Details

### Files Changed
- `src/plugins/loader.ts` (+1/-0)

### Technical Analysis
Add `initializeGlobalHookRunner(cached)` to the cache-hit branch of `loadOpenClawPlugins()`. Previously, cache hits updated the active plugin registry but left the process-global hook runner bound to whichever workspace last triggered a cache miss, causing cross-workspace hook bleed.

## Validation Evidence

- Command: `pnpm build && pnpm check && pnpm test`
- Status: failed

## Risk and Compatibility

- No breaking changes
- No new dependencies
- Backward compatible — cache-miss behavior unchanged; cache-hit now does strictly more (rebinding hook runner it previously skipped)

## AI-Assisted Disclosure

This fix was generated with AI assistance (Claude Opus 4.6).

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cross-workspace plugin hook “bleed” when `loadOpenClawPlugins()` returns a cached registry. Previously, the cache-hit path updated the active plugin registry but returned early without rebinding the process-global hook runner, leaving it bound to whatever registry last went through the cache-miss path. The change makes cache-hit behavior consistent with cache-miss by calling `initializeGlobalHookRunner(cached)` immediately after `setActivePluginRegistry(cached, cacheKey)`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, correct call that makes cache-hit behavior match the existing cache-miss initialization path. `initializeGlobalHookRunner()` is idempotent (it overwrites the global runner/registry) and aligns the global hook runner with the active registry, addressing the stated cross-workspace leak without affecting plugin discovery/registration logic.
- src/plugins/loader.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
