### PR TITLE
(fix): .env vars not available during runtime config reloads (healthchecks fail with MissingEnvVarError)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web_search: normalize direct Perplexity model IDs while keeping OpenRouter model IDs unchanged. (#12795) Thanks @cdorsey.
 - Model failover: treat HTTP 400 errors as failover-eligible, enabling automatic model fallback. (#1879) Thanks @orenyomtov.
 - Errors: prevent false positive context overflow detection when conversation mentions "context overflow" topic. (#2078) Thanks @sbking.
+- Config: re-hydrate state-dir `.env` during runtime config loads so `${VAR}` substitutions remain resolvable. (#12748) Thanks @rodrigouroz.
 - Gateway: no more post-compaction amnesia; injected transcript writes now preserve Pi session `parentId` chain so agents can remember again. (#12283) Thanks @Takhoffman.
 - Gateway: fix multi-agent sessions.usage discovery. (#11523) Thanks @Takhoffman.
 - Agents: recover from context overflow caused by oversized tool results (pre-emptive capping + fallback truncation). (#11579) Thanks @tyler6204.

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -79,33 +79,37 @@ describe("config env vars", () => {
 
   it("loads ${VAR} substitutions from ~/.openclaw/.env on repeated runtime loads", async () => {
     await withTempHome(async (home) => {
-      const configDir = resolveStateDir(process.env, () => home);
-      await fs.mkdir(configDir, { recursive: true });
-      await fs.writeFile(
-        path.join(configDir, "openclaw.json"),
-        JSON.stringify(
-          {
-            tools: {
-              web: {
-                search: {
-                  apiKey: "${BRAVE_API_KEY}",
-                },
-              },
-            },
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
-      await fs.writeFile(path.join(configDir, ".env"), "BRAVE_API_KEY=from-dotenv\n", "utf-8");
-
       await withEnvOverride(
         {
+          OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
+          CLAWDBOT_STATE_DIR: undefined,
+          OPENCLAW_HOME: undefined,
+          CLAWDBOT_HOME: undefined,
           BRAVE_API_KEY: undefined,
           OPENCLAW_DISABLE_CONFIG_CACHE: "1",
         },
         async () => {
+          const configDir = resolveStateDir(process.env, () => home);
+          await fs.mkdir(configDir, { recursive: true });
+          await fs.writeFile(
+            path.join(configDir, "openclaw.json"),
+            JSON.stringify(
+              {
+                tools: {
+                  web: {
+                    search: {
+                      apiKey: "${BRAVE_API_KEY}",
+                    },
+                  },
+                },
+              },
+              null,
+              2,
+            ),
+            "utf-8",
+          );
+          await fs.writeFile(path.join(configDir, ".env"), "BRAVE_API_KEY=from-dotenv\n", "utf-8");
+
           const { loadConfig } = await import("./config.js");
 
           const first = loadConfig();

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveStateDir } from "./paths.js";
 import { withEnvOverride, withTempHome } from "./test-helpers.js";
 
 describe("config env vars", () => {
@@ -73,6 +74,48 @@ describe("config env vars", () => {
         loadConfig();
         expect(process.env.GROQ_API_KEY).toBe("gsk-config");
       });
+    });
+  });
+
+  it("loads ${VAR} substitutions from ~/.openclaw/.env on repeated runtime loads", async () => {
+    await withTempHome(async (home) => {
+      const configDir = resolveStateDir(process.env, () => home);
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            tools: {
+              web: {
+                search: {
+                  apiKey: "${BRAVE_API_KEY}",
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      await fs.writeFile(path.join(configDir, ".env"), "BRAVE_API_KEY=from-dotenv\n", "utf-8");
+
+      await withEnvOverride(
+        {
+          BRAVE_API_KEY: undefined,
+          OPENCLAW_DISABLE_CONFIG_CACHE: "1",
+        },
+        async () => {
+          const { loadConfig } = await import("./config.js");
+
+          const first = loadConfig();
+          expect(first.tools?.web?.search?.apiKey).toBe("from-dotenv");
+
+          delete process.env.BRAVE_API_KEY;
+          const second = loadConfig();
+          expect(second.tools?.web?.search?.apiKey).toBe("from-dotenv");
+        },
+      );
     });
   });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
+import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {
   loadShellEnvFallback,
@@ -191,6 +192,15 @@ function normalizeDeps(overrides: ConfigIoDeps = {}): Required<ConfigIoDeps> {
   };
 }
 
+function maybeLoadDotEnvForConfig(env: NodeJS.ProcessEnv): void {
+  // Only hydrate dotenv for the real process env. Callers using injected env
+  // objects (tests/diagnostics) should stay isolated.
+  if (env !== process.env) {
+    return;
+  }
+  loadDotEnv({ quiet: true });
+}
+
 export function parseConfigJson5(
   raw: string,
   json5: { parse: (value: string) => unknown } = JSON5,
@@ -213,6 +223,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
   function loadConfig(): OpenClawConfig {
     try {
+      maybeLoadDotEnvForConfig(deps.env);
       if (!deps.fs.existsSync(configPath)) {
         if (shouldEnableShellEnvFallback(deps.env) && !shouldDeferShellEnvFallback(deps.env)) {
           loadShellEnvFallback({
@@ -323,6 +334,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
   }
 
   async function readConfigFileSnapshot(): Promise<ConfigFileSnapshot> {
+    maybeLoadDotEnvForConfig(deps.env);
     const exists = deps.fs.existsSync(configPath);
     if (!exists) {
       const hash = hashConfigRaw(null);


### PR DESCRIPTION
## Problem

  Config env substitution with `${VAR}` works at startup but can fail later during runtime config reads (healthchecks/hot-reload paths), even when the key is present in the
  documented `.env` location.

  Example:
  - Config: `tools.web.search.apiKey: "${BRAVE_API_KEY}"`
  - Key set in: `~/.openclaw/.env` (or `$OPENCLAW_STATE_DIR/.env`)
  - Runtime error:
    `MissingEnvVarError: Missing env var "BRAVE_API_KEY" referenced at config path: tools.web.search.apiKey`

  ## Why this happens

  `loadDotEnv()` is called at process entrypoints, but runtime calls to `loadConfig()` / config snapshot reads do env substitution against current `process.env`.
  If the daemon/service environment does not already include those vars (launchd/systemd without explicit env injection), substitution can fail during later reads.

  ## Expected behavior

  Config read paths should hydrate `.env` before env substitution so `${VAR}` remains resolvable on runtime reload/healthcheck paths, not only on initial startup.

  ## Repro (high-level)

  1. Put in config:
     - `tools.web.search.apiKey: "${BRAVE_API_KEY}"`
  2. Put in state-dir `.env`:
     - `BRAVE_API_KEY=...`
  3. Start gateway in environment that does not pre-export `BRAVE_API_KEY`.
  4. Trigger runtime config load (healthcheck/reload).
  5. Observe `MissingEnvVarError` for `tools.web.search.apiKey`.

  ## Proposed fix

  In config IO read paths, load dotenv before env substitution (without overriding already-set env vars), and keep behavior isolated for injected non-`process.env` test env
  objects.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change ensures `${VAR}` config substitutions continue to work on runtime config reload paths by re-hydrating dotenv (CWD + state-dir `.env`) inside config IO reads when using the real `process.env`. A regression test was added to cover repeated `loadConfig()` calls resolving an API key from the state-dir `.env` even when the variable is not pre-exported in the service environment.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the new test is made hermetic with respect to state-dir env overrides.
- Core logic change is small and aligns with existing entrypoints that already call loadDotEnv at startup; the main concrete issue found is a new test that can write/read outside the temp home when OPENCLAW_STATE_DIR is set, causing non-deterministic failures/pollution.
- src/config/config.env-vars.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->