### PR TITLE
fix(discord): compact custom IDs + dynamic /think levels for model picker

### DIFF
--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -331,8 +331,10 @@ export function resolveCommandArgMenu(params: {
   command: ChatCommandDefinition;
   args?: CommandArgs;
   cfg?: OpenClawConfig;
+  provider?: string;
+  model?: string;
 }): { arg: CommandArgDefinition; choices: ResolvedCommandArgChoice[]; title?: string } | null {
-  const { command, args, cfg } = params;
+  const { command, args, cfg, provider, model } = params;
   if (!command.args || !command.argsMenu) {
     return null;
   }
@@ -342,7 +344,9 @@ export function resolveCommandArgMenu(params: {
   const argSpec = command.argsMenu;
   const argName =
     argSpec === "auto"
-      ? command.args.find((arg) => resolveCommandArgChoices({ command, arg, cfg }).length > 0)?.name
+      ? command.args.find(
+          (arg) => resolveCommandArgChoices({ command, arg, cfg, provider, model }).length > 0,
+        )?.name
       : argSpec.arg;
   if (!argName) {
     return null;
@@ -357,7 +361,7 @@ export function resolveCommandArgMenu(params: {
   if (!arg) {
     return null;
   }
-  const choices = resolveCommandArgChoices({ command, arg, cfg });
+  const choices = resolveCommandArgChoices({ command, arg, cfg, provider, model });
   if (choices.length === 0) {
     return null;
   }

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -6,6 +6,7 @@ export const ModelApiSchema = z.union([
   z.literal("openai-responses"),
   z.literal("anthropic-messages"),
   z.literal("google-generative-ai"),
+  z.literal("google-gemini-cli"),
   z.literal("github-copilot"),
   z.literal("bedrock-converse-stream"),
 ]);


### PR DESCRIPTION
## Summary

Fixes three issues with the Discord `/model` and `/think` slash command button pickers:

### Problem

1. **Custom IDs exceeding Discord's 100-char limit** — Long model names like `google-antigravity/claude-sonnet-4-5-thinking` produced custom IDs of 106 chars, causing Discord to reject the button components with "Unknown error at component index".

2. **`/think` always showing the same levels regardless of model** — The thinking level picker used config defaults instead of the session's current model override. Models like `openai-codex/gpt-5.3-codex` support `xhigh` but it never appeared.

3. **`resolveCommandArgMenu` had no model context** — Dynamic choice functions (like `listThinkingLevels`) received config-default provider/model instead of the session's active overrides.

### Changes

**`src/discord/monitor/native-command.ts`**
- Shortened custom ID format: `cmdarg:command=X;arg=Y;value=Z;user=U` → `ca:c=X;a=Y;v=Z;u=U` (saves ~19 chars, all IDs stay under 100)
- Parser supports both old (`command`/`arg`/`value`/`user`) and new (`c`/`a`/`v`/`u`) key formats for backward compatibility
- Added session model override lookup before menu generation: resolves agent route → loads session store → reads `providerOverride`/`modelOverride` → passes to `resolveCommandArgMenu`
- Fallback button custom ID updated to match new prefix

**`src/auto-reply/commands-registry.ts`**
- Added optional `provider`/`model` params to `resolveCommandArgMenu()`
- Threaded them through to `resolveCommandArgChoices()` so dynamic choice functions receive session context

**`src/auto-reply/commands-registry.data.ts`**
- Added `buildModelChoices()` for dynamic model picker generation from config (aliases, full keys, fallback chains)

### Testing

- `/model` (no args) → shows button picker → selecting a model applies the override correctly
- `/think` after switching to Codex 5.3 → shows `xhigh` level
- `/think` after switching to Claude/Gemini → shows standard levels (no `xhigh`)
- Custom IDs verified under 100 chars for all configured models

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves Discord `/model` and `/think` button pickers by compacting component custom IDs to stay under Discord’s 100-char limit and by plumbing session model context into `resolveCommandArgMenu` / `resolveCommandArgChoices` so dynamic choice functions can vary by active provider/model. It also adds a config-driven dynamic choice builder for the `/model` command and extends the config schema’s `ModelApiSchema` with an additional API string.

The main correctness concerns are around the new “direct model switch” fast-path and session context selection:
- The direct switch currently routes all model changes to the user’s DM session (even when the picker was invoked from a guild/channel), so it will update the wrong session for non-DM interactions.
- The session lookup used for dynamic menus may fall back to an arbitrary `:main` session key, which can generate menus for the wrong model in multi-session stores.
- Discord autocomplete still resolves dynamic choices using config defaults only, so it can offer incorrect suggestions for commands whose choices depend on the session’s overridden model (e.g. `/think`).

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to session routing/selection bugs in the Discord model switch and menu context resolution.
- While the custom ID compaction and provider/model plumbing look directionally correct, the new direct `/model` button handling deterministically targets a DM session regardless of where the interaction occurred, which will misapply overrides in guild/channel contexts. Additionally, the dynamic menu context lookup can select an unrelated `:main` session key, leading to incorrect `/think` options in some stores. These are functional issues likely to be hit in real Discord usage outside pure DMs.
- src/discord/monitor/native-command.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->