### PR TITLE
fix(tools): handle xAI Grok response format with web_search_call entries

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -10,7 +10,7 @@ const {
   resolveGrokApiKey,
   resolveGrokModel,
   resolveGrokInlineCitations,
-  extractGrokContent,
+  parseGrokResponse,
 } = __testing;
 
 describe("web_search perplexity baseUrl defaults", () => {
@@ -145,21 +145,77 @@ describe("web_search grok config resolution", () => {
 });
 
 describe("web_search grok response parsing", () => {
-  it("extracts content from Responses API output blocks", () => {
-    expect(
-      extractGrokContent({
-        output: [
-          {
-            content: [{ text: "hello from output" }],
-          },
-        ],
-      }),
-    ).toBe("hello from output");
+  it("extracts content from new API format with web_search_call entries", () => {
+    const response = {
+      output: [
+        { type: "web_search_call", role: null },
+        { type: "web_search_call", role: null },
+        {
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: "The weather is sunny and 83°F.",
+              annotations: [
+                { type: "url_citation", url: "https://weather.com/antigua" },
+                { type: "url_citation", url: "https://accuweather.com/antigua" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = parseGrokResponse(response);
+    expect(result.content).toBe("The weather is sunny and 83°F.");
+    expect(result.citations).toEqual([
+      "https://weather.com/antigua",
+      "https://accuweather.com/antigua",
+    ]);
   });
 
-  it("falls back to deprecated output_text", () => {
-    expect(extractGrokContent({ output_text: "hello from output_text" })).toBe(
-      "hello from output_text",
-    );
+  it("handles simple response without web_search_call entries", () => {
+    const response = {
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "2 + 2 = 4" }],
+        },
+      ],
+    };
+    const result = parseGrokResponse(response);
+    expect(result.content).toBe("2 + 2 = 4");
+    expect(result.citations).toEqual([]);
+  });
+
+  it("falls back to legacy output_text format", () => {
+    const response = {
+      output_text: "Legacy response text",
+      citations: ["https://example.com"],
+    };
+    const result = parseGrokResponse(response);
+    expect(result.content).toBe("Legacy response text");
+    expect(result.citations).toEqual(["https://example.com"]);
+  });
+
+  it("returns 'No response' when output is empty", () => {
+    const result = parseGrokResponse({});
+    expect(result.content).toBe("No response");
+    expect(result.citations).toEqual([]);
+  });
+
+  it("returns 'No response' when assistant message has no text content", () => {
+    const response = {
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "other_type", data: "something" }],
+        },
+      ],
+    };
+    const result = parseGrokResponse(response);
+    expect(result.content).toBe("No response");
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -106,12 +106,21 @@ type GrokSearchResponse = {
   output?: Array<{
     type?: string;
     role?: string;
+    status?: string;
     content?: Array<{
       type?: string;
       text?: string;
+      annotations?: Array<{
+        type: string;
+        url?: string;
+        start_index?: number;
+        end_index?: number;
+        title?: string;
+      }>;
     }>;
   }>;
-  output_text?: string; // deprecated field - kept for backwards compatibility
+  // Legacy fields (kept for backwards compat)
+  output_text?: string;
   citations?: string[];
   inline_citations?: Array<{
     start_index: number;
@@ -130,15 +139,6 @@ type PerplexitySearchResponse = {
 };
 
 type PerplexityBaseUrlHint = "direct" | "openrouter";
-
-function extractGrokContent(data: GrokSearchResponse): string | undefined {
-  // xAI Responses API format: output[0].content[0].text
-  const fromResponses = data.output?.[0]?.content?.[0]?.text;
-  if (typeof fromResponses === "string" && fromResponses) {
-    return fromResponses;
-  }
-  return typeof data.output_text === "string" ? data.output_text : undefined;
-}
 
 function resolveSearchConfig(cfg?: OpenClawConfig): WebSearchConfig {
   const search = cfg?.tools?.web?.search;
@@ -493,9 +493,40 @@ async function runGrokSearch(params: {
   }
 
   const data = (await res.json()) as GrokSearchResponse;
-  const content = extractGrokContent(data) ?? "No response";
-  const citations = data.citations ?? [];
-  const inlineCitations = data.inline_citations;
+  return parseGrokResponse(data);
+}
+
+/**
+ * Parse Grok API response, handling both new output[] format and legacy output_text format.
+ * The new format returns web_search_call entries first, with the assistant message last.
+ */
+function parseGrokResponse(data: GrokSearchResponse): {
+  content: string;
+  citations: string[];
+  inlineCitations?: GrokSearchResponse["inline_citations"];
+} {
+  let content = "No response";
+  let citations: string[] = [];
+  let inlineCitations: GrokSearchResponse["inline_citations"];
+
+  // Find the assistant message (may not be first if web_search_call entries precede it)
+  const assistantMessage = data.output?.find(
+    (o) => o.type === "message" && o.role === "assistant" && o.content,
+  );
+  if (assistantMessage?.content) {
+    const textContent = assistantMessage.content.find((c) => c.type === "output_text");
+    if (textContent?.text) {
+      content = textContent.text;
+    }
+    // Extract citations from annotations
+    const annotations = textContent?.annotations ?? [];
+    citations = annotations.filter((a) => a.type === "url_citation" && a.url).map((a) => a.url!);
+  } else if (data.output_text) {
+    // Legacy format fallback
+    content = data.output_text;
+    citations = data.citations ?? [];
+    inlineCitations = data.inline_citations;
+  }
 
   return { content, citations, inlineCitations };
 }
@@ -730,5 +761,5 @@ export const __testing = {
   resolveGrokApiKey,
   resolveGrokModel,
   resolveGrokInlineCitations,
-  extractGrokContent,
+  parseGrokResponse,
 } as const;


### PR DESCRIPTION
## Problem

The `web_search` tool returns "No response" when using the Grok provider, even though the xAI API is being called correctly.

## Root Cause

The xAI `/v1/responses` endpoint returns an `output[]` array where:
- First items are `web_search_call` entries (tool invocations, no text content)
- Last item is the `message` with `role: "assistant"` containing the actual response

The existing code assumed `output[0]` contained the text, but when web search is invoked, `output[0]` is a `web_search_call` with no content.

Example response structure (from [xAI docs](https://docs.x.ai/docs/guides/live-search)):
```json
{
  "output": [
    { "type": "web_search_call", "role": null },
    { "type": "web_search_call", "role": null },
    {
      "type": "message",
      "role": "assistant",
      "content": [{ "type": "output_text", "text": "..." }]
    }
  ]
}
```

## Solution

- Update `GrokSearchResponse` type to match actual API response structure
- Extract `parseGrokResponse()` function that finds the assistant message by `type === "message" && role === "assistant"`
- Add comprehensive tests for response parsing
- Maintain backwards compatibility with legacy `output_text` format

## Testing

- Added 5 new tests covering: web_search_call handling, simple responses, legacy fallback, empty responses
- All existing + new tests pass

## Related

- Fixes #12860
- This fixes the Grok provider that was added in #12419

## References

- [xAI Live Search Guide](https://docs.x.ai/docs/guides/live-search)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed Grok web search by correctly parsing xAI API responses that include `web_search_call` entries before the assistant message.

- Updated `GrokSearchResponse` type to match actual API structure with nested `output[]` array
- Extracted `parseGrokResponse()` function that uses `.find()` to locate the assistant message instead of assuming it is always first
- Maintained backwards compatibility with legacy `output_text` format
- Added comprehensive test coverage for web search responses, legacy format, and edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the root cause with proper response parsing logic, includes comprehensive test coverage (5 new tests covering all scenarios), maintains backwards compatibility, and follows defensive coding practices with proper null checking and fallbacks

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->