### PR TITLE
voice-call: add Asterisk ARI provider + core STT

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -110,6 +110,7 @@ const VoiceCallToolSchema = Type.Union([
   Type.Object({
     action: Type.Literal("initiate_call"),
     to: Type.Optional(Type.String({ description: "Call target" })),
+    fromName: Type.Optional(Type.String({ description: "Caller display name (e.g. agent name)" })),
     message: Type.String({ description: "Intro message" }),
     mode: Type.Optional(Type.Union([Type.Literal("notify"), Type.Literal("conversation")])),
   }),
@@ -359,6 +360,7 @@ const voiceCallPlugin = {
                     params.mode === "notify" || params.mode === "conversation"
                       ? params.mode
                       : undefined,
+                  fromName: typeof (params as any).fromName === "string" ? String((params as any).fromName) : undefined,
                 });
                 if (!result.success) {
                   throw new Error(result.error || "initiate failed");

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -360,7 +360,10 @@ const voiceCallPlugin = {
                     params.mode === "notify" || params.mode === "conversation"
                       ? params.mode
                       : undefined,
-                  fromName: typeof (params as any).fromName === "string" ? String((params as any).fromName) : undefined,
+                  fromName:
+                    typeof (params as any).fromName === "string"
+                      ? String((params as any).fromName)
+                      : undefined,
                 });
                 if (!result.success) {
                   throw new Error(result.error || "initiate failed");

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -361,8 +361,8 @@ const voiceCallPlugin = {
                       ? params.mode
                       : undefined,
                   fromName:
-                    typeof (params as any).fromName === "string"
-                      ? String((params as any).fromName)
+                    typeof (params as { fromName?: unknown }).fromName === "string"
+                      ? String((params as { fromName?: unknown }).fromName)
                       : undefined,
                 });
                 if (!result.success) {

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -168,7 +168,7 @@
       },
       "provider": {
         "type": "string",
-        "enum": ["telnyx", "twilio", "plivo", "mock"]
+        "enum": ["telnyx", "twilio", "plivo", "mock", "asterisk-ari"]
       },
       "telnyx": {
         "type": "object",
@@ -207,6 +207,20 @@
           "authToken": {
             "type": "string"
           }
+        }
+      },
+      "asteriskAri": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "baseUrl": { "type": "string" },
+          "username": { "type": "string" },
+          "password": { "type": "string" },
+          "app": { "type": "string" },
+          "trunk": { "type": "string" },
+          "rtpHost": { "type": "string" },
+          "rtpPort": { "type": "integer", "minimum": 1024, "maximum": 65535 },
+          "format": { "type": "string", "enum": ["ulaw", "alaw"] }
         }
       },
       "fromNumber": {

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -220,7 +220,7 @@
           "trunk": { "type": "string" },
           "rtpHost": { "type": "string" },
           "rtpPort": { "type": "integer", "minimum": 1024, "maximum": 65535 },
-          "format": { "type": "string", "enum": ["ulaw", "alaw"] }
+          "codec": { "type": "string", "enum": ["ulaw", "alaw"] }
         }
       },
       "fromNumber": {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -524,7 +524,7 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     if (!a?.password)
       errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
     if (!a?.app) errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
-    if (!a?.trunk) errors.push("plugins.entries.voice-call.config.asteriskAri.trunk is required");
+    // trunk is optional: if set, outbound calls dial via PJSIP/<trunk>/<to>; otherwise PJSIP/<to>
     if (!a?.rtpHost)
       errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
   }

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -211,36 +211,15 @@ export const VoiceCallTunnelConfigSchema = z
      * will be allowed only for loopback requests (ngrok local agent).
      */
     allowNgrokFreeTierLoopbackBypass: z.boolean().default(false),
+    /**
+     * Legacy ngrok free tier compatibility mode (deprecated).
+     * Use allowNgrokFreeTierLoopbackBypass instead.
+     */
+    allowNgrokFreeTier: z.boolean().optional(),
   })
   .strict()
   .default({ provider: "none", allowNgrokFreeTierLoopbackBypass: false });
 export type VoiceCallTunnelConfig = z.infer<typeof VoiceCallTunnelConfigSchema>;
-
-// -----------------------------------------------------------------------------
-// Webhook Security Configuration
-// -----------------------------------------------------------------------------
-
-export const VoiceCallWebhookSecurityConfigSchema = z
-  .object({
-    /**
-     * Allowed hostnames for webhook URL reconstruction.
-     * Only these hosts are accepted from forwarding headers.
-     */
-    allowedHosts: z.array(z.string().min(1)).default([]),
-    /**
-     * Trust X-Forwarded-* headers without a hostname allowlist.
-     * WARNING: Only enable if you trust your proxy configuration.
-     */
-    trustForwardingHeaders: z.boolean().default(false),
-    /**
-     * Trusted proxy IP addresses. Forwarded headers are only trusted when
-     * the remote IP matches one of these addresses.
-     */
-    trustedProxyIPs: z.array(z.string().min(1)).default([]),
-  })
-  .strict()
-  .default({ allowedHosts: [], trustForwardingHeaders: false, trustedProxyIPs: [] });
-export type WebhookSecurityConfig = z.infer<typeof VoiceCallWebhookSecurityConfigSchema>;
 
 // -----------------------------------------------------------------------------
 // Outbound Call Configuration
@@ -301,13 +280,33 @@ export type VoiceCallStreamingConfig = z.infer<typeof VoiceCallStreamingConfigSc
 // Main Voice Call Configuration
 // -----------------------------------------------------------------------------
 
+export const AsteriskAriConfigSchema = z
+  .object({
+    /** ARI base URL, e.g. http://10.8.0.1:8088 */
+    baseUrl: z.string().min(1),
+    username: z.string().min(1),
+    password: z.string().min(1),
+    /** Stasis app name */
+    app: z.string().min(1),
+    /** Trunk name for GSM, e.g. gsmtrunk */
+    trunk: z.string().min(1),
+    /** Where Asterisk should send RTP for ExternalMedia */
+    rtpHost: z.string().min(1),
+    /** Local UDP port to receive RTP from Asterisk */
+    rtpPort: z.number().int().min(1024).max(65535).default(12000),
+    /** RTP payload format; use ulaw for PCMU */
+    format: z.enum(["ulaw", "alaw"]).default("ulaw"),
+  })
+  .strict();
+export type AsteriskAriConfig = z.infer<typeof AsteriskAriConfigSchema>;
+
 export const VoiceCallConfigSchema = z
   .object({
     /** Enable voice call functionality */
     enabled: z.boolean().default(false),
 
-    /** Active provider (telnyx, twilio, plivo, or mock) */
-    provider: z.enum(["telnyx", "twilio", "plivo", "mock"]).optional(),
+    /** Active provider (telnyx, twilio, plivo, mock, or asterisk-ari) */
+    provider: z.enum(["telnyx", "twilio", "plivo", "mock", "asterisk-ari"]).optional(),
 
     /** Telnyx-specific configuration */
     telnyx: TelnyxConfigSchema.optional(),
@@ -317,6 +316,9 @@ export const VoiceCallConfigSchema = z
 
     /** Plivo-specific configuration */
     plivo: PlivoConfigSchema.optional(),
+
+    /** Asterisk ARI (SIP/GSM via Asterisk) */
+    asteriskAri: AsteriskAriConfigSchema.optional(),
 
     /** Phone number to call from (E.164) */
     fromNumber: E164Schema.optional(),
@@ -359,9 +361,6 @@ export const VoiceCallConfigSchema = z
 
     /** Tunnel configuration (unified ngrok/tailscale) */
     tunnel: VoiceCallTunnelConfigSchema,
-
-    /** Webhook signature reconstruction and proxy trust configuration */
-    webhookSecurity: VoiceCallWebhookSecurityConfigSchema,
 
     /** Real-time audio streaming configuration */
     streaming: VoiceCallStreamingConfigSchema,
@@ -427,26 +426,29 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
     resolved.plivo.authToken = resolved.plivo.authToken ?? process.env.PLIVO_AUTH_TOKEN;
   }
 
+  // Asterisk ARI
+  if (resolved.provider === "asterisk-ari") {
+    resolved.asteriskAri = resolved.asteriskAri ?? {
+      baseUrl: process.env.ASTERISK_ARI_BASE_URL || "",
+      username: process.env.ASTERISK_ARI_USERNAME || "",
+      password: process.env.ASTERISK_ARI_PASSWORD || "",
+      app: process.env.ASTERISK_ARI_APP || "",
+      trunk: process.env.ASTERISK_ARI_TRUNK || "",
+      rtpHost: process.env.ASTERISK_ARI_RTP_HOST || "",
+      rtpPort: process.env.ASTERISK_ARI_RTP_PORT ? Number(process.env.ASTERISK_ARI_RTP_PORT) : 12000,
+      format: (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) || "ulaw",
+    };
+  }
+
   // Tunnel Config
   resolved.tunnel = resolved.tunnel ?? {
     provider: "none",
     allowNgrokFreeTierLoopbackBypass: false,
   };
   resolved.tunnel.allowNgrokFreeTierLoopbackBypass =
-    resolved.tunnel.allowNgrokFreeTierLoopbackBypass ?? false;
+    resolved.tunnel.allowNgrokFreeTierLoopbackBypass || resolved.tunnel.allowNgrokFreeTier || false;
   resolved.tunnel.ngrokAuthToken = resolved.tunnel.ngrokAuthToken ?? process.env.NGROK_AUTHTOKEN;
   resolved.tunnel.ngrokDomain = resolved.tunnel.ngrokDomain ?? process.env.NGROK_DOMAIN;
-
-  // Webhook Security Config
-  resolved.webhookSecurity = resolved.webhookSecurity ?? {
-    allowedHosts: [],
-    trustForwardingHeaders: false,
-    trustedProxyIPs: [],
-  };
-  resolved.webhookSecurity.allowedHosts = resolved.webhookSecurity.allowedHosts ?? [];
-  resolved.webhookSecurity.trustForwardingHeaders =
-    resolved.webhookSecurity.trustForwardingHeaders ?? false;
-  resolved.webhookSecurity.trustedProxyIPs = resolved.webhookSecurity.trustedProxyIPs ?? [];
 
   return resolved;
 }
@@ -468,7 +470,7 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     errors.push("plugins.entries.voice-call.config.provider is required");
   }
 
-  if (!config.fromNumber && config.provider !== "mock") {
+  if (!config.fromNumber && config.provider !== "mock" && config.provider !== "asterisk-ari") {
     errors.push("plugins.entries.voice-call.config.fromNumber is required");
   }
 
@@ -481,14 +483,6 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     if (!config.telnyx?.connectionId) {
       errors.push(
         "plugins.entries.voice-call.config.telnyx.connectionId is required (or set TELNYX_CONNECTION_ID env)",
-      );
-    }
-    if (
-      (config.inboundPolicy === "allowlist" || config.inboundPolicy === "pairing") &&
-      !config.telnyx?.publicKey
-    ) {
-      errors.push(
-        "plugins.entries.voice-call.config.telnyx.publicKey is required for inboundPolicy allowlist/pairing",
       );
     }
   }
@@ -517,6 +511,16 @@ export function validateProviderConfig(config: VoiceCallConfig): {
         "plugins.entries.voice-call.config.plivo.authToken is required (or set PLIVO_AUTH_TOKEN env)",
       );
     }
+  }
+
+  if (config.provider === "asterisk-ari") {
+    const a = config.asteriskAri;
+    if (!a?.baseUrl) errors.push("plugins.entries.voice-call.config.asteriskAri.baseUrl is required");
+    if (!a?.username) errors.push("plugins.entries.voice-call.config.asteriskAri.username is required");
+    if (!a?.password) errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
+    if (!a?.app) errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
+    if (!a?.trunk) errors.push("plugins.entries.voice-call.config.asteriskAri.trunk is required");
+    if (!a?.rtpHost) errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
   }
 
   return { valid: errors.length === 0, errors };

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -444,20 +444,59 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
 
   // Asterisk ARI
   if (resolved.provider === "asterisk-ari") {
-    const trunkEnv = (process.env.ASTERISK_ARI_TRUNK || "").trim();
-
     resolved.asteriskAri = resolved.asteriskAri ?? {
-      baseUrl: process.env.ASTERISK_ARI_BASE_URL || "",
-      username: process.env.ASTERISK_ARI_USERNAME || "",
-      password: process.env.ASTERISK_ARI_PASSWORD || "",
-      app: process.env.ASTERISK_ARI_APP || "",
-      ...(trunkEnv ? { trunk: trunkEnv } : {}),
-      rtpHost: process.env.ASTERISK_ARI_RTP_HOST || "",
-      rtpPort: process.env.ASTERISK_ARI_RTP_PORT
-        ? Number(process.env.ASTERISK_ARI_RTP_PORT)
-        : 12000,
-      codec: (process.env.ASTERISK_ARI_CODEC as "ulaw" | "alaw" | undefined) || "ulaw",
+      baseUrl: "",
+      username: "",
+      password: "",
+      app: "",
+      rtpHost: "",
+      rtpPort: 12000,
+      codec: "ulaw",
     };
+
+    // Apply env overrides in a validated/coerced way so bad env values don't break runtime.
+    const trunkEnv = (process.env.ASTERISK_ARI_TRUNK || "").trim();
+    if (trunkEnv) {
+      resolved.asteriskAri.trunk = trunkEnv;
+    }
+
+    const baseUrlEnv = (process.env.ASTERISK_ARI_BASE_URL || "").trim();
+    if (baseUrlEnv) {
+      resolved.asteriskAri.baseUrl = baseUrlEnv;
+    }
+
+    const userEnv = (process.env.ASTERISK_ARI_USERNAME || "").trim();
+    if (userEnv) {
+      resolved.asteriskAri.username = userEnv;
+    }
+
+    const passEnv = (process.env.ASTERISK_ARI_PASSWORD || "").trim();
+    if (passEnv) {
+      resolved.asteriskAri.password = passEnv;
+    }
+
+    const appEnv = (process.env.ASTERISK_ARI_APP || "").trim();
+    if (appEnv) {
+      resolved.asteriskAri.app = appEnv;
+    }
+
+    const rtpHostEnv = (process.env.ASTERISK_ARI_RTP_HOST || "").trim();
+    if (rtpHostEnv) {
+      resolved.asteriskAri.rtpHost = rtpHostEnv;
+    }
+
+    const portEnv = (process.env.ASTERISK_ARI_RTP_PORT || "").trim();
+    if (portEnv) {
+      const portNum = Number(portEnv);
+      if (Number.isInteger(portNum) && portNum >= 1024 && portNum <= 65535) {
+        resolved.asteriskAri.rtpPort = portNum;
+      }
+    }
+
+    const codecEnv = (process.env.ASTERISK_ARI_CODEC || "").trim();
+    if (codecEnv === "ulaw" || codecEnv === "alaw") {
+      resolved.asteriskAri.codec = codecEnv;
+    }
   }
 
   // Tunnel Config

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -503,6 +503,14 @@ export function validateProviderConfig(config: VoiceCallConfig): {
         "plugins.entries.voice-call.config.telnyx.connectionId is required (or set TELNYX_CONNECTION_ID env)",
       );
     }
