### PR TITLE
fix(tools): recognise tool groups that expand to plugin tools in allowlist validation

### DIFF
--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -53,4 +53,48 @@ describe("stripPluginOnlyAllowlist", () => {
     expect(policy.policy?.allow).toEqual(["read", "lobster"]);
     expect(policy.unknownAllowlist).toEqual(["lobster"]);
   });
+
+  it("recognises tool groups that expand to plugin tools (group:memory)", () => {
+    // memory_search and memory_get are provided by the memory-core plugin
+    const memoryPlugins: PluginToolGroups = {
+      all: ["memory_search", "memory_get"],
+      byPlugin: new Map([["memory-core", ["memory_search", "memory_get"]]]),
+    };
+    const policy = stripPluginOnlyAllowlist(
+      { allow: ["read", "group:memory"] },
+      memoryPlugins,
+      coreTools,
+    );
+    expect(policy.policy?.allow).toEqual(["read", "group:memory"]);
+    expect(policy.unknownAllowlist).toEqual([]);
+  });
+
+  it("strips allowlist when group expands only to plugin tools and no core tools", () => {
+    const memoryPlugins: PluginToolGroups = {
+      all: ["memory_search", "memory_get"],
+      byPlugin: new Map([["memory-core", ["memory_search", "memory_get"]]]),
+    };
+    const policy = stripPluginOnlyAllowlist({ allow: ["group:memory"] }, memoryPlugins, coreTools);
+    expect(policy.policy?.allow).toBeUndefined();
+    expect(policy.unknownAllowlist).toEqual([]);
+  });
+
+  it("does not flag group entries whose expansion maps to plugin tools as unknown", () => {
+    // Regression test for #12643: group:memory was treated as unknown
+    // even when memory_search/memory_get were registered plugin tools.
+    const memoryPlugins: PluginToolGroups = {
+      all: ["memory_search", "memory_get", "lobster"],
+      byPlugin: new Map([
+        ["memory-core", ["memory_search", "memory_get"]],
+        ["lobster", ["lobster"]],
+      ]),
+    };
+    const policy = stripPluginOnlyAllowlist(
+      { allow: ["exec", "group:memory", "lobster"] },
+      memoryPlugins,
+      coreTools,
+    );
+    expect(policy.policy?.allow).toEqual(["exec", "group:memory", "lobster"]);
+    expect(policy.unknownAllowlist).toEqual([]);
+  });
 });

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -169,9 +169,12 @@ export function stripPluginOnlyAllowlist(
       hasCoreEntry = true;
       continue;
     }
-    const isPluginEntry =
-      entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
     const expanded = expandToolGroups([entry]);
+    const isPluginEntry =
+      entry === "group:plugins" ||
+      pluginIds.has(entry) ||
+      pluginTools.has(entry) ||
+      expanded.some((tool) => pluginTools.has(tool));
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
     if (isCoreEntry) {
       hasCoreEntry = true;


### PR DESCRIPTION
## Summary

Fixes #12643

`stripPluginOnlyAllowlist()` incorrectly flagged tool group entries like `group:memory` as "unknown" when the group expanded to plugin-provided tools (e.g. `memory_search`, `memory_get` from `memory-core`).

**Root cause:** The function checked whether the raw entry name (`group:memory`) was a plugin ID or plugin tool name, but never checked whether the *expanded* tool names were plugin tools. Since `group:memory` itself isn't a plugin ID, and `memory_search`/`memory_get` are plugin tools (not core tools), the entry fell through both checks and was reported as unknown.

**Fix:** After expanding a group entry via `expandToolGroups()`, also check if any of the expanded tool names exist in the `pluginTools` set. This one-line addition correctly classifies groups whose members are plugin tools.

- Moved `expandToolGroups([entry])` call before the `isPluginEntry` check
- Added `expanded.some((tool) => pluginTools.has(tool))` to the `isPluginEntry` condition

## Test plan

- [x] Write 3 new tests that reproduce the bug (all fail before fix, pass after)
- [x] Test: `group:memory` mixed with core tools → not flagged as unknown
- [x] Test: `group:memory` alone (plugin-only) → stripped but not flagged as unknown
- [x] Test: `group:memory` + plugin tools + core tools → all recognised correctly
- [x] All 6 pre-existing tests still pass (zero regressions)
- [x] All 8 tests across related test suites pass
- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] `codex review --base main` clean (zero issues)

All 3 new tests fail before the fix, pass after (TDD).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `stripPluginOnlyAllowlist()` to correctly treat tool-group allowlist entries (e.g. `group:memory`) as plugin entries when the group expands to plugin-provided tool names. The function now expands each entry via `expandToolGroups()` before classifying it, and considers an entry “plugin” if any expanded tool is present in the `pluginTools` set.

It also adds three Vitest cases to cover the regression from #12643, including mixed core + group entries, group-only (plugin-only) stripping behavior, and group + explicit plugin tool entries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (classification logic in `stripPluginOnlyAllowlist`) and is directly covered by new regression tests. The added condition only broadens plugin-entry detection to include group expansions and does not change how core tools are detected or how stripping decisions are made.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->