### PR TITLE
fix(agents): strip orphaned tool_result when tool_use is sanitized on retry

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -13,7 +13,7 @@ import {
 } from "../pi-embedded-helpers.js";
 import { cleanToolSchemaForGemini } from "../pi-tools.schema.js";
 import {
-  sanitizeToolCallInputs,
+  repairToolCallInputs,
   sanitizeToolUseResultPairing,
 } from "../session-transcript-repair.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
@@ -349,8 +349,14 @@ export async function sanitizeSessionHistory(params: {
   const sanitizedThinking = policy.normalizeAntigravityThinkingBlocks
     ? sanitizeAntigravityThinkingBlocks(sanitizedImages)
     : sanitizedImages;
-  const sanitizedToolCalls = sanitizeToolCallInputs(sanitizedThinking);
-  const repairedTools = policy.repairToolUseResultPairing
+  const toolCallRepair = repairToolCallInputs(sanitizedThinking);
+  const sanitizedToolCalls = toolCallRepair.messages;
+  // Always repair tool_use/tool_result pairing when tool calls were
+  // stripped — even if the provider policy does not normally require it —
+  // to prevent orphaned tool_result blocks from corrupting the session.
+  const needsPairingRepair =
+    policy.repairToolUseResultPairing || toolCallRepair.droppedToolCalls > 0;
+  const repairedTools = needsPairingRepair
     ? sanitizeToolUseResultPairing(sanitizedToolCalls)
     : sanitizedToolCalls;
 

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  repairToolCallInputs,
   sanitizeToolCallInputs,
   sanitizeToolUseResultPairing,
 } from "./session-transcript-repair.js";
@@ -146,5 +147,77 @@ describe("sanitizeToolCallInputs", () => {
       ? assistant.content.map((block) => (block as { type?: unknown }).type)
       : [];
     expect(types).toEqual(["text", "toolUse"]);
+  });
+
+  it("removes orphaned tool_result messages when their tool_use is stripped", () => {
+    // Reproduces the bug from #12392: when tool_use blocks without input
+    // are stripped but the corresponding tool_result messages survive, the
+    // API rejects with "unexpected tool_use_id" on every subsequent request,
+    // permanently corrupting the session.
+    const input: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me try" },
+          { type: "toolCall", id: "call_valid", name: "exec", arguments: { cmd: "ls" } },
+          { type: "toolCall", id: "call_broken", name: "exec" }, // no input
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_valid",
+        toolName: "exec",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_broken",
+        toolName: "exec",
+        content: [{ type: "text", text: "error" }],
+        isError: true,
+      },
+      { role: "user", content: "what happened?" },
+    ];
+
+    const report = repairToolCallInputs(input);
+    // The tool_use "call_broken" (no input) should be stripped, AND its
+    // tool_result should also be removed to maintain the pairing invariant.
+    expect(report.droppedToolCalls).toBe(1);
+    const roles = report.messages.map((m) => m.role);
+    expect(roles).toEqual(["assistant", "toolResult", "user"]);
+    // The surviving tool_result must belong to the valid tool call.
+    expect((report.messages[1] as { toolCallId?: string }).toolCallId).toBe("call_valid");
+  });
+
+  it("drops all tool_results when the entire assistant message is removed", () => {
+    const input: AgentMessage[] = [
+      { role: "user", content: "run it" },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_a", name: "exec" }, // no input
+          { type: "toolCall", id: "call_b", name: "exec" }, // no input
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_a",
+        toolName: "exec",
+        content: [{ type: "text", text: "failed" }],
+        isError: true,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_b",
+        toolName: "exec",
+        content: [{ type: "text", text: "failed" }],
+        isError: true,
+      },
+      { role: "user", content: "what happened?" },
+    ];
+
+    const out = sanitizeToolCallInputs(input);
+    expect(out.map((m) => m.role)).toEqual(["user", "user"]);
   });
 });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -127,8 +127,9 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
         droppedToolCalls += 1;
         droppedInMessage += 1;
         changed = true;
-        if (typeof block.id === "string" && block.id) {
-          strippedToolCallIds.add(block.id);
+        const toolBlock = block as ToolCallBlock;
+        if (typeof toolBlock.id === "string" && toolBlock.id) {
+          strippedToolCallIds.add(toolBlock.id);
         }
         continue;
       }
