### PR TITLE
fix(gateway): normalize session key casing to prevent ghost sessions

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -10,9 +10,13 @@ const mocks = vi.hoisted(() => ({
   loadConfigReturn: {} as Record<string, unknown>,
 }));
 
-vi.mock("../session-utils.js", () => ({
-  loadSessionEntry: mocks.loadSessionEntry,
-}));
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    loadSessionEntry: mocks.loadSessionEntry,
+  };
+});
 
 vi.mock("../../config/sessions.js", async () => {
   const actual = await vi.importActual<typeof import("../../config/sessions.js")>(

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -27,7 +27,13 @@ vi.mock("../../config/sessions.js", async () => {
     updateSessionStore: mocks.updateSessionStore,
     resolveAgentIdFromSessionKey: () => "main",
     resolveExplicitAgentSessionKey: () => undefined,
-    resolveAgentMainSessionKey: () => "agent:main:main",
+    resolveAgentMainSessionKey: ({
+      cfg,
+      agentId,
+    }: {
+      cfg?: { session?: { mainKey?: string } };
+      agentId: string;
+    }) => `agent:${agentId}:${cfg?.session?.mainKey ?? "main"}`,
   };
 });
 
@@ -216,5 +222,55 @@ describe("gateway agent handler", () => {
     // Should be undefined, not cause an error
     expect(capturedEntry?.cliSessionIds).toBeUndefined();
     expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("prunes legacy main alias keys when writing a canonical session entry", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {
+        session: { mainKey: "work" },
+        agents: { list: [{ id: "main", default: true }] },
+      },
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "existing-session-id",
+        updatedAt: Date.now(),
+      },
+      canonicalKey: "agent:main:work",
+    });
+
+    let capturedStore: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:work": { sessionId: "existing-session-id", updatedAt: 10 },
+        "agent:main:MAIN": { sessionId: "legacy-session-id", updatedAt: 5 },
+      };
+      await updater(store);
+      capturedStore = store;
+    });
+
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    const respond = vi.fn();
+    await agentHandlers.agent({
+      params: {
+        message: "test",
+        agentId: "main",
+        sessionKey: "main",
+        idempotencyKey: "test-idem-alias-prune",
+      },
+      respond,
+      context: makeContext(),
+      req: { type: "req", id: "3", method: "agent" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.updateSessionStore).toHaveBeenCalled();
+    expect(capturedStore).toBeDefined();
+    expect(capturedStore?.["agent:main:work"]).toBeDefined();
+    expect(capturedStore?.["agent:main:MAIN"]).toBeUndefined();
   });
 });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -38,7 +38,11 @@ import {
   validateAgentParams,
   validateAgentWaitParams,
 } from "../protocol/index.js";
-import { loadSessionEntry } from "../session-utils.js";
+import {
+  canonicalizeSpawnedByForAgent,
+  findStoreKeysIgnoreCase,
+  loadSessionEntry,
+} from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { waitForAgentJob } from "./agent-job.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
@@ -213,6 +217,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     let sessionEntry: SessionEntry | undefined;
     let bestEffortDeliver = false;
     let cfgForAgent: ReturnType<typeof loadConfig> | undefined;
