### PR TITLE
fix: align extension tests and fetch typing for gate stability

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -83,6 +83,7 @@ vi.mock("@opentelemetry/sdk-trace-base", () => ({
 }));
 
 vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: vi.fn((attrs: Record<string, unknown>) => attrs),
   Resource: class {
     // eslint-disable-next-line @typescript-eslint/no-useless-constructor
     constructor(_value?: unknown) {}

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -50,7 +50,7 @@ export type MonitorMattermostOpts = {
   statusSink?: (patch: Partial<ChannelAccountSnapshot>) => void;
 };
 
-type FetchLike = typeof fetch;
+type FetchLike = (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>;
 type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
 type MattermostEventPayload = {

--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -36,7 +36,7 @@ vi.mock("./utils/twitch.js", () => ({
 describe("outbound", () => {
   const mockAccount = {
     username: "testbot",
-    token: "oauth:test123",
+    accessToken: "oauth:test123",
     clientId: "test-client-id",
     channel: "#testchannel",
   };
@@ -196,7 +196,14 @@ describe("outbound", () => {
 
       expect(result.channel).toBe("twitch");
       expect(result.messageId).toBe("twitch-msg-123");
-      expect(result.to).toBe("testchannel");
+      expect(sendMessageTwitchInternal).toHaveBeenCalledWith(
+        "testchannel",
+        "Hello Twitch!",
+        mockConfig,
+        "default",
+        true,
+        console,
+      );
       expect(result.timestamp).toBeGreaterThan(0);
     });
 

--- a/extensions/twitch/src/probe.test.ts
+++ b/extensions/twitch/src/probe.test.ts
@@ -54,7 +54,8 @@ vi.mock("@twurple/auth", () => ({
 describe("probeTwitch", () => {
   const mockAccount: TwitchAccountConfig = {
     username: "testbot",
-    token: "oauth:test123456789",
+    accessToken: "oauth:test123456789",
+    clientId: "test-client-id",
     channel: "testchannel",
   };
 
@@ -74,7 +75,7 @@ describe("probeTwitch", () => {
   });
 
   it("returns error when token is missing", async () => {
-    const account = { ...mockAccount, token: "" };
+    const account = { ...mockAccount, accessToken: "" };
     const result = await probeTwitch(account, 5000);
 
     expect(result.ok).toBe(false);
@@ -84,7 +85,7 @@ describe("probeTwitch", () => {
   it("attempts connection regardless of token prefix", async () => {
     // Note: probeTwitch doesn't validate token format - it tries to connect with whatever token is provided
     // The actual connection would fail in production with an invalid token
-    const account = { ...mockAccount, token: "raw_token_no_prefix" };
+    const account = { ...mockAccount, accessToken: "raw_token_no_prefix" };
     const result = await probeTwitch(account, 5000);
 
     // With mock, connection succeeds even without oauth: prefix
@@ -166,7 +167,7 @@ describe("probeTwitch", () => {
   it("trims token before validation", async () => {
     const account: TwitchAccountConfig = {
       ...mockAccount,
-      token: "  oauth:test123456789  ",
+      accessToken: "  oauth:test123456789  ",
     };
 
     const result = await probeTwitch(account, 5000);


### PR DESCRIPTION
## Summary
- split out unrelated extension gate-fix changes from #12795 into a dedicated branch
- add missing `resourceFromAttributes` in the diagnostics OTel test mock
- align Mattermost fetch typing and Twitch tests with current account field names and outbound behavior

## Testing
- pnpm exec vitest run extensions/diagnostics-otel/src/service.test.ts extensions/twitch/src/outbound.test.ts extensions/twitch/src/probe.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates a few extensions to keep tests/types aligned with recent API/config changes:

- `extensions/diagnostics-otel`: extends the OpenTelemetry resources mock to include `resourceFromAttributes` so the service test can run against the current OTel SDK surface.
- `extensions/twitch`: updates test fixtures and assertions to use the current Twitch account field names (`accessToken`/`clientId`) and to assert the outbound path calls `sendMessageTwitchInternal` with the expected normalized channel and options.
- `extensions/mattermost`: changes the local `FetchLike` type to a custom fetch signature for use when downloading remote media.

The changes are isolated to extension tests plus a small type alias adjustment in the Mattermost monitor implementation.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there is a type-definition issue that can break builds in some TS/lib.dom configurations.
- Most changes are test-only alignment and a harmless OTel mock addition. The only production-code change is the `FetchLike` typedef in the Mattermost monitor; narrowing it away from `typeof fetch` can create type incompatibilities depending on how `fetchRemoteMedia` is typed and the configured DOM lib overloads.
- extensions/mattermost/src/mattermost/monitor.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->