### PR TITLE
docs(subagents): clarify allowAgents is per-agent only

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -156,6 +156,7 @@ Parameters:
 Allowlist:
 
 - `agents.list[].subagents.allowAgents`: list of agent ids allowed via `agentId` (`["*"]` to allow any). Default: only the requester agent.
+- `allowAgents` is per-agent and is **not supported** under `agents.defaults.subagents`.
 
 Discovery:
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -206,6 +206,12 @@ By default, sub-agents can only spawn under their own agent id. To allow an agen
 }
 ```
 
+<Note>
+`allowAgents` is **per-agent only** and belongs under `agents.list[].subagents`.
+
+`agents.defaults.subagents` supports defaults like `model`, `thinking`, `maxConcurrent`, and `archiveAfterMinutes`, but **does not** accept `allowAgents`.
+</Note>
+
 <Tip>
 Use the `agents_list` tool to discover which agent ids are currently allowed for `sessions_spawn`.
 </Tip>


### PR DESCRIPTION
## Summary
Clarifies that `allowAgents` is a per-agent setting and is not supported under `agents.defaults.subagents`.

## What changed
- Added a note in `docs/tools/subagents.md` under Cross-Agent Spawning:
  - `allowAgents` belongs under `agents.list[].subagents`
  - `agents.defaults.subagents` does not accept `allowAgents`
- Added the same clarification in `docs/concepts/session-tool.md` in the `sessions_spawn` allowlist section.

## Why
Users naturally place `allowAgents` under `agents.defaults.subagents` (because other subagent defaults live there), which causes config validation errors. This makes the docs explicit at the two places users check first.

Closes #11982

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Docs-only PR clarifying that `allowAgents` is configured per-agent under `agents.list[].subagents`, and is not a valid key under `agents.defaults.subagents`. The same clarification is added in the `sessions_spawn` allowlist section of the Session Tools doc and as a note under the Sub-Agents tool “Cross-Agent Spawning” section to prevent common config validation errors when users place `allowAgents` in the global defaults block.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it only adds clear, consistent documentation notes.
- Changes are limited to two docs files and accurately describe existing config semantics (per-agent `allowAgents` vs global `agents.defaults.subagents`). No behavioral or code changes, and the added notes are consistent with the surrounding sections and examples.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->

## Contributing checklist
- [x] AI-assisted: yes (prepared with OpenClaw assistant, model: `openai-codex/gpt-5.3-codex`)
- [x] Testing level: lightly tested (docs-only change; link/build/test not run for this docs PR)
- [x] Confirmed understanding of change and impact

