### PR TITLE
fix(config): add missing customBindHost to gateway Zod schema 

### DIFF
--- a/src/config/config.gateway-custom-bind-host.test.ts
+++ b/src/config/config.gateway-custom-bind-host.test.ts
@@ -13,11 +13,14 @@ describe("gateway.customBindHost", () => {
     expect(res.ok).toBe(true);
   });
 
-  it("accepts customBindHost without bind mode", async () => {
+  it("accepts customBindHost with lan bind mode", async () => {
+    // customBindHost is documented for bind="custom", but Zod validates
+    // schema shape only - runtime handles semantic validation.
     vi.resetModules();
     const { validateConfigObject } = await import("./config.js");
     const res = validateConfigObject({
       gateway: {
+        bind: "lan",
         customBindHost: "10.0.0.5",
       },
     });

--- a/src/config/config.gateway-custom-bind-host.test.ts
+++ b/src/config/config.gateway-custom-bind-host.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("gateway.customBindHost", () => {
+  it("accepts custom bind mode with customBindHost", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "192.168.1.100",
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts customBindHost without bind mode", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      gateway: {
+        customBindHost: "10.0.0.5",
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts customBindHost with 0.0.0.0", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "0.0.0.0",
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -377,6 +377,7 @@ export const OpenClawSchema = z
             z.literal("tailnet"),
           ])
           .optional(),
+        customBindHost: z.string().optional(),
         controlUi: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Add `customBindHost: z.string().optional()` to the gateway object in `src/config/zod-schema.ts`
- Add test coverage for `customBindHost` with various bind modes

Fixes #5435

## Context

`gateway.customBindHost` is defined in the TypeScript type (`src/config/types.gateway.ts:233`) and used across onboarding, dashboard, doctor, status, and gateway runtime, but missing from the Zod schema. Since the schema uses  `.strict()`, any config containing `customBindHost` fails validation with `Unrecognized key: "customBindHost"`.

Previously submitted as PR #5534, which was auto-closed by triage bot.

## Test plan

- [ ] `pnpm test src/config/config.gateway-custom-bind-host.test.ts` passes
- [ ] Existing config tests unaffected

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the config validation schema (`src/config/zod-schema.ts`) to accept the existing `gateway.customBindHost` field (already present in the Gateway config type) and adds a Vitest ensuring configs containing `gateway.customBindHost` no longer fail Zod `.strict()` validation.

Net effect: users can include `gateway.customBindHost` in their config without receiving an “unrecognized key” validation error during `validateConfigObject()` (which parses configs via `OpenClawSchema.safeParse()`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped (one optional schema field + a small unit test) and matches the existing config type usage; no runtime behavior changes beyond allowing previously-rejected config keys.
- src/config/config.gateway-custom-bind-host.test.ts (test isolation)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->