### PR TITLE
fix(logging): use Symbol.for for externalTransports to survive jiti module isolation

### DIFF
--- a/src/logging/logger-transport.test.ts
+++ b/src/logging/logger-transport.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { LogTransport } from "./logger.js";
+
+const EXTERNAL_TRANSPORTS_KEY = Symbol.for("openclaw.logging.externalTransports");
+
+describe("registerLogTransport global sharing", () => {
+  it("externalTransports is stored on globalThis via Symbol.for", () => {
+    // Importing logger.ts should have populated the global key.
+    const g = globalThis as typeof globalThis & {
+      [key: symbol]: Set<LogTransport> | undefined;
+    };
+    expect(g[EXTERNAL_TRANSPORTS_KEY]).toBeInstanceOf(Set);
+  });
+
+  it("registerLogTransport adds to the shared global Set", async () => {
+    const { registerLogTransport } = await import("./logger.js");
+
+    const g = globalThis as typeof globalThis & {
+      [key: symbol]: Set<LogTransport> | undefined;
+    };
+    const set = g[EXTERNAL_TRANSPORTS_KEY]!;
+    const sizeBefore = set.size;
+
+    const transport: LogTransport = () => {};
+    const unregister = registerLogTransport(transport);
+
+    expect(set.size).toBe(sizeBefore + 1);
+    expect(set.has(transport)).toBe(true);
+
+    unregister();
+
+    expect(set.has(transport)).toBe(false);
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -36,7 +36,25 @@ export type LoggerResolvedSettings = ResolvedSettings;
 export type LogTransportRecord = Record<string, unknown>;
 export type LogTransport = (logObj: LogTransportRecord) => void;
 
-const externalTransports = new Set<LogTransport>();
+// Use Symbol.for() to store transports on globalThis so that jiti-loaded
+// plugin modules share the same Set instance as the main process.  Without
+// this, registerLogTransport() called from a plugin writes to a different
+// Set than the one buildLogger() iterates over.
+const EXTERNAL_TRANSPORTS_KEY = Symbol.for("openclaw.logging.externalTransports");
+
+type GlobalWithTransports = typeof globalThis & {
+  [key: symbol]: Set<LogTransport> | undefined;
+};
+
+function getExternalTransports(): Set<LogTransport> {
+  const g = globalThis as GlobalWithTransports;
+  if (!g[EXTERNAL_TRANSPORTS_KEY]) {
+    g[EXTERNAL_TRANSPORTS_KEY] = new Set<LogTransport>();
+  }
+  return g[EXTERNAL_TRANSPORTS_KEY];
+}
+
+const externalTransports = getExternalTransports();
 
 function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {
   logger.attachTransport((logObj: LogObj) => {


### PR DESCRIPTION
## Summary

Fixes #12473

Plugins loaded via jiti get their own module cache, so the module-level `externalTransports` Set in `logger.ts` becomes a **separate instance** in the plugin context. Any transport registered by a plugin via `registerLogTransport()` is silently lost when `buildLogger()` iterates the main process's Set.

### Root cause

```
Main process:   import logger.ts  ->  externalTransports = new Set() (A)
Plugin (jiti):  import logger.ts  ->  externalTransports = new Set() (B)

Plugin calls registerLogTransport(fn)  ->  adds to Set B
buildLogger() iterates Set A           ->  fn is missing
```

### Fix

Store the Set on `globalThis[Symbol.for("openclaw.logging.externalTransports")]` so all module instances -- regardless of how they were loaded -- share the same collection.

This matches the pattern already established in:
- `src/infra/warning-filter.ts` (`Symbol.for("openclaw.warning-filter")`)
- `src/plugins/runtime.ts` (`Symbol.for("openclaw.pluginRegistryState")`)

### Files changed

| File | Change |
|------|--------|
| `src/logging/logger.ts` | Replace `new Set()` with `globalThis[Symbol.for()]` getter |
| `src/logging/logger-transport.test.ts` | Verify shared Set and register/unregister lifecycle |

## Test plan

- [x] New test: `externalTransports` is stored on `globalThis` via `Symbol.for`
- [x] New test: `registerLogTransport` adds to and removes from the shared global Set
- [x] All 27 existing logging + diagnostics-otel tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `src/logging/logger.ts` to store the `externalTransports` Set on `globalThis[Symbol.for("openclaw.logging.externalTransports")]` so transports registered from jiti-loaded plugin module instances are visible to the main process logger builder.

It also adds `src/logging/logger-transport.test.ts` to validate that the Set is shared via `Symbol.for` and that `registerLogTransport()` mutates the shared Set (including unregister cleanup).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the newly added tests are order-dependent and can fail in isolation/sharded runs.
- The production change in logger.ts is small and follows established patterns (Symbol.for + globalThis). The only clear issues found are in the new test file, which assumes logger.js has already been executed and dereferences the global Set before ensuring initialization.
- src/logging/logger-transport.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->