### PR TITLE
Clawd/tool calling fix

### DIFF
--- a/src/agents/pi-embedded-runner/clawd-non-streaming.ts
+++ b/src/agents/pi-embedded-runner/clawd-non-streaming.ts
@@ -1,0 +1,298 @@
+/**
+ * CLAWD PATCH: Non-streaming streamFn for openai-completions models.
+ *
+ * Ollama (and some vLLM setups) return tool_calls as raw text when streaming,
+ * but return proper structured tool_calls with stream=false.
+ * See: https://github.com/openclaw/openclaw/issues/5769
+ *       https://github.com/openclaw/openclaw/issues/1866
+ */
+
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+
+interface ToolDef {
+  name: string;
+  description: string;
+  parameters: unknown;
+}
+
+interface OllamaToolCall {
+  id?: string;
+  type?: string;
+  function: { name: string; arguments: string };
+}
+
+interface OllamaChoice {
+  message: {
+    role: string;
+    content: string | null;
+    tool_calls?: OllamaToolCall[];
+  };
+  finish_reason: string;
+}
+
+interface OllamaResponse {
+  choices: OllamaChoice[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+}
+
+/**
+ * Minimal event stream that implements AsyncIterable.
+ * Buffers events and resolves waiting consumers.
+ */
+class SimpleEventStream {
+  private buffer: any[] = [];
+  private resolve: ((v: IteratorResult<any>) => void) | null = null;
+  private isDone = false;
+  private finalMessage: any = null;
+  private resultResolve: ((v: any) => void) | null = null;
+  private resultPromise: Promise<any>;
+
+  constructor() {
+    this.resultPromise = new Promise((resolve) => {
+      this.resultResolve = resolve;
+    });
+  }
+
+  push(event: any) {
+    // Capture the final message from the "done" event
+    if (event.type === "done" && event.message) {
+      this.finalMessage = event.message;
+    }
+    if (this.resolve) {
+      const r = this.resolve;
+      this.resolve = null;
+      r({ value: event, done: false });
+    } else {
+      this.buffer.push(event);
+    }
+  }
+
+  end() {
+    this.isDone = true;
+    if (this.resultResolve) {
+      this.resultResolve(this.finalMessage);
+      this.resultResolve = null;
+    }
+    if (this.resolve) {
+      const r = this.resolve;
+      this.resolve = null;
+      r({ value: undefined, done: true });
+    }
+  }
+
+  /** Returns a promise that resolves to the final assistant message. */
+  result(): Promise<any> {
+    return this.resultPromise;
+  }
+
+  [Symbol.asyncIterator]() {
+    return {
+      next: (): Promise<IteratorResult<any>> => {
+        if (this.buffer.length > 0) {
+          return Promise.resolve({ value: this.buffer.shift(), done: false });
+        }
+        if (this.isDone) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        return new Promise((resolve) => {
+          this.resolve = resolve;
+        });
+      },
+    };
+  }
+}
+
+export function createNonStreamingOllamaFn(toolDefs: ToolDef[]): StreamFn {
+  return ((model: any, context: any, _options: any) => {
+    const stream = new SimpleEventStream();
+
+    const output: any = {
+      role: "assistant",
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    (async () => {
+      try {
+        // Convert context messages to OpenAI format
+        const messages = (context.messages ?? []).map((msg: any) => {
+          if (msg.role === "user") {
+            if (typeof msg.content === "string") {
+              return { role: "user", content: msg.content };
+            }
+            if (Array.isArray(msg.content)) {
+              const text = msg.content
+                .filter((b: any) => b.type === "text")
+                .map((b: any) => b.text)
+                .join("\n");
+              return { role: "user", content: text || "" };
+            }
+            return { role: "user", content: String(msg.content ?? "") };
+          }
+          if (msg.role === "assistant") {
+            if (typeof msg.content === "string") {
+              return { role: "assistant", content: msg.content };
+            }
+            if (Array.isArray(msg.content)) {
+              const textParts = msg.content
+                .filter((b: any) => b.type === "text")
+                .map((b: any) => b.text);
+              const toolCalls = msg.content
+                .filter((b: any) => b.type === "toolCall")
+                .map((b: any) => ({
+                  id: b.id || "call_0",
+                  type: "function" as const,
+                  function: {
+                    name: b.name,
+                    arguments:
+                      typeof b.arguments === "string"
+                        ? b.arguments
+                        : JSON.stringify(b.arguments ?? {}),
+                  },
+                }));
+              const result: any = { role: "assistant", content: textParts.join("\n") || null };
+              if (toolCalls.length > 0) {
+                result.tool_calls = toolCalls;
+              }
+              return result;
+            }
+            return { role: "assistant", content: "" };
+          }
+          if (msg.role === "toolResult") {
+            const content = Array.isArray(msg.content)
+              ? msg.content.map((b: any) => b.text ?? JSON.stringify(b)).join("\n")
+              : String(msg.content ?? "");
+            return { role: "tool", tool_call_id: msg.toolCallId || "call_0", content };
+          }
+          if (msg.role === "system") {
+            if (typeof msg.content === "string") {
+              return { role: "system", content: msg.content };
+            }
+            if (Array.isArray(msg.content)) {
+              return {
+                role: "system",
+                content: msg.content.map((b: any) => b.text ?? "").join("\n"),
+              };
+            }
+            return { role: "system", content: String(msg.content ?? "") };
+          }
+          return msg;
+        });
+
+        // Build tools
+        const tools = toolDefs.map((t) => ({
+          type: "function" as const,
+          function: { name: t.name, description: t.description, parameters: t.parameters },
+        }));
+
+        const body: any = { model: model.id, messages, stream: false };
+        if (tools.length > 0) {
+          body.tools = tools;
+          body.tool_choice = "auto";
+        }
+
+        if (process.env.CLAWDBOT_DEBUG_TOOLS) {
+          console.error(
+            `[CLAWD] non-streaming: model=${model.id} tools=${tools.length} msgs=${messages.length}`,
+          );
+        }
+
+        const apiKey = _options?.apiKey || process.env.OLLAMA_API_KEY || "ollama-local";
+        const resp = await fetch(`${model.baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+          body: JSON.stringify(body),
+          signal: _options?.signal,
+        });
+
+        if (!resp.ok) {
+          throw new Error(`Ollama API error (${resp.status}): ${await resp.text()}`);
+        }
+
+        const data = (await resp.json()) as OllamaResponse;
+        const choice = data.choices?.[0];
+        if (!choice) {
+          throw new Error("No choices in response");
+        }
+
+        stream.push({ type: "start", partial: output });
+
+        const msg = choice.message;
+        let blockIdx = 0;
+
+        if (msg.content) {
+          output.content.push({ type: "text", text: msg.content });
+          stream.push({ type: "text_start", contentIndex: blockIdx, partial: output });
+          stream.push({
+            type: "text_delta",
+            contentIndex: blockIdx,
+            text: msg.content,
+            partial: output,
+          });
+          blockIdx++;
+        }
+
+        if (msg.tool_calls?.length) {
+          output.stopReason = "toolCall";
+          for (const tc of msg.tool_calls) {
+            let args: Record<string, unknown> = {};
+            try {
+              args = JSON.parse(tc.function.arguments);
+            } catch {
+              args = { raw: tc.function.arguments };
+            }
+            output.content.push({
+              type: "toolCall",
+              id: tc.id || `call_${blockIdx}`,
+              name: tc.function.name,
+              arguments: args,
+            });
+            stream.push({ type: "toolcall_start", contentIndex: blockIdx, partial: output });
+            stream.push({
+              type: "toolcall_delta",
+              contentIndex: blockIdx,
+              name: tc.function.name,
+              argumentsDelta: tc.function.arguments,
+              partial: output,
+            });
+            blockIdx++;
+          }
+        }
+
+        if (data.usage) {
+          output.usage.input = data.usage.prompt_tokens ?? 0;
+          output.usage.output = data.usage.completion_tokens ?? 0;
+          output.usage.totalTokens = data.usage.total_tokens ?? 0;
+        }
+
+        if (process.env.CLAWDBOT_DEBUG_TOOLS) {
+          console.error(
+            `[CLAWD] response: text=${!!msg.content} tool_calls=${msg.tool_calls?.length ?? 0}`,
+          );
+        }
+
+        stream.push({ type: "done", reason: output.stopReason, message: output });
+        stream.end();
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error(`[CLAWD] error:`, error.message);
+        stream.push({ type: "error", error });
+        stream.end();
+      }
+    })();
+
+    return stream as any;
+  }) satisfies StreamFn;
+}

--- a/src/agents/pi-embedded-runner/clawd-non-streaming.ts
+++ b/src/agents/pi-embedded-runner/clawd-non-streaming.ts
@@ -207,6 +207,15 @@ export function createNonStreamingOllamaFn(toolDefs: ToolDef[]): StreamFn {
           console.error(
             `[CLAWD] non-streaming: model=${model.id} tools=${tools.length} msgs=${messages.length}`,
           );
+          // Dump system message content for debugging
+          const sysMsgs = messages.filter((m: any) => m.role === "system");
+          for (const sm of sysMsgs) {
+            const content =
+              typeof sm.content === "string" ? sm.content : JSON.stringify(sm.content);
+            console.error(
+              `[CLAWD] system msg (${content.length} chars): ${content.slice(0, 500)}...`,
+            );
+          }
         }
 
         const apiKey = _options?.apiKey || process.env.OLLAMA_API_KEY || "ollama-local";

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -341,7 +341,15 @@ export async function runEmbeddedAttempt(
       },
     });
     const isDefaultAgent = sessionAgentId === defaultAgentId;
-    const promptMode = isSubagentSessionKey(params.sessionKey) ? "minimal" : "full";
+    // CLAWD PATCH: Use "none" prompt mode to skip OpenClaw boilerplate.
+    // Our workspace files (AGENTS.md) contain the full system prompt.
+    // This keeps the system prompt lean for small context windows (8K).
+    const promptMode =
+      process.env.CLAWD_LEAN_PROMPT === "1"
+        ? ("none" as const)
+        : isSubagentSessionKey(params.sessionKey)
+          ? "minimal"
+          : "full";
     const docsPath = await resolveOpenClawDocsPath({
       workspaceDir: effectiveWorkspace,
       argv1: process.argv[1],

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
@@ -62,6 +62,7 @@ import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
+import { createNonStreamingOllamaFn } from "../clawd-non-streaming.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
 import {
@@ -86,6 +87,7 @@ import {
   createSystemPromptOverride,
 } from "../system-prompt.js";
 import { splitSdkTools } from "../tool-split.js";
+import { stripThinkingFromAssistantToolCallMessages } from "../toolcall-thinking.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
 import { detectAndLoadPromptImages } from "./images.js";
 
@@ -516,6 +518,35 @@ export async function runEmbeddedAttempt(
 
       // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
       activeSession.agent.streamFn = streamSimple;
+
+      // CLAWD PATCH: For openai-completions models (Ollama, vLLM), replace the streaming
+      // streamFn with a non-streaming one that calls fetch() directly with stream=false.
+      // This fixes two issues:
+      // 1. customTools don't populate context.tools (issue #1866)
+      // 2. Streaming breaks tool_calls parsing with Ollama (issue #5769)
+      const isOpenAICompletions = params.model?.api === "openai-completions";
+      if (isOpenAICompletions) {
+        const toolDefs = tools.map((t) => ({
+          name: t.name,
+          description: t.description ?? "",
+          parameters: t.parameters,
+        }));
+        if (process.env.CLAWDBOT_DEBUG_TOOLS) {
+          console.error(
+            `[CLAWD PATCH] using non-streaming streamFn for openai-completions with ${toolDefs.length} tools: ${toolDefs.map((t) => t.name).join(", ")}`,
+          );
+        }
+        activeSession.agent.streamFn = createNonStreamingOllamaFn(toolDefs);
+      } else {
+        // Remove thinking blocks from assistant messages that also include tool calls.
+        // Some OpenAI-compatible APIs reject assistant messages that include both `content` and
+        // `thinking` when tool calls are present (pi-ai surfaces this as a template error).
+        const originalStreamFn: StreamFn = activeSession.agent.streamFn ?? streamSimple;
+        activeSession.agent.streamFn = ((model, context, options) => {
+          const sanitized = stripThinkingFromAssistantToolCallMessages(context) as typeof context;
+          return originalStreamFn(model, sanitized, options);
+        }) satisfies StreamFn;
+      }
 
       applyExtraParamsToAgent(
         activeSession.agent,

--- a/src/agents/pi-embedded-runner/toolcall-thinking.ts
+++ b/src/agents/pi-embedded-runner/toolcall-thinking.ts
@@ -1,0 +1,53 @@
+/**
+ * CLAWD PATCH: Stub for stripThinkingFromAssistantToolCallMessages.
+ *
+ * Some OpenAI-compatible APIs reject assistant messages that include both
+ * `content` (with thinking blocks) and `tool_calls`. This utility strips
+ * thinking blocks from assistant messages that also contain tool calls,
+ * preventing template errors in pi-ai.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/5769
+ */
+
+interface MessageContent {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface Message {
+  role: string;
+  content: string | MessageContent[] | unknown;
+  [key: string]: unknown;
+}
+
+interface Context {
+  messages?: Message[];
+  [key: string]: unknown;
+}
+
+/**
+ * Strips thinking blocks from assistant messages that also include tool calls.
+ * Returns a shallow copy of context with sanitized messages.
+ */
+export function stripThinkingFromAssistantToolCallMessages(context: Context): Context {
+  if (!context.messages) return context;
+
+  const messages = context.messages.map((msg) => {
+    if (msg.role !== "assistant") return msg;
+    if (!Array.isArray(msg.content)) return msg;
+
+    const hasToolCall = msg.content.some(
+      (block: MessageContent) => block.type === "toolCall" || block.type === "tool_use",
+    );
+    if (!hasToolCall) return msg;
+
+    const hasThinking = msg.content.some((block: MessageContent) => block.type === "thinking");
+    if (!hasThinking) return msg;
+
+    // Remove thinking blocks, keep everything else
+    const filtered = msg.content.filter((block: MessageContent) => block.type !== "thinking");
+    return { ...msg, content: filtered };
+  });
+
+  return { ...context, messages };
+}

--- a/src/agents/pi-embedded-runner/toolcall-thinking.ts
+++ b/src/agents/pi-embedded-runner/toolcall-thinking.ts
@@ -9,21 +9,7 @@
  * See: https://github.com/openclaw/openclaw/issues/5769
  */
 
-interface MessageContent {
-  type: string;
-  [key: string]: unknown;
-}
-
-interface Message {
-  role: string;
-  content: string | MessageContent[] | unknown;
-  [key: string]: unknown;
-}
-
-interface Context {
-  messages?: Message[];
-  [key: string]: unknown;
-}
+import type { Context, Message } from "@mariozechner/pi-ai";
 
 /**
  * Strips thinking blocks from assistant messages that also include tool calls.
@@ -32,20 +18,20 @@ interface Context {
 export function stripThinkingFromAssistantToolCallMessages(context: Context): Context {
   if (!context.messages) return context;
 
-  const messages = context.messages.map((msg) => {
+  const messages = context.messages.map((msg: Message) => {
     if (msg.role !== "assistant") return msg;
     if (!Array.isArray(msg.content)) return msg;
 
     const hasToolCall = msg.content.some(
-      (block: MessageContent) => block.type === "toolCall" || block.type === "tool_use",
+      (block) => (block as { type: string }).type === "toolCall" || (block as { type: string }).type === "tool_use",
     );
     if (!hasToolCall) return msg;
 
-    const hasThinking = msg.content.some((block: MessageContent) => block.type === "thinking");
+    const hasThinking = msg.content.some((block) => (block as { type: string }).type === "thinking");
     if (!hasThinking) return msg;
 
     // Remove thinking blocks, keep everything else
-    const filtered = msg.content.filter((block: MessageContent) => block.type !== "thinking");
+    const filtered = msg.content.filter((block) => (block as { type: string }).type !== "thinking");
     return { ...msg, content: filtered };
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -372,9 +372,35 @@ export function buildAgentSystemPrompt(params: {
   });
   const workspaceNotes = (params.workspaceNotes ?? []).map((note) => note.trim()).filter(Boolean);
 
-  // For "none" mode, return just the basic identity line
+  // For "none" mode, skip OpenClaw boilerplate but keep workspace files + tool listing + runtime
   if (promptMode === "none") {
-    return "You are a personal assistant running inside OpenClaw.";
+    const noneLines: string[] = [];
+    // Tool listing (just the available tool names)
+    if (toolLines.length > 0) {
+      noneLines.push("Available tools: " + toolLines.join(", "));
+      noneLines.push("");
+    }
+    // Workspace files (AGENTS.md, SOUL.md, TOOLS.md — the actual system prompt)
+    const noneContextFiles = params.contextFiles ?? [];
+    for (const file of noneContextFiles) {
+      if (file.content?.trim()) {
+        noneLines.push(file.content);
+        noneLines.push("");
+      }
+    }
+    // Runtime info (model, host)
+    if (params.runtimeInfo) {
+      const ri = params.runtimeInfo;
+      const parts = [
+        ri.agentId ? `agent=${ri.agentId}` : "",
+        ri.host ? `host=${ri.host}` : "",
+        ri.model ? `model=${ri.model}` : "",
+      ].filter(Boolean);
+      if (parts.length > 0) {
+        noneLines.push(`Runtime: ${parts.join(" | ")}`);
+      }
+    }
+    return noneLines.join("\n");
   }
 
   const lines = [


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds several CLAWD-specific patches around tool calling and prompt construction:

- `exec` tool host selection now always uses the configured host, ignoring model-supplied `host` values (with optional debug logging).
- For `openai-completions` models, the embedded runner can swap the streaming `streamFn` for a new non-streaming implementation that calls `/chat/completions` with `stream=false` to get structured `tool_calls` and work around tool parsing issues.
- For other models, the runner wraps the stream function with a sanitizer that removes `thinking` blocks from assistant messages that include tool calls.
- `PromptMode: "none"` is expanded to include context files, a tool listing, and runtime info rather than only a single identity line.

The changes live in the embedded runner path (`src/agents/pi-embedded-runner/**`) and system prompt builder (`src/agents/system-prompt.ts`), affecting how sessions are prompted and how tool calls are represented when using OpenAI-compatible backends.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of concrete correctness issues in the new non-streaming OpenAI-completions adapter and the "none" prompt-mode tool listing.
- Core changes are localized and appear intentional, but the non-streaming adapter’s tool result mapping can produce invalid/mismatched tool_call_id values (breaking tool execution on OpenAI-completions backends), and the "none" prompt-mode tool list format is internally inconsistent with its own intent and likely to confuse models.
- src/agents/pi-embedded-runner/clawd-non-streaming.ts, src/agents/system-prompt.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->