+    let resolvedSessionKey = requestedSessionKey;
 
     if (requestedSessionKey) {
       const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(requestedSessionKey);
@@ -220,7 +225,12 @@ export const agentHandlers: GatewayRequestHandlers = {
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
       const labelValue = request.label?.trim() || entry?.label;
-      spawnedByValue = spawnedByValue || entry?.spawnedBy;
+      const sessionAgent = resolveAgentIdFromSessionKey(canonicalKey);
+      spawnedByValue = canonicalizeSpawnedByForAgent(
+        cfg,
+        sessionAgent,
+        spawnedByValue || entry?.spawnedBy,
+      );
       let inheritedGroup:
         | { groupId?: string; groupChannel?: string; groupSpace?: string }
         | undefined;
@@ -268,7 +278,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       const sendPolicy = resolveSendPolicy({
         cfg,
         entry,
-        sessionKey: requestedSessionKey,
+        sessionKey: canonicalKey,
         channel: entry?.channel,
         chatType: entry?.chatType,
       });
@@ -282,21 +292,27 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
       resolvedSessionId = sessionId;
       const canonicalSessionKey = canonicalKey;
+      resolvedSessionKey = canonicalSessionKey;
       const agentId = resolveAgentIdFromSessionKey(canonicalSessionKey);
       const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId });
       if (storePath) {
         await updateSessionStore(storePath, (store) => {
+          for (const variant of findStoreKeysIgnoreCase(store, canonicalSessionKey)) {
+            if (variant !== canonicalSessionKey) {
+              delete store[variant];
+            }
+          }
           store[canonicalSessionKey] = nextEntry;
         });
       }
       if (canonicalSessionKey === mainSessionKey || canonicalSessionKey === "global") {
         context.addChatRun(idem, {
-          sessionKey: requestedSessionKey,
+          sessionKey: canonicalSessionKey,
           clientRunId: idem,
         });
         bestEffortDeliver = true;
       }
-      registerAgentRunContext(idem, { sessionKey: requestedSessionKey });
+      registerAgentRunContext(idem, { sessionKey: canonicalSessionKey });
     }
 
     const runId = idem;
@@ -378,7 +394,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         images,
         to: resolvedTo,
         sessionId: resolvedSessionId,
