### PR TITLE
docs: add ClawRun managed hosting page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -827,6 +827,7 @@
               {
                 "group": "Hosting and deployment",
                 "pages": [
+                  "install/clawrun",
                   "install/fly",
                   "install/hetzner",
                   "install/gcp",

--- a/docs/install/clawrun.md
+++ b/docs/install/clawrun.md
@@ -1,0 +1,60 @@
+---
+summary: "Managed hosting for OpenClaw on DigitalOcean — one-click deploy, GUI setup, security by default"
+read_when:
+  - You want the easiest way to run OpenClaw 24/7 without managing a server yourself
+  - You want a managed, security-first hosting option for OpenClaw
+  - You want one-click deployment with a GUI setup wizard
+title: "ClawRun"
+---
+
+# ClawRun
+
+ClawRun is a managed hosting platform for deploying OpenClaw agents on DigitalOcean VPS.
+It provides one-click deployment, a GUI setup wizard, and security-first design so you
+can get an always-on agent running without touching a terminal.
+
+## What you get
+
+- **One-click deployment** — provision an agent with a single click, no server setup required
+- **GUI setup wizard** — configure your model, API keys, skills, and messaging channels through a web interface
+- **Security-first design** — no open ports by default; the web dashboard is served through an authenticated reverse proxy
+- **Web terminal** — access a terminal session in your browser when you need it
+- **Pay-per-agent billing** — pay only for the agents you run
+
+## Getting started
+
+1. **Sign up** at ClawRun
+2. **Create an agent** — choose a name and region
+3. **Complete payment** — billing is per-agent
+4. **Agent is provisioned** — your DigitalOcean VPS is created automatically
+5. **Access the dashboard** — open the web dashboard to complete setup via the GUI wizard
+
+The setup wizard walks you through model selection, API key entry, skill configuration,
+and messaging channel connections.
+
+## Security
+
+ClawRun takes a security-first approach:
+
+- **No open ports by default** — your agent's VPS does not expose any ports to the public internet
+- **Authenticated reverse proxy** — the web dashboard is served through a reverse proxy that requires authentication
+- **SSH key management** — optionally add SSH keys for direct access to your agent's VPS
+
+## Accessing your agent
+
+- **Web dashboard** — the primary interface; access your agent's Control UI through the authenticated reverse proxy
+- **Web terminal** — run commands on your agent's VPS directly from the browser
+- **SSH** (optional) — add your SSH keys through the dashboard for direct terminal access
+
+## Connecting channels
+
+Configure messaging channels through the GUI setup wizard:
+
+- Telegram
+- WhatsApp
+- Discord
+- Slack
+- Other supported channels
+
+Channel credentials and configuration are managed entirely through the web interface —
+no need to edit config files or environment variables manually.

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -25,6 +25,7 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 
 ## VPS & hosting
 
+- ClawRun (one-click + GUI + secure proxy): [ClawRun](/install/clawrun)
 - VPS hub: [VPS hosting](/vps)
 - Fly.io: [Fly.io](/install/fly)
 - Hetzner (Docker): [Hetzner](/install/hetzner)

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -13,6 +13,7 @@ deployments work at a high level.
 
 ## Pick a provider
 
+- **ClawRun** (one‑click + GUI setup + security‑first): [ClawRun](/install/clawrun)
 - **Railway** (one‑click + browser setup): [Railway](/install/railway)
 - **Northflank** (one‑click + browser setup): [Northflank](/install/northflank)
 - **Oracle Cloud (Always Free)**: [Oracle](/platforms/oracle) — $0/month (Always Free, ARM; capacity/signup can be finicky)


### PR DESCRIPTION
## Summary

- Add new `docs/install/clawrun.md` page documenting ClawRun, a managed hosting platform for deploying OpenClaw agents on DigitalOcean
- Add ClawRun to the "Hosting and deployment" nav group in `docs.json`
- Add ClawRun as the first entry in the VPS hub provider list (`docs/vps.md`)
- Add ClawRun to the "VPS & hosting" section of the Platforms index (`docs/platforms/index.md`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new ClawRun documentation page (`docs/install/clawrun.md`) describing a managed hosting option for running OpenClaw on DigitalOcean, and links it into the existing docs navigation and index pages. Specifically, it adds the new page to the “Hosting and deployment” nav group in `docs/docs.json`, and adds cross-links from the VPS hub (`docs/vps.md`) and Platforms index (`docs/platforms/index.md`) so users can discover the managed hosting option from the main hosting-related entry points.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to documentation content and navigation entries; the added page path matches the file layout and the new links point to an existing docs route. No functional code paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->