### PR TITLE
security: prefix bare .md file references with ./ to prevent TLD resolution

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -109,7 +109,7 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
 function extractToolListText(systemPrompt: string): string {
   const markerA = "Tool names are case-sensitive. Call tools exactly as listed.\n";
   const markerB =
-    "\nTOOLS.md does not control tool availability; it is user guidance for how to use external tools.";
+    "\n./TOOLS.md does not control tool availability; it is user guidance for how to use external tools.";
   const extracted = extractBetween(systemPrompt, markerA, markerB);
   if (!extracted.found) {
     return "";

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -393,9 +393,9 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("# Project Context");
-    expect(prompt).toContain("## AGENTS.md");
+    expect(prompt).toContain("## ./AGENTS.md");
     expect(prompt).toContain("Alpha");
-    expect(prompt).toContain("## IDENTITY.md");
+    expect(prompt).toContain("## ./IDENTITY.md");
     expect(prompt).toContain("Bravo");
   });
 
@@ -410,7 +410,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("# Project Context");
-    expect(prompt).toContain("## AGENTS.md");
+    expect(prompt).toContain("## ./AGENTS.md");
     expect(prompt).toContain("Alpha");
     expect(prompt).not.toContain("Missing path");
     expect(prompt).not.toContain("Blank path");
