### PR TITLE
feat: add maxLines option for memory chunk splitting

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -42,6 +42,7 @@ export type ResolvedMemorySearchConfig = {
   chunking: {
     tokens: number;
     overlap: number;
+    maxLines?: number;
   };
   sync: {
     onSessionStart: boolean;
@@ -194,6 +195,7 @@ function mergeConfig(
   const chunking = {
     tokens: overrides?.chunking?.tokens ?? defaults?.chunking?.tokens ?? DEFAULT_CHUNK_TOKENS,
     overlap: overrides?.chunking?.overlap ?? defaults?.chunking?.overlap ?? DEFAULT_CHUNK_OVERLAP,
+    maxLines: overrides?.chunking?.maxLines ?? defaults?.chunking?.maxLines,
   };
   const sync = {
     onSessionStart: overrides?.sync?.onSessionStart ?? defaults?.sync?.onSessionStart ?? true,

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -267,7 +267,11 @@ function mergeConfig(
     model,
     local,
     store,
-    chunking: { tokens: Math.max(1, chunking.tokens), overlap },
+    chunking: {
+      tokens: Math.max(1, chunking.tokens),
+      overlap,
+      maxLines: chunking.maxLines,
+    },
     sync: {
       ...sync,
       sessions: {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -254,6 +254,10 @@ function mergeConfig(
   const candidateMultiplier = clampInt(hybrid.candidateMultiplier, 1, 20);
   const deltaBytes = clampInt(sync.sessions.deltaBytes, 0, Number.MAX_SAFE_INTEGER);
   const deltaMessages = clampInt(sync.sessions.deltaMessages, 0, Number.MAX_SAFE_INTEGER);
+  const maxLines =
+    typeof chunking.maxLines === "number" && Number.isFinite(chunking.maxLines)
+      ? Math.max(1, Math.floor(chunking.maxLines))
+      : undefined;
   return {
     enabled,
     sources,
@@ -270,7 +274,7 @@ function mergeConfig(
     chunking: {
       tokens: Math.max(1, chunking.tokens),
       overlap,
-      maxLines: chunking.maxLines,
+      maxLines,
     },
     sync: {
       ...sync,

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -284,6 +284,7 @@ export type MemorySearchConfig = {
   chunking?: {
     tokens?: number;
     overlap?: number;
+    maxLines?: number;
   };
   /** Sync behavior. */
   sync?: {

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -165,7 +165,7 @@ export async function buildFileEntry(
 
 export function chunkMarkdown(
   content: string,
-  chunking: { tokens: number; overlap: number },
+  chunking: { tokens: number; overlap: number; maxLines?: number },
 ): MemoryChunk[] {
   const lines = content.split("\n");
   if (lines.length === 0) {
@@ -173,6 +173,7 @@ export function chunkMarkdown(
   }
   const maxChars = Math.max(32, chunking.tokens * 4);
   const overlapChars = Math.max(0, chunking.overlap * 4);
+  const maxLinesPerChunk = chunking.maxLines ?? Infinity;
   const chunks: MemoryChunk[] = [];
 
   let current: Array<{ line: string; lineNo: number }> = [];
@@ -234,7 +235,10 @@ export function chunkMarkdown(
     }
     for (const segment of segments) {
       const lineSize = segment.length + 1;
-      if (currentChars + lineSize > maxChars && current.length > 0) {
+      if (
+        (currentChars + lineSize > maxChars || current.length >= maxLinesPerChunk) &&
+        current.length > 0
+      ) {
         flush();
         carryOverlap();
       }

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -2328,8 +2328,12 @@ export class MemoryIndexManager implements MemorySearchManager {
       let maxChunkSize = 0;
       for (const chunk of chunks) {
         const size = Buffer.byteLength(chunk.text, "utf-8");
-        if (size < minChunkSize) minChunkSize = size;
-        if (size > maxChunkSize) maxChunkSize = size;
+        if (size < minChunkSize) {
+          minChunkSize = size;
+        }
+        if (size > maxChunkSize) {
+          maxChunkSize = size;
+        }
       }
       if (chunks.length === 0) {
         minChunkSize = 0;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -14,10 +14,10 @@ import type {
   MemorySource,
   MemorySyncProgressUpdate,
 } from "./types.js";
-import { isVerbose, logVerbose } from "../globals.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
+import { isVerbose, logVerbose } from "../globals.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveUserPath } from "../utils.js";
@@ -2330,14 +2330,17 @@ export class MemoryIndexManager implements MemorySearchManager {
       const avgLinesPerChunk = chunks.length > 0 ? Math.round(totalLines / chunks.length) : 0;
 
       const maxChars = Math.max(32, this.settings.chunking.tokens * 4);
-      const maxLinesConfig = this.settings.chunking.maxLines
-        ? `, maxLines=${this.settings.chunking.maxLines}`
-        : "";
+      const maxLinesConfig =
+        typeof this.settings.chunking.maxLines === "number"
+          ? `, maxLines=${this.settings.chunking.maxLines}`
+          : "";
       logVerbose(`📄 ${entry.path}`);
       logVerbose(
         `   Chunks: ${chunks.length} from ${totalLines} lines (~${avgLinesPerChunk} lines/chunk)`,
       );
-      logVerbose(`   Size: ${totalBytes} bytes (avg=${avgChunkSize}, min=${minChunkSize}, max=${maxChunkSize})`);
+      logVerbose(
+        `   Size: ${totalBytes} bytes (avg=${avgChunkSize}, min=${minChunkSize}, max=${maxChunkSize})`,
+      );
       logVerbose(
         `   Config: maxChars=${maxChars} (tokens=${this.settings.chunking.tokens}${maxLinesConfig})`,
       );


### PR DESCRIPTION
- Add optional maxLines parameter to chunking configuration
- Split chunks when either maxChars OR maxLines threshold is reached
- Improves search granularity for short-entry collections (quotes, facts, etc)
- Add verbose logging to display maxLines in config output
- Backward compatible: maxLines is optional, defaults to Infinity

This fixes memory indexing where files with many short entries created too few chunks for effective search. Users can now configure maxLines to control chunk splitting based on line count.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an optional `maxLines` parameter to memory chunking and updates the markdown chunker to flush a chunk when either the character budget (`tokens`) or the line budget (`maxLines`) is reached. It also adds verbose per-file chunking diagnostics during indexing.

Within the codebase, chunking configuration is resolved in `src/agents/memory-search.ts` and then consumed by the memory indexer (`src/memory/manager.ts`) which calls `chunkMarkdown` from `src/memory/internal.ts` to split file content into chunks before embedding and indexing.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the new maxLines option is computed but not propagated into the resolved config, so the feature does not work.
- The chunker supports maxLines, but `ResolvedMemorySearchConfig` currently drops `maxLines` when returning the final chunking config, making the change ineffective. Minor logging correctness issues also exist for falsy numeric values.
- src/agents/memory-search.ts (config resolution); src/memory/manager.ts (verbose logging edge case)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->