### PR TITLE
Slack: keep thread starters in thread sessions

### DIFF
--- a/src/slack/monitor/message-handler/prepare.thread-root-session.test.ts
+++ b/src/slack/monitor/message-handler/prepare.thread-root-session.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SlackMonitorContext } from "../context.js";
+import { prepareSlackMessage } from "./prepare.js";
+
+describe("prepareSlackMessage thread root session routing", () => {
+  it("routes thread starters (thread_ts == ts) to a thread-scoped sessionKey + historyKey", async () => {
+    const ctx = {
+      cfg: {
+        agents: { defaults: { model: "openai/gpt-4.1", workspace: "/tmp/openclaw" } },
+        channels: { slack: {} },
+      },
+      accountId: "default",
+      botToken: "xoxb",
+      app: { client: {} },
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: (code: number): never => {
+          throw new Error(`exit ${code}`);
+        },
+      },
+      botUserId: "BOT",
+      teamId: "T1",
+      apiAppId: "A1",
+      historyLimit: 0,
+      channelHistories: new Map(),
+      sessionScope: "per-sender",
+      mainKey: "agent:main:main",
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: [],
+      groupDmEnabled: false,
+      groupDmChannels: [],
+      defaultRequireMention: true,
+      groupPolicy: "open",
+      useAccessGroups: false,
+      reactionMode: "off",
+      reactionAllowlist: [],
+      replyToMode: "off",
+      threadHistoryScope: "thread",
+      threadInheritParent: false,
+      slashCommand: { command: "/openclaw", enabled: true },
+      textLimit: 2000,
+      ackReactionScope: "off",
+      mediaMaxBytes: 1000,
+      removeAckAfterReply: false,
+      logger: { info: vi.fn() },
+      markMessageSeen: () => false,
+      shouldDropMismatchedSlackEvent: () => false,
+      resolveSlackSystemEventSessionKey: () => "agent:main:slack:channel:c1",
+      isChannelAllowed: () => true,
+      resolveChannelName: async () => ({
+        name: "general",
+        type: "channel",
+      }),
+      resolveUserName: async () => ({ name: "Alice" }),
+      isSlackThreadActive: () => false,
+      setSlackThreadStatus: async () => undefined,
+    } satisfies SlackMonitorContext;
+
+    const ts = "1700000000.0001";
+    const result = await prepareSlackMessage({
+      ctx,
+      account: { accountId: "default", config: {} } as never,
+      message: {
+        type: "message",
+        channel: "C1",
+        channel_type: "channel",
+        text: "<@BOT> start a thread task",
+        user: "U1",
+        ts,
+        thread_ts: ts,
+        event_ts: ts,
+      } as never,
+      opts: { source: "message", wasMentioned: true },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.ctxPayload.SessionKey).toContain(`:thread:${ts}`);
+    expect(result?.historyKey).toContain(`:thread:${ts}`);
+  });
+
+  it("keeps non-threaded channel messages channel-scoped", async () => {
+    const ctx = {
+      cfg: {
+        agents: { defaults: { model: "openai/gpt-4.1", workspace: "/tmp/openclaw" } },
+        channels: { slack: {} },
+      },
+      accountId: "default",
+      botToken: "xoxb",
+      app: { client: {} },
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: (code: number): never => {
+          throw new Error(`exit ${code}`);
+        },
+      },
+      botUserId: "BOT",
+      teamId: "T1",
+      apiAppId: "A1",
+      historyLimit: 0,
+      channelHistories: new Map(),
+      sessionScope: "per-sender",
+      mainKey: "agent:main:main",
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: [],
+      groupDmEnabled: false,
+      groupDmChannels: [],
+      defaultRequireMention: true,
+      groupPolicy: "open",
+      useAccessGroups: false,
+      reactionMode: "off",
+      reactionAllowlist: [],
+      replyToMode: "off",
+      threadHistoryScope: "thread",
+      threadInheritParent: false,
+      slashCommand: { command: "/openclaw", enabled: true },
+      textLimit: 2000,
+      ackReactionScope: "off",
+      mediaMaxBytes: 1000,
+      removeAckAfterReply: false,
+      logger: { info: vi.fn() },
+      markMessageSeen: () => false,
+      shouldDropMismatchedSlackEvent: () => false,
+      resolveSlackSystemEventSessionKey: () => "agent:main:slack:channel:c1",
+      isChannelAllowed: () => true,
+      resolveChannelName: async () => ({
+        name: "general",
+        type: "channel",
+      }),
+      resolveUserName: async () => ({ name: "Alice" }),
+      isSlackThreadActive: () => false,
+      setSlackThreadStatus: async () => undefined,
+    } satisfies SlackMonitorContext;
+
+    const result = await prepareSlackMessage({
+      ctx,
+      account: { accountId: "default", config: {} } as never,
+      message: {
+        type: "message",
+        channel: "C1",
+        channel_type: "channel",
+        text: "<@BOT> hi",
+        user: "U1",
+        ts: "1700000000.0002",
+        event_ts: "1700000000.0002",
+      } as never,
+      opts: { source: "message", wasMentioned: true },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.ctxPayload.SessionKey).not.toContain(":thread:");
+    expect(result?.historyKey).toBe("C1");
+  });
+});


### PR DESCRIPTION
Fix Slack thread continuity when Slack provides `thread_ts` for the thread starter (often equal to `ts`).

Previously, we only applied `:thread:<thread_ts>` session keys for thread replies. If the bot answered the thread starter in-thread, the starter + first bot reply could be stored under the channel session while later user replies were stored under the thread session, causing the agent to lose earlier context for that same thread.

Changes
- Route Slack inbound messages to thread-scoped session keys whenever `thread_ts` is present (even when `thread_ts === ts`).
- Align `historyKey` so thread starters use thread-scoped history when `threadHistoryScope === "thread"`.
- Add regression tests.

Testing
- `pnpm test -- src/slack/monitor/message-handler/prepare.thread-root-session.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes Slack inbound message preparation so that whenever Slack provides a `thread_ts` (including for thread starters where `thread_ts === ts`), the message is routed to a thread-scoped session key (`...:thread:<thread_ts>`). It also aligns `historyKey` so thread starters use thread-scoped history when `threadHistoryScope === "thread"`, and adds regression tests covering thread-root routing vs non-threaded channel messages.

The change integrates into the existing Slack message ingestion pipeline in `prepareSlackMessage`, which determines mention gating, builds the envelope, and records sessions/history; the thread-scoped routing affects the `sessionKey` used for session storage and the key used for pending history entries.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness issue in session timestamp lookups for thread-scoped routing.
- The core thread session routing change looks consistent with how `resolveThreadSessionKeys` works and is covered by a regression test, but `previousTimestamp` is still read using the base `route.sessionKey`, which will be wrong whenever the inbound message is routed to a thread session key. Test execution could not be verified in this environment (pnpm unavailable), so confidence is reduced.
- src/slack/monitor/message-handler/prepare.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->