### PR TITLE
Clawd/tool calling fix

### DIFF
--- a/src/agents/pi-embedded-runner/clawd-non-streaming.ts
+++ b/src/agents/pi-embedded-runner/clawd-non-streaming.ts
@@ -1,0 +1,298 @@
+/**
+ * CLAWD PATCH: Non-streaming streamFn for openai-completions models.
+ *
+ * Ollama (and some vLLM setups) return tool_calls as raw text when streaming,
+ * but return proper structured tool_calls with stream=false.
+ * See: https://github.com/openclaw/openclaw/issues/5769
+ *       https://github.com/openclaw/openclaw/issues/1866
+ */
+
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+
+interface ToolDef {
+  name: string;
+  description: string;
+  parameters: unknown;
+}
+
+interface OllamaToolCall {
+  id?: string;
+  type?: string;
+  function: { name: string; arguments: string };
+}
+
+interface OllamaChoice {
+  message: {
+    role: string;
+    content: string | null;
+    tool_calls?: OllamaToolCall[];
+  };
+  finish_reason: string;
+}
+
+interface OllamaResponse {
+  choices: OllamaChoice[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+}
+
+/**
+ * Minimal event stream that implements AsyncIterable.
+ * Buffers events and resolves waiting consumers.
+ */
+class SimpleEventStream {
+  private buffer: any[] = [];
+  private resolve: ((v: IteratorResult<any>) => void) | null = null;
+  private isDone = false;
+  private finalMessage: any = null;
+  private resultResolve: ((v: any) => void) | null = null;
+  private resultPromise: Promise<any>;
+
+  constructor() {
+    this.resultPromise = new Promise((resolve) => {
+      this.resultResolve = resolve;
+    });
+  }
+
+  push(event: any) {
+    // Capture the final message from the "done" event
+    if (event.type === "done" && event.message) {
+      this.finalMessage = event.message;
+    }
+    if (this.resolve) {
+      const r = this.resolve;
+      this.resolve = null;
+      r({ value: event, done: false });
+    } else {
+      this.buffer.push(event);
+    }
+  }
+
+  end() {
+    this.isDone = true;
+    if (this.resultResolve) {
+      this.resultResolve(this.finalMessage);
+      this.resultResolve = null;
+    }
+    if (this.resolve) {
+      const r = this.resolve;
+      this.resolve = null;
+      r({ value: undefined, done: true });
+    }
+  }
+
+  /** Returns a promise that resolves to the final assistant message. */
+  result(): Promise<any> {
+    return this.resultPromise;
+  }
+
+  [Symbol.asyncIterator]() {
+    return {
+      next: (): Promise<IteratorResult<any>> => {
+        if (this.buffer.length > 0) {
+          return Promise.resolve({ value: this.buffer.shift(), done: false });
+        }
+        if (this.isDone) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        return new Promise((resolve) => {
+          this.resolve = resolve;
+        });
+      },
+    };
+  }
+}
+
+export function createNonStreamingOllamaFn(toolDefs: ToolDef[]): StreamFn {
+  return ((model: any, context: any, _options: any) => {
+    const stream = new SimpleEventStream();
+
+    const output: any = {
+      role: "assistant",
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    (async () => {
+      try {
+        // Convert context messages to OpenAI format
+        const messages = (context.messages ?? []).map((msg: any) => {
+          if (msg.role === "user") {
+            if (typeof msg.content === "string") {
+              return { role: "user", content: msg.content };
+            }
+            if (Array.isArray(msg.content)) {
+              const text = msg.content
+                .filter((b: any) => b.type === "text")
+                .map((b: any) => b.text)
+                .join("\n");
+              return { role: "user", content: text || "" };
+            }
+            return { role: "user", content: String(msg.content ?? "") };
+          }
+          if (msg.role === "assistant") {
+            if (typeof msg.content === "string") {
+              return { role: "assistant", content: msg.content };
+            }
+            if (Array.isArray(msg.content)) {
+              const textParts = msg.content
+                .filter((b: any) => b.type === "text")
+                .map((b: any) => b.text);
+              const toolCalls = msg.content
+                .filter((b: any) => b.type === "toolCall")
+                .map((b: any) => ({
+                  id: b.id || "call_0",
+                  type: "function" as const,
+                  function: {
+                    name: b.name,
+                    arguments:
+                      typeof b.arguments === "string"
+                        ? b.arguments
+                        : JSON.stringify(b.arguments ?? {}),
+                  },
+                }));
+              const result: any = { role: "assistant", content: textParts.join("\n") || null };
+              if (toolCalls.length > 0) {
+                result.tool_calls = toolCalls;
+              }
+              return result;
+            }
+            return { role: "assistant", content: "" };
+          }
+          if (msg.role === "toolResult") {
+            const content = Array.isArray(msg.content)
+              ? msg.content.map((b: any) => b.text ?? JSON.stringify(b)).join("\n")
+              : String(msg.content ?? "");
+            return { role: "tool", tool_call_id: msg.toolCallId || "call_0", content };
+          }
+          if (msg.role === "system") {
+            if (typeof msg.content === "string") {
+              return { role: "system", content: msg.content };
+            }
+            if (Array.isArray(msg.content)) {
+              return {
+                role: "system",
+                content: msg.content.map((b: any) => b.text ?? "").join("\n"),
+              };
+            }
+            return { role: "system", content: String(msg.content ?? "") };
+          }
+          return msg;
+        });
+
+        // Build tools
+        const tools = toolDefs.map((t) => ({
+          type: "function" as const,
+          function: { name: t.name, description: t.description, parameters: t.parameters },
+        }));
+
+        const body: any = { model: model.id, messages, stream: false };
+        if (tools.length > 0) {
+          body.tools = tools;
+          body.tool_choice = "auto";
+        }
+
+        if (process.env.CLAWDBOT_DEBUG_TOOLS) {
+          console.error(
+            `[CLAWD] non-streaming: model=${model.id} tools=${tools.length} msgs=${messages.length}`,
+          );
+        }
+
+        const apiKey = _options?.apiKey || process.env.OLLAMA_API_KEY || "ollama-local";
+        const resp = await fetch(`${model.baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+          body: JSON.stringify(body),
+          signal: _options?.signal,
+        });
+
+        if (!resp.ok) {
+          throw new Error(`Ollama API error (${resp.status}): ${await resp.text()}`);
+        }
+
+        const data = (await resp.json()) as OllamaResponse;
+        const choice = data.choices?.[0];
+        if (!choice) {
+          throw new Error("No choices in response");
+        }
+
+        stream.push({ type: "start", partial: output });
+
+        const msg = choice.message;
+        let blockIdx = 0;
+
+        if (msg.content) {
+          output.content.push({ type: "text", text: msg.content });
+          stream.push({ type: "text_start", contentIndex: blockIdx, partial: output });
+          stream.push({
+            type: "text_delta",
+            contentIndex: blockIdx,
+            text: msg.content,
+            partial: output,
+          });
+          blockIdx++;
+        }
+
+        if (msg.tool_calls?.length) {
+          output.stopReason = "toolCall";
+          for (const tc of msg.tool_calls) {
+            let args: Record<string, unknown> = {};
+            try {
+              args = JSON.parse(tc.function.arguments);
+            } catch {
+              args = { raw: tc.function.arguments };
+            }
+            output.content.push({
+              type: "toolCall",
+              id: tc.id || `call_${blockIdx}`,
+              name: tc.function.name,
+              arguments: args,
+            });
+            stream.push({ type: "toolcall_start", contentIndex: blockIdx, partial: output });
+            stream.push({
+              type: "toolcall_delta",
+              contentIndex: blockIdx,
+              name: tc.function.name,
+              argumentsDelta: tc.function.arguments,
+              partial: output,
+            });
+            blockIdx++;
+          }
+        }
+
+        if (data.usage) {
+          output.usage.input = data.usage.prompt_tokens ?? 0;
+          output.usage.output = data.usage.completion_tokens ?? 0;
+          output.usage.totalTokens = data.usage.total_tokens ?? 0;
+        }
+
+        if (process.env.CLAWDBOT_DEBUG_TOOLS) {
+          console.error(
+            `[CLAWD] response: text=${!!msg.content} tool_calls=${msg.tool_calls?.length ?? 0}`,
+          );
+        }
+
+        stream.push({ type: "done", reason: output.stopReason, message: output });
+        stream.end();
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error(`[CLAWD] error:`, error.message);
+        stream.push({ type: "error", error });
+        stream.end();
+      }
+    })();
+
+    return stream as any;
+  }) satisfies StreamFn;
+}

--- a/src/agents/pi-embedded-runner/clawd-non-streaming.ts
+++ b/src/agents/pi-embedded-runner/clawd-non-streaming.ts
@@ -207,6 +207,15 @@ export function createNonStreamingOllamaFn(toolDefs: ToolDef[]): StreamFn {
           console.error(
             `[CLAWD] non-streaming: model=${model.id} tools=${tools.length} msgs=${messages.length}`,
           );
+          // Dump system message content for debugging
+          const sysMsgs = messages.filter((m: any) => m.role === "system");
+          for (const sm of sysMsgs) {
+            const content =
+              typeof sm.content === "string" ? sm.content : JSON.stringify(sm.content);
+            console.error(
+              `[CLAWD] system msg (${content.length} chars): ${content.slice(0, 500)}...`,
+            );
+          }
         }
 
         const apiKey = _options?.apiKey || process.env.OLLAMA_API_KEY || "ollama-local";

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
@@ -62,6 +62,7 @@ import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
+import { createNonStreamingOllamaFn } from "../clawd-non-streaming.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
 import {
@@ -86,6 +87,7 @@ import {
   createSystemPromptOverride,
 } from "../system-prompt.js";
 import { splitSdkTools } from "../tool-split.js";
+import { stripThinkingFromAssistantToolCallMessages } from "../toolcall-thinking.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
 import { detectAndLoadPromptImages } from "./images.js";
 
@@ -516,6 +518,35 @@ export async function runEmbeddedAttempt(
 
       // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
       activeSession.agent.streamFn = streamSimple;
+
+      // CLAWD PATCH: For openai-completions models (Ollama, vLLM), replace the streaming
+      // streamFn with a non-streaming one that calls fetch() directly with stream=false.
+      // This fixes two issues:
+      // 1. customTools don't populate context.tools (issue #1866)
+      // 2. Streaming breaks tool_calls parsing with Ollama (issue #5769)
+      const isOpenAICompletions = params.model?.api === "openai-completions";
+      if (isOpenAICompletions) {
+        const toolDefs = tools.map((t) => ({
+          name: t.name,
+          description: t.description ?? "",
+          parameters: t.parameters,
+        }));
+        if (process.env.CLAWDBOT_DEBUG_TOOLS) {
+          console.error(
+            `[CLAWD PATCH] using non-streaming streamFn for openai-completions with ${toolDefs.length} tools: ${toolDefs.map((t) => t.name).join(", ")}`,
+          );
+        }
+        activeSession.agent.streamFn = createNonStreamingOllamaFn(toolDefs);
+      } else {
+        // Remove thinking blocks from assistant messages that also include tool calls.
+        // Some OpenAI-compatible APIs reject assistant messages that include both `content` and
+        // `thinking` when tool calls are present (pi-ai surfaces this as a template error).
+        const originalStreamFn: StreamFn = activeSession.agent.streamFn ?? streamSimple;
+        activeSession.agent.streamFn = ((model, context, options) => {
+          const sanitized = stripThinkingFromAssistantToolCallMessages(context) as typeof context;
+          return originalStreamFn(model, sanitized, options);
+        }) satisfies StreamFn;
+      }
 
       applyExtraParamsToAgent(
         activeSession.agent,

--- a/src/agents/pi-embedded-runner/toolcall-thinking.ts
+++ b/src/agents/pi-embedded-runner/toolcall-thinking.ts
@@ -1,0 +1,53 @@
+/**
+ * CLAWD PATCH: Stub for stripThinkingFromAssistantToolCallMessages.
+ *
+ * Some OpenAI-compatible APIs reject assistant messages that include both
+ * `content` (with thinking blocks) and `tool_calls`. This utility strips
+ * thinking blocks from assistant messages that also contain tool calls,
+ * preventing template errors in pi-ai.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/5769
+ */
+
+interface MessageContent {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface Message {
+  role: string;
+  content: string | MessageContent[] | unknown;
+  [key: string]: unknown;
+}
+
+interface Context {
+  messages?: Message[];
+  [key: string]: unknown;
+}
+
+/**
+ * Strips thinking blocks from assistant messages that also include tool calls.
+ * Returns a shallow copy of context with sanitized messages.
+ */
+export function stripThinkingFromAssistantToolCallMessages(context: Context): Context {
+  if (!context.messages) return context;
+
+  const messages = context.messages.map((msg) => {
+    if (msg.role !== "assistant") return msg;
+    if (!Array.isArray(msg.content)) return msg;
+
+    const hasToolCall = msg.content.some(
+      (block: MessageContent) => block.type === "toolCall" || block.type === "tool_use",
+    );
+    if (!hasToolCall) return msg;
+
+    const hasThinking = msg.content.some((block: MessageContent) => block.type === "thinking");
+    if (!hasThinking) return msg;
+
+    // Remove thinking blocks, keep everything else
+    const filtered = msg.content.filter((block: MessageContent) => block.type !== "thinking");
+    return { ...msg, content: filtered };
+  });
+
+  return { ...context, messages };
+}

--- a/src/agents/pi-embedded-runner/toolcall-thinking.ts
+++ b/src/agents/pi-embedded-runner/toolcall-thinking.ts
@@ -9,21 +9,7 @@
  * See: https://github.com/openclaw/openclaw/issues/5769
  */
 
-interface MessageContent {
-  type: string;
-  [key: string]: unknown;
-}
-
-interface Message {
-  role: string;
-  content: string | MessageContent[] | unknown;
-  [key: string]: unknown;
-}
-
-interface Context {
-  messages?: Message[];
-  [key: string]: unknown;
-}
+import type { Context, Message } from "@mariozechner/pi-ai";
 
 /**
  * Strips thinking blocks from assistant messages that also include tool calls.
@@ -32,20 +18,20 @@ interface Context {
 export function stripThinkingFromAssistantToolCallMessages(context: Context): Context {
   if (!context.messages) return context;
 
-  const messages = context.messages.map((msg) => {
+  const messages = context.messages.map((msg: Message) => {
     if (msg.role !== "assistant") return msg;
     if (!Array.isArray(msg.content)) return msg;
 
     const hasToolCall = msg.content.some(
-      (block: MessageContent) => block.type === "toolCall" || block.type === "tool_use",
+      (block) => (block as { type: string }).type === "toolCall" || (block as { type: string }).type === "tool_use",
     );
     if (!hasToolCall) return msg;
 
-    const hasThinking = msg.content.some((block: MessageContent) => block.type === "thinking");
+    const hasThinking = msg.content.some((block) => (block as { type: string }).type === "thinking");
     if (!hasThinking) return msg;
 
     // Remove thinking blocks, keep everything else
-    const filtered = msg.content.filter((block: MessageContent) => block.type !== "thinking");
+    const filtered = msg.content.filter((block) => (block as { type: string }).type !== "thinking");
     return { ...msg, content: filtered };
   });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two “CLAWD PATCH” utilities to improve tool calling with OpenAI-compatible `openai-completions` backends (Ollama/vLLM):
- A non-streaming `StreamFn` that calls `/chat/completions` with `stream=false` and re-emits a synthetic event stream (`clawd-non-streaming.ts`).
- A sanitizer that strips `thinking` blocks from assistant messages when tool calls are present, and wires it into the embedded runner (`toolcall-thinking.ts`, `run/attempt.ts`).

The changes are localized to the embedded runner’s streamFn selection/wrapping logic and aim to avoid tool-call parsing/template errors from OpenAI-compatible providers.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge until the runtime/tool-call edge cases are fixed.
- The core approach is reasonable, but there are concrete runtime correctness issues: the non-streaming path assumes a global fetch implementation, and tool-call ID fallbacks can create duplicated IDs that break tool/result pairing. The thinking-stripper also likely misses tool-call block variants used in this codebase, so the intended template-error mitigation may not work reliably.
- src/agents/pi-embedded-runner/clawd-non-streaming.ts, src/agents/pi-embedded-runner/toolcall-thinking.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->