### PR TITLE
fix(mattermost): preserve Markdown formatting + native tables

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMention } from "./monitor-helpers.js";
+
+describe("normalizeMention", () => {
+  it("returns trimmed text when no mention provided", () => {
+    expect(normalizeMention("  hello world  ", undefined)).toBe("hello world");
+  });
+
+  it("strips bot mention from text", () => {
+    expect(normalizeMention("@echobot hello", "echobot")).toBe("hello");
+  });
+
+  it("strips mention case-insensitively", () => {
+    expect(normalizeMention("@EchoBot hello", "echobot")).toBe("hello");
+  });
+
+  it("preserves newlines in multi-line messages", () => {
+    const input = "@echobot\nline1\nline2\nline3";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toBe("line1\nline2\nline3");
+  });
+
+  it("preserves Markdown headings", () => {
+    const input = "@echobot\n# Heading\n\nSome text";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("# Heading");
+    expect(result).toContain("\n");
+  });
+
+  it("preserves Markdown blockquotes", () => {
+    const input = "@echobot\n> quoted line\n> second line";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("> quoted line");
+    expect(result).toContain("> second line");
+  });
+
+  it("preserves Markdown lists", () => {
+    const input = "@echobot\n- item A\n- item B\n  - sub B1";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("- item A");
+    expect(result).toContain("- item B");
+  });
+
+  it("preserves task lists", () => {
+    const input = "@echobot\n- [ ] todo\n- [x] done";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("- [ ] todo");
+    expect(result).toContain("- [x] done");
+  });
+
+  it("handles mention in middle of text", () => {
+    const input = "hey @echobot check this\nout";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toBe("hey check this\nout");
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -164,3 +164,22 @@ export function resolveThreadSessionKeys(params: {
     : params.baseSessionKey;
   return { sessionKey, parentSessionKey: params.parentSessionKey };
 }
+
+/**
+ * Strip bot mention from message text while preserving newlines and
+ * block-level Markdown formatting (headings, lists, blockquotes).
+ */
+export function normalizeMention(text: string, mention: string | undefined): string {
+  if (!mention) {
+    return text.trim();
+  }
+  const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`@${escaped}\\b`, "gi");
+  // Replace the mention itself, then collapse only horizontal whitespace (spaces/tabs)
+  // to preserve newlines and block-level Markdown formatting.
+  return text
+    .replace(re, " ")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ ?\n ?/g, "\n")
+    .trim();
+}

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -35,6 +35,7 @@ import {
 import {
   createDedupeCache,
   formatInboundFromLabel,
+  normalizeMention,
   rawDataToString,
   resolveThreadSessionKeys,
 } from "./monitor-helpers.js";
@@ -92,15 +93,6 @@ function resolveRuntime(opts: MonitorMattermostOpts): RuntimeEnv {
       },
     }
   );
-}
-
-function normalizeMention(text: string, mention: string | undefined): string {
-  if (!mention) {
-    return text.trim();
-  }
-  const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(`@${escaped}\\b`, "gi");
-  return text.replace(re, " ").replace(/\s+/g, " ").trim();
 }
 
 function resolveOncharPrefixes(prefixes: string[] | undefined): string[] {

--- a/src/config/markdown-tables.test.ts
+++ b/src/config/markdown-tables.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+// We test the DEFAULT_TABLE_MODES map indirectly.
+// resolveMarkdownTableMode requires the plugin registry (normalizeChannelId),
+// so we import the module and verify the map entries are correct.
+
+describe("DEFAULT_TABLE_MODES (mattermost)", () => {
+  it("mattermost entry is present in source", async () => {
+    // Read the source to verify the entry exists — the runtime function
+    // requires plugin registry initialization which is heavy for unit tests.
+    const fs = await import("node:fs");
+    const src = fs.readFileSync(
+      new URL("./markdown-tables.ts", import.meta.url).pathname.replace(
+        "markdown-tables.test.ts",
+        "markdown-tables.ts",
+      ),
+      "utf-8",
+    );
+    expect(src).toContain('["mattermost", "off"]');
+  });
+
+  it("signal and whatsapp entries are preserved", async () => {
+    const fs = await import("node:fs");
+    const src = fs.readFileSync(
+      new URL("./markdown-tables.ts", import.meta.url).pathname.replace(
+        "markdown-tables.test.ts",
+        "markdown-tables.ts",
+      ),
+      "utf-8",
+    );
+    expect(src).toContain('["signal", "bullets"]');
+    expect(src).toContain('["whatsapp", "bullets"]');
+  });
+});

--- a/src/config/markdown-tables.ts
+++ b/src/config/markdown-tables.ts
@@ -16,6 +16,7 @@ type MarkdownConfigSection = MarkdownConfigEntry & {
 const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
   ["signal", "bullets"],
   ["whatsapp", "bullets"],
+  ["mattermost", "off"],
 ]);
 
 const isMarkdownTableMode = (value: unknown): value is MarkdownTableMode =>


### PR DESCRIPTION
Fixes three related Mattermost Markdown issues:

- Inbound mention normalization collapsed newlines (used /\s+/), flattening block-level Markdown.
- Mattermost table mode defaulted to "code", wrapping pipe tables in fenced code blocks.
- When tableMode="code" and a message had tables, the whole message was re-rendered through the IR pipeline, degrading non-table block formatting.

Changes:
- Preserve newlines in mention stripping (collapse only horizontal whitespace).
- Default mattermost markdown.tables to "off" (Mattermost supports native tables).
- Extract normalizeMention to monitor-helpers for testability.
- Add unit tests.

Fixes #12247 #12245 #12238

Tests:
- pnpm vitest run extensions/mattermost/

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Mattermost Markdown handling by extracting `normalizeMention()` into `monitor-helpers.ts` and changing it to preserve newlines/block-level formatting (collapse horizontal whitespace only). It also changes the default Markdown table mode for the Mattermost channel to `off` (native tables), and adds unit tests for mention normalization plus a config regression test around the default table mode.

The changes integrate into the existing inbound Mattermost monitor (`extensions/mattermost/src/mattermost/monitor.ts`) by applying the new `normalizeMention()` to inbound message bodies before building the reply context, and into the shared config resolver (`src/config/markdown-tables.ts`) by updating channel defaults for table conversion.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a couple correctness/testing issues that should be addressed first.
- Core logic changes are small and well-scoped, but `normalizeMention()` can fail to strip mentions if the configured bot username includes a leading '@'/extra whitespace, and the new markdown-tables test is brittle because it asserts against raw source text instead of behavior. CI also can’t be validated locally here due to missing pnpm in the environment.
- extensions/mattermost/src/mattermost/monitor-helpers.ts, src/config/markdown-tables.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->