### PR TITLE
fix(telegram): discard stale update offset after bot token swap

### DIFF
--- a/src/telegram/update-offset-store.test.ts
+++ b/src/telegram/update-offset-store.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
+import {
+  computeBotTokenHash,
+  readTelegramUpdateOffset,
+  writeTelegramUpdateOffset,
+} from "./update-offset-store.js";
 
 async function withTempStateDir<T>(fn: (dir: string) => Promise<T>) {
   const previous = process.env.OPENCLAW_STATE_DIR;
@@ -31,6 +35,44 @@ describe("telegram update offset store", () => {
       });
 
       expect(await readTelegramUpdateOffset({ accountId: "primary" })).toBe(421);
+    });
+  });
+
+  it("discards offset when tokenHash does not match (bot token swap)", async () => {
+    await withTempStateDir(async () => {
+      const hashOld = computeBotTokenHash("old-bot-token");
+      const hashNew = computeBotTokenHash("new-bot-token");
+
+      await writeTelegramUpdateOffset({
+        accountId: "primary",
+        updateId: 999_999,
+        tokenHash: hashOld,
+      });
+
+      // Same token hash reads back fine
+      expect(await readTelegramUpdateOffset({ accountId: "primary", tokenHash: hashOld })).toBe(
+        999_999,
+      );
+
+      // Different token hash resets to null (prevents silent message drop)
+      expect(
+        await readTelegramUpdateOffset({ accountId: "primary", tokenHash: hashNew }),
+      ).toBeNull();
+    });
+  });
+
+  it("reads legacy offset files without tokenHash (backward compat)", async () => {
+    await withTempStateDir(async () => {
+      // Legacy file written without tokenHash
+      await writeTelegramUpdateOffset({
+        accountId: "primary",
+        updateId: 500,
+      });
+
+      // Reading with a tokenHash should still return the offset
+      // (legacy file has no tokenHash to mismatch against)
+      const hash = computeBotTokenHash("any-token");
+      expect(await readTelegramUpdateOffset({ accountId: "primary", tokenHash: hash })).toBe(500);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #12250

When a user changes their Telegram bot token (e.g. during migration from Windows to Linux, or reconfiguring the bot), the persisted `lastUpdateId` from the old bot can be far higher than the new bot's `update_id` sequence. This causes `shouldSkipUpdate()` to silently drop **every** incoming message because `updateId <= lastUpdateId` is always true.

The user sees messages arriving in `raw-update` logs but no session is ever created -- the update is discarded before reaching any handler.

### Root cause

The update offset file (`update-offset-{account}.json`) is keyed by `accountId` only, with no awareness of which bot token produced the offset. After a token swap, the stale high offset causes all new updates to be classified as "already processed".

### Fix

- Store a truncated SHA-256 hash of the bot token (`tokenHash`) alongside the offset
- On startup, if the stored `tokenHash` does not match the current token, discard the offset so the bot processes updates from scratch
- Legacy offset files (without `tokenHash`) are still accepted to preserve backward compatibility

### Files changed

| File | Change |
|------|--------|
| `src/telegram/update-offset-store.ts` | Add `tokenHash` field, hash comparison in read, `computeBotTokenHash()` export |
| `src/telegram/monitor.ts` | Pass `tokenHash` to read/write calls |
| `src/telegram/update-offset-store.test.ts` | Token mismatch reset test + legacy backward compat test |

## Test plan

- [x] New test: offset discarded when tokenHash does not match (bot token swap)
- [x] New test: legacy offset files without tokenHash still readable (backward compat)
- [x] Existing test: persists and reloads offset (unchanged behavior)
- [x] All 3 tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Telegram polling offset persistence so a stored `lastUpdateId` is associated with the bot token that produced it. The offset JSON now optionally includes a truncated SHA-256 `tokenHash`; when reading the offset, callers can supply the current `tokenHash` and the store will return `null` if the persisted hash is present and mismatched, preventing a token swap from causing all future updates to be skipped.

`monitorTelegramProvider` computes the bot token hash at startup and threads it through `readTelegramUpdateOffset`/`writeTelegramUpdateOffset`. Tests cover the token-mismatch reset behavior and confirm legacy offset files (without `tokenHash`) still load for backwards compatibility.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to Telegram offset persistence, are backwards compatible (legacy files still load), and are covered by targeted unit tests for the new token-mismatch behavior. No behavioral regressions were identified in the monitoring flow beyond the intended offset reset on bot token changes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->