### PR TITLE
fix(exec): return tool result on foreground failures

### DIFF
--- a/src/agents/bash-tools.exec.failure-does-not-throw.test.ts
+++ b/src/agents/bash-tools.exec.failure-does-not-throw.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+const isWin = process.platform === "win32";
+
+describe("exec tool failure handling", () => {
+  it("returns a failed tool result (does not throw) when command exits non-zero", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+    });
+
+    const result = await tool.execute("call1", {
+      command: "bash -lc 'echo boom 1>&2; exit 7'",
+      timeout: 30,
+    });
+
+    expect(result.details?.status).toBe("failed");
+    if (result.details && result.details.status === "failed") {
+      expect(result.details.exitCode).toBe(7);
+      expect(result.details.error).toBeTruthy();
+    }
+
+    const text = result.content.find((entry) => entry.type === "text")?.text ?? "";
+    expect(text).toContain("Command failed");
+    expect(text).toContain("boom");
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1542,7 +1542,7 @@ export function createExecTool(
         signal.addEventListener("abort", onAbortSignal, { once: true });
       }
 
-      return new Promise<AgentToolResult<ExecToolDetails>>((resolve, reject) => {
+      return new Promise<AgentToolResult<ExecToolDetails>>((resolve) => {
         const resolveRunning = () =>
           resolve({
             content: [

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -255,6 +255,11 @@ export type ExecToolDetails =
       durationMs: number;
       aggregated: string;
       cwd?: string;
+      truncated?: boolean;
+      originalChars?: number;
+      keptChars?: number;
+      /** Human-readable failure reason (only meaningful when status=failed). */
+      error?: string;
     }
   | {
       status: "approval-pending";


### PR DESCRIPTION
## Problem\nForeground exec failures (non-zero exit / spawn errors) can throw/reject and break the tool-use chain, preventing the model from seeing exitCode/stderr and self-correcting.\n\n## Change\n- Return a toolResult with details.status=failed, exitCode/error, and truncated output instead of throwing for foreground failures.\n- Add regression test for non-zero exit returning a failed tool result.\n\n## Notes\nThis aligns exec behavior with recovery workflows: failures become visible signals rather than exceptions that abort the run.\n

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the `exec` tool’s foreground behavior so non-zero exits and spawn errors return a structured tool result (`details.status="failed"`, exitCode/error, plus truncated output) instead of rejecting/throwing, and adds a regression test for the non-zero exit path.

This fits the broader tool-use flow by keeping failures visible to the model/caller (via `AgentToolResult.details`) rather than aborting the tool chain with an exception.

Key issues to address before merge:
- The returned `details` shape now includes `error`, but `ExecToolDetails`’s type definition doesn’t include that field, and the new test asserts it.
- Foreground failure text rendering currently duplicates output because `outcome.reason` already contains the aggregated output on failure.
- The new regression test is coupled to `bash`/gateway availability and may be flaky in CI environments.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has a couple of contract/test issues to fix before it’s safe to merge.
- The behavioral change (returning failed tool results instead of throwing for foreground failures) is coherent and tested, but the current code/test expects a `details.error` field that is not part of `ExecToolDetails`, and the failure rendering duplicates output because `outcome.reason` already embeds the aggregated output. The added test is also environment-coupled to `bash`/gateway availability, which can cause CI failures unrelated to the intended regression.
- src/agents/bash-tools.exec.ts; src/agents/bash-tools.exec.failure-does-not-throw.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->