### PR TITLE
fix(status): show third-party memory plugins as active instead of unavailable

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -315,32 +315,45 @@ export async function statusCommand(
       return muted(`enabled (${slot}) · unavailable`);
     }
     const parts: string[] = [];
-    const dirtySuffix = memory.dirty ? ` · ${warn("dirty")}` : "";
-    parts.push(`${memory.files} files · ${memory.chunks} chunks${dirtySuffix}`);
-    if (memory.sources?.length) {
-      parts.push(`sources ${memory.sources.join(", ")}`);
-    }
-    if (memoryPlugin.slot) {
+    const isPluginMemory = memoryPlugin.slot !== "memory-core";
+    if (isPluginMemory) {
+      // Third-party memory plugin — show entries or active status
+      const probed = (memory.custom as Record<string, unknown> | undefined)?.pluginProbed === true;
+      if (probed && typeof memory.chunks === "number" && memory.chunks > 0) {
+        parts.push(`${memory.chunks} entries`);
+      } else {
+        parts.push(ok("active"));
+      }
       parts.push(`plugin ${memoryPlugin.slot}`);
-    }
-    const colorByTone = (tone: Tone, text: string) =>
-      tone === "ok" ? ok(text) : tone === "warn" ? warn(text) : muted(text);
-    const vector = memory.vector;
-    if (vector) {
-      const state = resolveMemoryVectorState(vector);
-      const label = state.state === "disabled" ? "vector off" : `vector ${state.state}`;
-      parts.push(colorByTone(state.tone, label));
-    }
-    const fts = memory.fts;
-    if (fts) {
-      const state = resolveMemoryFtsState(fts);
-      const label = state.state === "disabled" ? "fts off" : `fts ${state.state}`;
-      parts.push(colorByTone(state.tone, label));
-    }
-    const cache = memory.cache;
-    if (cache) {
-      const summary = resolveMemoryCacheSummary(cache);
-      parts.push(colorByTone(summary.tone, summary.text));
+    } else {
+      // Core memory — show files/chunks/dirty + vector/fts/cache details
+      const dirtySuffix = memory.dirty ? ` · ${warn("dirty")}` : "";
+      parts.push(`${memory.files} files · ${memory.chunks} chunks${dirtySuffix}`);
+      if (memory.sources?.length) {
+        parts.push(`sources ${memory.sources.join(", ")}`);
+      }
+      if (memoryPlugin.slot) {
+        parts.push(`plugin ${memoryPlugin.slot}`);
+      }
+      const colorByTone = (tone: Tone, text: string) =>
+        tone === "ok" ? ok(text) : tone === "warn" ? warn(text) : muted(text);
+      const vector = memory.vector;
+      if (vector) {
+        const state = resolveMemoryVectorState(vector);
+        const label = state.state === "disabled" ? "vector off" : `vector ${state.state}`;
+        parts.push(colorByTone(state.tone, label));
+      }
+      const fts = memory.fts;
+      if (fts) {
+        const state = resolveMemoryFtsState(fts);
+        const label = state.state === "disabled" ? "fts off" : `fts ${state.state}`;
+        parts.push(colorByTone(state.tone, label));
+      }
+      const cache = memory.cache;
+      if (cache) {
+        const summary = resolveMemoryCacheSummary(cache);
+        parts.push(colorByTone(summary.tone, summary.text));
+      }
     }
     return parts.join(" · ");
   })();

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -155,7 +155,41 @@ export async function scanStatus(
           return null;
         }
         if (memoryPlugin.slot !== "memory-core") {
-          return null;
+          // Third-party memory plugin — probe via gateway RPC if available
+          const agentId = agentStatus.defaultId ?? "main";
+          if (gatewayReachable) {
+            try {
+              const result = await callGateway<Record<string, unknown>>({
+                method: "memory.status",
+                params: {},
+                timeoutMs: 3000,
+              });
+              if (result && typeof result === "object") {
+                return {
+                  agentId,
+                  backend: "builtin",
+                  provider: typeof result.provider === "string" ? result.provider : (memoryPlugin.slot ?? "unknown"),
+                  model: typeof result.model === "string" ? result.model : undefined,
+                  files: 0,
+                  chunks: typeof result.entries === "number" ? result.entries : 0,
+                  dirty: false,
+                  custom: { pluginProbed: true },
+                };
+              }
+            } catch {
+              // Gateway method not available — fall through to unprobed status
+            }
+          }
+          // Gateway not reachable or method not implemented — report as active but unprobed
+          return {
+            agentId,
+            backend: "builtin",
+            provider: memoryPlugin.slot ?? "unknown",
+            files: 0,
+            chunks: 0,
+            dirty: false,
+            custom: { pluginProbed: false },
+          };
         }
         const agentId = agentStatus.defaultId ?? "main";
         const { manager } = await getMemorySearchManager({ cfg, agentId });


### PR DESCRIPTION
## Summary

Fixes #7273 — `openclaw status` shows "unavailable" for working third-party memory plugins.

**Root cause:** `status.scan.ts` line 157-158 has a hardcoded early return:
```typescript
if (memoryPlugin.slot !== "memory-core") {
  return null;  // null → renderer shows "unavailable"
}
```

This PR replaces the early `return null` with a proper probe:

1. **If gateway is reachable**: Try `memory.status` RPC call to get entry count from the plugin
2. **If gateway is unreachable**: Return a minimal status object marking the plugin as active but unprobed

## Changes

- **`src/commands/status.scan.ts`**: For non-core plugins, attempt gateway RPC `memory.status` probe. If that fails, return a minimal status object instead of `null`.
- **`src/commands/status.command.ts`**: Detect plugin memory via `memoryPlugin.slot` (not `memory.files === 0`). Render "N entries" when probed or "active" when unprobed.

## Before
```
Memory │ enabled (plugin memory-lancedb) · unavailable
```

## After
```
Memory │ active · plugin memory-lancedb
```
Or when the plugin implements `memory.status` gateway method:
```
Memory │ 345 entries · plugin memory-lancedb
```

## Test plan

- [x] `tsc --noEmit` — zero type errors
- [x] `vitest run src/commands/status.test.ts` — 5/5 tests pass (existing tests cover core memory path)
- [x] Manual: configure `plugins.slots.memory = "memory-lancedb"`, run `openclaw status` → should show "active" instead of "unavailable"
- [ ] Manual: with core memory → output unchanged

## Notes

- **Minimal scope**: 2 files, ~50 lines changed — intentionally scoped to ONLY the status rendering fix
- **No new dependencies, no breaking changes**
- **Aware of #7289**: That PR bundles 32 files including unrelated features. This PR is the minimal fix that solves the user-facing bug.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the status scan/rendering path for memory so that non-core (`plugins.slots.memory != "memory-core"`) plugins no longer show as “unavailable”.

- In `src/commands/status.scan.ts`, the scanner now returns a minimal `MemoryProviderStatus` snapshot for third‑party plugins instead of `null`, optionally probing the gateway via `memory.status` to get an entry count.
- In `src/commands/status.command.ts`, rendering is updated to treat non-core slots as plugin memory and display either `N entries` (when probed) or `active` (when unprobed), followed by `plugin <slot>`.

Overall this keeps the existing core-memory status output intact while improving the UX for third-party memory plugins.


<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but has a couple of correctness risks in how plugin status is probed and rendered.
- The changes are localized and don’t alter core-memory probing, but the new plugin probe path depends on `callGateway` defaults and a loosely-typed RPC response, which can lead to false “active”/entry counts or contradictory UI in misconfiguration scenarios.
- src/commands/status.scan.ts, src/commands/status.command.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->