### PR TITLE
fix: prevent sanitizeUserFacingText false-positives on 402 in normal text

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -28,4 +28,16 @@ describe("isBillingErrorMessage", () => {
     expect(isBillingErrorMessage("invalid api key")).toBe(false);
     expect(isBillingErrorMessage("context length exceeded")).toBe(false);
   });
+
+  it("does not match 402 in dollar amounts", () => {
+    expect(isBillingErrorMessage("Your total spend is $402.55 this month.")).toBe(false);
+  });
+
+  it("does not false-positive on multi-sentence assistant prose about billing", () => {
+    const longBillingProse =
+      "Here's how to set up Stripe billing for your SaaS application. " +
+      "First, create a product and pricing plan in the Stripe dashboard. " +
+      "Then integrate the checkout session to collect payment from your customers.";
+    expect(isBillingErrorMessage(longBillingProse)).toBe(false);
+  });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -60,4 +60,49 @@ describe("sanitizeUserFacingText", () => {
     const text = "Hello there!\n\nDifferent line.";
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
+
+  it("does not replace text containing 402 in dollar amounts", () => {
+    const text = "Your total spend this month is $402.55 across all services.";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("does not replace multi-paragraph prose discussing errors", () => {
+    const prose =
+      "Error handling is an important part of building robust applications.\n\n" +
+      "When a 500 Internal Server Error occurs, you should log the error and return a user-friendly message.";
+    expect(sanitizeUserFacingText(prose)).toBe(prose);
+  });
+
+  it("does not replace assistant text discussing billing topics", () => {
+    const billingProse =
+      "Here's how Stripe billing works:\n\n" +
+      "1. Create a plan with the pricing you want\n" +
+      "2. Subscribe customers to the plan\n" +
+      "3. Payment is collected automatically via credits";
+    expect(sanitizeUserFacingText(billingProse)).toBe(billingProse);
+  });
+
+  it("does not replace text with markdown formatting", () => {
+    const markdown =
+      "## Error Codes\n\n- 400: Bad request\n- 402: Payment required\n- 500: Internal server error";
+    expect(sanitizeUserFacingText(markdown)).toBe(markdown);
+  });
+
+  it("does not replace long multi-sentence text starting with error-like prefix", () => {
+    const longError =
+      "Error handling in distributed systems requires careful consideration. You need to handle timeouts, retries, and circuit breakers properly. Here are the key patterns to follow.";
+    expect(sanitizeUserFacingText(longError)).toBe(longError);
+  });
+
+  it("still catches short actual billing error messages", () => {
+    expect(sanitizeUserFacingText("HTTP 402 Payment Required")).toContain("billing error");
+    expect(sanitizeUserFacingText("insufficient credits")).toContain("billing error");
+  });
+
+  it("still catches short error messages with error prefix", () => {
+    expect(sanitizeUserFacingText("Error: rate limit exceeded")).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+    expect(sanitizeUserFacingText("Error: request timed out")).toBe("LLM request timed out.");
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #12711

`sanitizeUserFacingText()` calls `isBillingErrorMessage()` on **all** outbound messaging text. The `/\b402\b/` regex matches "402" in any word-boundary context — including `$402.55` in cost reports — replacing the entire response with the billing error warning on channel surfaces (Signal, Telegram, etc.).

## Root Cause
Two issues combine to create the false positive:
1. **Loose regex**: `/\b402\b/` matches "402" in `$402.55` because `$` is not a word character (word boundary at `$`→`4`)
2. **No prose guard**: `sanitizeUserFacingText` applies error heuristics to all text equally, whether it's a short API error or a multi-paragraph assistant response

## Changes
- **Add `looksLikeAssistantProse()` guard** — detects multi-sentence text (3+ sentences), paragraph breaks (`\n\n`), and markdown formatting. When text looks like prose, skip all heuristic error checks (billing, HTTP, error prefix)
- **Tighten 402 regex** — replace bare `/\b402\b/` with context-requiring patterns (`/(?:HTTP[/ ]\s*|status[: ]\s*|^)402\s+payment\s+required/i` and `/\berror\b.*\b402\b/i`). The existing `"payment required"` string pattern already catches the real error case
- **Move JSON error check first** — `isRawApiErrorPayload` is structurally identifiable (JSON structure) and should always be caught regardless of text length
- **Apply prose guard to `isBillingErrorMessage`** — the loose keyword branch (`billing` + `upgrade`/`credits`/`payment`/`plan`) also skips prose

## Test Plan
- 134 existing `pi-embedded-helpers` tests pass
- 8 new tests cover false-positive scenarios:
  - `$402.55` in dollar amounts
  - Multi-paragraph error discussion prose
  - Billing topic prose with markdown
  - Multi-sentence text with error-like prefix
- Verified real billing errors still caught: "HTTP 402 Payment Required", "insufficient credits", "Error: rate limit exceeded"
- `pnpm lint` (0 errors), `pnpm build`, `pnpm format` all pass

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reduces false-positive sanitization of normal assistant responses by adding a `looksLikeAssistantProse()` guard in `sanitizeUserFacingText()`, tightening the 402 billing regex to require HTTP/error context, and prioritizing structurally-identifiable JSON error payload detection. It also adds test coverage for previously problematic cases like `$402.55` in cost reports and multi-paragraph/markdown assistant text.

Main integration point is `src/agents/pi-embedded-helpers/errors.ts`, which is used by multiple helpers (`sanitizeUserFacingText`, `formatAssistantErrorText`, and failover classification) to decide when to rewrite/label outbound text as an error versus leaving it as user-facing content.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one guard may hide real billing errors in formatted/multi-line error texts.
- Changes are localized and well-covered by new tests for the reported false positive, and the 402 regex tightening is sensible. The main remaining risk is the new early-return in `isBillingErrorMessage()` that can suppress legitimate billing detection for errors containing blank lines/markdown wrappers, which can impact user messaging and failover classification.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->