### PR TITLE
fix(memory-flush): fire on every compaction cycle instead of skipping alternate cycles (#12590)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
+- Memory flush: fire on every compaction cycle instead of skipping alternate cycles. (#12590)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
 - CI: Implement pipeline and workflow order. Thanks @quotentiroler.

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -162,20 +162,17 @@ export async function runMemoryFlushIfNeeded(params: {
         });
       },
     });
-    let memoryFlushCompactionCount =
+    const memoryFlushCompactionCount =
       activeSessionEntry?.compactionCount ??
       (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??
       0;
     if (memoryCompactionCompleted) {
-      const nextCount = await incrementCompactionCount({
+      await incrementCompactionCount({
         sessionEntry: activeSessionEntry,
         sessionStore: activeSessionStore,
         sessionKey: params.sessionKey,
         storePath: params.storePath,
       });
-      if (typeof nextCount === "number") {
-        memoryFlushCompactionCount = nextCount;
-      }
     }
     if (params.storePath && params.sessionKey) {
       try {

--- a/src/auto-reply/reply/agent-runner.memory-flush.runreplyagent-memory-flush.increments-compaction-count-flush-compaction-completes.test.ts
+++ b/src/auto-reply/reply/agent-runner.memory-flush.runreplyagent-memory-flush.increments-compaction-count-flush-compaction-completes.test.ts
@@ -182,6 +182,6 @@ describe("runReplyAgent memory flush", () => {
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].compactionCount).toBe(2);
-    expect(stored[sessionKey].memoryFlushCompactionCount).toBe(2);
+    expect(stored[sessionKey].memoryFlushCompactionCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
Fixes #12590

## Problem
`memoryFlush` only fires on every **other** auto-compaction cycle. After a flush where compaction also completes, `incrementCompactionCount` bumps `compactionCount` from N to N+1, and the code assigns this new value to `memoryFlushCompactionCount` — synchronizing both counters. On the next cycle, `shouldRunMemoryFlush` sees them equal and skips the flush.

## Fix
Stop overwriting `memoryFlushCompactionCount` with the post-increment value. The flush records the **pre-increment** `compactionCount`, so the next compaction cycle sees `compactionCount > memoryFlushCompactionCount` and correctly triggers the flush.

Change: 3 lines removed (the `nextCount` reassignment), `let` to `const`.

## Reproduction and Verification

### Before fix (main branch) — Bug reproduced:
```
PASS Cycle 1: first flush (compactionCount=1, no prior flush): got=true
FAIL Cycle 2: after flush+compaction (compactionCount=2, memoryFlushCompactionCount=2): got=false, expected=true
PASS Cycle 3: next compaction (compactionCount=3, memoryFlushCompactionCount=2): got=true
FAIL Cycle 4: after flush+compaction again (compactionCount=4, memoryFlushCompactionCount=4): got=false, expected=true

BUG CONFIRMED: memoryFlush skips cycles where counters are synchronized
```

### After fix — All verified:
```
PASS Cycle 1: first flush triggers
PASS Cycle 2: flush triggers (compactionCount=2, flushCount=1)
PASS Cycle 3: flush triggers (compactionCount=3, flushCount=2)
PASS Cycle 4: flush triggers (compactionCount=4, flushCount=3)
PASS Dedup: same compactionCount, already flushed
PASS Under threshold: low tokens
PASS No entry: undefined

All checks passed
```

## Effect on User Experience

**Before fix:** Users with `memoryFlush` enabled see memories saved only on ~50% of compaction cycles. Important context is silently lost.

**After fix:** `memoryFlush` fires reliably on every compaction cycle.

## Testing
- 11 unit tests pass (`memory-flush.test.ts`)
- 8 integration tests pass (`agent-runner.memory-flush.*.test.ts`)
- Lint passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes a regression where `memoryFlush` was only firing every other auto-compaction cycle. In `src/auto-reply/reply/agent-runner-memory.ts`, the flush now records `memoryFlushCompactionCount` using the *pre-increment* `compactionCount` and no longer overwrites it with the post-increment value returned by `incrementCompactionCount`, which previously synchronized the counters and caused the next cycle to be skipped.

Tests were updated to reflect the intended behavior by asserting `memoryFlushCompactionCount` remains at the pre-increment value even when `compactionCount` is incremented after a flush, and a new unit test was added to confirm `shouldRunMemoryFlush` triggers across successive compaction counts.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and directly addresses the described counter-sync bug; it aligns with how `incrementCompactionCount` persists only the compaction increment while `memoryFlushCompactionCount` is persisted separately. Updated tests lock in the intended pre-increment recording behavior and cover the regression scenario at the unit and integration level.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->