### PR TITLE
fix(telegram): drop message_thread_id=1 for DM chats

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,8 +43,12 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("keeps thread id=1 for dm threads", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
+  it("drops thread id=1 for dm threads", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
+  });
+
+  it("keeps thread id=1 for non-forum group threads", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "none" })).toEqual({
       message_thread_id: 1,
     });
   });

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -57,14 +57,15 @@ export function resolveTelegramThreadSpec(params: {
 /**
  * Build thread params for Telegram API calls (messages, media).
  * General forum topic (id=1) must be treated like a regular supergroup send:
- * Telegram rejects sendMessage/sendMedia with message_thread_id=1 ("thread not found").
+ * Telegram rejects sendMessage/sendMedia with message_thread_id=1 in both
+ * forum groups ("thread not found") and DM chats ("message thread not found").
  */
 export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
   if (!thread?.id) {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);
-  if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
+  if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope !== "none") {
     return undefined;
   }
   return { message_thread_id: normalized };


### PR DESCRIPTION
## Summary

Fixes #12625 — cron job announcements fail in Telegram DMs with "message thread not found" error.

- `buildTelegramThreadParams()` now drops `message_thread_id=1` for DM chats (not just forum groups)
- Changed scope check from `=== "forum"` to `!== "none"` so both forum and DM scopes correctly omit the thread parameter
- Updated test expectations and added edge case coverage for `scope: "none"`

## Root Cause

Commit `19b8416a8` introduced a regression where `message_thread_id=1` is sent for DM chats. Telegram's API rejects this for DMs with "message thread not found". The fix in `buildTelegramThreadParams` only stripped thread_id=1 for `scope === "forum"`, missing the `"dm"` case.

## Test plan

- [x] `pnpm test src/telegram/bot/helpers.test.ts` — 25/25 tests pass
- [x] `pnpm build` — type check passes
- [x] `pnpm check` — no lint/format issues in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)