### PR TITLE
status: mask phone numbers in terminal channel output

### DIFF
--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -191,6 +191,19 @@ const buildAccountNotes = (params: {
   return notes;
 };
 
+function maskPhoneNumber(value: string): string {
+  const trimmed = value.trim();
+  const hasPlus = trimmed.startsWith("+");
+  const digits = trimmed.replace(/\D/g, "");
+  if (digits.length <= 4) {
+    return hasPlus ? `+${digits}` : digits;
+  }
+  const head = digits.slice(0, Math.min(3, Math.max(1, digits.length - 2)));
+  const tail = digits.slice(-2);
+  const stars = "*".repeat(Math.max(2, digits.length - head.length - tail.length));
+  return `${hasPlus ? "+" : ""}${head}${stars}${tail}`;
+}
+
 function resolveLinkFields(summary: unknown): {
   linked: boolean | null;
   authAgeMs: number | null;
@@ -433,7 +446,7 @@ export async function buildChannelsTable(
         const base = link.linked ? "linked" : "not linked";
         const extra: string[] = [];
         if (link.linked && link.selfE164) {
-          extra.push(link.selfE164);
+          extra.push(maskPhoneNumber(link.selfE164));
         }
         if (link.linked && link.authAgeMs != null && link.authAgeMs >= 0) {
           extra.push(`auth ${formatTimeAgo(link.authAgeMs)}`);


### PR DESCRIPTION
Mask phone numbers in terminal status output so full WhatsApp/E.164 numbers are not exposed in clear text.

Changes:
- status-all/channels: mask linked self phone
- channels/status: mask allowFrom phone samples

Why: reduce accidental disclosure risk while preserving operator context.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates CLI status output to avoid printing full phone numbers in clear text. Specifically:
- `channels status` now masks `allowFrom` sample entries when they look like phone numbers.
- `status --all` channel table now masks the linked account’s `selfE164` value before rendering.

The changes are localized to terminal output formatting and don’t affect gateway calls or persisted configuration; they only modify what operators see in status output.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge; changes are output-only but redaction strength likely needs adjustment to meet the stated disclosure-reduction goal.
- The PR is small and limited to terminal formatting, so runtime risk is low. The main concern is functional: the current masking still exposes a stable prefix+suffix that may be considered sensitive given the PR’s purpose; if the project expects stronger redaction, this should be updated before merge.
- src/commands/channels/status.ts; src/commands/status-all/channels.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->