@@ -426,7 +426,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain(
-      "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
+      "If ./SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
     );
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -53,7 +53,7 @@ function buildMemorySection(params: {
   }
   const lines = [
     "## Memory Recall",
-    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
+    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on ./MEMORY.md + ./memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
   ];
   if (params.citationsMode === "off") {
     lines.push(
@@ -453,7 +453,7 @@ export function buildAgentSystemPrompt(params: {
           "- subagents: list/steer/kill sub-agent runs",
           '- session_status: show usage/time/model state and answer "what model are we using?"',
         ].join("\n"),
-    "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
+    "./TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
     `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
     "If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.",
     "Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).",
@@ -618,12 +618,17 @@ export function buildAgentSystemPrompt(params: {
     lines.push("# Project Context", "", "The following project context files have been loaded:");
     if (hasSoulFile) {
       lines.push(
-        "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
+        "If ./SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
       );
     }
     lines.push("");
     for (const file of validContextFiles) {
-      lines.push(`## ${file.path}`, "", file.content, "");
+      // Prefix bare filenames (e.g. "SOUL.md") with "./" to prevent .md TLD resolution
+      const displayPath =
+        !file.path.includes("/") && !file.path.includes("\\") && !file.path.startsWith("./")
+          ? `./${file.path}`
+          : file.path;
+      lines.push(`## ${displayPath}`, "", file.content, "");
     }
   }
 

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -50,7 +50,7 @@ export function createMemorySearchTool(options: {
     label: "Memory Search",
     name: "memory_search",
     description:
-      "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
+      "Mandatory recall step: semantically search ./MEMORY.md + ./memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
     parameters: MemorySearchSchema,
     execute: async (_toolCallId, params) => {
       const query = readStringParam(params, "query", { required: true });
@@ -111,7 +111,7 @@ export function createMemoryGetTool(options: {
     label: "Memory Get",
     name: "memory_get",
     description:
-      "Safe snippet read from MEMORY.md or memory/*.md with optional from/lines; use after memory_search to pull only the needed lines and keep context small.",
+      "Safe snippet read from ./MEMORY.md or ./memory/*.md with optional from/lines; use after memory_search to pull only the needed lines and keep context small.",
     parameters: MemoryGetSchema,
     execute: async (_toolCallId, params) => {
       const relPath = readStringParam(params, "path", { required: true });

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -4,7 +4,7 @@ import { HEARTBEAT_TOKEN } from "./tokens.js";
 // Default heartbeat prompt (used when config.agents.defaults.heartbeat.prompt is unset).
 // Keep it tight and avoid encouraging the model to invent/rehash "open loops" from prior chat context.
 export const HEARTBEAT_PROMPT =
-  "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
+  "Read ./HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -30,8 +30,8 @@ export async function prependSystemEvents(params: {
       return null;
     }
     // Filter out the actual heartbeat prompt, but not cron jobs that mention "heartbeat"
-    // The heartbeat prompt starts with "Read HEARTBEAT.md" - cron payloads won't match this
-    if (lower.startsWith("read heartbeat.md")) {
+    // Match both ./HEARTBEAT.md and legacy HEARTBEAT.md, with flexible whitespace
+    if (/^read\s+(\.\/)?heartbeat\.md\b/i.test(trimmed)) {
       return null;
     }
     // Also filter heartbeat poll/wake noise

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -217,9 +217,9 @@ export type AgentDefaultsConfig = {
     to?: string;
     /** Optional account id for multi-account channels. */
     accountId?: string;
-    /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."). */
+    /** Override the heartbeat prompt body (default: "Read ./HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."). */
     prompt?: string;
-    /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */
+    /** Max chars allowed after HEARTBEAT_OK before delivery (default: 300). */
     ackMaxChars?: number;
     /** Suppress tool error warning payloads during heartbeat runs. */
     suppressToolErrorWarnings?: boolean;


### PR DESCRIPTION
## Summary

Since `.md` is a valid top-level domain (Moldova), bare references like `MEMORY.md`, `SOUL.md`, `HEARTBEAT.md` in LLM-facing prompts could potentially be resolved as URLs (e.g., `https://memory.md`, `https://soul.md`) instead of local file paths.

This is a security risk: an attacker could register these domains and serve malicious content that the agent might fetch and execute as instructions.

## Fix

Prefix all bare `.md` file references in system prompts, tool descriptions, and heartbeat prompts with `./` to unambiguously mark them as local paths.

## Changes (7 files, 11 lines)

| File | Change |
|------|--------|
| `src/agents/system-prompt.ts` | `MEMORY.md` → `./MEMORY.md`, `TOOLS.md` → `./TOOLS.md`, `SOUL.md` → `./SOUL.md` |
| `src/agents/system-prompt-report.ts` | `TOOLS.md` marker string → `./TOOLS.md` |
| `src/agents/system-prompt.test.ts` | Update test expectation for `./SOUL.md` |
| `src/agents/tools/memory-tool.ts` | `MEMORY.md` → `./MEMORY.md` in memory_search and memory_get descriptions |
| `src/auto-reply/heartbeat.ts` | `HEARTBEAT.md` → `./HEARTBEAT.md` in default prompt |
| `src/auto-reply/reply/session-updates.ts` | Update heartbeat filter + backward compat for old prompt format |
| `src/config/types.agent-defaults.ts` | JSDoc default string consistency |

## Background

The `.md` TLD is actively registered — for example, `heartbeat.md` is a purchasable domain. If an LLM sees a bare `HEARTBEAT.md` in its system prompt and has access to web tools, it could attempt to fetch `https://heartbeat.md` instead of reading the local file, potentially executing attacker-controlled instructions.

The `./` prefix makes the reference unambiguously a relative file path, which no URL parser will resolve as a domain.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates multiple LLM-facing prompt strings to prefix bare `*.md` references with `./` (e.g., `MEMORY.md` → `./MEMORY.md`, `HEARTBEAT.md` → `./HEARTBEAT.md`) to prevent accidental URL/TLD resolution in models that might treat bare `heartbeat.md` as a domain.

Changes are localized to system-prompt generation/reporting, memory tool descriptions, the default heartbeat prompt, and a system-event filter intended to suppress the heartbeat prompt line from session updates.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but there’s a functional regression risk in session update filtering when users override the heartbeat prompt.
- The string-prefix changes are straightforward and low-risk, but `prependSystemEvents` now filters heartbeat prompts using a hard-coded prefix that only matches the default/legacy prompt format; custom heartbeat prompts will leak into system event blocks unexpectedly.
- src/auto-reply/reply/session-updates.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->