### PR TITLE
fix: prune stale session entries, cap entry count, and rotate sessions.json

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -288,10 +288,10 @@ describe("sessions", () => {
 
     await Promise.all([
       updateSessionStore(storePath, (store) => {
-        store["agent:main:one"] = { sessionId: "sess-1", updatedAt: 1 };
+        store["agent:main:one"] = { sessionId: "sess-1", updatedAt: Date.now() };
       }),
       updateSessionStore(storePath, (store) => {
-        store["agent:main:two"] = { sessionId: "sess-2", updatedAt: 2 };
+        store["agent:main:two"] = { sessionId: "sess-2", updatedAt: Date.now() };
       }),
     ]);
 
@@ -306,7 +306,7 @@ describe("sessions", () => {
     await fs.writeFile(storePath, "[]", "utf-8");
 
     await updateSessionStore(storePath, (store) => {
-      store["agent:main:main"] = { sessionId: "sess-1", updatedAt: 1 };
+      store["agent:main:main"] = { sessionId: "sess-1", updatedAt: Date.now() };
     });
 
     const store = loadSessionStore(storePath);
@@ -324,7 +324,7 @@ describe("sessions", () => {
     await updateSessionStore(storePath, (store) => {
       store["agent:main:main"] = {
         sessionId: "sess-normalized",
-        updatedAt: 1,
+        updatedAt: Date.now(),
         lastChannel: " WhatsApp ",
         lastTo: " +1555 ",
         lastAccountId: " acct-1 ",
@@ -349,8 +349,8 @@ describe("sessions", () => {
       storePath,
       JSON.stringify(
         {
-          "agent:main:old": { sessionId: "sess-old", updatedAt: 1 },
-          "agent:main:keep": { sessionId: "sess-keep", updatedAt: 2 },
+          "agent:main:old": { sessionId: "sess-old", updatedAt: Date.now() },
+          "agent:main:keep": { sessionId: "sess-keep", updatedAt: Date.now() },
         },
         null,
         2,
@@ -363,7 +363,7 @@ describe("sessions", () => {
         delete store["agent:main:old"];
       }),
       updateSessionStore(storePath, (store) => {
-        store["agent:main:new"] = { sessionId: "sess-new", updatedAt: 3 };
+        store["agent:main:new"] = { sessionId: "sess-new", updatedAt: Date.now() };
       }),
     ]);
 

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -1,0 +1,490 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "./types.js";
+import {
+  capEntryCount,
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  pruneStaleEntries,
+  rotateSessionFile,
+  saveSessionStore,
+} from "./store.js";
+
+// Mock loadConfig so resolveMaintenanceConfig() never reads a real openclaw.json.
+// Unit tests always pass explicit overrides so this mock is inert for them.
+// Integration tests set return values to control the config.
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn().mockReturnValue({}),
+}));
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeEntry(updatedAt: number): SessionEntry {
+  return { sessionId: crypto.randomUUID(), updatedAt };
+}
+
+function makeStore(entries: Array<[string, SessionEntry]>): Record<string, SessionEntry> {
+  return Object.fromEntries(entries);
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — each function called with explicit override parameters.
+// No config loading needed; overrides bypass resolveMaintenanceConfig().
+// ---------------------------------------------------------------------------
+
+describe("pruneStaleEntries", () => {
+  it("removes entries older than maxAgeDays", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["old", makeEntry(now - 31 * DAY_MS)],
+      ["fresh", makeEntry(now - 1 * DAY_MS)],
+    ]);
+
+    const pruned = pruneStaleEntries(store, 30);
+
+    expect(pruned).toBe(1);
+    expect(store.old).toBeUndefined();
+    expect(store.fresh).toBeDefined();
+  });
+
+  it("keeps entries newer than maxAgeDays", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["a", makeEntry(now - 1 * DAY_MS)],
+      ["b", makeEntry(now - 6 * DAY_MS)],
+      ["c", makeEntry(now)],
+    ]);
+
+    const pruned = pruneStaleEntries(store, 7);
+
+    expect(pruned).toBe(0);
+    expect(Object.keys(store)).toHaveLength(3);
+  });
+
+  it("keeps entries with no updatedAt", () => {
+    const store: Record<string, SessionEntry> = {
+      noDate: { sessionId: crypto.randomUUID() } as SessionEntry,
+      fresh: makeEntry(Date.now()),
+    };
+
+    const pruned = pruneStaleEntries(store, 1);
+
+    expect(pruned).toBe(0);
+    expect(store.noDate).toBeDefined();
+  });
+
+  it("empty store is a no-op", () => {
+    const store: Record<string, SessionEntry> = {};
+    const pruned = pruneStaleEntries(store, 30);
+
+    expect(pruned).toBe(0);
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it("all entries stale results in empty store", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["a", makeEntry(now - 10 * DAY_MS)],
+      ["b", makeEntry(now - 20 * DAY_MS)],
+      ["c", makeEntry(now - 100 * DAY_MS)],
+    ]);
+
+    const pruned = pruneStaleEntries(store, 5);
+
+    expect(pruned).toBe(3);
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it("returns count of pruned entries", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["stale1", makeEntry(now - 15 * DAY_MS)],
+      ["stale2", makeEntry(now - 30 * DAY_MS)],
+      ["fresh1", makeEntry(now - 5 * DAY_MS)],
+      ["fresh2", makeEntry(now)],
+    ]);
+
+    const pruned = pruneStaleEntries(store, 10);
+
+    expect(pruned).toBe(2);
+    expect(Object.keys(store)).toHaveLength(2);
+  });
+
+  it("entry exactly at the boundary is kept", () => {
+    const now = Date.now();
+    const store = makeStore([["borderline", makeEntry(now - 30 * DAY_MS + 1000)]]);
+
+    const pruned = pruneStaleEntries(store, 30);
+
+    expect(pruned).toBe(0);
+    expect(store.borderline).toBeDefined();
+  });
+
+  it("falls back to built-in default (30 days) when no override given", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["old", makeEntry(now - 31 * DAY_MS)],
+      ["fresh", makeEntry(now - 29 * DAY_MS)],
+    ]);
+
+    // loadConfig mock returns {} → maintenance is undefined → default 30 days
+    const pruned = pruneStaleEntries(store);
+
+    expect(pruned).toBe(1);
+    expect(store.old).toBeUndefined();
+    expect(store.fresh).toBeDefined();
+  });
+});
+
+describe("capEntryCount", () => {
+  it("over limit: keeps N most recent by updatedAt, deletes rest", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["oldest", makeEntry(now - 4 * DAY_MS)],
+      ["old", makeEntry(now - 3 * DAY_MS)],
+      ["mid", makeEntry(now - 2 * DAY_MS)],
+      ["recent", makeEntry(now - 1 * DAY_MS)],
+      ["newest", makeEntry(now)],
+    ]);
+
+    const evicted = capEntryCount(store, 3);
+
+    expect(evicted).toBe(2);
+    expect(Object.keys(store)).toHaveLength(3);
+    expect(store.newest).toBeDefined();
+    expect(store.recent).toBeDefined();
+    expect(store.mid).toBeDefined();
+    expect(store.oldest).toBeUndefined();
+    expect(store.old).toBeUndefined();
+  });
+
+  it("under limit: no-op", () => {
+    const store = makeStore([
+      ["a", makeEntry(Date.now())],
+      ["b", makeEntry(Date.now() - DAY_MS)],
+    ]);
+
+    const evicted = capEntryCount(store, 10);
+
+    expect(evicted).toBe(0);
+    expect(Object.keys(store)).toHaveLength(2);
+  });
+
+  it("exactly at limit: no-op", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["a", makeEntry(now)],
+      ["b", makeEntry(now - DAY_MS)],
+      ["c", makeEntry(now - 2 * DAY_MS)],
+    ]);
+
+    const evicted = capEntryCount(store, 3);
+
+    expect(evicted).toBe(0);
+    expect(Object.keys(store)).toHaveLength(3);
+  });
+
+  it("entries without updatedAt are evicted first (lowest priority)", () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      noDate1: { sessionId: crypto.randomUUID() } as SessionEntry,
+      noDate2: { sessionId: crypto.randomUUID() } as SessionEntry,
+      recent: makeEntry(now),
+      older: makeEntry(now - DAY_MS),
+    };
+
+    const evicted = capEntryCount(store, 2);
+
+    expect(evicted).toBe(2);
+    expect(store.recent).toBeDefined();
+    expect(store.older).toBeDefined();
+    expect(store.noDate1).toBeUndefined();
+    expect(store.noDate2).toBeUndefined();
+  });
+
+  it("returns count of evicted entries", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["a", makeEntry(now)],
+      ["b", makeEntry(now - DAY_MS)],
+      ["c", makeEntry(now - 2 * DAY_MS)],
+    ]);
+
+    const evicted = capEntryCount(store, 1);
+
+    expect(evicted).toBe(2);
+    expect(Object.keys(store)).toHaveLength(1);
+    expect(store.a).toBeDefined();
+  });
+
+  it("falls back to built-in default (500) when no override given", () => {
+    const now = Date.now();
+    const entries: Array<[string, SessionEntry]> = [];
+    for (let i = 0; i < 501; i++) {
+      entries.push([`key-${i}`, makeEntry(now - i * 1000)]);
+    }
+    const store = makeStore(entries);
+
+    // loadConfig mock returns {} → maintenance is undefined → default 500
+    const evicted = capEntryCount(store);
+
+    expect(evicted).toBe(1);
+    expect(Object.keys(store)).toHaveLength(500);
+    expect(store["key-0"]).toBeDefined();
+    expect(store["key-500"]).toBeUndefined();
+  });
+
+  it("empty store is a no-op", () => {
+    const store: Record<string, SessionEntry> = {};
+
+    const evicted = capEntryCount(store, 5);
+
+    expect(evicted).toBe(0);
+  });
+});
+
+describe("rotateSessionFile", () => {
+  let testDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rotate-"));
+    storePath = path.join(testDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it("file under maxBytes: no rotation (returns false)", async () => {
+    await fs.writeFile(storePath, "x".repeat(500), "utf-8");
+
+    const rotated = await rotateSessionFile(storePath, 1000);
+
+    expect(rotated).toBe(false);
+    const content = await fs.readFile(storePath, "utf-8");
+    expect(content).toBe("x".repeat(500));
+  });
+
+  it("file over maxBytes: renamed to .bak.{timestamp}, returns true", async () => {
+    const bigContent = "x".repeat(200);
+    await fs.writeFile(storePath, bigContent, "utf-8");
+
+    const rotated = await rotateSessionFile(storePath, 100);
+
+    expect(rotated).toBe(true);
+    await expect(fs.stat(storePath)).rejects.toThrow();
+    const files = await fs.readdir(testDir);
+    const bakFiles = files.filter((f) => f.startsWith("sessions.json.bak."));
+    expect(bakFiles).toHaveLength(1);
+    const bakContent = await fs.readFile(path.join(testDir, bakFiles[0]), "utf-8");
+    expect(bakContent).toBe(bigContent);
+  });
+
+  it("multiple rotations: only keeps 3 most recent .bak files", async () => {
+    for (let i = 0; i < 5; i++) {
+      await fs.writeFile(storePath, `data-${i}-${"x".repeat(100)}`, "utf-8");
+      await rotateSessionFile(storePath, 50);
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const files = await fs.readdir(testDir);
+    const bakFiles = files.filter((f) => f.startsWith("sessions.json.bak.")).toSorted();
+
+    expect(bakFiles.length).toBeLessThanOrEqual(3);
+  });
+
+  it("non-existent file: no rotation (returns false)", async () => {
+    const missingPath = path.join(testDir, "missing.json");
+
+    const rotated = await rotateSessionFile(missingPath, 100);
+
+    expect(rotated).toBe(false);
+  });
+
+  it("file exactly at maxBytes: no rotation (returns false)", async () => {
+    await fs.writeFile(storePath, "x".repeat(100), "utf-8");
+
+    const rotated = await rotateSessionFile(storePath, 100);
+
+    expect(rotated).toBe(false);
+  });
+
+  it("backup file name includes a timestamp", async () => {
+    await fs.writeFile(storePath, "x".repeat(100), "utf-8");
+    const before = Date.now();
+
+    await rotateSessionFile(storePath, 50);
+
+    const after = Date.now();
+    const files = await fs.readdir(testDir);
+    const bakFiles = files.filter((f) => f.startsWith("sessions.json.bak."));
+    expect(bakFiles).toHaveLength(1);
+    const timestamp = Number(bakFiles[0].replace("sessions.json.bak.", ""));
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — exercise saveSessionStore end-to-end.
+// The file-level vi.mock("../config.js") stubs loadConfig; per-test
+// mockReturnValue controls what resolveMaintenanceConfig() returns.
+// ---------------------------------------------------------------------------
+
+describe("Integration: saveSessionStore with pruning", () => {
+  let testDir: string;
+  let storePath: string;
+  let savedCacheTtl: string | undefined;
+  let mockLoadConfig: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pruning-integ-"));
+    storePath = path.join(testDir, "sessions.json");
+    savedCacheTtl = process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "0";
+    clearSessionStoreCacheForTest();
+
+    const configModule = await import("../config.js");
+    mockLoadConfig = configModule.loadConfig as ReturnType<typeof vi.fn>;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+    clearSessionStoreCacheForTest();
+    if (savedCacheTtl === undefined) {
+      delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    } else {
+      process.env.OPENCLAW_SESSION_CACHE_TTL_MS = savedCacheTtl;
+    }
+  });
+
+  it("saveSessionStore prunes stale entries on write", async () => {
+    mockLoadConfig.mockReturnValue({
+      session: { maintenance: { pruneDays: 7, maxEntries: 500, rotateBytes: 10_485_760 } },
+    });
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      stale: makeEntry(now - 30 * DAY_MS),
+      fresh: makeEntry(now),
+    };
+
+    await saveSessionStore(storePath, store);
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded.stale).toBeUndefined();
+    expect(loaded.fresh).toBeDefined();
+  });
+
+  it("saveSessionStore caps entries over limit", async () => {
+    mockLoadConfig.mockReturnValue({
+      session: { maintenance: { pruneDays: 30, maxEntries: 5, rotateBytes: 10_485_760 } },
+    });
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {};
+    for (let i = 0; i < 10; i++) {
+      store[`key-${i}`] = makeEntry(now - i * 1000);
+    }
+
+    await saveSessionStore(storePath, store);
+
+    const loaded = loadSessionStore(storePath);
+    expect(Object.keys(loaded)).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect(loaded[`key-${i}`]).toBeDefined();
+    }
+    for (let i = 5; i < 10; i++) {
+      expect(loaded[`key-${i}`]).toBeUndefined();
+    }
+  });
+
+  it("saveSessionStore rotates file when over size limit and creates .bak", async () => {
+    mockLoadConfig.mockReturnValue({
+      session: { maintenance: { pruneDays: 30, maxEntries: 500, rotateBytes: 100 } },
+    });
+
+    const now = Date.now();
+    const largeStore: Record<string, SessionEntry> = {};
+    for (let i = 0; i < 50; i++) {
+      largeStore[`agent:main:session-${crypto.randomUUID()}`] = makeEntry(now - i * 1000);
+    }
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify(largeStore, null, 2), "utf-8");
+
+    const statBefore = await fs.stat(storePath);
+    expect(statBefore.size).toBeGreaterThan(100);
+
+    const smallStore: Record<string, SessionEntry> = {
+      only: makeEntry(now),
+    };
+    await saveSessionStore(storePath, smallStore);
+
+    const files = await fs.readdir(testDir);
+    const bakFiles = files.filter((f) => f.startsWith("sessions.json.bak."));
+    expect(bakFiles.length).toBeGreaterThanOrEqual(1);
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded.only).toBeDefined();
+  });
+
+  it("saveSessionStore applies both pruning and capping together", async () => {
+    mockLoadConfig.mockReturnValue({
+      session: { maintenance: { pruneDays: 10, maxEntries: 3, rotateBytes: 10_485_760 } },
+    });
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      stale1: makeEntry(now - 15 * DAY_MS),
+      stale2: makeEntry(now - 20 * DAY_MS),
+      fresh1: makeEntry(now),
+      fresh2: makeEntry(now - 1 * DAY_MS),
+      fresh3: makeEntry(now - 2 * DAY_MS),
+      fresh4: makeEntry(now - 5 * DAY_MS),
+    };
+
+    await saveSessionStore(storePath, store);
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded.stale1).toBeUndefined();
+    expect(loaded.stale2).toBeUndefined();
+    expect(Object.keys(loaded).length).toBeLessThanOrEqual(3);
+    expect(loaded.fresh1).toBeDefined();
+    expect(loaded.fresh2).toBeDefined();
+    expect(loaded.fresh3).toBeDefined();
+    expect(loaded.fresh4).toBeUndefined();
+  });
+
+  it("resolveMaintenanceConfig reads from loadConfig().session.maintenance", async () => {
+    mockLoadConfig.mockReturnValue({
+      session: { maintenance: { pruneDays: 7, maxEntries: 100, rotateBytes: 5_000_000 } },
+    });
+
+    const { resolveMaintenanceConfig } = await import("./store.js");
+    const config = resolveMaintenanceConfig();
+
+    expect(config).toEqual({
+      pruneDays: 7,
+      maxEntries: 100,
+      rotateBytes: 5_000_000,
+    });
+  });
+
+  it("resolveMaintenanceConfig uses defaults for missing fields", async () => {
+    mockLoadConfig.mockReturnValue({ session: { maintenance: { pruneDays: 14 } } });
+
+    const { resolveMaintenanceConfig } = await import("./store.js");
+    const config = resolveMaintenanceConfig();
+
+    expect(config).toEqual({
+      pruneDays: 14,
+      maxEntries: 500,
+      rotateBytes: 10_485_760,
+    });
+  });
+});

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -99,6 +99,17 @@ export type SessionConfig = {
     /** Max ping-pong turns between requester/target (0–5). Default: 5. */
     maxPingPongTurns?: number;
   };
