### PR TITLE
Add configurable resetPrompt option to config, customizing prompt after /new or /reset

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -199,7 +199,9 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset ? BARE_SESSION_RESET_PROMPT : baseBody;
+  const baseBodyFinal = isBareSessionReset
+    ? (agentCfg?.resetPrompt ?? BARE_SESSION_RESET_PROMPT)
+    : baseBody;
   const baseBodyTrimmed = baseBodyFinal.trim();
   if (!baseBodyTrimmed) {
     await typing.onReplyStart();

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -108,6 +108,8 @@ export type AgentDefaultsConfig = {
   skipBootstrap?: boolean;
   /** Max chars for injected bootstrap files before truncation (default: 20000). */
   bootstrapMaxChars?: number;
+  /** Override the session reset prompt body (default: "A new session was started via /new or /reset..."). */
+  resetPrompt?: string;
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;
   /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -47,6 +47,7 @@ export const AgentDefaultsSchema = z
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
+    resetPrompt: z.string().optional(),
     userTimezone: z.string().optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     envelopeTimezone: z.string().optional(),


### PR DESCRIPTION
Currently, users can't easily modify the prompt given to the agent every time a new session is started. This PR makes that possible with a new optional agents.defaults.resetPrompt setting. The default is the same old prompt from before.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new optional `agents.defaults.resetPrompt` config field to let users override the default “bare /new or /reset” prompt body, and wires it into the session-reset detection in `runPreparedReply`.

The config surface is updated in both the TypeScript `AgentDefaultsConfig` type and the Zod validation schema, and `src/auto-reply/reply/get-reply-run.ts` now uses `agentCfg?.resetPrompt ?? BARE_SESSION_RESET_PROMPT` when a new session is started with no user content (or with a bare `/new`/`/reset`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and consistent across type definitions, schema validation, and runtime usage. The new field is optional with a clear fallback to the previous constant, and the existing reset detection logic remains intact.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->