### PR TITLE
ci: add SwiftPM cache, fix Mintlify frontmatter

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -1,7 +1,7 @@
 name: Setup Node environment
 description: >
-  Checkout with submodule retry, install Node 22, pnpm, optionally Bun,
-  and run pnpm install. Used by CI gates and test jobs.
+  Initialize submodules with retry, install Node 22, pnpm, optionally Bun,
+  and run pnpm install. Requires actions/checkout to run first.
 inputs:
   node-version:
     description: Node.js version to install.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,16 @@ jobs:
           swiftlint --config .swiftlint.yml
           swiftformat --lint apps/macos/Sources --config .swiftformat
 
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('apps/macos/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-
+
       - name: Swift build (release)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,9 +446,7 @@ jobs:
       - name: Cache SwiftPM
         uses: actions/cache@v4
         with:
-          path: |
-            ~/Library/Caches/org.swift.swiftpm
-            ~/Library/Developer/Xcode/DerivedData
+          path: ~/Library/Caches/org.swift.swiftpm
           key: ${{ runner.os }}-swiftpm-${{ hashFiles('apps/macos/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-swiftpm-

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 ---
 title: CI Pipeline
-description: How the OpenClaw CI pipeline works and why jobs are ordered the way they are. Latest changes: Feb 09, 2026
+description: How the OpenClaw CI pipeline works and why jobs are ordered the way they are. Latest changes - Feb 09, 2026
 ---
 
 # CI Pipeline
@@ -128,11 +128,14 @@ The analysis skips: `node_modules`, `dist`, `vendor`, `.git`, `coverage`,
 The `setup-node-env` composite action (`.github/actions/setup-node-env/`)
 handles the shared setup boilerplate:
 
-- Submodule checkout with retry (5 attempts)
+- Submodule init/update with retry (5 attempts, exponential backoff)
 - Node.js 22 setup
 - pnpm via corepack + store cache
 - Optional Bun install
 - `pnpm install` with retry
+
+The `macos` job also caches SwiftPM packages (`~/Library/Caches/org.swift.swiftpm`)
+and Xcode DerivedData to speed up Swift builds.
 
 This eliminates ~40 lines of duplicated YAML per job.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 ---
 title: CI Pipeline
-description: How the OpenClaw CI pipeline works and why jobs are ordered the way they are. Latest changes - Feb 09, 2026
+description: How the OpenClaw CI pipeline works and why jobs are ordered the way they are.
 ---
 
 # CI Pipeline
@@ -135,7 +135,7 @@ handles the shared setup boilerplate:
 - `pnpm install` with retry
 
 The `macos` job also caches SwiftPM packages (`~/Library/Caches/org.swift.swiftpm`)
-and Xcode DerivedData to speed up Swift builds.
+to speed up dependency resolution.
 
 This eliminates ~40 lines of duplicated YAML per job.
 


### PR DESCRIPTION
Adds SwiftPM caching to the macOS job and fixes the docs/ci.md frontmatter that was breaking Mintlify deployment.

**Changes:**
- Cache \~/Library/Caches/org.swift.swiftpm\ for faster Swift dependency resolution
- Remove DerivedData from cache (risky across Xcode version changes)
- Fix YAML frontmatter in docs/ci.md (remove colon that caused parse error)

Follow-up to the tiered CI gates work from #12810.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the shared `setup-node-env` composite action description to reflect that it assumes `actions/checkout` has already run, adds a SwiftPM cache step to the `macos` CI job (caching `~/Library/Caches/org.swift.swiftpm` keyed by `apps/macos/Package.resolved`), and fixes the Mintlify docs frontmatter in `docs/ci.md` by removing the trailing “Latest changes: …” portion that was breaking YAML parsing.

These changes fit into the existing tiered CI gates by reducing repeated setup wording, improving macOS job performance via Swift dependency caching, and unblocking docs deployment without altering the CI dependency graph.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are limited to CI/docs tweaks; the SwiftPM cache path and key reference an existing `apps/macos/Package.resolved`, and the docs frontmatter fix is syntactically valid. No functional CI logic changes beyond adding an additive cache step were found.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->