### PR TITLE
docs: add troubleshooting guide for thinking.signature error

### DIFF
--- a/docs/debug/thinking-signature-error.md
+++ b/docs/debug/thinking-signature-error.md
@@ -1,0 +1,78 @@
+---
+summary: "Missing thinking.signature error when session history is corrupted by external AI messages"
+read_when:
+  - Getting "thinking.signature: Field required" error
+  - Session crashes after Meta AI or other AI responds in same channel
+  - Claude Extended Thinking chain integrity issues
+title: "Thinking Signature Error"
+---
+
+# Missing `thinking.signature` Session Crash
+
+## Summary
+
+When using Claude models with Extended Thinking (e.g., Claude 4.5 Opus) on WhatsApp, a collision can occur if Meta's built-in AI also responds in the same chat. This corrupts the session history file and causes an unrecoverable crash.
+
+## Error Message
+
+```
+[openclaw] LLM request rejected:
+messages.X.content.Y.thinking.signature: Field required
+```
+
+Where `X` and `Y` are indices pointing to the corrupted message in the session history.
+
+## Cause
+
+Claude's Extended Thinking feature uses cryptographic signatures to maintain reasoning chain integrity across conversation turns. When a foreign message (like Meta AI's response) gets written to the local `.jsonl` session file without the required `thinking.signature` metadata, the API rejects subsequent requests.
+
+### What happens:
+
+1. OpenClaw picks up a message from WhatsApp
+2. Meta AI (built into WhatsApp) also responds to the same message
+3. Meta AI's response gets logged to OpenClaw's session file
+4. The Meta AI message lacks `thinking.signature` metadata
+5. On next turn, Claude API rejects the request due to broken chain integrity
+
+## Solutions
+
+### Option 1: Delete the Session File (Recommended)
+
+The fastest fix is to remove the corrupted session file:
+
+```bash
+# Find your session file
+ls ~/.openclaw/agents/main/sessions/
+
+# Delete the corrupted session
+rm ~/.openclaw/agents/main/sessions/<session-id>.jsonl
+```
+
+**Note:** This loses conversation history for that session.
+
+### Option 2: Manual Edit (Advanced)
+
+If you want to preserve history, you can try editing the session file:
+
+1. Open `~/.openclaw/agents/main/sessions/<session-id>.jsonl`
+2. Find the line index from the error (e.g., `messages.17` = line 17)
+3. Remove lines containing messages without `thoughtSignature`
+4. Restart OpenClaw
+
+**Warning:** This often doesn't work if the thinking chain is already broken. The signature validation is cryptographic, so partial fixes may still fail.
+
+## Prevention
+
+- **Disable Meta AI:** In WhatsApp settings, disable Meta AI if you're running OpenClaw on the same number
+- **Use separate channels:** Run OpenClaw on a channel without competing AI assistants
+- **Monitor for collisions:** If you see duplicate responses (one from OpenClaw, one from Meta AI), check your session file promptly
+
+## Environment
+
+- Affected models: Claude models with Extended Thinking enabled
+- Affected channels: WhatsApp (with Meta AI enabled), potentially others with built-in AI
+- All platforms (Windows, macOS, Linux)
+
+## Related
+
+- [Anthropic Extended Thinking Documentation](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new troubleshooting doc (`docs/debug/thinking-signature-error.md`) explaining the `thinking.signature: Field required` failure mode and how to recover (delete or manually edit the corrupted session `.jsonl`) when external AI messages are written into the session history.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after correcting a misleading field name in the troubleshooting instructions.
- The change is documentation-only and limited in scope, but the current manual-edit recovery steps reference a different key (`thoughtSignature`) than the actual error path (`thinking.signature`), which would directly prevent users from following the fix.
- docs/debug/thinking-signature-error.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->