### PR TITLE
fix(heartbeat): pass per-agent heartbeat model to getReplyFromConfig

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -79,7 +79,9 @@ export async function getReplyFromConfig(
   let provider = defaultProvider;
   let model = defaultModel;
   if (opts?.isHeartbeat) {
-    const heartbeatRaw = agentCfg?.heartbeat?.model?.trim() ?? "";
+    // Prefer explicit heartbeatModel from options (passed by heartbeat-runner with per-agent config),
+    // then fall back to global agents.defaults.heartbeat.model.
+    const heartbeatRaw = opts.heartbeatModel?.trim() || agentCfg?.heartbeat?.model?.trim() || "";
     const heartbeatRef = heartbeatRaw
       ? resolveModelRefFromString({
           raw: heartbeatRaw,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -27,6 +27,8 @@ export type GetReplyOptions = {
   onTypingCleanup?: () => void;
   onTypingController?: (typing: TypingController) => void;
   isHeartbeat?: boolean;
+  /** Override model for heartbeat runs (e.g., "ollama/qwen2.5:3b"). */
+  heartbeatModel?: string;
   onPartialReply?: (payload: ReplyPayload) => Promise<void> | void;
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
   onBlockReply?: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -637,7 +637,7 @@ export async function runHeartbeatOnce(opts: {
   };
 
   try {
-    const heartbeatModel = heartbeat?.model?.trim();
+    const heartbeatModel = heartbeat?.model?.trim() || undefined;
     const replyResult = await getReplyFromConfig(ctx, { isHeartbeat: true, heartbeatModel }, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -637,7 +637,8 @@ export async function runHeartbeatOnce(opts: {
   };
 
   try {
-    const replyResult = await getReplyFromConfig(ctx, { isHeartbeat: true }, cfg);
+    const heartbeatModel = heartbeat?.model?.trim();
+    const replyResult = await getReplyFromConfig(ctx, { isHeartbeat: true, heartbeatModel }, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
     const reasoningPayloads = includeReasoning


### PR DESCRIPTION
## Summary

Fixes #9556

Per-agent heartbeat model override was not being respected. `getReplyFromConfig()` only read the heartbeat model from global `agents.defaults.heartbeat.model`, ignoring the per-agent configuration that `resolveHeartbeatConfig()` computes in `heartbeat-runner.ts`.

## Changes

- `src/auto-reply/types.ts` — Added `heartbeatModel` option to `GetReplyOptions`
- `src/auto-reply/reply/get-reply.ts` — Updated heartbeat model resolution to prefer `opts.heartbeatModel` over global defaults
- `src/infra/heartbeat-runner.ts` — Pass resolved per-agent heartbeat model to `getReplyFromConfig()`
- `src/auto-reply/reply.heartbeat-typing.test.ts` — Added tests for override and fallback behaviors

## Test plan

- [x] Added test: "uses heartbeatModel option over global defaults"
- [x] Added test: "falls back to global heartbeat.model when heartbeatModel option is not provided"
- [x] All 4 tests pass: `npx vitest run src/auto-reply/reply.heartbeat-typing.test.ts`
- [x] `pnpm build` — passes
- [x] `pnpm check` — passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes per-agent heartbeat model overrides by threading a resolved `heartbeatModel` through the heartbeat runner into `getReplyFromConfig()`.

Concretely:
- `GetReplyOptions` gains an optional `heartbeatModel` field.
- `getReplyFromConfig()` now prefers `opts.heartbeatModel` for heartbeat runs, falling back to the global `agents.defaults.heartbeat.model` when not provided.
- `heartbeat-runner.ts` passes the per-agent resolved heartbeat model to `getReplyFromConfig()`, normalizing empty/whitespace values to `undefined`.
- Tests were added to validate override-vs-fallback behavior.

This integrates cleanly with existing model selection (`resolveDefaultModel` + `resolveModelRefFromString`) while leaving non-heartbeat runs unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to heartbeat model selection, preserve existing default behavior when the override is absent, and include targeted tests covering both override and fallback paths. Call-site normalization to `undefined` avoids empty-string edge cases.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->