### PR TITLE
fix: ensure CLI exits after command completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI: lazily load outbound provider dependencies and remove forced success-path exits so commands terminate naturally without killing intentional long-running foreground actions. (#12906) Thanks @DrCrinkle.
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -22,9 +22,9 @@ export function registerAcpCli(program: Command) {
       "after",
       () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/acp", "docs.openclaw.ai/cli/acp")}\n`,
     )
-    .action((opts) => {
+    .action(async (opts) => {
       try {
-        serveAcpGateway({
+        await serveAcpGateway({
           gatewayUrl: opts.url as string | undefined,
           gatewayToken: opts.token as string | undefined,
           gatewayPassword: opts.password as string | undefined,

--- a/src/cli/daemon-cli/register.ts
+++ b/src/cli/daemon-cli/register.ts
@@ -1,7 +1,6 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-import { createDefaultDeps } from "../deps.js";
 import {
   runDaemonInstall,
   runDaemonRestart,
@@ -83,7 +82,4 @@ export function registerDaemonCli(program: Command) {
     .action(async (opts) => {
       await runDaemonRestart(opts);
     });
-
-  // Build default deps (parity with other commands).
-  void createDefaultDeps();
 }

--- a/src/cli/deps.test.ts
+++ b/src/cli/deps.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultDeps } from "./deps.js";
+
+const moduleLoads = vi.hoisted(() => ({
+  whatsapp: vi.fn(),
+  telegram: vi.fn(),
+  discord: vi.fn(),
+  slack: vi.fn(),
+  signal: vi.fn(),
+  imessage: vi.fn(),
+}));
+
+const sendFns = vi.hoisted(() => ({
+  whatsapp: vi.fn(async () => ({ messageId: "w1", toJid: "whatsapp:1" })),
+  telegram: vi.fn(async () => ({ messageId: "t1", chatId: "telegram:1" })),
+  discord: vi.fn(async () => ({ messageId: "d1", channelId: "discord:1" })),
+  slack: vi.fn(async () => ({ messageId: "s1", channelId: "slack:1" })),
+  signal: vi.fn(async () => ({ messageId: "sg1", conversationId: "signal:1" })),
+  imessage: vi.fn(async () => ({ messageId: "i1", chatId: "imessage:1" })),
+}));
+
+vi.mock("../channels/web/index.js", () => {
+  moduleLoads.whatsapp();
+  return { sendMessageWhatsApp: sendFns.whatsapp };
+});
+
+vi.mock("../telegram/send.js", () => {
+  moduleLoads.telegram();
+  return { sendMessageTelegram: sendFns.telegram };
+});
+
+vi.mock("../discord/send.js", () => {
+  moduleLoads.discord();
+  return { sendMessageDiscord: sendFns.discord };
+});
+
+vi.mock("../slack/send.js", () => {
+  moduleLoads.slack();
+  return { sendMessageSlack: sendFns.slack };
+});
+
+vi.mock("../signal/send.js", () => {
+  moduleLoads.signal();
+  return { sendMessageSignal: sendFns.signal };
+});
+
+vi.mock("../imessage/send.js", () => {
+  moduleLoads.imessage();
+  return { sendMessageIMessage: sendFns.imessage };
+});
+
+describe("createDefaultDeps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not load provider modules until a dependency is used", async () => {
+    const deps = createDefaultDeps();
+
+    expect(moduleLoads.whatsapp).not.toHaveBeenCalled();
+    expect(moduleLoads.telegram).not.toHaveBeenCalled();
+    expect(moduleLoads.discord).not.toHaveBeenCalled();
+    expect(moduleLoads.slack).not.toHaveBeenCalled();
+    expect(moduleLoads.signal).not.toHaveBeenCalled();
+    expect(moduleLoads.imessage).not.toHaveBeenCalled();
+
+    const sendTelegram = deps.sendMessageTelegram as unknown as (
+      ...args: unknown[]
+    ) => Promise<unknown>;
+    await sendTelegram("chat", "hello", { verbose: false });
+
+    expect(moduleLoads.telegram).toHaveBeenCalledTimes(1);
+    expect(sendFns.telegram).toHaveBeenCalledTimes(1);
+    expect(moduleLoads.whatsapp).not.toHaveBeenCalled();
+    expect(moduleLoads.discord).not.toHaveBeenCalled();
+    expect(moduleLoads.slack).not.toHaveBeenCalled();
+    expect(moduleLoads.signal).not.toHaveBeenCalled();
+    expect(moduleLoads.imessage).not.toHaveBeenCalled();
+  });
+
+  it("reuses module cache after first dynamic import", async () => {
+    const deps = createDefaultDeps();
+    const sendDiscord = deps.sendMessageDiscord as unknown as (
+      ...args: unknown[]
+    ) => Promise<unknown>;
+
+    await sendDiscord("channel", "first", { verbose: false });
+    await sendDiscord("channel", "second", { verbose: false });
+
+    expect(moduleLoads.discord).toHaveBeenCalledTimes(1);
+    expect(sendFns.discord).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -1,10 +1,10 @@
+import type { sendMessageWhatsApp } from "../channels/web/index.js";
+import type { sendMessageDiscord } from "../discord/send.js";
+import type { sendMessageIMessage } from "../imessage/send.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
-import { logWebSelfId, sendMessageWhatsApp } from "../channels/web/index.js";
-import { sendMessageDiscord } from "../discord/send.js";
-import { sendMessageIMessage } from "../imessage/send.js";
-import { sendMessageSignal } from "../signal/send.js";
-import { sendMessageSlack } from "../slack/send.js";
-import { sendMessageTelegram } from "../telegram/send.js";
+import type { sendMessageSignal } from "../signal/send.js";
+import type { sendMessageSlack } from "../slack/send.js";
+import type { sendMessageTelegram } from "../telegram/send.js";
 
 export type CliDeps = {
   sendMessageWhatsApp: typeof sendMessageWhatsApp;
@@ -17,12 +17,30 @@ export type CliDeps = {
 
 export function createDefaultDeps(): CliDeps {
   return {
-    sendMessageWhatsApp,
-    sendMessageTelegram,
-    sendMessageDiscord,
-    sendMessageSlack,
-    sendMessageSignal,
-    sendMessageIMessage,
+    sendMessageWhatsApp: async (...args) => {
+      const { sendMessageWhatsApp } = await import("../channels/web/index.js");
+      return await sendMessageWhatsApp(...args);
+    },
+    sendMessageTelegram: async (...args) => {
+      const { sendMessageTelegram } = await import("../telegram/send.js");
+      return await sendMessageTelegram(...args);
+    },
+    sendMessageDiscord: async (...args) => {
+      const { sendMessageDiscord } = await import("../discord/send.js");
+      return await sendMessageDiscord(...args);
+    },
+    sendMessageSlack: async (...args) => {
+      const { sendMessageSlack } = await import("../slack/send.js");
+      return await sendMessageSlack(...args);
+    },
+    sendMessageSignal: async (...args) => {
+      const { sendMessageSignal } = await import("../signal/send.js");
+      return await sendMessageSignal(...args);
+    },
+    sendMessageIMessage: async (...args) => {
+      const { sendMessageIMessage } = await import("../imessage/send.js");
+      return await sendMessageIMessage(...args);
+    },
   };
 }
 
@@ -38,4 +56,4 @@ export function createOutboundSendDeps(deps: CliDeps): OutboundSendDeps {
   };
 }
 
-export { logWebSelfId };
+export { logWebSelfId } from "../web/auth-store.js";

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -1,0 +1,49 @@
+import process from "node:process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tryRouteCliMock = vi.hoisted(() => vi.fn());
+const loadDotEnvMock = vi.hoisted(() => vi.fn());
+const normalizeEnvMock = vi.hoisted(() => vi.fn());
+const ensurePathMock = vi.hoisted(() => vi.fn());
+const assertRuntimeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./route.js", () => ({
+  tryRouteCli: tryRouteCliMock,
+}));
+
+vi.mock("../infra/dotenv.js", () => ({
+  loadDotEnv: loadDotEnvMock,
+}));
+
+vi.mock("../infra/env.js", () => ({
+  normalizeEnv: normalizeEnvMock,
+}));
+
+vi.mock("../infra/path-env.js", () => ({
+  ensureOpenClawCliOnPath: ensurePathMock,
+}));
+
+vi.mock("../infra/runtime-guard.js", () => ({
+  assertSupportedRuntime: assertRuntimeMock,
+}));
+
+const { runCli } = await import("./run-main.js");
+
+describe("runCli exit behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not force process.exit after successful routed command", async () => {
+    tryRouteCliMock.mockResolvedValueOnce(true);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`unexpected process.exit(${String(code)})`);
+    }) as typeof process.exit);
+
+    await runCli(["node", "openclaw", "status"]);
+
+    expect(tryRouteCliMock).toHaveBeenCalledWith(["node", "openclaw", "status"]);
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+});

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -34,7 +34,6 @@ export async function runCli(argv: string[] = process.argv) {
   assertSupportedRuntime();
 
   if (await tryRouteCli(normalizedArgv)) {
-    await flushAndExit(Number(process.exitCode ?? 0));
     return;
   }
 
@@ -70,25 +69,6 @@ export async function runCli(argv: string[] = process.argv) {
   }
 
   await program.parseAsync(parseArgv);
-
-  // Exit explicitly once the command action resolves.  Without this,
-  // eager side-effect imports (e.g. messaging-provider modules) can keep
-  // the Node event loop alive and the CLI hangs after the command finishes.
-  await flushAndExit(Number(process.exitCode ?? 0));
-}
-
-/** Drain stdout/stderr so piped output is not truncated, then exit. */
-async function flushAndExit(code: number): Promise<void> {
-  process.exitCode = code;
-  await Promise.all([
-    new Promise<void>((r) => {
-      process.stdout.write("", () => r());
-    }),
-    new Promise<void>((r) => {
-      process.stderr.write("", () => r());
-    }),
-  ]);
-  process.exit();
 }
 
 function stripWindowsNodeExec(argv: string[]): string[] {


### PR DESCRIPTION
## Summary

- Add explicit `process.exit(process.exitCode ?? 0)` after `program.parseAsync()` in `runCli()` so the CLI exits cleanly once any command finishes
- Remove unnecessary `void createDefaultDeps()` from daemon-cli registration — daemon lifecycle commands don't use messaging deps

## Problem

After any CLI command completes successfully, the process hangs indefinitely because:
1. `runCli()` returns without calling `process.exit()`, and Commander.js doesn't force-exit
2. Eagerly-imported messaging-provider modules (WhatsApp, Telegram, Discord, etc.) keep the Node.js event loop alive with persistent connections/timers

Failure paths work fine since they call `defaultRuntime.exit(1)` — only success paths hang.

Fixes #12904
Related: #7662

## Test plan

- [x] `vitest run src/cli/program.smoke.test.ts src/cli/daemon-cli` — all 20 tests pass
- [ ] Run `openclaw gateway restart` and verify the CLI exits immediately after printing the success message
- [ ] Run `openclaw daemon status` and verify clean exit
- [ ] Verify `process.exitCode` is respected (e.g. `openclaw memory` error paths still exit with code 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR forces the CLI process to terminate after command completion by adding an explicit drain-and-exit path (`flushAndExit`) after both routed CLI handling and Commander’s `program.parseAsync()`.

It also updates the ACP gateway server entrypoint to return a `Promise<void>` representing an intentional shutdown, awaits that promise from the `openclaw acp` command action, and removes eager default dependency initialization from daemon CLI registration to avoid keeping the event loop alive unnecessarily.

<h3>Confidence Score: 3/5</h3>

- This PR addresses a real hang, but it changes success-path lifecycle semantics in a way that can break long-running commands.
- The forced `process.exit()` after routed/Commander execution will reliably fix the hang caused by lingering side-effect imports, but it will also terminate any command that intentionally returns while keeping background work alive. The change is small and localized, but the behavioral risk is non-trivial without an opt-out mechanism.
- src/cli/run-main.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->