### PR TITLE
Gateway: add inbound webhook dispatch framework

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -121,4 +121,9 @@ export type HooksConfig = {
   gmail?: HooksGmailConfig;
   /** Internal agent event hooks */
   internal?: InternalHooksConfig;
+  /** Inbound webhook configuration */
+  webhooks?: {
+    enabled?: boolean;
+    presets?: string[];
+  };
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -306,6 +306,13 @@ export const OpenClawSchema = z
         mappings: z.array(HookMappingSchema).optional(),
         gmail: HooksGmailSchema,
         internal: InternalHooksSchema,
+        webhooks: z
+          .object({
+            enabled: z.boolean().optional(),
+            presets: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from "node:http";
 import { randomUUID } from "node:crypto";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { WebhooksConfigResolved } from "./webhooks-http.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { type HookMappingResolved, resolveHookMappings } from "./hooks-mapping.js";
@@ -230,4 +231,27 @@ export function normalizeAgentPayload(
       timeoutSeconds,
     },
   };
+}
+
+export function resolveWebhooksConfig(cfg: OpenClawConfig): WebhooksConfigResolved | null {
+  if (cfg.hooks?.enabled !== true) {
+    return null;
+  }
+  const webhooks = cfg.hooks?.webhooks;
+  if (!webhooks || webhooks.enabled === false) {
+    return null;
+  }
+  const token = cfg.hooks?.token?.trim();
+  if (!token) {
+    return null;
+  }
+  const presets = webhooks.presets ?? [];
+  if (presets.length === 0) {
+    return null;
+  }
+  const maxBodyBytes =
+    cfg.hooks?.maxBodyBytes && cfg.hooks.maxBodyBytes > 0
+      ? cfg.hooks.maxBodyBytes
+      : DEFAULT_HOOKS_MAX_BODY_BYTES;
+  return { token, presets, maxBodyBytes };
 }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -283,6 +283,7 @@ export function createGatewayHttpServer(opts: {
   openResponsesEnabled: boolean;
   openResponsesConfig?: import("../config/types.gateway.js").GatewayHttpResponsesConfig;
   handleHooksRequest: HooksRequestHandler;
+  handleWebhooksRequest?: HooksRequestHandler;
   handlePluginRequest?: HooksRequestHandler;
   resolvedAuth: ResolvedGatewayAuth;
   tlsOptions?: TlsOptions;
@@ -297,6 +298,7 @@ export function createGatewayHttpServer(opts: {
     openResponsesEnabled,
     openResponsesConfig,
     handleHooksRequest,
+    handleWebhooksRequest,
     handlePluginRequest,
     resolvedAuth,
   } = opts;
@@ -318,6 +320,9 @@ export function createGatewayHttpServer(opts: {
       const configSnapshot = loadConfig();
       const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
       if (await handleHooksRequest(req, res)) {
+        return;
+      }
+      if (handleWebhooksRequest && (await handleWebhooksRequest(req, res))) {
         return;
       }
       if (

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -12,12 +12,13 @@ import {
 } from "../infra/restart.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
-import { resolveHooksConfig } from "./hooks.js";
+import { resolveHooksConfig, resolveWebhooksConfig } from "./hooks.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
 
 type GatewayHotReloadState = {
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
+  webhooksConfig: ReturnType<typeof resolveWebhooksConfig>;
   heartbeatRunner: HeartbeatRunner;
   cronState: GatewayCronState;
   browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> | null;
@@ -51,6 +52,7 @@ export function createGatewayReloadHandlers(params: {
     if (plan.reloadHooks) {
       try {
         nextState.hooksConfig = resolveHooksConfig(nextConfig);
+        nextState.webhooksConfig = resolveWebhooksConfig(nextConfig);
       } catch (err) {
         params.logHooks.warn(`hooks config reload failed: ${String(err)}`);
       }

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -10,7 +10,7 @@ import {
   resolveGatewayAuth,
 } from "./auth.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
-import { resolveHooksConfig } from "./hooks.js";
+import { resolveHooksConfig, resolveWebhooksConfig } from "./hooks.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "./net.js";
 
 export type GatewayRuntimeConfig = {
@@ -26,6 +26,7 @@ export type GatewayRuntimeConfig = {
   tailscaleConfig: GatewayTailscaleConfig;
   tailscaleMode: "off" | "serve" | "funnel";
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
+  webhooksConfig: ReturnType<typeof resolveWebhooksConfig>;
   canvasHostEnabled: boolean;
 };
 
@@ -82,6 +83,7 @@ export async function resolveGatewayRuntimeConfig(params: {
   const hasSharedSecret =
     (authMode === "token" && hasToken) || (authMode === "password" && hasPassword);
   const hooksConfig = resolveHooksConfig(params.cfg);
+  const webhooksConfig = resolveWebhooksConfig(params.cfg);
   const canvasHostEnabled =
     process.env.OPENCLAW_SKIP_CANVAS_HOST !== "1" && params.cfg.canvasHost?.enabled !== false;
 
@@ -115,6 +117,7 @@ export async function resolveGatewayRuntimeConfig(params: {
     tailscaleConfig,
     tailscaleMode,
     hooksConfig,
+    webhooksConfig,
     canvasHostEnabled,
   };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -92,6 +92,7 @@ const logHealth = log.child("health");
 const logCron = log.child("cron");
 const logReload = log.child("reload");
 const logHooks = log.child("hooks");
+const logWebhooks = log.child("webhooks");
 const logPlugins = log.child("plugins");
 const logWsControl = log.child("ws");
 const gatewayRuntime = runtimeForLogger(log);
@@ -267,6 +268,7 @@ export async function startGatewayServer(
     tailscaleMode,
   } = runtimeConfig;
   let hooksConfig = runtimeConfig.hooksConfig;
+  let webhooksConfig = runtimeConfig.webhooksConfig;
   const canvasHostEnabled = runtimeConfig.canvasHostEnabled;
 
   let controlUiRootState: ControlUiRootState | undefined;
@@ -341,6 +343,7 @@ export async function startGatewayServer(
     resolvedAuth,
     gatewayTls,
     hooksConfig: () => hooksConfig,
+    webhooksConfig: () => webhooksConfig,
     pluginRegistry,
     deps,
     canvasRuntime,
@@ -349,6 +352,7 @@ export async function startGatewayServer(
     logCanvas,
     log,
     logHooks,
+    logWebhooks,
     logPlugins,
   });
   let bonjourStop: (() => Promise<void>) | null = null;
@@ -563,12 +567,14 @@ export async function startGatewayServer(
     broadcast,
     getState: () => ({
       hooksConfig,
+      webhooksConfig,
       heartbeatRunner,
       cronState,
       browserControl,
     }),
     setState: (nextState) => {
       hooksConfig = nextState.hooksConfig;
+      webhooksConfig = nextState.webhooksConfig;
       heartbeatRunner = nextState.heartbeatRunner;
       cronState = nextState.cronState;
       cron = cronState.cron;

--- a/src/gateway/server/webhooks.ts
+++ b/src/gateway/server/webhooks.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import type { CliDeps } from "../../cli/deps.js";
+import type { CronJob } from "../../cron/types.js";
+import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { WebhooksConfigResolved } from "../webhooks-http.js";
+import { loadConfig } from "../../config/config.js";
+import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
+import { runCronIsolatedAgentTurn } from "../../cron/isolated-agent.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { createWebhooksRequestHandler } from "../webhooks-http.js";
+
+type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+export function createGatewayWebhooksRequestHandler(params: {
+  deps: CliDeps;
+  getWebhooksConfig: () => WebhooksConfigResolved | null;
+  bindHost: string;
+  port: number;
+  logWebhooks: SubsystemLogger;
+}) {
+  const { deps, getWebhooksConfig, bindHost, port, logWebhooks } = params;
+
+  const dispatchAgentHook = (value: {
+    message: string;
+    name: string;
+    wakeMode: "now" | "next-heartbeat";
+    sessionKey: string;
+    deliver: boolean;
+    channel: import("../hooks.js").HookMessageChannel;
+    to?: string;
+    model?: string;
+    thinking?: string;
+    timeoutSeconds?: number;
+    allowUnsafeExternalContent?: boolean;
+  }) => {
+    const sessionKey = value.sessionKey.trim()
+      ? value.sessionKey.trim()
+      : `webhook:${randomUUID()}`;
+    const mainSessionKey = resolveMainSessionKeyFromConfig();
+    const jobId = randomUUID();
+    const now = Date.now();
+    const job: CronJob = {
+      id: jobId,
+      name: value.name,
+      enabled: true,
+      createdAtMs: now,
+      updatedAtMs: now,
+      schedule: { kind: "at", at: new Date(now).toISOString() },
+      sessionTarget: "isolated",
+      wakeMode: value.wakeMode,
+      payload: {
+        kind: "agentTurn",
+        message: value.message,
+        model: value.model,
+        thinking: value.thinking,
+        timeoutSeconds: value.timeoutSeconds,
+        deliver: value.deliver,
+        channel: value.channel,
+        to: value.to,
+        allowUnsafeExternalContent: value.allowUnsafeExternalContent,
+      },
+      state: { nextRunAtMs: now },
+    };
+
+    const runId = randomUUID();
+    void (async () => {
+      try {
+        const cfg = loadConfig();
+        const result = await runCronIsolatedAgentTurn({
+          cfg,
+          deps,
+          job,
+          message: value.message,
+          sessionKey,
+          lane: "cron",
+        });
+        const summary = result.summary?.trim() || result.error?.trim() || result.status;
+        const prefix =
+          result.status === "ok"
+            ? `Webhook ${value.name}`
+            : `Webhook ${value.name} (${result.status})`;
+        enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
+          sessionKey: mainSessionKey,
+        });
+        if (value.wakeMode === "now") {
+          requestHeartbeatNow({ reason: `webhook:${jobId}` });
+        }
+      } catch (err) {
+        logWebhooks.warn(`webhook agent failed: ${String(err)}`);
+        enqueueSystemEvent(`Webhook ${value.name} (error): ${String(err)}`, {
+          sessionKey: mainSessionKey,
+        });
+        if (value.wakeMode === "now") {
+          requestHeartbeatNow({ reason: `webhook:${jobId}:error` });
+        }
+      }
+    })();
+
+    return runId;
+  };
+
+  return createWebhooksRequestHandler({
+    getWebhooksConfig,
+    bindHost,
+    port,
+    logWebhooks,
+    dispatchAgentHook,
+  });
+}

--- a/src/gateway/webhook-transforms/index.ts
+++ b/src/gateway/webhook-transforms/index.ts
@@ -1,0 +1,34 @@
+import type { OwnerRezTransformResult } from "./ownerrez.js";
+import type { QuickBooksTransformResult } from "./quickbooks.js";
+import type { ReadAiTransformResult } from "./readai.js";
+import type { ShopifyTransformResult } from "./shopify.js";
+import { transformOwnerRezPayload } from "./ownerrez.js";
+import { transformQuickBooksPayload } from "./quickbooks.js";
+import { transformReadAiPayload } from "./readai.js";
+import { transformShopifyPayload } from "./shopify.js";
+
+export type WebhookTransformResult = {
+  message: string;
+  name: string;
+  sessionKey: string;
+} | null;
+
+export type WebhookTransformFn = (payload: Record<string, unknown>) => WebhookTransformResult;
+
+const webhookTransforms: Record<string, WebhookTransformFn> = {
+  readai: transformReadAiPayload as WebhookTransformFn,
+  quickbooks: transformQuickBooksPayload as WebhookTransformFn,
+  ownerrez: transformOwnerRezPayload as WebhookTransformFn,
+  shopify: transformShopifyPayload as WebhookTransformFn,
+};
+
+export function getWebhookTransform(source: string): WebhookTransformFn | undefined {
+  return webhookTransforms[source];
+}
+
+export type {
+  OwnerRezTransformResult,
+  QuickBooksTransformResult,
+  ReadAiTransformResult,
+  ShopifyTransformResult,
+};

--- a/src/gateway/webhook-transforms/ownerrez.test.ts
+++ b/src/gateway/webhook-transforms/ownerrez.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "vitest";
+import { transformOwnerRezPayload } from "./ownerrez.js";
+
+describe("transformOwnerRezPayload", () => {
+  test("formats a booking insert with embedded entity", () => {
+    const payload = {
+      id: "wh-1",
+      user_id: 12345,
+      action: "entity_insert",
+      entity_type: "booking",
+      entity_id: "bk-100",
+      categories: ["reservation"],
+      entity: {
+        arrival: "2026-03-15",
+        departure: "2026-03-20",
+        adults: 2,
+        children: 1,
+        status: "confirmed",
+        guest_name: "Alice Smith",
+        property_name: "Lakeside Cabin",
+        total_amount: "1250.00",
+        currency: "USD",
+        source: "Airbnb",
+        booked_utc: "2026-02-08T14:30:00Z",
+      },
+    };
+
+    const result = transformOwnerRezPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("OwnerRez");
+    expect(result!.message).toContain("## OwnerRez: Booking Created");
+    expect(result!.message).toContain("**Booking ID:** bk-100");
+    expect(result!.message).toContain("**Guest:** Alice Smith");
+    expect(result!.message).toContain("**Property:** Lakeside Cabin");
+    expect(result!.message).toContain("**Dates:** 2026-03-15 to 2026-03-20");
+    expect(result!.message).toContain("**Guests:** 2 adults, 1 child");
+    expect(result!.message).toContain("**Status:** confirmed");
+    expect(result!.message).toContain("**Total:** 1250.00 USD");
+    expect(result!.message).toContain("**Source:** Airbnb");
+    expect(result!.sessionKey).toBe("webhook:ownerrez:booking:bk-100");
+  });
+
+  test("formats a booking update without entity details", () => {
+    const payload = {
+      id: "wh-2",
+      user_id: 12345,
+      action: "entity_update",
+      entity_type: "booking",
+      entity_id: "bk-200",
+      categories: ["cancellation"],
+    };
+
+    const result = transformOwnerRezPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("## OwnerRez: Booking Updated");
+    expect(result!.message).toContain("**Categories:** cancellation");
+  });
+
+  test("formats a booking delete", () => {
+    const payload = {
+      id: "wh-3",
+      action: "entity_delete",
+      entity_type: "booking",
+      entity_id: "bk-300",
+    };
+
+    const result = transformOwnerRezPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("## OwnerRez: Booking Deleted");
+  });
+
+  test("formats a contact insert with embedded entity", () => {
+    const payload = {
+      id: "wh-4",
+      action: "entity_insert",
+      entity_type: "contact",
+      entity_id: "ct-50",
+      entity: {
+        first_name: "Bob",
+        last_name: "Jones",
+        email: "bob@example.com",
+        phone: "+15551234567",
+      },
+    };
+
+    const result = transformOwnerRezPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("## OwnerRez: Contact Created");
+    expect(result!.message).toContain("**Name:** Bob Jones");
+    expect(result!.message).toContain("**Email:** bob@example.com");
+    expect(result!.message).toContain("**Phone:** +15551234567");
+    expect(result!.sessionKey).toBe("webhook:ownerrez:contact:ct-50");
+  });
+
+  test("handles authorization revoked", () => {
+    const payload = {
+      action: "application_authorization_revoked",
+      user_id: 999,
+    };
+
+    const result = transformOwnerRezPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("authorization has been revoked");
+    expect(result!.sessionKey).toContain("auth-revoked");
+  });
+
+  test("handles property entity type", () => {
+    const payload = {
+      id: "wh-5",
+      action: "entity_update",
+      entity_type: "property",
+      entity_id: "prop-10",
+    };
+
+    const result = transformOwnerRezPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("## OwnerRez: Property Updated");
+  });
+
+  test("returns null for empty payload", () => {
+    expect(transformOwnerRezPayload({})).toBeNull();
+  });
+
+  test("returns null for unknown action", () => {
+    const payload = { action: "some_random_action" };
+    expect(transformOwnerRezPayload(payload)).toBeNull();
+  });
+
+  test("returns null when entity_type is missing", () => {
+    const payload = { action: "entity_insert" };
+    expect(transformOwnerRezPayload(payload)).toBeNull();
+  });
+
+  test("handles multiple children correctly in guest count", () => {
+    const payload = {
+      id: "wh-6",
+      action: "entity_insert",
+      entity_type: "booking",
+      entity_id: "bk-400",
+      entity: {
+        adults: 1,
+        children: 3,
+      },
+    };
+
+    const result = transformOwnerRezPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("1 adult");
+    expect(result!.message).toContain("3 children");
+  });
+});

--- a/src/gateway/webhook-transforms/ownerrez.ts
+++ b/src/gateway/webhook-transforms/ownerrez.ts
@@ -1,0 +1,202 @@
+export type OwnerRezTransformResult = {
+  message: string;
+  name: string;
+  sessionKey: string;
+} | null;
+
+/**
+ * Transforms an OwnerRez webhook payload into an agent message.
+ *
+ * OwnerRez webhooks send a JSON body with fields:
+ * - id: unique payload id (for dedup)
+ * - user_id: OwnerRez user id
+ * - action: "entity_insert" | "entity_update" | "entity_delete" | "application_authorization_revoked"
+ * - entity_type: "booking" | "contact" | "property" | etc.
+ * - entity_id: the id of the affected entity
+ * - categories: array of strings categorizing the change
+ * - entity: optional embedded object with the full entity data
+ */
+export function transformOwnerRezPayload(
+  payload: Record<string, unknown>,
+): OwnerRezTransformResult {
+  const action = stringField(payload, "action");
+  if (!action) {
+    return null;
+  }
+
+  // Handle authorization revoked separately
+  if (action === "application_authorization_revoked") {
+    return {
+      message: "## OwnerRez\n\nApplication authorization has been revoked.",
+      name: "OwnerRez",
+      sessionKey: `webhook:ownerrez:auth-revoked:${stringField(payload, "user_id") || "unknown"}`,
+    };
+  }
+
+  // Must be an entity action
+  if (!action.startsWith("entity_")) {
+    return null;
+  }
+
+  const entityType = stringField(payload, "entity_type");
+  const entityId = stringField(payload, "entity_id");
+  if (!entityType) {
+    return null;
+  }
+
+  const operation = parseOperation(action);
+  const label = ENTITY_LABELS[entityType.toLowerCase()] || capitalize(entityType);
+  const categories = Array.isArray(payload.categories) ? payload.categories : [];
+  const entity =
+    typeof payload.entity === "object" && payload.entity !== null
+      ? (payload.entity as Record<string, unknown>)
+      : null;
+
+  const lines: string[] = [];
+  lines.push(`## OwnerRez: ${label} ${operation}`);
+  lines.push("");
+
+  if (entityId) {
+    lines.push(`**${label} ID:** ${entityId}`);
+  }
+
+  if (categories.length > 0) {
+    const categoryStrings: string[] = categories.filter((c): c is string => typeof c === "string");
+    if (categoryStrings.length > 0) {
+      lines.push(`**Categories:** ${categoryStrings.join(", ")}`);
+    }
+  }
+
+  // Extract useful details from embedded entity
+  if (entity && entityType.toLowerCase() === "booking") {
+    formatBookingEntity(entity, lines);
+  } else if (entity && entityType.toLowerCase() === "contact") {
+    formatContactEntity(entity, lines);
+  }
+
+  const payloadId = stringField(payload, "id");
+  const message = lines.join("\n").trim();
+  const sessionKey = `webhook:ownerrez:${entityType}:${entityId || payloadId || "unknown"}`;
+
+  return { message, name: "OwnerRez", sessionKey };
+}
+
+function formatBookingEntity(entity: Record<string, unknown>, lines: string[]) {
+  const arrival = stringField(entity, "arrival");
+  const departure = stringField(entity, "departure");
+  const adults = entity.adults;
+  const children = entity.children;
+  const status = stringField(entity, "status");
+  const guestName =
+    stringField(entity, "guest_name") ||
+    stringField(entity, "guest_first_name") ||
+    stringField(entity, "name");
+  const propertyName = stringField(entity, "property_name");
+  const totalAmountRaw = entity.total_amount ?? entity.total;
+  const totalAmount =
+    typeof totalAmountRaw === "string" || typeof totalAmountRaw === "number"
+      ? String(totalAmountRaw)
+      : "";
+  const currency = stringField(entity, "currency");
+  const bookedUtc = stringField(entity, "booked_utc");
+  const source = stringField(entity, "source") || stringField(entity, "channel_name");
+
+  lines.push("");
+
+  if (guestName) {
+    lines.push(`**Guest:** ${guestName}`);
+  }
+  if (propertyName) {
+    lines.push(`**Property:** ${propertyName}`);
+  }
+  if (arrival || departure) {
+    const range = [arrival, departure].filter(Boolean).join(" to ");
+    lines.push(`**Dates:** ${range}`);
+  }
+  if (typeof adults === "number" || typeof children === "number") {
+    const parts: string[] = [];
+    if (typeof adults === "number") {
+      parts.push(`${adults} adult${adults !== 1 ? "s" : ""}`);
+    }
+    if (typeof children === "number" && children > 0) {
+      parts.push(`${children} child${children !== 1 ? "ren" : ""}`);
+    }
+    lines.push(`**Guests:** ${parts.join(", ")}`);
+  }
+  if (status) {
+    lines.push(`**Status:** ${status}`);
+  }
+  if (totalAmount) {
+    const formatted = currency ? `${totalAmount} ${currency}` : totalAmount;
+    lines.push(`**Total:** ${formatted}`);
+  }
+  if (source) {
+    lines.push(`**Source:** ${source}`);
+  }
+  if (bookedUtc) {
+    lines.push(`**Booked:** ${bookedUtc}`);
+  }
+}
+
+function formatContactEntity(entity: Record<string, unknown>, lines: string[]) {
+  const firstName = stringField(entity, "first_name");
+  const lastName = stringField(entity, "last_name");
+  const email = stringField(entity, "email") || stringField(entity, "email_address");
+  const phone = stringField(entity, "phone") || stringField(entity, "phone_number");
+  const name = [firstName, lastName].filter(Boolean).join(" ") || stringField(entity, "name");
+
+  lines.push("");
+
+  if (name) {
+    lines.push(`**Name:** ${name}`);
+  }
+  if (email) {
+    lines.push(`**Email:** ${email}`);
+  }
+  if (phone) {
+    lines.push(`**Phone:** ${phone}`);
+  }
+}
+
+function parseOperation(action: string): string {
+  switch (action) {
+    case "entity_insert":
+      return "Created";
+    case "entity_update":
+      return "Updated";
+    case "entity_delete":
+      return "Deleted";
+    default:
+      return capitalize(action.replace("entity_", ""));
+  }
+}
+
+function capitalize(str: string): string {
+  if (!str) {
+    return str;
+  }
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function stringField(obj: Record<string, unknown>, key: string): string {
+  const val = obj[key];
+  return typeof val === "string" ? val.trim() : "";
+}
+
+const ENTITY_LABELS: Record<string, string> = {
+  booking: "Booking",
+  contact: "Contact",
+  property: "Property",
+  block: "Block",
+  quote: "Quote",
+  inquiry: "Inquiry",
+  review: "Review",
+  owner_statement: "Owner Statement",
+  expense: "Expense",
+  charge: "Charge",
+  payment: "Payment",
+  refund: "Refund",
+  message: "Message",
+  task: "Task",
+  note: "Note",
+};

--- a/src/gateway/webhook-transforms/quickbooks.test.ts
+++ b/src/gateway/webhook-transforms/quickbooks.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "vitest";
+import { transformQuickBooksPayload } from "./quickbooks.js";
+
+describe("transformQuickBooksPayload", () => {
+  describe("legacy format", () => {
+    test("formats a single entity notification", () => {
+      const payload = {
+        eventNotifications: [
+          {
+            realmId: "123456",
+            dataChangeEvent: {
+              entities: [
+                {
+                  id: "42",
+                  name: "Invoice",
+                  operation: "Create",
+                  lastUpdated: "2026-02-08T10:00:00Z",
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      const result = transformQuickBooksPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("QuickBooks");
+      expect(result!.message).toContain("## QuickBooks Update");
+      expect(result!.message).toContain("**Company ID:** 123456");
+      expect(result!.message).toContain("**Invoice** Create");
+      expect(result!.message).toContain("(ID: 42)");
+      expect(result!.message).toContain("2026-02-08T10:00:00Z");
+      expect(result!.sessionKey).toBe("webhook:quickbooks:Invoice:42:Create");
+    });
+
+    test("formats multiple entities in one notification", () => {
+      const payload = {
+        eventNotifications: [
+          {
+            realmId: "789",
+            dataChangeEvent: {
+              entities: [
+                {
+                  id: "10",
+                  name: "Invoice",
+                  operation: "Create",
+                  lastUpdated: "2026-02-08T10:00:00Z",
+                },
+                {
+                  id: "20",
+                  name: "Payment",
+                  operation: "Create",
+                  lastUpdated: "2026-02-08T10:01:00Z",
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      const result = transformQuickBooksPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("### Events");
+      expect(result!.message).toContain("- **Invoice** Create");
+      expect(result!.message).toContain("- **Payment** Create");
+    });
+
+    test("formats Bill entity with human-readable label", () => {
+      const payload = {
+        eventNotifications: [
+          {
+            realmId: "111",
+            dataChangeEvent: {
+              entities: [{ id: "5", name: "Bill", operation: "Update", lastUpdated: "" }],
+            },
+          },
+        ],
+      };
+
+      const result = transformQuickBooksPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("**Bill** Update");
+    });
+
+    test("handles Void and Delete operations", () => {
+      const payload = {
+        eventNotifications: [
+          {
+            realmId: "222",
+            dataChangeEvent: {
+              entities: [
+                { id: "7", name: "Invoice", operation: "Void", lastUpdated: "" },
+                { id: "8", name: "Customer", operation: "Delete", lastUpdated: "" },
+              ],
+            },
+          },
+        ],
+      };
+
+      const result = transformQuickBooksPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("**Invoice** Void");
+      expect(result!.message).toContain("**Customer** Delete");
+    });
+
+    test("handles multiple notifications with different realmIds", () => {
+      const payload = {
+        eventNotifications: [
+          {
+            realmId: "aaa",
+            dataChangeEvent: {
+              entities: [{ id: "1", name: "Invoice", operation: "Create", lastUpdated: "" }],
+            },
+          },
+          {
+            realmId: "bbb",
+            dataChangeEvent: {
+              entities: [{ id: "2", name: "Bill", operation: "Create", lastUpdated: "" }],
+            },
+          },
+        ],
+      };
+
+      const result = transformQuickBooksPayload(payload);
+      expect(result).not.toBeNull();
+      // Should not show a single company ID when there are multiple
+      expect(result!.message).not.toContain("**Company ID:**");
+    });
+
+    test("returns null for empty eventNotifications", () => {
+      const payload = { eventNotifications: [] };
+      expect(transformQuickBooksPayload(payload)).toBeNull();
+    });
+
+    test("returns null for notifications with no entities", () => {
+      const payload = {
+        eventNotifications: [{ realmId: "123", dataChangeEvent: { entities: [] } }],
+      };
+      expect(transformQuickBooksPayload(payload)).toBeNull();
+    });
+  });
+
+  describe("CloudEvents format", () => {
+    test("formats a single CloudEvent", () => {
+      const payload = {
+        specversion: "1.0",
+        id: "event-uuid-1",
+        source: "intuit.abc123",
+        type: "qbo.invoice.created.v1",
+        datacontenttype: "application/json",
+        time: "2026-02-08T14:00:00Z",
+        intuitentityid: "99",
+        intuitaccountid: "456789",
+        data: {},
+      };
+
+      const result = transformQuickBooksPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("QuickBooks");
+      expect(result!.message).toContain("## QuickBooks Update");
+      expect(result!.message).toContain("**Company ID:** 456789");
+      expect(result!.message).toContain("**Invoice** Created");
+      expect(result!.message).toContain("(ID: 99)");
+      expect(result!.sessionKey).toContain("webhook:quickbooks:");
+    });
+
+    test("formats multiple CloudEvents via events wrapper", () => {
+      const payload = {
+        events: [
+          {
+            specversion: "1.0",
+            id: "e1",
+            type: "qbo.bill.created.v1",
+            time: "2026-02-08T15:00:00Z",
+            intuitentityid: "50",
+            intuitaccountid: "111",
+          },
+          {
+            specversion: "1.0",
+            id: "e2",
+            type: "qbo.payment.updated.v1",
+            time: "2026-02-08T15:01:00Z",
+            intuitentityid: "51",
+            intuitaccountid: "111",
+          },
+        ],
+      };
+
+      const result = transformQuickBooksPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("### Events");
+      expect(result!.message).toContain("- **Bill** Created");
+      expect(result!.message).toContain("- **Payment** Updated");
+    });
+
+    test("parses CloudEvents type correctly", () => {
+      const payload = {
+        specversion: "1.0",
+        id: "e1",
+        type: "qbo.salesreceipt.voided.v1",
+        time: "",
+        intuitentityid: "77",
+        intuitaccountid: "333",
+      };
+
+      const result = transformQuickBooksPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("**Sales Receipt** Voided");
+    });
+  });
+
+  describe("unknown payloads", () => {
+    test("returns null for completely unrelated payload", () => {
+      const payload = { foo: "bar", baz: 42 };
+      expect(transformQuickBooksPayload(payload)).toBeNull();
+    });
+
+    test("returns null for empty object", () => {
+      expect(transformQuickBooksPayload({})).toBeNull();
+    });
+  });
+});

--- a/src/gateway/webhook-transforms/quickbooks.ts
+++ b/src/gateway/webhook-transforms/quickbooks.ts
@@ -1,0 +1,275 @@
+export type QuickBooksTransformResult = {
+  message: string;
+  name: string;
+  sessionKey: string;
+} | null;
+
+/**
+ * Transforms a QuickBooks Online webhook payload into an agent message.
+ *
+ * Supports both the legacy format (`eventNotifications`) and the new
+ * CloudEvents format (array of CloudEvents objects, migrating by May 2026).
+ */
+export function transformQuickBooksPayload(
+  payload: Record<string, unknown>,
+): QuickBooksTransformResult {
+  // Try CloudEvents format first (array at top level comes through as payload wrapper)
+  const cloudEvents = extractCloudEvents(payload);
+  if (cloudEvents.length > 0) {
+    return formatCloudEvents(cloudEvents);
+  }
+
+  // Legacy format: { eventNotifications: [...] }
+  const notifications = extractLegacyNotifications(payload);
+  if (notifications.length > 0) {
+    return formatLegacyNotifications(notifications);
+  }
+
+  return null;
+}
+
+// -- Legacy format parsing --
+
+type LegacyEntity = {
+  id: string;
+  name: string;
+  operation: string;
+  lastUpdated: string;
+};
+
+type LegacyNotification = {
+  realmId: string;
+  entities: LegacyEntity[];
+};
+
+function extractLegacyNotifications(payload: Record<string, unknown>): LegacyNotification[] {
+  const raw = payload.eventNotifications;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const results: LegacyNotification[] = [];
+  for (const notification of raw) {
+    if (typeof notification !== "object" || notification === null) {
+      continue;
+    }
+    const rec = notification as Record<string, unknown>;
+    const realmId = typeof rec.realmId === "string" ? rec.realmId : "";
+    const dataChangeEvent = rec.dataChangeEvent as Record<string, unknown> | undefined;
+    if (!dataChangeEvent || !Array.isArray(dataChangeEvent.entities)) {
+      continue;
+    }
+    const entities: LegacyEntity[] = [];
+    for (const entity of dataChangeEvent.entities) {
+      if (typeof entity !== "object" || entity === null) {
+        continue;
+      }
+      const e = entity as Record<string, unknown>;
+      entities.push({
+        id: typeof e.id === "string" ? e.id : "",
+        name: typeof e.name === "string" ? e.name : "",
+        operation: typeof e.operation === "string" ? e.operation : "",
+        lastUpdated: typeof e.lastUpdated === "string" ? e.lastUpdated : "",
+      });
+    }
+    if (entities.length > 0) {
+      results.push({ realmId, entities });
+    }
+  }
+  return results;
+}
+
+function formatLegacyNotifications(notifications: LegacyNotification[]): QuickBooksTransformResult {
+  const allEntities: Array<LegacyEntity & { realmId: string }> = [];
+  for (const n of notifications) {
+    for (const e of n.entities) {
+      allEntities.push({ ...e, realmId: n.realmId });
+    }
+  }
+  if (allEntities.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = [];
+  lines.push("## QuickBooks Update");
+  lines.push("");
+
+  const realmIds = [...new Set(allEntities.map((e) => e.realmId).filter(Boolean))];
+  if (realmIds.length === 1) {
+    lines.push(`**Company ID:** ${realmIds[0]}`);
+    lines.push("");
+  }
+
+  if (allEntities.length === 1) {
+    const e = allEntities[0];
+    lines.push(formatEntityLine(e.name, e.operation, e.id, e.lastUpdated));
+    if (realmIds.length > 1) {
+      lines.push(`  Company ID: ${e.realmId}`);
+    }
+  } else {
+    lines.push("### Events");
+    lines.push("");
+    for (const e of allEntities) {
+      lines.push(`- ${formatEntityLine(e.name, e.operation, e.id, e.lastUpdated)}`);
+    }
+  }
+
+  const message = lines.join("\n").trim();
+  const sessionKey = deriveSessionKey(allEntities.map((e) => `${e.name}:${e.id}:${e.operation}`));
+
+  return { message, name: "QuickBooks", sessionKey };
+}
+
+// -- CloudEvents format parsing --
+
+type CloudEvent = {
+  id: string;
+  type: string;
+  time: string;
+  entityId: string;
+  accountId: string;
+};
+
+function extractCloudEvents(payload: Record<string, unknown>): CloudEvent[] {
+  // CloudEvents come as a top-level array, but since our webhook handler
+  // parses JSON and the result may be an array wrapped in an object,
+  // we also check for a direct array. The webhook handler coerces non-object
+  // values to {}, so for a top-level array the caller needs to send it
+  // as the body. We check both "events" wrapper and the array indicators.
+  let rawEvents: unknown[] = [];
+
+  // Direct array payload (if somehow preserved)
+  if (Array.isArray(payload)) {
+    rawEvents = payload;
+  }
+  // Wrapped in an "events" key
+  else if (Array.isArray(payload.events)) {
+    rawEvents = payload.events;
+  }
+  // Check if it looks like a single CloudEvent
+  else if (typeof payload.specversion === "string" && typeof payload.type === "string") {
+    rawEvents = [payload];
+  }
+
+  const results: CloudEvent[] = [];
+  for (const event of rawEvents) {
+    if (typeof event !== "object" || event === null) {
+      continue;
+    }
+    const rec = event as Record<string, unknown>;
+    if (typeof rec.specversion !== "string" || typeof rec.type !== "string") {
+      continue;
+    }
+    results.push({
+      id: typeof rec.id === "string" ? rec.id : "",
+      type: typeof rec.type === "string" ? rec.type : "",
+      time: typeof rec.time === "string" ? rec.time : "",
+      entityId: typeof rec.intuitentityid === "string" ? rec.intuitentityid : "",
+      accountId: typeof rec.intuitaccountid === "string" ? rec.intuitaccountid : "",
+    });
+  }
+  return results;
+}
+
+function formatCloudEvents(events: CloudEvent[]): QuickBooksTransformResult {
+  if (events.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = [];
+  lines.push("## QuickBooks Update");
+  lines.push("");
+
+  const accountIds = [...new Set(events.map((e) => e.accountId).filter(Boolean))];
+  if (accountIds.length === 1) {
+    lines.push(`**Company ID:** ${accountIds[0]}`);
+    lines.push("");
+  }
+
+  if (events.length === 1) {
+    const e = events[0];
+    const parsed = parseCloudEventType(e.type);
+    lines.push(formatEntityLine(parsed.entity, parsed.operation, e.entityId, e.time));
+  } else {
+    lines.push("### Events");
+    lines.push("");
+    for (const e of events) {
+      const parsed = parseCloudEventType(e.type);
+      lines.push(`- ${formatEntityLine(parsed.entity, parsed.operation, e.entityId, e.time)}`);
+    }
+  }
+
+  const message = lines.join("\n").trim();
+  const sessionKey = deriveSessionKey(events.map((e) => `${e.type}:${e.entityId}`));
+
+  return { message, name: "QuickBooks", sessionKey };
+}
+
+/**
+ * Parse CloudEvents type string like "qbo.invoice.created.v1"
+ * into { entity: "Invoice", operation: "Created" }
+ */
+function parseCloudEventType(type: string): { entity: string; operation: string } {
+  const parts = type.split(".");
+  // Expected: namespace.entity.operation.version (e.g., qbo.invoice.created.v1)
+  const entity = parts.length >= 2 ? capitalize(parts[1]) : type;
+  const operation = parts.length >= 3 ? capitalize(parts[2]) : "Unknown";
+  return { entity, operation };
+}
+
+// -- Shared helpers --
+
+function formatEntityLine(name: string, operation: string, id: string, timestamp: string): string {
+  const label = ENTITY_LABELS[name.toLowerCase()] || name;
+  const parts = [`**${label}** ${operation}`];
+  if (id) {
+    parts.push(`(ID: ${id})`);
+  }
+  if (timestamp) {
+    parts.push(`at ${timestamp}`);
+  }
+  return parts.join(" ");
+}
+
+function deriveSessionKey(parts: string[]): string {
+  // Use a stable key based on the first entity so related updates group together
+  const base = parts[0] || "unknown";
+  return `webhook:quickbooks:${base}`;
+}
+
+function capitalize(str: string): string {
+  if (!str) {
+    return str;
+  }
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/** Human-readable labels for common QuickBooks entity names */
+const ENTITY_LABELS: Record<string, string> = {
+  invoice: "Invoice",
+  bill: "Bill",
+  payment: "Payment",
+  customer: "Customer",
+  vendor: "Vendor",
+  estimate: "Estimate",
+  account: "Account",
+  item: "Item",
+  creditmemo: "Credit Memo",
+  salesreceipt: "Sales Receipt",
+  purchaseorder: "Purchase Order",
+  purchase: "Purchase",
+  journalentry: "Journal Entry",
+  deposit: "Deposit",
+  transfer: "Transfer",
+  refundreceipt: "Refund Receipt",
+  billpayment: "Bill Payment",
+  vendorcredit: "Vendor Credit",
+  timeactivity: "Time Activity",
+  employee: "Employee",
+  class: "Class",
+  department: "Department",
+  taxcode: "Tax Code",
+  taxrate: "Tax Rate",
+  term: "Term",
+  paymentmethod: "Payment Method",
+  budget: "Budget",
+};

--- a/src/gateway/webhook-transforms/readai.test.ts
+++ b/src/gateway/webhook-transforms/readai.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import { transformReadAiPayload } from "./readai.js";
+
+describe("transformReadAiPayload", () => {
+  test("formats a full meeting_end payload", () => {
+    const payload = {
+      trigger: "meeting_end",
+      session_id: "sess-123",
+      title: "Weekly Standup",
+      start_time: "2026-02-08T10:00:00Z",
+      end_time: "2026-02-08T10:30:00Z",
+      summary: "Discussed sprint progress and blockers.",
+      report_url: "https://read.ai/reports/sess-123",
+      owner: { name: "John", email: "john@example.com" },
+      participants: [
+        { name: "Alice", email: "alice@example.com" },
+        { name: "Bob", email: "bob@example.com" },
+      ],
+      action_items: ["Review PR #42", "Update docs"],
+      key_questions: ["When is the deadline?"],
+      topics: ["Sprint review", "Deployment plan"],
+    };
+
+    const result = transformReadAiPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Read.ai");
+    expect(result!.sessionKey).toBe("webhook:readai:sess-123");
+    expect(result!.message).toContain("## Meeting Notes: Weekly Standup");
+    expect(result!.message).toContain("**Organizer:** John");
+    expect(result!.message).toContain("Alice, Bob");
+    expect(result!.message).toContain("### Summary");
+    expect(result!.message).toContain("Discussed sprint progress");
+    expect(result!.message).toContain("- Review PR #42");
+    expect(result!.message).toContain("- Update docs");
+    expect(result!.message).toContain("- When is the deadline?");
+    expect(result!.message).toContain("- Sprint review");
+    expect(result!.message).toContain("https://read.ai/reports/sess-123");
+  });
+
+  test("returns null for non-meeting_end triggers", () => {
+    const payload = {
+      trigger: "meeting_start",
+      session_id: "sess-456",
+      title: "Team Sync",
+    };
+    expect(transformReadAiPayload(payload)).toBeNull();
+  });
+
+  test("returns null when trigger is missing", () => {
+    const payload = {
+      session_id: "sess-789",
+      title: "No Trigger",
+    };
+    expect(transformReadAiPayload(payload)).toBeNull();
+  });
+
+  test("handles missing optional fields gracefully", () => {
+    const payload = {
+      trigger: "meeting_end",
+      session_id: "sess-minimal",
+      title: "Quick Chat",
+    };
+
+    const result = transformReadAiPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("## Meeting Notes: Quick Chat");
+    expect(result!.message).not.toContain("### Summary");
+    expect(result!.message).not.toContain("### Action Items");
+    expect(result!.message).not.toContain("### Key Questions");
+    expect(result!.message).not.toContain("### Topics Discussed");
+    expect(result!.sessionKey).toBe("webhook:readai:sess-minimal");
+  });
+
+  test("handles string participants", () => {
+    const payload = {
+      trigger: "meeting_end",
+      session_id: "sess-str",
+      title: "Test",
+      participants: ["Alice", "Bob"],
+    };
+    const result = transformReadAiPayload(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("Alice, Bob");
+  });
+
+  test("session key derivation", () => {
+    const result = transformReadAiPayload({
+      trigger: "meeting_end",
+      session_id: "abc-def-123",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.sessionKey).toBe("webhook:readai:abc-def-123");
+  });
+
+  test("defaults title when missing", () => {
+    const result = transformReadAiPayload({
+      trigger: "meeting_end",
+      session_id: "x",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("Untitled Meeting");
+  });
+});

--- a/src/gateway/webhook-transforms/readai.ts
+++ b/src/gateway/webhook-transforms/readai.ts
@@ -1,0 +1,114 @@
+export type ReadAiTransformResult = {
+  message: string;
+  name: string;
+  sessionKey: string;
+} | null;
+
+export function transformReadAiPayload(payload: Record<string, unknown>): ReadAiTransformResult {
+  const trigger = typeof payload.trigger === "string" ? payload.trigger : "";
+  if (trigger !== "meeting_end") {
+    return null;
+  }
+
+  const title = stringField(payload, "title") || "Untitled Meeting";
+  const sessionId = stringField(payload, "session_id") || "unknown";
+  const summary = stringField(payload, "summary") || "";
+  const reportUrl = stringField(payload, "report_url") || "";
+
+  const owner = payload.owner as Record<string, unknown> | undefined;
+  const organizer = owner ? stringField(owner, "name") || stringField(owner, "email") || "" : "";
+
+  const startDate = stringField(payload, "start_time") || "";
+  const endDate = stringField(payload, "end_time") || "";
+
+  const participants = Array.isArray(payload.participants) ? payload.participants : [];
+  const actionItems = Array.isArray(payload.action_items) ? payload.action_items : [];
+  const keyQuestions = Array.isArray(payload.key_questions) ? payload.key_questions : [];
+  const topics = Array.isArray(payload.topics) ? payload.topics : [];
+
+  const lines: string[] = [];
+  lines.push(`## Meeting Notes: ${title}`);
+
+  if (startDate || endDate) {
+    const range = [startDate, endDate].filter(Boolean).join(" - ");
+    lines.push(`**Date:** ${range}`);
+  }
+  if (organizer) {
+    lines.push(`**Organizer:** ${organizer}`);
+  }
+  if (participants.length > 0) {
+    const names = participants
+      .map((p) => {
+        if (typeof p === "string") {
+          return p;
+        }
+        if (typeof p === "object" && p !== null) {
+          const rec = p as Record<string, unknown>;
+          return stringField(rec, "name") || stringField(rec, "email") || "";
+        }
+        return "";
+      })
+      .filter(Boolean);
+    if (names.length > 0) {
+      lines.push(`**Participants:** ${names.join(", ")}`);
+    }
+  }
+  if (reportUrl) {
+    lines.push(`**Report:** ${reportUrl}`);
+  }
+
+  lines.push("");
+
+  if (summary) {
+    lines.push("### Summary");
+    lines.push(summary);
+    lines.push("");
+  }
+
+  if (actionItems.length > 0) {
+    lines.push("### Action Items");
+    for (const item of actionItems) {
+      const text = typeof item === "string" ? item : "";
+      if (text) {
+        lines.push(`- ${text}`);
+      }
+    }
+    lines.push("");
+  }
+
+  if (keyQuestions.length > 0) {
+    lines.push("### Key Questions");
+    for (const q of keyQuestions) {
+      const text = typeof q === "string" ? q : "";
+      if (text) {
+        lines.push(`- ${text}`);
+      }
+    }
+    lines.push("");
+  }
+
+  if (topics.length > 0) {
+    lines.push("### Topics Discussed");
+    for (const topic of topics) {
+      const text = typeof topic === "string" ? topic : "";
+      if (text) {
+        lines.push(`- ${text}`);
+      }
+    }
+    lines.push("");
+  }
+
+  const message = lines.join("\n").trim();
+  const sessionKey = `webhook:readai:${sessionId}`;
+
+  return {
+    message,
+    name: "Read.ai",
+    sessionKey,
+  };
+}
+
+function stringField(obj: Record<string, unknown>, key: string): string {
+  const val = obj[key];
+  return typeof val === "string" ? val.trim() : "";
+}

--- a/src/gateway/webhook-transforms/shopify.test.ts
+++ b/src/gateway/webhook-transforms/shopify.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "vitest";
+import { transformShopifyPayload } from "./shopify.js";
+
+describe("transformShopifyPayload", () => {
+  describe("orders", () => {
+    test("formats a new order", () => {
+      const payload = {
+        id: 12345,
+        order_number: 1042,
+        email: "alice@example.com",
+        financial_status: "paid",
+        fulfillment_status: null,
+        total_price: "89.99",
+        currency: "USD",
+        created_at: "2026-02-08T10:00:00Z",
+        note: "Please gift wrap",
+        customer: {
+          first_name: "Alice",
+          last_name: "Smith",
+        },
+        line_items: [
+          { title: "Widget Pro", quantity: 2, price: "29.99" },
+          { title: "Accessory Pack", quantity: 1, price: "30.01" },
+        ],
+        shipping_address: {
+          city: "Portland",
+          province: "Oregon",
+          country: "US",
+        },
+      };
+
+      const result = transformShopifyPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("Shopify");
+      expect(result!.message).toContain("## Shopify Order Paid");
+      expect(result!.message).toContain("**Order:** #1042");
+      expect(result!.message).toContain("**Customer:** Alice Smith (alice@example.com)");
+      expect(result!.message).toContain("**Total:** 89.99 USD");
+      expect(result!.message).toContain("**Payment:** paid");
+      expect(result!.message).toContain("**Ship to:** Portland, Oregon, US");
+      expect(result!.message).toContain("### Items");
+      expect(result!.message).toContain("- Widget Pro x2 ($29.99)");
+      expect(result!.message).toContain("- Accessory Pack ($30.01)");
+      expect(result!.message).toContain("**Note:** Please gift wrap");
+      expect(result!.sessionKey).toBe("webhook:shopify:order:12345");
+    });
+
+    test("formats a fulfilled order", () => {
+      const payload = {
+        id: 999,
+        order_number: 1050,
+        financial_status: "paid",
+        fulfillment_status: "fulfilled",
+        total_price: "50.00",
+        line_items: [],
+      };
+
+      const result = transformShopifyPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("## Shopify Order Fulfilled");
+    });
+
+    test("formats a cancelled order", () => {
+      const payload = {
+        id: 888,
+        order_number: 1060,
+        financial_status: "refunded",
+        fulfillment_status: "unfulfilled",
+        cancelled_at: "2026-02-08T12:00:00Z",
+        total_price: "25.00",
+        line_items: [],
+      };
+
+      const result = transformShopifyPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("## Shopify Order Cancelled");
+    });
+
+    test("handles order with only email, no customer object", () => {
+      const payload = {
+        id: 777,
+        order_number: 1070,
+        email: "solo@example.com",
+        financial_status: "paid",
+        total_price: "10.00",
+        line_items: [],
+      };
+
+      const result = transformShopifyPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("**Customer:** solo@example.com");
+    });
+  });
+
+  describe("customers", () => {
+    test("formats a customer event", () => {
+      const payload = {
+        id: 5001,
+        first_name: "Bob",
+        last_name: "Jones",
+        email: "bob@example.com",
+        phone: "+15559876543",
+        orders_count: 12,
+        total_spent: "450.00",
+        tags: "vip, wholesale",
+        created_at: "2024-06-15T08:00:00Z",
+      };
+
+      const result = transformShopifyPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("## Shopify Customer Update");
+      expect(result!.message).toContain("**Name:** Bob Jones");
+      expect(result!.message).toContain("**Email:** bob@example.com");
+      expect(result!.message).toContain("**Orders:** 12");
+      expect(result!.message).toContain("**Total spent:** $450.00");
+      expect(result!.message).toContain("**Tags:** vip, wholesale");
+      expect(result!.sessionKey).toBe("webhook:shopify:customer:5001");
+    });
+  });
+
+  describe("products", () => {
+    test("formats a product event", () => {
+      const payload = {
+        id: 3001,
+        title: "Super Widget",
+        product_type: "Gadgets",
+        vendor: "WidgetCo",
+        status: "active",
+        variants: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      };
+
+      const result = transformShopifyPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("## Shopify Product Update");
+      expect(result!.message).toContain("**Product:** Super Widget");
+      expect(result!.message).toContain("**Type:** Gadgets");
+      expect(result!.message).toContain("**Vendor:** WidgetCo");
+      expect(result!.message).toContain("**Variants:** 3");
+      expect(result!.sessionKey).toBe("webhook:shopify:product:3001");
+    });
+  });
+
+  describe("refunds", () => {
+    test("formats a refund event", () => {
+      const payload = {
+        id: 8001,
+        order_id: 12345,
+        created_at: "2026-02-08T15:00:00Z",
+        note: "Customer changed mind",
+        refund_line_items: [{ id: 1 }, { id: 2 }],
+      };
+
+      const result = transformShopifyPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("## Shopify Refund");
+      expect(result!.message).toContain("**Order ID:** 12345");
+      expect(result!.message).toContain("**Reason:** Customer changed mind");
+      expect(result!.message).toContain("**Items refunded:** 2");
+      expect(result!.sessionKey).toBe("webhook:shopify:refund:8001");
+    });
+  });
+
+  describe("generic and edge cases", () => {
+    test("formats unknown entity with id as generic", () => {
+      const payload = {
+        id: 9999,
+        status: "active",
+        name: "Something",
+      };
+
+      const result = transformShopifyPayload(payload);
+      expect(result).not.toBeNull();
+      expect(result!.message).toContain("## Shopify Event");
+      expect(result!.message).toContain("**Entity ID:** 9999");
+    });
+
+    test("returns null for empty payload", () => {
+      expect(transformShopifyPayload({})).toBeNull();
+    });
+
+    test("returns null for payload without id or recognizable shape", () => {
+      const payload = { foo: "bar", baz: 42 };
+      expect(transformShopifyPayload(payload)).toBeNull();
+    });
+  });
+});

--- a/src/gateway/webhook-transforms/shopify.ts
+++ b/src/gateway/webhook-transforms/shopify.ts
@@ -1,0 +1,328 @@
+export type ShopifyTransformResult = {
+  message: string;
+  name: string;
+  sessionKey: string;
+} | null;
+
+/**
+ * Transforms a Shopify webhook payload into an agent message.
+ *
+ * Shopify sends the topic in the X-Shopify-Topic header, but since we receive
+ * just the JSON body, we infer the event type from the payload shape.
+ *
+ * Common topics: orders/create, orders/updated, orders/paid, orders/cancelled,
+ * orders/fulfilled, customers/create, customers/update, products/create,
+ * products/update, refunds/create, etc.
+ *
+ * The payload contains full entity details (order, customer, product, etc.).
+ */
+export function transformShopifyPayload(payload: Record<string, unknown>): ShopifyTransformResult {
+  // Detect payload type by presence of distinctive fields
+  if (isOrderPayload(payload)) {
+    return formatOrder(payload);
+  }
+  if (isCustomerPayload(payload)) {
+    return formatCustomer(payload);
+  }
+  if (isProductPayload(payload)) {
+    return formatProduct(payload);
+  }
+  if (isRefundPayload(payload)) {
+    return formatRefund(payload);
+  }
+
+  // Generic fallback for any Shopify payload with an id
+  if (payload.id !== undefined) {
+    return formatGeneric(payload);
+  }
+
+  return null;
+}
+
+// -- Order --
+
+function isOrderPayload(payload: Record<string, unknown>): boolean {
+  return (
+    payload.order_number !== undefined ||
+    (payload.financial_status !== undefined && payload.line_items !== undefined)
+  );
+}
+
+function formatOrder(payload: Record<string, unknown>): ShopifyTransformResult {
+  const orderId = toStr(payload.id);
+  const orderNumber = toStr(payload.order_number ?? payload.number);
+  const email = stringField(payload, "email");
+  const financialStatus = stringField(payload, "financial_status");
+  const fulfillmentStatus = stringField(payload, "fulfillment_status") || "unfulfilled";
+  const totalPrice = stringField(payload, "total_price");
+  const currency = stringField(payload, "currency");
+  const createdAt = stringField(payload, "created_at");
+  const cancelledAt = stringField(payload, "cancelled_at");
+  const note = stringField(payload, "note");
+
+  const customer = payload.customer as Record<string, unknown> | undefined;
+  const customerName = customer
+    ? [stringField(customer, "first_name"), stringField(customer, "last_name")]
+        .filter(Boolean)
+        .join(" ")
+    : "";
+
+  const lineItems = Array.isArray(payload.line_items) ? payload.line_items : [];
+  const shippingAddress = payload.shipping_address as Record<string, unknown> | undefined;
+
+  const isCancelled = Boolean(cancelledAt);
+  const action = isCancelled ? "Cancelled" : inferOrderAction(financialStatus, fulfillmentStatus);
+
+  const lines: string[] = [];
+  lines.push(`## Shopify Order ${action}`);
+  lines.push("");
+
+  if (orderNumber) {
+    lines.push(`**Order:** #${orderNumber}`);
+  }
+  if (customerName || email) {
+    lines.push(
+      `**Customer:** ${customerName || email}${customerName && email ? ` (${email})` : ""}`,
+    );
+  }
+  if (totalPrice) {
+    lines.push(`**Total:** ${totalPrice}${currency ? ` ${currency}` : ""}`);
+  }
+  if (financialStatus) {
+    lines.push(`**Payment:** ${financialStatus}`);
+  }
+  if (fulfillmentStatus) {
+    lines.push(`**Fulfillment:** ${fulfillmentStatus}`);
+  }
+  if (createdAt) {
+    lines.push(`**Date:** ${createdAt}`);
+  }
+
+  if (shippingAddress) {
+    const city = stringField(shippingAddress, "city");
+    const province = stringField(shippingAddress, "province");
+    const country = stringField(shippingAddress, "country");
+    const location = [city, province, country].filter(Boolean).join(", ");
+    if (location) {
+      lines.push(`**Ship to:** ${location}`);
+    }
+  }
+
+  if (lineItems.length > 0) {
+    lines.push("");
+    lines.push("### Items");
+    lines.push("");
+    for (const item of lineItems) {
+      if (typeof item !== "object" || item === null) {
+        continue;
+      }
+      const rec = item as Record<string, unknown>;
+      const title = stringField(rec, "title");
+      const quantity = rec.quantity;
+      const price = stringField(rec, "price");
+      if (title) {
+        const parts = [title];
+        if (typeof quantity === "number" && quantity > 1) {
+          parts.push(`x${quantity}`);
+        }
+        if (price) {
+          parts.push(`($${price})`);
+        }
+        lines.push(`- ${parts.join(" ")}`);
+      }
+    }
+  }
+
+  if (note) {
+    lines.push("");
+    lines.push(`**Note:** ${note}`);
+  }
+
+  const message = lines.join("\n").trim();
+  const sessionKey = `webhook:shopify:order:${orderId || orderNumber || "unknown"}`;
+
+  return { message, name: "Shopify", sessionKey };
+}
+
+function inferOrderAction(financialStatus: string, fulfillmentStatus: string): string {
+  if (fulfillmentStatus === "fulfilled") {
+    return "Fulfilled";
+  }
+  if (financialStatus === "paid") {
+    return "Paid";
+  }
+  if (financialStatus === "refunded" || financialStatus === "partially_refunded") {
+    return "Refunded";
+  }
+  return "Update";
+}
+
+// -- Customer --
+
+function isCustomerPayload(payload: Record<string, unknown>): boolean {
+  return (
+    payload.orders_count !== undefined &&
+    payload.total_spent !== undefined &&
+    payload.first_name !== undefined
+  );
+}
+
+function formatCustomer(payload: Record<string, unknown>): ShopifyTransformResult {
+  const id = toStr(payload.id);
+  const firstName = stringField(payload, "first_name");
+  const lastName = stringField(payload, "last_name");
+  const name = [firstName, lastName].filter(Boolean).join(" ");
+  const email = stringField(payload, "email");
+  const phone = stringField(payload, "phone");
+  const ordersCount = payload.orders_count;
+  const totalSpent = stringField(payload, "total_spent");
+  const createdAt = stringField(payload, "created_at");
+  const tags = stringField(payload, "tags");
+
+  const lines: string[] = [];
+  lines.push("## Shopify Customer Update");
+  lines.push("");
+
+  if (name) {
+    lines.push(`**Name:** ${name}`);
+  }
+  if (email) {
+    lines.push(`**Email:** ${email}`);
+  }
+  if (phone) {
+    lines.push(`**Phone:** ${phone}`);
+  }
+  if (typeof ordersCount === "number") {
+    lines.push(`**Orders:** ${ordersCount}`);
+  }
+  if (totalSpent) {
+    lines.push(`**Total spent:** $${totalSpent}`);
+  }
+  if (tags) {
+    lines.push(`**Tags:** ${tags}`);
+  }
+  if (createdAt) {
+    lines.push(`**Since:** ${createdAt}`);
+  }
+
+  const message = lines.join("\n").trim();
+  const sessionKey = `webhook:shopify:customer:${id || "unknown"}`;
+
+  return { message, name: "Shopify", sessionKey };
+}
+
+// -- Product --
+
+function isProductPayload(payload: Record<string, unknown>): boolean {
+  return payload.product_type !== undefined && payload.variants !== undefined;
+}
+
+function formatProduct(payload: Record<string, unknown>): ShopifyTransformResult {
+  const id = toStr(payload.id);
+  const title = stringField(payload, "title");
+  const productType = stringField(payload, "product_type");
+  const vendor = stringField(payload, "vendor");
+  const status = stringField(payload, "status");
+  const variants = Array.isArray(payload.variants) ? payload.variants : [];
+
+  const lines: string[] = [];
+  lines.push("## Shopify Product Update");
+  lines.push("");
+
+  if (title) {
+    lines.push(`**Product:** ${title}`);
+  }
+  if (productType) {
+    lines.push(`**Type:** ${productType}`);
+  }
+  if (vendor) {
+    lines.push(`**Vendor:** ${vendor}`);
+  }
+  if (status) {
+    lines.push(`**Status:** ${status}`);
+  }
+  if (variants.length > 0) {
+    lines.push(`**Variants:** ${variants.length}`);
+  }
+
+  const message = lines.join("\n").trim();
+  const sessionKey = `webhook:shopify:product:${id || "unknown"}`;
+
+  return { message, name: "Shopify", sessionKey };
+}
+
+// -- Refund --
+
+function isRefundPayload(payload: Record<string, unknown>): boolean {
+  return payload.order_id !== undefined && payload.refund_line_items !== undefined;
+}
+
+function formatRefund(payload: Record<string, unknown>): ShopifyTransformResult {
+  const id = toStr(payload.id);
+  const orderId = toStr(payload.order_id);
+  const createdAt = stringField(payload, "created_at");
+  const note = stringField(payload, "note");
+  const refundLineItems = Array.isArray(payload.refund_line_items) ? payload.refund_line_items : [];
+
+  const lines: string[] = [];
+  lines.push("## Shopify Refund");
+  lines.push("");
+
+  if (orderId) {
+    lines.push(`**Order ID:** ${orderId}`);
+  }
+  if (createdAt) {
+    lines.push(`**Date:** ${createdAt}`);
+  }
+  if (note) {
+    lines.push(`**Reason:** ${note}`);
+  }
+  if (refundLineItems.length > 0) {
+    lines.push(`**Items refunded:** ${refundLineItems.length}`);
+  }
+
+  const message = lines.join("\n").trim();
+  const sessionKey = `webhook:shopify:refund:${id || orderId || "unknown"}`;
+
+  return { message, name: "Shopify", sessionKey };
+}
+
+// -- Generic fallback --
+
+function formatGeneric(payload: Record<string, unknown>): ShopifyTransformResult {
+  const id = toStr(payload.id);
+  const lines: string[] = [];
+  lines.push("## Shopify Event");
+  lines.push("");
+  lines.push(`**Entity ID:** ${id}`);
+
+  const keys = Object.keys(payload)
+    .filter((k) => k !== "id")
+    .slice(0, 5);
+  for (const key of keys) {
+    const val = payload[key];
+    if (typeof val === "string" || typeof val === "number" || typeof val === "boolean") {
+      lines.push(`**${key}:** ${String(val)}`);
+    }
+  }
+
+  const message = lines.join("\n").trim();
+  const sessionKey = `webhook:shopify:entity:${id || "unknown"}`;
+
+  return { message, name: "Shopify", sessionKey };
+}
+
+function stringField(obj: Record<string, unknown>, key: string): string {
+  const val = obj[key];
+  return typeof val === "string" ? val.trim() : "";
+}
+
+function toStr(val: unknown): string {
+  if (typeof val === "string") {
+    return val;
+  }
+  if (typeof val === "number" || typeof val === "boolean") {
+    return String(val);
+  }
+  return "";
+}

--- a/src/gateway/webhooks-http.test.ts
+++ b/src/gateway/webhooks-http.test.ts
@@ -1,0 +1,223 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { EventEmitter } from "node:events";
+import { describe, expect, test, vi } from "vitest";
+import type { WebhooksConfigResolved } from "./webhooks-http.js";
+import { createWebhooksRequestHandler } from "./webhooks-http.js";
+
+function createMockReq(opts: { method?: string; url?: string; body?: string }): IncomingMessage {
+  const emitter = new EventEmitter();
+  const req = emitter as unknown as IncomingMessage;
+  req.method = opts.method ?? "POST";
+  req.url = opts.url ?? "/";
+  req.headers = {};
+  req.destroy = vi.fn() as unknown as IncomingMessage["destroy"];
+
+  if (opts.body !== undefined) {
+    process.nextTick(() => {
+      emitter.emit("data", Buffer.from(opts.body!, "utf-8"));
+      emitter.emit("end");
+    });
+  } else {
+    process.nextTick(() => {
+      emitter.emit("end");
+    });
+  }
+  return req;
+}
+
+function createMockRes(): ServerResponse & { _body: string; _status: number } {
+  const res = {
+    statusCode: 200,
+    _body: "",
+    _status: 200,
+    setHeader: vi.fn(),
+    end: vi.fn((body?: string) => {
+      res._body = body ?? "";
+      res._status = res.statusCode;
+    }),
+  } as unknown as ServerResponse & { _body: string; _status: number };
+  return res;
+}
+
+const TOKEN = "test-webhook-token-12345";
+
+function createHandler(opts?: {
+  config?: WebhooksConfigResolved | null;
+  dispatchAgentHook?: () => string;
+}) {
+  const config: WebhooksConfigResolved | null =
+    opts?.config !== undefined
+      ? opts.config
+      : { token: TOKEN, presets: ["readai"], maxBodyBytes: 256 * 1024 };
+
+  const dispatchAgentHook = opts?.dispatchAgentHook ?? (() => "run-id-1");
+
+  return createWebhooksRequestHandler({
+    getWebhooksConfig: () => config,
+    bindHost: "127.0.0.1",
+    port: 3000,
+    logWebhooks: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      child: vi.fn(),
+    } as never,
+    dispatchAgentHook: dispatchAgentHook as never,
+  });
+}
+
+describe("webhooks-http", () => {
+  test("returns false for non-webhook paths", async () => {
+    const handler = createHandler();
+    const req = createMockReq({ url: "/hooks/agent" });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(false);
+  });
+
+  test("returns false when webhooks config is null", async () => {
+    const handler = createHandler({ config: null });
+    const req = createMockReq({ url: `/webhooks/${TOKEN}/readai` });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(false);
+  });
+
+  test("returns 404 for invalid token", async () => {
+    const handler = createHandler();
+    const req = createMockReq({
+      url: "/webhooks/wrong-token/readai",
+      body: "{}",
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+  });
+
+  test("returns 404 for token with different length", async () => {
+    const handler = createHandler();
+    const req = createMockReq({
+      url: "/webhooks/short/readai",
+      body: "{}",
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+  });
+
+  test("returns 405 for non-POST methods", async () => {
+    const handler = createHandler();
+    const req = createMockReq({
+      method: "GET",
+      url: `/webhooks/${TOKEN}/readai`,
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(405);
+  });
+
+  test("returns 404 for unknown source", async () => {
+    const handler = createHandler();
+    const req = createMockReq({
+      url: `/webhooks/${TOKEN}/unknown`,
+      body: "{}",
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+  });
+
+  test("returns 404 when no source segment", async () => {
+    const handler = createHandler();
+    const req = createMockReq({
+      url: `/webhooks/${TOKEN}`,
+      body: "{}",
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+  });
+
+  test("dispatches valid readai meeting_end webhook", async () => {
+    const dispatchFn = vi.fn().mockReturnValue("run-42");
+    const handler = createHandler({ dispatchAgentHook: dispatchFn });
+    const body = JSON.stringify({
+      trigger: "meeting_end",
+      session_id: "sess-1",
+      title: "Team Sync",
+      summary: "Great meeting.",
+      action_items: ["Fix bug"],
+      key_questions: [],
+      topics: [],
+      owner: { name: "John" },
+      participants: [],
+    });
+    const req = createMockReq({
+      url: `/webhooks/${TOKEN}/readai`,
+      body,
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+    const parsed = JSON.parse(res._body) as { ok: boolean; runId: string };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.runId).toBe("run-42");
+    expect(dispatchFn).toHaveBeenCalledOnce();
+    const call = dispatchFn.mock.calls[0][0];
+    expect(call.name).toBe("Read.ai");
+    expect(call.sessionKey).toBe("webhook:readai:sess-1");
+    expect(call.message).toContain("Team Sync");
+  });
+
+  test("skips non-meeting_end triggers with ok+skipped", async () => {
+    const handler = createHandler();
+    const body = JSON.stringify({
+      trigger: "meeting_start",
+      session_id: "sess-2",
+    });
+    const req = createMockReq({
+      url: `/webhooks/${TOKEN}/readai`,
+      body,
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+    const parsed = JSON.parse(res._body) as { ok: boolean; skipped: boolean };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.skipped).toBe(true);
+  });
+
+  test("returns 400 for malformed JSON body", async () => {
+    const handler = createHandler();
+    const req = createMockReq({
+      url: `/webhooks/${TOKEN}/readai`,
+      body: "not-json{",
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(400);
+  });
+
+  test("returns 413 for too-large body", async () => {
+    const handler = createHandler({
+      config: { token: TOKEN, presets: ["readai"], maxBodyBytes: 10 },
+    });
+    const req = createMockReq({
+      url: `/webhooks/${TOKEN}/readai`,
+      body: JSON.stringify({ trigger: "meeting_end", data: "x".repeat(100) }),
+    });
+    const res = createMockRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(413);
+  });
+});

--- a/src/gateway/webhooks-http.ts
+++ b/src/gateway/webhooks-http.ts
@@ -1,0 +1,162 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { timingSafeEqual } from "node:crypto";
+import type { createSubsystemLogger } from "../logging/subsystem.js";
+import type { HookMessageChannel } from "./hooks.js";
+import { readJsonBody } from "./hooks.js";
+import { getWebhookTransform } from "./webhook-transforms/index.js";
+
+type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+const WEBHOOKS_PREFIX = "/webhooks/";
+
+export type WebhooksConfigResolved = {
+  token: string;
+  presets: string[];
+  maxBodyBytes: number;
+};
+
+export type WebhooksRequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => Promise<boolean>;
+
+function sendJson(res: ServerResponse, status: number, body: unknown) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}
+
+function constantTimeTokenMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided, "utf-8");
+  const b = Buffer.from(expected, "utf-8");
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+export function createWebhooksRequestHandler(opts: {
+  getWebhooksConfig: () => WebhooksConfigResolved | null;
+  bindHost: string;
+  port: number;
+  logWebhooks: SubsystemLogger;
+  dispatchAgentHook: (value: {
+    message: string;
+    name: string;
+    wakeMode: "now" | "next-heartbeat";
+    sessionKey: string;
+    deliver: boolean;
+    channel: HookMessageChannel;
+    to?: string;
+    model?: string;
+    thinking?: string;
+    timeoutSeconds?: number;
+    allowUnsafeExternalContent?: boolean;
+  }) => string;
+}): WebhooksRequestHandler {
+  const { getWebhooksConfig, bindHost, port, logWebhooks, dispatchAgentHook } = opts;
+
+  return async (req, res) => {
+    const webhooksConfig = getWebhooksConfig();
+    if (!webhooksConfig) {
+      return false;
+    }
+
+    const url = new URL(req.url ?? "/", `http://${bindHost}:${port}`);
+    if (!url.pathname.startsWith(WEBHOOKS_PREFIX)) {
+      return false;
+    }
+
+    // Parse /webhooks/{token}/{source}
+    const rest = url.pathname.slice(WEBHOOKS_PREFIX.length);
+    const slashIndex = rest.indexOf("/");
+    if (slashIndex < 0) {
+      // No source segment — return 404
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Not Found");
+      return true;
+    }
+
+    const token = rest.slice(0, slashIndex);
+    const source = rest.slice(slashIndex + 1).replace(/\/+$/, "");
+
+    if (!token || !source) {
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Not Found");
+      return true;
+    }
+
+    // Validate token with constant-time comparison
+    if (!constantTimeTokenMatch(token, webhooksConfig.token)) {
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Not Found");
+      return true;
+    }
+
+    // POST only
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.setHeader("Allow", "POST");
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Method Not Allowed");
+      return true;
+    }
+
+    // Check source is an enabled preset
+    if (!webhooksConfig.presets.includes(source)) {
+      logWebhooks.warn(`webhook source "${source}" is not an enabled preset`);
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Not Found");
+      return true;
+    }
+
+    // Look up transform
+    const transform = getWebhookTransform(source);
+    if (!transform) {
+      logWebhooks.warn(`no transform found for webhook source "${source}"`);
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Not Found");
+      return true;
+    }
+
+    // Parse JSON body
+    const body = await readJsonBody(req, webhooksConfig.maxBodyBytes);
+    if (!body.ok) {
+      const status = body.error === "payload too large" ? 413 : 400;
+      sendJson(res, status, { ok: false, error: body.error });
+      return true;
+    }
+
+    const payload =
+      typeof body.value === "object" && body.value !== null
+        ? (body.value as Record<string, unknown>)
+        : {};
+
+    // Transform payload
+    const result = transform(payload);
+    if (result === null) {
+      // Transform says skip (e.g., non-meeting_end trigger)
+      sendJson(res, 200, { ok: true, skipped: true });
+      return true;
+    }
+
+    // Dispatch to agent
+    const runId = dispatchAgentHook({
+      message: result.message,
+      name: result.name,
+      wakeMode: "now",
+      sessionKey: result.sessionKey,
+      deliver: true,
+      channel: "last",
+    });
+
+    logWebhooks.info(`webhook dispatched: source=${source} runId=${runId}`);
+    sendJson(res, 200, { ok: true, runId });
+    return true;
+  };
+}


### PR DESCRIPTION
Hey! I've been running OpenClaw as my daily gateway and kept finding myself wanting external services to push events directly into the agent. So I built a generic webhook framework that plugs into the existing hooks/gateway infrastructure. Figured this would be useful for the wider community too.

## Summary

- Adds a generic webhook HTTP endpoint at `/webhooks/{token}/{source}` on the gateway
- Receives POST payloads from external services and dispatches them to the agent via the cron isolated-agent system
- Uses constant-time token validation (reuses the existing hooks token)
- Pluggable transform architecture — easy to add new services

### Architecture

```
POST /webhooks/{token}/{source}
  → token validation (constant-time)
  → source lookup in enabled presets
  → transform function converts raw payload → structured message
  → dispatch to agent via isolated cron job
  → system event enqueued for visibility
```

**Files:**
- `src/gateway/webhooks-http.ts` — Core HTTP handler
- `src/gateway/server/webhooks.ts` — Gateway integration (agent dispatch)
- `src/gateway/webhook-transforms/index.ts` — Transform registry
- `src/gateway/webhook-transforms/*.ts` — Per-service transforms
- Config wiring: `server-http.ts`, `server-runtime-config.ts`, `server-runtime-state.ts`, `server-reload-handlers.ts`, `server.impl.ts`
- Schema: `types.hooks.ts`, `zod-schema.ts`

### Built-in transforms (4 services, 50 tests)

| Service | Events | Notes |
|---------|--------|-------|
| **Shopify** | Orders, customers, products, refunds | Infers event type from payload shape |
| **QuickBooks** | Entity CRUD | Supports both legacy and CloudEvents (May 2026 migration) |
| **Read.ai** | Meeting notes | Triggers on `meeting_end` only |
| **OwnerRez** | Bookings, contacts, properties | Entity insert/update/delete with embedded entity parsing |

### Configuration

```yaml
hooks:
  enabled: true
  token: "your-secret-token"
  webhooks:
    enabled: true
    presets:
      - shopify
      - quickbooks
      - readai
      - ownerrez
```

## Test plan

- [x] All 50 webhook tests pass (`pnpm vitest run src/gateway/webhook-transforms/ src/gateway/webhooks-http.test.ts`)
- [x] Build passes (`pnpm build`)
- [x] Type-check and lint pass (`pnpm check` — only pre-existing `.vercel/project.json` format issue)
- [ ] Integration test: deploy and POST sample payloads to `/webhooks/{token}/{source}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an inbound webhook framework to the gateway: a new `/webhooks/{token}/{source}` endpoint validates the existing hooks token, selects an enabled source preset, transforms the received JSON payload into a structured agent message (Shopify / QuickBooks / Read.ai / OwnerRez), and dispatches it to the agent via an isolated cron job. Runtime/config wiring is added so the endpoint can be enabled/disabled and hot-reloaded alongside existing hooks.

The main correctness gap is around payload shape support: the HTTP handler currently coerces any non-object JSON body (including top-level arrays) into `{}`, while the QuickBooks transform includes logic to handle top-level array CloudEvents. As written, direct-array CloudEvents batches will be silently dropped and never reach the transform.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge once array-payload handling is clarified/fixed.
- Core wiring and token validation are straightforward and covered by tests, but there is a concrete behavioral mismatch: the HTTP layer normalizes non-object JSON bodies to `{}`, making the QuickBooks CloudEvents top-level array path unreachable and causing real payloads to be ignored depending on sender format.
- src/gateway/webhooks-http.ts, src/gateway/webhook-transforms/quickbooks.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->