### PR TITLE
Fix: preserve Signal group ID case during normalization

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -28,4 +28,10 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);
   });
+
+  it("does not lowercase base64 Signal group IDs (case-sensitive)", () => {
+    // Synthetic base64-ish group id (Signal group IDs are case-sensitive)
+    const mixedCase = "group:AbCdEfGhIjKlMnOpQrStUvWxYz0123+/AbCdEfGhIjK=";
+    expect(normalizeSignalMessagingTarget(mixedCase)).toBe(mixedCase);
+  });
 });

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,9 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    // IMPORTANT: Signal group IDs are base64 and case-sensitive.
+    // Lowercasing them corrupts the ID and causes "Group not found" errors.
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
Forgive me I haven't looked into the proper PR etiquette for this repo, but I ran into a bug and wanted to help fix it. (This change was done by my openclaw agent.)

I told the bot to make a cron job to send a message to a Signal group chat after some time. But it turns out there's a bug where it converts the Signal group ID to lowercase, which is not something valid to do, because Base64 is case sensitive and now that's a different group. And then it hits this error:
```
$ openclaw message send --channel signal --target 'group:lwmiZCgpZk5zoCAmEZGYp89SZL+dbgGY0Wd********=' --message 'hello test' --verbose --json
Error: Signal RPC -1: Group not found: lwmizcgpzk5zocamezgyp89szl+dbggy0wd********=
````
I've redacted a couple characters, but you can see it's converting the group to lowercase. (you can get this group ID from an existing Signal session if you've set up the tool.) And oddly, the bot replying to a message in a Signal group chat works, but not when it tries to run like the command above, which I guess it does from openclaw cron tasks.

But sending via signal-cli directly works:
```
$ signal-cli -u +*********** send -m "hello test (signal-cli direct)" -g 'lwmiZCgpZk5zoCAmEZGYp89SZL+dbgGY0Wd********='
INFO  SignalAccount - Config file is in use by another instance, waiting…
INFO  SignalAccount - Config file lock acquired.
177064603****
```
I've redacted the phone number and part of the group ID again, but anyway I can confirm I received the message, and it returned an ID here which it printed out.

Hope to see this get merged and let me know if anything else is required.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Signal group target normalization by no longer lowercasing `group:<base64>` targets (group IDs are base64 and case-sensitive), and adds a regression test to ensure mixed-case group IDs are preserved.

Change is localized to the Signal normalization plugin used to canonicalize/validate messaging targets before routing/dispatch, aligning manual `openclaw message send --channel signal --target group:...` usage with signal-cli’s case-sensitive group IDs.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge after addressing a small normalization inconsistency and updating the test fixture.
- Core fix (stop lowercasing base64 group IDs) is correct and narrowly scoped, but current implementation can preserve mixed-case `Group:` prefixes and the test fixture appears to embed a realistic group identifier string.
- src/channels/plugins/normalize/signal.ts; src/channels/plugins/normalize/signal.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->