### PR TITLE
fix: prevent sanitizeUserFacingText false-positives on assistant prose

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -28,4 +28,20 @@ describe("isBillingErrorMessage", () => {
     expect(isBillingErrorMessage("invalid api key")).toBe(false);
     expect(isBillingErrorMessage("context length exceeded")).toBe(false);
   });
+
+  it("does not false-positive on long assistant prose about billing topics", () => {
+    const longBillingProse =
+      "Here's how to set up Stripe billing for your SaaS application. " +
+      "First, create a product and pricing plan in the Stripe dashboard. " +
+      "Then integrate the checkout session to collect payment from your customers. " +
+      "You can offer multiple plan tiers with different credits allocations. " +
+      "Consider offering a free tier to let users try before they upgrade. " +
+      "The billing portal lets customers manage their own subscriptions, " +
+      "view invoices, and update their payment methods. " +
+      "For enterprise customers, you might want to offer custom billing " +
+      "arrangements with volume discounts and dedicated support. " +
+      "Make sure to handle webhook events for subscription lifecycle changes " +
+      "like renewals, cancellations, and failed payment retries.";
+    expect(isBillingErrorMessage(longBillingProse)).toBe(false);
+  });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -27,4 +27,42 @@ describe("sanitizeUserFacingText", () => {
     const raw = '{"type":"error","error":{"message":"Something exploded","type":"server_error"}}';
     expect(sanitizeUserFacingText(raw)).toBe("The AI service returned an error. Please try again.");
   });
+
+  it("does not replace multi-paragraph assistant prose", () => {
+    const prose =
+      "Error handling is an important part of building robust applications.\n\n" +
+      "When a 500 Internal Server Error occurs, you should log the error and return a user-friendly message.";
+    expect(sanitizeUserFacingText(prose)).toBe(prose);
+  });
+
+  it("does not replace assistant text discussing billing topics", () => {
+    const billingProse =
+      "Here's how Stripe billing works:\n\n" +
+      "1. Create a plan with the pricing you want\n" +
+      "2. Subscribe customers to the plan\n" +
+      "3. Payment is collected automatically via credits";
+    expect(sanitizeUserFacingText(billingProse)).toBe(billingProse);
+  });
+
+  it("does not replace long text starting with error-like prefix", () => {
+    const longError =
+      "Error handling in distributed systems requires careful consideration.\n\n" +
+      "You need to handle timeouts, retries, and circuit breakers properly.";
+    expect(sanitizeUserFacingText(longError)).toBe(longError);
+  });
+
+  it("does not replace text with markdown formatting", () => {
+    const markdown = "## Error Codes\n\n- 400: Bad request\n- 500: Internal server error";
+    expect(sanitizeUserFacingText(markdown)).toBe(markdown);
+  });
+
+  it("still catches short actual error messages", () => {
+    expect(sanitizeUserFacingText("Error: rate limit exceeded")).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+    expect(sanitizeUserFacingText("Error: request timed out")).toBe("LLM request timed out.");
+    expect(sanitizeUserFacingText("Failed: overloaded")).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #12676

`sanitizeUserFacingText` applies error-detection heuristics to **all** outbound messaging text, including normal assistant responses. When an assistant discusses topics like billing, error handling, or HTTP status codes, the heuristic pattern-matching can misclassify the response as an API error and replace it with a generic error message.

## Changes
- Add `looksLikeAssistantProse()` guard that detects multi-sentence text, paragraph breaks, and markdown formatting — structural signals that distinguish assistant prose from short API error messages
- Move the `isRawApiErrorPayload` check (JSON structure) before the prose guard since JSON payloads are always worth catching
- Skip heuristic checks (`isLikelyHttpErrorText`, `ERROR_PREFIX_RE`) when text looks like prose
- Tighten `isBillingErrorMessage` loose keyword branch (`billing` + `upgrade`/`credits`/`payment`/`plan`) to also skip prose text
- Add tests covering false-positive scenarios (multi-paragraph, billing-topic, markdown, error-prefix prose)

## Test Plan
- All 107 existing `pi-embedded-helpers` tests pass
- 5 new tests verify false-positive prevention on assistant prose
- Existing error-catching behavior preserved for short, actual error messages
- `pnpm lint`, `pnpm build`, `pnpm format` all pass

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `sanitizeUserFacingText` to reduce false-positives where normal assistant prose (multi-paragraph text, markdown, multi-sentence explanations) was being misclassified as an API error and replaced with a generic error message. It introduces a `looksLikeAssistantProse()` guard, moves JSON error-payload detection earlier, and tightens the billing “loose keyword” heuristic to avoid classifying assistant discussions about billing as real billing errors. Tests were added to cover multi-paragraph/markdown/billing-topic prose while preserving sanitization for short, actual error-like strings.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but has a couple logic edge-cases that can reintroduce false-positives and can also let long real errors through unsanitized.
- Core approach and tests address the reported false positives, but (1) `isBillingErrorMessage` lowercases before applying `looksLikeAssistantProse`, breaking its sentence heuristic, and (2) the early prose return bypasses all heuristic sanitization for any text >500 chars, which can expose verbose real errors.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->