### PR TITLE
feat(tools): typed tool schemas for xAI/Grok compatibility

### DIFF
--- a/src/agents/tools/browser-tool.schema.ts
+++ b/src/agents/tools/browser-tool.schema.ts
@@ -65,8 +65,16 @@ const BrowserActSchema = Type.Object({
   endRef: Type.Optional(Type.String()),
   // select
   values: Type.Optional(Type.Array(Type.String())),
-  // fill - use permissive array of objects
-  fields: Type.Optional(Type.Array(Type.Object({}, { additionalProperties: true }))),
+  // fill - array of field name/value pairs
+  fields: Type.Optional(
+    Type.Array(
+      Type.Object({
+        ref: Type.Optional(Type.String()),
+        targetId: Type.Optional(Type.String()),
+        value: Type.Optional(Type.String()),
+      }),
+    ),
+  ),
   // resize
   width: Type.Optional(Type.Number()),
   height: Type.Optional(Type.Number()),

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -10,20 +10,66 @@ import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool, type GatewayCallOptions } from "./gateway.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
 
-// NOTE: We use Type.Object({}, { additionalProperties: true }) for job/patch
-// instead of CronAddParamsSchema/CronJobPatchSchema because the gateway schemas
-// contain nested unions. Tool schemas need to stay provider-friendly, so we
-// accept "any object" here and validate at runtime.
-
 const CRON_ACTIONS = ["status", "list", "add", "update", "remove", "run", "runs", "wake"] as const;
 
 const CRON_WAKE_MODES = ["now", "next-heartbeat"] as const;
 const CRON_RUN_MODES = ["due", "force"] as const;
+const CRON_SCHEDULE_KINDS = ["at", "every", "cron"] as const;
+const CRON_PAYLOAD_KINDS = ["systemEvent", "agentTurn"] as const;
+const CRON_SESSION_TARGETS = ["main", "isolated"] as const;
+const CRON_DELIVERY_MODES = ["none", "announce"] as const;
 
 const REMINDER_CONTEXT_MESSAGES_MAX = 10;
 const REMINDER_CONTEXT_PER_MESSAGE_MAX = 220;
 const REMINDER_CONTEXT_TOTAL_MAX = 700;
 const REMINDER_CONTEXT_MARKER = "\n\nRecent context:\n";
+
+// Fully typed schedule schema (flattened union — kind determines which fields apply).
+const CronScheduleSchema = Type.Object({
+  kind: stringEnum(CRON_SCHEDULE_KINDS),
+  at: Type.Optional(Type.String({ description: "ISO-8601 timestamp (kind=at)" })),
+  expr: Type.Optional(Type.String({ description: "Cron expression (kind=cron)" })),
+  tz: Type.Optional(Type.String({ description: "Timezone (kind=cron)" })),
+  everyMs: Type.Optional(Type.Number({ description: "Interval in ms (kind=every)" })),
+  anchorMs: Type.Optional(Type.Number({ description: "Anchor epoch ms (kind=every)" })),
+});
+
+// Fully typed payload schema (flattened union — kind determines which fields apply).
+const CronPayloadSchema = Type.Object({
+  kind: stringEnum(CRON_PAYLOAD_KINDS),
+  text: Type.Optional(Type.String({ description: "Message text (kind=systemEvent)" })),
+  message: Type.Optional(Type.String({ description: "Agent prompt (kind=agentTurn)" })),
+  model: Type.Optional(Type.String()),
+  thinking: Type.Optional(Type.String()),
+  timeoutSeconds: Type.Optional(Type.Number()),
+});
+
+const CronDeliverySchema = Type.Object({
+  mode: Type.Optional(stringEnum(CRON_DELIVERY_MODES)),
+  channel: Type.Optional(Type.String()),
+  to: Type.Optional(Type.String()),
+  bestEffort: Type.Optional(Type.Boolean()),
+});
+
+// Typed job schema for add action. Runtime normalization still handles coercion.
+const CronJobSchema = Type.Object({
+  name: Type.Optional(Type.String({ description: "Job name" })),
+  schedule: CronScheduleSchema,
+  payload: CronPayloadSchema,
+  sessionTarget: stringEnum(CRON_SESSION_TARGETS),
+  delivery: Type.Optional(CronDeliverySchema),
+  enabled: Type.Optional(Type.Boolean()),
+});
+
+// Typed patch schema for update action.
+const CronPatchSchema = Type.Object({
+  name: Type.Optional(Type.String()),
+  schedule: Type.Optional(CronScheduleSchema),
+  payload: Type.Optional(CronPayloadSchema),
+  sessionTarget: Type.Optional(stringEnum(CRON_SESSION_TARGETS)),
+  delivery: Type.Optional(CronDeliverySchema),
+  enabled: Type.Optional(Type.Boolean()),
+});
 
 // Flattened schema: runtime validates per-action requirements.
 const CronToolSchema = Type.Object({
@@ -32,10 +78,10 @@ const CronToolSchema = Type.Object({
   gatewayToken: Type.Optional(Type.String()),
   timeoutMs: Type.Optional(Type.Number()),
   includeDisabled: Type.Optional(Type.Boolean()),
-  job: Type.Optional(Type.Object({}, { additionalProperties: true })),
+  job: Type.Optional(CronJobSchema),
   jobId: Type.Optional(Type.String()),
   id: Type.Optional(Type.String()),
-  patch: Type.Optional(Type.Object({}, { additionalProperties: true })),
+  patch: Type.Optional(CronPatchSchema),
   text: Type.Optional(Type.String()),
   mode: optionalStringEnum(CRON_WAKE_MODES),
   runMode: optionalStringEnum(CRON_RUN_MODES),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -96,9 +96,22 @@ function buildSendSchema(options: { includeButtons: boolean; includeCards: boole
     ),
     card: Type.Optional(
       Type.Object(
-        {},
         {
-          additionalProperties: true,
+          type: Type.Optional(Type.String({ description: "Card type, e.g. AdaptiveCard" })),
+          version: Type.Optional(Type.String()),
+          body: Type.Optional(
+            Type.Array(
+              Type.Object({
+                type: Type.Optional(Type.String()),
+                text: Type.Optional(Type.String()),
+                size: Type.Optional(Type.String()),
+                weight: Type.Optional(Type.String()),
+                wrap: Type.Optional(Type.Boolean()),
+              }),
+            ),
+          ),
+        },
+        {
           description: "Adaptive Card JSON object (when supported by the channel)",
         },
       ),

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -36,7 +36,7 @@ const OPENAI_MODEL_APIS = new Set([
   "openai-responses",
   "openai-codex-responses",
 ]);
-const OPENAI_PROVIDERS = new Set(["openai", "openai-codex"]);
+const OPENAI_PROVIDERS = new Set(["openai", "openai-codex", "xai"]);
 
 function isOpenAiApi(modelApi?: string | null): boolean {
   if (!modelApi) {


### PR DESCRIPTION
## Problem

When using xAI Grok models with OpenClaw, tool calls frequently fail. The root cause is that several tool schemas use `Type.Object({}, { additionalProperties: true })` — which produces `{"type": "object"}` with **no defined properties** in the JSON Schema sent to the LLM.

Claude infers the expected fields from natural-language descriptions, but Grok follows the schema literally and sends empty objects (e.g. `job: {}`), causing runtime validation failures.

**Affected tools:** `cron-tool`, `browser-tool`, `message-tool`

## Solution

Replace the loose/permissive object schemas with fully typed TypeBox definitions:

- **cron-tool.ts**: Added `CronJobSchema`, `CronPatchSchema`, `CronScheduleSchema`, `CronPayloadSchema`, `CronDeliverySchema` with all fields, types, and enums. Uses a flattened-union pattern (single object with `kind` discriminator, variant fields as optional) to stay provider-friendly.
- **browser-tool.schema.ts**: Replaced loose `fields` array items with typed `{ ref, targetId, value }` objects.
- **message-tool.ts**: Replaced loose `card` object with typed Adaptive Card schema (`type`, `version`, `body` array with text block fields).
- **transcript-policy.ts**: Added `"xai"` to `OPENAI_PROVIDERS` so xAI models get the correct transcript sanitization mode (`images-only`), matching their OpenAI-compatible API.

## Impact

- **Backward compatible**: All schemas are strictly additive — existing fields and behavior are preserved. Models that previously worked (Claude, OpenAI, etc.) will continue to work identically since they already handle well-typed schemas.
- **No runtime behavior changes**: The tool handlers still perform the same runtime validation. The only change is that the LLM now receives proper field definitions instead of empty objects.
- **All existing tests pass** (855 test files, 5512 tests).

## Testing

- Verified that `pnpm build` succeeds
- Verified that `pnpm test` passes (all 5512 tests)
- Manually tested cron job creation with xAI Grok — tool calls now include correct field values instead of empty objects

## Related

This works in conjunction with a companion change in [pi-mono](https://github.com/badlogic/pi-mono) that adds configurable `strict` mode for xAI tool schemas (PR submitted separately). However, **this PR is independently valuable** — typed schemas improve tool reliability for all providers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR replaces permissive `Type.Object({}, { additionalProperties: true })` tool parameter schemas with more explicit TypeBox object shapes for the cron tool (`job`/`patch` with schedule/payload/delivery sub-schemas), browser tool `fill.fields`, and message tool `card`. It also treats `xai` as an OpenAI-like provider in `resolveTranscriptPolicy` so xAI models get the OpenAI transcript sanitization behavior.

These changes fit into the existing “flattened object schema” approach used elsewhere in the agents/tools layer to keep schemas provider-friendly while preserving runtime validation and normalization in the tool handlers.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a likely runtime crash in the Message tool schema construction.
- Most changes are schema-tightening and should be low risk, but the updated `Type.Object` call in `message-tool.ts` appears to use an invalid signature (extra argument), which would throw during module evaluation and break tool initialization. Until that is corrected and validated, merge risk is high.
- src/agents/tools/message-tool.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->