### PR TITLE
docs: clarify which workspace files are injected into context window

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,7 +59,7 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
-- `MEMORY.md` or `memory.md` (when present in the workspace; both are recognized)
+- `MEMORY.md` and/or `memory.md` (when present in the workspace; either or both may be injected)
 
 All of these files are **injected into the context window** on every turn, which
 means they consume tokens. Keep them concise — especially `MEMORY.md`, which can

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,10 +59,23 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
+- `MEMORY.md` (when present in the workspace)
+
+All of these files are **injected into the context window** on every turn, which
+means they consume tokens. Keep them concise — especially `MEMORY.md`, which can
+grow over time and lead to unexpectedly high context usage and more frequent
+compaction.
+
+> **Note:** `memory/*.md` daily files are **not** injected automatically. They
+> are accessed on demand via the `memory_search` and `memory_get` tools, so they
+> do not count against the context window unless the model explicitly reads them.
 
 Large files are truncated with a marker. The max per-file size is controlled by
 `agents.defaults.bootstrapMaxChars` (default: 20000). Missing files inject a
 short missing-file marker.
+
+Sub-agent sessions only inject `AGENTS.md` and `TOOLS.md` (other bootstrap files
+are filtered out to keep the sub-agent context small).
 
 Internal hooks can intercept this step via `agent:bootstrap` to mutate or replace
 the injected bootstrap files (for example swapping `SOUL.md` for an alternate persona).

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,7 +59,7 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
-- `MEMORY.md` (when present in the workspace)
+- `MEMORY.md` or `memory.md` (when present in the workspace; both are recognized)
 
 All of these files are **injected into the context window** on every turn, which
 means they consume tokens. Keep them concise — especially `MEMORY.md`, which can

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -18,7 +18,7 @@ OpenClaw assembles its own system prompt on every run. It includes:
 - Tool list + short descriptions
 - Skills list (only metadata; instructions are loaded on demand with `read`)
 - Self-update instructions
-- Workspace + bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md` when new). Large files are truncated by `agents.defaults.bootstrapMaxChars` (default: 20000).
+- Workspace + bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md` when new, plus `MEMORY.md` and/or `memory.md` when present). Large files are truncated by `agents.defaults.bootstrapMaxChars` (default: 20000). `memory/*.md` files are on-demand via memory tools and are not auto-injected.
 - Time (UTC + user timezone)
 - Reply tags + heartbeat behavior
 - Runtime metadata (host/OS/model/thinking)


### PR DESCRIPTION
## Summary

Fixes the system prompt documentation page which omitted `MEMORY.md` from the list of auto-injected bootstrap files, leading users to incorrectly assume memory files are on-demand only.

## Problem

Users designing their workspace file structure based on the docs assumed memory files (`MEMORY.md`) were accessed only via `memory_search`/`memory_get` tools and did not count against the context window. In reality, `MEMORY.md` is injected as a bootstrap file on every turn, consuming tokens and causing unexpectedly high context usage.

## Changes

**`docs/concepts/system-prompt.md`**
- Added `MEMORY.md` to the bootstrap file list
- Added note that all listed files consume tokens on every turn (keep them concise)
- Clarified that `memory/*.md` daily files are NOT injected (on-demand via tools only)
- Documented sub-agent bootstrap filtering (only `AGENTS.md` + `TOOLS.md`)

## Verified against source

Confirmed behavior by reading `src/agents/workspace.ts`:
- `loadWorkspaceBootstrapFiles()` includes `MEMORY.md` via `resolveMemoryBootstrapEntries()`
- `filterBootstrapFilesForSession()` filters sub-agents to only `AGENTS.md` + `TOOLS.md`

## Notes

- 🤖 AI-assisted (Claude) — docs-only change, verified against source code
- No code changes, no tests affected

Closes #12909

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/concepts/system-prompt.md` to clarify which workspace “bootstrap” files are automatically injected into the system prompt on every turn, and explains the token/context implications (notably adding `MEMORY.md` to the documented list). It also documents that `memory/*.md` daily files are accessed on-demand via memory tools, and that sub-agent sessions filter bootstrap injection down to `AGENTS.md` + `TOOLS.md`.

In the codebase, bootstrap file discovery happens in `src/agents/workspace.ts` (with per-session filtering applied in `src/agents/bootstrap-files.ts` before prompt assembly).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after a small documentation accuracy fix.
- Docs-only change with behavior verified against source; the only blocking issue found is that the docs list `MEMORY.md` but omit the also-supported `memory.md` filename, which could mislead users about what is always injected.
- docs/concepts/system-prompt.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->