### PR TITLE
fix(telegram): omit message_thread_id for private DM chats

### DIFF
--- a/src/telegram/bot-message-context.dm-threads.test.ts
+++ b/src/telegram/bot-message-context.dm-threads.test.ts
@@ -51,7 +51,9 @@ describe("buildTelegramMessageContext dm thread sessions", () => {
     });
 
     expect(ctx).not.toBeNull();
-    expect(ctx?.ctxPayload?.MessageThreadId).toBe(42);
+    // DM thread IDs are NOT propagated as MessageThreadId to prevent
+    // Telegram "message thread not found" errors on proactive sends (#12929).
+    expect(ctx?.ctxPayload?.MessageThreadId).toBeUndefined();
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main:thread:42");
   });
 

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -626,8 +626,10 @@ export const buildTelegramMessageContext = async ({
     Sticker: allMedia[0]?.stickerMetadata,
     ...(locationData ? toLocationContext(locationData) : undefined),
     CommandAuthorized: commandAuthorized,
-    // For groups: use resolved forum topic id; for DMs: use raw messageThreadId
-    MessageThreadId: threadSpec.id,
+    // Only propagate forum topic thread IDs into the message context.
+    // DM "thread IDs" are ephemeral reply threads and must NOT be stored as
+    // lastThreadId — Telegram rejects message_thread_id on private chats (#12929).
+    MessageThreadId: threadSpec.scope === "forum" ? threadSpec.id : undefined,
     IsForum: isForum,
     // Originating channel for reply routing.
     OriginatingChannel: "telegram" as const,

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -138,7 +138,7 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("keeps message_thread_id=1 when allowed", async () => {
+  it("omits message_thread_id for dm threads (Telegram rejects it in private chats)", async () => {
     const runtime = { error: vi.fn(), log: vi.fn() };
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 4,
@@ -160,8 +160,8 @@ describe("deliverReplies", () => {
     expect(sendMessage).toHaveBeenCalledWith(
       "123",
       expect.any(String),
-      expect.objectContaining({
-        message_thread_id: 1,
+      expect.not.objectContaining({
+        message_thread_id: expect.anything(),
       }),
     );
   });

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,10 +43,9 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("keeps thread id=1 for dm threads", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
-      message_thread_id: 1,
-    });
+  it("omits thread id for dm threads (Telegram rejects message_thread_id in private chats)", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: 99, scope: "dm" })).toBeUndefined();
   });
 
   it("normalizes thread ids to integers", () => {

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   expandTextLinks,
   normalizeForwardedContext,
   resolveTelegramForumThreadId,
+  resolveTelegramThreadSpec,
 } from "./helpers.js";
 
 describe("resolveTelegramForumThreadId", () => {
@@ -29,6 +30,33 @@ describe("resolveTelegramForumThreadId", () => {
 
   it("returns the topic id for forum groups with messageThreadId", () => {
     expect(resolveTelegramForumThreadId({ isForum: true, messageThreadId: 99 })).toBe(99);
+  });
+});
+
+describe("resolveTelegramThreadSpec", () => {
+  it("returns forum scope for DM chats with topics enabled (Bot API 9.3+)", () => {
+    const spec = resolveTelegramThreadSpec({
+      isGroup: false,
+      isForum: true,
+      messageThreadId: 42,
+    });
+    expect(spec).toEqual({ id: 42, scope: "forum" });
+  });
+
+  it("returns dm scope for plain DM chats without topics", () => {
+    const spec = resolveTelegramThreadSpec({
+      isGroup: false,
+      isForum: false,
+      messageThreadId: 7,
+    });
+    expect(spec).toEqual({ id: 7, scope: "dm" });
+  });
+
+  it("returns dm scope with no id when no thread id provided", () => {
+    const spec = resolveTelegramThreadSpec({
+      isGroup: false,
+    });
+    expect(spec).toEqual({ scope: "dm" });
   });
 });
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -63,6 +63,11 @@ export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
   if (!thread?.id) {
     return undefined;
   }
+  // Private DM chats do not support message_thread_id — Telegram rejects it
+  // with "message thread not found" (400). Only include it for forum topics.
+  if (thread.scope === "dm") {
+    return undefined;
+  }
   const normalized = Math.trunc(thread.id);
   if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
     return undefined;

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -48,6 +48,15 @@ export function resolveTelegramThreadSpec(params: {
   if (params.messageThreadId == null) {
     return { scope: "dm" };
   }
+  // Since Bot API 9.3, private chats can have topics (has_topics_enabled).
+  // When isForum is true for a DM, treat the thread as a forum topic so
+  // message_thread_id is preserved; otherwise suppress it (#12929).
+  if (params.isForum) {
+    return {
+      id: params.messageThreadId,
+      scope: "forum",
+    };
+  }
   return {
     id: params.messageThreadId,
     scope: "dm",

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -34,7 +34,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
   });
 
-  it("keeps message_thread_id for dm threads", () => {
+  it("omits message_thread_id for dm threads (Telegram rejects it in private chats)", () => {
     const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
     const stream = createTelegramDraftStream({
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -46,8 +46,7 @@ describe("createTelegramDraftStream", () => {
 
     stream.update("Hello");
 
-    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
-      message_thread_id: 1,
-    });
+    // DM scope → no message_thread_id (#12929)
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
   });
 });


### PR DESCRIPTION
## Summary

Fixes Telegram proactive sends (cron delivery, message tool) failing with `400: message thread not found` when targeting private DM chats.

## Problem

OpenClaw stores `message_thread_id` from inbound Telegram messages as `lastThreadId`. When sending proactively to a private DM, this thread ID gets passed to the Telegram API — but private chats do not support `message_thread_id`, causing a 400 error.

## Changes

**`src/telegram/bot/helpers.ts`**
- `buildTelegramThreadParams()` now returns `undefined` when `scope === "dm"`, preventing `message_thread_id` from being included in API calls to private chats

**`src/telegram/bot/helpers.test.ts`**
- Updated test to verify DM thread IDs are omitted (previously tested the buggy behavior)
- Added coverage for multiple DM thread ID values

**`src/telegram/bot/delivery.test.ts`**
- Updated delivery test to verify `message_thread_id` is NOT included when thread scope is `dm`

## Testing

- All 24 helper tests pass ✅
- All 10 delivery tests pass ✅  
- All 9 DM thread/dispatch tests pass ✅
- `pnpm exec vitest run src/telegram/` — all Telegram tests green

## Notes

- 🤖 AI-assisted (Claude) — fully tested, all changes understood
- The `send.ts` path already had a `sendWithThreadFallback` retry mechanism; this fix prevents the error at the source in the `delivery.ts` path

Closes #12929

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `buildTelegramThreadParams()` to return `undefined` for `scope: "dm"`, preventing `message_thread_id` from being sent to Telegram private chats (which can fail with `400: message thread not found`). Tests in `src/telegram/bot/helpers.test.ts` and `src/telegram/bot/delivery.test.ts` are updated to assert DM sends omit `message_thread_id`.

One integration surface remains inconsistent: `createTelegramDraftStream` uses `buildTelegramThreadParams` and will now omit DM thread params, but `src/telegram/draft-stream.test.ts` still expects DM drafts to include `message_thread_id`. That test (or the draft-stream behavior) needs to be updated for the PR’s new contract to be consistent across send paths.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a cross-file test/behavior mismatch that needs to be resolved.
- Core change is small and well-tested in the modified files, but the new DM behavior in `buildTelegramThreadParams` conflicts with existing expectations in the telegram draft stream tests, indicating an unaddressed integration update that will break CI or leave inconsistent behavior.
- src/telegram/draft-stream.test.ts (and confirm intended behavior in src/telegram/draft-stream.ts)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->