### PR TITLE
feat(mattermost): add read, search, and channel-list actions

### DIFF
--- a/extensions/mattermost/src/actions.test.ts
+++ b/extensions/mattermost/src/actions.test.ts
@@ -1,0 +1,245 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mattermostMessageActions } from "./actions.js";
+import {
+  createMattermostClient,
+  fetchChannelPosts,
+  fetchTeamChannels,
+  searchPosts,
+  type MattermostPostList,
+} from "./mattermost/client.js";
+
+type MattermostClient = ReturnType<typeof createMattermostClient>;
+
+function mockFetch(body: unknown, status = 200): typeof fetch {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}
+
+function clientWith(fetchImpl: typeof fetch): MattermostClient {
+  return createMattermostClient({ baseUrl: "https://mm.test", botToken: "tok", fetchImpl });
+}
+
+const emptyPostList: MattermostPostList = { order: [], posts: {} };
+
+function baseCfg(overrides?: Record<string, unknown>): OpenClawConfig {
+  return {
+    channels: {
+      mattermost: { enabled: true, botToken: "tok", baseUrl: "https://mm.test", ...overrides },
+    },
+  };
+}
+
+describe("fetchChannelPosts", () => {
+  it("builds URL with query params and returns posts", async () => {
+    const data: MattermostPostList = {
+      order: ["p1"],
+      posts: { p1: { id: "p1", message: "hello" } },
+    };
+    const f = mockFetch(data);
+    const result = await fetchChannelPosts(clientWith(f), "ch1", {
+      limit: 10,
+      before: "b",
+      after: "a",
+    });
+    const url = (f as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain("/channels/ch1/posts");
+    expect(url).toContain("per_page=10");
+    expect(url).toContain("before=b");
+    expect(result.posts.p1.message).toBe("hello");
+  });
+
+  it("propagates API errors", async () => {
+    await expect(
+      fetchChannelPosts(clientWith(mockFetch({ message: "Not found" }, 404)), "bad"),
+    ).rejects.toThrow(/404.*Not found/);
+  });
+});
+
+describe("searchPosts", () => {
+  it("sends search terms with channel and author filters", async () => {
+    const f = mockFetch(emptyPostList);
+    await searchPosts(clientWith(f), "team1", "bug", { channelId: "dev", authorId: "alice" });
+    const call = (f as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toContain("/teams/team1/posts/search");
+    const body = JSON.parse(call[1].body as string);
+    expect(body.terms).toBe("from:alice in:dev bug");
+  });
+});
+
+describe("fetchTeamChannels", () => {
+  it("fetches channels for team", async () => {
+    const channels = [{ id: "c1", name: "general", type: "O" }];
+    const f = mockFetch(channels);
+    const result = await fetchTeamChannels(clientWith(f), "team1", { limit: 5 });
+    const url = (f as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain("/teams/team1/channels");
+    expect(url).toContain("per_page=5");
+    expect(result[0].name).toBe("general");
+  });
+});
+
+describe("createMattermostClient", () => {
+  it("throws when baseUrl is empty", () => {
+    expect(() => createMattermostClient({ baseUrl: "", botToken: "tok" })).toThrow(/baseUrl/);
+  });
+
+  it("sets auth header and extracts error messages", async () => {
+    const f = mockFetch({ message: "Forbidden" }, 403);
+    const client = clientWith(f);
+    await expect(client.request("/test")).rejects.toThrow(/403.*Forbidden/);
+    const headers = (f as ReturnType<typeof vi.fn>).mock.calls[0][1].headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer tok");
+  });
+
+  it("normalizes baseUrl variants", async () => {
+    const f = mockFetch({ ok: true });
+    const client = createMattermostClient({
+      baseUrl: "https://mm.test/api/v4/",
+      botToken: "tok",
+      fetchImpl: f,
+    });
+    await client.request("/users/me");
+    expect((f as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      "https://mm.test/api/v4/users/me",
+    );
+  });
+});
+
+describe("mattermostMessageActions", () => {
+  describe("listActions", () => {
+    it("gates actions based on config", () => {
+      const all = mattermostMessageActions.listActions!({ cfg: baseCfg() });
+      expect(all).toContain("send");
+      expect(all).toContain("read");
+      expect(all).toContain("search");
+      expect(all).toContain("channel-list");
+
+      const gated = mattermostMessageActions.listActions!({
+        cfg: baseCfg({
+          actions: { messages: false, search: false, channelInfo: false, reactions: false },
+        }),
+      });
+      expect(gated).toEqual(["send"]);
+    });
+
+    it("returns empty when disabled", () => {
+      expect(
+        mattermostMessageActions.listActions!({
+          cfg: { channels: { mattermost: { enabled: false } } },
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("extractToolSend", () => {
+    it("extracts send params", () => {
+      expect(
+        mattermostMessageActions.extractToolSend!({
+          args: { action: "sendMessage", to: "#ch", accountId: "work" },
+        }),
+      ).toEqual({ to: "#ch", accountId: "work" });
+    });
+
+    it("returns null for non-send or invalid args", () => {
+      expect(
+        mattermostMessageActions.extractToolSend!({ args: { action: "read", to: "#ch" } }),
+      ).toBeNull();
+      expect(
+        mattermostMessageActions.extractToolSend!({ args: { action: "sendMessage" } }),
+      ).toBeNull();
+    });
+  });
+
+  describe("handleAction", () => {
+    let origFetch: typeof fetch;
+    const stubFetch = (f: typeof fetch) => {
+      origFetch = globalThis.fetch;
+      globalThis.fetch = f;
+    };
+    afterEach(() => origFetch && (globalThis.fetch = origFetch));
+
+    it("read fetches channel posts", async () => {
+      const f = mockFetch(emptyPostList);
+      stubFetch(f);
+      await mattermostMessageActions.handleAction!({
+        channel: "mattermost",
+        action: "read",
+        params: { channelId: "ch1", limit: 10 },
+        cfg: baseCfg(),
+      });
+      const url = (f as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(url).toContain("/channels/ch1/posts");
+    });
+
+    it("search posts to team endpoint", async () => {
+      const f = mockFetch(emptyPostList);
+      stubFetch(f);
+      await mattermostMessageActions.handleAction!({
+        channel: "mattermost",
+        action: "search",
+        params: { query: "test", teamId: "t1" },
+        cfg: baseCfg(),
+      });
+      expect((f as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain("/teams/t1/posts/search");
+    });
+
+    it("channel-list and channel-info work", async () => {
+      const f = mockFetch([{ id: "c1", name: "general" }]);
+      stubFetch(f);
+      await mattermostMessageActions.handleAction!({
+        channel: "mattermost",
+        action: "channel-list",
+        params: { teamId: "t1" },
+        cfg: baseCfg(),
+      });
+      expect((f as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain("/teams/t1/channels");
+
+      const f2 = mockFetch({ id: "c1", name: "general", type: "O" });
+      stubFetch(f2);
+      const result = await mattermostMessageActions.handleAction!({
+        channel: "mattermost",
+        action: "channel-info",
+        params: { channelId: "c1" },
+        cfg: baseCfg(),
+      });
+      expect((result.content as { text: string }[])[0].text).toContain("general");
+    });
+
+    it("validates required params", async () => {
+      await expect(
+        mattermostMessageActions.handleAction!({
+          channel: "mattermost",
+          action: "read",
+          params: {},
+          cfg: baseCfg(),
+        }),
+      ).rejects.toThrow(/to required/);
+
+      await expect(
+        mattermostMessageActions.handleAction!({
+          channel: "mattermost",
+          action: "search",
+          params: { query: "x" },
+          cfg: baseCfg(),
+        }),
+      ).rejects.toThrow(/teamId required/);
+    });
+
+    it("propagates API errors", async () => {
+      stubFetch(mockFetch({ message: "Forbidden" }, 403));
+      await expect(
+        mattermostMessageActions.handleAction!({
+          channel: "mattermost",
+          action: "read",
+          params: { to: "ch1" },
+          cfg: baseCfg(),
+        }),
+      ).rejects.toThrow(/403.*Forbidden/);
+    });
+  });
+});

--- a/extensions/mattermost/src/actions.ts
+++ b/extensions/mattermost/src/actions.ts
@@ -1,0 +1,173 @@
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionName,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk";
+import {
+  createActionGate,
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk";
+import { listEnabledMattermostAccounts, resolveMattermostAccount } from "./mattermost/accounts.js";
+import {
+  createMattermostClient,
+  fetchChannelPosts,
+  fetchMattermostChannel,
+  fetchTeamChannels,
+  searchPosts,
+} from "./mattermost/client.js";
+import { addMattermostReaction, removeMattermostReaction } from "./mattermost/reactions.js";
+import { sendMessageMattermost } from "./mattermost/send.js";
+import type { MattermostAccountConfig } from "./types.js";
+
+const providerId = "mattermost";
+
+type EnabledAccounts = ReturnType<typeof listEnabledMattermostAccounts>;
+type MattermostActions = NonNullable<MattermostAccountConfig["actions"]>;
+
+function isGateEnabled(
+  accounts: EnabledAccounts,
+  cfg: OpenClawConfig,
+  key: keyof MattermostActions,
+): boolean {
+  for (const account of accounts) {
+    const actions =
+      account.config.actions ??
+      (cfg.channels?.["mattermost"] as { actions?: MattermostActions } | undefined)?.actions;
+    const gate = createActionGate(actions);
+    if (gate(key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveClient(cfg: OpenClawConfig, accountId?: string | null) {
+  const account = resolveMattermostAccount({ cfg, accountId });
+  if (!account.botToken || !account.baseUrl) {
+    throw new Error("Mattermost credentials are missing.");
+  }
+  return createMattermostClient({
+    baseUrl: account.baseUrl,
+    botToken: account.botToken,
+  });
+}
+
+export const mattermostMessageActions: ChannelMessageActionAdapter = {
+  listActions: ({ cfg }) => {
+    const accounts = listEnabledMattermostAccounts(cfg).filter((a) =>
+      Boolean(a.botToken?.trim() && a.baseUrl?.trim()),
+    );
+    if (accounts.length === 0) {
+      return [];
+    }
+    const actions = new Set<ChannelMessageActionName>([]);
+    actions.add("send");
+    if (isGateEnabled(accounts, cfg, "messages")) {
+      actions.add("read");
+    }
+    if (isGateEnabled(accounts, cfg, "search")) {
+      actions.add("search");
+    }
+    if (isGateEnabled(accounts, cfg, "channelInfo")) {
+      actions.add("channel-list");
+      actions.add("channel-info");
+    }
+    if (isGateEnabled(accounts, cfg, "reactions")) {
+      actions.add("react");
+    }
+    return Array.from(actions);
+  },
+
+  extractToolSend: ({ args }) => {
+    const action = typeof args.action === "string" ? args.action.trim() : "";
+    if (action !== "sendMessage") {
+      return null;
+    }
+    const to = typeof args.to === "string" ? args.to : undefined;
+    if (!to) {
+      return null;
+    }
+    const accountId = typeof args.accountId === "string" ? args.accountId.trim() : undefined;
+    return { to, accountId };
+  },
+
+  handleAction: async ({ action, params, cfg, accountId }) => {
+    if (action === "send") {
+      const to = readStringParam(params, "to", { required: true });
+      const message = readStringParam(params, "message", { required: true, allowEmpty: true });
+      const mediaUrl = readStringParam(params, "media", { trim: false });
+      const result = await sendMessageMattermost(to, message, {
+        accountId: accountId ?? undefined,
+        mediaUrl: mediaUrl ?? undefined,
+      });
+      return jsonResult({ ok: true, ...result });
+    }
+
+    if (action === "react") {
+      const postId =
+        readStringParam(params, "messageId") ??
+        readStringParam(params, "postId", { required: true });
+      const emojiRaw = readStringParam(params, "emoji", { required: true });
+      const emojiName = emojiRaw.replace(/^:+|:+$/g, "");
+      const remove = params.remove === true;
+      const fn = remove ? removeMattermostReaction : addMattermostReaction;
+      const reactionResult = await fn({
+        cfg,
+        postId,
+        emojiName,
+        accountId: accountId ?? undefined,
+      });
+      if (!reactionResult.ok) {
+        throw new Error(reactionResult.error);
+      }
+      const verb = remove ? "Removed reaction" : "Reacted with";
+      return jsonResult({ ok: true, message: `${verb} :${emojiName}: on ${postId}` });
+    }
+
+    const client = resolveClient(cfg, accountId);
+
+    if (action === "read") {
+      const channelId =
+        readStringParam(params, "channelId") ?? readStringParam(params, "to", { required: true });
+      const limit = readNumberParam(params, "limit", { integer: true });
+      const before = readStringParam(params, "before");
+      const after = readStringParam(params, "after");
+      const since = readNumberParam(params, "since", { integer: true });
+      const posts = await fetchChannelPosts(client, channelId, {
+        limit: limit ?? undefined,
+        before: before ?? undefined,
+        after: after ?? undefined,
+        since: since ?? undefined,
+      });
+      return jsonResult({ ok: true, posts });
+    }
+
+    if (action === "search") {
+      const query = readStringParam(params, "query", { required: true });
+      const teamId = readStringParam(params, "teamId", { required: true });
+      const channelId = readStringParam(params, "channelId");
+      const authorId = readStringParam(params, "authorId");
+      const posts = await searchPosts(client, teamId, query, {
+        channelId: channelId ?? undefined,
+        authorId: authorId ?? undefined,
+      });
+      return jsonResult({ ok: true, posts });
+    }
+
+    if (action === "channel-list") {
+      const teamId = readStringParam(params, "teamId", { required: true });
+      const channels = await fetchTeamChannels(client, teamId);
+      return jsonResult({ ok: true, channels });
+    }
+
+    if (action === "channel-info") {
+      const channelId = readStringParam(params, "channelId", { required: true });
+      const channel = await fetchMattermostChannel(client, channelId);
+      return jsonResult({ ok: true, channel });
+    }
+
+    throw new Error(`Action ${action} is not supported for provider ${providerId}.`);
+  },
+};

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -7,10 +7,9 @@ import {
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
   setAccountEnabledInConfigSection,
-  type ChannelMessageActionAdapter,
-  type ChannelMessageActionName,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk";
+import { mattermostMessageActions } from "./actions.js";
 import { MattermostConfigSchema } from "./config-schema.js";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 import {
@@ -22,102 +21,10 @@ import {
 import { normalizeMattermostBaseUrl } from "./mattermost/client.js";
 import { monitorMattermostProvider } from "./mattermost/monitor.js";
 import { probeMattermost } from "./mattermost/probe.js";
-import { addMattermostReaction, removeMattermostReaction } from "./mattermost/reactions.js";
 import { sendMessageMattermost } from "./mattermost/send.js";
 import { looksLikeMattermostTargetId, normalizeMattermostMessagingTarget } from "./normalize.js";
 import { mattermostOnboardingAdapter } from "./onboarding.js";
 import { getMattermostRuntime } from "./runtime.js";
-
-const mattermostMessageActions: ChannelMessageActionAdapter = {
-  listActions: ({ cfg }) => {
-    const actionsConfig = cfg.channels?.mattermost?.actions as { reactions?: boolean } | undefined;
-    const baseReactions = actionsConfig?.reactions;
-    const hasReactionCapableAccount = listMattermostAccountIds(cfg)
-      .map((accountId) => resolveMattermostAccount({ cfg, accountId }))
-      .filter((account) => account.enabled)
-      .filter((account) => Boolean(account.botToken?.trim() && account.baseUrl?.trim()))
-      .some((account) => {
-        const accountActions = account.config.actions as { reactions?: boolean } | undefined;
-        return (accountActions?.reactions ?? baseReactions ?? true) !== false;
-      });
-
-    if (!hasReactionCapableAccount) {
-      return [];
-    }
-
-    return ["react"];
-  },
-  supportsAction: ({ action }) => {
-    return action === "react";
-  },
-  handleAction: async ({ action, params, cfg, accountId }) => {
-    if (action !== "react") {
-      throw new Error(`Mattermost action ${action} not supported`);
-    }
-    // Check reactions gate: per-account config takes precedence over base config
-    const mmBase = cfg?.channels?.mattermost as Record<string, unknown> | undefined;
-    const accounts = mmBase?.accounts as Record<string, Record<string, unknown>> | undefined;
-    const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
-    const acctConfig = accounts?.[resolvedAccountId];
-    const acctActions = acctConfig?.actions as { reactions?: boolean } | undefined;
-    const baseActions = mmBase?.actions as { reactions?: boolean } | undefined;
-    const reactionsEnabled = acctActions?.reactions ?? baseActions?.reactions ?? true;
-    if (!reactionsEnabled) {
-      throw new Error("Mattermost reactions are disabled in config");
-    }
-
-    const postIdRaw =
-      typeof (params as any)?.messageId === "string"
-        ? (params as any).messageId
-        : typeof (params as any)?.postId === "string"
-          ? (params as any).postId
-          : "";
-    const postId = postIdRaw.trim();
-    if (!postId) {
-      throw new Error("Mattermost react requires messageId (post id)");
-    }
-
-    const emojiRaw = typeof (params as any)?.emoji === "string" ? (params as any).emoji : "";
-    const emojiName = emojiRaw.trim().replace(/^:+|:+$/g, "");
-    if (!emojiName) {
-      throw new Error("Mattermost react requires emoji");
-    }
-
-    const remove = (params as any)?.remove === true;
-    if (remove) {
-      const result = await removeMattermostReaction({
-        cfg,
-        postId,
-        emojiName,
-        accountId: resolvedAccountId,
-      });
-      if (!result.ok) {
-        throw new Error(result.error);
-      }
-      return {
-        content: [
-          { type: "text" as const, text: `Removed reaction :${emojiName}: from ${postId}` },
-        ],
-        details: {},
-      };
-    }
-
-    const result = await addMattermostReaction({
-      cfg,
-      postId,
-      emojiName,
-      accountId: resolvedAccountId,
-    });
-    if (!result.ok) {
-      throw new Error(result.error);
-    }
-
-    return {
-      content: [{ type: "text" as const, text: `Reacted with :${emojiName}: on ${postId}` }],
-      details: {},
-    };
-  },
-};
 
 const meta = {
   id: "mattermost",

--- a/extensions/mattermost/src/config-schema.ts
+++ b/extensions/mattermost/src/config-schema.ts
@@ -31,6 +31,9 @@ const MattermostAccountSchemaBase = z
     actions: z
       .object({
         reactions: z.boolean().optional(),
+        messages: z.boolean().optional(),
+        search: z.boolean().optional(),
+        channelInfo: z.boolean().optional(),
       })
       .optional(),
   })

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -190,6 +190,66 @@ export async function createMattermostPost(
   });
 }
 
+export type MattermostPostList = {
+  order: string[];
+  posts: Record<string, MattermostPost>;
+};
+
+export async function fetchChannelPosts(
+  client: MattermostClient,
+  channelId: string,
+  opts?: { limit?: number; before?: string; after?: string; since?: number },
+): Promise<MattermostPostList> {
+  const params = new URLSearchParams();
+  if (opts?.limit != null) {
+    params.set("per_page", String(opts.limit));
+  }
+  if (opts?.before) {
+    params.set("before", opts.before);
+  }
+  if (opts?.after) {
+    params.set("after", opts.after);
+  }
+  if (opts?.since != null) {
+    params.set("since", String(opts.since));
+  }
+  const qs = params.toString();
+  const path = `/channels/${channelId}/posts${qs ? `?${qs}` : ""}`;
+  return await client.request<MattermostPostList>(path);
+}
+
+export async function searchPosts(
+  client: MattermostClient,
+  teamId: string,
+  terms: string,
+  opts?: { channelId?: string; authorId?: string },
+): Promise<MattermostPostList> {
+  let finalTerms = terms;
+  if (opts?.channelId) {
+    finalTerms = `in:${opts.channelId} ${finalTerms}`;
+  }
+  if (opts?.authorId) {
+    finalTerms = `from:${opts.authorId} ${finalTerms}`;
+  }
+  return await client.request<MattermostPostList>(`/teams/${teamId}/posts/search`, {
+    method: "POST",
+    body: JSON.stringify({ terms: finalTerms, is_or_search: false }),
+  });
+}
+
+export async function fetchTeamChannels(
+  client: MattermostClient,
+  teamId: string,
+  opts?: { limit?: number },
+): Promise<MattermostChannel[]> {
+  const params = new URLSearchParams();
+  if (opts?.limit != null) {
+    params.set("per_page", String(opts.limit));
+  }
+  const qs = params.toString();
+  const path = `/teams/${teamId}/channels${qs ? `?${qs}` : ""}`;
+  return await client.request<MattermostChannel[]>(path);
+}
 export async function uploadMattermostFile(
   client: MattermostClient,
   params: {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -556,6 +556,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         channel: "mattermost",
         accountId: account.accountId,
         groupId: channelId,
+        requireMentionOverride: account.requireMention,
       });
     const shouldBypassMention =
       isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -48,6 +48,12 @@ export type MattermostAccountConfig = {
   actions?: {
     /** Enable message reaction actions. Default: true. */
     reactions?: boolean;
+    /** Enable reading channel message history. Default: true. */
+    messages?: boolean;
+    /** Enable searching posts across channels. Default: true. */
+    search?: boolean;
+    /** Enable channel-list and channel-info lookups. Default: true. */
+    channelInfo?: boolean;
   };
 };
 


### PR DESCRIPTION
## Summary
Adds message actions for querying Mattermost channels - useful for agents that need to catch up on channel history or search for context.

## Changes
- `read`: fetch recent posts from a channel
- `search`: search posts across channels with filters (author, date range, etc.)
- `channel-list`: list available channels in a team

Also fixes a bug where account-level `requireMention: false` was ignored (the setting wasn't passed through to the channel resolver).

## Testing
- `pnpm check`
- `pnpm vitest extensions/mattermost/src/actions.test.ts extensions/mattermost/src/channel.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a Mattermost `actions` adapter to expose message-oriented tools (`read`, `search`, `channel-list`, `channel-info`) backed by new Mattermost client helpers (`fetchChannelPosts`, `searchPosts`, `fetchTeamChannels`). Also extends Mattermost account config/schema to support per-action toggles and fixes mention-gating behavior by passing the resolved account-level `requireMention` into the group require-mention resolver in the monitor.

These changes integrate with the existing channel plugin by wiring `mattermostMessageActions` into `extensions/mattermost/src/channel.ts` and leveraging existing account resolution/config merge behavior in `extensions/mattermost/src/mattermost/accounts.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to the Mattermost extension, include tests for the new client helpers and action adapter behavior, and the mention-gating fix aligns with how the account resolver computes `requireMention`. I did not find any introduced logic errors that would break existing flows.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->