### PR TITLE
fix(web_search): remove unsupported include param from Grok API calls

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -473,9 +473,10 @@ async function runGrokSearch(params: {
     tools: [{ type: "web_search" }],
   };
 
-  if (params.inlineCitations) {
-    body.include = ["inline_citations"];
-  }
+  // Note: xAI's /v1/responses endpoint does not support the `include`
+  // parameter (returns 400 "Argument not supported: include"). Inline
+  // citations are returned automatically when available — we just parse
+  // them from the response without requesting them explicitly (#12910).
 
   const res = await fetch(XAI_API_ENDPOINT, {
     method: "POST",


### PR DESCRIPTION
## Summary

Fixes Grok web_search provider failing with `400: Argument not supported: include`.

## Problem

The `executeGrokSearch` function sends `include: ["inline_citations"]` in the request body to xAI's `/v1/responses` endpoint when `inlineCitations` is enabled. xAI does not support this parameter and rejects the request.

## Changes

**`src/agents/tools/web-search.ts`**
- Removed the `include` parameter from the Grok search request body
- Inline citations are still parsed from the response when present (xAI returns them automatically)

## Testing

- All 22 web-search tests pass ✅
- 🤖 AI-assisted (Claude) — verified against xAI API behavior

Closes #12910

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Grok (`xAI /v1/responses`) web_search provider request body to stop sending `include: ["inline_citations"]`, which was causing 400 errors ("Argument not supported: include"). Inline citations are still parsed from the response if present.

Change is localized to `src/agents/tools/web-search.ts` in `runGrokSearch`, and does not affect other providers (Brave, Perplexity).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted removal of an API parameter that the upstream xAI endpoint rejects. The rest of the request/response handling remains unchanged, and the diff does not introduce new control flow or data handling paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->