### PR TITLE
docs(gateway): clarify there is no standalone clawrouter binary

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -13,6 +13,8 @@ The Gateway is OpenClaw’s WebSocket server (channels, nodes, sessions, hooks).
 
 Subcommands in this page live under `openclaw gateway …`.
 
+There is no standalone `clawrouter` binary. Routing/proxy behavior is part of the Gateway process (`openclaw gateway`).
+
 Related docs:
 
 - [/gateway/bonjour](/gateway/bonjour)


### PR DESCRIPTION
## Summary
Adds an explicit docs clarification that there is no standalone `clawrouter` binary and that routing/proxy behavior is part of `openclaw gateway`.

## What changed
- Updated `docs/cli/gateway.md` near the top-level command description:
  - Added: "There is no standalone `clawrouter` binary. Routing/proxy behavior is part of the Gateway process (`openclaw gateway`)."

## Why
Issue #11156 asks to remove/clarify lingering references to `clawrouter`. Even where users encounter that term externally (old notes/discussions), this page is the canonical CLI entrypoint and now directly disambiguates the command model.

## Duplicate-triage note
Checked issue timeline and open PRs before starting:
- No linked/cross-referenced PR already addressing #11156
- No existing `clawrouter` string references found in current docs tree

This PR is a focused clarification to prevent user confusion.

Closes #11156

## Contributing checklist
- [x] AI-assisted: yes (prepared with OpenClaw assistant, model: `openai-codex/gpt-5.3-codex`)
- [x] Testing level: lightly tested (docs-only change; link/build/test not run for this docs PR)
- [x] Confirmed understanding of change and impact

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Gateway CLI documentation (`docs/cli/gateway.md`) to explicitly state that there is no standalone `clawrouter` binary, and that routing/proxy behavior is implemented within the `openclaw gateway` process. The change is placed near the top of the page where the `openclaw gateway …` command namespace is described, making the CLI docs the canonical disambiguation point for users encountering older `clawrouter` references.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are limited to a single, self-contained documentation clarification and do not alter code paths, interfaces, or behavior. The added text is consistent with existing naming conventions in the docs and does not introduce broken links or formatting issues.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - docs/cli/agents.md ([source](https://app.greptile.com/review/custom-context?memory=057a11aa-5c5f-48bb-8d53-91b27b0fe3a2))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
</details>


<!-- /greptile_comment -->