### PR TITLE
Simplify ownership commands in hetzner.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: format forwarded command text as inline/fenced monospace for safer approval scanning across channels. (#11937)
 - Config: clamp `maxTokens` to `contextWindow` to prevent invalid model configs. (#5516) Thanks @lailoo.
 - Docs: fix language switcher ordering and Japanese locale flag in Mintlify nav. (#12023) Thanks @joshp123.
+- Docs: clarify Hetzner Docker bootstrap guidance for `--allow-unconfigured` and streamline ownership commands. (#12703) Thanks @vcastellm.
 - Paths: make internal path resolution respect `HOME`/`USERPROFILE` before `os.homedir()` across config, agents, sessions, pairing, cron, and CLI profiles. (#12091) Thanks @sebslight.
 - Paths: structurally resolve `OPENCLAW_HOME`-derived home paths and fix Windows drive-letter handling in tool meta shortening. (#12125) Thanks @mcaxtr.
 - Thinking: allow xhigh for `github-copilot/gpt-5.2-codex` and `github-copilot/gpt-5.2`. (#11646) Thanks @seans-openclawbot.

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -190,6 +190,7 @@ services:
         "${OPENCLAW_GATEWAY_BIND}",
         "--port",
         "${OPENCLAW_GATEWAY_PORT}",
+        "--allow-unconfigured"
       ]
 ```
 

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -113,12 +113,10 @@ Docker containers are ephemeral.
 All long-lived state must live on the host.
 
 ```bash
-mkdir -p /root/.openclaw
 mkdir -p /root/.openclaw/workspace
 
 # Set ownership to the container user (uid 1000):
 chown -R 1000:1000 /root/.openclaw
-chown -R 1000:1000 /root/.openclaw/workspace
 ```
 
 ---

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -190,9 +190,11 @@ services:
         "${OPENCLAW_GATEWAY_BIND}",
         "--port",
         "${OPENCLAW_GATEWAY_PORT}",
-        "--allow-unconfigured"
+        "--allow-unconfigured",
       ]
 ```
+
+`--allow-unconfigured` is only for bootstrap convenience, it is not a replacement for a proper gateway configuration. Still set auth (`gateway.auth.token` or password) and use safe bind settings for your deployment.
 
 ---
 


### PR DESCRIPTION
This pull request makes minor updates to the Hetzner installation documentation, mainly to streamline setup instructions and clarify container configuration.

*Documentation improvements:*

* Simplified the directory creation instructions by removing the redundant `mkdir -p /root/.openclaw` command and unnecessary ownership change for `/root/.openclaw/workspace`.

*Configuration update:*

* Added the `--allow-unconfigured` flag to the `openclaw-gateway` service configuration, enabling the gateway to run without requiring full configuration.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Hetzner (Docker) installation guide by streamlining the host directory/ownership commands and adding `--allow-unconfigured` to the `openclaw-gateway` docker-compose command so the gateway can start without a fully configured `gateway.mode=local`.

The changes are confined to `docs/install/hetzner.md` and affect copy/paste setup steps and the example compose snippet used to run the gateway container.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is because the updated docs contain copy/paste-breaking commands/snippet syntax.
- The PR is documentation-only, but the updated shell commands can fail on a fresh host and the compose snippet contains invalid YAML due to a missing comma, which will block users following the guide.
- docs/install/hetzner.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->