@@ -154,7 +155,7 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
     out = [];
     for (const msg of intermediate) {
       if (msg && typeof msg === "object" && msg.role === "toolResult") {
-        const id = extractToolResultId(msg as Extract<AgentMessage, { role: "toolResult" }>);
+        const id = extractToolResultId(msg);
         if (id && strippedToolCallIds.has(id)) {
           changed = true;
           continue;

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -101,16 +101,21 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
   let droppedToolCalls = 0;
   let droppedAssistantMessages = 0;
   let changed = false;
-  const out: AgentMessage[] = [];
+  const intermediate: AgentMessage[] = [];
+  // Track tool_use IDs that were stripped so we can also remove their
+  // orphaned tool_result messages.  Without this, the next API call will
+  // be rejected because tool_result references a tool_use_id that no
+  // longer exists in the transcript.
+  const strippedToolCallIds = new Set<string>();
 
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") {
-      out.push(msg);
+      intermediate.push(msg);
       continue;
     }
 
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
-      out.push(msg);
+      intermediate.push(msg);
       continue;
     }
 
@@ -122,6 +127,9 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
         droppedToolCalls += 1;
         droppedInMessage += 1;
         changed = true;
+        if (typeof block.id === "string" && block.id) {
+          strippedToolCallIds.add(block.id);
+        }
         continue;
       }
       nextContent.push(block);
@@ -133,11 +141,29 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
         changed = true;
         continue;
       }
-      out.push({ ...msg, content: nextContent });
+      intermediate.push({ ...msg, content: nextContent });
       continue;
     }
 
-    out.push(msg);
+    intermediate.push(msg);
+  }
+
+  // Second pass: remove tool_result messages whose tool_use was stripped.
+  let out: AgentMessage[];
+  if (strippedToolCallIds.size > 0) {
+    out = [];
+    for (const msg of intermediate) {
+      if (msg && typeof msg === "object" && msg.role === "toolResult") {
+        const id = extractToolResultId(msg as Extract<AgentMessage, { role: "toolResult" }>);
+        if (id && strippedToolCallIds.has(id)) {
+          changed = true;
+          continue;
+        }
+      }
+      out.push(msg);
+    }
+  } else {
+    out = intermediate;
   }
 
   return {


### PR DESCRIPTION
## Summary

When the Anthropic API rejects a request with a "Cloud Code Assist format error", the retry path calls `sanitizeToolCallInputs()` to strip malformed `tool_use` blocks (those missing `input`/`arguments`). However, the corresponding `tool_result` messages — which reference the now-removed `tool_use` IDs — were left in the transcript. Every subsequent API call is then permanently rejected with:

```
unexpected tool_use_id found in tool_result blocks: <id>.
Each tool_result block must have a corresponding tool_use block in the previous message.
```

The only recovery was `/new` or `/reset`.

## Changes

- **`src/agents/session-transcript-repair.ts`** — `repairToolCallInputs()` now tracks the IDs of stripped `tool_use` blocks and runs a second pass to remove any `tool_result` messages that reference those IDs
- **`src/agents/pi-embedded-runner/google.ts`** — `sanitizeSessionHistory()` now always calls `sanitizeToolUseResultPairing()` after `repairToolCallInputs()` when tool calls were dropped, even if the provider policy does not normally require pairing repair. This is a safety net to catch any edge cases the first pass might miss.
- **`src/agents/session-transcript-repair.test.ts`** — Two new test cases:
  - Verifies that orphaned `tool_result` messages are removed when their `tool_use` is stripped (partial strip)
  - Verifies that all `tool_result` messages are removed when the entire assistant message is dropped (full strip)

## Test plan

- All 8 existing + new tests in `session-transcript-repair.test.ts` pass
- After a Cloud Code Assist format error, retries no longer accumulate orphaned `tool_result` blocks
- Sessions no longer become permanently corrupted after format error retries
- Normal tool_use/tool_result pairing is unaffected (existing tests verify this)

Fixes #12392

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes transcript corruption on retry after a tool-call format error by ensuring that when malformed `tool_use` / `toolCall` blocks are stripped, any corresponding `tool_result` messages that reference the removed IDs are also removed. Concretely, `repairToolCallInputs()` now tracks stripped tool-call IDs and runs a second pass to drop matching `toolResult` entries, preventing strict providers from rejecting subsequent requests due to “unexpected tool_use_id”.

It also strengthens the Google embedded runner’s session sanitization by running tool-use/tool-result pairing repair whenever any tool calls were dropped, even if the provider policy wouldn’t normally require pairing repair, acting as a safety net for edge cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to transcript repair/sanitization logic, add targeted tests for the reported corruption scenario, and do not introduce new behavioral complexity beyond removing invalid tool_result entries that would otherwise make strict providers reject requests.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->