+  /** Automatic session store maintenance (pruning, capping, file rotation). */
+  maintenance?: SessionMaintenanceConfig;
+};
+
+export type SessionMaintenanceConfig = {
+  /** Remove session entries older than this many days. Default: 30. */
+  pruneDays?: number;
+  /** Maximum number of session entries to keep. Default: 500. */
+  maxEntries?: number;
+  /** Rotate sessions.json when it exceeds this size in bytes. Default: 10485760 (10 MB). */
+  rotateBytes?: number;
 };
 
 export type LoggingConfig = {

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -90,6 +90,14 @@ export const SessionSchema = z
       })
       .strict()
       .optional(),
+    maintenance: z
+      .object({
+        pruneDays: z.number().int().positive().optional(),
+        maxEntries: z.number().int().positive().optional(),
+        rotateBytes: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -732,7 +732,9 @@ async function migrateLegacySessions(
       }
       normalized[key] = normalizedEntry;
     }
-    await saveSessionStore(detected.sessions.targetStorePath, normalized);
+    await saveSessionStore(detected.sessions.targetStorePath, normalized, {
+      skipMaintenance: true,
+    });
     changes.push(`Merged sessions store → ${detected.sessions.targetStorePath}`);
     if (canonicalizedTarget.legacyKeys.length > 0) {
       changes.push(`Canonicalized ${canonicalizedTarget.legacyKeys.length} legacy session key(s)`);


### PR DESCRIPTION
## Problem

`sessions.json` grows unbounded over time. Every heartbeat tick (default: 30m) triggers multiple full rewrites, and session keys from groups, threads, and DMs accumulate indefinitely with large embedded objects (`skillsSnapshot`, `systemPromptReport`). At >50MB the synchronous JSON parse blocks the event loop, causing Telegram webhook timeouts and effectively taking the bot down.

## Fix

Three mitigations, all running inside `saveSessionStoreUnlocked()` on every write:

### 1. Prune stale entries
Remove entries with `updatedAt` older than 30 days. Entries without `updatedAt` are preserved (cannot determine staleness).

### 2. Cap entry count
Keep only the 500 most recently updated entries. Entries without `updatedAt` are evicted first (lowest priority).

### 3. File rotation
If the existing `sessions.json` exceeds 10MB before a write, rename it to `sessions.json.bak.{timestamp}`. Only the 3 most recent backups are kept.

## Configuration

All three thresholds are configurable via `openclaw.json` under `session.maintenance`:

```json
{
  "session": {
    "maintenance": {
      "pruneDays": 30,
      "maxEntries": 500,
      "rotateBytes": 10485760
    }
  }
}
```

All fields are optional — built-in defaults apply when unset. No env vars are used; configuration is purely through `openclaw.json`.

The `SessionMaintenanceConfig` type is added to `types.base.ts` and the Zod schema is added to `zod-schema.session.ts`.

The three exported functions also accept an optional override parameter for direct use in tests or programmatic callers:
- `pruneStaleEntries(store, overrideDays?)`
- `capEntryCount(store, overrideMax?)`
- `rotateSessionFile(storePath, overrideBytes?)`

## Changes

| File | Change |
|------|--------|
| `src/config/sessions/store.ts` | Three exported functions, `resolveMaintenanceConfig()` reads from `openclaw.json`, wired into `saveSessionStoreUnlocked()` |
| `src/config/sessions/store.pruning.test.ts` | 25 new tests across 4 describe blocks (unit + integration). Unit tests use override params; integration tests mock `loadConfig` to control config |
| `src/config/types.base.ts` | `SessionMaintenanceConfig` type definition |
| `src/config/zod-schema.session.ts` | `maintenance` field added to `SessionSchema` |
| `src/config/sessions.test.ts` | Updated 4 existing tests to use `Date.now()` instead of epoch-relative timestamps |

## Test results

72 tests pass (7 test files).

## Notes

- Pruning and capping mutate the store object in-place before serialization. File rotation renames the on-disk file before the new write.
- No changes to function signatures of existing exported functions.
- Logged via `createSubsystemLogger("sessions/store")` at info level when entries are pruned, capped, or the file is rotated.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds automatic `sessions.json` maintenance during session store writes: pruning entries older than a configurable age, capping total entries to a configurable maximum, and rotating the on-disk file when it exceeds a size threshold (keeping a small set of `.bak.{timestamp}` backups). Configuration is wired through `openclaw.json` under `session.maintenance` with a new `SessionMaintenanceConfig` type and Zod validation. Migrations are updated to be able to bypass maintenance during one-time legacy merges.

One issue to fix before merge: the new pruning/capping/rotation test suite references `crypto.randomUUID()` without importing `crypto`, which will break in environments where `crypto` is not a global in tests.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one clear test/runtime issue to fix.
- Core maintenance logic (pruning/capping/rotation) is internally consistent and call sites remain compatible via an optional options param, but the new test file relies on an undeclared `crypto` identifier which can cause CI failures depending on the test runtime globals.
- src/config/sessions/store.pruning.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->