### PR TITLE
feat: cron catch-up for missed scheduled jobs (#12799)

### DIFF
--- a/src/cron/service.catchup.test.ts
+++ b/src/cron/service.catchup.test.ts
@@ -1,0 +1,265 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CronJob } from "./types.js";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-catchup-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function writeStore(storePath: string, jobs: unknown[]) {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(
+    storePath,
+    JSON.stringify({ version: 1, jobs }, null, 2),
+    "utf-8",
+  );
+}
+
+describe("CronService catch-up for missed jobs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-13T00:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("logs missed job and runs it when catchUp is not enabled", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const baseMs = Date.parse("2025-12-13T00:00:00.000Z");
+
+    // Job was due 5 minutes ago
+    await writeStore(store.storePath, [
+      {
+        id: "missed-no-catchup",
+        name: "missed job",
+        enabled: true,
+        createdAtMs: baseMs - 600_000,
+        updatedAtMs: baseMs - 600_000,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: baseMs - 600_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "hello" },
+        state: { nextRunAtMs: baseMs - 300_000 },
+      },
+    ]);
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+
+    // Job should have been run once on startup
+    expect(enqueueSystemEvent).toHaveBeenCalledWith("hello", { agentId: undefined });
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const job = jobs.find((j) => j.id === "missed-no-catchup");
+    expect(job?.state.lastStatus).toBe("ok");
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("catches up missed job with strategy 'once' (default)", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const baseMs = Date.parse("2025-12-13T00:00:00.000Z");
+
+    // Job was due 5 minutes ago, catchUp enabled
+    await writeStore(store.storePath, [
+      {
+        id: "catchup-once",
+        name: "catchup once job",
+        enabled: true,
+        createdAtMs: baseMs - 600_000,
+        updatedAtMs: baseMs - 600_000,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: baseMs - 600_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "catch-once" },
+        catchUp: { enabled: true, strategy: "once" },
+        state: { nextRunAtMs: baseMs - 300_000 },
+      },
+    ]);
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+
+    // Should fire exactly once despite multiple missed occurrences
+    const calls = enqueueSystemEvent.mock.calls.filter((args) => args[0] === "catch-once");
+    expect(calls.length).toBe(1);
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("catches up all missed occurrences with strategy 'all'", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const baseMs = Date.parse("2025-12-13T00:00:00.000Z");
+
+    // Job with 60s interval, missed by 5 minutes = ~5 missed occurrences
+    await writeStore(store.storePath, [
+      {
+        id: "catchup-all",
+        name: "catchup all job",
+        enabled: true,
+        createdAtMs: baseMs - 600_000,
+        updatedAtMs: baseMs - 600_000,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: baseMs - 600_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "catch-all" },
+        catchUp: { enabled: true, strategy: "all" },
+        state: { nextRunAtMs: baseMs - 300_000 },
+      },
+    ]);
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+
+    // Should fire multiple times (one per missed occurrence)
+    const calls = enqueueSystemEvent.mock.calls.filter((args) => args[0] === "catch-all");
+    expect(calls.length).toBeGreaterThan(1);
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("skips catch-up when missed time exceeds maxDelayMs", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const baseMs = Date.parse("2025-12-13T00:00:00.000Z");
+
+    // Job missed by 5 minutes, but maxDelayMs is only 2 minutes
+    await writeStore(store.storePath, [
+      {
+        id: "catchup-expired",
+        name: "expired catchup job",
+        enabled: true,
+        createdAtMs: baseMs - 600_000,
+        updatedAtMs: baseMs - 600_000,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: baseMs - 600_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "expired" },
+        catchUp: { enabled: true, maxDelayMs: 120_000 },
+        state: { nextRunAtMs: baseMs - 300_000 },
+      },
+    ]);
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+
+    // Should NOT fire — exceeded maxDelayMs
+    const calls = enqueueSystemEvent.mock.calls.filter((args) => args[0] === "expired");
+    expect(calls.length).toBe(0);
+
+    // Should have logged a warning
+    expect(noopLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "catchup-expired" }),
+      expect.stringContaining("maxDelayMs"),
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("recomputes nextRunAtMs after catch-up", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const baseMs = Date.parse("2025-12-13T00:00:00.000Z");
+
+    await writeStore(store.storePath, [
+      {
+        id: "catchup-recompute",
+        name: "recompute job",
+        enabled: true,
+        createdAtMs: baseMs - 600_000,
+        updatedAtMs: baseMs - 600_000,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: baseMs - 600_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "recompute" },
+        catchUp: { enabled: true },
+        state: { nextRunAtMs: baseMs - 300_000 },
+      },
+    ]);
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const job = jobs.find((j) => j.id === "catchup-recompute");
+    // nextRunAtMs should be in the future now
+    expect(job?.state.nextRunAtMs).toBeGreaterThanOrEqual(baseMs);
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -180,6 +180,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     wakeMode: input.wakeMode,
     payload: input.payload,
     delivery: input.delivery,
