### PR TITLE
fix(agents): prevent TimeoutOverflowWarning when timeout is disabled

### DIFF
--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentTimeoutMs } from "./timeout.js";
+import { NO_TIMEOUT, resolveAgentTimeoutMs } from "./timeout.js";
 
 describe("resolveAgentTimeoutMs", () => {
-  it("uses a timer-safe sentinel for no-timeout overrides", () => {
-    expect(resolveAgentTimeoutMs({ overrideSeconds: 0 })).toBe(2_147_000_000);
-    expect(resolveAgentTimeoutMs({ overrideMs: 0 })).toBe(2_147_000_000);
+  it("returns NO_TIMEOUT (0) for no-timeout overrides so callers skip the timer", () => {
+    expect(resolveAgentTimeoutMs({ overrideSeconds: 0 })).toBe(NO_TIMEOUT);
+    expect(resolveAgentTimeoutMs({ overrideMs: 0 })).toBe(NO_TIMEOUT);
+    expect(NO_TIMEOUT).toBe(0);
   });
 
   it("clamps very large timeout overrides to timer-safe values", () => {

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -79,7 +79,9 @@ export async function waitForAgentJob(params: {
   if (cached) {
     return cached;
   }
-  if (timeoutMs <= 0) {
+  // timeoutMs === 0 means "no timeout" — wait indefinitely for the agent
+  // to finish.  Only bail out for truly invalid (negative) values.
+  if (timeoutMs < 0) {
     return null;
   }
 

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -127,8 +127,13 @@ export async function waitForAgentJob(params: {
       recordAgentRunSnapshot(snapshot);
       finish(snapshot);
     });
-    const timerDelayMs = Math.max(1, Math.min(Math.floor(timeoutMs), 2_147_483_647));
-    const timer = setTimeout(() => finish(null), timerDelayMs);
+    // When timeoutMs is 0 the caller requested "no timeout" — skip the
+    // completion timer instead of scheduling one that overflows Node's
+    // 32-bit signed integer limit for setTimeout.
+    const timer =
+      timeoutMs > 0
+        ? setTimeout(() => finish(null), Math.min(Math.floor(timeoutMs), 2_147_483_647))
+        : undefined;
   });
 }
 


### PR DESCRIPTION
## Summary

`resolveAgentTimeoutMs` uses a 30-day constant (`2,592,000,000 ms`) to represent "no timeout" when the caller sets `timeout: 0`. This exceeds Node's 32-bit signed integer limit for `setTimeout` (`2,147,483,647 ms`), causing Node to emit `TimeoutOverflowWarning` and clamp the value to `1 ms` — which prematurely kills sub-agents almost immediately instead of letting them run indefinitely.

The fix eliminates the overflowing constant entirely. Instead of scheduling a timer with a huge value, callers skip timer creation when no timeout is requested.

## Changes

- `src/agents/timeout.ts` — return `0` for "no timeout" instead of the overflowing 30-day constant; export a documented `NO_TIMEOUT` sentinel callers can reference
- `src/agents/pi-embedded-runner/run/attempt.ts` — skip the abort timer when `timeoutMs` is `0` instead of passing it to `setTimeout`
- `src/gateway/server-methods/agent-job.ts` — skip the completion timer when `timeoutMs` is `0`

`block-reply-pipeline.ts` already handles `timeoutMs <= 0` correctly (returns the promise directly without a timer).

## Test plan

- `sessions_spawn` with `timeout: 0` no longer emits `TimeoutOverflowWarning` in Node logs
- Sub-agents with no explicit timeout run until completion instead of being killed at 1 ms
- Explicit positive timeouts (e.g. `timeout: 600`) behave exactly as before
- `clearTimeout(undefined)` is a safe no-op in Node, so cleanup paths remain correct

Fixes #12407

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the agent timeout semantics so that an explicit `timeout: 0` no longer maps to a huge “effectively infinite” millisecond value (which overflows Node’s `setTimeout` limit and gets clamped to `1ms`). Instead, `resolveAgentTimeoutMs` returns a `NO_TIMEOUT = 0` sentinel and call sites in the embedded runner and gateway job-waiter skip creating timers when `timeoutMs === 0`.

The overall direction matches the described bug (prevent `TimeoutOverflowWarning` and premature aborts), but there’s one behavior mismatch in the gateway’s `waitForAgentJob` path that currently treats `timeoutMs <= 0` as an immediate timeout response rather than an indefinite wait.

<h3>Confidence Score: 3/5</h3>

- This PR addresses the Node timeout overflow issue but has a semantic regression in the gateway wait path for `timeoutMs=0`.
- Main fix (stop scheduling overflowing timers) is correct in the embedded runner, but `src/gateway/server-methods/agent-job.ts` still returns immediately for `timeoutMs <= 0`, which conflicts with the new `NO_TIMEOUT = 0` sentinel meaning and will cause `agent.wait` to report an immediate timeout when clients pass 0 to mean “no timeout”.
- src/gateway/server-methods/agent-job.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->