### PR TITLE
fix(weather): add precipitation cross-check guidance to prevent misleading rain reports

### DIFF
--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -47,3 +47,31 @@ curl -s "https://api.open-meteo.com/v1/forecast?latitude=51.5&longitude=-0.12&cu
 Find coordinates for a city, then query. Returns JSON with temp, windspeed, weathercode.
 
 Docs: https://open-meteo.com/en/docs
+
+## Precipitation: Always Cross-Check
+
+**Never report `precipitation_probability_max` on its own.** It is frequently misleading -- the API can return high probability (e.g. 65%) with 0mm actual expected precipitation.
+
+When checking rain, always request **both** fields:
+
+```bash
+curl -s "https://api.open-meteo.com/v1/forecast?latitude=19.43&longitude=-99.13&current_weather=true&daily=precipitation_probability_max,precipitation_sum&timezone=auto&forecast_days=1"
+```
+
+Then apply this logic:
+
+| `precipitation_sum` | `precipitation_probability_max` | Interpretation |
+|---|---|---|
+| 0mm | Any value | **No rain.** Ignore the probability. |
+| >0mm | High | Rain likely. Report both values. |
+| >0mm | Low | Light/brief rain possible. Mention it. |
+
+### Seasonal awareness
+
+Some cities have pronounced dry/wet seasons where probability numbers are especially unreliable:
+
+- **Mexico City**: Dry season Nov-Apr (essentially zero rain). Wet season May-Oct.
+- **Mediterranean climates**: Dry summers, wet winters.
+- **Monsoon regions**: Pronounced wet/dry cycles.
+
+If `precipitation_sum` is 0mm during a known dry season, skip the rain mention entirely -- don't confuse users with phantom probabilities.


### PR DESCRIPTION
## Problem

The weather skill's Open-Meteo section only shows how to fetch `current_weather`. When agents use `precipitation_probability_max` for rain forecasts, the API can return misleadingly high values (e.g. 65%) even when `precipitation_sum` is 0mm -- meaning no actual rain is expected.

This is especially bad during dry seasons. For example, Mexico City in February (deep dry season) returns 65% probability with 0.00mm precipitation sum. An agent naively reporting "65% chance of rain" would be completely wrong.

## Fix

Added a "Precipitation: Always Cross-Check" section to the weather SKILL.md:

- **Cross-check table**: always compare `precipitation_sum` vs `probability_max` before reporting rain
- **Rule**: if `precipitation_sum` is 0mm, ignore the probability entirely
- **Example API call** that fetches both fields together
- **Seasonal awareness** notes for dry/wet season cities where probability is especially unreliable

## Testing

Verified with Open-Meteo API for Mexico City (Feb 9, 2026):
- `precipitation_probability_max: 65` 
- `precipitation_sum: 0.00`
- With the new guidance, the agent correctly ignores the phantom probability.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `skills/weather/SKILL.md` to add explicit guidance for agents using Open‑Meteo daily precipitation fields.

It introduces a new “Precipitation: Always Cross‑Check” section that (1) warns against reporting `precipitation_probability_max` in isolation, (2) provides an example Open‑Meteo request that fetches both `precipitation_probability_max` and `precipitation_sum`, and (3) adds a simple interpretation table plus seasonal notes (e.g., dry-season cities) to reduce misleading “chance of rain” reports when forecast precipitation totals are 0 mm.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Only documentation was changed (weather skill guidance). The added section is self-contained, does not affect runtime behavior, and follows existing doc conventions in the repository.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->