### PR TITLE
fix(daemon): use wrapper script for pnpm global installs in service config

### DIFF
--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -5,13 +5,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const fsMocks = vi.hoisted(() => ({
   access: vi.fn(),
   realpath: vi.fn(),
-  constants: { X_OK: 1 },
 }));
 
 vi.mock("node:fs/promises", () => ({
-  default: { access: fsMocks.access, realpath: fsMocks.realpath, constants: { X_OK: 1 } },
+  default: { access: fsMocks.access, realpath: fsMocks.realpath },
   access: fsMocks.access,
   realpath: fsMocks.realpath,
+}));
+
+vi.mock("node:fs", () => ({
   constants: { X_OK: 1 },
 }));
 

--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -1,15 +1,18 @@
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const fsMocks = vi.hoisted(() => ({
   access: vi.fn(),
   realpath: vi.fn(),
+  constants: { X_OK: 1 },
 }));
 
 vi.mock("node:fs/promises", () => ({
-  default: { access: fsMocks.access, realpath: fsMocks.realpath },
+  default: { access: fsMocks.access, realpath: fsMocks.realpath, constants: { X_OK: 1 } },
   access: fsMocks.access,
   realpath: fsMocks.realpath,
+  constants: { X_OK: 1 },
 }));
 
 import { resolveGatewayProgramArguments } from "./program-args.js";
@@ -86,5 +89,53 @@ describe("resolveGatewayProgramArguments", () => {
       "--port",
       "18789",
     ]);
