### PR TITLE
fix(twitch): align test mocks with TwitchAccountConfig + add test type-checking

### DIFF
--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -36,7 +36,7 @@ vi.mock("./utils/twitch.js", () => ({
 describe("outbound", () => {
   const mockAccount = {
     username: "testbot",
-    token: "oauth:test123",
+    accessToken: "oauth:test123",
     clientId: "test-client-id",
     channel: "#testchannel",
   };
@@ -196,7 +196,6 @@ describe("outbound", () => {
 
       expect(result.channel).toBe("twitch");
       expect(result.messageId).toBe("twitch-msg-123");
-      expect(result.to).toBe("testchannel");
       expect(result.timestamp).toBeGreaterThan(0);
     });
 

--- a/extensions/twitch/src/probe.test.ts
+++ b/extensions/twitch/src/probe.test.ts
@@ -54,7 +54,8 @@ vi.mock("@twurple/auth", () => ({
 describe("probeTwitch", () => {
   const mockAccount: TwitchAccountConfig = {
     username: "testbot",
-    token: "oauth:test123456789",
+    accessToken: "oauth:test123456789",
+    clientId: "test-client-id",
     channel: "testchannel",
   };
 
@@ -74,7 +75,7 @@ describe("probeTwitch", () => {
   });
 
   it("returns error when token is missing", async () => {
-    const account = { ...mockAccount, token: "" };
+    const account = { ...mockAccount, accessToken: "" };
     const result = await probeTwitch(account, 5000);
 
     expect(result.ok).toBe(false);
@@ -84,7 +85,7 @@ describe("probeTwitch", () => {
   it("attempts connection regardless of token prefix", async () => {
     // Note: probeTwitch doesn't validate token format - it tries to connect with whatever token is provided
     // The actual connection would fail in production with an invalid token
-    const account = { ...mockAccount, token: "raw_token_no_prefix" };
+    const account = { ...mockAccount, accessToken: "raw_token_no_prefix" };
     const result = await probeTwitch(account, 5000);
 
     // With mock, connection succeeds even without oauth: prefix
@@ -166,7 +167,7 @@ describe("probeTwitch", () => {
   it("trims token before validation", async () => {
     const account: TwitchAccountConfig = {
       ...mockAccount,
-      token: "  oauth:test123456789  ",
+      accessToken: "  oauth:test123456789  ",
     };
 
     const result = await probeTwitch(account, 5000);

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "test:live": "OPENCLAW_LIVE_TEST=1 CLAWDBOT_LIVE_TEST=1 vitest run --config vitest.live.config.ts",
     "test:ui": "pnpm --dir ui test",
     "test:watch": "vitest",
+    "tsgo:test": "tsgo -p tsconfig.test.json",
     "tui": "node scripts/run-node.mjs tui",
     "tui:dev": "OPENCLAW_PROFILE=dev CLAWDBOT_PROFILE=dev node scripts/run-node.mjs --dev tui",
     "ui:build": "node scripts/ui.js build",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.test.ts", "extensions/**/*.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Fix twitch test mocks to use accessToken instead of token. Add tsconfig.test.json for type-checking tests. See #12816 for related fixes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Twitch extension unit tests to match the `TwitchAccountConfig` shape (switching mock fields from `token` to `accessToken` and adding a missing `clientId`), and adds a dedicated `tsconfig.test.json` plus a `tsgo:test` script to type-check test files via `tsgo`.

The changes are limited to test files and repo tooling configuration; no production Twitch logic was modified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk (test/tooling-only changes).
- Diff is small and scoped to test mocks and adding a separate tsconfig for test type-checking. The test mock changes align with the expected config shape, and the removed assertion was for a non-existent property. No production code paths were touched.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->