### PR TITLE
fix: preserve original filename for WhatsApp inbound documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WhatsApp: preserve original filenames for inbound documents. (#12691) Thanks @akramcodez.
 - Telegram: harden quote parsing; preserve quote context; avoid QUOTE_TEXT_INVALID; avoid nested reply quote misclassification. (#12156) Thanks @rybnikov.
 - Telegram: recover proactive sends when stale topic thread IDs are used by retrying without `message_thread_id`. (#11620)
 - Telegram: render markdown spoilers with `<tg-spoiler>` HTML tags. (#11543) Thanks @ezhikkk.

--- a/src/web/inbound.media.test.ts
+++ b/src/web/inbound.media.test.ts
@@ -88,6 +88,11 @@ vi.mock("./session.js", () => {
 
 import { monitorWebInbox, resetWebInboundDedupe } from "./inbound.js";
 
+async function waitForMessage(onMessage: ReturnType<typeof vi.fn>) {
+  await vi.waitFor(() => expect(onMessage).toHaveBeenCalledTimes(1));
+  return onMessage.mock.calls[0][0];
+}
+
 describe("web inbound media saves with extension", () => {
   beforeEach(() => {
     saveMediaBufferSpy.mockClear();
@@ -125,16 +130,7 @@ describe("web inbound media saves with extension", () => {
 
     realSock.ev.emit("messages.upsert", upsert);
 
-    // Allow a brief window for the async handler to fire on slower hosts.
-    for (let i = 0; i < 50; i++) {
-      if (onMessage.mock.calls.length > 0) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-
-    expect(onMessage).toHaveBeenCalledTimes(1);
-    const msg = onMessage.mock.calls[0][0];
+    const msg = await waitForMessage(onMessage);
     const mediaPath = msg.mediaPath;
     expect(mediaPath).toBeDefined();
     expect(path.extname(mediaPath as string)).toBe(".jpg");
@@ -179,15 +175,7 @@ describe("web inbound media saves with extension", () => {
 
     realSock.ev.emit("messages.upsert", upsert);
 
-    for (let i = 0; i < 50; i++) {
-      if (onMessage.mock.calls.length > 0) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-
-    expect(onMessage).toHaveBeenCalledTimes(1);
-    const msg = onMessage.mock.calls[0][0];
+    const msg = await waitForMessage(onMessage);
     expect(msg.chatType).toBe("group");
     expect(msg.mentionedJids).toEqual(["999@s.whatsapp.net"]);
 
@@ -221,14 +209,7 @@ describe("web inbound media saves with extension", () => {
 
     realSock.ev.emit("messages.upsert", upsert);
 
-    for (let i = 0; i < 50; i++) {
-      if (onMessage.mock.calls.length > 0) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-
-    expect(onMessage).toHaveBeenCalledTimes(1);
+    await waitForMessage(onMessage);
     expect(saveMediaBufferSpy).toHaveBeenCalled();
     const lastCall = saveMediaBufferSpy.mock.calls.at(-1);
     expect(lastCall?.[3]).toBe(1 * 1024 * 1024);
@@ -260,15 +241,7 @@ describe("web inbound media saves with extension", () => {
 
     realSock.ev.emit("messages.upsert", upsert);
 
-    for (let i = 0; i < 50; i++) {
-      if (onMessage.mock.calls.length > 0) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-
-    expect(onMessage).toHaveBeenCalledTimes(1);
-    const msg = onMessage.mock.calls[0][0];
+    const msg = await waitForMessage(onMessage);
     expect(msg.mediaFileName).toBe(fileName);
     expect(saveMediaBufferSpy).toHaveBeenCalled();
     const lastCall = saveMediaBufferSpy.mock.calls.at(-1);

--- a/src/web/inbound/media.ts
+++ b/src/web/inbound/media.ts
@@ -11,7 +11,7 @@ function unwrapMessage(message: proto.IMessage | undefined): proto.IMessage | un
 export async function downloadInboundMedia(
   msg: proto.IWebMessageInfo,
   sock: Awaited<ReturnType<typeof createWaSocket>>,
-): Promise<{ buffer: Buffer; mimetype?: string } | undefined> {
+): Promise<{ buffer: Buffer; mimetype?: string; fileName?: string } | undefined> {
   const message = unwrapMessage(msg.message as proto.IMessage | undefined);
   if (!message) {
     return undefined;
@@ -23,6 +23,7 @@ export async function downloadInboundMedia(
     message.audioMessage?.mimetype ??
     message.stickerMessage?.mimetype ??
     undefined;
+  const fileName = message.documentMessage?.fileName ?? undefined;
   if (
     !message.imageMessage &&
     !message.videoMessage &&
@@ -42,7 +43,7 @@ export async function downloadInboundMedia(
         logger: sock.logger,
       },
     );
-    return { buffer, mimetype };
+    return { buffer, mimetype, fileName };
   } catch (err) {
     logVerbose(`downloadMediaMessage failed: ${String(err)}`);
     return undefined;

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -253,6 +253,7 @@ export async function monitorWebInbox(options: {
 
       let mediaPath: string | undefined;
       let mediaType: string | undefined;
+      let mediaFileName: string | undefined;
       try {
         const inboundMedia = await downloadInboundMedia(msg as proto.IWebMessageInfo, sock);
         if (inboundMedia) {
@@ -266,9 +267,11 @@ export async function monitorWebInbox(options: {
             inboundMedia.mimetype,
             "inbound",
             maxBytes,
+            inboundMedia.fileName,
           );
           mediaPath = saved.path;
           mediaType = inboundMedia.mimetype;
+          mediaFileName = inboundMedia.fileName;
         }
       } catch (err) {
         logVerbose(`Inbound media download failed: ${String(err)}`);
@@ -293,7 +296,7 @@ export async function monitorWebInbox(options: {
       const senderName = msg.pushName ?? undefined;
 
       inboundLogger.info(
-        { from, to: selfE164 ?? "me", body, mediaPath, mediaType, timestamp },
+        { from, to: selfE164 ?? "me", body, mediaPath, mediaType, mediaFileName, timestamp },
         "inbound message",
       );
       const inboundMessage: WebInboundMessage = {
@@ -326,6 +329,7 @@ export async function monitorWebInbox(options: {
         sendMedia,
         mediaPath,
         mediaType,
+        mediaFileName,
       };
       try {
         const task = Promise.resolve(debouncer.enqueue(inboundMessage));

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -37,6 +37,7 @@ export type WebInboundMessage = {
   sendMedia: (payload: AnyMessageContent) => Promise<void>;
   mediaPath?: string;
   mediaType?: string;
+  mediaFileName?: string;
   mediaUrl?: string;
   wasMentioned?: boolean;
 };


### PR DESCRIPTION
### Problem

WhatsApp inbound documents are saved with UUID-only filenames, causing the original filename metadata to be lost.


### Solution

Extract `documentMessage.fileName` from WhatsApp messages and pass it through the inbound pipeline to `saveMediaBuffer`.


### Changes

| File | Change |
| --- | --- |
| `src/web/inbound/media.ts` | Extract `fileName` from `documentMessage` |
| `src/web/inbound/monitor.ts` | Pass `fileName` to `saveMediaBuffer`, add to logs and inbound message |
| `src/web/inbound/types.ts` | Add `mediaFileName` field to `WebInboundMessage` |


### Testing

- All 154 tests in `src/web/` pass


fixes #12614

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads WhatsApp document filenames through the inbound WhatsApp media pipeline. `downloadInboundMedia` now extracts `documentMessage.fileName`, `monitorWebInbox` forwards it into `saveMediaBuffer` (which supports embedding original names into stored IDs), and `WebInboundMessage` gains a `mediaFileName` field so downstream handlers/logs can access the original name.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, scoped to WhatsApp inbound media handling, and align with the existing `saveMediaBuffer` API (which already supports `originalFilename`). The new field is optional and is only populated for document messages; other media paths remain unchanged. No new error paths or behavioral regressions were found in the touched call sites.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->