### PR TITLE
fix: drop heartbeat runs that arrive while another run is active

### DIFF
--- a/src/auto-reply/reply/agent-runner.heartbeat-typing.runreplyagent-typing-heartbeat.skips-followup-drain-for-heartbeat-runs.test.ts
+++ b/src/auto-reply/reply/agent-runner.heartbeat-typing.runreplyagent-typing-heartbeat.skips-followup-drain-for-heartbeat-runs.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { TypingMode } from "../../config/types.js";
+import type { TemplateContext } from "../templating.js";
+import type { GetReplyOptions } from "../types.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: async ({
+    provider,
+    model,
+    run,
+  }: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => ({
+    result: await run(provider, model),
+    provider,
+    model,
+  }),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+}));
+
+const enqueueFollowupRunMock = vi.fn();
+
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: (...args: unknown[]) => enqueueFollowupRunMock(...args),
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
+
+import { runReplyAgent } from "./agent-runner.js";
+
+function createMinimalRun(params?: {
+  opts?: GetReplyOptions;
+  resolvedVerboseLevel?: "off" | "on";
+  sessionStore?: Record<string, SessionEntry>;
+  sessionEntry?: SessionEntry;
+  sessionKey?: string;
+  storePath?: string;
+  typingMode?: TypingMode;
+  blockStreamingEnabled?: boolean;
+  isActive?: boolean;
+  shouldFollowup?: boolean;
+  resolvedQueueMode?: string;
+}) {
+  const typing = createMockTypingController();
+  const opts = params?.opts;
+  const sessionCtx = {
+    Provider: "whatsapp",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = {
+    mode: params?.resolvedQueueMode ?? "collect",
+  } as unknown as QueueSettings;
+  const sessionKey = params?.sessionKey ?? "main";
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey,
+      messageProvider: "whatsapp",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: params?.resolvedVerboseLevel ?? "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return {
+    typing,
+    opts,
+    run: () =>
+      runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: params?.shouldFollowup ?? true,
+        isActive: params?.isActive ?? false,
+        isStreaming: false,
+        opts,
+        typing,
+        sessionEntry: params?.sessionEntry,
+        sessionStore: params?.sessionStore,
+        sessionKey,
+        storePath: params?.storePath,
+        sessionCtx,
+        defaultModel: "anthropic/claude-opus-4-5",
+        resolvedVerboseLevel: params?.resolvedVerboseLevel ?? "off",
+        isNewSession: false,
+        blockStreamingEnabled: params?.blockStreamingEnabled ?? false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: params?.typingMode ?? "instant",
+      }),
+  };
+}
+
+describe("runReplyAgent heartbeat followup guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("drops heartbeat run when another run is active instead of enqueueing", async () => {
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: true },
+      isActive: true,
+      shouldFollowup: true,
+    });
+    const result = await run();
+
+    expect(result).toBeUndefined();
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues normal (non-heartbeat) run when another run is active", async () => {
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: false },
+      isActive: true,
+      shouldFollowup: true,
+    });
+    const result = await run();
+
+    expect(result).toBeUndefined();
+    expect(enqueueFollowupRunMock).toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("runs heartbeat normally when no other run is active", async () => {
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+      payloads: [{ text: "HEARTBEAT_OK" }],
+      meta: {},
+    }));
+
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: true },
+      isActive: false,
+      shouldFollowup: false,
+    });
+    const result = await run();
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalled();
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    // Heartbeat run completes normally and returns a payload (not dropped).
+    expect(result).toBeDefined();
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -223,6 +223,7 @@ export async function runReplyAgent(params: {
     const steered = queueEmbeddedPiMessage(followupRun.run.sessionId, followupRun.prompt);
     if (steered && !shouldFollowup) {
       await touchActiveSessionEntry();
+      typing.markRunComplete();
       typing.cleanup();
       return undefined;
     }
@@ -242,6 +243,7 @@ export async function runReplyAgent(params: {
   if (isActive && (shouldFollowup || resolvedQueue.mode === "steer")) {
     enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
     await touchActiveSessionEntry();
+    typing.markRunComplete();
     typing.cleanup();
     return undefined;
   }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -234,6 +234,7 @@ export async function runReplyAgent(params: {
   // branches delivered to the user (see #8063).  The next heartbeat interval
   // will re-check the session independently.
   if (isHeartbeat && isActive) {
+    typing.markRunComplete();
     typing.cleanup();
     return undefined;
   }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -228,6 +228,16 @@ export async function runReplyAgent(params: {
     }
   }
 
+  // Heartbeat runs arriving while another run is active are silently dropped
+  // rather than enqueued as followups.  Enqueueing a heartbeat would create a
+  // duplicate agent run when the queue drains, producing extra response
+  // branches delivered to the user (see #8063).  The next heartbeat interval
+  // will re-check the session independently.
+  if (isHeartbeat && isActive) {
+    typing.cleanup();
+    return undefined;
+  }
+
   if (isActive && (shouldFollowup || resolvedQueue.mode === "steer")) {
     enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
     await touchActiveSessionEntry();


### PR DESCRIPTION
## Summary

Fixes #8063

When a heartbeat run arrives while another agent run is already active for the same session, it was being enqueued as a followup. When the followup queue later drained, the stale heartbeat produced a duplicate agent run — sending extra response branches to the user.

This change adds an early-return guard in `runReplyAgent` that silently drops heartbeat runs when `isActive` is true, before they reach the enqueue path. The next heartbeat interval will independently re-check the session.

- Non-heartbeat runs are unaffected — they continue to enqueue normally
- The followup drain mechanism remains fully intact for legitimate queued messages
- Heartbeat runs that arrive when no other run is active execute normally

## Test plan

- [x] New test: heartbeat run is dropped (returns `undefined`, no enqueue) when `isActive: true`
- [x] New test: non-heartbeat run still enqueues when `isActive: true`  
- [x] New test: heartbeat run executes normally when `isActive: false`
- [x] All 3 new tests fail before the fix, pass after (TDD)
- [x] Existing agent-runner test suites pass (13 test files)
- [x] Existing heartbeat-runner test suites pass (43 tests)
- [x] `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a guard in `src/auto-reply/reply/agent-runner.ts` to silently drop heartbeat-triggered runs when another run is already active for the same session, preventing stale heartbeat followups from being enqueued and later producing duplicate agent runs/extra response branches (fix for #8063). It also adds a focused vitest suite that asserts: (1) heartbeat+active returns `undefined` and does not enqueue, (2) non-heartbeat+active still enqueues, and (3) heartbeat+inactive proceeds to execute normally.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (an early-return guard for a specific heartbeat+active condition) and is covered by new targeted tests that validate both the new behavior and non-regression for non-heartbeat runs. The previously reported run-completion bookkeeping gap on the early-return path is addressed in the current diff via explicit `typing.markRunComplete()` calls.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->