-        sessionKey: requestedSessionKey,
+        sessionKey: resolvedSessionKey,
         thinking: request.thinking,
         deliver,
         deliveryTargetMode,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -28,6 +28,7 @@ import {
 } from "../protocol/index.js";
 import {
   archiveFileOnDisk,
+  findStoreKeysIgnoreCase,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
   loadSessionEntry,
@@ -104,12 +105,18 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     for (const key of keys) {
       try {
-        const target = resolveGatewaySessionStoreTarget({ cfg, key });
+        const target = resolveGatewaySessionStoreTarget({ cfg, key, scanLegacyKeys: false });
         const store = storeCache.get(target.storePath) ?? loadSessionStore(target.storePath);
         storeCache.set(target.storePath, store);
         const entry =
+          store[target.canonicalKey] ??
           target.storeKeys.map((candidate) => store[candidate]).find(Boolean) ??
-          store[target.canonicalKey];
+          // Case-insensitive fallback for legacy mixed-case store keys (store already loaded).
+          (() => {
+            const lowered = target.canonicalKey.toLowerCase();
+            const legacyHit = Object.keys(store).find((k) => k.toLowerCase() === lowered);
+            return legacyHit ? store[legacyHit] : undefined;
+          })();
         if (!entry?.sessionId) {
           previews.push({ key, status: "missing", items: [] });
           continue;
@@ -134,7 +141,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     respond(true, { ts: Date.now(), previews } satisfies SessionsPreviewResult, undefined);
   },
-  "sessions.resolve": ({ params, respond }) => {
+  "sessions.resolve": async ({ params, respond }) => {
     if (!validateSessionsResolveParams(params)) {
       respond(
         false,
@@ -149,7 +156,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const p = params;
     const cfg = loadConfig();
 
-    const resolved = resolveSessionKeyFromResolveParams({ cfg, p });
+    const resolved = await resolveSessionKeyFromResolveParams({ cfg, p });
     if (!resolved.ok) {
       respond(false, undefined, resolved.error);
       return;
@@ -180,10 +187,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const storePath = target.storePath;
     const applied = await updateSessionStore(storePath, async (store) => {
       const primaryKey = target.storeKeys[0] ?? key;
-      const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
+      // Migrate first legacy entry to canonical key, then clean up all case variants.
+      if (!store[primaryKey]) {
+        const existingKey = target.storeKeys.find((candidate) => store[candidate]);
+        if (existingKey) {
+          store[primaryKey] = store[existingKey];
+        }
+      }
+      for (const variant of findStoreKeysIgnoreCase(store, primaryKey)) {
+        if (variant !== primaryKey) {
+          delete store[variant];
+        }
       }
       return await applySessionsPatchToStore({
         cfg,
@@ -236,10 +250,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const storePath = target.storePath;
     const next = await updateSessionStore(storePath, (store) => {
       const primaryKey = target.storeKeys[0] ?? key;
-      const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
+      // Migrate first legacy entry to canonical key, then clean up all case variants.
+      if (!store[primaryKey]) {
+        const existingKey = target.storeKeys.find((candidate) => store[candidate]);
+        if (existingKey) {
+          store[primaryKey] = store[existingKey];
+        }
+      }
+      for (const variant of findStoreKeysIgnoreCase(store, primaryKey)) {
+        if (variant !== primaryKey) {
+          delete store[variant];
+        }
       }
       const entry = store[primaryKey];
       const now = Date.now();
@@ -332,10 +353,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
     await updateSessionStore(storePath, (store) => {
       const primaryKey = target.storeKeys[0] ?? key;
-      const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
+      // Migrate first legacy entry to canonical key, then clean up all case variants.
+      if (!store[primaryKey]) {
+        const existingKey = target.storeKeys.find((candidate) => store[candidate]);
+        if (existingKey) {
+          store[primaryKey] = store[existingKey];
+        }
+      }
+      for (const variant of findStoreKeysIgnoreCase(store, primaryKey)) {
+        if (variant !== primaryKey) {
+          delete store[variant];
+        }
       }
       if (store[primaryKey]) {
         delete store[primaryKey];
@@ -393,10 +421,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     // Lock + read in a short critical section; transcript work happens outside.
     const compactTarget = await updateSessionStore(storePath, (store) => {
       const primaryKey = target.storeKeys[0] ?? key;
-      const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
+      // Migrate first legacy entry to canonical key, then clean up all case variants.
+      if (!store[primaryKey]) {
+        const existingKey = target.storeKeys.find((candidate) => store[candidate]);
+        if (existingKey) {
+          store[primaryKey] = store[existingKey];
+        }
+      }
+      for (const variant of findStoreKeysIgnoreCase(store, primaryKey)) {
+        if (variant !== primaryKey) {
+          delete store[variant];
+        }
       }
       return { entry: store[primaryKey], primaryKey };
     });

--- a/src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
@@ -419,6 +419,129 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.preview resolves legacy mixed-case main alias with custom mainKey", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-preview-alias-"));
+    const storePath = path.join(dir, "sessions.json");
+    testState.sessionStorePath = storePath;
+    testState.agentsConfig = { list: [{ id: "ops", default: true }] };
+    testState.sessionConfig = { mainKey: "work" };
+    const sessionId = "sess-legacy-main";
+    const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: sessionId }),
+      JSON.stringify({ message: { role: "assistant", content: "Legacy alias transcript" } }),
+    ];
+    await fs.writeFile(transcriptPath, lines.join("\n"), "utf-8");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:ops:MAIN": {
+            sessionId,
+            updatedAt: Date.now(),
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const { ws } = await openClient();
+    const preview = await rpcReq<{
+      previews: Array<{
+        key: string;
+        status: string;
+        items: Array<{ role: string; text: string }>;
+      }>;
+    }>(ws, "sessions.preview", { keys: ["main"], limit: 3, maxChars: 120 });
+
+    expect(preview.ok).toBe(true);
+    const entry = preview.payload?.previews[0];
+    expect(entry?.key).toBe("main");
+    expect(entry?.status).toBe("ok");
+    expect(entry?.items[0]?.text).toContain("Legacy alias transcript");
+
+    ws.close();
+  });
+
+  test("sessions.resolve and mutators clean legacy main-alias ghost keys", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-cleanup-alias-"));
+    const storePath = path.join(dir, "sessions.json");
+    testState.sessionStorePath = storePath;
+    testState.agentsConfig = { list: [{ id: "ops", default: true }] };
+    testState.sessionConfig = { mainKey: "work" };
+    const sessionId = "sess-alias-cleanup";
+    const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
+    await fs.writeFile(
+      transcriptPath,
+      `${Array.from({ length: 8 })
+        .map((_, idx) => JSON.stringify({ role: "assistant", content: `line ${idx}` }))
+        .join("\n")}\n`,
+      "utf-8",
+    );
+
+    const writeRawStore = async (store: Record<string, unknown>) => {
+      await fs.writeFile(storePath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+    };
+    const readStore = async () =>
+      JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, Record<string, unknown>>;
+
+    await writeRawStore({
+      "agent:ops:MAIN": { sessionId, updatedAt: Date.now() - 2_000 },
+      "agent:ops:Main": { sessionId, updatedAt: Date.now() - 1_000 },
+    });
+
+    const { ws } = await openClient();
+
+    const resolved = await rpcReq<{ ok: true; key: string }>(ws, "sessions.resolve", {
+      key: "main",
+    });
+    expect(resolved.ok).toBe(true);
+    expect(resolved.payload?.key).toBe("agent:ops:work");
+    let store = await readStore();
+    expect(Object.keys(store).toSorted()).toEqual(["agent:ops:work"]);
+
+    await writeRawStore({
+      ...store,
+      "agent:ops:MAIN": { ...store["agent:ops:work"] },
+    });
+    const patched = await rpcReq<{ ok: true; key: string }>(ws, "sessions.patch", {
+      key: "main",
+      thinkingLevel: "medium",
+    });
+    expect(patched.ok).toBe(true);
+    expect(patched.payload?.key).toBe("agent:ops:work");
+    store = await readStore();
+    expect(Object.keys(store).toSorted()).toEqual(["agent:ops:work"]);
+    expect(store["agent:ops:work"]?.thinkingLevel).toBe("medium");
+
+    await writeRawStore({
+      ...store,
+      "agent:ops:MAIN": { ...store["agent:ops:work"] },
+    });
+    const compacted = await rpcReq<{ ok: true; compacted: boolean }>(ws, "sessions.compact", {
+      key: "main",
+      maxLines: 3,
+    });
+    expect(compacted.ok).toBe(true);
+    expect(compacted.payload?.compacted).toBe(true);
+    store = await readStore();
+    expect(Object.keys(store).toSorted()).toEqual(["agent:ops:work"]);
+
+    await writeRawStore({
+      ...store,
+      "agent:ops:MAIN": { ...store["agent:ops:work"] },
+    });
+    const reset = await rpcReq<{ ok: true; key: string }>(ws, "sessions.reset", { key: "main" });
+    expect(reset.ok).toBe(true);
+    expect(reset.payload?.key).toBe("agent:ops:work");
+    store = await readStore();
+    expect(Object.keys(store).toSorted()).toEqual(["agent:ops:work"]);
+
+    ws.close();
+  });
+
   test("sessions.delete rejects main and aborts active runs", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-"));
     const storePath = path.join(dir, "sessions.json");

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
@@ -50,6 +51,9 @@ describe("gateway session utils", () => {
     expect(resolveSessionStoreKey({ cfg, sessionKey: "main" })).toBe("agent:ops:work");
     expect(resolveSessionStoreKey({ cfg, sessionKey: "work" })).toBe("agent:ops:work");
     expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:ops:main" })).toBe("agent:ops:work");
+    // Mixed-case main alias must also resolve to the configured mainKey (idempotent)
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:ops:MAIN" })).toBe("agent:ops:work");
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "MAIN" })).toBe("agent:ops:work");
   });
 
   test("resolveSessionStoreKey canonicalizes bare keys to default agent", () => {
@@ -62,6 +66,23 @@ describe("gateway session utils", () => {
     );
     expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:alpha:main" })).toBe(
       "agent:alpha:main",
+    );
+  });
+
+  test("resolveSessionStoreKey normalizes session key casing", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    // Bare keys with different casing must resolve to the same canonical key
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "CoP" })).toBe(
+      resolveSessionStoreKey({ cfg, sessionKey: "cop" }),
+    );
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "MySession" })).toBe("agent:ops:mysession");
+    // Prefixed agent keys with mixed-case rest must also normalize
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:ops:CoP" })).toBe("agent:ops:cop");
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:alpha:MySession" })).toBe(
+      "agent:alpha:mysession",
     );
   });
 
