### PR TITLE
fix: prevent false positive billing error detection in sanitizeUserFacingText

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -66,6 +66,43 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("does not rewrite normal text containing '402' even in error context", () => {
+    // Dollar amounts (GitHub issue #12711) — must pass through even when errorContext: true
+    expect(sanitizeUserFacingText("Your MTD spend is $402.55", { errorContext: true })).toBe(
+      "Your MTD spend is $402.55",
+    );
+    // Street addresses
+    expect(sanitizeUserFacingText("Meet me at 402 Main Street", { errorContext: true })).toBe(
+      "Meet me at 402 Main Street",
+    );
+    // General numeric context
+    expect(
+      sanitizeUserFacingText("The report lists 402 items in total", { errorContext: true }),
+    ).toBe("The report lists 402 items in total");
+    // Historical year
+    expect(
+      sanitizeUserFacingText("In the year 1402 the empire expanded", { errorContext: true }),
+    ).toBe("In the year 1402 the empire expanded");
+  });
+
+  it("still rewrites leaked billing error payloads when in error context", () => {
+    // HTTP status error
+    expect(sanitizeUserFacingText("402 Payment Required", { errorContext: true })).toContain(
+      "billing",
+    );
+    // Error-prefix form
+    expect(sanitizeUserFacingText("Error: 402 Payment Required", { errorContext: true })).toContain(
+      "billing",
+    );
+    // JSON API error payload with billing keywords
+    expect(
+      sanitizeUserFacingText(
+        '{"type":"error","error":{"message":"insufficient credits","type":"billing_error"}}',
+        { errorContext: true },
+      ),
+    ).toContain("billing");
+  });
+
   it("collapses consecutive duplicate paragraphs", () => {
     const text = "Hello there!\n\nHello there!";
     expect(sanitizeUserFacingText(text)).toBe("Hello there!");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -128,6 +128,7 @@ const HTTP_ERROR_HINTS = [
   "invalid",
   "too many requests",
   "permission",
+  "payment",
 ];
 
 function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {
@@ -523,7 +524,14 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
       );
     }
 
-    if (isBillingErrorMessage(trimmed)) {
+    // Only rewrite billing errors when the text looks like a leaked error payload,
+    // not normal assistant text that happens to contain "402" (e.g., "$402.55").
+    if (
+      isBillingErrorMessage(trimmed) &&
+      (isRawApiErrorPayload(trimmed) ||
+        isLikelyHttpErrorText(trimmed) ||
+        ERROR_PREFIX_RE.test(trimmed))
+    ) {
       return BILLING_ERROR_USER_MESSAGE;
     }
 


### PR DESCRIPTION
#### Summary

`sanitizeUserFacingText()` pattern-matches `/\b402\b/` via `isBillingErrorMessage()` on **all** assistant text before channel delivery. This causes any response containing the literal number "402" in normal context (e.g., "$402.55" in a cost report, street addresses, item counts) to be silently replaced with a billing error warning on the channel surface.

Fixes #12711.

lobster-biscuit

#### Repro Steps

1. Have the assistant generate a response containing "402" in any non-error context (e.g., "$402.55 MTD spend")
2. Response is delivered to the channel as: `⚠️ API provider returned a billing error...`
3. Dashboard view shows the original, correct response

#### Root Cause

`sanitizeUserFacingText()` calls `isBillingErrorMessage(trimmed)` unconditionally on all user-facing text. The billing error patterns include `/\b402\b/`, which matches "402" at any word boundary — including after `$` (since `$` is not a word character). Normal dollar amounts like "$402.55", addresses like "402 Main Street", and counts like "402 items" all trigger the false positive.

The context overflow check in the same function already gates itself behind error-like indicators (`isRawApiErrorPayload`, `isLikelyHttpErrorText`, `ERROR_PREFIX_RE`), but the billing check had no such guard.

#### Behavior Changes

- `sanitizeUserFacingText()` now only rewrites billing errors when the text **also** looks like a leaked error payload (raw API JSON, HTTP status line, or error-prefixed text)
- Normal assistant text containing "402" passes through unchanged
- `isBillingErrorMessage()` itself is unchanged — it remains sensitive for use in `formatAssistantErrorText()` and `classifyFailoverReason()` where the input is already known to be an error message
- Added `"payment"` to `HTTP_ERROR_HINTS` so "402 Payment Required" is properly recognized as an HTTP error

#### Codebase and GitHub Search

- Searched all callers of `sanitizeUserFacingText` (normalize-reply, agent-runner-execution, sessions-helpers, pi-embedded-utils)
- Searched all callers of `isBillingErrorMessage` to confirm the function itself should not change (used in formatAssistantErrorText and classifyFailoverReason where input is known-error)
- Reviewed the parallel pattern in `shouldRewriteContextOverflowText` which already gates context overflow detection behind error indicators

#### Tests

All pass (`pnpm check` + `pnpm test`):

- **New: "does not rewrite normal text containing '402'"** — dollar amounts (`$402.55`), street addresses, item counts, historical years
- **New: "still rewrites leaked billing error payloads"** — HTTP status ("402 Payment Required"), error-prefixed ("Error: 402 Payment Required"), JSON API error payloads with billing keywords
- Existing `isBillingErrorMessage` tests unchanged and passing
- Pre-existing failure in `isCompactionFailureError` test is unrelated (present on main)

**Sign-Off**

- Models used: Claude claude-4.6-opus-high-thinking (Cursor agent)
- Submitter effort: guided/reviewed by human

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `sanitizeUserFacingText()` to avoid rewriting normal assistant output into the billing warning when the text merely contains the number `402` (e.g. `$402.55`). It does this by gating the billing rewrite behind additional “looks like an error payload” checks (`isRawApiErrorPayload`, `isLikelyHttpErrorText`, or `ERROR_PREFIX_RE`). It also adds `"payment"` to `HTTP_ERROR_HINTS` so plain HTTP status lines like `402 Payment Required` are recognized as HTTP-ish error text, and adds tests covering both the non-rewrite and rewrite cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized to `sanitizeUserFacingText()`, and the new gating logic directly addresses the reported false positive without changing `isBillingErrorMessage()` behavior for known-error contexts. Added tests cover the new behavior, and the `HTTP_ERROR_HINTS` tweak aligns with existing `isLikelyHttpErrorText()` semantics. No additional call sites or invariants appear to be broken by this change.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->