### PR TITLE
fix(telegram): omit thread_id=1 for DMs to prevent cron delivery fail…

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,10 +43,8 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("keeps thread id=1 for dm threads", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
-      message_thread_id: 1,
-    });
+  it("omits General topic thread id=1 for dm threads", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
   });
 
   it("normalizes thread ids to integers", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -64,7 +64,10 @@ export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);
-  if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
+  if (
+    normalized === TELEGRAM_GENERAL_TOPIC_ID &&
+    (thread.scope === "forum" || thread.scope === "dm")
+  ) {
     return undefined;
   }
   return { message_thread_id: normalized };


### PR DESCRIPTION
…ures (#12625)

- Fix buildTelegramThreadParams to skip message_thread_id=1 for both forum and dm scopes
- This resolves the 'message thread not found' error in Telegram DMs
- Related to #10926 and commit 19b8416a8 which introduced the regression
- Update test to reflect correct behavior for DM threads with id=1

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `buildTelegramThreadParams` to omit `message_thread_id` when the normalized thread id is `1` (Telegram “General topic”) not only for `forum` scope but also for `dm` scope. The associated unit test is updated to assert that `{ id: 1, scope: "dm" }` returns `undefined`, matching the intent to prevent Telegram API errors ("message thread not found") when sending DM messages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and localized, only affects thread param construction and the corresponding test. The new behavior aligns with Telegram semantics where `message_thread_id=1` should not be sent for non-topic contexts (including DMs) and prevents a known API error.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->