### PR TITLE
feat: auto-prune expired cron run sessions

### DIFF
--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -2,4 +2,10 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  /**
+   * How long to retain completed cron run sessions before automatic pruning.
+   * Accepts a duration string (e.g. "24h", "7d", "1h30m") or `false` to disable pruning.
+   * Default: "24h".
+   */
+  sessionRetention?: string | false;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -292,6 +292,7 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
+        sessionRetention: z.union([z.string(), z.literal(false)]).optional(),
       })
       .strict()
       .optional(),

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -1,3 +1,4 @@
+import type { CronConfig } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import type { CronJob, CronJobCreate, CronJobPatch, CronStoreFile } from "../types.js";
 
@@ -26,6 +27,10 @@ export type CronServiceDeps = {
   log: Logger;
   storePath: string;
   cronEnabled: boolean;
+  /** CronConfig for session retention settings. */
+  cronConfig?: CronConfig;
+  /** Path to the session store (sessions.json) for reaper use. */
+  sessionStorePath?: string;
   enqueueSystemEvent: (text: string, opts?: { agentId?: string }) => void;
   requestHeartbeatNow: (opts?: { reason?: string }) => void;
   runHeartbeatOnce?: (opts?: { reason?: string }) => Promise<HeartbeatRunResult>;

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Logger } from "./service/state.js";
+import {
+  sweepCronRunSessions,
+  resolveRetentionMs,
+  isCronRunSessionKey,
+  resetReaperThrottle,
+} from "./session-reaper.js";
+
+function createTestLogger(): Logger {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+}
+
+describe("resolveRetentionMs", () => {
+  it("returns 24h default when no config", () => {
+    expect(resolveRetentionMs()).toBe(24 * 3_600_000);
+  });
+
+  it("returns 24h default when config is empty", () => {
+    expect(resolveRetentionMs({})).toBe(24 * 3_600_000);
+  });
+
+  it("parses duration string", () => {
+    expect(resolveRetentionMs({ sessionRetention: "1h" })).toBe(3_600_000);
+    expect(resolveRetentionMs({ sessionRetention: "7d" })).toBe(7 * 86_400_000);
+    expect(resolveRetentionMs({ sessionRetention: "30m" })).toBe(30 * 60_000);
+  });
+
+  it("returns null when disabled", () => {
+    expect(resolveRetentionMs({ sessionRetention: false })).toBeNull();
+  });
+
+  it("falls back to default on invalid string", () => {
+    expect(resolveRetentionMs({ sessionRetention: "abc" })).toBe(24 * 3_600_000);
+  });
+});
+
+describe("isCronRunSessionKey", () => {
+  it("matches cron run session keys", () => {
+    expect(isCronRunSessionKey("agent:main:cron:abc-123:run:def-456")).toBe(true);
+    expect(isCronRunSessionKey("agent:debugger:cron:249ecf82:run:1102aabb")).toBe(true);
+  });
+
+  it("does not match base cron session keys", () => {
+    expect(isCronRunSessionKey("agent:main:cron:abc-123")).toBe(false);
+  });
+
+  it("does not match regular session keys", () => {
+    expect(isCronRunSessionKey("agent:main:telegram:dm:123")).toBe(false);
+  });
+});
+
+describe("sweepCronRunSessions", () => {
+  let tmpDir: string;
+  let storePath: string;
+  const log = createTestLogger();
+
+  beforeEach(async () => {
+    resetReaperThrottle();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cron-reaper-"));
+    storePath = path.join(tmpDir, "sessions.json");
+  });
+
+  it("prunes expired cron run sessions", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:job1": {
+        sessionId: "base-session",
+        updatedAt: now,
+      },
+      "agent:main:cron:job1:run:old-run": {
+        sessionId: "old-run",
+        updatedAt: now - 25 * 3_600_000, // 25h ago — expired
+      },
+      "agent:main:cron:job1:run:recent-run": {
+        sessionId: "recent-run",
+        updatedAt: now - 1 * 3_600_000, // 1h ago — not expired
+      },
+      "agent:main:telegram:dm:123": {
+        sessionId: "regular-session",
+        updatedAt: now - 100 * 3_600_000, // old but not a cron run
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.swept).toBe(true);
+    expect(result.pruned).toBe(1);
+
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated["agent:main:cron:job1"]).toBeDefined();
+    expect(updated["agent:main:cron:job1:run:old-run"]).toBeUndefined();
+    expect(updated["agent:main:cron:job1:run:recent-run"]).toBeDefined();
+    expect(updated["agent:main:telegram:dm:123"]).toBeDefined();
+  });
+
+  it("respects custom retention", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:job1:run:run1": {
+        sessionId: "run1",
+        updatedAt: now - 2 * 3_600_000, // 2h ago
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      cronConfig: { sessionRetention: "1h" },
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.pruned).toBe(1);
+  });
+
+  it("does nothing when pruning is disabled", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:job1:run:run1": {
+        sessionId: "run1",
+        updatedAt: now - 100 * 3_600_000,
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      cronConfig: { sessionRetention: false },
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.swept).toBe(false);
+    expect(result.pruned).toBe(0);
+  });
+
+  it("throttles sweeps without force", async () => {
+    const now = Date.now();
+    fs.writeFileSync(storePath, JSON.stringify({}));
+
+    // First sweep runs
+    const r1 = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+    });
+    expect(r1.swept).toBe(true);
+
+    // Second sweep (1 second later) is throttled
+    const r2 = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now + 1000,
+      log,
+    });
+    expect(r2.swept).toBe(false);
+  });
+});

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -1,0 +1,118 @@
+/**
+ * Cron session reaper — prunes completed isolated cron run sessions
+ * from the session store after a configurable retention period.
+ *
+ * Pattern: sessions keyed as `...:cron:<jobId>:run:<uuid>` are ephemeral
+ * run records. The base session (`...:cron:<jobId>`) is kept as-is.
+ */
+
+import type { CronConfig } from "../config/types.cron.js";
+import type { Logger } from "./service/state.js";
+import { parseDurationMs } from "../cli/parse-duration.js";
+import { updateSessionStore } from "../config/sessions.js";
+
+const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
+const CRON_RUN_KEY_PATTERN = /:cron:[^:]+:run:/;
+
+/** Minimum interval between reaper sweeps (avoid running every timer tick). */
+const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
+
+let lastSweepAtMs = 0;
+
+export function resolveRetentionMs(cronConfig?: CronConfig): number | null {
+  if (cronConfig?.sessionRetention === false) {
+    return null; // pruning disabled
+  }
+  const raw = cronConfig?.sessionRetention;
+  if (typeof raw === "string" && raw.trim()) {
+    try {
+      return parseDurationMs(raw.trim(), { defaultUnit: "h" });
+    } catch {
+      return DEFAULT_RETENTION_MS;
+    }
+  }
+  return DEFAULT_RETENTION_MS;
+}
+
+export function isCronRunSessionKey(key: string): boolean {
+  return CRON_RUN_KEY_PATTERN.test(key);
+}
+
+export type ReaperResult = {
+  swept: boolean;
+  pruned: number;
+};
+
+/**
+ * Sweep the session store and prune expired cron run sessions.
+ * Designed to be called from the cron timer tick — self-throttles via
+ * MIN_SWEEP_INTERVAL_MS to avoid excessive I/O.
+ *
+ * Lock ordering: this function acquires the session-store file lock via
+ * `updateSessionStore`. It must be called OUTSIDE of the cron service's
+ * own `locked()` section to avoid lock-order inversions. The cron timer
+ * calls this after all `locked()` sections have been released.
+ */
+export async function sweepCronRunSessions(params: {
+  cronConfig?: CronConfig;
+  /** Resolved path to sessions.json — required. */
+  sessionStorePath: string;
+  nowMs?: number;
+  log: Logger;
+  /** Override for testing — skips the min-interval throttle. */
+  force?: boolean;
+}): Promise<ReaperResult> {
+  const now = params.nowMs ?? Date.now();
+
+  // Throttle: don't sweep more often than every 5 minutes.
+  if (!params.force && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
+    return { swept: false, pruned: 0 };
+  }
+
+  const retentionMs = resolveRetentionMs(params.cronConfig);
+  if (retentionMs === null) {
+    return { swept: false, pruned: 0 };
+  }
+
+  const storePath = params.sessionStorePath;
+
+  let pruned = 0;
+  try {
+    await updateSessionStore(storePath, (store) => {
+      const cutoff = now - retentionMs;
+      for (const key of Object.keys(store)) {
+        if (!isCronRunSessionKey(key)) {
+          continue;
+        }
+        const entry = store[key];
+        if (!entry) {
+          continue;
+        }
+        const updatedAt = entry.updatedAt ?? 0;
+        if (updatedAt < cutoff) {
+          delete store[key];
+          pruned++;
+        }
+      }
+    });
+  } catch (err) {
+    params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
+    return { swept: false, pruned: 0 };
+  }
+
+  lastSweepAtMs = now;
+
+  if (pruned > 0) {
+    params.log.info(
+      { pruned, retentionMs },
+      `cron-reaper: pruned ${pruned} expired cron run session(s)`,
+    );
+  }
+
+  return { swept: true, pruned };
+}
+
+/** Reset the throttle timer (for tests). */
+export function resetReaperThrottle(): void {
+  lastSweepAtMs = 0;
+}

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -2,6 +2,7 @@ import type { CliDeps } from "../cli/deps.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { resolveAgentMainSessionKey } from "../config/sessions.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { appendCronRunLog, resolveCronRunLogPath } from "../cron/run-log.js";
 import { CronService } from "../cron/service.js";