@@ -91,6 +112,74 @@ describe("gateway session utils", () => {
     expect(target.canonicalKey).toBe("agent:ops:main");
     expect(target.storeKeys).toEqual(expect.arrayContaining(["agent:ops:main", "main"]));
     expect(target.storePath).toBe(path.resolve(storeTemplate.replace("{agentId}", "ops")));
+  });
+
+  test("resolveGatewaySessionStoreTarget includes legacy mixed-case store key", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-case-"));
+    const storePath = path.join(dir, "sessions.json");
+    // Simulate a legacy store with a mixed-case key
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ "agent:ops:MySession": { sessionId: "s1", updatedAt: 1 } }),
+      "utf8",
+    );
+    const cfg = {
+      session: { mainKey: "main", store: storePath },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    // Client passes the lowercased canonical key (as returned by sessions.list)
+    const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
+    expect(target.canonicalKey).toBe("agent:ops:mysession");
+    // storeKeys must include the legacy mixed-case key from the on-disk store
+    expect(target.storeKeys).toEqual(
+      expect.arrayContaining(["agent:ops:mysession", "agent:ops:MySession"]),
+    );
+    // The legacy key must resolve to the actual entry in the store
+    const store = JSON.parse(fs.readFileSync(storePath, "utf8"));
+    const found = target.storeKeys.some((k) => Boolean(store[k]));
+    expect(found).toBe(true);
+  });
+
+  test("resolveGatewaySessionStoreTarget includes all case-variant duplicate keys", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-dupes-"));
+    const storePath = path.join(dir, "sessions.json");
+    // Simulate a store with both canonical and legacy mixed-case entries
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:ops:mysession": { sessionId: "s-lower", updatedAt: 2 },
+        "agent:ops:MySession": { sessionId: "s-mixed", updatedAt: 1 },
+      }),
+      "utf8",
+    );
+    const cfg = {
+      session: { mainKey: "main", store: storePath },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
+    // storeKeys must include BOTH variants so delete/reset/patch can clean up all duplicates
+    expect(target.storeKeys).toEqual(
+      expect.arrayContaining(["agent:ops:mysession", "agent:ops:MySession"]),
+    );
+  });
+
+  test("resolveGatewaySessionStoreTarget finds legacy main alias key when mainKey is customized", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-alias-"));
+    const storePath = path.join(dir, "sessions.json");
+    // Legacy store has entry under "agent:ops:MAIN" but mainKey is "work"
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ "agent:ops:MAIN": { sessionId: "s1", updatedAt: 1 } }),
+      "utf8",
+    );
+    const cfg = {
+      session: { mainKey: "work", store: storePath },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:main" });
+    expect(target.canonicalKey).toBe("agent:ops:work");
+    // storeKeys must include the legacy mixed-case alias key
+    expect(target.storeKeys).toEqual(expect.arrayContaining(["agent:ops:MAIN"]));
   });
 });
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -10,6 +10,7 @@ import {
   deriveSessionTitle,
   listSessionsFromStore,
   parseGroupKey,
+  pruneLegacyStoreKeys,
   resolveGatewaySessionStoreTarget,
   resolveSessionStoreKey,
 } from "./session-utils.js";
