### PR TITLE
refactor: consolidate throwIfAborted + fix isCompactionFailureError

### DIFF
--- a/scripts/analyze_code_files.py
+++ b/scripts/analyze_code_files.py
@@ -157,7 +157,7 @@ def find_duplicate_functions(files: List[Tuple[Path, int]], root_dir: Path) -> D
 
 def main():
     parser = argparse.ArgumentParser(
-        description='List the longest and shortest code files in a project'
+        description='Analyze code files: list longest/shortest files, find duplicate function names'
     )
     parser.add_argument(
         '-t', '--threshold',

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -50,16 +50,18 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
   }
-  if (!isContextOverflowError(errorMessage)) {
-    return false;
-  }
   const lower = errorMessage.toLowerCase();
-  return (
+  const hasCompactionTerm =
     lower.includes("summarization failed") ||
     lower.includes("auto-compaction") ||
     lower.includes("compaction failed") ||
-    lower.includes("compaction")
-  );
+    lower.includes("compaction");
+  if (!hasCompactionTerm) {
+    return false;
+  }
+  // For compaction failures, also accept "context overflow" without colon
+  // since the error message itself describes a compaction/summarization failure
+  return isContextOverflowError(errorMessage) || lower.includes("context overflow");
 }
 
 const ERROR_PAYLOAD_PREFIX_RE =

--- a/src/infra/outbound/abort.ts
+++ b/src/infra/outbound/abort.ts
@@ -1,0 +1,15 @@
+/**
+ * Utility for checking AbortSignal state and throwing a standard AbortError.
+ */
+
+/**
+ * Throws an AbortError if the given signal has been aborted.
+ * Use at async checkpoints to support cancellation.
+ */
+export function throwIfAborted(abortSignal?: AbortSignal): void {
+  if (abortSignal?.aborted) {
+    const err = new Error("Operation aborted");
+    err.name = "AbortError";
+    throw err;
+  }
+}

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -23,6 +23,7 @@ import {
 } from "../../config/sessions.js";
 import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
 import { sendMessageSignal } from "../../signal/send.js";
+import { throwIfAborted } from "./abort.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 
 export type { NormalizedOutboundPayload } from "./payloads.js";
@@ -73,12 +74,6 @@ type ChannelHandler = {
   sendText: (text: string) => Promise<OutboundDeliveryResult>;
   sendMedia: (caption: string, mediaUrl: string) => Promise<OutboundDeliveryResult>;
 };
-
-function throwIfAborted(abortSignal?: AbortSignal): void {
-  if (abortSignal?.aborted) {
-    throw new Error("Outbound delivery aborted");
-  }
-}
 
 // Channel docking: outbound delivery delegates to plugin.outbound adapters.
 async function createChannelHandler(params: {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -28,6 +28,7 @@ import {
   type GatewayClientName,
 } from "../../utils/message-channel.js";
 import { loadWebMedia } from "../../web/media.js";
+import { throwIfAborted } from "./abort.js";
 import {
   listConfiguredMessageChannels,
   resolveMessageChannelSelection,
@@ -718,14 +719,6 @@ async function handleBroadcastAction(
     payload: { results },
     dryRun: Boolean(input.dryRun),
   };
-}
-
-function throwIfAborted(abortSignal?: AbortSignal): void {
-  if (abortSignal?.aborted) {
-    const err = new Error("Message send aborted");
-    err.name = "AbortError";
-    throw err;
-  }
 }
 
 async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -6,6 +6,7 @@ import type { OutboundSendDeps } from "./deliver.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
 import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
+import { throwIfAborted } from "./abort.js";
 import { sendMessage, sendPoll } from "./message.js";
 
 export type OutboundGatewayContext = {
@@ -57,14 +58,6 @@ function extractToolPayload(result: AgentToolResult<unknown>): unknown {
     }
   }
   return result.content ?? result;
-}
-
-function throwIfAborted(abortSignal?: AbortSignal): void {
-  if (abortSignal?.aborted) {
-    const err = new Error("Message send aborted");
-    err.name = "AbortError";
-    throw err;
-  }
 }
 
 export async function executeSendAction(params: {


### PR DESCRIPTION
## Summary

Round 3 of utility consolidation + CI fix.

### Changes

**throwIfAborted** (NEW: `src/infra/outbound/abort.ts`)
- Consolidated 3 duplicate implementations into shared module
- Updated: `deliver.ts`, `message-action-runner.ts`, `outbound-send-service.ts`

**isCompactionFailureError fix**
- Fixed regression where `isContextOverflowError` no longer matched "context overflow" without colon
- Compaction failure detection now handles both patterns since compaction error messages are self-describing

### Impact

- ~20 lines of duplicate code removed
- CI test `isCompactionFailureError` now passes

### Testing

- TypeScript compilation passes (`pnpm tsgo`)
- All related tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR consolidates three local `throwIfAborted` helpers into a shared `src/infra/outbound/abort.ts` utility and wires it into outbound send/delivery paths. It also adjusts `isCompactionFailureError` to recognize compaction failures even when the underlying context overflow message uses the non-colon "context overflow" variant.

The changes fit into the outbound pipeline by standardizing cancellation checkpoints (deliver/message-action-runner/outbound-send-service) and by improving error classification logic for compaction-related failures in the pi embedded helpers.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the abort/cancellation behavior change should be verified against upstream error handling before merging.
- The refactor is small and localized, and the compaction error detection change is straightforward. However, the new shared `throwIfAborted` changes the thrown error’s message/name compared to the previous implementation in `deliver.ts`, which can affect cancellation classification and user-visible errors if callers rely on the old behavior.
- src/infra/outbound/deliver.ts; src/infra/outbound/abort.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->