### PR TITLE
Docker: add /workspace symlink for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ ENV NODE_ENV=production
 # Allow non-root user to write temp files during runtime/tests.
 RUN chown -R node:node /app
 
+# Keep a stable workspace path for agents and docs.
+RUN ln -sf /home/node/.openclaw/workspace /workspace
+
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges


### PR DESCRIPTION
Context
Adds the /workspace symlink inside the container image so the documented paths in AGENTS.md and SOUL.md work without manual setup.

What changed
- Create /workspace -> /home/node/.openclaw/workspace during image build.

Why
This removes a recurring papercut for container users and keeps documentation paths accurate.

Issue
Fixes #11301

Checks
- pnpm build
- pnpm test
- pnpm check (fails due to pre-existing format issue in ui/src/ui/components/resizable-divider.ts)
