### PR TITLE
fix(status): show runtime model after fallback instead of configured primary

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -190,7 +190,9 @@ describe("buildStatusMessage", () => {
     expect(optionsLine).not.toContain("elevated");
   });
 
-  it("prefers model overrides over last-run model", () => {
+  it("shows runtime model (after fallback) over configured override", () => {
+    // When the system falls back to a different model (e.g., due to rate limits),
+    // /status should show the actual runtime model, not the user's configured preference.
     const text = buildStatusMessage({
       agent: {
         model: "anthropic/claude-opus-4-5",
@@ -203,6 +205,31 @@ describe("buildStatusMessage", () => {
         modelOverride: "gpt-4.1-mini",
         modelProvider: "anthropic",
         model: "claude-haiku-4-5",
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    // Runtime model (modelProvider/model) takes precedence over override
+    expect(normalizeTestText(text)).toContain("Model: anthropic/claude-haiku-4-5");
+  });
+
+  it("falls back to override when no runtime model is recorded", () => {
+    // When no API call has been made yet, show the user's configured override
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/claude-opus-4-5",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "no-runtime",
+        updatedAt: 0,
+        providerOverride: "openai",
+        modelOverride: "gpt-4.1-mini",
+        // No modelProvider/model set (no API call yet)
         contextTokens: 32_000,
       },
       sessionKey: "agent:main:main",

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -241,6 +241,32 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Model: openai/gpt-4.1-mini");
   });
 
+  it("does not mix runtime provider with override model", () => {
+    // When only modelProvider is set but model is missing, fall back to override pair
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/claude-opus-4-5",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "partial-runtime",
+        updatedAt: 0,
+        providerOverride: "openai",
+        modelOverride: "gpt-4.1-mini",
+        modelProvider: "anthropic",
+        // model is NOT set — partial runtime
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    // Should use the override pair, not mix anthropic provider with gpt model
+    expect(normalizeTestText(text)).toContain("Model: openai/gpt-4.1-mini");
+  });
+
   it("keeps provider prefix from configured model", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -339,8 +339,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const provider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
-  let model = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+  // Prefer actual runtime model (set after fallback) over user-configured overrides.
+  // modelProvider/model = actual used model; providerOverride/modelOverride = user preference.
+  const provider =
+    entry?.modelProvider ?? entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
+  let model = entry?.model ?? entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
   let contextTokens =
     entry?.contextTokens ??
     args.agent?.contextTokens ??

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -340,10 +340,19 @@ export function buildStatusMessage(args: StatusArgs): string {
     defaultModel: DEFAULT_MODEL,
   });
   // Prefer actual runtime model (set after fallback) over user-configured overrides.
-  // modelProvider/model = actual used model; providerOverride/modelOverride = user preference.
-  const provider =
-    entry?.modelProvider ?? entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
-  let model = entry?.model ?? entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+  // Select provider+model as a consistent pair to avoid mismatches.
+  const hasRuntimeModel = entry?.modelProvider != null && entry?.model != null;
+  const hasOverrideModel = entry?.providerOverride != null || entry?.modelOverride != null;
+  const provider = hasRuntimeModel
+    ? entry.modelProvider
+    : hasOverrideModel
+      ? (entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER)
+      : (resolved.provider ?? DEFAULT_PROVIDER);
+  let model = hasRuntimeModel
+    ? entry.model
+    : hasOverrideModel
+      ? (entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL)
+      : (resolved.model ?? DEFAULT_MODEL);
   let contextTokens =
     entry?.contextTokens ??
     args.agent?.contextTokens ??


### PR DESCRIPTION
## Summary

Fixes #9571

When a model fallback occurs (e.g., due to rate limits), `/status` now correctly displays the actual runtime model that was used, instead of the configured primary model.

## Changes

- `src/auto-reply/status.ts`: Changed `buildStatusMessage()` to prioritize `entry.modelProvider`/`entry.model` (the actual runtime values set by `persistSessionUsageUpdate()` after each API call) over `entry.providerOverride`/`entry.modelOverride` (user-configured preferences).

- `src/auto-reply/status.test.ts`: Updated existing test to reflect correct behavior and added a new test case for the fallback scenario.

## Root Cause

The session entry has two sets of model fields:
- `modelProvider`/`model` — actual model used in the last API call (set by `persistSessionUsageUpdate()`)
- `providerOverride`/`modelOverride` — user's configured preference (set via `/model` command)

The status message was reading from overrides first, missing the runtime model entirely when a fallback occurred.

## Test plan

- [x] Existing test updated to verify runtime model takes precedence
- [x] Added test for fallback-to-override scenario (when no runtime model is recorded)
- [x] All 20 tests pass: `npx vitest run src/auto-reply/status.test.ts`
- [x] `pnpm build` — passes
- [x] `pnpm check` — passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `/status` message generation to prefer the recorded runtime provider+model (`sessionEntry.modelProvider`/`sessionEntry.model`) over the user-configured override pair, so when a fallback happens the status output reflects what actually ran. The selection is done as a consistent provider+model pair (only using runtime values when both are present; otherwise falling back to overrides or resolved defaults).

Tests in `src/auto-reply/status.test.ts` were updated/expanded to cover: runtime-precedence over overrides, override fallback when runtime isn’t recorded yet, and the partial-runtime edge case to prevent mixed provider/model pairs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to model selection for the `/status` output, keeps provider+model pairing consistent, and is covered by targeted unit tests including the partial-runtime case mentioned in prior review threads.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->