### PR TITLE
feat(session-memory): add model config for slug generation

### DIFF
--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -59,9 +59,10 @@ The hook uses your configured LLM provider to generate slugs, so it works with a
 
 The hook supports optional configuration:
 
-| Option     | Type   | Default | Description                                                     |
-| ---------- | ------ | ------- | --------------------------------------------------------------- |
-| `messages` | number | 15      | Number of user/assistant messages to include in the memory file |
+| Option     | Type   | Default         | Description                                                     |
+| ---------- | ------ | --------------- | --------------------------------------------------------------- |
+| `messages` | number | 15              | Number of user/assistant messages to include in the memory file |
+| `model`    | string | (primary model) | Model to use for slug generation (e.g. `google/gemini-3-flash`) |
 
 Example configuration:
 
@@ -72,7 +73,8 @@ Example configuration:
       "entries": {
         "session-memory": {
           "enabled": true,
-          "messages": 25
+          "messages": 25,
+          "model": "google/gemini-3-flash"
         }
       }
     }

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -104,12 +104,16 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     const sessionFile = currentSessionFile || undefined;
 
-    // Read message count from hook config (default: 15)
+    // Read hook config (message count + optional model override)
     const hookConfig = resolveHookConfig(cfg, "session-memory");
     const messageCount =
       typeof hookConfig?.messages === "number" && hookConfig.messages > 0
         ? hookConfig.messages
         : 15;
+    const slugModel =
+      typeof hookConfig?.model === "string" && hookConfig.model.trim()
+        ? hookConfig.model.trim()
+        : undefined;
 
     let slug: string | null = null;
     let sessionContent: string | null = null;
@@ -126,7 +130,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
       if (sessionContent && cfg && !process.env.VITEST && process.env.NODE_ENV !== "test") {
         log.debug("Calling generateSlugViaLLM...");
         // Use LLM to generate a descriptive slug
-        slug = await generateSlugViaLLM({ sessionContent, cfg });
+        slug = await generateSlugViaLLM({ sessionContent, cfg, model: slugModel });
         log.debug("Generated slug", { slug });
       }
     }

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -19,6 +19,7 @@ import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 export async function generateSlugViaLLM(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
+  model?: string;
 }): Promise<string | null> {
   let tempSessionFile: string | null = null;
 
@@ -49,6 +50,7 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
+      ...(params.model ? { model: params.model } : {}),
     });
 
     // Extract text from payloads


### PR DESCRIPTION
## Summary

Allow users to specify a dedicated model for slug generation in the `session-memory` hook, avoiding the use of expensive primary models for trivial slug generation.

## Changes

- **`src/hooks/llm-slug-generator.ts`**: Accept optional `model` parameter and pass it to `runEmbeddedPiAgent`
- **`src/hooks/bundled/session-memory/handler.ts`**: Read `model` from hook config and forward to `generateSlugViaLLM`
- **`src/hooks/bundled/session-memory/HOOK.md`**: Document the new `model` config option

## Configuration

```json
{
  "hooks": {
    "internal": {
      "entries": {
        "session-memory": {
          "model": "google/gemini-3-flash"
        }
      }
    }
  }
}
```

When not specified, the default primary model is used (backward compatible).

## Motivation

The slug generation prompt is trivial ("generate a 1-2 word filename slug") — any small model handles it well. Users with expensive primary models (Opus, GPT-4) are currently spending premium tokens on this.

Closes #12458

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `model` override to the bundled `session-memory` hook so slug generation can run on a cheaper model than the primary/default. The hook handler reads `model` from `hooks.internal.entries["session-memory"]` config, forwards it into `generateSlugViaLLM`, and `llm-slug-generator` passes it through to `runEmbeddedPiAgent`. Documentation (`HOOK.md`) is updated to describe the new config option and show an example.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized: a new optional config field is plumbed through to an existing agent runner parameter, with sane defaulting when omitted. I verified `runEmbeddedPiAgent` already supports a `model` parameter and defaults are preserved, and no other behavior is changed beyond selecting the model used for slug generation.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->