### PR TITLE
fix(telegram): match DM allowFrom against sender user id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 - Telegram: harden quote parsing; preserve quote context; avoid QUOTE_TEXT_INVALID; avoid nested reply quote misclassification. (#12156) Thanks @rybnikov.
 - Telegram: truncate command registration to 100 entries to avoid `BOT_COMMANDS_TOO_MUCH` failures on startup. (#12356) Thanks @arosstale.
+- Telegram: match DM `allowFrom` against sender user id (fallback to chat id) and clarify pairing logs. (#12779) Thanks @liuxiaopai-ai.
 - Tools/web_search: include provider-specific settings in the web search cache key, and pass `inlineCitations` for Grok. (#12419) Thanks @app/clawdinator.
 - Model failover: treat HTTP 400 errors as failover-eligible, enabling automatic model fallback. (#1879) Thanks @orenyomtov.
 - Errors: prevent false positive context overflow detection when conversation mentions "context overflow" topic. (#2078) Thanks @sbking.

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -229,8 +229,9 @@ export const buildTelegramMessageContext = async ({
     }
 
     if (dmPolicy !== "open") {
-      const candidate = String(chatId);
       const senderUsername = msg.from?.username ?? "";
+      const senderUserId = msg.from?.id != null ? String(msg.from.id) : null;
+      const candidate = senderUserId ?? String(chatId);
       const allowMatch = resolveSenderAllowMatch({
         allow: effectiveDmAllow,
         senderId: candidate,

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -266,7 +266,8 @@ export const buildTelegramMessageContext = async ({
             if (created) {
               logger.info(
                 {
-                  chatId: candidate,
+                  chatId: String(chatId),
+                  senderUserId: senderUserId ?? undefined,
                   username: from?.username,
                   firstName: from?.first_name,
                   lastName: from?.last_name,

--- a/src/telegram/bot.create-telegram-bot.matches-usernames-case-insensitively-grouppolicy-is.test.ts
+++ b/src/telegram/bot.create-telegram-bot.matches-usernames-case-insensitively-grouppolicy-is.test.ts
@@ -274,6 +274,61 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
+  it("matches direct message allowFrom against sender user id when chat id differs", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<typeof vi.fn>;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          allowFrom: ["123456789"],
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 777777777, type: "private" },
+        from: { id: 123456789, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+  it("falls back to direct message chat id when sender user id is missing", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<typeof vi.fn>;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          allowFrom: ["123456789"],
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 123456789, type: "private" },
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
   it("allows group messages with wildcard in allowFrom when groupPolicy is 'allowlist'", async () => {
     onSpy.mockReset();
     const replySpy = replyModule.__replySpy as unknown as ReturnType<typeof vi.fn>;


### PR DESCRIPTION
## Summary
- keep DM allowFrom matching on sender user id (`msg.from.id`) with fallback to DM chat id when sender id is missing
- fix pairing telemetry fields to log explicit `chatId` and `senderUserId`
- add regression tests proving allowFrom matches sender id when `chat.id != from.id`
- add fallback test for missing sender id

## Why
This addresses review blockers from #11306:
- missing targeted regression coverage for sender-id-vs-chat-id path
- ambiguous pairing log field after candidate-key change

Supersedes #11306 (head repo detached / not pushable from maintainer checkout).
Closes #4515

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Telegram DM access-control matching so `allowFrom` is checked against the sender’s user id (`msg.from.id`), falling back to the DM chat id when the sender id is missing. It also clarifies pairing-request telemetry by logging `chatId` and `senderUserId` as separate fields, and adds regression tests covering the sender-id-vs-chat-id scenario plus the missing-sender-id fallback.

The change is localized to `buildTelegramMessageContext`’s DM gating path, and the tests exercise `createTelegramBot` end-to-end through the `message` handler to validate the new matching behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and appears to fix the intended DM allowFrom regression.
- Changes are small and scoped (DM allowFrom candidate selection and log fields) and the added tests cover the previously untested sender-id-vs-chat-id path plus a fallback scenario. I could not execute the test suite in this environment due to missing node/pnpm dependencies, so confidence is slightly reduced.
- src/telegram/bot-message-context.ts (DM allowFrom gating + pairing-request id/logging)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->