@@ -43,9 +44,16 @@ export function buildGatewayCronService(params: {
     return { agentId, cfg: runtimeConfig };
   };
 
+  const defaultAgentId = resolveDefaultAgentId(params.cfg);
+  const sessionStorePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: defaultAgentId,
+  });
+
   const cron = new CronService({
     storePath,
     cronEnabled,
+    cronConfig: params.cfg.cron,
+    sessionStorePath,
     enqueueSystemEvent: (text, opts) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(opts?.agentId);
       const sessionKey = resolveAgentMainSessionKey({


### PR DESCRIPTION
## The problem

Every isolated cron job creates a `cron:jobId:run:uuid` entry in `sessions.json` that is never cleaned up. If you have 20 jobs running every 15 minutes, that is ~100 orphan entries per day. In a month, 3000+ entries in a JSON file that gets read and written on every session operation. Performance degrades, disk grows, and any tool that lists sessions gets slower over time.

Closes #12289
Related: #11260, #11643, #12374
See also: #12570 (alternative approach)

## What this does

Adds a simple garbage collector for expired cron run sessions, following the same pattern as Kubernetes `ttlSecondsAfterFinished` — persist normally for observability, then clean up after a configurable retention period.

Default: 24 hours. Configurable:

    cron:
      sessionRetention: "24h"   # or "7d", "1h", false to disable

## Where the lines come from

- **~35 lines** of actual logic (the reaper sweep function)
- **115 lines** total for the reaper module (types, config parsing, throttle, exports)
- **174 lines** of tests (12 tests covering every path)
- **34 lines** of wiring (connecting to the existing cron timer + passing config)

The complexity is in the tests, not the code.

## Why it is safe

1. Uses `updateSessionStore` which already has file locking — no race conditions
2. Only deletes keys matching `:cron:*:run:*` — regular sessions are untouchable
3. Wrapped in try/catch — if the reaper fails, it logs a warning and moves on. Zero impact on job execution
4. Conservative default (24h) — plenty of time for debugging recent runs
5. Can be fully disabled with `sessionRetention: false`
6. Zero breaking changes — existing setups get automatic cleanup with no config needed

## How it works

The reaper piggybacks on the cron timer tick that already runs every ~1 minute. It self-throttles to sweep at most every 5 minutes to avoid unnecessary I/O. On each sweep it reads the session store, deletes expired `cron:*:run:*` entries, and writes back. That is it.

## What I tested

Manually tested on a live production gateway:

1. **Baseline**: 161 sessions in `sessions.json`, 156 of them orphaned `cron:*:run:*` entries (oldest 272 minutes old)
2. **Config**: Set `cron.sessionRetention: "2m"` to accelerate testing (instead of waiting 24h)
3. **Test cron job**: Created a lightweight job running every 1 minute (`Say "ping"` via Sonnet, delivery: none) to generate new sessions and trigger the reaper
4. **Result**: After gateway restart with the new build, the reaper cleaned **148 expired sessions** (161 → 13). The remaining 8 run sessions were all < 3 minutes old (within the 2-minute retention window)
5. **Cleanup**: Removed the test cron job, restored `sessionRetention: "24h"`

The reaper correctly:
- Pruned all sessions older than the retention period
- Preserved sessions within the retention window
- Left non-cron sessions untouched (1 main session preserved)
- Left cron base sessions intact (4 base sessions preserved)
- Ran silently without impacting cron job execution

## Comparison with #12570

Both PRs solve the same core problem. Here is a direct comparison:

| | This PR (#12588) | #12570 |
|---|---|---|
| **Strategy** | TTL-based reaper (delete after retention expires) | Immediate delete after run + 10min backup sweeper |
| **Default behavior** | Keep sessions for 24h, then prune | Delete immediately on completion |
| **Observability** | Recent runs visible for debugging via `sessions_list` | Sessions gone immediately — no post-mortem window |
| **Config** | `cron.sessionRetention: "24h" / "7d" / false` | Per-job `cleanup: "delete" / "keep"` |
| **Scope** | Single config for all cron jobs | Per-job control, but no global TTL |
| **Multi-agent stores** | Path resolved from config, passed explicitly | Sweeper only scans default agent store (Greptile finding) |
| **Key matching** | Regex `:cron:[^:]+:run:` (anchored to cron) | `/:run:/` pattern (may match non-cron sessions — Greptile finding) |
| **Files changed** | 7 files, +326 / -0 | 9 files, +361 / -3 |
| **Tests** | 12 new, 100/100 cron suite | 7 new, 252/252 full suite |
| **Greptile score** | 3/5 (both findings addressed in follow-up) | 3/5 (2 open findings: wrong-store sweep + broad key match) |

**Key tradeoffs:**
- **#12570** is more aggressive (immediate cleanup) which saves disk faster, but loses the ability to inspect recent runs for debugging
- **This PR** is more conservative (24h window) which preserves observability, follows industry-standard TTL patterns, and avoids the two correctness issues flagged in #12570