### PR TITLE
docs: clarify MEMORY.md injection and memory file behavior

### DIFF
--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -111,6 +111,9 @@ By default, OpenClaw injects a fixed set of workspace files (if present):
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (first-run only)
+- `MEMORY.md` (optional)
+
+`memory/*.md` files are not auto-injected into Project Context. They are available through memory tools and indexing.
 
 Large files are truncated per-file using `agents.defaults.bootstrapMaxChars` (default `20000` chars). `/context` shows **raw vs injected** sizes and whether truncation happened.
 

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,6 +59,9 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
+- `MEMORY.md` (optional; injected in normal sessions when present)
+
+`memory/*.md` files are not auto-injected into Project Context. They are read on demand via memory tools (`memory_search` / `memory_get`) and memory indexing.
 
 Large files are truncated with a marker. The max per-file size is controlled by
 `agents.defaults.bootstrapMaxChars` (default: 20000). Missing files inject a


### PR DESCRIPTION
## Summary

Clarifies system prompt/context docs to match runtime behavior for memory files.

## Changes

- Add `MEMORY.md` to injected workspace files in:
  - `docs/concepts/system-prompt.md`
  - `docs/concepts/context.md`
- Explicitly clarify that `memory/*.md` files are **not** auto-injected into Project Context.
- Clarify that `memory/*.md` are accessed via memory tooling/indexing.

## Testing

- Docs-only change.
- Reproduced behavior before opening this PR and verified with runtime evidence:
  - Checked latest session `systemPromptReport` (`/context detail`) and confirmed `MEMORY.md` appears in `injectedWorkspaceFiles` with raw/injected char counts.
  - Confirmed no `memory/YYYY-MM-DD.md` entries appear in injected workspace files for that run.
  - Cross-checked code path in `src/agents/workspace.ts` (`resolveMemoryBootstrapEntries`) which includes only `MEMORY.md` / `memory.md` for bootstrap injection.
- Also confirmed docs inconsistency this PR fixes:
  - `docs/start/openclaw.md` already states `MEMORY.md` is loaded for normal sessions.
  - `docs/concepts/system-prompt.md` and `docs/concepts/context.md` previously omitted it.

## Contributing checklist

- [x] Focused PR that addresses a single issue
- [x] AI-assisted: yes
- [x] Model used: `openai-codex/gpt-5.3-codex`
- [x] Testing disclosed (docs-only + runtime and code-path verification)

Closes #12909
