### PR TITLE
fix(heartbeat): suppress HEARTBEAT_OK token delivery

### DIFF
--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -92,7 +92,7 @@ describe("resolveHeartbeatIntervalMs", () => {
     }
   });
 
-  it("sends HEARTBEAT_OK when visibility.showOk is true", async () => {
+  it("does not relay HEARTBEAT_OK token even when visibility.showOk is true", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-"));
     const storePath = path.join(tmpDir, "sessions.json");
     const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
@@ -146,8 +146,7 @@ describe("resolveHeartbeatIntervalMs", () => {
         },
       });
 
-      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
-      expect(sendWhatsApp).toHaveBeenCalledWith("+1555", "HEARTBEAT_OK", expect.any(Object));
+      expect(sendWhatsApp).not.toHaveBeenCalled();
     } finally {
       replySpy.mockRestore();
       await fs.rm(tmpDir, { recursive: true, force: true });

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
   );
 });
 
-describe("resolveHeartbeatIntervalMs", () => {
+describe("runHeartbeatOnce", () => {
   it("respects ackMaxChars for heartbeat acks", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-"));
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -687,8 +687,7 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
-      // HEARTBEAT_OK from the model is an internal ack token and should be discarded.
-      // Do not relay it to user channels, even when showOk is enabled.
+      // HEARTBEAT_OK from the model is an internal ack token and should be discarded, even when showOk is enabled.
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -687,14 +687,15 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
-      const okSent = await maybeSendHeartbeatOk();
+      // HEARTBEAT_OK from the model is an internal ack token and should be discarded.
+      // Do not relay it to user channels, even when showOk is enabled.
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,
         durationMs: Date.now() - startedAt,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
         accountId: delivery.accountId,
-        silent: !okSent,
+        silent: true,
         indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-token") : undefined,
       });
       return { status: "ran", durationMs: Date.now() - startedAt };


### PR DESCRIPTION
## Summary

Fixes a heartbeat delivery edge case where model heartbeat ack tokens (`HEARTBEAT_OK`) could be relayed to user channels.

## Changes

- In `runHeartbeatOnce`, when a heartbeat reply normalizes to an `ok-token` skip (`HEARTBEAT_OK` with no deliverable content), the runner now discards it.
- `HEARTBEAT_OK` is no longer relayed to user channels in that path (even when `visibility.showOk` is enabled).
- Updated test coverage in:
  - `src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts`

## Why this is not a duplicate

- Checked issue timeline and cross-references before starting.
- No open PR was found that fixes #12767 directly.
- #12785 references #12767 as a starter-issues list, not an implementation PR.

## Testing

- Ran locally:
  - `pnpm test src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts`
- Result: **1 file passed, 9 tests passed**

## Contributing checklist

- [x] Focused PR that addresses a single issue
- [x] AI-assisted: yes
- [x] Model used: `openai-codex/gpt-5.3-codex`
- [x] Testing disclosed (targeted test above)

Closes #12767

