### PR TITLE
feat(ui): add copy button to logs page

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1210,7 +1210,24 @@ export function renderApp(state: AppViewState) {
                 onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
                 onRefresh: () => loadLogs(state, { reset: true }),
                 onExport: (lines, label) => state.exportLogs(lines, label),
-                onCopy: (lines) => void navigator.clipboard.writeText(lines.join("\n")),
+                onCopy: (lines) => {
+                  navigator.clipboard.writeText(lines.join("\n")).then(
+                    () => {
+                      if (state.logsCopiedTimer) {
+                        clearTimeout(state.logsCopiedTimer);
+                      }
+                      state.logsCopied = true;
+                      state.logsCopiedTimer = setTimeout(() => {
+                        state.logsCopied = false;
+                        state.logsCopiedTimer = null;
+                      }, 1500);
+                    },
+                    () => {
+                      /* clipboard write failed — button stays as "Copy" */
+                    },
+                  );
+                },
+                copied: state.logsCopied,
                 onScroll: (event) => state.handleLogsScroll(event),
               })
             : nothing

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1210,6 +1210,7 @@ export function renderApp(state: AppViewState) {
                 onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
                 onRefresh: () => loadLogs(state, { reset: true }),
                 onExport: (lines, label) => state.exportLogs(lines, label),
+                onCopy: (lines) => void navigator.clipboard.writeText(lines.join("\n")),
                 onScroll: (event) => state.handleLogsScroll(event),
               })
             : nothing

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -219,6 +219,8 @@ export type AppViewState = {
   logsLimit: number;
   logsMaxBytes: number;
   logsAtBottom: boolean;
+  logsCopied: boolean;
+  logsCopiedTimer: ReturnType<typeof setTimeout> | null;
   client: GatewayBrowserClient | null;
   refreshSessionsAfterChat: Set<string>;
   connect: () => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -323,6 +323,8 @@ export class OpenClawApp extends LitElement {
   @state() logsLimit = 500;
   @state() logsMaxBytes = 250_000;
   @state() logsAtBottom = true;
+  @state() logsCopied = false;
+  private logsCopiedTimer: ReturnType<typeof setTimeout> | null = null;
 
   client: GatewayBrowserClient | null = null;
   private chatScrollFrame: number | null = null;

--- a/ui/src/ui/views/logs.ts
+++ b/ui/src/ui/views/logs.ts
@@ -17,6 +17,7 @@ export type LogsProps = {
   onToggleAutoFollow: (next: boolean) => void;
   onRefresh: () => void;
   onExport: (lines: string[], label: string) => void;
+  onCopy: (lines: string[]) => void;
   onScroll: (event: Event) => void;
 };
 
@@ -63,6 +64,13 @@ export function renderLogs(props: LogsProps) {
         <div class="row" style="gap: 8px;">
           <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
             ${props.loading ? "Loading…" : "Refresh"}
+          </button>
+          <button
+            class="btn"
+            ?disabled=${filtered.length === 0}
+            @click=${() => props.onCopy(filtered.map((entry) => entry.raw))}
+          >
+            Copy
           </button>
           <button
             class="btn"

--- a/ui/src/ui/views/logs.ts
+++ b/ui/src/ui/views/logs.ts
@@ -18,6 +18,7 @@ export type LogsProps = {
   onRefresh: () => void;
   onExport: (lines: string[], label: string) => void;
   onCopy: (lines: string[]) => void;
+  copied: boolean;
   onScroll: (event: Event) => void;
 };
 
@@ -67,10 +68,10 @@ export function renderLogs(props: LogsProps) {
           </button>
           <button
             class="btn"
-            ?disabled=${filtered.length === 0}
+            ?disabled=${filtered.length === 0 || props.copied}
             @click=${() => props.onCopy(filtered.map((entry) => entry.raw))}
           >
-            Copy
+            ${props.copied ? "Copied!" : "Copy"}
           </button>
           <button
             class="btn"


### PR DESCRIPTION
## Summary

- Add a Copy button to the gateway Control UI logs page that copies filtered log entries to the clipboard
- Button shows brief "Copied!" feedback for 1.5s after clicking, matching the existing chat copy button pattern

## Test plan

- [ ] Open Control UI → Logs tab
- [ ] Click Copy button → verify logs copied to clipboard and button briefly shows "Copied!"
- [ ] Apply filters → verify Copy only includes filtered entries
- [ ] Verify button is disabled when no log entries are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `onCopy` callback to the Logs view and wires it up in `renderApp` to copy the currently visible (filtered) log lines to the clipboard. The Logs page now renders a Copy button alongside Refresh/Export, and briefly changes its label to “Copied!” after clicking.

Main integration points:
- `ui/src/ui/app-render.ts` passes an `onCopy` implementation to `renderLogs`.
- `ui/src/ui/views/logs.ts` computes `filtered` entries and uses them for both Export and Copy actions.

Key issues to address before merge are around copy feedback/state management and error handling for clipboard writes.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has user-visible correctness issues around copy feedback/error handling.
- The feature is small and localized, but the current implementation can show “Copied!” even when clipboard writes fail, and the feedback is not tied to reactive render state (can desync on re-render/multiple clicks). Fixing these should make behavior reliable.
- ui/src/ui/views/logs.ts, ui/src/ui/app-render.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->