+    if (
+      (config.inboundPolicy === "allowlist" || config.inboundPolicy === "pairing") &&
+      !config.telnyx?.publicKey
+    ) {
+      errors.push(
+        "plugins.entries.voice-call.config.telnyx.publicKey is required for inboundPolicy allowlist/pairing",
+      );
+    }
   }
 
   if (config.provider === "twilio") {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -533,16 +533,22 @@ export function validateProviderConfig(config: VoiceCallConfig): {
 
   if (config.provider === "asterisk-ari") {
     const a = config.asteriskAri;
-    if (!a?.baseUrl)
+    if (!a?.baseUrl) {
       errors.push("plugins.entries.voice-call.config.asteriskAri.baseUrl is required");
-    if (!a?.username)
+    }
+    if (!a?.username) {
       errors.push("plugins.entries.voice-call.config.asteriskAri.username is required");
-    if (!a?.password)
+    }
+    if (!a?.password) {
       errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
-    if (!a?.app) errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
+    }
+    if (!a?.app) {
+      errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
+    }
     // trunk is optional: if set, outbound calls dial via PJSIP/<trunk>/<to>; otherwise PJSIP/<to>
-    if (!a?.rtpHost)
+    if (!a?.rtpHost) {
       errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
+    }
   }
 
   return { valid: errors.length === 0, errors };

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -158,6 +158,19 @@ export type VoiceCallTtsConfig = z.infer<typeof TtsConfigSchema>;
 // Webhook Server Configuration
 // -----------------------------------------------------------------------------
 
+export const WebhookSecurityConfigSchema = z
+  .object({
+    /** Host allowlist (compared against request Host / forwarded host) */
+    allowedHosts: z.array(z.string().min(1)).default([]),
+    /** Whether to trust X-Forwarded-* style headers */
+    trustForwardingHeaders: z.boolean().default(false),
+    /** Allowlist of trusted reverse proxy IPs (required when trusting forwarded headers) */
+    trustedProxyIPs: z.array(z.string().min(1)).default([]),
+  })
+  .strict()
+  .default({ allowedHosts: [], trustForwardingHeaders: false, trustedProxyIPs: [] });
+export type WebhookSecurityConfig = z.infer<typeof WebhookSecurityConfigSchema>;
+
 export const VoiceCallServeConfigSchema = z
   .object({
     /** Port to listen on */
@@ -361,6 +374,9 @@ export const VoiceCallConfigSchema = z
 
     /** Tunnel configuration (unified ngrok/tailscale) */
     tunnel: VoiceCallTunnelConfigSchema,
+
+    /** Webhook security options (forwarded headers / host allowlist) */
+    webhookSecurity: WebhookSecurityConfigSchema,
 
     /** Real-time audio streaming configuration */
     streaming: VoiceCallStreamingConfigSchema,

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -435,7 +435,9 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
       app: process.env.ASTERISK_ARI_APP || "",
       trunk: process.env.ASTERISK_ARI_TRUNK || "",
       rtpHost: process.env.ASTERISK_ARI_RTP_HOST || "",
-      rtpPort: process.env.ASTERISK_ARI_RTP_PORT ? Number(process.env.ASTERISK_ARI_RTP_PORT) : 12000,
+      rtpPort: process.env.ASTERISK_ARI_RTP_PORT
+        ? Number(process.env.ASTERISK_ARI_RTP_PORT)
+        : 12000,
       format: (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) || "ulaw",
     };
   }
@@ -515,12 +517,16 @@ export function validateProviderConfig(config: VoiceCallConfig): {
 
   if (config.provider === "asterisk-ari") {
     const a = config.asteriskAri;
-    if (!a?.baseUrl) errors.push("plugins.entries.voice-call.config.asteriskAri.baseUrl is required");
-    if (!a?.username) errors.push("plugins.entries.voice-call.config.asteriskAri.username is required");
-    if (!a?.password) errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
+    if (!a?.baseUrl)
+      errors.push("plugins.entries.voice-call.config.asteriskAri.baseUrl is required");
+    if (!a?.username)
+      errors.push("plugins.entries.voice-call.config.asteriskAri.username is required");
+    if (!a?.password)
+      errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
     if (!a?.app) errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
     if (!a?.trunk) errors.push("plugins.entries.voice-call.config.asteriskAri.trunk is required");
-    if (!a?.rtpHost) errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
+    if (!a?.rtpHost)
+      errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
   }
 
   return { valid: errors.length === 0, errors };

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -444,12 +444,14 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
 
   // Asterisk ARI
   if (resolved.provider === "asterisk-ari") {
+    const trunkEnv = (process.env.ASTERISK_ARI_TRUNK || "").trim();
+
     resolved.asteriskAri = resolved.asteriskAri ?? {
       baseUrl: process.env.ASTERISK_ARI_BASE_URL || "",
       username: process.env.ASTERISK_ARI_USERNAME || "",
       password: process.env.ASTERISK_ARI_PASSWORD || "",
       app: process.env.ASTERISK_ARI_APP || "",
-      trunk: process.env.ASTERISK_ARI_TRUNK || "",
+      ...(trunkEnv ? { trunk: trunkEnv } : {}),
       rtpHost: process.env.ASTERISK_ARI_RTP_HOST || "",
       rtpPort: process.env.ASTERISK_ARI_RTP_PORT
         ? Number(process.env.ASTERISK_ARI_RTP_PORT)

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -301,8 +301,8 @@ export const AsteriskAriConfigSchema = z
     password: z.string().min(1),
     /** Stasis app name */
     app: z.string().min(1),
-    /** Trunk name for GSM, e.g. gsmtrunk */
-    trunk: z.string().min(1),
+    /** Trunk name for outbound dialing, e.g. gsmtrunk (optional; omit to dial PJSIP/<to> directly) */
+    trunk: z.string().min(1).optional(),
     /** Where Asterisk should send RTP for ExternalMedia */
     rtpHost: z.string().min(1),
     /** Local UDP port to receive RTP from Asterisk */

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -307,8 +307,11 @@ export const AsteriskAriConfigSchema = z
     rtpHost: z.string().min(1),
     /** Local UDP port to receive RTP from Asterisk */
     rtpPort: z.number().int().min(1024).max(65535).default(12000),
-    /** RTP payload format; use ulaw for PCMU */
-    format: z.enum(["ulaw", "alaw"]).default("ulaw"),
+    /** RTP payload codec; use ulaw for PCMU */
+    codec: z.enum(["ulaw", "alaw"]).default("ulaw"),
+
+    /** @deprecated Use `codec` instead. Kept for backward compatibility. */
+    format: z.enum(["ulaw", "alaw"]).optional(),
   })
   .strict();
 export type AsteriskAriConfig = z.infer<typeof AsteriskAriConfigSchema>;
@@ -456,7 +459,10 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
       rtpPort: process.env.ASTERISK_ARI_RTP_PORT
         ? Number(process.env.ASTERISK_ARI_RTP_PORT)
         : 12000,
-      format: (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) || "ulaw",
+      codec:
+        (process.env.ASTERISK_ARI_CODEC as "ulaw" | "alaw" | undefined) ||
+        (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) ||
+        "ulaw",
     };
   }
 

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -309,9 +309,6 @@ export const AsteriskAriConfigSchema = z
     rtpPort: z.number().int().min(1024).max(65535).default(12000),
     /** RTP payload codec; use ulaw for PCMU */
     codec: z.enum(["ulaw", "alaw"]).default("ulaw"),
-
-    /** @deprecated Use `codec` instead. Kept for backward compatibility. */
-    format: z.enum(["ulaw", "alaw"]).optional(),
   })
   .strict();
 export type AsteriskAriConfig = z.infer<typeof AsteriskAriConfigSchema>;
@@ -459,10 +456,7 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
       rtpPort: process.env.ASTERISK_ARI_RTP_PORT
         ? Number(process.env.ASTERISK_ARI_RTP_PORT)
         : 12000,
-      codec:
-        (process.env.ASTERISK_ARI_CODEC as "ulaw" | "alaw" | undefined) ||
-        (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) ||
-        "ulaw",
+      codec: (process.env.ASTERISK_ARI_CODEC as "ulaw" | "alaw" | undefined) || "ulaw",
     };
   }
 

--- a/extensions/voice-call/src/core-bridge.ts
+++ b/extensions/voice-call/src/core-bridge.ts
@@ -56,6 +56,12 @@ type CoreAgentDeps = {
     entry: unknown,
     opts?: { agentId?: string },
   ) => string;
+  transcribeAudioWithCore: (params: {
+    cfg: CoreConfig;
+    filePath?: string;
+    buffer?: Buffer;
+    mime?: string;
+  }) => Promise<{ text: string | null; provider?: string; model?: string }>;
   DEFAULT_MODEL: string;
   DEFAULT_PROVIDER: string;
 };
