### PR TITLE
Test: add missing unit tests for src/utils modules

### DIFF
--- a/src/utils/account-id.test.ts
+++ b/src/utils/account-id.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAccountId } from "./account-id.js";
+
+describe("normalizeAccountId", () => {
+  it("returns the string as-is when already trimmed", () => {
+    expect(normalizeAccountId("abc")).toBe("abc");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(normalizeAccountId("  abc  ")).toBe("abc");
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(normalizeAccountId("")).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only string", () => {
+    expect(normalizeAccountId("   ")).toBeUndefined();
+  });
+
+  it("returns undefined when called with no argument", () => {
+    expect(normalizeAccountId()).toBeUndefined();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(normalizeAccountId(undefined)).toBeUndefined();
+  });
+});

--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { isReasoningTagProvider } from "./provider-utils.js";
+
+describe("isReasoningTagProvider", () => {
+  it("returns true for exact match: ollama", () => {
+    expect(isReasoningTagProvider("ollama")).toBe(true);
+  });
+
+  it("returns true for exact match: google-gemini-cli", () => {
+    expect(isReasoningTagProvider("google-gemini-cli")).toBe(true);
+  });
+
+  it("returns true for exact match: google-generative-ai", () => {
+    expect(isReasoningTagProvider("google-generative-ai")).toBe(true);
+  });
+
+  it("returns true for google-antigravity substring", () => {
+    expect(isReasoningTagProvider("google-antigravity")).toBe(true);
+    expect(isReasoningTagProvider("google-antigravity/gemini-3")).toBe(true);
+  });
+
+  it("returns true for minimax substring", () => {
+    expect(isReasoningTagProvider("minimax")).toBe(true);
+    expect(isReasoningTagProvider("minimax-portal")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isReasoningTagProvider("OLLAMA")).toBe(true);
+    expect(isReasoningTagProvider("Google-Gemini-CLI")).toBe(true);
+    expect(isReasoningTagProvider("MINIMAX")).toBe(true);
+  });
+
+  it("trims whitespace", () => {
+    expect(isReasoningTagProvider("  ollama  ")).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isReasoningTagProvider(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isReasoningTagProvider(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isReasoningTagProvider("")).toBe(false);
+  });
+
+  it("returns false for unrelated providers", () => {
+    expect(isReasoningTagProvider("anthropic")).toBe(false);
+    expect(isReasoningTagProvider("openai")).toBe(false);
+    expect(isReasoningTagProvider("deepseek")).toBe(false);
+  });
+});

--- a/src/utils/shell-argv.test.ts
+++ b/src/utils/shell-argv.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { splitShellArgs } from "./shell-argv.js";
+
+describe("splitShellArgs", () => {
+  it("splits basic whitespace-separated tokens", () => {
+    expect(splitShellArgs("foo bar baz")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(splitShellArgs("")).toEqual([]);
+  });
+
+  it("returns empty array for whitespace-only input", () => {
+    expect(splitShellArgs("   ")).toEqual([]);
+  });
+
+  it("handles single-quoted strings", () => {
+    expect(splitShellArgs("foo 'bar baz'")).toEqual(["foo", "bar baz"]);
+  });
+
+  it("handles double-quoted strings", () => {
+    expect(splitShellArgs('foo "bar baz"')).toEqual(["foo", "bar baz"]);
+  });
+
+  it("handles backslash escaping outside quotes", () => {
+    expect(splitShellArgs("foo\\ bar baz")).toEqual(["foo bar", "baz"]);
+  });
+
+  it("does not interpret backslash inside single quotes", () => {
+    expect(splitShellArgs("'foo\\bar'")).toEqual(["foo\\bar"]);
+  });
+
+  it("does not interpret backslash inside double quotes", () => {
+    expect(splitShellArgs('"foo\\bar"')).toEqual(["foo\\bar"]);
+  });
+
+  it("handles adjacent quoted and unquoted segments", () => {
+    expect(splitShellArgs("foo'bar'baz")).toEqual(["foobarbaz"]);
+  });
+
+  it("handles multiple spaces between tokens", () => {
+    expect(splitShellArgs("foo   bar")).toEqual(["foo", "bar"]);
+  });
+
+  it("handles tabs and mixed whitespace", () => {
+    expect(splitShellArgs("foo\tbar\t baz")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("returns null for unterminated single quote", () => {
+    expect(splitShellArgs("foo 'bar")).toBeNull();
+  });
+
+  it("returns null for unterminated double quote", () => {
+    expect(splitShellArgs('foo "bar')).toBeNull();
+  });
+
+  it("returns null for trailing backslash", () => {
+    expect(splitShellArgs("foo\\")).toBeNull();
+  });
+
+  it("handles empty quoted strings as empty tokens", () => {
+    expect(splitShellArgs("foo '' bar")).toEqual(["foo", "bar"]);
+  });
+
+  it("handles single token with no spaces", () => {
+    expect(splitShellArgs("hello")).toEqual(["hello"]);
+  });
+
+  it("handles mixed quote styles", () => {
+    expect(splitShellArgs(`"foo" 'bar' baz`)).toEqual(["foo", "bar", "baz"]);
+  });
+});

--- a/src/utils/shell-argv.test.ts
+++ b/src/utils/shell-argv.test.ts
@@ -58,7 +58,7 @@ describe("splitShellArgs", () => {
     expect(splitShellArgs("foo\\")).toBeNull();
   });
 
-  it("handles empty quoted strings as empty tokens", () => {
+  it("drops empty quoted strings", () => {
     expect(splitShellArgs("foo '' bar")).toEqual(["foo", "bar"]);
   });
 


### PR DESCRIPTION
#### Summary

Add unit test coverage for three `src/utils` modules that had zero direct tests despite being used in production code:

- **`shell-argv.ts`** (`splitShellArgs`) — used in `src/memory/backend-config.ts`, 0 prior tests
- **`provider-utils.ts`** (`isReasoningTagProvider`) — used across 4 production files (agent runner, compaction, reply handling), 0 prior tests
- **`account-id.ts`** (`normalizeAccountId`) — used in LINE channel accounts, 0 direct tests

#### Gap Covered

These utilities handle argument parsing, provider detection, and ID normalization. Tests cover:
- Happy paths, edge cases (empty/whitespace input, null/undefined)
- `splitShellArgs`: single/double quotes, backslash escaping, unterminated quote detection
- `isReasoningTagProvider`: exact matches, substring matches, case insensitivity, trimming
- `normalizeAccountId`: trimming, empty strings, undefined handling

#### Behavior Changes

None. Pure test additions — no production code modified.

#### Codebase and GitHub Search

- Searched for existing test files: `shell-argv.test.ts`, `provider-utils.test.ts`, `account-id.test.ts` — none exist
- Confirmed test pattern from `src/utils/boolean.test.ts`
- Verified these utils are imported in production code via grep

#### Tests

- 3 new test files, 27 total test cases
- Pattern follows existing `src/utils/boolean.test.ts` conventions

lobster-biscuit

**Sign-Off**

- Submitter effort: manual review of source code + test authoring

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds unit tests for three previously-untested utility modules under `src/utils`: `normalizeAccountId`, `isReasoningTagProvider`, and `splitShellArgs`. The tests follow the existing Vitest co-located test convention (e.g., `src/utils/boolean.test.ts`) and exercise common/edge behaviors like trimming, null/undefined handling, quoted argument parsing, and error cases (unterminated quotes / trailing backslash).

No production code is modified; this PR increases coverage around utilities that are referenced by multiple production paths (provider selection logic, argument parsing, and channel account ID normalization).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it only adds test coverage with no production behavior changes.
- Reviewed the added tests against the current implementations of `normalizeAccountId`, `isReasoningTagProvider`, and `splitShellArgs`. Assertions match actual behavior, and no changes touch runtime code paths. Only minor issue is a misleading test description in `shell-argv.test.ts` (assertion is fine, wording is inconsistent).
- src/utils/shell-argv.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->