### PR TITLE
fix(memory): strip null bytes from workspace paths causing ENOTDIR

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -216,6 +216,15 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.join(path.resolve(home), ".openclaw", "workspace"));
   });
 
+  it("strips null bytes from configured workspace path", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/home/user/workspace\0" } },
+    } as unknown as OpenClawConfig;
+    const workspace = resolveAgentWorkspaceDir(cfg, "main");
+    expect(workspace).not.toContain("\0");
+    expect(workspace).toBe("/home/user/workspace");
+  });
+
   it("uses OPENCLAW_HOME for default agentDir", () => {
     const home = path.join(path.sep, "srv", "openclaw-home");
     vi.stubEnv("OPENCLAW_HOME", home);

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -167,13 +167,14 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.workspace?.trim();
   if (configured) {
-    return resolveUserPath(configured);
+    // Strip null bytes that may leak from config sources (#12919).
+    return resolveUserPath(configured).replaceAll("\0", "");
   }
   const defaultAgentId = resolveDefaultAgentId(cfg);
   if (id === defaultAgentId) {
     const fallback = cfg.agents?.defaults?.workspace?.trim();
     if (fallback) {
-      return resolveUserPath(fallback);
+      return resolveUserPath(fallback).replaceAll("\0", "");
     }
     return resolveDefaultAgentWorkspaceDir(process.env);
   }

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -167,19 +167,23 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.workspace?.trim();
   if (configured) {
-    // Strip null bytes that may leak from config sources (#12919).
-    return resolveUserPath(configured).replaceAll("\0", "");
+    return stripNullBytes(resolveUserPath(configured));
   }
   const defaultAgentId = resolveDefaultAgentId(cfg);
   if (id === defaultAgentId) {
     const fallback = cfg.agents?.defaults?.workspace?.trim();
     if (fallback) {
-      return resolveUserPath(fallback).replaceAll("\0", "");
+      return stripNullBytes(resolveUserPath(fallback));
     }
-    return resolveDefaultAgentWorkspaceDir(process.env);
+    return stripNullBytes(resolveDefaultAgentWorkspaceDir(process.env));
   }
   const stateDir = resolveStateDir(process.env);
-  return path.join(stateDir, `workspace-${id}`);
+  return stripNullBytes(path.join(stateDir, `workspace-${id}`));
+}
+
+/** Strip null bytes that may leak from config sources or env vars (#12919). */
+function stripNullBytes(value: string): string {
+  return value.replaceAll("\0", "");
 }
 
 export function resolveAgentDir(cfg: OpenClawConfig, agentId: string) {

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -73,6 +73,20 @@ describe("resolveMemoryBackendConfig", () => {
     expect(custom?.path).toBe(path.resolve(workspaceRoot, "notes"));
   });
 
+  it("strips null bytes from default collection paths", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/home/user/clawd\0" } },
+      memory: {
+        backend: "qmd",
+        qmd: {},
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    for (const collection of resolved.qmd?.collections ?? []) {
+      expect(collection.path).not.toContain("\0");
+    }
+  });
+
   it("resolves qmd update timeout overrides", () => {
     const cfg = {
       agents: { defaults: { workspace: "/tmp/memory-test" } },

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -238,10 +238,13 @@ function resolveDefaultCollections(
   if (!include) {
     return [];
   }
+  // Strip null bytes from workspace path — some config sources introduce
+  // trailing \0 which causes ENOTDIR when QMD opens the file (#12919).
+  const sanitizedDir = workspaceDir.replaceAll("\0", "");
   const entries: Array<{ path: string; pattern: string; base: string }> = [
-    { path: workspaceDir, pattern: "MEMORY.md", base: "memory-root" },
-    { path: workspaceDir, pattern: "memory.md", base: "memory-alt" },
-    { path: path.join(workspaceDir, "memory"), pattern: "**/*.md", base: "memory-dir" },
+    { path: sanitizedDir, pattern: "MEMORY.md", base: "memory-root" },
+    { path: sanitizedDir, pattern: "memory.md", base: "memory-alt" },
+    { path: path.join(sanitizedDir, "memory"), pattern: "**/*.md", base: "memory-dir" },
   ];
   return entries.map((entry) => ({
     name: ensureUniqueName(entry.base, existing),

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -92,7 +92,9 @@ export class QmdMemoryManager implements MemorySearchManager {
     this.cfg = params.cfg;
     this.agentId = params.agentId;
     this.qmd = params.resolved;
-    this.workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    // Strip null bytes from the workspace path — some config sources or file
+    // system operations can introduce trailing \0 which causes ENOTDIR (#12919).
+    this.workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId).replaceAll("\0", "");
     this.stateDir = resolveStateDir(process.env, os.homedir);
     this.agentStateDir = path.join(this.stateDir, "agents", this.agentId);
     this.qmdDir = path.join(this.agentStateDir, "qmd");


### PR DESCRIPTION
## Summary

Fixes QMD boot failure where `MEMORY.md` path contains a trailing null byte (`\0`), causing `ENOTDIR` when the indexer tries to open the file.

## Problem

Some config sources or file system operations introduce trailing null bytes in workspace directory paths. When QMD passes these paths to `fs.open()`, Node rejects with `ENOTDIR`:

```
ENOTDIR: not a directory, open '/home/cosmo/clawd/MEMORY.md\^@'
```

## Changes

**`src/agents/agent-scope.ts`**
- `resolveAgentWorkspaceDir()` now strips null bytes from resolved paths (root fix)

**`src/memory/qmd-manager.ts`**
- QMD manager constructor strips null bytes from workspace dir (defense-in-depth)

**`src/memory/backend-config.ts`**
- `resolveDefaultCollections()` strips null bytes before building collection paths (defense-in-depth)

**Tests:**
- `src/agents/agent-scope.test.ts` — new test verifying null byte stripping
- `src/memory/backend-config.test.ts` — new test verifying collection paths are clean

## Testing

- All 17 agent-scope + backend-config tests pass ✅
- 🤖 AI-assisted (Claude) — fully tested, all changes understood

Closes #12919

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a boot-time QMD failure where workspace paths can contain trailing NUL ("\0") bytes, causing Node `fs.open()`/path operations to throw `ENOTDIR`.

Changes include:
- Sanitizing agent workspace directory resolution by stripping `\0` bytes in `resolveAgentWorkspaceDir()`.
- Additional defense-in-depth sanitization in the QMD manager constructor and when building default QMD collection roots.
- New tests ensuring configured workspace paths and default collection paths do not contain `\0`.

Overall, the approach fits the codebase by centralizing the main fix in agent workspace resolution and adding targeted safeguards around QMD’s path usage, but there are still a couple call paths where `workspaceDir` can remain unsanitized (default workspace branch and custom QMD paths).

<h3>Confidence Score: 3/5</h3>

- Reasonably safe but still leaves known null-byte path cases unsanitized in some branches.
- Core sanitization is implemented and tests cover configured workspace + default collections, but the default workspace path branch (via OPENCLAW_HOME) is not sanitized and relative custom QMD paths/session export dirs can still inherit a NUL-containing workspace base. Those gaps mean the reported ENOTDIR class of failure can still occur for some configurations.
- src/agents/agent-scope.ts, src/memory/backend-config.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->