+    catchUp: input.catchUp,
     state: {
       ...input.state,
     },

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -213,6 +213,9 @@ export function applyJobPatch(job: CronJob, patch: CronJobPatch) {
   if (patch.wakeMode) {
     job.wakeMode = patch.wakeMode;
   }
+  if (patch.catchUp !== undefined) {
+    job.catchUp = patch.catchUp;
+  }
   if (patch.payload) {
     job.payload = mergeCronPayload(job.payload, patch.payload);
   }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -63,6 +63,12 @@ export type CronJobState = {
   consecutiveErrors?: number;
 };
 
+export type CronCatchUp = {
+  enabled?: boolean;
+  maxDelayMs?: number;
+  strategy?: "once" | "all";
+};
+
 export type CronJob = {
   id: string;
   agentId?: string;
@@ -77,6 +83,7 @@ export type CronJob = {
   wakeMode: CronWakeMode;
   payload: CronPayload;
   delivery?: CronDelivery;
+  catchUp?: CronCatchUp;
   state: CronJobState;
 };
 


### PR DESCRIPTION
## Summary

When the gateway restarts after downtime, missed cron jobs are now detected and optionally re-executed instead of being silently skipped.

Fixes #12799

## Changes

- **`src/cron/types.ts`**: Added `CronCatchUp` type with `enabled`, `maxDelayMs`, and `strategy` ('once' | 'all') options
- **`src/cron/service/timer.ts`**: Enhanced `runMissedJobs()` to detect and optionally catch up missed jobs on startup, with logging for all missed jobs regardless of catch-up setting
- **`src/cron/service/jobs.ts`**: Pass `catchUp` through in job creation
- **`src/cron/service.catchup.test.ts`**: 5 new tests covering all scenarios

## Behavior

- **Default (no catchUp):** Missed jobs are now logged (no more silent skipping), then run once (existing behavior)
- **catchUp.enabled + strategy 'once':** Run the missed job once on startup
- **catchUp.enabled + strategy 'all':** Compute and run all missed occurrences (capped at 100)
- **maxDelayMs:** Only catch up if the job was missed within this time window

## Testing

All 98 existing tests + 5 new tests pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `catchUp` configuration to cron jobs and extends startup behavior to detect jobs whose `nextRunAtMs` is in the past after a restart. Missed jobs are now always logged, and (when `catchUp.enabled` is set) can either run once or attempt to run all missed occurrences (capped).

The changes integrate into the existing cron service startup path (`ops.start()` loads the store without recomputing, clears stale running markers, runs missed jobs, recomputes next runs, persists, then arms the timer). Job creation is extended to persist the new `catchUp` settings.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged until catch-up configuration updates and the 'all' catch-up execution semantics are corrected.
- Score is reduced because (1) `CronService.update()` currently cannot apply `catchUp` changes due to missing handling in `applyJobPatch`, and (2) the 'all' strategy computes missed occurrence timestamps but executes the job repeatedly without using them, making behavior diverge from the intended “replay missed ticks” semantics. These are functional issues that affect correctness and user expectations.
- src/cron/service/jobs.ts, src/cron/service/timer.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->