### PR TITLE
Slack: allow thread replies without mentions

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -49,6 +49,16 @@ Use the manifest below so scopes and events stay in sync.
 
 Multi-account support: use `channels.slack.accounts` with per-account tokens and optional `name`. See [`gateway/configuration`](/gateway/configuration#telegramaccounts--discordaccounts--slackaccounts--signalaccounts--imessageaccounts) for the shared pattern.
 
+### Official intake via bot mention
+
+If you want the Slack channel intake to be explicit, use bot mentions as the official entrypoint:
+
+1. Keep `requireMention: true` on the channel (default for Slack).
+2. Invite the bot to the channel.
+3. Start tasks by mentioning the bot (for example, `@OpenClaw ...`).
+
+This keeps the channel clean and makes task intake explicit. Slash commands remain optional.
+
 ### OpenClaw config (minimal)
 
 Set tokens via env vars (recommended):
@@ -464,6 +474,13 @@ For fine-grained control, use these tags in agent responses:
 
 - `[[reply_to_current]]` — reply to the triggering message (start/continue thread).
 - `[[reply_to:<id>]]` — reply to a specific message id.
+
+### Task threading policy (recommended)
+
+- For channel tasks, start the first reply in a thread using `[[reply_to_current]]`.
+- Keep subsequent task updates in the same thread.
+- For non-task discussion, reply in-channel without reply tags.
+- When a task completes, post a short thread summary with a ✅ marker.
 
 ## Sessions + routing
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -515,6 +515,7 @@ Channel options (`channels.slack.channels.<id>` or `channels.slack.channels.<nam
 
 - `allow`: allow/deny the channel when `groupPolicy="allowlist"`.
 - `requireMention`: mention gating for the channel.
+- `implicitMentionInThreads`: when `true`, thread replies bypass mention gating (top-level messages still require @mention).
 - `tools`: optional per-channel tool policy overrides (`allow`/`deny`/`alsoAllow`).
 - `toolsBySender`: optional per-sender tool policy overrides within the channel (keys are sender ids/@handles/emails; `"*"` wildcard supported).
 - `allowBots`: allow bot-authored messages in this channel (default: false).
@@ -557,6 +558,7 @@ Slack tool actions can be gated with `channels.slack.actions.*`:
 ## Notes
 
 - Mention gating is controlled via `channels.slack.channels` (set `requireMention` to `true`); `agents.list[].groupChat.mentionPatterns` (or `messages.groupChat.mentionPatterns`) also count as mentions.
+- If you need thread replies to bypass mention gating, set `channels.slack.channels.<id>.implicitMentionInThreads: true`.
 - Multi-agent override: set per-agent patterns on `agents.list[].groupChat.mentionPatterns`.
 - Reaction notifications follow `channels.slack.reactionNotifications` (use `reactionAllowlist` with mode `allowlist`).
 - Bot-authored messages are ignored by default; enable via `channels.slack.allowBots` or `channels.slack.channels.<id>.allowBots`.

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -301,6 +301,13 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
       allowTagsWhenOff: true,
       buildToolContext: (params) => buildSlackThreadingToolContext(params),
     },
+    agentPrompt: {
+      messageToolHints: () => [
+        "- Slack tasks: when a channel message becomes a task, start the reply in a thread with `[[reply_to_current]]` and keep task updates in that thread.",
+        "- Slack chats: if it is not a task, reply in-channel without reply tags.",
+        "- When finishing a task, post a short thread summary with a ✅ marker.",
+      ],
+    },
   },
   signal: {
     id: "signal",

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -31,6 +31,8 @@ export type SlackChannelConfig = {
   allow?: boolean;
   /** Require mentioning the bot to trigger replies. */
   requireMention?: boolean;
+  /** If true, thread replies bypass mention gating (channel messages still require @mention). */
+  implicitMentionInThreads?: boolean;
   /** Optional tool policy overrides for this channel. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -429,6 +429,7 @@ export const SlackChannelSchema = z
     enabled: z.boolean().optional(),
     allow: z.boolean().optional(),
     requireMention: z.boolean().optional(),
+    implicitMentionInThreads: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     allowBots: z.boolean().optional(),

--- a/src/slack/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/src/slack/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -547,6 +547,93 @@ describe("monitorSlackProvider tool results", () => {
     expect(replyMock.mock.calls[0][0].WasMentioned).toBe(true);
   });
 
+  it("does not bypass mention gating for top-level messages when implicitMentionInThreads is enabled", async () => {
+    slackTestState.config = {
+      channels: {
+        slack: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          channels: {
+            C1: { allow: true, requireMention: true, implicitMentionInThreads: true },
+          },
+        },
+      },
+    };
+
+    const controller = new AbortController();
+    const run = monitorSlackProvider({
+      botToken: "bot-token",
+      appToken: "app-token",
+      abortSignal: controller.signal,
+    });
+
+    await waitForSlackEvent("message");
+    const handler = getSlackHandlers()?.get("message");
+    if (!handler) {
+      throw new Error("Slack message handler not registered");
+    }
+
+    await handler({
+      event: {
+        type: "message",
+        user: "U1",
+        text: "top level",
+        ts: "124",
+        channel: "C1",
+        channel_type: "channel",
+      },
+    });
+
+    await flush();
+    controller.abort();
+    await run;
+
+    expect(replyMock).not.toHaveBeenCalled();
+  });
+
+  it("does not bypass mention gating for thread roots when implicitMentionInThreads is enabled", async () => {
+    slackTestState.config = {
+      channels: {
+        slack: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          channels: {
+            C1: { allow: true, requireMention: true, implicitMentionInThreads: true },
+          },
+        },
+      },
+    };
+
+    const controller = new AbortController();
+    const run = monitorSlackProvider({
+      botToken: "bot-token",
+      appToken: "app-token",
+      abortSignal: controller.signal,
+    });
+
+    await waitForSlackEvent("message");
+    const handler = getSlackHandlers()?.get("message");
+    if (!handler) {
+      throw new Error("Slack message handler not registered");
+    }
+
+    await handler({
+      event: {
+        type: "message",
+        user: "U1",
+        text: "thread root",
+        ts: "125",
+        thread_ts: "125",
+        channel: "C1",
+        channel_type: "channel",
+      },
+    });
+
+    await flush();
+    controller.abort();
+    await run;
+
+    expect(replyMock).not.toHaveBeenCalled();
+  });
+
   it("accepts channel messages without mention when channels.slack.requireMention is false", async () => {
     slackTestState.config = {
       channels: {

--- a/src/slack/monitor/channel-config.test.ts
+++ b/src/slack/monitor/channel-config.test.ts
@@ -64,4 +64,17 @@ describe("resolveSlackChannelConfig", () => {
       implicitMentionInThreads: true,
     });
   });
+
+  it("inherits implicitMentionInThreads from wildcard entries", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: { "*": { allow: true, implicitMentionInThreads: true } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({
+      implicitMentionInThreads: true,
+      matchKey: "*",
+      matchSource: "wildcard",
+    });
+  });
 });

--- a/src/slack/monitor/channel-config.test.ts
+++ b/src/slack/monitor/channel-config.test.ts
@@ -53,4 +53,15 @@ describe("resolveSlackChannelConfig", () => {
       matchSource: "direct",
     });
   });
+
+  it("resolves implicitMentionInThreads from channel config", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: { C1: { allow: true, implicitMentionInThreads: true } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({
+      implicitMentionInThreads: true,
+    });
+  });
 });

--- a/src/slack/monitor/channel-config.ts
+++ b/src/slack/monitor/channel-config.ts
@@ -11,6 +11,7 @@ import { allowListMatches, normalizeAllowListLower, normalizeSlackSlug } from ".
 export type SlackChannelConfigResolved = {
   allowed: boolean;
   requireMention: boolean;
+  implicitMentionInThreads?: boolean;
   allowBots?: boolean;
   users?: Array<string | number>;
   skills?: string[];
@@ -80,6 +81,7 @@ export function resolveSlackChannelConfig(params: {
       enabled?: boolean;
       allow?: boolean;
       requireMention?: boolean;
+      implicitMentionInThreads?: boolean;
       allowBots?: boolean;
       users?: Array<string | number>;
       skills?: string[];
@@ -121,6 +123,10 @@ export function resolveSlackChannelConfig(params: {
   const requireMention =
     firstDefined(resolved.requireMention, fallback?.requireMention, requireMentionDefault) ??
     requireMentionDefault;
+  const implicitMentionInThreads = firstDefined(
+    resolved.implicitMentionInThreads,
+    fallback?.implicitMentionInThreads,
+  );
   const allowBots = firstDefined(resolved.allowBots, fallback?.allowBots);
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);
@@ -128,6 +134,7 @@ export function resolveSlackChannelConfig(params: {
   const result: SlackChannelConfigResolved = {
     allowed,
     requireMention,
+    implicitMentionInThreads,
     allowBots,
     users,
     skills,

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -76,6 +76,7 @@ export type SlackMonitorContext = {
       enabled?: boolean;
       allow?: boolean;
       requireMention?: boolean;
+      implicitMentionInThreads?: boolean;
       allowBots?: boolean;
       users?: Array<string | number>;
       skills?: string[];

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -223,11 +223,11 @@ export async function prepareSlackMessage(params: {
           canResolveExplicit: Boolean(ctx.botUserId),
         },
       }));
+  const threadReplyImplicit = Boolean(channelConfig?.implicitMentionInThreads && isThreadReply);
   const implicitMention = Boolean(
     !isDirectMessage &&
-    ctx.botUserId &&
     message.thread_ts &&
-    message.parent_user_id === ctx.botUserId,
+    (threadReplyImplicit || (ctx.botUserId && message.parent_user_id === ctx.botUserId)),
   );
 
   const sender = message.user ? await ctx.resolveUserName(message.user) : null;


### PR DESCRIPTION
## Summary
- add `implicitMentionInThreads` per-channel Slack config to allow thread replies without @mentions
- treat thread replies as implicit mentions when the flag is enabled
- cover with tests and document the new flag

## Testing
- OPENCLAW_STATE_DIR=$(mktemp -d) pnpm vitest run src/slack/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts src/slack/monitor/channel-config.test.ts src/hooks/loader.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new per-channel Slack configuration flag (`implicitMentionInThreads`) and threads it through the config types + zod schema. In Slack message preparation, thread replies can now be treated as an implicit mention when the flag is enabled, allowing mention-gated channels to accept follow-ups inside threads without requiring repeated `@bot` mentions. Tests and Slack docs were updated accordingly, and Slack-specific agent prompt hints were added to encourage threaded task updates.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge once the mention-bypass semantics are clarified/guarded.
- Changes are small, well-scoped, and covered by tests, but the new bypass can make threaded replies count as mentions even in scenarios where bot identity/mention detection may be unavailable, which can unintentionally weaken mention gating for some deployments.
- src/slack/monitor/message-handler/prepare.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->