### PR TITLE
chore: add tsconfig.test.json for type-checking test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "test:live": "OPENCLAW_LIVE_TEST=1 CLAWDBOT_LIVE_TEST=1 vitest run --config vitest.live.config.ts",
     "test:ui": "pnpm --dir ui test",
     "test:watch": "vitest",
+    "tsgo:test": "tsgo -p tsconfig.test.json",
     "tui": "node scripts/run-node.mjs tui",
     "tui:dev": "OPENCLAW_PROFILE=dev CLAWDBOT_PROFILE=dev node scripts/run-node.mjs --dev tui",
     "ui:build": "node scripts/ui.js build",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.test.ts", "extensions/**/*.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Adds tsconfig.test.json that includes only test files excluded from the main tsconfig. Available via pnpm tsgo:test for incremental cleanup. Not wired into check yet  ~2.8k pre-existing errors need fixing first. Companion to #12816.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `tsconfig.test.json` that extends the main `tsconfig.json` but includes only `*.test.ts` files, plus a new `pnpm tsgo:test` script to type-check those tests separately. This supports incremental cleanup of test-only type errors without wiring the check into the main `pnpm check` gate yet.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is additive (new tsconfig + new npm script) and does not affect runtime behavior or CI gates. The config is small and self-contained, and no functional code paths are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->