### PR TITLE
fix(agents): attempt OAuth token refresh before applying cooldown on 401 errors

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -656,7 +656,13 @@ export async function runEmbeddedPiAgent(
             const promptFailoverReason = classifyFailoverReason(errorText);
             // Attempt reactive OAuth token refresh before applying cooldown on auth errors.
             // This avoids killing single-profile OAuth sessions when the token simply expired.
-            if (promptFailoverReason === "auth" && lastProfileId && !authRefreshAttempted) {
+            // Only attempt for OAuth profiles — api_key/token profiles would just re-apply the same credential.
+            if (
+              promptFailoverReason === "auth" &&
+              lastProfileId &&
+              !authRefreshAttempted &&
+              apiKeyInfo?.mode === "oauth"
+            ) {
               authRefreshAttempted = true;
               try {
                 await applyApiKeyInfo(lastProfileId);
@@ -749,11 +755,13 @@ export async function runEmbeddedPiAgent(
           const shouldRotate = (!aborted && failoverFailure) || timedOut;
 
           // Attempt reactive OAuth token refresh before applying cooldown on auth errors.
+          // Only attempt for OAuth profiles — api_key/token profiles would just re-apply the same credential.
           if (
             shouldRotate &&
             assistantFailoverReason === "auth" &&
             lastProfileId &&
-            !authRefreshAttempted
+            !authRefreshAttempted &&
+            apiKeyInfo?.mode === "oauth"
           ) {
             authRefreshAttempted = true;
             try {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -661,7 +661,7 @@ export async function runEmbeddedPiAgent(
               promptFailoverReason === "auth" &&
               lastProfileId &&
               !authRefreshAttempted &&
-              apiKeyInfo?.mode === "oauth"
+              (apiKeyInfo as ApiKeyInfo | null)?.mode === "oauth"
             ) {
               authRefreshAttempted = true;
               try {
@@ -761,7 +761,7 @@ export async function runEmbeddedPiAgent(
             assistantFailoverReason === "auth" &&
             lastProfileId &&
             !authRefreshAttempted &&
-            apiKeyInfo?.mode === "oauth"
+            (apiKeyInfo as ApiKeyInfo | null)?.mode === "oauth"
           ) {
             authRefreshAttempted = true;
             try {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -388,6 +388,9 @@ export async function runEmbeddedPiAgent(
       let toolResultTruncationAttempted = false;
       const usageAccumulator = createUsageAccumulator();
       let autoCompactionCount = 0;
+      // Guard: allow at most one OAuth token refresh attempt per error cycle.
+      // Reset on successful API call (markAuthProfileGood path).
+      let authRefreshAttempted = false;
       try {
         while (true) {
           attemptedThinking.add(thinkLevel);
@@ -651,6 +654,17 @@ export async function runEmbeddedPiAgent(
               };
             }
             const promptFailoverReason = classifyFailoverReason(errorText);
+            // Attempt reactive OAuth token refresh before applying cooldown on auth errors.
+            // This avoids killing single-profile OAuth sessions when the token simply expired.
+            if (promptFailoverReason === "auth" && lastProfileId && !authRefreshAttempted) {
+              authRefreshAttempted = true;
+              try {
+                await applyApiKeyInfo(lastProfileId);
+                continue; // retry with refreshed token
+              } catch {
+                // refresh failed, fall through to existing cooldown logic
+              }
+            }
             if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
               await markAuthProfileFailure({
                 store: authStore,
@@ -733,6 +747,22 @@ export async function runEmbeddedPiAgent(
 
           // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
           const shouldRotate = (!aborted && failoverFailure) || timedOut;
+
+          // Attempt reactive OAuth token refresh before applying cooldown on auth errors.
+          if (
+            shouldRotate &&
+            assistantFailoverReason === "auth" &&
+            lastProfileId &&
+            !authRefreshAttempted
+          ) {
+            authRefreshAttempted = true;
+            try {
+              await applyApiKeyInfo(lastProfileId);
+              continue; // retry with refreshed token
+            } catch {
+              // refresh failed, fall through to existing cooldown/rotation logic
+            }
+          }
 
           if (shouldRotate) {
             if (lastProfileId) {
@@ -822,6 +852,7 @@ export async function runEmbeddedPiAgent(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );
           if (lastProfileId) {
+            authRefreshAttempted = false; // reset guard on successful API call
             await markAuthProfileGood({
               store: authStore,
               provider,


### PR DESCRIPTION
#### Summary

When an OAuth token expires mid-session, the agent receives a 401 error and immediately applies a cooldown/backoff. The token may have already been refreshed by the OAuth layer, but the agent doesn't retry with the new token — it just waits. This adds reactive OAuth token refresh in the two 401 error handler paths (prompt failover and assistant failover).

lobster-biscuit

#### Behavior Changes

- On 401 errors, the agent now attempts one OAuth token refresh before applying cooldown
- Uses `authRefreshAttempted` guard boolean to prevent infinite refresh loops
- Guard resets on successful API calls (`markAuthProfileGood` path)
- No behavior change for non-OAuth sessions (401 handling unchanged when no OAuth profile exists)

#### Codebase and GitHub Search

- Searched for `401` handling in `run.ts` — found two independent error paths (prompt and assistant failover)
- Searched for existing OAuth refresh logic — found `refreshOAuthToken()` existed but was not called reactively on 401
- No existing issue found for this specific scenario

#### Tests

- Manual testing only — verified OAuth token refresh triggers on 401 and session continues
- Guard boolean prevents infinite retry loops (tested by forcing repeated 401s)

#### Manual Testing

### Prerequisites

- OpenClaw instance with OAuth authentication configured
- Ability to force token expiry (e.g., short-lived tokens)

### Steps

1. Start a long-running agent session with OAuth auth
2. Wait for or force token expiry
3. Verify agent recovers seamlessly without manual intervention
4. Verify no infinite retry loop if refresh fails

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: Human-directed, AI-implemented with manual testing
- Agent notes: Found during long-running gateway sessions where OAuth tokens expired after ~1 hour. The cooldown delay (up to 30s) was noticeable and unnecessary when the token had already been refreshed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a single “reactive credential refresh” retry when a run hits an auth/401-style failure in either of the two existing failover paths (prompt submission errors and assistant failover errors). It introduces an `authRefreshAttempted` guard to avoid repeated refresh loops and resets the guard on a successful run (near the `markAuthProfileGood` path), so subsequent auth errors can trigger another refresh attempt.

Within the runner’s retry/rotation loop (`runEmbeddedPiAgent`), this fits as an early retry before the existing cooldown + profile rotation logic runs, intended to avoid waiting out cooldown when an OAuth token has simply expired mid-session.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but it introduces a definite behavior change for non-OAuth auth failures that should be fixed first.
- The change is localized and follows existing retry/rotation structure, but the new refresh retry currently triggers on any auth-classified failure without confirming an OAuth profile, causing an extra deterministic retry on non-OAuth 401s before cooldown/rotation.
- src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->