@@ -135,6 +141,7 @@ async function importCoreExtensionAPI(): Promise<{
   loadSessionStore: CoreAgentDeps["loadSessionStore"];
   saveSessionStore: CoreAgentDeps["saveSessionStore"];
   resolveSessionFilePath: CoreAgentDeps["resolveSessionFilePath"];
+  transcribeAudioWithCore: CoreAgentDeps["transcribeAudioWithCore"];
 }> {
   // Do not import any other module. You can't touch this or you will be fired.
   const distPath = path.join(resolveOpenClawRoot(), "dist", "extensionAPI.js");

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -564,7 +564,7 @@ export class CallManager {
         if (this.provider && event.providerCallId) {
           void this.provider
             .hangupCall({
-              callId: event.callId,
+              callId: event.providerCallId ?? event.callId,
               providerCallId: event.providerCallId,
               reason: "rejected",
             })

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -561,7 +561,7 @@ export class CallManager {
         if (this.provider && event.providerCallId) {
           void this.provider
             .hangupCall({
-              callId: event.providerCallId,
+              callId: event.callId,
               providerCallId: event.providerCallId,
               reason: "rejected",
             })

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -557,7 +557,22 @@ export class CallManager {
     if (!call && event.direction === "inbound" && event.providerCallId) {
       // Check if we should accept this inbound call
       if (!this.shouldAcceptInbound(event.from)) {
-        // TODO: Could hang up the call here
+        // Reject inbound call at provider level to avoid leaving callers ringing/connected.
+        if (this.provider && event.providerCallId) {
+          void this.provider
+            .hangupCall({
+              callId: event.providerCallId,
+              providerCallId: event.providerCallId,
+              reason: "rejected",
+            })
+            .catch((err) => {
+              console.warn(
+                `[voice-call] Failed to reject inbound call ${event.providerCallId}: ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              );
+            });
+        }
         return;
       }
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -480,11 +480,14 @@ export class CallManager {
 
       case "allowlist":
       case "pairing": {
-        const normalized = from?.replace(/\D/g, "") || "";
-        const allowed = (allowFrom || []).some((num) => {
-          const normalizedAllow = num.replace(/\D/g, "");
-          return normalized.endsWith(normalizedAllow) || normalizedAllow.endsWith(normalized);
-        });
+        if (!from) {
+          console.log("[voice-call] Inbound call rejected: missing caller ID");
+          return false;
+        }
+
+        const normalized = from.replace(/\D/g, "");
+        const allowed = (allowFrom || []).some((num) => num.replace(/\D/g, "") === normalized);
+
         const status = allowed ? "accepted" : "rejected";
         console.log(
           `[voice-call] Inbound call ${status}: ${from} ${allowed ? "is in" : "not in"} allowlist`,

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -133,6 +133,8 @@ export class CallManager {
       return { callId: "", success: false, error: "fromNumber not configured" };
     }
 
+    const fromName = typeof opts.fromName === "string" ? opts.fromName.trim() : "";
+
     // Create call record with mode in metadata
     const callRecord: CallRecord = {
       callId,
@@ -166,6 +168,7 @@ export class CallManager {
       const result = await this.provider.initiateCall({
         callId,
         from,
+        ...(fromName ? { fromName } : {}),
         to,
         webhookUrl: this.webhookUrl,
         inlineTwiml,

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -47,7 +47,10 @@ export async function initiateCall(
 
   const callId = crypto.randomUUID();
   const from =
-    ctx.config.fromNumber || (ctx.provider?.name === "mock" ? "+15550000000" : undefined);
+    ctx.config.fromNumber ||
+    (ctx.provider?.name === "mock" || ctx.provider?.name === "asterisk-ari"
+      ? "+15550000000"
+      : undefined);
   if (!from) {
     return { callId: "", success: false, error: "fromNumber not configured" };
   }

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -55,6 +55,8 @@ export async function initiateCall(
     return { callId: "", success: false, error: "fromNumber not configured" };
   }
 
+  const fromName = typeof opts.fromName === "string" ? opts.fromName.trim() : "";
+
   const callRecord: CallRecord = {
     callId,
     provider: ctx.provider.name,
@@ -87,6 +89,7 @@ export async function initiateCall(
     const result = await ctx.provider.initiateCall({
       callId,
       from,
+      ...(fromName ? { fromName } : {}),
       to,
       webhookUrl: ctx.webhookUrl,
       inlineTwiml,

--- a/extensions/voice-call/src/providers/asterisk-ari.test.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import type { VoiceCallConfig } from "../config.js";
+import { AsteriskAriProvider, buildEndpoint } from "./asterisk-ari.js";
+
+function createProvider() {
+  const config = {
+    enabled: true,
+    provider: "asterisk-ari",
+    outbound: { defaultMode: "conversation" },
+    asteriskAri: {
+      baseUrl: "http://127.0.0.1:8088",
+      username: "user",
+      password: "pass",
+      app: "openclaw",
+      rtpHost: "127.0.0.1",
+      rtpPort: 12000,
+      codec: "ulaw",
+    },
+  } as unknown as VoiceCallConfig;
+
+  const managerStub = {
+    processEvent: () => undefined,
+    getCallByProviderCallId: () => undefined,
+    getCall: () => undefined,
+  } as any;
+
+  return new AsteriskAriProvider({ config, manager: managerStub });
+}
+
+describe("AsteriskAriProvider", () => {
+  it("verifyWebhook returns ok", () => {
+    const provider = createProvider();
+    const result = provider.verifyWebhook({
+      headers: {},
+      rawBody: "",
+      url: "http://localhost",
+      method: "POST",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("parseWebhookEvent returns empty events", () => {
+    const provider = createProvider();
+    const result = provider.parseWebhookEvent({
+      headers: {},
+      rawBody: "",
+      url: "http://localhost",
+      method: "POST",
+    });
+    expect(result.events).toHaveLength(0);
+  });
+});
+
+describe("asterisk-ari buildEndpoint", () => {
+  it("keeps explicit dialstrings", () => {
+    expect(buildEndpoint("PJSIP/1000")).toBe("PJSIP/1000");
+    expect(buildEndpoint("SIP/1234")).toBe("SIP/1234");
+  });
+
+  it("builds PJSIP endpoint without trunk", () => {
+    expect(buildEndpoint("1000")).toBe("PJSIP/1000");
+  });
+
+  it("builds PJSIP endpoint with trunk", () => {
+    expect(buildEndpoint("1000", "trunk-1")).toBe("PJSIP/trunk-1/1000");
+  });
+});

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -132,11 +132,12 @@ export class AsteriskAriProvider implements VoiceCallProvider {
     }
 
     // 2. Originate call
+    const callerId = input.fromName ? `${input.fromName} <${input.from}>` : input.from;
     const ch = await this.client.createChannel({
       endpoint,
       app: this.cfg.app,
       appArgs: providerCallId,
-      callerId: input.fromName ? `${input.fromName} <${input.from}>` : undefined,
+      callerId,
     });
 
     const state: CallState = {

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -641,6 +641,10 @@ export class AsteriskAriProvider implements VoiceCallProvider {
 
     const enqueue = (pcm: Buffer) => {
       if (pendingSegments >= maxPendingSegments) {
+        console.warn("[ari] STT backpressure: dropping segment", {
+          pendingSegments,
+          maxPendingSegments,
+        });
         return;
       }
       pendingSegments += 1;
@@ -695,6 +699,10 @@ export class AsteriskAriProvider implements VoiceCallProvider {
           return;
         }
         if (bufferBytes >= maxBufferBytes) {
+          console.warn("[ari] STT buffer limit reached, flushing", {
+            bufferBytes,
+            maxBufferBytes,
+          });
           flush();
           return;
         }

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -172,7 +172,16 @@ export class AsteriskAriProvider implements VoiceCallProvider {
   async hangupCall(input: HangupCallInput): Promise<void> {
     const state = this.calls.get(input.providerCallId);
     if (!state) {
-      await this.client.safeHangupChannel(input.providerCallId).catch(() => {});
+      const call = this.manager.getCall(input.callId);
+      const channelId = call?.providerCallId ?? input.providerCallId;
+      if (!channelId) {
+        console.warn("[ari] hangup skipped; missing channel id", {
+          callId: input.callId,
+          providerCallId: input.providerCallId,
+        });
+        return;
+      }
+      await this.client.safeHangupChannel(channelId).catch(() => {});
       return;
     }
 

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -735,8 +735,8 @@ export class AsteriskAriProvider implements VoiceCallProvider {
     if (!sipChannelId) return;
 
     const providerCallId = sipChannelId;
-    const from = evt.channel?.caller?.number || "unknown";
-    const to = evt.channel?.name || "unknown";
+    const from = evt.channel?.caller?.number;
+    const to = evt.channel?.name;
 
     this.manager.processEvent(
       makeEvent({

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -492,11 +492,8 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       }),
     );
 
-    // Speak greeting for inbound
-    if (!params.isOutbound) {
-      const greeting = "Czesc. Tu Eryk.";
-      await this.playTts({ callId: st.callId, providerCallId, text: greeting } as any);
-    }
+    // For inbound calls, do not auto-speak here.
+    // Let the higher-level CallManager / response generator decide what (if anything) to say.
   }
 
   async initiateCall(input: InitiateCallInput): Promise<InitiateCallResult> {

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -225,6 +225,10 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       // Only accept from learned peer.
       if (st.rtpPeer.address !== rinfo.address || st.rtpPeer.port !== rinfo.port) continue;
 
+      if (st.speaking) {
+        return;
+      }
+
       if (st.stt) {
         st.stt.sendAudio(payload);
       }
@@ -379,6 +383,7 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       query: {
         endpoint,
         app: this.cfg.app,
+        callerId: input.fromName ? `${input.fromName} <${input.from}>` : undefined,
       },
     });
 

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -212,11 +212,17 @@ export class AsteriskAriProvider implements VoiceCallProvider {
 
     for (const ch of channels) {
       const chObj = ch as Record<string, unknown>;
-      const id = String(chObj.id || "");
-      const name = String(chObj.name || "");
-      const dp = (chObj.dialplan as Record<string, unknown> | undefined) || undefined;
-      const appName = String(dp?.app_name || "");
-      const appData = String(dp?.app_data || "");
+
+      const id = typeof chObj.id === "string" ? chObj.id : "";
+      const name = typeof chObj.name === "string" ? chObj.name : "";
+
+      const dp =
+        typeof chObj.dialplan === "object" && chObj.dialplan
+          ? (chObj.dialplan as Record<string, unknown>)
+          : undefined;
+
+      const appName = typeof dp?.app_name === "string" ? dp.app_name : "";
+      const appData = typeof dp?.app_data === "string" ? dp.app_data : "";
       if (!id || !name) {
         continue;
       }
@@ -252,6 +258,10 @@ export class AsteriskAriProvider implements VoiceCallProvider {
     });
     this.ws.on("message", (data) => {
       let evt: AriEvent | null = null;
+      if (!(typeof data === "string" || Buffer.isBuffer(data))) {
+        return;
+      }
+
       try {
         evt = JSON.parse(data.toString());
       } catch {

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -250,6 +250,24 @@ export class AsteriskAriProvider implements VoiceCallProvider {
           });
         }
       }
+    } else if (evt.type === "ChannelDtmfReceived") {
+      const chId = evt.channel?.id;
+      const digit = evt.digit;
+      if (!chId || !digit) return;
+
+      for (const state of this.calls.values()) {
+        if (state.sipChannelId === chId) {
+          this.manager.processEvent(
+            makeEvent({
+              type: "call.dtmf",
+              callId: state.callId,
+              providerCallId: state.providerCallId,
+              digits: digit,
+            }),
+          );
+          break;
+        }
+      }
     } else if (evt.type === "StasisEnd") {
       const chId = evt.channel?.id;
       for (const [pId, state] of this.calls.entries()) {

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -163,7 +163,10 @@ export class AsteriskAriProvider implements VoiceCallProvider {
 
   async hangupCall(input: HangupCallInput): Promise<void> {
     const state = this.calls.get(input.providerCallId);
-    if (!state) return;
+    if (!state) {
+      await this.client.safeHangupChannel(input.providerCallId).catch(() => {});
+      return;
+    }
 
     await this.client.safeHangupChannel(state.sipChannelId);
     await this.cleanup(input.providerCallId, input.reason);

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -1,9 +1,8 @@
 import crypto from "node:crypto";
-import dgram from "node:dgram";
-import WebSocket from "ws";
 import type { VoiceCallConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import type {
+  EndReason,
   HangupCallInput,
   InitiateCallInput,
   InitiateCallResult,
@@ -16,82 +15,24 @@ import type {
   NormalizedEvent,
 } from "../types.js";
 import type { VoiceCallProvider } from "./base.js";
-import { convertPcmToMulaw8k, chunkAudio } from "../telephony-audio.js";
-
-function alawToMulawByte(aLaw: number): number {
-  // Standard G.711 A-law to linear PCM conversion, then PCM to mu-law.
-  // Implementation based on common reference algorithms (no deps).
-  let a = aLaw ^ 0x55;
-  let t = (a & 0x0f) << 4;
-  const seg = (a & 0x70) >> 4;
-  switch (seg) {
-    case 0:
-      t += 8;
-      break;
-    case 1:
-      t += 0x108;
-      break;
-    default:
-      t += 0x108;
-      t <<= seg - 1;
-      break;
-  }
-  const pcm = a & 0x80 ? t : -t;
-
-  // PCM16 -> mu-law
-  const MU_LAW_MAX = 0x1fff;
-  const BIAS = 0x84;
-  let p = pcm;
-  let mask = 0x7f;
-  if (p < 0) {
-    p = -p;
-    mask = 0xff;
-  }
-  if (p > MU_LAW_MAX) {
-    p = MU_LAW_MAX;
-  }
-  p += BIAS;
-
-  let seg2 = 0;
-  let tmp = p >> 7;
-  while (tmp) {
-    seg2++;
-    tmp >>= 1;
-  }
-
-  const uval = (seg2 << 4) | ((p >> (seg2 + 3)) & 0x0f);
-  return (uval ^ mask) & 0xff;
-}
-
-function alawToMulaw(buf: Buffer): Buffer {
-  const out = Buffer.allocUnsafe(buf.length);
-  for (let i = 0; i < buf.length; i++) {
-    out[i] = alawToMulawByte(buf[i]);
-  }
-  return out;
-}
-
+import { AriClient, type AriEvent } from "./asterisk-ari/ari-client.js";
+import { AriMedia, type MediaGraph } from "./asterisk-ari/ari-media.js";
 import { OpenAIRealtimeSTTProvider } from "./stt-openai-realtime.js";
-import { OpenAITTSProvider } from "./tts-openai.js";
+import { chunkAudio } from "../telephony-audio.js";
+import type { TelephonyTtsProvider } from "../telephony-tts.js";
 
 type AriConfig = NonNullable<VoiceCallConfig["asteriskAri"]>;
 
-type AriEvent = {
-  type: string;
-  application?: string;
-  timestamp?: string;
-  channel?: {
-    id: string;
-    name?: string;
-    state?: string;
-    caller?: { number?: string };
-    connected?: { number?: string };
-  };
-  args?: string[];
-};
-
 function nowMs(): number {
   return Date.now();
+}
+
+export function buildEndpoint(to: string, trunk?: string): string {
+  if (to.includes("/")) {
+    return to;
+  }
+  const t = trunk?.trim();
+  return t ? `PJSIP/${t}/${to}` : `PJSIP/${to}`;
 }
 
 function makeEvent(partial: Omit<NormalizedEvent, "id" | "timestamp">): NormalizedEvent {
@@ -102,96 +43,44 @@ function makeEvent(partial: Omit<NormalizedEvent, "id" | "timestamp">): Normaliz
   } as NormalizedEvent;
 }
 
-function basicAuthHeader(user: string, pass: string): string {
-  const token = Buffer.from(user + ":" + pass).toString("base64");
-  return "Basic " + token;
-}
-
-async function ariFetchJson(params: {
-  baseUrl: string;
-  username: string;
-  password: string;
-  path: string;
-  method?: string;
-  query?: Record<string, string | number | boolean | undefined>;
-  body?: unknown;
-}): Promise<unknown> {
-  const url = new URL(params.baseUrl.replace(/\/$/, "") + "/ari" + params.path);
-  if (params.query) {
-    for (const [k, v] of Object.entries(params.query)) {
-      if (v === undefined) {
-        continue;
-      }
-      url.searchParams.set(k, String(v));
-    }
-  }
-
-  const res = await fetch(url.toString(), {
-    method: params.method ?? "GET",
-    headers: {
-      Authorization: basicAuthHeader(params.username, params.password),
-      "Content-Type": "application/json",
-    },
-    body: params.body ? JSON.stringify(params.body) : undefined,
-  });
-
-  if (!res.ok) {
-    const txt = await res.text().catch(() => "");
-    throw new Error("ARI HTTP " + res.status + " " + res.statusText + (txt ? ": " + txt : ""));
-  }
-
-  const ct = res.headers.get("content-type") || "";
-  if (ct.includes("application/json")) {
-    return res.json();
-  }
-  return res.text();
-}
+type CallState = {
+  callId: string;
+  providerCallId: string;
+  sipChannelId: string;
+  media?: MediaGraph;
+  speaking: boolean;
+  stt?: ReturnType<OpenAIRealtimeSTTProvider["createSession"]>;
+  pendingMulaw?: Buffer;
+  rtpPeer?: { address: string; port: number };
+  rtpSeen?: boolean;
+  rtpState?: { seq: number; ts: number; ssrc: number };
+};
 
 export class AsteriskAriProvider implements VoiceCallProvider {
   readonly name = "asterisk-ari" as const;
 
-  private cfg: AriConfig;
-  private manager: CallManager;
-
-  private ws: WebSocket | null = null;
+  private readonly cfg: AriConfig;
+  private readonly manager: CallManager;
+  private readonly client: AriClient;
+  private readonly mediaFactory: AriMedia;
+  private ttsProvider: TelephonyTtsProvider | null = null;
 
   // providerCallId -> state
-  private callMap = new Map<
-    string,
-    {
-      callId: string;
-      sipChannelId: string;
-      extChannelId: string;
-      bridgeId: string;
-      rtpPort?: number;
-      rtpPeer?: { address: string; port: number };
-      udp?: dgram.Socket;
-      stt?: ReturnType<OpenAIRealtimeSTTProvider["createSession"]>;
-      speaking: boolean;
-    }
-  >();
-
-  private nextRtpPort: number;
-
-  // Outbound calls: we need to wait for StasisStart before issuing bridge/externalMedia actions.
-  private pendingStasisStart = new Map<
-    string,
-    { resolve: () => void; reject: (err: Error) => void; timeout: NodeJS.Timeout }
-  >();
+  private readonly calls = new Map<string, CallState>();
 
   constructor(params: { config: VoiceCallConfig; manager: CallManager }) {
     const a = params.config.asteriskAri;
-    if (!a) {
-      throw new Error("asteriskAri config missing");
-    }
+    if (!a) throw new Error("asteriskAri config missing");
     this.cfg = a;
     this.manager = params.manager;
+    this.client = new AriClient(this.cfg);
+    this.mediaFactory = new AriMedia(this.cfg, this.client);
 
-    // Allocate per-call RTP ports/sockets to avoid cross-call audio leakage.
-    // Start at configured base port and increment per call.
-    this.nextRtpPort = this.cfg.rtpPort;
+    this.client.connectWs((evt) => this.onAriEvent(evt));
+  }
 
-    this.connectWs();
+  setTTSProvider(provider: TelephonyTtsProvider) {
+    this.ttsProvider = provider;
   }
 
   verifyWebhook(_ctx: WebhookContext): WebhookVerificationResult {
@@ -199,529 +88,50 @@ export class AsteriskAriProvider implements VoiceCallProvider {
   }
 
   parseWebhookEvent(_ctx: WebhookContext): ProviderWebhookParseResult {
-    return { events: [], statusCode: 200, providerResponseBody: "OK" };
-  }
-
-  private async safeHangupChannel(channelId: string | undefined) {
-    const id = (channelId || "").trim();
-    if (!id) {
-      return;
-    }
-
-    // ARI supports different hangup semantics depending on channel type.
-    // - Normal SIP channels generally work with POST /channels/{id}/hangup
-    // - ExternalMedia (UnicastRTP/...) often does NOT expose /hangup and must be deleted: DELETE /channels/{id}
-    try {
-      await ariFetchJson({
-        baseUrl: this.cfg.baseUrl,
-        username: this.cfg.username,
-        password: this.cfg.password,
-        path: "/channels/" + encodeURIComponent(id) + "/hangup",
-        method: "POST",
-      });
-      return;
-    } catch {
-      // fall through
-    }
-
-    try {
-      await ariFetchJson({
-        baseUrl: this.cfg.baseUrl,
-        username: this.cfg.username,
-        password: this.cfg.password,
-        path: "/channels/" + encodeURIComponent(id),
-        method: "DELETE",
-      });
-    } catch {
-      // ignore
-    }
-  }
-
-  private async cleanupStaleExternalMedia() {
-    // Kill any orphaned UnicastRTP channels that are still in our Stasis app.
-    // This can happen if the gateway restarts or ARI WS drops before we get StasisEnd.
-    const channels = await ariFetchJson({
-      baseUrl: this.cfg.baseUrl,
-      username: this.cfg.username,
-      password: this.cfg.password,
-      path: "/channels",
-      method: "GET",
-    });
-
-    if (!Array.isArray(channels)) {
-      return;
-    }
-
-    const activeExt = new Set<string>();
-    for (const st of this.callMap.values()) {
-      if (st.extChannelId) {
-        activeExt.add(st.extChannelId);
-      }
-    }
-
-    for (const ch of channels) {
-      const chObj = ch as Record<string, unknown>;
-
-      const id = typeof chObj.id === "string" ? chObj.id : "";
-      const name = typeof chObj.name === "string" ? chObj.name : "";
-
-      const dp =
-        typeof chObj.dialplan === "object" && chObj.dialplan
-          ? (chObj.dialplan as Record<string, unknown>)
-          : undefined;
-
-      const appName = typeof dp?.app_name === "string" ? dp.app_name : "";
-      const appData = typeof dp?.app_data === "string" ? dp.app_data : "";
-      if (!id || !name) {
-        continue;
-      }
-      // ExternalMedia channels show up as dialplan Stasis(<app>) in ARI channel.dialplan fields.
-      if (appName != "Stasis" || appData !== this.cfg.app) {
-        continue;
-      }
-      if (!name.startsWith("UnicastRTP/")) {
-        continue;
-      }
-      if (activeExt.has(id)) {
-        continue;
-      }
-      await this.safeHangupChannel(id);
-    }
-  }
-
-  private connectWs() {
-    const base = this.cfg.baseUrl.replace(/\/$/, "");
-    const wsBase = base.replace(/^http/, "ws");
-    const qp = new URLSearchParams({
-      app: this.cfg.app,
-    });
-    const url = wsBase + "/ari/events?" + qp.toString();
-
-    // Avoid embedding credentials in the URL query string (can be logged by proxies/clients).
-    // ARI WS endpoint supports HTTP Basic auth during the upgrade request.
-    this.ws = new WebSocket(url, {
-      headers: {
-        Authorization: basicAuthHeader(this.cfg.username, this.cfg.password),
-      },
-    });
-    this.ws.on("open", () => {
-      // Best-effort recovery: if the gateway previously crashed or missed StasisEnd events,
-      // Asterisk may still have orphaned UnicastRTP ExternalMedia channels in our Stasis app.
-      // Clean them up to avoid leaking channels and breaking RTP peer learning.
-      void this.cleanupStaleExternalMedia().catch(() => undefined);
-    });
-    this.ws.on("message", (data) => {
-      let evt: AriEvent | null = null;
-      if (!(typeof data === "string" || Buffer.isBuffer(data))) {
-        return;
-      }
-
-      try {
-        evt = JSON.parse(data.toString());
-      } catch {
-        return;
-      }
-      if (!evt) {
-        return;
-      }
-      this.onAriEvent(evt);
-    });
-    this.ws.on("close", () => {
-      // reconnect
-      setTimeout(() => this.connectWs(), 1500);
-    });
-    this.ws.on("error", () => {
-      // ignore; reconnect via close
-    });
-  }
-
-  private onAriEvent(evt: AriEvent) {
-    if (evt.type === "StasisStart" && evt.channel?.id) {
-      // Outbound: resolve pending promise when the originated channel enters our Stasis app.
-      // This must run regardless of channel technology (PJSIP/Local/SIP/...), otherwise
-      // initiateCall() with a full dialstring would never set up ExternalMedia/STT.
-      const pending = this.pendingStasisStart.get(evt.channel.id);
-      if (pending) {
-        clearTimeout(pending.timeout);
-        this.pendingStasisStart.delete(evt.channel.id);
-        pending.resolve();
-        return;
-      }
-
-      // Outbound race guard:
-      // If Asterisk emits StasisStart before the /channels POST returns (so pending isn't set yet),
-      // use appArgs to map back to providerCallId and treat it as outbound.
-      const arg0 = evt.args?.[0];
-      if (arg0 && this.callMap.has(arg0)) {
-        const st = this.callMap.get(arg0);
-        if (st && !st.sipChannelId) {
-          st.sipChannelId = evt.channel.id;
-        }
-        return;
-      }
-
-      // Inbound classification: only treat real inbound SIP calls as inbound.
-      // ExternalMedia (UnicastRTP/...) also enters Stasis and must be ignored,
-      // otherwise we'd recursively create more ExternalMedia channels and leak resources.
-      const chName = evt.channel?.name || "";
-      if (!chName.startsWith("PJSIP/")) {
-        return;
-      }
-
-      // inbound call into this Stasis app
-      const sipChannelId = evt.channel.id;
-      const providerCallId = sipChannelId;
-      const from = evt.channel?.caller?.number || "unknown";
-      const to = evt.channel?.connected?.number || "unknown";
-
-      const callId = crypto.randomUUID();
-      this.callMap.set(providerCallId, {
-        callId,
-        sipChannelId,
-        extChannelId: "",
-        bridgeId: "",
-        speaking: false,
-      });
-
-      this.manager.processEvent(
-        makeEvent({
-          type: "call.ringing",
-          callId,
-          providerCallId,
-          direction: "inbound",
-          from,
-          to,
-        }),
-      );
-
-      // Answer + attach external media. Any greeting should be handled at a higher level.
-      void this.setupConversation({ providerCallId, sipChannelId, isOutbound: false });
-    }
-
-    if (evt.type === "StasisEnd" && evt.channel?.id) {
-      const channelId = evt.channel.id;
-
-      // Inbound: providerCallId == sip channel id
-      if (this.callMap.has(channelId)) {
-        const providerCallId = channelId;
-        const st = this.callMap.get(providerCallId);
-        if (!st) {
-          return;
-        }
-        this.manager.processEvent(
-          makeEvent({
-            type: "call.ended",
-            callId: st.callId,
-            providerCallId,
-            reason: "completed",
-          }),
-        );
-        this.cleanup(providerCallId).catch(() => undefined);
-        return;
-      }
-
-      // Outbound: providerCallId is a UUID; find matching state by sipChannelId
-      for (const [providerCallId, st] of this.callMap.entries()) {
-        if (st.sipChannelId === channelId) {
-          this.manager.processEvent(
-            makeEvent({
-              type: "call.ended",
-              callId: st.callId,
-              providerCallId,
-              reason: "completed",
-            }),
-          );
-          this.cleanup(providerCallId).catch(() => undefined);
-          return;
-        }
-      }
-    }
-  }
-
-  private handleRtp(providerCallId: string, msg: Buffer, rinfo: dgram.RemoteInfo) {
-    const st = this.callMap.get(providerCallId);
-    if (!st) {
-      return;
-    }
-
-    // RTP header is 12 bytes.
-    if (msg.length <= 12) {
-      return;
-    }
-
-    // Learn peer from first packet (per-call socket, so this is scoped correctly).
-    if (!st.rtpPeer) {
-      st.rtpPeer = { address: rinfo.address, port: rinfo.port };
-    }
-
-    // Only accept from learned peer.
-    if (st.rtpPeer.address !== rinfo.address || st.rtpPeer.port !== rinfo.port) {
-      return;
-    }
-
-    let payload = msg.subarray(12);
-
-    // Always feed RTP into STT, even while we're speaking.
-    // OpenAI Realtime STT session here is configured for G.711 mu-law.
-    if (st.stt) {
-      if (this.cfg.codec === "alaw") {
-        payload = alawToMulaw(payload);
-      }
-      st.stt.sendAudio(payload);
-    }
-  }
-
-  private async setupConversation(params: {
-    providerCallId: string;
-    sipChannelId: string;
-    isOutbound: boolean;
-  }) {
-    const providerCallId = params.providerCallId;
-    const st = this.callMap.get(providerCallId);
-    if (!st) {
-      return;
-    }
-
-    // Answer channel (inbound) if needed
-    try {
-      await ariFetchJson({
-        baseUrl: this.cfg.baseUrl,
-        username: this.cfg.username,
-        password: this.cfg.password,
-        path: "/channels/" + encodeURIComponent(params.sipChannelId) + "/answer",
-        method: "POST",
-      });
-    } catch {
-      // ignore
-    }
-
-    let udp: dgram.Socket | undefined;
-    let bridgeId: string | undefined;
-    let extChannelId: string | undefined;
-
-    try {
-      // Create mixing bridge
-      const bridge = await ariFetchJson({
-        baseUrl: this.cfg.baseUrl,
-        username: this.cfg.username,
-        password: this.cfg.password,
-        path: "/bridges",
-        method: "POST",
-        query: { type: "mixing" },
-      });
-      bridgeId = (bridge as { id?: string }).id;
-      if (!bridgeId) {
-        throw new Error("ARI: missing bridge id");
-      }
-
-      // Allocate a per-call UDP socket/port for RTP (prevents cross-call leakage when maxConcurrentCalls > 1).
-      // Collision-safe: retry on EADDRINUSE; fall back to ephemeral port if needed.
-      udp = dgram.createSocket("udp4");
-
-      const bindUdp = async (port: number): Promise<number> => {
-        await new Promise<void>((resolve, reject) => {
-          const onError = (err: unknown) => {
-            udp?.off("listening", onListening);
-            reject(err);
-          };
-          const onListening = () => {
-            udp?.off("error", onError);
-            resolve();
-          };
-          udp?.once("error", onError);
-          udp?.once("listening", onListening);
-          udp?.bind(port, "0.0.0.0");
-        });
-        const addr = udp?.address();
-        return typeof addr === "object" ? addr.port : port;
-      };
-
-      let rtpPort: number | undefined;
-      for (let i = 0; i < 20; i++) {
-        const candidate = this.nextRtpPort++;
-        try {
-          rtpPort = await bindUdp(candidate);
-          break;
-        } catch (err) {
-          const code = (err as { code?: string } | null)?.code;
-          if (code === "EADDRINUSE") {
-            continue;
-          }
-          throw err;
-        }
-      }
-
-      if (!rtpPort) {
-        // Let the OS pick an ephemeral port.
-        rtpPort = await bindUdp(0);
-      }
-
-      if (!udp) {
-        throw new Error("RTP socket not initialized");
-      }
-
-      udp.on("message", (msg, rinfo) => this.handleRtp(providerCallId, msg, rinfo));
-
-      st.udp = udp;
-      st.rtpPort = rtpPort;
-
-      // Create ExternalMedia channel
-      const ext = await ariFetchJson({
-        baseUrl: this.cfg.baseUrl,
-        username: this.cfg.username,
-        password: this.cfg.password,
-        path: "/channels/externalMedia",
-        method: "POST",
-        query: {
-          app: this.cfg.app,
-          external_host: this.cfg.rtpHost + ":" + rtpPort,
-          format: this.cfg.codec,
-        },
-      });
-      extChannelId = (ext as { id?: string }).id;
-      if (!extChannelId) {
-        throw new Error("ARI: missing externalMedia channel id");
-      }
-
-      // Add both channels to bridge
-      await ariFetchJson({
-        baseUrl: this.cfg.baseUrl,
-        username: this.cfg.username,
-        password: this.cfg.password,
-        path: "/bridges/" + encodeURIComponent(bridgeId) + "/addChannel",
-        method: "POST",
-        query: { channel: params.sipChannelId + "," + extChannelId },
-      });
-
-      st.bridgeId = bridgeId;
-      st.extChannelId = extChannelId;
-    } catch (err) {
-      // Best-effort cleanup on partial setup failures.
-      try {
-        udp?.close();
-      } catch {
-        // ignore
-      }
-
-      // If we created external media, tear it down.
-      await this.safeHangupChannel(extChannelId);
-
-      // If we created the bridge, delete it.
-      try {
-        if (bridgeId) {
-          await ariFetchJson({
-            baseUrl: this.cfg.baseUrl,
-            username: this.cfg.username,
-            password: this.cfg.password,
-            path: "/bridges/" + encodeURIComponent(bridgeId),
-            method: "DELETE",
-          });
-        }
-      } catch {
-        // ignore
-      }
-
-      // Clear any partially assigned state.
-      if (st.udp === udp) {
-        st.udp = undefined;
-        st.rtpPort = undefined;
-      }
-      st.bridgeId = "";
-      st.extChannelId = "";
-
-      throw err;
-    }
-
-    // STT session
-    const apiKey = (process.env.OPENAI_API_KEY || "").trim();
-    if (!apiKey) {
-      // Allow basic call bridging even when STT is not configured.
-      // (Streaming/STT can be enabled later by providing OPENAI_API_KEY.)
-      this.manager.processEvent(
-        makeEvent({
-          type: "call.answered",
-          callId: st.callId,
-          providerCallId,
-        }),
-      );
-      this.manager.processEvent(
-        makeEvent({
-          type: "call.active",
-          callId: st.callId,
-          providerCallId,
-        }),
-      );
-      return;
-    }
-    const sttProvider = new OpenAIRealtimeSTTProvider({
-      apiKey,
-      model: process.env.OPENAI_REALTIME_STT_MODEL || undefined,
-      silenceDurationMs: 800,
-      vadThreshold: 0.5,
-    });
-    const session = sttProvider.createSession();
-    await session.connect();
-    session.onSpeechStart(() => {
-      // barge-in: stop speaking
-      const s = this.callMap.get(providerCallId);
-      if (s) {
-        s.speaking = false;
-      }
-    });
-    session.onTranscript((t) => {
-      const s = this.callMap.get(providerCallId);
-      if (!s) {
-        return;
-      }
-      this.manager.processEvent(
-        makeEvent({
-          type: "call.speech",
-          callId: s.callId,
-          providerCallId,
-          transcript: t,
-          isFinal: true,
-        }),
-      );
-    });
-    st.stt = session;
-
-    // Mark answered
-    this.manager.processEvent(
-      makeEvent({
-        type: "call.answered",
-        callId: st.callId,
-        providerCallId,
-      }),
-    );
-    this.manager.processEvent(
-      makeEvent({
-        type: "call.active",
-        callId: st.callId,
-        providerCallId,
-      }),
-    );
-
-    // For inbound calls, do not auto-speak here.
-    // Let the higher-level CallManager / response generator decide what (if anything) to say.
+    return { events: [], statusCode: 200 };
   }
 
   async initiateCall(input: InitiateCallInput): Promise<InitiateCallResult> {
     const providerCallId = crypto.randomUUID();
-    const callId = input.callId;
+    const endpoint = buildEndpoint(input.to, this.cfg.trunk);
 
-    // Create call state
-    this.callMap.set(providerCallId, {
-      callId,
-      sipChannelId: "",
-      extChannelId: "",
-      bridgeId: "",
-      speaking: false,
+    // 1. Check endpoint online (only for direct PJSIP/<resource>, not trunks)
+    if (endpoint.toUpperCase().startsWith("PJSIP/")) {
+      const parts = endpoint.split("/");
+      if (parts.length === 2) {
+        const resource = parts[1];
+        try {
+          const state = await this.client.getEndpointState(resource);
+          if (state.state.toLowerCase() !== "online") {
+            throw new Error(`Endpoint PJSIP/${resource} is ${state.state}`);
+          }
+        } catch (err: any) {
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new Error(`Endpoint PJSIP/${resource} unavailable (${msg})`);
+        }
+      }
+    }
+
+    // 2. Originate call
+    const ch = await this.client.createChannel({
+      endpoint,
+      app: this.cfg.app,
+      appArgs: providerCallId,
+      callerId: input.fromName ? `${input.fromName} <${input.from}>` : undefined,
     });
+
+    const state: CallState = {
+      callId: input.callId,
+      providerCallId,
+      sipChannelId: ch.id,
+      speaking: false,
+    };
+    this.calls.set(providerCallId, state);
 
     this.manager.processEvent(
       makeEvent({
         type: "call.initiated",
-        callId,
+        callId: input.callId,
         providerCallId,
         direction: "outbound",
         from: input.from,
@@ -729,219 +139,397 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       }),
     );
 
-    // Originate channel into Stasis app
-    // - If `to` already looks like a full dialstring (e.g. "PJSIP/1000" or "Local/1000@default"), use it as-is.
-    // - Else, if trunk is configured, dial through it: PJSIP/<trunk>/<to>
-    // - Else, dial the endpoint directly: PJSIP/<to>
-    const endpoint = input.to.includes("/")
-      ? input.to
-      : this.cfg.trunk?.trim()
-        ? `PJSIP/${this.cfg.trunk}/${input.to}`
-        : `PJSIP/${input.to}`;
-    const ch = await ariFetchJson({
-      baseUrl: this.cfg.baseUrl,
-      username: this.cfg.username,
-      password: this.cfg.password,
-      path: "/channels",
-      method: "POST",
-      query: {
-        endpoint,
-        app: this.cfg.app,
-        // Tag the originated channel so we can reliably map StasisStart -> providerCallId,
-        // even if the StasisStart event arrives before the /channels POST returns.
-        appArgs: providerCallId,
-        callerId: input.fromName ? `${input.fromName} <${input.from}>` : undefined,
-      },
-    });
-
-    const sipChannelId = ch.id as string;
-    const st = this.callMap.get(providerCallId);
-    if (st) {
-      st.sipChannelId = sipChannelId;
-    }
-
     this.manager.processEvent(
       makeEvent({
         type: "call.ringing",
-        callId,
+        callId: input.callId,
         providerCallId,
       }),
     );
-
-    // Prefer an immediate setup attempt: if StasisStart already happened (race), this succeeds.
-    // If the channel isn't in Stasis yet, we'll fall back to waiting for StasisStart.
-    try {
-      await this.setupConversation({ providerCallId, sipChannelId, isOutbound: true });
-    } catch {
-      // Wait until channel is actually in our Stasis app (avoids 422 Channel not in Stasis application).
-      // Best-effort: if it never enters Stasis, we still let the outbound call ring (basic telephony works).
-      try {
-        await new Promise<void>((resolve, reject) => {
-          const timeout = setTimeout(() => {
-            const pending = this.pendingStasisStart.get(sipChannelId);
-            if (pending) {
-              clearTimeout(pending.timeout);
-            }
-            this.pendingStasisStart.delete(sipChannelId);
-            reject(new Error("Timed out waiting for StasisStart"));
-          }, 8000);
-          this.pendingStasisStart.set(sipChannelId, { resolve, reject, timeout });
-        });
-
-        await this.setupConversation({ providerCallId, sipChannelId, isOutbound: true });
-      } catch {
-        // Degrade gracefully: call may still be ringing/answered outside Stasis.
-      }
-    }
 
     return { providerCallId, status: "initiated" };
   }
 
   async hangupCall(input: HangupCallInput): Promise<void> {
-    const st = this.callMap.get(input.providerCallId);
-    if (!st) {
-      return;
-    }
-    try {
-      await ariFetchJson({
-        baseUrl: this.cfg.baseUrl,
-        username: this.cfg.username,
-        password: this.cfg.password,
-        path: "/channels/" + encodeURIComponent(st.sipChannelId) + "/hangup",
-        method: "POST",
-      });
-    } catch {
-      // ignore
-    }
-    await this.cleanup(input.providerCallId);
+    const state = this.calls.get(input.providerCallId);
+    if (!state) return;
+
+    await this.client.safeHangupChannel(state.sipChannelId);
+    await this.cleanup(input.providerCallId, input.reason);
   }
 
   async playTts(input: PlayTtsInput): Promise<void> {
-    const st = this.callMap.get(input.providerCallId);
-    if (!st) {
-      return;
+    const state = this.calls.get(input.providerCallId);
+    if (!state || !state.media) return;
+
+    if (!this.ttsProvider) {
+      throw new Error("Telephony TTS provider not configured for asterisk-ari");
     }
+    const mulaw = await this.ttsProvider.synthesizeForTelephony(input.text);
 
-    const apiKey = (process.env.OPENAI_API_KEY || "").trim();
-
-    let mulaw: Buffer;
-    if (apiKey) {
-      const tts = new OpenAITTSProvider({ apiKey });
-      const pcm24k = await tts.synthesize(input.text);
-      mulaw = convertPcmToMulaw8k(pcm24k, 24000);
-    } else {
-      throw new Error("TTS requires OPENAI_API_KEY (or a configured TTS provider). ");
-    }
-
-    // Stream as RTP 20ms frames
-    st.speaking = true;
+    state.speaking = true;
     this.manager.processEvent(
       makeEvent({
         type: "call.speaking",
-        callId: st.callId,
-        providerCallId: input.providerCallId,
+        callId: state.callId,
+        providerCallId: state.providerCallId,
         text: input.text,
       }),
     );
 
-    const peer = st.rtpPeer;
-    if (!peer) {
-      // We haven't learned RTP peer yet; wait a bit.
-      await new Promise((r) => setTimeout(r, 300));
-    }
-    const peer2 = st.rtpPeer;
-    if (!peer2) {
-      throw new Error("No RTP peer learned yet");
-    }
-
-    let seq = 0;
-    let ts = 0;
-    const ssrc = 0x12345678;
-
-    for (const frame of chunkAudio(mulaw, 160)) {
-      if (!st.speaking) {
-        break;
-      }
-
-      const header = Buffer.alloc(12);
-      header[0] = 0x80;
-      header[1] = 0x00;
-      header.writeUInt16BE(seq & 0xffff, 2);
-      header.writeUInt32BE(ts >>> 0, 4);
-      header.writeUInt32BE(ssrc >>> 0, 8);
-      seq++;
-      ts += 160;
-
-      const packet = Buffer.concat([header, frame]);
-      await new Promise<void>((resolve, reject) => {
-        if (!st.udp) {
-          throw new Error("RTP socket not initialized");
-        }
-
-        st.udp.send(packet, peer2.port, peer2.address, (err) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-          resolve();
-        });
-      });
-
-      await new Promise((r) => setTimeout(r, 20));
+    const rtpPeer = this.getRtpPeer(state);
+    if (!rtpPeer) {
+      // Wait until we receive at least one RTP packet from Asterisk (then we know its port).
+      state.pendingMulaw = mulaw;
+      console.warn("[ari] No RTP peer learned yet; queued TTS until RTP starts flowing");
+      state.speaking = false;
+      return;
     }
 
-    st.speaking = false;
+    this.sendMulawRtp(state, mulaw, rtpPeer);
   }
 
   async startListening(_input: StartListeningInput): Promise<void> {
-    // STT is always on for now.
+    // STT is always-on in this architecture (via snoop)
   }
 
   async stopListening(_input: StopListeningInput): Promise<void> {
-    // STT is always on for now.
+    // no-op
   }
 
-  private async cleanup(providerCallId: string): Promise<void> {
-    const st = this.callMap.get(providerCallId);
-    if (!st) {
+  private async onAriEvent(evt: AriEvent) {
+    if (evt.type === "StasisStart") {
+      const args = evt.args || [];
+      const providerCallId = args[0];
+
+      // Inbound call: no appArgs provided
+      if (!providerCallId) {
+        const name = evt.channel?.name || "";
+        // Ignore non-SIP channels (ExternalMedia/Snoop) entering Stasis
+        if (!name.startsWith("PJSIP/") && !name.startsWith("SIP/")) {
+          return;
+        }
+        await this.handleInboundStart(evt);
+        return;
+      }
+
+      const state = this.calls.get(providerCallId);
+      if (!state) return; // Maybe zombie call
+
+      if (!state.media) {
+        try {
+          await this.setupMedia(state);
+        } catch (err) {
+          console.error("[ari] Media setup failed", err);
+          this.manager.processEvent(
+            makeEvent({
+              type: "call.error",
+              callId: state.callId,
+              providerCallId: state.providerCallId,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+          await this.hangupCall({
+            callId: state.callId,
+            providerCallId: state.providerCallId,
+            reason: "error",
+          });
+        }
+      }
+    } else if (evt.type === "StasisEnd") {
+      const chId = evt.channel?.id;
+      for (const [pId, state] of this.calls.entries()) {
+        if (state.sipChannelId === chId) {
+          await this.cleanup(pId, "hangup-user");
+          break;
+        }
+      }
+    }
+  }
+
+  private async setupMedia(state: CallState): Promise<void> {
+    if (state.media) return;
+
+    const media = await this.mediaFactory.createMediaGraph({ sipChannelId: state.sipChannelId });
+    state.media = media;
+
+    await this.seedRtpPeer(state);
+    this.wireRtp(state);
+    await this.setupStt(state);
+
+    this.manager.processEvent(
+      makeEvent({
+        type: "call.answered",
+        callId: state.callId,
+        providerCallId: state.providerCallId,
+      }),
+    );
+
+    this.manager.processEvent(
+      makeEvent({
+        type: "call.active",
+        callId: state.callId,
+        providerCallId: state.providerCallId,
+      }),
+    );
+  }
+
+  private async seedRtpPeer(state: CallState): Promise<void> {
+    if (!state.media || state.rtpPeer) return;
+    try {
+      const portStr = await this.client.getChannelVar(state.media.extChannelId, "UNICASTRTP_LOCAL_PORT");
+      const addrStr = await this.client.getChannelVar(state.media.extChannelId, "UNICASTRTP_LOCAL_ADDRESS");
+      const port = portStr ? Number(portStr) : null;
+      const address = addrStr || this.cfg.rtpHost;
+      if (port && address) {
+        this.setRtpPeer(state, { address, port });
+        console.log("[ari] seeded RTP peer", { address, port });
+      }
+    } catch {}
+  }
+
+  private wireRtp(state: CallState): void {
+    if (!state.media) return;
+    state.media.udp.on("message", (msg, rinfo) => {
+      if (!state.rtpSeen) {
+        state.rtpSeen = true;
+        console.log("[ari] RTP in from Asterisk", { rinfo, bytes: msg.length });
+      }
+      const prev = this.getRtpPeer(state);
+      if (!prev) {
+        console.log("[ari] Learned RTP peer from Asterisk:", rinfo);
+        this.setRtpPeer(state, rinfo);
+      }
+
+      const pending = state.pendingMulaw;
+      if (pending && !state.speaking) {
+        state.pendingMulaw = undefined;
+        const peer = this.getRtpPeer(state) || rinfo;
+        this.sendMulawRtp(state, pending, peer);
+      }
+    });
+  }
+
+  private getRtpPeer(state: CallState) {
+    return state.rtpPeer;
+  }
+
+  private setRtpPeer(state: CallState, rinfo: { address: string; port: number }) {
+    state.rtpPeer = rinfo;
+  }
+
+  private sendMulawRtp(state: CallState, mulaw: Buffer, peer: { address: string; port: number }) {
+    if (!state.media) return;
+    const udp = state.media.udp;
+    state.speaking = true;
+    const chunkIter = chunkAudio(mulaw, 160);
+    let i = 0;
+    const interval = setInterval(() => {
+      if (!this.calls.has(state.providerCallId) || !state.speaking) {
+        clearInterval(interval);
+        state.speaking = false;
+        return;
+      }
+
+      const next = chunkIter.next();
+      if (next.done || !next.value) {
+        clearInterval(interval);
+        state.speaking = false;
+        return;
+      }
+
+      const pkt = this.makeRtpPacket(state, next.value);
+      if (i === 0) {
+        try {
+          console.log("[ari] RTP send", { bytes: pkt.length, to: peer, from: udp.address() });
+        } catch {
+          console.log("[ari] RTP send", { bytes: pkt.length, to: peer });
+        }
+      }
+      udp.send(pkt, peer.port, peer.address, (err) => {
+        if (err) {
+          console.warn("[ari] RTP send error", err);
+        }
+      });
+      i++;
+    }, 20);
+  }
+
+  private ensureRtpState(state: CallState): { seq: number; ts: number; ssrc: number } {
+    if (!state.rtpState) {
+      state.rtpState = {
+        seq: Math.floor(Math.random() * 0xffff),
+        ts: Math.floor(Math.random() * 0xffffffff),
+        ssrc: Math.floor(Math.random() * 0xffffffff),
+      };
+    }
+    return state.rtpState;
+  }
+
+  private makeRtpPacket(state: CallState, payload: Buffer): Buffer {
+    const r = this.ensureRtpState(state);
+    const header = Buffer.alloc(12);
+    header[0] = 0x80; // V=2, P=0, X=0, CC=0
+    header[1] = 0x00; // M=0, PT=0 (PCMU)
+    header.writeUInt16BE(r.seq & 0xffff, 2);
+    header.writeUInt32BE(r.ts >>> 0, 4);
+    header.writeUInt32BE(r.ssrc >>> 0, 8);
+
+    r.seq = (r.seq + 1) & 0xffff;
+    r.ts = (r.ts + 160) >>> 0; // 20ms @ 8kHz
+
+    return Buffer.concat([header, payload]);
+  }
+
+  private stripRtpHeader(pkt: Buffer): Buffer {
+    if (pkt.length < 12) return Buffer.alloc(0);
+    const cc = pkt[0] & 0x0f;
+    const hasExt = (pkt[0] & 0x10) !== 0;
+    let headerLen = 12 + cc * 4;
+    if (hasExt) {
+      if (pkt.length < headerLen + 4) return Buffer.alloc(0);
+      const extLen = pkt.readUInt16BE(headerLen + 2); // in 32-bit words
+      headerLen += 4 + extLen * 4;
+    }
+    if (pkt.length <= headerLen) return Buffer.alloc(0);
+    return pkt.subarray(headerLen);
+  }
+
+  private async setupStt(state: CallState): Promise<void> {
+    if (!state.media) return;
+    const apiKey = (process.env.OPENAI_API_KEY || "").trim();
+    if (!apiKey) {
+      console.warn("[ari] STT disabled: OPENAI_API_KEY missing");
       return;
     }
 
     try {
-      st.stt?.close();
-    } catch {
-      // ignore
+      const session = new OpenAIRealtimeSTTProvider({
+        apiKey,
+        model: "gpt-4o-transcribe", // default
+      }).createSession();
+
+      await session.connect();
+      console.log("[ari] STT connected");
+
+      session.onTranscript((text) => {
+        console.log("[ari] STT transcript -> call.speech", { text });
+        this.manager.processEvent(
+          makeEvent({
+            type: "call.speech",
+            callId: state.callId,
+            providerCallId: state.providerCallId,
+            transcript: text,
+            isFinal: true,
+          }),
+        );
+      });
+
+      let loggedPayload = false;
+      state.media.sttUdp.on("message", (msg) => {
+        const payload = this.stripRtpHeader(msg);
+        if (payload.length) {
+          if (!loggedPayload) {
+            loggedPayload = true;
+            console.log("[ari] STT payload", {
+              bytes: payload.length,
+              head: payload.subarray(0, 8).toString("hex"),
+            });
+          }
+          session.sendAudio(payload);
+        }
+      });
+
+      state.stt = session;
+      console.log("[ari] STT setup ok");
+    } catch (err) {
+      console.warn("[ari] STT setup failed", err);
     }
+  }
+
+  private async handleInboundStart(evt: AriEvent): Promise<void> {
+    const sipChannelId = evt.channel?.id;
+    if (!sipChannelId) return;
+
+    const providerCallId = sipChannelId;
+    const from = evt.channel?.caller?.number || "unknown";
+    const to = evt.channel?.name || "unknown";
+
+    this.manager.processEvent(
+      makeEvent({
+        type: "call.initiated",
+        callId: providerCallId,
+        providerCallId,
+        direction: "inbound",
+        from,
+        to,
+      }),
+    );
+
+    const call = this.manager.getCallByProviderCallId(providerCallId);
+    if (!call) {
+      return;
+    }
+
+    const state: CallState = {
+      callId: call.callId,
+      providerCallId,
+      sipChannelId,
+      speaking: false,
+    };
+    this.calls.set(providerCallId, state);
 
     try {
-      st.udp?.close();
-    } catch {
-      // ignore
-    }
-
-    // Best-effort tear down in reverse order.
-    // IMPORTANT: ExternalMedia (UnicastRTP/...) can remain alive even if the bridge is deleted.
-    // Always try to hang up the external channel to avoid leaking UnicastRTP channels.
-    await this.safeHangupChannel(st.extChannelId);
-
-    // Optionally hang up the SIP channel as well (bridge deletion + SIP hangup should end the call anyway).
-    // This is best-effort; if the call was already hung up, ARI will error.
-    await this.safeHangupChannel(st.sipChannelId);
+      await this.client.answerChannel(sipChannelId);
+    } catch {}
 
     try {
-      if (st.bridgeId) {
-        await ariFetchJson({
-          baseUrl: this.cfg.baseUrl,
-          username: this.cfg.username,
-          password: this.cfg.password,
-          path: "/bridges/" + encodeURIComponent(st.bridgeId),
-          method: "DELETE",
-        });
-      }
-    } catch {
-      // ignore
+      await this.setupMedia(state);
+    } catch (err) {
+      console.error("[ari] Inbound media setup failed", err);
+      this.manager.processEvent(
+        makeEvent({
+          type: "call.error",
+          callId: state.callId,
+          providerCallId: state.providerCallId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      await this.hangupCall({
+        callId: state.callId,
+        providerCallId: state.providerCallId,
+        reason: "error",
+      });
+    }
+  }
+
+  private async cleanup(providerCallId: string, reason: EndReason = "completed") {
+    const state = this.calls.get(providerCallId);
+    if (!state) return;
+
+    this.calls.delete(providerCallId);
+
+    if (state.sipChannelId) {
+      await this.client.safeHangupChannel(state.sipChannelId).catch(() => {});
     }
 
-    this.callMap.delete(providerCallId);
+    if (state.media) {
+      await this.mediaFactory.teardown(state.media);
+    }
+    if (state.stt) {
+      try {
+        state.stt.close();
+      } catch {}
+      state.stt = undefined;
+    }
+
+    this.manager.processEvent(
+      makeEvent({
+        type: "call.ended",
+        callId: state.callId,
+        providerCallId: state.providerCallId,
+        reason,
+      }),
+    );
   }
 }

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -508,7 +508,7 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       query: {
         app: this.cfg.app,
         external_host: this.cfg.rtpHost + ":" + rtpPort,
-        format: this.cfg.codec || this.cfg.format || "ulaw",
+        format: this.cfg.codec,
       },
     });
     const extChannelId = ext.id as string;

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -383,10 +383,8 @@ export class AsteriskAriProvider implements VoiceCallProvider {
         continue;
       }
 
-      if (st.speaking) {
-        return;
-      }
-
+      // Always feed inbound RTP into STT, even while we're speaking.
+      // Otherwise onSpeechStart never fires and barge-in can't interrupt TTS.
       if (st.stt) {
         st.stt.sendAudio(payload);
       }

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -77,7 +77,12 @@ export class AsteriskAriProvider implements VoiceCallProvider {
   // providerCallId -> state
   private readonly calls = new Map<string, CallState>();
 
-  constructor(params: { config: VoiceCallConfig; manager: CallManager; coreConfig?: CoreConfig }) {
+  constructor(params: {
+    config: VoiceCallConfig;
+    manager: CallManager;
+    coreConfig?: CoreConfig;
+    connectWs?: boolean;
+  }) {
     const a = params.config.asteriskAri;
     if (!a) throw new Error("asteriskAri config missing");
     this.voiceConfig = params.config;
@@ -87,7 +92,9 @@ export class AsteriskAriProvider implements VoiceCallProvider {
     this.client = new AriClient(this.cfg);
     this.mediaFactory = new AriMedia(this.cfg, this.client);
 
-    this.client.connectWs((evt) => this.onAriEvent(evt));
+    if (params.connectWs !== false) {
+      this.client.connectWs((evt) => this.onAriEvent(evt));
+    }
   }
 
   setTTSProvider(provider: TelephonyTtsProvider) {

--- a/extensions/voice-call/src/providers/asterisk-ari/ari-client.test.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/ari-client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AriClient } from "./ari-client.js";
+
+const cfg = {
+  baseUrl: "http://127.0.0.1:8088",
+  username: "user",
+  password: "pass",
+  app: "openclaw",
+  rtpHost: "127.0.0.1",
+  rtpPort: 12000,
+  codec: "ulaw",
+} as const;
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  if (originalFetch) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = originalFetch;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("AriClient", () => {
+  it("creates ExternalMedia with expected query params", async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      new Response(JSON.stringify({ id: "chan" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = fetchMock;
+
+    const client = new AriClient(cfg);
+    await client.createExternalMedia({
+      app: "openclaw",
+      externalHost: "127.0.0.1:12000",
+      format: "ulaw",
+      direction: "both",
+      encapsulation: "rtp",
+      transport: "udp",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = new URL(fetchMock.mock.calls[0]?.[0] as string);
+    expect(calledUrl.pathname).toBe("/ari/channels/externalMedia");
+    expect(calledUrl.searchParams.get("app")).toBe("openclaw");
+    expect(calledUrl.searchParams.get("external_host")).toBe("127.0.0.1:12000");
+    expect(calledUrl.searchParams.get("format")).toBe("ulaw");
+    expect(calledUrl.searchParams.get("direction")).toBe("both");
+    expect(calledUrl.searchParams.get("encapsulation")).toBe("rtp");
+    expect(calledUrl.searchParams.get("transport")).toBe("udp");
+  });
+
+  it("safeHangupChannel falls back to DELETE when hangup fails", async () => {
+    const responses = [
+      new Response("fail", { status: 500, statusText: "err" }),
+      new Response("", { status: 200 }),
+    ];
+    const fetchMock = vi.fn(async () => responses.shift() as Response);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = fetchMock;
+
+    const client = new AriClient(cfg);
+    await client.safeHangupChannel("chan-1");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstUrl = new URL(fetchMock.mock.calls[0]?.[0] as string);
+    const secondUrl = new URL(fetchMock.mock.calls[1]?.[0] as string);
+    expect(firstUrl.pathname).toBe("/ari/channels/chan-1/hangup");
+    expect(secondUrl.pathname).toBe("/ari/channels/chan-1");
+  });
+});

--- a/extensions/voice-call/src/providers/asterisk-ari/ari-client.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/ari-client.ts
@@ -137,13 +137,13 @@ export class AriClient {
     try {
       await this.hangupChannel(channelId);
       return;
-    } catch {
-      // fall through
+    } catch (err) {
+      console.warn("[ari] hangup failed, falling back to delete", { channelId, err });
     }
     try {
       await this.deleteChannel(channelId);
-    } catch {
-      // ignore
+    } catch (err) {
+      console.warn("[ari] delete channel failed", { channelId, err });
     }
   }
 

--- a/extensions/voice-call/src/providers/asterisk-ari/ari-client.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/ari-client.ts
@@ -5,6 +5,7 @@ export type AriEvent = {
   type: string;
   channel?: AriChannel;
   args?: string[];
+  digit?: string;
 };
 
 export type AriWsHandler = (event: AriEvent) => void;

--- a/extensions/voice-call/src/providers/asterisk-ari/ari-client.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/ari-client.ts
@@ -1,0 +1,247 @@
+import type { AriBridge, AriChannel, AriEndpointState, AriConfig } from "./types.js";
+import WebSocket from "ws";
+
+export type AriEvent = {
+  type: string;
+  channel?: AriChannel;
+  args?: string[];
+};
+
+export type AriWsHandler = (event: AriEvent) => void;
+
+export class AriClient {
+  private cfg: AriConfig;
+  private ws: WebSocket | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private reconnectAttempts = 0;
+
+  constructor(cfg: AriConfig) {
+    this.cfg = cfg;
+  }
+
+  async getEndpointState(resource: string): Promise<AriEndpointState> {
+    return this.fetchJson<AriEndpointState>(`/endpoints/PJSIP/${encodeURIComponent(resource)}`);
+  }
+
+  async createChannel(params: {
+    endpoint: string;
+    app: string;
+    appArgs?: string;
+    callerId?: string;
+  }): Promise<AriChannel> {
+    return this.fetchJson<AriChannel>("/channels", {
+      method: "POST",
+      query: {
+        endpoint: params.endpoint,
+        app: params.app,
+        appArgs: params.appArgs,
+        callerId: params.callerId,
+      },
+    });
+  }
+
+  async createBridge(type: "mixing"): Promise<AriBridge> {
+    return this.fetchJson<AriBridge>("/bridges", { method: "POST", query: { type } });
+  }
+
+  async getBridge(bridgeId: string): Promise<AriBridge> {
+    return this.fetchJson<AriBridge>(`/bridges/${encodeURIComponent(bridgeId)}`);
+  }
+
+  async getChannelVar(channelId: string, variable: string): Promise<string | null> {
+    try {
+      const res = await this.fetchJson<{ value?: string }>(
+        `/channels/${encodeURIComponent(channelId)}/variable`,
+        { method: "GET", query: { variable } },
+      );
+      return res?.value ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async addChannelToBridge(bridgeId: string, channelId: string): Promise<void> {
+    await this.fetchJson(`/bridges/${encodeURIComponent(bridgeId)}/addChannel`, {
+      method: "POST",
+      query: { channel: channelId },
+    });
+  }
+
+  async addChannelsToBridge(bridgeId: string, channelIds: string[]): Promise<void> {
+    await this.fetchJson(`/bridges/${encodeURIComponent(bridgeId)}/addChannel`, {
+      method: "POST",
+      query: { channel: channelIds.join(",") },
+    });
+  }
+
+  async createExternalMedia(params: {
+    app: string;
+    externalHost: string;
+    format: "ulaw" | "alaw";
+    direction?: "both" | "in" | "out";
+    encapsulation?: "rtp" | "audiosocket";
+    transport?: "udp" | "tcp";
+  }): Promise<AriChannel> {
+    return this.fetchJson<AriChannel>("/channels/externalMedia", {
+      method: "POST",
+      query: {
+        app: params.app,
+        external_host: params.externalHost,
+        format: params.format,
+        direction: params.direction,
+        encapsulation: params.encapsulation,
+        transport: params.transport,
+      },
+    });
+  }
+
+  async createSnoop(params: {
+    app: string;
+    channelId: string;
+    spy: "in" | "out" | "both";
+    whisper: "none" | "in" | "out" | "both";
+    appArgs?: string;
+  }): Promise<AriChannel> {
+    return this.fetchJson<AriChannel>(
+      `/channels/${encodeURIComponent(params.channelId)}/snoop`,
+      {
+        method: "POST",
+        query: {
+          app: params.app,
+          spy: params.spy,
+          whisper: params.whisper,
+          appArgs: params.appArgs,
+        },
+      },
+    );
+  }
+
+  async deleteBridge(bridgeId: string): Promise<void> {
+    await this.fetchJson(`/bridges/${encodeURIComponent(bridgeId)}`, { method: "DELETE" });
+  }
+
+  async deleteChannel(channelId: string): Promise<void> {
+    await this.fetchJson(`/channels/${encodeURIComponent(channelId)}`, { method: "DELETE" });
+  }
+
+  async answerChannel(channelId: string): Promise<void> {
+    await this.fetchJson(`/channels/${encodeURIComponent(channelId)}/answer`, { method: "POST" });
+  }
+
+  async hangupChannel(channelId: string): Promise<void> {
+    await this.fetchJson(`/channels/${encodeURIComponent(channelId)}/hangup`, { method: "POST" });
+  }
+
+  async safeHangupChannel(channelId: string): Promise<void> {
+    try {
+      await this.hangupChannel(channelId);
+      return;
+    } catch {
+      // fall through
+    }
+    try {
+      await this.deleteChannel(channelId);
+    } catch {
+      // ignore
+    }
+  }
+
+  connectWs(handler: AriWsHandler): void {
+    if (this.ws) {
+      return;
+    }
+    const wsUrl = this.cfg.baseUrl.replace(/^http/, "ws") +
+      `/ari/events?app=${encodeURIComponent(this.cfg.app)}`;
+    const ws = new WebSocket(wsUrl, {
+      headers: {
+        Authorization:
+          "Basic " + Buffer.from(`${this.cfg.username}:${this.cfg.password}`).toString("base64"),
+      },
+    });
+
+    ws.onmessage = (evt) => {
+      try {
+        const data = JSON.parse(String(evt.data));
+        handler(data as AriEvent);
+      } catch {
+        // ignore parse errors
+      }
+    };
+
+    ws.onopen = () => {
+      this.reconnectAttempts = 0;
+    };
+
+    ws.onerror = () => {
+      try {
+        ws.close();
+      } catch {}
+    };
+
+    ws.onclose = () => {
+      this.ws = null;
+      this.scheduleReconnect(handler);
+    };
+
+    this.ws = ws;
+  }
+
+  private scheduleReconnect(handler: AriWsHandler): void {
+    if (this.reconnectTimer) return;
+    const attempt = Math.min(this.reconnectAttempts, 5);
+    const delay = 500 * Math.pow(2, attempt);
+    this.reconnectAttempts += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connectWs(handler);
+    }, delay);
+  }
+
+  closeWs(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {}
+      this.ws = null;
+    }
+  }
+
+  private async fetchJson<T = unknown>(
+    path: string,
+    opts?: {
+      method?: string;
+      query?: Record<string, string | number | boolean | undefined>;
+      body?: unknown;
+    },
+  ): Promise<T> {
+    const url = new URL(this.cfg.baseUrl.replace(/\/$/, "") + "/ari" + path);
+    if (opts?.query) {
+      for (const [k, v] of Object.entries(opts.query)) {
+        if (v === undefined) continue;
+        url.searchParams.set(k, String(v));
+      }
+    }
+
+    const res = await fetch(url.toString(), {
+      method: opts?.method ?? "GET",
+      headers: {
+        Authorization:
+          "Basic " + Buffer.from(`${this.cfg.username}:${this.cfg.password}`).toString("base64"),
+        "Content-Type": "application/json",
+      },
+      body: opts?.body ? JSON.stringify(opts.body) : undefined,
+    });
+
+    if (!res.ok) {
+      const txt = await res.text().catch(() => "");
+      throw new Error(`ARI HTTP ${res.status} ${res.statusText}${txt ? ": " + txt : ""}`);
+    }
+
+    const text = await res.text();
+    return text ? (JSON.parse(text) as T) : (undefined as T);
+  }
+}

--- a/extensions/voice-call/src/providers/asterisk-ari/ari-media.test.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/ari-media.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:dgram", async () => {
+  const { EventEmitter } = await import("node:events");
+  class FakeSocket extends EventEmitter {
+    private port = 0;
+    bind(port: number) {
+      this.port = port || 5555;
+      queueMicrotask(() => this.emit("listening"));
+    }
+    address() {
+      return { port: this.port || 5555 } as any;
+    }
+    close() {}
+  }
+  return {
+    default: {
+      createSocket: () => new FakeSocket(),
+    },
+  };
+});
+
+import { AriMedia } from "./ari-media.js";
+
+const cfg = {
+  baseUrl: "http://127.0.0.1:8088",
+  username: "user",
+  password: "pass",
+  app: "openclaw",
+  rtpHost: "127.0.0.1",
+  rtpPort: 12000,
+  codec: "ulaw",
+} as const;
+
+describe("AriMedia", () => {
+  it("retries addChannelsToBridge on error", async () => {
+    const client = {
+      createBridge: vi
+        .fn()
+        .mockResolvedValueOnce({ id: "bridge-1" })
+        .mockResolvedValueOnce({ id: "bridge-2" }),
+      createExternalMedia: vi
+        .fn()
+        .mockResolvedValueOnce({ id: "ext-1" })
+        .mockResolvedValueOnce({ id: "stt-ext-1" }),
+      addChannelsToBridge: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValueOnce(undefined),
+      getBridge: vi.fn().mockResolvedValue({ id: "bridge-1", channels: ["sip-1", "ext-1"] }),
+      createSnoop: vi.fn().mockResolvedValue({ id: "snoop-1" }),
+      addChannelToBridge: vi.fn().mockResolvedValue(undefined),
+      deleteBridge: vi.fn().mockResolvedValue(undefined),
+      safeHangupChannel: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    const media = new AriMedia(cfg, client);
+    const graph = await media.createMediaGraph({ sipChannelId: "sip-1" });
+
+    expect(client.addChannelsToBridge).toHaveBeenCalledTimes(2);
+    expect(graph.extChannelId).toBe("ext-1");
+    expect(graph.sttExtChannelId).toBe("stt-ext-1");
+    expect(graph.snoopChannelId).toBe("snoop-1");
+
+    await media.teardown(graph);
+    expect(client.safeHangupChannel).toHaveBeenCalledTimes(3);
+    expect(client.deleteBridge).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/voice-call/src/providers/asterisk-ari/ari-media.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/ari-media.ts
@@ -45,11 +45,20 @@ export class AriMedia {
 
       const bridge = await this.client.createBridge("mixing");
       bridgeId = bridge.id;
-      console.log("[ari] media graph", { rtpPort, sttRtpPort, bridgeId });
+      const externalHost = `${this.cfg.rtpHost}:${rtpPort}`;
+      const sttExternalHost = `${this.cfg.rtpHost}:${sttRtpPort}`;
+      console.log("[ari] media graph", {
+        rtpHost: this.cfg.rtpHost,
+        externalHost,
+        sttExternalHost,
+        rtpPort,
+        sttRtpPort,
+        bridgeId,
+      });
 
       const ext = await this.client.createExternalMedia({
         app: this.cfg.app,
-        externalHost: `${this.cfg.rtpHost}:${rtpPort}`,
+        externalHost,
         format: this.cfg.codec,
         direction: "both",
         encapsulation: "rtp",
@@ -59,7 +68,7 @@ export class AriMedia {
 
       const sttExt = await this.client.createExternalMedia({
         app: this.cfg.app,
-        externalHost: `${this.cfg.rtpHost}:${sttRtpPort}`,
+        externalHost: sttExternalHost,
         format: this.cfg.codec,
         direction: "out",
         encapsulation: "rtp",

--- a/extensions/voice-call/src/providers/asterisk-ari/ari-media.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/ari-media.ts
@@ -67,8 +67,12 @@ export class AriMedia {
       });
       sttExtChannelId = sttExt.id;
 
-      await this.client.addChannelsToBridge(bridgeId, [params.sipChannelId, extChannelId]);
-      await this.client.addChannelsToBridge(bridgeId, [params.sipChannelId, extChannelId]);
+      try {
+        await this.client.addChannelsToBridge(bridgeId, [params.sipChannelId, extChannelId]);
+      } catch (err) {
+        console.warn("[ari] addChannelsToBridge failed, retrying", err);
+        await this.client.addChannelsToBridge(bridgeId, [params.sipChannelId, extChannelId]);
+      }
       try {
         const b = await this.client.getBridge(bridgeId);
         console.log("[ari] bridge state", { bridgeId, channels: (b as AriChannel).channels });

--- a/extensions/voice-call/src/providers/asterisk-ari/ari-media.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/ari-media.ts
@@ -1,0 +1,179 @@
+import dgram from "node:dgram";
+import type { AriChannel, AriConfig } from "./types.js";
+import type { AriClient } from "./ari-client.js";
+
+export type MediaGraph = {
+  bridgeId: string;
+  sipChannelId: string;
+  extChannelId: string;
+  sttExtChannelId: string;
+  snoopChannelId: string;
+  sttBridgeId?: string;
+  rtpPort: number;
+  sttRtpPort: number;
+  udp: dgram.Socket;
+  sttUdp: dgram.Socket;
+};
+
+export class AriMedia {
+  private cfg: AriConfig;
+  private client: AriClient;
+  private nextRtpPort: number;
+
+  constructor(cfg: AriConfig, client: AriClient) {
+    this.cfg = cfg;
+    this.client = client;
+    this.nextRtpPort = cfg.rtpPort;
+  }
+
+  async createMediaGraph(params: { sipChannelId: string }): Promise<MediaGraph> {
+    const udp = dgram.createSocket("udp4");
+    const sttUdp = dgram.createSocket("udp4");
+
+    let rtpPort = 0;
+    let sttRtpPort = 0;
+
+    let bridgeId = "";
+    let sttBridgeId = "";
+    let extChannelId = "";
+    let sttExtChannelId = "";
+    let snoopChannelId = "";
+
+    try {
+      rtpPort = await this.allocatePort(udp);
+      sttRtpPort = await this.allocatePort(sttUdp);
+
+      const bridge = await this.client.createBridge("mixing");
+      bridgeId = bridge.id;
+      console.log("[ari] media graph", { rtpPort, sttRtpPort, bridgeId });
+
+      const ext = await this.client.createExternalMedia({
+        app: this.cfg.app,
+        externalHost: `${this.cfg.rtpHost}:${rtpPort}`,
+        format: this.cfg.codec,
+        direction: "both",
+        encapsulation: "rtp",
+        transport: "udp",
+      });
+      extChannelId = ext.id;
+
+      const sttExt = await this.client.createExternalMedia({
+        app: this.cfg.app,
+        externalHost: `${this.cfg.rtpHost}:${sttRtpPort}`,
+        format: this.cfg.codec,
+        direction: "out",
+        encapsulation: "rtp",
+        transport: "udp",
+      });
+      sttExtChannelId = sttExt.id;
+
+      await this.client.addChannelsToBridge(bridgeId, [params.sipChannelId, extChannelId]);
+      await this.client.addChannelsToBridge(bridgeId, [params.sipChannelId, extChannelId]);
+      try {
+        const b = await this.client.getBridge(bridgeId);
+        console.log("[ari] bridge state", { bridgeId, channels: (b as AriChannel).channels });
+      } catch (err) {
+        console.warn("[ari] bridge state fetch failed", err);
+      }
+
+      const snoop = await this.client.createSnoop({
+        app: this.cfg.app,
+        channelId: params.sipChannelId,
+        spy: "in",
+        whisper: "none",
+        appArgs: "snoop",
+      });
+      snoopChannelId = snoop.id;
+
+      const sttBridge = await this.client.createBridge("mixing");
+      sttBridgeId = sttBridge.id;
+      await this.client.addChannelToBridge(sttBridgeId, snoopChannelId);
+      await this.client.addChannelToBridge(sttBridgeId, sttExtChannelId);
+      try {
+        const sb = await this.client.getBridge(sttBridgeId);
+        console.log("[ari] stt bridge state", { sttBridgeId, channels: (sb as AriChannel).channels });
+      } catch (err) {
+        console.warn("[ari] stt bridge state fetch failed", err);
+      }
+
+      return {
+        bridgeId,
+        sttBridgeId,
+        sipChannelId: params.sipChannelId,
+        extChannelId,
+        sttExtChannelId,
+        snoopChannelId,
+        rtpPort,
+        sttRtpPort,
+        udp,
+        sttUdp,
+      };
+    } catch (err) {
+      await this.safeTeardown({
+        bridgeId,
+        sttBridgeId,
+        sipChannelId: params.sipChannelId,
+        extChannelId,
+        sttExtChannelId,
+        snoopChannelId,
+        rtpPort,
+        sttRtpPort,
+        udp,
+        sttUdp,
+      });
+      throw err;
+    }
+  }
+
+  async teardown(graph: MediaGraph): Promise<void> {
+    await this.safeTeardown(graph);
+  }
+
+  private async safeTeardown(graph: MediaGraph): Promise<void> {
+    try {
+      graph.udp?.close();
+    } catch {}
+    try {
+      graph.sttUdp?.close();
+    } catch {}
+
+    if (graph.extChannelId) await this.client.safeHangupChannel(graph.extChannelId).catch(() => {});
+    if (graph.sttExtChannelId)
+      await this.client.safeHangupChannel(graph.sttExtChannelId).catch(() => {});
+    if (graph.snoopChannelId)
+      await this.client.safeHangupChannel(graph.snoopChannelId).catch(() => {});
+
+    if (graph.bridgeId) await this.client.deleteBridge(graph.bridgeId).catch(() => {});
+    if (graph.sttBridgeId) await this.client.deleteBridge(graph.sttBridgeId).catch(() => {});
+  }
+
+  private async allocatePort(socket: dgram.Socket): Promise<number> {
+    for (let i = 0; i < 20; i++) {
+      const candidate = this.nextRtpPort++;
+      try {
+        await this.bindUdp(socket, candidate);
+        return candidate;
+      } catch (err: any) {
+        if (err.code !== "EADDRINUSE") throw err;
+      }
+    }
+    await this.bindUdp(socket, 0);
+    return (socket.address() as any).port;
+  }
+
+  private async bindUdp(udp: dgram.Socket, port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const onError = (err: unknown) => {
+        udp.off("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        udp.off("error", onError);
+        resolve();
+      };
+      udp.once("error", onError);
+      udp.once("listening", onListening);
+      udp.bind(port, "0.0.0.0");
+    });
+  }
+}

--- a/extensions/voice-call/src/providers/asterisk-ari/types.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari/types.ts
@@ -1,0 +1,35 @@
+export type AriConfig = {
+  baseUrl: string;
+  username: string;
+  password: string;
+  app: string;
+  rtpHost: string;
+  rtpPort: number;
+  codec: "ulaw" | "alaw";
+  trunk?: string;
+};
+
+export type AriChannel = {
+  id: string;
+  name?: string;
+  state?: string;
+  dialplan?: {
+    app_name?: string;
+    app_data?: string;
+  };
+  caller?: {
+    number?: string;
+    name?: string;
+  };
+};
+
+export type AriBridge = {
+  id: string;
+  channels?: string[];
+};
+
+export type AriEndpointState = {
+  technology: string;
+  resource: string;
+  state: string;
+};

--- a/extensions/voice-call/src/providers/index.ts
+++ b/extensions/voice-call/src/providers/index.ts
@@ -8,3 +8,4 @@ export {
 export { TelnyxProvider } from "./telnyx.js";
 export { TwilioProvider } from "./twilio.js";
 export { PlivoProvider } from "./plivo.js";
+export { AsteriskAriProvider } from "./asterisk-ari.js";

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -56,8 +56,10 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
           publicKey: config.telnyx?.publicKey,
         },
         {
-          // Keep previous behavior: when explicitly skipping verification (dev), allow unsigned.
-          allowUnsignedWebhooks: config.skipSignatureVerification,
+          // Preserve upstream behavior: allow unsigned webhooks only when inbound is effectively off.
+          // (Inbound allowlist/pairing requires telnyx.publicKey; see validateProviderConfig.)
+          allowUnsignedWebhooks:
+            config.inboundPolicy === "open" || config.inboundPolicy === "disabled",
         },
       );
     case "twilio":

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -4,11 +4,11 @@ import type { VoiceCallProvider } from "./providers/base.js";
 import type { TelephonyTtsRuntime } from "./telephony-tts.js";
 import { resolveVoiceCallConfig, validateProviderConfig } from "./config.js";
 import { CallManager } from "./manager.js";
+import { AsteriskAriProvider } from "./providers/asterisk-ari.js";
 import { MockProvider } from "./providers/mock.js";
 import { PlivoProvider } from "./providers/plivo.js";
 import { TelnyxProvider } from "./providers/telnyx.js";
 import { TwilioProvider } from "./providers/twilio.js";
-import { AsteriskAriProvider } from "./providers/asterisk-ari.js";
 import { createTelephonyTtsProvider } from "./telephony-tts.js";
 import { startTunnel, type TunnelResult } from "./tunnel.js";
 import {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -49,11 +49,17 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
 
   switch (config.provider) {
     case "telnyx":
-      return new TelnyxProvider({
-        apiKey: config.telnyx?.apiKey,
-        connectionId: config.telnyx?.connectionId,
-        publicKey: config.telnyx?.publicKey,
-      });
+      return new TelnyxProvider(
+        {
+          apiKey: config.telnyx?.apiKey,
+          connectionId: config.telnyx?.connectionId,
+          publicKey: config.telnyx?.publicKey,
+        },
+        {
+          // Keep previous behavior: when explicitly skipping verification (dev), allow unsigned.
+          allowUnsignedWebhooks: config.skipSignatureVerification,
+        },
+      );
     case "twilio":
       return new TwilioProvider(
         {
@@ -65,6 +71,7 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
           publicUrl: config.publicUrl,
           skipVerification: config.skipSignatureVerification,
           streamPath: config.streaming?.enabled ? config.streaming.streamPath : undefined,
+          webhookSecurity: config.webhookSecurity,
         },
       );
     case "plivo":
@@ -77,6 +84,7 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
           publicUrl: config.publicUrl,
           skipVerification: config.skipSignatureVerification,
           ringTimeoutSec: Math.max(1, Math.floor(config.ringTimeoutMs / 1000)),
+          webhookSecurity: config.webhookSecurity,
         },
       );
     case "mock":

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -41,7 +41,11 @@ function isLoopbackBind(bind: string | undefined): boolean {
   return bind === "127.0.0.1" || bind === "::1" || bind === "localhost";
 }
 
-function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCallProvider {
+function resolveProvider(
+  config: VoiceCallConfig,
+  manager: CallManager,
+  coreConfig?: CoreConfig,
+): VoiceCallProvider {
   const allowNgrokFreeTierLoopbackBypass =
     config.tunnel?.provider === "ngrok" &&
     isLoopbackBind(config.serve?.bind) &&
@@ -92,7 +96,7 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
     case "mock":
       return new MockProvider();
     case "asterisk-ari":
-      return new AsteriskAriProvider({ config, manager });
+      return new AsteriskAriProvider({ config, manager, coreConfig });
     default:
       throw new Error(`Unsupported voice-call provider: ${String(config.provider)}`);
   }
@@ -124,7 +128,7 @@ export async function createVoiceCallRuntime(params: {
   }
 
   const manager = new CallManager(config);
-  const provider = resolveProvider(config, manager);
+  const provider = resolveProvider(config, manager, coreConfig);
   const webhookServer = new VoiceCallWebhookServer(config, manager, provider, coreConfig);
 
   const localUrl = await webhookServer.start();

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -5,7 +5,7 @@ import type { CallMode } from "./config.js";
 // Provider Identifiers
 // -----------------------------------------------------------------------------
 
-export const ProviderNameSchema = z.enum(["telnyx", "twilio", "plivo", "mock"]);
+export const ProviderNameSchema = z.enum(["telnyx", "twilio", "plivo", "mock", "asterisk-ari"]);
 export type ProviderName = z.infer<typeof ProviderNameSchema>;
 
 // -----------------------------------------------------------------------------

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -196,6 +196,8 @@ export type ProviderWebhookParseResult = {
 export type InitiateCallInput = {
   callId: CallId;
   from: string;
+  /** Optional caller name (display name). */
+  fromName?: string;
   to: string;
   webhookUrl: string;
   clientState?: Record<string, string>;
@@ -242,6 +244,8 @@ export type OutboundCallOptions = {
   message?: string;
   /** Call mode (overrides config default) */
   mode?: CallMode;
+  /** Optional caller name (display name). */
+  fromName?: string;
 };
 
 // -----------------------------------------------------------------------------

--- a/src/extensionAPI.ts
+++ b/src/extensionAPI.ts
@@ -6,6 +6,7 @@ export { resolveThinkingDefault } from "./agents/model-selection.ts";
 export { runEmbeddedPiAgent } from "./agents/pi-embedded.ts";
 export { resolveAgentTimeoutMs } from "./agents/timeout.ts";
 export { ensureAgentWorkspace } from "./agents/workspace.ts";
+export { transcribeAudioWithCore } from "./media-understanding/transcribe.ts";
 export {
   resolveStorePath,
   loadSessionStore,

--- a/src/media-understanding/transcribe.ts
+++ b/src/media-understanding/transcribe.ts
@@ -103,7 +103,7 @@ function resolveProviderQuery(params: {
   const compat = buildDeepgramCompatQuery({ ...config?.deepgram, ...entry.deepgram });
   for (const [key, value] of Object.entries(compat ?? {})) {
     if (query[key] === undefined) {
-      query[key] = value as string | number | boolean;
+      query[key] = value;
     }
   }
   return Object.keys(query).length > 0 ? query : undefined;

--- a/src/media-understanding/transcribe.ts
+++ b/src/media-understanding/transcribe.ts
@@ -1,0 +1,296 @@
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type {
+  MediaUnderstandingConfig,
+  MediaUnderstandingModelConfig,
+} from "../config/types.tools.js";
+import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
+import {
+  buildProviderRegistry,
+  createMediaAttachmentCache,
+  normalizeMediaAttachments,
+  runCapability,
+} from "./runner.js";
+import { DEFAULT_AUDIO_MODELS, DEFAULT_TIMEOUT_SECONDS } from "./defaults.js";
+import {
+  resolveMaxBytes,
+  resolveMaxChars,
+  resolvePrompt,
+  resolveTimeoutMs,
+  resolveModelEntries,
+} from "./resolve.js";
+import {
+  getMediaUnderstandingProvider,
+  normalizeMediaProviderId,
+} from "./providers/index.js";
+import type { MediaUnderstandingDecision } from "./types.js";
+
+export type CoreAudioTranscriptionResult = {
+  text: string | null;
+  provider?: string;
+  model?: string;
+  decision: MediaUnderstandingDecision;
+};
+
+const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google"] as const;
+
+type ProviderQuery = Record<string, string | number | boolean>;
+
+function normalizeProviderQuery(
+  options?: Record<string, string | number | boolean>,
+): ProviderQuery | undefined {
+  if (!options) {
+    return undefined;
+  }
+  const query: ProviderQuery = {};
+  for (const [key, value] of Object.entries(options)) {
+    if (value === undefined) {
+      continue;
+    }
+    query[key] = value;
+  }
+  return Object.keys(query).length > 0 ? query : undefined;
+}
+
+function buildDeepgramCompatQuery(options?: {
+  detectLanguage?: boolean;
+  punctuate?: boolean;
+  smartFormat?: boolean;
+}): ProviderQuery | undefined {
+  if (!options) {
+    return undefined;
+  }
+  const query: ProviderQuery = {};
+  if (typeof options.detectLanguage === "boolean") {
+    query.detect_language = options.detectLanguage;
+  }
+  if (typeof options.punctuate === "boolean") {
+    query.punctuate = options.punctuate;
+  }
+  if (typeof options.smartFormat === "boolean") {
+    query.smart_format = options.smartFormat;
+  }
+  return Object.keys(query).length > 0 ? query : undefined;
+}
+
+function normalizeDeepgramQueryKeys(query: ProviderQuery): ProviderQuery {
+  const normalized = { ...query };
+  if ("detectLanguage" in normalized) {
+    normalized.detect_language = normalized.detectLanguage as boolean;
+    delete normalized.detectLanguage;
+  }
+  if ("smartFormat" in normalized) {
+    normalized.smart_format = normalized.smartFormat as boolean;
+    delete normalized.smartFormat;
+  }
+  return normalized;
+}
+
+function resolveProviderQuery(params: {
+  providerId: string;
+  config?: MediaUnderstandingConfig;
+  entry: MediaUnderstandingModelConfig;
+}): ProviderQuery | undefined {
+  const { providerId, config, entry } = params;
+  const mergedOptions = normalizeProviderQuery({
+    ...config?.providerOptions?.[providerId],
+    ...entry.providerOptions?.[providerId],
+  });
+  if (providerId !== "deepgram") {
+    return mergedOptions;
+  }
+  let query = normalizeDeepgramQueryKeys(mergedOptions ?? {});
+  const compat = buildDeepgramCompatQuery({ ...config?.deepgram, ...entry.deepgram });
+  for (const [key, value] of Object.entries(compat ?? {})) {
+    if (query[key] === undefined) {
+      query[key] = value as string | number | boolean;
+    }
+  }
+  return Object.keys(query).length > 0 ? query : undefined;
+}
+
+function trimOutput(text: string, maxChars?: number): string {
+  const trimmed = text.trim();
+  if (!maxChars || trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return trimmed.slice(0, maxChars).trim();
+}
+
+async function resolveAutoAudioEntry(params: {
+  cfg: OpenClawConfig;
+  providerRegistry: Map<string, { capabilities?: string[] }>;
+}): Promise<MediaUnderstandingModelConfig | null> {
+  for (const providerId of AUTO_AUDIO_KEY_PROVIDERS) {
+    const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
+    if (!provider || !provider.transcribeAudio) {
+      continue;
+    }
+    try {
+      await resolveApiKeyForProvider({ provider: providerId, cfg: params.cfg });
+      return { type: "provider", provider: providerId };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+async function transcribeAudioBufferWithCore(params: {
+  cfg: OpenClawConfig;
+  buffer: Buffer;
+  mime?: string;
+  fileName?: string;
+}): Promise<CoreAudioTranscriptionResult> {
+  const config = params.cfg.tools?.media?.audio;
+  if (config?.enabled === false) {
+    return {
+      text: null,
+      decision: { capability: "audio", outcome: "disabled", attachments: [] },
+    };
+  }
+
+  const providerRegistry = buildProviderRegistry();
+  let entries = resolveModelEntries({
+    cfg: params.cfg,
+    capability: "audio",
+    config,
+    providerRegistry,
+  });
+  if (entries.length === 0) {
+    const auto = await resolveAutoAudioEntry({ cfg: params.cfg, providerRegistry });
+    if (auto) {
+      entries = [auto];
+    }
+  }
+
+  if (entries.length === 0) {
+    return {
+      text: null,
+      decision: { capability: "audio", outcome: "skipped", attachments: [] },
+    };
+  }
+
+  for (const entry of entries) {
+    if ((entry.type ?? (entry.command ? "cli" : "provider")) !== "provider") {
+      continue;
+    }
+    const providerIdRaw = entry.provider?.trim();
+    if (!providerIdRaw) {
+      continue;
+    }
+    const providerId = normalizeMediaProviderId(providerIdRaw) ?? providerIdRaw;
+    const provider = getMediaUnderstandingProvider(providerId, providerRegistry);
+    if (!provider?.transcribeAudio) {
+      continue;
+    }
+
+    const maxBytes = resolveMaxBytes({ capability: "audio", entry, cfg: params.cfg, config });
+    if (params.buffer.length > maxBytes) {
+      continue;
+    }
+
+    const maxChars = resolveMaxChars({ capability: "audio", entry, cfg: params.cfg, config });
+    const timeoutMs = resolveTimeoutMs(
+      entry.timeoutSeconds ?? config?.timeoutSeconds ?? params.cfg.tools?.media?.audio?.timeoutSeconds,
+      DEFAULT_TIMEOUT_SECONDS,
+    );
+    const prompt = resolvePrompt("audio", entry.prompt ?? config?.prompt, maxChars);
+
+    const auth = await resolveApiKeyForProvider({ provider: providerId, cfg: params.cfg });
+    const apiKey = requireApiKey(auth, providerId);
+    const providerConfig = params.cfg.models?.providers?.[providerId];
+    const baseUrl = entry.baseUrl ?? config?.baseUrl ?? providerConfig?.baseUrl;
+    const mergedHeaders = {
+      ...providerConfig?.headers,
+      ...config?.headers,
+      ...entry.headers,
+    };
+    const headers = Object.keys(mergedHeaders).length > 0 ? mergedHeaders : undefined;
+    const providerQuery = resolveProviderQuery({ providerId, config, entry });
+    const model = entry.model?.trim() || DEFAULT_AUDIO_MODELS[providerId] || entry.model;
+
+    try {
+      const result = await provider.transcribeAudio({
+        buffer: params.buffer,
+        fileName: params.fileName ?? "audio.wav",
+        mime: params.mime ?? "audio/wav",
+        apiKey,
+        baseUrl,
+        headers,
+        model,
+        language: entry.language ?? config?.language ?? params.cfg.tools?.media?.audio?.language,
+        prompt,
+        query: providerQuery,
+        timeoutMs,
+      });
+      const text = trimOutput(result.text, maxChars);
+      if (text) {
+        return {
+          text,
+          provider: providerId,
+          model: result.model ?? model,
+          decision: { capability: "audio", outcome: "success", attachments: [] },
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return {
+    text: null,
+    decision: { capability: "audio", outcome: "skipped", attachments: [] },
+  };
+}
+
+export async function transcribeAudioWithCore(params: {
+  cfg: OpenClawConfig;
+  filePath?: string;
+  buffer?: Buffer;
+  mime?: string;
+  ctx?: MsgContext;
+}): Promise<CoreAudioTranscriptionResult> {
+  if (params.buffer) {
+    return await transcribeAudioBufferWithCore({
+      cfg: params.cfg,
+      buffer: params.buffer,
+      mime: params.mime,
+      fileName: params.filePath ? params.filePath.split("/").pop() : undefined,
+    });
+  }
+  if (!params.filePath) {
+    return {
+      text: null,
+      decision: { capability: "audio", outcome: "skipped", attachments: [] },
+    };
+  }
+
+  const ctx: MsgContext =
+    params.ctx ?? ({ MediaPath: params.filePath, MediaType: params.mime ?? "audio/wav" } as MsgContext);
+
+  const media = normalizeMediaAttachments(ctx);
+  const cache = createMediaAttachmentCache(media);
+  const providerRegistry = buildProviderRegistry();
+
+  try {
+    const result = await runCapability({
+      capability: "audio",
+      cfg: params.cfg,
+      ctx,
+      attachments: cache,
+      media,
+      providerRegistry,
+    });
+
+    const output = result.outputs[0];
+    return {
+      text: output?.text ?? null,
+      provider: output?.provider,
+      model: output?.model,
+      decision: result.decision,
+    };
+  } finally {
+    await cache.cleanup();
+  }
+}

--- a/src/media-understanding/transcribe.ts
+++ b/src/media-understanding/transcribe.ts
@@ -23,7 +23,7 @@ import {
   getMediaUnderstandingProvider,
   normalizeMediaProviderId,
 } from "./providers/index.js";
-import type { MediaUnderstandingDecision } from "./types.js";
+import type { MediaUnderstandingDecision, MediaUnderstandingProvider } from "./types.js";
 
 export type CoreAudioTranscriptionResult = {
   text: string | null;
@@ -119,7 +119,7 @@ function trimOutput(text: string, maxChars?: number): string {
 
 async function resolveAutoAudioEntry(params: {
   cfg: OpenClawConfig;
-  providerRegistry: Map<string, { capabilities?: string[] }>;
+  providerRegistry: Map<string, MediaUnderstandingProvider>;
 }): Promise<MediaUnderstandingModelConfig | null> {
   for (const providerId of AUTO_AUDIO_KEY_PROVIDERS) {
     const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);

--- a/src/media-understanding/transcribe.ts
+++ b/src/media-understanding/transcribe.ts
@@ -197,8 +197,6 @@ async function transcribeAudioBufferWithCore(params: {
     );
     const prompt = resolvePrompt("audio", entry.prompt ?? config?.prompt, maxChars);
 
-    const auth = await resolveApiKeyForProvider({ provider: providerId, cfg: params.cfg });
-    const apiKey = requireApiKey(auth, providerId);
     const providerConfig = params.cfg.models?.providers?.[providerId];
     const baseUrl = entry.baseUrl ?? config?.baseUrl ?? providerConfig?.baseUrl;
     const mergedHeaders = {
@@ -211,6 +209,8 @@ async function transcribeAudioBufferWithCore(params: {
     const model = entry.model?.trim() || DEFAULT_AUDIO_MODELS[providerId] || entry.model;
 
     try {
+      const auth = await resolveApiKeyForProvider({ provider: providerId, cfg: params.cfg });
+      const apiKey = requireApiKey(auth, providerId);
       const result = await provider.transcribeAudio({
         buffer: params.buffer,
         fileName: params.fileName ?? "audio.wav",


### PR DESCRIPTION
AI-assisted PR.

## Problem
We need a stable way to handle voice calls across multiple telephony worlds (SIP endpoints, SIP trunks, GSM gateways) while keeping **one consistent OpenClaw integration**. Asterisk is the natural telecom router, but **ARI (Stasis) has no built‑in STT**. That means call control alone isn’t enough if we want `call.speech` events and the same transcription semantics as other providers. RTP media can also be fragile (codec/PT/NAT), and without a deterministic setup you end up with “rings but silence.”

## Solution
Add/refresh the **`asterisk-ari`** provider and split responsibilities cleanly:
- **Asterisk ARI (Stasis)** for call control (channels, bridges, events, DTMF)
- **ExternalMedia / UnicastRTP** for deterministic audio bridging
- **OpenClaw core transcription** for STT (with auto‑fallback across configured engines)

Key decision: **STT lives in core**, not inside the provider. This keeps behavior consistent across providers (events, VAD, fallback), regardless of the audio source.

## Functionality
**1) Call handling (outbound/inbound)**
- Outbound: originate → Stasis → mixing bridge → ExternalMedia → RTP → TTS playback
- Inbound: Stasis entry → bridge → ExternalMedia → RTP → core STT → `call.speech`

**2) Audio + codecs**
- Uses `asteriskAri.codec` (no `format` field in schemas)
- RTP payload type matches codec (PCMU=0 / PCMA=8)
- μ‑law ↔ A‑law conversion supported
- **Per‑call RTP sockets/ports** + deterministic media setup

**3) STT via OpenClaw core**
- In‑memory buffering → WAV → core transcription
- VAD with dynamic noise floor + hangover + pre‑roll + backpressure
- Emits standard `call.speech` events

**4) DTMF**
- `ChannelDtmfReceived` → `call.dtmf`

**5) Cleanup + resilience**
- Best‑effort ExternalMedia cleanup (idempotent)
- Inbound reject: hangup by SIP channel id (best‑effort; channel may already be gone)

## Testing
**Unit tests:**
- npx -y vitest run extensions/voice-call/src/providers/asterisk-ari.test.ts
- npx -y vitest run extensions/voice-call/src/providers/asterisk-ari/ari-client.test.ts
- npx -y vitest run extensions/voice-call/src/providers/asterisk-ari/ari-media.test.ts

**Manual checklist (summary):**
- Asterisk config + Stasis app name matches `asteriskAri.app`
- Outbound: call → TTS audible → `call.speech`
- Inbound: Stasis route → greeting → `call.speech`
- DTMF: digits → `call.dtmf`
- STT/VAD: silence vs short utterances vs noise

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `asterisk-ari` voice-call provider that uses Asterisk ARI/Stasis for call control and ExternalMedia/UnicastRTP for deterministic RTP bridging, while moving STT into core (via a new `transcribeAudioWithCore` entry point). Voice-call config/schema is extended to support the provider (`asteriskAri` block, codec/ports, provider enum updates) and outbound call initiation now supports an optional `fromName` display name.

At runtime, the voice-call extension resolves `asterisk-ari` as a provider and wires it into the existing `CallManager`/webhook server flow; ARI events are consumed over WebSocket and normalized into standard `call.*` events so the rest of the voice-call stack stays consistent across providers.

<h3>Confidence Score: 3/5</h3>

- This PR is close but has a couple of call lifecycle issues that can break hangup/association in real inbound/outbound scenarios.
- Most changes are additive and well-scoped (new provider + core transcription entrypoint), but there are at least two definite lifecycle bugs: inbound call ID consistency relies on CallManager mutating the same event object, and hangup fallback attempts to hang up a non-channel UUID when state is missing. These can lead to orphaned calls and failed hangups.
- extensions/voice-call/src/providers/asterisk-ari.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->