### PR TITLE
Docs/security link secure starter

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,3 +75,11 @@ Run locally:
 pip install detect-secrets==1.5.0
 detect-secrets scan --baseline .secrets.baseline
 ```
+
+## Community hardening template (unofficial)
+
+For a lightweight, reproducible, **local-only** starter with guardrails (policy-as-code verification / CI gate + short runbook + reliable deep audit runner), see:
+
+- https://github.com/YOUR_GITHUB_USERNAME/openclaw-secure-starter
+
+This is community-maintained and not an official OpenClaw component. Please review before use.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,6 +80,6 @@ detect-secrets scan --baseline .secrets.baseline
 
 For a lightweight, reproducible, **local-only** starter with guardrails (policy-as-code verification / CI gate + short runbook + reliable deep audit runner), see:
 
-- https://github.com/YOUR_GITHUB_USERNAME/openclaw-secure-starter
+- https://github.com/swen-chan/openclaw-secure-starter
 
 This is community-maintained and not an official OpenClaw component. Please review before use.


### PR DESCRIPTION
### What
Add a short note in `SECURITY.md` linking to a community-maintained **local-only secure starter** template.

### Why
New users often want a reproducible, safer-by-default starting point (local-only port bindings + basic guardrails) without changing OpenClaw core.

### Scope / non-goals
- Documentation-only change (no runtime behavior changes).
- The linked repo is **unofficial** and community-maintained.
- Does not claim to solve public Internet exposure or prompt injection; local-only by default.

### Link
- https://github.com/swen-chan/openclaw-secure-starter

If you prefer, I can keep the link only in SECURITY.md (not README) to avoid implying endorsement.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes a documentation-only update to `SECURITY.md`, adding a short “Community hardening template (unofficial)” section that links to a community-maintained local-only secure starter template. The text explicitly notes that the template is unofficial and should be reviewed before use.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk (docs-only link addition).
- Change is confined to SECURITY.md and only adds an explicitly-labeled unofficial community link; no code or runtime behavior is affected, and there are no formatting/whitespace issues in the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->