### PR TITLE
docs(hooks): document plugin hook names and clarify naming

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -246,15 +246,21 @@ These hooks are not event-stream listeners; they let plugins synchronously adjus
 
 - **`tool_result_persist`**: transform tool results before they are written to the session transcript. Must be synchronous; return the updated tool result payload or `undefined` to keep it as-is. See [Agent Loop](/concepts/agent-loop).
 
-### Future Events
+### Future Events (internal hooks)
 
-Planned event types:
+Planned **internal hook** event types:
 
 - **`session:start`**: When a new session begins
 - **`session:end`**: When a session ends
 - **`agent:error`**: When an agent encounters an error
 - **`message:sent`**: When a message is sent
 - **`message:received`**: When a message is received
+
+<Note>
+These `type:action` names are for **internal hooks** on this page.
+
+Plugin hooks use separate underscore names (for example `message_received`, `message_sending`, `message_sent`, `before_agent_start`, `before_tool_call`, `session_start`). See [Plugin hooks](/tools/plugin#plugin-hooks).
+</Note>
 
 ## Creating Custom Hooks
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -327,6 +327,19 @@ Notes:
 - Plugin-managed hooks show up in `openclaw hooks list` with `plugin:<id>`.
 - You cannot enable/disable plugin-managed hooks via `openclaw hooks`; enable/disable the plugin instead.
 
+Available plugin hook names:
+
+- `before_agent_start` (modifying): inject context or override system prompt before the run starts.
+- `agent_end` (void): inspect final message list and run metadata.
+- `message_received` (void): observe inbound messages before the run.
+- `message_sending` (modifying): adjust outbound message payload before delivery.
+- `message_sent` (void): observe successful outbound delivery.
+- `before_tool_call` (modifying): adjust tool params before execution.
+- `after_tool_call` (void): observe tool result metadata after execution.
+- `session_start` / `session_end` (void): session lifecycle boundaries.
+
+Use underscore names exactly (for example `message_received`, not `message:received`).
+
 ## Provider plugins (model auth)
 
 Plugins can register **model provider auth** flows so users can run OAuth or


### PR DESCRIPTION
## Summary
Documents currently implemented plugin hook names and clarifies internal-hook vs plugin-hook naming to prevent confusion.

## What changed
- Updated `docs/tools/plugin.md` (`Plugin hooks` section):
  - Added the currently available plugin hook names:
    - `before_agent_start`, `agent_end`
    - `message_received`, `message_sending`, `message_sent`
    - `before_tool_call`, `after_tool_call`
    - `session_start`, `session_end`
  - Added a naming note to use underscore hook names exactly (for example `message_received`, not `message:received`).

- Updated `docs/automation/hooks.md`:
  - Renamed `Future Events` to `Future Events (internal hooks)`
  - Clarified that the listed `type:action` names belong to internal hooks
  - Added a note pointing readers to plugin hook names under `/tools/plugin#plugin-hooks`

## Why
Issue #12436 reports confusion where plugin hooks appeared undocumented and `message:received` looked like a future-only event. The actual confusion is between two hook systems with different naming conventions (internal `type:action` vs plugin underscore names). This PR documents the available plugin hooks and disambiguates naming.

Closes #12436

## Contributing checklist
- [x] AI-assisted: yes (prepared with OpenClaw assistant, model: `openai-codex/gpt-5.3-codex`)
- [x] Testing level: lightly tested (docs-only change; link/build/test not run for this docs PR)
- [x] Confirmed understanding of change and impact
