### PR TITLE
feat: comprehensive self-healing reliability improvements

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -163,6 +163,10 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 400) {
     return "format";
   }
+  // Treat server errors as transient; failover to next provider.
+  if (status !== undefined && status >= 500 && status < 600) {
+    return "timeout";
+  }
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
   if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -155,7 +155,7 @@ export async function monitorWebChannel(
     let unregisterUnhandled: (() => void) | null = null;
 
     // Watchdog to detect stuck message processing (e.g., event emitter died)
-    const MESSAGE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes without any messages
+    const MESSAGE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes without any messages
     const WATCHDOG_CHECK_MS = 60 * 1000; // Check every minute
 
     const backgroundTasks = new Set<Promise<unknown>>();


### PR DESCRIPTION
- Channel auto-restart with exponential backoff (5s-5min, max 12 attempts)
- LLM 5xx errors now trigger failover instead of failing directly
- Provider circuit breaker: skip after 5 consecutive failures for 60s
- Streaming idle timeout: abort after 30s of no data and failover
- BlueBubbles health check loop: ping every 60s, restart after 3 failures
- WhatsApp silence detection reduced from 30min to 5min
- Outbound message retry: 3 attempts with 1s-4s backoff on transient errors
- Gateway memory monitoring: warn at 70%, GC at 85%, restart at 95%
- Resource limits: cap unbounded maps (agentRunSeq, chatRunBuffers)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds multiple self-healing mechanisms across the gateway and agent runtime: channel auto-restart with exponential backoff, provider failover improvements (treat 5xx as failover-worthy), a per-provider circuit breaker in model fallback, streaming idle timeout aborts for embedded runs, tighter WhatsApp “silence” watchdog timing, outbound message retries on transient network/5xx errors, periodic BlueBubbles health checks that trigger restart after repeated failures, gateway memory monitoring (warn/GC/restart thresholds), and caps for previously unbounded in-memory maps (`agentRunSeq`, `chatRunBuffers`).

The changes integrate into existing channel lifecycle management (`src/gateway/server-channels.ts`), gateway maintenance timers (`src/gateway/server-maintenance.ts`), and agent/model selection and embedded-run streaming paths (`src/agents/*`, `src/agents/pi-embedded-runner/*`), aiming to reduce stuck states and improve resilience under provider/network failures.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally solid but has a couple of correctness issues that should be fixed before merge.
- Two changes look like they won’t behave as intended in production: (1) channel auto-restart backoff state is reset on every start, which prevents exponential backoff and the max-attempt cap from ever being reached; (2) the memory critical path uses `process.emit("SIGUSR1")`, which does not send an OS signal and likely won’t trigger the intended graceful restart mechanism. The rest of the changes are mostly additive resilience logic with bounded impact.
- src/gateway/server-channels.ts, src/gateway/server-maintenance.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->