+  });
+
+  it("prefers wrapper script over pnpm global store path for stable service config", async () => {
+    // Simulates pnpm global install where the CLI runs directly from the store path
+    // (not via symlink). The wrapper script at ~/.local/bin/openclaw should be preferred
+    // because pnpm regenerates it automatically during updates.
+    const home = os.homedir();
+    const pnpmStorePath = path.resolve(
+      `${home}/.local/share/pnpm/5/.pnpm/openclaw@2026.2.6-3_abc123/node_modules/openclaw/openclaw.mjs`,
+    );
+    const wrapperPath = path.resolve(`${home}/.local/bin/openclaw`);
+    process.argv = ["node", pnpmStorePath];
+    fsMocks.realpath.mockResolvedValue(pnpmStorePath);
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === pnpmStorePath || target === wrapperPath) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const result = await resolveGatewayProgramArguments({ port: 18789 });
+
+    // Should use the wrapper script, not the versioned pnpm store path
+    expect(result.programArguments[1]).toBe(wrapperPath);
+    expect(result.programArguments[1]).not.toContain(".pnpm");
+    expect(result.programArguments[1]).not.toContain("@2026.2.6-3");
+  });
+
+  it("falls back to pnpm store dist path when wrapper is not found", async () => {
+    // If the wrapper script doesn't exist, fall back to the store path
+    const home = os.homedir();
+    const pnpmStoreDistPath = path.resolve(
+      `${home}/.local/share/pnpm/5/.pnpm/openclaw@2026.2.6-3_abc123/node_modules/openclaw/dist/entry.mjs`,
+    );
+    process.argv = ["node", pnpmStoreDistPath];
+    fsMocks.realpath.mockResolvedValue(pnpmStoreDistPath);
+    fsMocks.access.mockImplementation(async (target: string) => {
+      // Only the store dist path exists, wrapper is missing
+      if (target === pnpmStoreDistPath) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const result = await resolveGatewayProgramArguments({ port: 18789 });
+
+    // Should fall back to the store path since wrapper doesn't exist
+    expect(result.programArguments[1]).toBe(pnpmStoreDistPath);
   });
 });

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -54,7 +55,7 @@ async function resolvePnpmGlobalWrapperPath(cliName: string): Promise<string | n
 
   for (const candidate of candidates) {
     try {
-      await fs.access(candidate, fs.constants.X_OK);
+      await fs.access(candidate, fsConstants.X_OK);
       return candidate;
     } catch {
       // Try next candidate
@@ -77,7 +78,8 @@ async function resolveCliEntrypointPathForService(): Promise<string> {
   // while the store path contains version-specific directories that break after updates.
   if (isPnpmGlobalStorePath(resolvedPath)) {
     // Extract CLI name from the path (e.g., "openclaw" from ".../openclaw/openclaw.mjs")
-    const pathParts = resolvedPath.split(path.sep);
+    // Split on both / and \ to handle mixed separators (common in pnpm paths on Windows)
+    const pathParts = resolvedPath.split(/[/\\]/);
     const nodeModulesIdx = pathParts.lastIndexOf("node_modules");
     const cliName =
       nodeModulesIdx >= 0 && nodeModulesIdx < pathParts.length - 1

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 type GatewayProgramArgs = {
@@ -18,6 +19,50 @@ function isBunRuntime(execPath: string): boolean {
   return base === "bun" || base === "bun.exe";
 }
 
+/**
+ * Detect if a path is inside a pnpm global store (version-specific directory).
+ * These paths break after pnpm updates because the version hash changes.
+ */
+function isPnpmGlobalStorePath(inputPath: string): boolean {
+  const normalized = inputPath.replaceAll("\\", "/");
+  // Match patterns like:
+  // - ~/.local/share/pnpm/5/.pnpm/openclaw@X.Y.Z.../
+  // - /home/user/.local/share/pnpm/.../.pnpm/...
+  return (
+    normalized.includes("/.pnpm/") &&
+    (normalized.includes("/.local/share/pnpm/") || normalized.includes("/pnpm/5/"))
+  );
+}
+
+/**
+ * Try to find the CLI wrapper script that pnpm creates for global installs.
+ * The wrapper is stable across updates (pnpm regenerates it with new paths).
+ */
+async function resolvePnpmGlobalWrapperPath(cliName: string): Promise<string | null> {
+  const home = os.homedir();
+  const candidates =
+    process.platform === "win32"
+      ? [
+          path.join(home, "AppData", "Local", "pnpm", `${cliName}.cmd`),
+          path.join(home, "AppData", "Local", "pnpm", `${cliName}.ps1`),
+        ]
+      : [
+          path.join(home, ".local", "bin", cliName),
+          path.join(home, ".local", "share", "pnpm", cliName),
+          `/usr/local/bin/${cliName}`,
+        ];
+
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Try next candidate
+    }
+  }
+  return null;
+}
+
 async function resolveCliEntrypointPathForService(): Promise<string> {
   const argv1 = process.argv[1];
   if (!argv1) {
@@ -26,6 +71,26 @@ async function resolveCliEntrypointPathForService(): Promise<string> {
 
   const normalized = path.resolve(argv1);
   const resolvedPath = await resolveRealpathSafe(normalized);
+
+  // For pnpm global installs, prefer the wrapper script over the versioned store path.
+  // The wrapper is stable across updates (pnpm regenerates it automatically),
+  // while the store path contains version-specific directories that break after updates.
+  if (isPnpmGlobalStorePath(resolvedPath)) {
+    // Extract CLI name from the path (e.g., "openclaw" from ".../openclaw/openclaw.mjs")
+    const pathParts = resolvedPath.split(path.sep);
+    const nodeModulesIdx = pathParts.lastIndexOf("node_modules");
+    const cliName =
+      nodeModulesIdx >= 0 && nodeModulesIdx < pathParts.length - 1
+        ? pathParts[nodeModulesIdx + 1]
+        : "openclaw";
+
+    const wrapperPath = await resolvePnpmGlobalWrapperPath(cliName);
+    if (wrapperPath) {
+      return wrapperPath;
+    }
+    // Fall through to existing logic if wrapper not found
+  }
+
   const looksLikeDist = /[/\\]dist[/\\].+\.(cjs|js|mjs)$/.test(resolvedPath);
   if (looksLikeDist) {
     await fs.access(resolvedPath);

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -13,6 +13,8 @@ const VERSION_MANAGER_MARKERS = [
   "/.nodenv/",
   "/.nodebrew/",
   "/nvs/",
+  // pnpm global store paths contain version-specific hashes that break after updates
+  "/.pnpm/",
 ];
 
 function getPathModule(platform: NodeJS.Platform) {


### PR DESCRIPTION
## Summary

When installing the gateway service via `openclaw gateway install` from a pnpm global install, the CLI was writing the full pnpm store path into the systemd/launchd service config:

```
ExecStart="/home/user/.local/share/pnpm/5/.pnpm/openclaw@2026.2.6-3_abc123.../node_modules/openclaw/openclaw.mjs" gateway --port 18789
```

This path contains version-specific directories (including a content hash) that change with every pnpm update. After running `pnpm add -g openclaw@latest`, the old path no longer exists, and the service fails to start.

## Problem

PR #1505 attempted to fix this by preferring symlinked paths over realpath-resolved paths. However, this doesn't help pnpm global installs because:

1. The wrapper script at `~/.local/bin/openclaw` runs `exec node /full/pnpm/store/path/openclaw.mjs`
2. `process.argv[1]` is already the full versioned path (no symlink involved)
3. `normalized === resolvedPath`, so the symlink preservation logic doesn't trigger

## Solution

1. **Detect pnpm global store paths** - Check if the path contains `/.pnpm/` combined with `/.local/share/pnpm/`
2. **Prefer the wrapper script** - Look for the CLI wrapper at `~/.local/bin/openclaw` (or platform-specific equivalents)
3. **Fall back gracefully** - If the wrapper isn't found, use the original path

The wrapper script is the correct choice because pnpm automatically regenerates it with updated paths during package updates.

## Changes

- `src/daemon/program-args.ts`: Add `isPnpmGlobalStorePath()` and `resolvePnpmGlobalWrapperPath()` functions
- `src/daemon/runtime-paths.ts`: Add `/.pnpm/` to `VERSION_MANAGER_MARKERS` so doctor can warn about it
- `src/daemon/program-args.test.ts`: Add test coverage for pnpm global path detection

## Test plan

- [x] All existing tests pass
- [x] New tests for pnpm global path detection
- [x] Lint passes

## Related

- PR #1505 - Original symlink preservation fix (works for local pnpm installs, not global)
- Issue #6318 - Windows npm upgrade path fragility (similar problem domain)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates daemon service argument resolution to avoid embedding pnpm global store paths (which include version/hash segments) into systemd/launchd configs. It adds pnpm-store path detection, attempts to prefer the pnpm-generated wrapper script for global installs, and expands `VERSION_MANAGER_MARKERS` so doctor can warn on `/.pnpm/` paths. Tests were added to cover wrapper preference and fallback behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a likely runtime crash and a Windows-specific parsing bug to address before merge.
- The overall approach is reasonable and covered by new tests, but `fs.constants.X_OK` is used off `node:fs/promises` (likely undefined at runtime), and Windows path parsing for extracting the CLI name is unreliable when the path contains `/` separators; both can break wrapper resolution in real installs.
- src/daemon/program-args.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->