### PR TITLE
fix(memory): bootstrap session indexing on cold start

### DIFF
--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -213,9 +213,10 @@ function loadHookEntries(
   });
 
   const merged = new Map<string, Hook>();
-  // Precedence: extra < bundled < managed < workspace (workspace wins)
-  for (const hook of extraHooks) merged.set(hook.name, hook);
+  // Precedence: bundled < extra < managed < workspace (workspace wins)
+  // extraDirs are user-provided overrides and should take priority over bundled.
   for (const hook of bundledHooks) merged.set(hook.name, hook);
+  for (const hook of extraHooks) merged.set(hook.name, hook);
   for (const hook of managedHooks) merged.set(hook.name, hook);
   for (const hook of workspaceHooks) merged.set(hook.name, hook);
 


### PR DESCRIPTION
## Problem

Two related bugs prevent session memory from working correctly:

### 1. Cold-start deadlock in `shouldSyncSessions()` (src/memory/manager.ts)

After a restart, `sessionsDirty` is `false` and `sessionsDirtyFiles` is empty (both are only set by runtime delta events). If `needsFullReindex` is also `false` (DB exists with valid fingerprint), the method always returns `false` and session files are never indexed.

**Observed:** 115 session files on disk, only 53 indexed. The 62 missing files are permanently invisible.

### 2. `extraDirs` hooks overridden by bundled hooks (src/hooks/workspace.ts)

The hook merge order places `extraDirs` *before* bundled hooks:
```
extra → bundled → managed → workspace
```
Since later entries overwrite earlier ones in the Map, bundled hooks always win over `extraDirs` with the same name. This makes it impossible to patch a bundled hook (e.g. `session-memory`) via `extraDirs`.

## Fixes

### Commit 1: `fix(memory): bootstrap session indexing on cold start`
- Add a one-time cold-start check in `shouldSyncSessions()` comparing indexed session rows vs files on disk
- When files outnumber indexed rows, force a catch-up sync
- Check runs at most once per manager lifetime (cached in `sessionsColdStartNeeded`)
- Uses sync `readdirSync` to stay cheap
- Logs `sessions cold-start: N files on disk, M indexed — will sync` for observability

### Commit 2: `fix(hooks): extraDirs should override bundled hooks, not the reverse`
- Swap merge order: bundled loads first, then `extraDirs` overwrites
- Managed and workspace hooks still take highest priority
- One-line change + comment update

## Scope

2 files changed: `src/memory/manager.ts` (+40 lines), `src/hooks/workspace.ts` (+3/-2 lines)

## Not addressed (future work)

- Bounded/chunked bootstrap sync for very large session directories (timeout mitigation)
- `--verbose` skip-reason logging for `shouldSyncSessions`

Ref: #12633