### PR TITLE
fix: prevent 402 regex from matching currency amounts in responses

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -28,4 +28,12 @@ describe("isBillingErrorMessage", () => {
     expect(isBillingErrorMessage("invalid api key")).toBe(false);
     expect(isBillingErrorMessage("context length exceeded")).toBe(false);
   });
+
+  it("matches bare 402 (for use in error context)", () => {
+    // Note: isBillingErrorMessage itself still matches 402,
+    // but sanitizeUserFacingText guards against false positives
+    // by only applying it to error-like text
+    expect(isBillingErrorMessage("402")).toBe(true);
+    expect(isBillingErrorMessage("error 402")).toBe(true);
+  });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -60,4 +60,31 @@ describe("sanitizeUserFacingText", () => {
     const text = "Hello there!\n\nDifferent line.";
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
+
+  it("does not replace currency amounts containing 402", () => {
+    // Issue #12711: $402.55 was being replaced with billing error warning
+    expect(sanitizeUserFacingText("The total cost is $402.55")).toBe("The total cost is $402.55");
+    expect(sanitizeUserFacingText("You spent $402 on groceries")).toBe(
+      "You spent $402 on groceries",
+    );
+    expect(sanitizeUserFacingText("Invoice #402: $150.00")).toBe("Invoice #402: $150.00");
+    expect(sanitizeUserFacingText("Room 402 is available")).toBe("Room 402 is available");
+    expect(sanitizeUserFacingText("The year 1402 was significant")).toBe(
+      "The year 1402 was significant",
+    );
+    expect(sanitizeUserFacingText("Order #1402 shipped")).toBe("Order #1402 shipped");
+  });
+
+  it("still catches actual 402 billing errors in error payloads", () => {
+    // Real API error payloads should still be caught
+    const apiError =
+      '{"type":"error","error":{"message":"Payment Required","type":"billing_error"}}';
+    expect(sanitizeUserFacingText(apiError)).toContain("billing");
+  });
+
+  it("still catches HTTP 402 errors", () => {
+    // HTTP status format errors should still be caught
+    expect(sanitizeUserFacingText("402 Payment Required")).toContain("billing");
+    expect(sanitizeUserFacingText("HTTP 402 Payment Required")).toContain("billing");
+  });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -87,4 +87,14 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("402 Payment Required")).toContain("billing");
     expect(sanitizeUserFacingText("HTTP 402 Payment Required")).toContain("billing");
   });
+
+  it("still catches plain-text billing errors with explicit keywords", () => {
+    // Plain billing messages should still be caught via explicit keyword matching
+    expect(sanitizeUserFacingText("insufficient credits")).toContain("billing");
+    expect(sanitizeUserFacingText("Your credit balance is low")).toContain("billing");
+    expect(sanitizeUserFacingText("Please visit plans & billing")).toContain("billing");
+    expect(sanitizeUserFacingText("Payment required to continue")).toContain("billing");
+    expect(sanitizeUserFacingText("Please upgrade your billing plan")).toContain("billing");
+    expect(sanitizeUserFacingText("Check your billing page for credits")).toContain("billing");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -87,6 +87,7 @@ const HTTP_ERROR_HINTS = [
   "timed out",
   "invalid",
   "too many requests",
+  "payment required",
   "permission",
 ];
 
@@ -137,6 +138,22 @@ function isLikelyHttpErrorText(raw: string): boolean {
   }
   const message = match[2].toLowerCase();
   return HTTP_ERROR_HINTS.some((hint) => message.includes(hint));
+}
+
+/**
+ * Checks if text looks like an error message rather than normal assistant output.
+ * Used to guard error-specific rewrites from matching numbers in conversational text.
+ */
+function looksLikeErrorText(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return (
+    isRawApiErrorPayload(raw) ||
+    isLikelyHttpErrorText(raw) ||
+    ERROR_PREFIX_RE.test(raw) ||
+    CONTEXT_OVERFLOW_ERROR_HEAD_RE.test(raw)
+  );
 }
 
 function shouldRewriteContextOverflowText(raw: string): boolean {
@@ -426,7 +443,9 @@ export function sanitizeUserFacingText(text: string): string {
     );
   }
 
-  if (isBillingErrorMessage(trimmed)) {
+  // Only apply billing error detection when text looks like an error message,
+  // not on normal assistant output that might contain numbers like "$402.55"
+  if (looksLikeErrorText(trimmed) && isBillingErrorMessage(trimmed)) {
     return BILLING_ERROR_USER_MESSAGE;
   }
 


### PR DESCRIPTION
Fixes #12711

## What
Fixes false positive billing error detection that replaced normal responses containing '402' with error warnings.

## Why
The `isBillingErrorMessage()` regex `/\b402\b/` matches any word-bounded '402', including currency amounts like '$402.55'. This caused legitimate assistant responses to be replaced with billing error messages on channel delivery.

## How
Added a `looksLikeErrorText()` guard function that checks if text appears to be an actual error message (JSON API payloads, HTTP status codes with error hints, or text starting with error prefixes). The billing error check in `sanitizeUserFacingText()` now only applies when this guard returns true.

Also added 'payment required' to `HTTP_ERROR_HINTS` so that "402 Payment Required" HTTP errors are still properly detected.

## Testing
- [x] Added unit tests for currency amounts containing 402 ("$402.55", "Room 402", etc.)
- [x] Verified actual 402 billing errors (HTTP 402, API error payloads) are still detected
- [x] `pnpm check` passes
- [x] `pnpm test` passes (related tests)

## AI-Assisted
This PR was built with AI assistance (Claude via OpenClaw). The code has been reviewed, tested, and I understand what it does.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts billing-error sanitization to avoid false positives when the assistant output contains the substring `402` in normal text (e.g. currency amounts). It introduces a `looksLikeErrorText()` guard and expands HTTP error hints to include "payment required", plus adds unit tests covering currency/room-number cases and ensuring HTTP 402 / JSON billing payloads are still caught.

The change integrates into the existing error-rewrite pipeline by gating the `isBillingErrorMessage()` rewrite inside `sanitizeUserFacingText()`, which is used by reply normalization/channel delivery.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but it introduces a likely behavior regression for plain-text billing errors in the sanitizeUserFacingText pathway.
- Core fix (guarding against "$402.55" false positives) is solid and tested, but the new `looksLikeErrorText()` gate appears to prevent rewriting of several real billing errors that arrive as plain text (not HTTP-status-line or JSON), which can change user-visible behavior in channel delivery.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->