@@ -180,6 +181,21 @@ describe("gateway session utils", () => {
     expect(target.canonicalKey).toBe("agent:ops:work");
     // storeKeys must include the legacy mixed-case alias key
     expect(target.storeKeys).toEqual(expect.arrayContaining(["agent:ops:MAIN"]));
+  });
+
+  test("pruneLegacyStoreKeys removes alias and case-variant ghost keys", () => {
+    const store: Record<string, unknown> = {
+      "agent:ops:work": { sessionId: "canonical", updatedAt: 3 },
+      "agent:ops:MAIN": { sessionId: "legacy-upper", updatedAt: 1 },
+      "agent:ops:Main": { sessionId: "legacy-mixed", updatedAt: 2 },
+      "agent:ops:main": { sessionId: "legacy-lower", updatedAt: 4 },
+    };
+    pruneLegacyStoreKeys({
+      store,
+      canonicalKey: "agent:ops:work",
+      candidates: ["agent:ops:work", "agent:ops:main"],
+    });
+    expect(Object.keys(store).toSorted()).toEqual(["agent:ops:work"]);
   });
 });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -189,8 +189,52 @@ export function loadSessionEntry(sessionKey: string) {
   const agentId = resolveSessionStoreAgentId(cfg, canonicalKey);
   const storePath = resolveStorePath(sessionCfg?.store, { agentId });
   const store = loadSessionStore(storePath);
-  const entry = store[canonicalKey];
-  return { cfg, storePath, store, entry, canonicalKey };
+  const match = findStoreMatch(store, canonicalKey, sessionKey.trim());
+  const legacyKey = match?.key !== canonicalKey ? match?.key : undefined;
+  return { cfg, storePath, store, entry: match?.entry, canonicalKey, legacyKey };
+}
+
+/**
+ * Find a session entry by exact or case-insensitive key match.
+ * Returns both the entry and the actual store key it was found under,
+ * so callers can clean up legacy mixed-case keys when they differ from canonicalKey.
+ */
+function findStoreMatch(
+  store: Record<string, SessionEntry>,
+  ...candidates: string[]
+): { entry: SessionEntry; key: string } | undefined {
+  // Exact match first.
+  for (const candidate of candidates) {
+    if (candidate && store[candidate]) {
+      return { entry: store[candidate], key: candidate };
+    }
+  }
+  // Case-insensitive scan for ALL candidates.
+  const loweredSet = new Set(candidates.filter(Boolean).map((c) => c.toLowerCase()));
+  for (const key of Object.keys(store)) {
+    if (loweredSet.has(key.toLowerCase())) {
+      return { entry: store[key], key };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Find all on-disk store keys that match the given key case-insensitively.
+ * Returns every key from the store whose lowercased form equals the target's lowercased form.
+ */
+export function findStoreKeysIgnoreCase(
+  store: Record<string, unknown>,
+  targetKey: string,
+): string[] {
+  const lowered = targetKey.toLowerCase();
+  const matches: string[] = [];
+  for (const key of Object.keys(store)) {
+    if (key.toLowerCase() === lowered) {
+      matches.push(key);
+    }
+  }
+  return matches;
 }
 
 export function classifySessionKey(key: string, entry?: SessionEntry): GatewaySessionRow["kind"] {
@@ -334,13 +378,14 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
 }
 
 function canonicalizeSessionKeyForAgent(agentId: string, key: string): string {
-  if (key === "global" || key === "unknown") {
-    return key;
+  const lowered = key.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
   }
-  if (key.startsWith("agent:")) {
-    return key;
+  if (lowered.startsWith("agent:")) {
+    return lowered;
   }
-  return `agent:${normalizeAgentId(agentId)}:${key}`;
+  return `agent:${normalizeAgentId(agentId)}:${lowered}`;
 }
 
 function resolveDefaultStoreAgentId(cfg: OpenClawConfig): string {
@@ -355,30 +400,33 @@ export function resolveSessionStoreKey(params: {
   if (!raw) {
     return raw;
   }
-  if (raw === "global" || raw === "unknown") {
-    return raw;
+  const rawLower = raw.toLowerCase();
+  if (rawLower === "global" || rawLower === "unknown") {
+    return rawLower;
   }
 
   const parsed = parseAgentSessionKey(raw);
   if (parsed) {
     const agentId = normalizeAgentId(parsed.agentId);
+    const lowered = raw.toLowerCase();
     const canonical = canonicalizeMainSessionAlias({
       cfg: params.cfg,
       agentId,
-      sessionKey: raw,
+      sessionKey: lowered,
     });
-    if (canonical !== raw) {
+    if (canonical !== lowered) {
       return canonical;
     }
-    return raw;
+    return lowered;
   }
 
+  const lowered = raw.toLowerCase();
   const rawMainKey = normalizeMainKey(params.cfg.session?.mainKey);
-  if (raw === "main" || raw === rawMainKey) {
+  if (lowered === "main" || lowered === rawMainKey) {
     return resolveMainSessionKey(params.cfg);
   }
   const agentId = resolveDefaultStoreAgentId(params.cfg);
-  return canonicalizeSessionKeyForAgent(agentId, raw);
+  return canonicalizeSessionKeyForAgent(agentId, lowered);
 }
 
 function resolveSessionStoreAgentId(cfg: OpenClawConfig, canonicalKey: string): string {
@@ -392,21 +440,36 @@ function resolveSessionStoreAgentId(cfg: OpenClawConfig, canonicalKey: string): 
   return resolveDefaultStoreAgentId(cfg);
 }
 
-function canonicalizeSpawnedByForAgent(agentId: string, spawnedBy?: string): string | undefined {
+export function canonicalizeSpawnedByForAgent(
+  cfg: OpenClawConfig,
+  agentId: string,
+  spawnedBy?: string,
+): string | undefined {
   const raw = spawnedBy?.trim();
   if (!raw) {
     return undefined;
   }
-  if (raw === "global" || raw === "unknown") {
-    return raw;
+  const lower = raw.toLowerCase();
+  if (lower === "global" || lower === "unknown") {
+    return lower;
   }
-  if (raw.startsWith("agent:")) {
-    return raw;
+  let result: string;
+  if (raw.toLowerCase().startsWith("agent:")) {
+    result = raw.toLowerCase();
+  } else {
+    result = `agent:${normalizeAgentId(agentId)}:${lower}`;
   }
-  return `agent:${normalizeAgentId(agentId)}:${raw}`;
+  // Resolve main-alias references (e.g. agent:ops:main → configured main key).
+  const parsed = parseAgentSessionKey(result);
+  const resolvedAgent = parsed?.agentId ? normalizeAgentId(parsed.agentId) : agentId;
+  return canonicalizeMainSessionAlias({ cfg, agentId: resolvedAgent, sessionKey: result });
 }
 
-export function resolveGatewaySessionStoreTarget(params: { cfg: OpenClawConfig; key: string }): {
+export function resolveGatewaySessionStoreTarget(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  scanLegacyKeys?: boolean;
+}): {
   agentId: string;
   storePath: string;
   canonicalKey: string;
@@ -431,6 +494,20 @@ export function resolveGatewaySessionStoreTarget(params: { cfg: OpenClawConfig; 
   if (key && key !== canonicalKey) {
     storeKeys.add(key);
   }
+  if (params.scanLegacyKeys !== false) {
+    // Build a set of scan targets: all known keys plus the main alias key so we
+    // catch legacy entries stored under "agent:{id}:MAIN" when mainKey != "main".
+    const scanTargets = new Set(storeKeys);
+    scanTargets.add(`agent:${agentId}:main`);
+    // Scan the on-disk store for case variants of every target to find
+    // legacy mixed-case entries (e.g. "agent:ops:MAIN" when canonical is "agent:ops:work").
+    const store = loadSessionStore(storePath);
+    for (const seed of scanTargets) {
+      for (const legacyKey of findStoreKeysIgnoreCase(store, seed)) {
+        storeKeys.add(legacyKey);
+      }
+    }
+  }
   return {
     agentId,
     storePath,
@@ -441,25 +518,30 @@ export function resolveGatewaySessionStoreTarget(params: { cfg: OpenClawConfig; 
 
 // Merge with existing entry based on latest timestamp to ensure data consistency and avoid overwriting with less complete data.
 function mergeSessionEntryIntoCombined(params: {
+  cfg: OpenClawConfig;
   combined: Record<string, SessionEntry>;
   entry: SessionEntry;
   agentId: string;
   canonicalKey: string;
 }) {
-  const { combined, entry, agentId, canonicalKey } = params;
+  const { cfg, combined, entry, agentId, canonicalKey } = params;
   const existing = combined[canonicalKey];
 
   if (existing && (existing.updatedAt ?? 0) > (entry.updatedAt ?? 0)) {
     combined[canonicalKey] = {
       ...entry,
       ...existing,
-      spawnedBy: canonicalizeSpawnedByForAgent(agentId, existing.spawnedBy ?? entry.spawnedBy),
+      spawnedBy: canonicalizeSpawnedByForAgent(cfg, agentId, existing.spawnedBy ?? entry.spawnedBy),
     };
   } else {
     combined[canonicalKey] = {
       ...existing,
       ...entry,
-      spawnedBy: canonicalizeSpawnedByForAgent(agentId, entry.spawnedBy ?? existing?.spawnedBy),
+      spawnedBy: canonicalizeSpawnedByForAgent(
+        cfg,
+        agentId,
+        entry.spawnedBy ?? existing?.spawnedBy,
+      ),
     };
   }
 }
@@ -477,6 +559,7 @@ export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = canonicalizeSessionKeyForAgent(defaultAgentId, key);
       mergeSessionEntryIntoCombined({
+        cfg,
         combined,
         entry,
         agentId: defaultAgentId,
@@ -494,6 +577,7 @@ export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = canonicalizeSessionKeyForAgent(agentId, key);
       mergeSessionEntryIntoCombined({
+        cfg,
         combined,
         entry,
         agentId,


### PR DESCRIPTION
## Summary

Fixes #12603

Session keys with mixed casing (e.g. `MySession` vs `mysession`) create ghost duplicate entries on case-sensitive filesystems (Linux). The root cause is that `canonicalizeSessionKeyForAgent()` in the gateway code path did not lowercase keys, while `toAgentStoreSessionKey()` in routing and `resolveSessionKey()` in config both did — causing inconsistent canonical keys depending on the code path.

### Changes

- **Normalize casing in `canonicalizeSessionKeyForAgent` and `resolveSessionStoreKey`**: All session keys are now lowercased consistently, matching the behavior in `routing/session-key.ts` and `config/sessions/session-key.ts`
- **Idempotent main-alias resolution**: The main-alias check now operates on the lowered key so `agent:ops:MAIN` resolves to `agent:ops:work` in a single pass (not two)
- **Backward-compatible legacy key discovery**: `resolveGatewaySessionStoreTarget` scans the on-disk store for all case-variant keys (including main alias variants) and includes them in `storeKeys`, ensuring `sessions.delete`/`sessions.patch`/`sessions.reset` can find and clean up pre-existing mixed-case entries
- **Case-insensitive fallback in `loadSessionEntry`**: Finds entries stored under legacy mixed-case keys when looked up by the new canonical (lowered) key

### Key files
- `src/gateway/session-utils.ts` — core normalization + backward-compat helpers
- `src/gateway/session-utils.test.ts` — 6 new test cases

## Test plan

- [x] Write failing test: `resolveSessionStoreKey normalizes session key casing` — fails before fix, passes after
- [x] Write test: `resolveGatewaySessionStoreTarget includes legacy mixed-case store key` — verifies backward compat with single legacy key
- [x] Write test: `resolveGatewaySessionStoreTarget includes all case-variant duplicate keys` — verifies both canonical and mixed-case keys found
- [x] Write test: `resolveGatewaySessionStoreTarget finds legacy main alias key when mainKey is customized` — verifies `agent:ops:MAIN` found when canonical is `agent:ops:work`
- [x] Write test: `resolveSessionStoreKey maps main aliases (mixed-case)` — verifies `agent:ops:MAIN` and `MAIN` resolve to `agent:ops:work`
- [x] All 32 tests pass (6 new)
- [x] `pnpm build` passes
- [x] `pnpm check` passes

TDD: All 6 new tests fail before fix, pass after.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR normalizes gateway session-store key handling by lowercasing canonical session keys (including `global`/`unknown`) and making main-alias resolution idempotent, so different gateway code paths no longer generate divergent keys on case-sensitive filesystems. It also adds backward-compat behavior to discover and clean up on-disk mixed-case legacy keys (including main-alias variants) during resolve/write operations, and extends preview/load logic with case-insensitive fallbacks to prevent “missing” previews when only legacy keys exist.

The changes primarily live in `src/gateway/session-utils.ts` and are wired into gateway handlers (`agent`, `sessions.*`, and node events) to delete all case-variant duplicates on each write. Tests in `src/gateway/session-utils.test.ts` cover the new casing normalization and legacy key discovery behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to session-key canonicalization and legacy-key cleanup, with comprehensive tests added for mixed-case and main-alias scenarios. Call sites were updated consistently (including async resolve) and write paths now converge stores by deleting all case-variant duplicates.
- src/gateway/session-utils.ts (key canonicalization and legacy scanning logic)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->