### PR TITLE
fix(mattermost): preserve Markdown formatting + native tables

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -53,4 +53,18 @@ describe("normalizeMention", () => {
     const result = normalizeMention(input, "echobot");
     expect(result).toBe("hey check this\nout");
   });
+
+  it("preserves leading indentation for nested lists", () => {
+    const input = "@echobot\n- item\n  - nested\n    - deep";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("  - nested");
+    expect(result).toContain("    - deep");
+  });
+
+  it("preserves indented code blocks", () => {
+    const input = "@echobot\ntext\n    code line 1\n    code line 2";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("    code line 1");
+    expect(result).toContain("    code line 2");
+  });
 });

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMention } from "./monitor-helpers.js";
+
+describe("normalizeMention", () => {
+  it("returns trimmed text when no mention provided", () => {
+    expect(normalizeMention("  hello world  ", undefined)).toBe("hello world");
+  });
+
+  it("strips bot mention from text", () => {
+    expect(normalizeMention("@echobot hello", "echobot")).toBe("hello");
+  });
+
+  it("strips mention case-insensitively", () => {
+    expect(normalizeMention("@EchoBot hello", "echobot")).toBe("hello");
+  });
+
+  it("preserves newlines in multi-line messages", () => {
+    const input = "@echobot\nline1\nline2\nline3";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toBe("line1\nline2\nline3");
+  });
+
+  it("preserves Markdown headings", () => {
+    const input = "@echobot\n# Heading\n\nSome text";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("# Heading");
+    expect(result).toContain("\n");
+  });
+
+  it("preserves Markdown blockquotes", () => {
+    const input = "@echobot\n> quoted line\n> second line";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("> quoted line");
+    expect(result).toContain("> second line");
+  });
+
+  it("preserves Markdown lists", () => {
+    const input = "@echobot\n- item A\n- item B\n  - sub B1";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("- item A");
+    expect(result).toContain("- item B");
+  });
+
+  it("preserves task lists", () => {
+    const input = "@echobot\n- [ ] todo\n- [x] done";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toContain("- [ ] todo");
+    expect(result).toContain("- [x] done");
+  });
+
+  it("handles mention in middle of text", () => {
+    const input = "hey @echobot check this\nout";
+    const result = normalizeMention(input, "echobot");
+    expect(result).toBe("hey check this\nout");
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -175,11 +175,15 @@ export function normalizeMention(text: string, mention: string | undefined): str
   }
   const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(`@${escaped}\\b`, "gi");
-  // Replace the mention itself, then collapse only horizontal whitespace (spaces/tabs)
-  // to preserve newlines and block-level Markdown formatting.
+  // Replace the mention itself, then clean up without destroying Markdown structure.
+  // 1. Remove the mention (replace with empty to avoid injecting spaces into indentation)
+  // 2. Collapse only runs of multiple spaces/tabs within a line (preserving leading indent)
+  // 3. Trim blank lines left by mention removal
   return text
-    .replace(re, " ")
-    .replace(/[^\S\n]+/g, " ")
-    .replace(/ ?\n ?/g, "\n")
+    .replace(re, "")
+    .split("\n")
+    .map((line) => line.replace(/(\S) {2,}/g, "$1 "))
+    .join("\n")
+    .replace(/^\s*\n/, "")
     .trim();
 }

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -164,3 +164,22 @@ export function resolveThreadSessionKeys(params: {
     : params.baseSessionKey;
   return { sessionKey, parentSessionKey: params.parentSessionKey };
 }
+
+/**
+ * Strip bot mention from message text while preserving newlines and
+ * block-level Markdown formatting (headings, lists, blockquotes).
+ */
+export function normalizeMention(text: string, mention: string | undefined): string {
+  if (!mention) {
+    return text.trim();
+  }
+  const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`@${escaped}\\b`, "gi");
+  // Replace the mention itself, then collapse only horizontal whitespace (spaces/tabs)
+  // to preserve newlines and block-level Markdown formatting.
+  return text
+    .replace(re, " ")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ ?\n ?/g, "\n")
+    .trim();
+}

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -35,6 +35,7 @@ import {
 import {
   createDedupeCache,
   formatInboundFromLabel,
+  normalizeMention,
   rawDataToString,
   resolveThreadSessionKeys,
 } from "./monitor-helpers.js";
@@ -92,15 +93,6 @@ function resolveRuntime(opts: MonitorMattermostOpts): RuntimeEnv {
       },
     }
   );
