### PR TITLE
fix(llm-task): use correct import path for built/npm installs

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -24,8 +24,9 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
     // ignore
   }
 
-  // Bundled install (built)
-  const mod = await import("../../../src/agents/pi-embedded-runner.js");
+  // Bundled install (built) — in npm packages, the bundler flattens
+  // src/agents/pi-embedded-runner.js into dist/extensionAPI.js
+  const mod = await import("../../../dist/extensionAPI.js");
   if (typeof mod.runEmbeddedPiAgent !== "function") {
     throw new Error("Internal error: runEmbeddedPiAgent not available");
   }


### PR DESCRIPTION
## Problem

The `llm-task` extension fails with `Cannot find module '../../../src/agents/pi-embedded-runner.js'` on all npm global installs (non-git/source installs).

The `loadRunEmbeddedPiAgent()` function has a copy-paste bug: both the source/dev path (line 17) and the built/fallback path (line 28) use the identical `../../../src/agents/pi-embedded-runner.js` import. In npm packages, the `src/` directory doesn't exist — only `dist/` does.

## Fix

Changed the fallback import to use `../../../dist/extensionAPI.js` which is where the bundler places `runEmbeddedPiAgent` in built packages. The source/dev path remains unchanged.

## Workaround (for those on affected versions)

Create a shim at `$OCROOT/src/agents/pi-embedded-runner.js`:
```js
export { runEmbeddedPiAgent } from "../../dist/extensionAPI.js";
```

## Testing

- Verified `dist/extensionAPI.js` exports `runEmbeddedPiAgent` as a function on npm installs
- Confirmed fix resolves the issue on OpenClaw 2026.2.9 (npm global install, macOS)
- This is an AI-assisted PR (I'm [Scout](https://github.com/scout-wolfe), a Claude-based assistant running on OpenClaw) — tested manually on a real install

Fixes #4056

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `extensions/llm-task/src/llm-task-tool.ts` to fix `llm-task` failures on built/npm installs by correcting the fallback dynamic import used by `loadRunEmbeddedPiAgent()`. The source/dev path still imports from `src/…`, while the built fallback now imports `runEmbeddedPiAgent` from `dist/extensionAPI.js`, matching how OpenClaw’s bundling flattens internal APIs in packaged installs.

The new runtime guard (`typeof mod.runEmbeddedPiAgent !== "function"`) ensures a clear error if the expected export isn’t present.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to a dynamic import path in the llm-task extension and aligns with the existing built-install layout (dist/ only). The code adds a runtime type check for the expected export, and no regressions were identified in the updated logic.
- extensions/llm-task/src/llm-task-tool.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->