### PR TITLE
feat(gateway): add agents.health RPC method for per-agent health over…

### DIFF
--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -38,6 +38,7 @@ const BASE_METHODS = [
   "agents.files.list",
   "agents.files.get",
   "agents.files.set",
+  "agents.health",
   "skills.status",
   "skills.bins",
   "skills.install",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -1,8 +1,8 @@
 import type { GatewayRequestHandlers, GatewayRequestOptions } from "./server-methods/types.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
 import { agentHandlers } from "./server-methods/agent.js";
-import { agentsHandlers } from "./server-methods/agents.js";
 import { agentsHealthHandlers } from "./server-methods/agents-health.js";
+import { agentsHandlers } from "./server-methods/agents.js";
 import { browserHandlers } from "./server-methods/browser.js";
 import { channelsHandlers } from "./server-methods/channels.js";
 import { chatHandlers } from "./server-methods/chat.js";

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -2,6 +2,7 @@ import type { GatewayRequestHandlers, GatewayRequestOptions } from "./server-met
 import { ErrorCodes, errorShape } from "./protocol/index.js";
 import { agentHandlers } from "./server-methods/agent.js";
 import { agentsHandlers } from "./server-methods/agents.js";
+import { agentsHealthHandlers } from "./server-methods/agents-health.js";
 import { browserHandlers } from "./server-methods/browser.js";
 import { channelsHandlers } from "./server-methods/channels.js";
 import { chatHandlers } from "./server-methods/chat.js";
@@ -59,6 +60,7 @@ const READ_METHODS = new Set([
   "tts.providers",
   "models.list",
   "agents.list",
+  "agents.health",
   "agent.identity.get",
   "skills.status",
   "voicewake.get",
@@ -187,6 +189,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...usageHandlers,
   ...agentHandlers,
   ...agentsHandlers,
+  ...agentsHealthHandlers,
   ...browserHandlers,
 };
 

--- a/src/gateway/server-methods/agents-health.test.ts
+++ b/src/gateway/server-methods/agents-health.test.ts
@@ -37,21 +37,36 @@ const mocks = vi.hoisted(() => ({
       agentId: "coding",
       name: "Ticket Nudger",
       enabled: true,
-      state: { lastStatus: "ok", nextRunAtMs: Date.now() + 600_000, lastRunAtMs: Date.now() - 60_000, lastDurationMs: 13000 },
+      state: {
+        lastStatus: "ok",
+        nextRunAtMs: Date.now() + 600_000,
+        lastRunAtMs: Date.now() - 60_000,
+        lastDurationMs: 13000,
+      },
     },
     {
       id: "job-2",
       agentId: "coding",
       name: "Daily Report",
       enabled: true,
-      state: { lastStatus: "error", nextRunAtMs: Date.now() + 3600_000, lastRunAtMs: Date.now() - 300_000, lastDurationMs: 5000 },
+      state: {
+        lastStatus: "error",
+        nextRunAtMs: Date.now() + 3600_000,
+        lastRunAtMs: Date.now() - 300_000,
+        lastDurationMs: 5000,
+      },
     },
     {
       id: "job-3",
       agentId: "main",
       name: "Backup",
       enabled: true,
-      state: { lastStatus: "ok", nextRunAtMs: Date.now() + 7200_000, lastRunAtMs: Date.now() - 1800_000, lastDurationMs: 17000 },
+      state: {
+        lastStatus: "ok",
+        nextRunAtMs: Date.now() + 7200_000,
+        lastRunAtMs: Date.now() - 1800_000,
+        lastDurationMs: 17000,
+      },
     },
     {
       id: "job-4",
@@ -111,11 +126,18 @@ describe("agents.health", () => {
 
     const context = {
       cron: {
-        list: vi.fn(async () => mocks.cronListReturn),
+        list: vi.fn(async () => ({ jobs: mocks.cronListReturn })),
       },
     };
 
-    await handler({ respond, context, params: {}, req: {}, client: null, isWebchatConnect: () => false });
+    await handler({
+      respond,
+      context,
+      params: {},
+      req: {},
+      client: null,
+      isWebchatConnect: () => false,
+    });
 
     expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
     const agents = (result as Record<string, unknown>).agents as Array<Record<string, unknown>>;
@@ -147,11 +169,18 @@ describe("agents.health", () => {
     });
 
     const context = {
-      cron: { list: vi.fn(async () => []) },
+      cron: { list: vi.fn(async () => ({ jobs: [] })) },
     };
 
     const before = Date.now();
-    await handler({ respond, context, params: {}, req: {}, client: null, isWebchatConnect: () => false });
+    await handler({
+      respond,
+      context,
+      params: {},
+      req: {},
+      client: null,
+      isWebchatConnect: () => false,
+    });
     const after = Date.now();
 
     expect((result as Record<string, unknown>).generatedAtMs).toBeGreaterThanOrEqual(before);

--- a/src/gateway/server-methods/agents-health.test.ts
+++ b/src/gateway/server-methods/agents-health.test.ts
@@ -88,10 +88,10 @@ vi.mock("../../config/config.js", () => ({
 
 vi.mock("../session-utils.js", () => ({
   listAgentsForGateway: () => mocks.listAgentsForGatewayReturn,
-}));
-
-vi.mock("../../config/sessions.js", () => ({
-  loadSessionStore: () => mocks.sessionStoreReturn,
+  loadCombinedSessionStoreForGateway: () => ({
+    storePath: "/tmp/test-store",
+    store: mocks.sessionStoreReturn,
+  }),
 }));
 
 vi.mock("../../routing/session-key.js", () => ({
@@ -102,8 +102,7 @@ vi.mock("../../routing/session-key.js", () => ({
 }));
 
 vi.mock("../protocol/index.js", () => ({
-  ErrorCodes: { INTERNAL_ERROR: -32603, INVALID_REQUEST: -32600 },
-  errorShape: (code: number, msg: string) => ({ code, message: msg }),
+  errorShape: (code: string, msg: string) => ({ code, message: msg }),
 }));
 
 /* ------------------------------------------------------------------ */

--- a/src/gateway/server-methods/agents-health.test.ts
+++ b/src/gateway/server-methods/agents-health.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+const mocks = vi.hoisted(() => ({
+  loadConfigReturn: {} as Record<string, unknown>,
+  listAgentIdsReturn: ["main", "coding", "books"] as string[],
+  listAgentsForGatewayReturn: {
+    defaultId: "main",
+    mainKey: "agent:main:main",
+    scope: "global",
+    agents: [
+      { agentId: "main", name: "Mia" },
+      { agentId: "coding", name: "Dev" },
+      { agentId: "books", name: "Books" },
+    ],
+  },
+  sessionStoreReturn: {
+    "agent:main:main": {
+      key: "agent:main:main",
+      model: "claude-opus-4-6",
+      totalTokens: 100000,
+      updatedAt: Date.now() - 5 * 60 * 1000, // 5 min ago
+    },
+    "agent:coding:main": {
+      key: "agent:coding:main",
+      model: "claude-opus-4-6",
+      totalTokens: 74000,
+      updatedAt: Date.now() - 2 * 60 * 1000, // 2 min ago
+    },
+  } as Record<string, unknown>,
+  cronListReturn: [
+    {
+      id: "job-1",
+      agentId: "coding",
+      name: "Ticket Nudger",
+      enabled: true,
+      state: { lastStatus: "ok", nextRunAtMs: Date.now() + 600_000, lastRunAtMs: Date.now() - 60_000, lastDurationMs: 13000 },
+    },
+    {
+      id: "job-2",
+      agentId: "coding",
+      name: "Daily Report",
+      enabled: true,
+      state: { lastStatus: "error", nextRunAtMs: Date.now() + 3600_000, lastRunAtMs: Date.now() - 300_000, lastDurationMs: 5000 },
+    },
+    {
+      id: "job-3",
+      agentId: "main",
+      name: "Backup",
+      enabled: true,
+      state: { lastStatus: "ok", nextRunAtMs: Date.now() + 7200_000, lastRunAtMs: Date.now() - 1800_000, lastDurationMs: 17000 },
+    },
+    {
+      id: "job-4",
+      agentId: "main",
+      name: "Disabled Job",
+      enabled: false,
+      state: {},
+    },
+  ],
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentIds: () => mocks.listAgentIdsReturn,
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => mocks.loadConfigReturn,
+}));
+
+vi.mock("../session-utils.js", () => ({
+  listAgentsForGateway: () => mocks.listAgentsForGatewayReturn,
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: () => mocks.sessionStoreReturn,
+}));
+
+vi.mock("../../routing/session-key.js", () => ({
+  parseAgentSessionKey: (key: string) => {
+    const parts = key.split(":");
+    return { agentId: parts[1] ?? "main" };
+  },
+}));
+
+vi.mock("../protocol/index.js", () => ({
+  ErrorCodes: { INTERNAL_ERROR: -32603, INVALID_REQUEST: -32600 },
+  errorShape: (code: number, msg: string) => ({ code, message: msg }),
+}));
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("agents.health", () => {
+  let handler: (opts: Record<string, unknown>) => Promise<void>;
+
+  beforeEach(async () => {
+    const mod = await import("./agents-health.js");
+    handler = mod.agentsHealthHandlers["agents.health"] as typeof handler;
+  });
+
+  it("returns health for all agents", async () => {
+    let result: Record<string, unknown> | undefined;
+    const respond = vi.fn((ok: boolean, payload: unknown) => {
+      result = payload as Record<string, unknown>;
+    });
+
+    const context = {
+      cron: {
+        list: vi.fn(async () => mocks.cronListReturn),
+      },
+    };
+
+    await handler({ respond, context, params: {}, req: {}, client: null, isWebchatConnect: () => false });
+
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    const agents = (result as Record<string, unknown>).agents as Array<Record<string, unknown>>;
+    expect(agents).toHaveLength(3);
+
+    // Main agent — healthy, 1 cron job enabled
+    const main = agents.find((a) => a.agentId === "main")!;
+    expect(main.status).toBe("healthy");
+    expect(main.mainSession).toBeTruthy();
+    expect((main.cron as Record<string, unknown>).enabled).toBe(1);
+    expect((main.cron as Record<string, unknown>).total).toBe(2);
+
+    // Coding agent — warning (1 failing cron)
+    const coding = agents.find((a) => a.agentId === "coding")!;
+    expect(coding.status).toBe("warning");
+    expect(coding.statusReason).toContain("failing");
+    expect((coding.cron as Record<string, unknown>).failing).toBe(1);
+
+    // Books agent — unknown (no session, no crons)
+    const books = agents.find((a) => a.agentId === "books")!;
+    expect(books.status).toBe("unknown");
+    expect(books.mainSession).toBeNull();
+  });
+
+  it("includes generatedAtMs timestamp", async () => {
+    let result: Record<string, unknown> | undefined;
+    const respond = vi.fn((_ok: boolean, payload: unknown) => {
+      result = payload as Record<string, unknown>;
+    });
+
+    const context = {
+      cron: { list: vi.fn(async () => []) },
+    };
+
+    const before = Date.now();
+    await handler({ respond, context, params: {}, req: {}, client: null, isWebchatConnect: () => false });
+    const after = Date.now();
+
+    expect((result as Record<string, unknown>).generatedAtMs).toBeGreaterThanOrEqual(before);
+    expect((result as Record<string, unknown>).generatedAtMs).toBeLessThanOrEqual(after);
+  });
+});

--- a/src/gateway/server-methods/agents-health.ts
+++ b/src/gateway/server-methods/agents-health.ts
@@ -11,8 +11,8 @@ import { listAgentIds } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
 import { loadSessionStore, type SessionEntry } from "../../config/sessions.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
-import { listAgentsForGateway } from "../session-utils.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
+import { listAgentsForGateway } from "../session-utils.js";
 
 /* ------------------------------------------------------------------ */
 /* Types                                                              */
@@ -110,10 +110,10 @@ export const agentsHealthHandlers: GatewayRequestHandlers = {
 
       // Load cron jobs
       const cronResult = await context.cron.list({ includeDisabled: true });
-      const cronJobs = cronResult ?? [];
+      const cronJobs = (cronResult as { jobs?: unknown[] })?.jobs ?? [];
       const cronByAgent = new Map<string, typeof cronJobs>();
       for (const job of cronJobs) {
-        const aid = (job as Record<string, unknown>).agentId as string ?? "main";
+        const aid = ((job as Record<string, unknown>).agentId as string) ?? "main";
         if (!cronByAgent.has(aid)) cronByAgent.set(aid, []);
         cronByAgent.get(aid)!.push(job);
       }
@@ -122,9 +122,7 @@ export const agentsHealthHandlers: GatewayRequestHandlers = {
       const agents: AgentHealthEntry[] = [];
 
       for (const agentId of agentIds) {
-        const meta = agentsMeta.agents?.find(
-          (a: Record<string, unknown>) => a.agentId === agentId,
-        );
+        const meta = agentsMeta.agents?.find((a: Record<string, unknown>) => a.agentId === agentId);
 
         // Main session
         const sessions = sessionsByAgent.get(agentId) ?? [];

--- a/src/gateway/server-methods/agents-health.ts
+++ b/src/gateway/server-methods/agents-health.ts
@@ -1,0 +1,214 @@
+/**
+ * agents.health — Aggregate per-agent health overview.
+ *
+ * Composes data already available via agents.list, sessions.list,
+ * sessions.usage, and cron.list into a single summary suitable for
+ * dashboard rendering or CLI output.
+ */
+
+import type { GatewayRequestHandlers } from "./types.js";
+import { listAgentIds } from "../../agents/agent-scope.js";
+import { loadConfig } from "../../config/config.js";
+import { loadSessionStore, type SessionEntry } from "../../config/sessions.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { listAgentsForGateway } from "../session-utils.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+
+/* ------------------------------------------------------------------ */
+/* Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export type AgentCronSummary = {
+  total: number;
+  enabled: number;
+  failing: number;
+  nextRunAtMs: number | null;
+  lastFailure: {
+    jobId: string;
+    jobName: string;
+    lastRunAtMs: number;
+    lastDurationMs: number;
+  } | null;
+};
+
+export type AgentSessionSummary = {
+  key: string;
+  model: string | undefined;
+  totalTokens: number;
+  updatedAtMs: number;
+};
+
+export type AgentHealthEntry = {
+  agentId: string;
+  displayName: string | undefined;
+  status: "healthy" | "warning" | "error" | "unknown";
+  statusReason: string | undefined;
+  mainSession: AgentSessionSummary | null;
+  activeSessions: number;
+  cron: AgentCronSummary;
+};
+
+export type AgentsHealthResult = {
+  agents: AgentHealthEntry[];
+  generatedAtMs: number;
+};
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const STALE_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+
+function deriveStatus(
+  mainSession: AgentSessionSummary | null,
+  cronSummary: AgentCronSummary,
+): { status: AgentHealthEntry["status"]; reason: string | undefined } {
+  if (cronSummary.failing > 0) {
+    return {
+      status: "warning",
+      reason: `${cronSummary.failing} cron job(s) failing`,
+    };
+  }
+
+  if (mainSession) {
+    const age = Date.now() - mainSession.updatedAtMs;
+    if (age > STALE_THRESHOLD_MS) {
+      return {
+        status: "warning",
+        reason: `main session idle for ${Math.round(age / 60_000)}m`,
+      };
+    }
+  }
+
+  if (!mainSession && cronSummary.total === 0) {
+    return { status: "unknown", reason: "no sessions or cron jobs" };
+  }
+
+  return { status: "healthy", reason: undefined };
+}
+
+/* ------------------------------------------------------------------ */
+/* Handler                                                            */
+/* ------------------------------------------------------------------ */
+
+export const agentsHealthHandlers: GatewayRequestHandlers = {
+  "agents.health": async ({ respond, context }) => {
+    try {
+      const cfg = loadConfig();
+      const agentIds = listAgentIds(cfg);
+      const agentsMeta = listAgentsForGateway(cfg);
+
+      // Load all sessions
+      const sessionStore = loadSessionStore();
+      const sessionsByAgent = new Map<string, SessionEntry[]>();
+      for (const [key, entry] of Object.entries(sessionStore)) {
+        const parsed = parseAgentSessionKey(key);
+        const aid = parsed?.agentId ?? "main";
+        if (!sessionsByAgent.has(aid)) sessionsByAgent.set(aid, []);
+        sessionsByAgent.get(aid)!.push(entry as SessionEntry);
+      }
+
+      // Load cron jobs
+      const cronResult = await context.cron.list({ includeDisabled: true });
+      const cronJobs = cronResult ?? [];
+      const cronByAgent = new Map<string, typeof cronJobs>();
+      for (const job of cronJobs) {
+        const aid = (job as Record<string, unknown>).agentId as string ?? "main";
+        if (!cronByAgent.has(aid)) cronByAgent.set(aid, []);
+        cronByAgent.get(aid)!.push(job);
+      }
+
+      // Build per-agent health
+      const agents: AgentHealthEntry[] = [];
+
+      for (const agentId of agentIds) {
+        const meta = agentsMeta.agents?.find(
+          (a: Record<string, unknown>) => a.agentId === agentId,
+        );
+
+        // Main session
+        const sessions = sessionsByAgent.get(agentId) ?? [];
+        const mainSessionEntry = sessions.find(
+          (s) => (s as Record<string, unknown>).key === `agent:${agentId}:main`,
+        ) as Record<string, unknown> | undefined;
+
+        const mainSession: AgentSessionSummary | null = mainSessionEntry
+          ? {
+              key: `agent:${agentId}:main`,
+              model: mainSessionEntry.model as string | undefined,
+              totalTokens: (mainSessionEntry.totalTokens as number) ?? 0,
+              updatedAtMs: (mainSessionEntry.updatedAt as number) ?? 0,
+            }
+          : null;
+
+        // Cron summary
+        const agentCrons = cronByAgent.get(agentId) ?? [];
+        const enabledCrons = agentCrons.filter(
+          (j) => (j as Record<string, unknown>).enabled !== false,
+        );
+        const failingCrons = enabledCrons.filter((j) => {
+          const state = (j as Record<string, unknown>).state as Record<string, unknown> | undefined;
+          return state?.lastStatus === "error";
+        });
+
+        let nextRunAtMs: number | null = null;
+        let lastFailure: AgentCronSummary["lastFailure"] = null;
+
+        for (const j of enabledCrons) {
+          const state = (j as Record<string, unknown>).state as Record<string, unknown> | undefined;
+          const next = state?.nextRunAtMs as number | undefined;
+          if (next && (nextRunAtMs === null || next < nextRunAtMs)) {
+            nextRunAtMs = next;
+          }
+        }
+
+        if (failingCrons.length > 0) {
+          const j = failingCrons[0] as Record<string, unknown>;
+          const state = j.state as Record<string, unknown>;
+          lastFailure = {
+            jobId: j.id as string,
+            jobName: j.name as string,
+            lastRunAtMs: (state?.lastRunAtMs as number) ?? 0,
+            lastDurationMs: (state?.lastDurationMs as number) ?? 0,
+          };
+        }
+
+        const cronSummary: AgentCronSummary = {
+          total: agentCrons.length,
+          enabled: enabledCrons.length,
+          failing: failingCrons.length,
+          nextRunAtMs,
+          lastFailure,
+        };
+
+        const { status, reason } = deriveStatus(mainSession, cronSummary);
+
+        agents.push({
+          agentId,
+          displayName: (meta as Record<string, unknown>)?.name as string | undefined,
+          status,
+          statusReason: reason,
+          mainSession,
+          activeSessions: sessions.length,
+          cron: cronSummary,
+        });
+      }
+
+      const result: AgentsHealthResult = {
+        agents,
+        generatedAtMs: Date.now(),
+      };
+
+      respond(true, result, undefined);
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INTERNAL_ERROR,
+          `agents.health failed: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    }
+  },
+};

--- a/src/gateway/server-methods/agents-health.ts
+++ b/src/gateway/server-methods/agents-health.ts
@@ -9,10 +9,10 @@
 import type { GatewayRequestHandlers } from "./types.js";
 import { listAgentIds } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
-import { loadSessionStore, type SessionEntry } from "../../config/sessions.js";
+import type { SessionEntry } from "../../config/sessions.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
-import { ErrorCodes, errorShape } from "../protocol/index.js";
-import { listAgentsForGateway } from "../session-utils.js";
+import { errorShape } from "../protocol/index.js";
+import { listAgentsForGateway, loadCombinedSessionStoreForGateway } from "../session-utils.js";
 
 /* ------------------------------------------------------------------ */
 /* Types                                                              */
@@ -99,7 +99,7 @@ export const agentsHealthHandlers: GatewayRequestHandlers = {
       const agentsMeta = listAgentsForGateway(cfg);
 
       // Load all sessions
-      const sessionStore = loadSessionStore();
+      const { store: sessionStore } = loadCombinedSessionStoreForGateway(cfg);
       const sessionsByAgent = new Map<string, SessionEntry[]>();
       for (const [key, entry] of Object.entries(sessionStore)) {
         const parsed = parseAgentSessionKey(key);
@@ -203,7 +203,7 @@ export const agentsHealthHandlers: GatewayRequestHandlers = {
         false,
         undefined,
         errorShape(
-          ErrorCodes.INTERNAL_ERROR,
+          "UNAVAILABLE",
           `agents.health failed: ${err instanceof Error ? err.message : String(err)}`,
         ),
       );

--- a/src/gateway/server-methods/agents-health.ts
+++ b/src/gateway/server-methods/agents-health.ts
@@ -6,10 +6,10 @@
  * dashboard rendering or CLI output.
  */
 
+import type { SessionEntry } from "../../config/sessions.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { listAgentIds } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
-import type { SessionEntry } from "../../config/sessions.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { errorShape } from "../protocol/index.js";
 import { listAgentsForGateway, loadCombinedSessionStoreForGateway } from "../session-utils.js";

--- a/src/gateway/server-methods/agents-health.ts
+++ b/src/gateway/server-methods/agents-health.ts
@@ -104,8 +104,12 @@ export const agentsHealthHandlers: GatewayRequestHandlers = {
       for (const [key, entry] of Object.entries(sessionStore)) {
         const parsed = parseAgentSessionKey(key);
         const aid = parsed?.agentId ?? "main";
-        if (!sessionsByAgent.has(aid)) sessionsByAgent.set(aid, []);
-        sessionsByAgent.get(aid)!.push(entry as SessionEntry);
+        const existing = sessionsByAgent.get(aid);
+        if (existing) {
+          existing.push(entry);
+        } else {
+          sessionsByAgent.set(aid, [entry]);
+        }
       }
 
       // Load cron jobs
@@ -114,8 +118,12 @@ export const agentsHealthHandlers: GatewayRequestHandlers = {
       const cronByAgent = new Map<string, typeof cronJobs>();
       for (const job of cronJobs) {
         const aid = ((job as Record<string, unknown>).agentId as string) ?? "main";
-        if (!cronByAgent.has(aid)) cronByAgent.set(aid, []);
-        cronByAgent.get(aid)!.push(job);
+        const existing = cronByAgent.get(aid);
+        if (existing) {
+          existing.push(job);
+        } else {
+          cronByAgent.set(aid, [job]);
+        }
       }
 
       // Build per-agent health


### PR DESCRIPTION
…view

Adds a new `agents.health` gateway RPC method that aggregates existing data from agents.list, sessions, and cron into a single per-agent health summary. Useful for dashboard rendering and CLI health checks.

Each agent entry includes:
- status (healthy/warning/error/unknown) with reason
- main session info (model, tokens, last activity)
- active session count
- cron summary (total, enabled, failing, next run, last failure)

Status is derived automatically:
- warning: cron jobs failing or main session idle >30m
- unknown: no sessions and no cron jobs
- healthy: everything nominal

Registered as a read-scope method, available in the control UI and via WebSocket RPC.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new gateway RPC method `agents.health`, registers it in the gateway method list, and grants it read-scope access. The new handler aggregates agent metadata, session store entries, and cron jobs into a per-agent health summary (status + reason, main session info, active session count, cron summary) intended for dashboards/CLI.

The overall approach fits the gateway’s existing “server-methods” pattern by adding a dedicated handler module and wiring it into `coreGatewayHandlers` alongside existing `agents.*`/`cron.*` methods.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a definite runtime bug in cron aggregation for `agents.health`.
- `agents.health` calls `context.cron.list` and treats its return value as an array, but the established contract returns an object `{ jobs }` (per existing `cron.list` handler). This will break cron grouping/status derivation at runtime, and the accompanying test currently mocks the wrong shape so it won’t catch the issue.
- src/gateway/server-methods/agents-health.ts, src/gateway/server-methods/agents-health.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->