### PR TITLE
fix(telegram): omit thread_id=1 for DMs to prevent cron delivery fail…

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,10 +43,8 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("keeps thread id=1 for dm threads", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
-      message_thread_id: 1,
-    });
+  it("omits General topic thread id=1 for dm threads", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
   });
 
   it("normalizes thread ids to integers", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -64,7 +64,10 @@ export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);
-  if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
+  if (
+    normalized === TELEGRAM_GENERAL_TOPIC_ID &&
+    (thread.scope === "forum" || thread.scope === "dm")
+  ) {
     return undefined;
   }
   return { message_thread_id: normalized };


### PR DESCRIPTION
…ures (#12625)

- Fix buildTelegramThreadParams to skip message_thread_id=1 for both forum and dm scopes
- This resolves the 'message thread not found' error in Telegram DMs
- Related to #10926 and commit 19b8416a8 which introduced the regression
- Update test to reflect correct behavior for DM threads with id=1

## Description

This PR fixes a critical bug in Telegram DM cron delivery where `message_thread_id=1` was being sent incorrectly, causing all cron jobs to fail with `"message thread not found"` error.

## Root Cause

The `buildTelegramThreadParams()` function only skipped `thread_id=1` for forum scopes, but not for DMs. This regression was introduced in commit 19b8416a8 related to #10926.

## Changes

- Modified `buildTelegramThreadParams()` to also skip `thread_id=1` for DM scopes
- Updated corresponding test to reflect correct behavior

## Impact

- Fixes #12625 - Cron delivery fails in Telegram DMs
- Prevents infinite retry loops that waste tokens
- Restores cron functionality for Telegram DM users

## Test Plan

- All existing tests pass
- Updated test specifically validates DM thread behavior

Solana Wallet for bounty: BYCgQQpJT1odaunfvk6gtm5hVd7Xu93vYwbumFfqgHb3

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Telegram thread parameter building so that `message_thread_id=1` (Telegram “General topic”) is omitted not only for forum topics but also for DM sends. This aligns DM sends with Telegram API behavior (where including `message_thread_id=1` can trigger `"message thread not found"`) and prevents cron delivery failures caused by repeated retries.

Tests were updated to assert that DM threads with `id=1` now return `undefined` from `buildTelegramThreadParams`, matching the new behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to omitting `message_thread_id=1` for DM sends, and call sites already tolerate missing thread params. The accompanying unit test was updated to reflect the intended behavior, and no other logic paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->