-}
-
-function normalizeMention(text: string, mention: string | undefined): string {
-  if (!mention) {
-    return text.trim();
-  }
-  const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(`@${escaped}\\b`, "gi");
-  return text.replace(re, " ").replace(/\s+/g, " ").trim();
 }
 
 function resolveOncharPrefixes(prefixes: string[] | undefined): string[] {

--- a/src/config/markdown-tables.test.ts
+++ b/src/config/markdown-tables.test.ts
@@ -1,34 +1,16 @@
 import { describe, expect, it } from "vitest";
+import { DEFAULT_TABLE_MODES } from "./markdown-tables.js";
 
-// We test the DEFAULT_TABLE_MODES map indirectly.
-// resolveMarkdownTableMode requires the plugin registry (normalizeChannelId),
-// so we import the module and verify the map entries are correct.
-
-describe("DEFAULT_TABLE_MODES (mattermost)", () => {
-  it("mattermost entry is present in source", async () => {
-    // Read the source to verify the entry exists — the runtime function
-    // requires plugin registry initialization which is heavy for unit tests.
-    const fs = await import("node:fs");
-    const src = fs.readFileSync(
-      new URL("./markdown-tables.ts", import.meta.url).pathname.replace(
-        "markdown-tables.test.ts",
-        "markdown-tables.ts",
-      ),
-      "utf-8",
-    );
-    expect(src).toContain('["mattermost", "off"]');
+describe("DEFAULT_TABLE_MODES", () => {
+  it("mattermost mode is off", () => {
+    expect(DEFAULT_TABLE_MODES.get("mattermost")).toBe("off");
   });
 
-  it("signal and whatsapp entries are preserved", async () => {
-    const fs = await import("node:fs");
-    const src = fs.readFileSync(
-      new URL("./markdown-tables.ts", import.meta.url).pathname.replace(
-        "markdown-tables.test.ts",
-        "markdown-tables.ts",
-      ),
-      "utf-8",
-    );
-    expect(src).toContain('["signal", "bullets"]');
-    expect(src).toContain('["whatsapp", "bullets"]');
+  it("signal mode is bullets", () => {
+    expect(DEFAULT_TABLE_MODES.get("signal")).toBe("bullets");
+  });
+
+  it("whatsapp mode is bullets", () => {
+    expect(DEFAULT_TABLE_MODES.get("whatsapp")).toBe("bullets");
   });
 });

--- a/src/config/markdown-tables.test.ts
+++ b/src/config/markdown-tables.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+// We test the DEFAULT_TABLE_MODES map indirectly.
+// resolveMarkdownTableMode requires the plugin registry (normalizeChannelId),
+// so we import the module and verify the map entries are correct.
+
+describe("DEFAULT_TABLE_MODES (mattermost)", () => {
+  it("mattermost entry is present in source", async () => {
+    // Read the source to verify the entry exists — the runtime function
+    // requires plugin registry initialization which is heavy for unit tests.
+    const fs = await import("node:fs");
+    const src = fs.readFileSync(
+      new URL("./markdown-tables.ts", import.meta.url).pathname.replace(
+        "markdown-tables.test.ts",
+        "markdown-tables.ts",
+      ),
+      "utf-8",
+    );
+    expect(src).toContain('["mattermost", "off"]');
+  });
+
+  it("signal and whatsapp entries are preserved", async () => {
+    const fs = await import("node:fs");
+    const src = fs.readFileSync(
+      new URL("./markdown-tables.ts", import.meta.url).pathname.replace(
+        "markdown-tables.test.ts",
+        "markdown-tables.ts",
+      ),
+      "utf-8",
+    );
+    expect(src).toContain('["signal", "bullets"]');
+    expect(src).toContain('["whatsapp", "bullets"]');
+  });
+});

--- a/src/config/markdown-tables.ts
+++ b/src/config/markdown-tables.ts
@@ -16,6 +16,7 @@ type MarkdownConfigSection = MarkdownConfigEntry & {
 const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
   ["signal", "bullets"],
   ["whatsapp", "bullets"],
+  ["mattermost", "off"],
 ]);
 
 const isMarkdownTableMode = (value: unknown): value is MarkdownTableMode =>

--- a/src/config/markdown-tables.ts
+++ b/src/config/markdown-tables.ts
@@ -13,7 +13,7 @@ type MarkdownConfigSection = MarkdownConfigEntry & {
   accounts?: Record<string, MarkdownConfigEntry>;
 };
 
-const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
+export const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
   ["signal", "bullets"],
   ["whatsapp", "bullets"],
   ["mattermost", "off"],


### PR DESCRIPTION
Fixes three related Mattermost Markdown issues:

- **Inbound Markdown block structure degraded (mentions + whitespace):** `normalizeMention()` used `/\s+/g` replacement which collapsed newlines into spaces, destroying block-level Markdown in inbound messages. Fixed with a line-by-line approach that preserves newlines and leading indentation.

- **Tables wrapped in code blocks (#12238):** `DEFAULT_TABLE_MODES` did not include mattermost, so it fell through to `"code"`. Mattermost clients render pipe tables natively, so the correct default is `"off"`.

- **Block formatting degraded (#12245):** When `tableMode="code"` and a message contained tables, the entire text was re-rendered through the IR pipeline which also stripped headings/blockquotes/lists from non-table content.

### Changes
- Preserve newlines and leading indentation in mention stripping (line-by-line collapse)
- Default mattermost `markdown.tables` to `"off"` (native table support)
- Extract `normalizeMention` to `monitor-helpers.ts` for testability
- Add unit tests for `normalizeMention` + table mode defaults

### Tests
```
pnpm vitest run extensions/mattermost/
# 2 files, 16 tests passed
```

Fixes #12245 #12238

Note: #12247 was closed as **not a bug**; inbound newlines are preserved. The confusion came from a system-event preview string that flattens whitespace via `/\s+/g` (see #12850 for the feature request to optionally preserve newlines in previews).