### PR TITLE
fix(bedrock): sanitize tool names for Bedrock Converse API constraints

### DIFF
--- a/src/agents/pi-embedded-runner/bedrock.test.ts
+++ b/src/agents/pi-embedded-runner/bedrock.test.ts
@@ -14,6 +14,10 @@ describe("sanitizeBedrockToolName", () => {
     expect(sanitizeBedrockToolName("tool@name!")).toBe("tool_name_");
   });
 
+  it("returns underscore for empty names", () => {
+    expect(sanitizeBedrockToolName("")).toBe("_");
+  });
+
   it("truncates names exceeding 64 characters", () => {
     const longName = "a".repeat(100);
     expect(sanitizeBedrockToolName(longName)).toHaveLength(64);
@@ -61,6 +65,16 @@ describe("sanitizeToolNamesForBedrock", () => {
       modelApi: "bedrock-converse-stream",
     });
     expect(result[0].name).toBe("tool_name");
+  });
+
+  it("deduplicates colliding names after sanitization", () => {
+    const tools = [makeTool("tool.name"), makeTool("tool_name")];
+    const result = sanitizeToolNamesForBedrock({
+      tools,
+      provider: "amazon-bedrock",
+    });
+    expect(result[0].name).toBe("tool_name");
+    expect(result[1].name).toBe("tool_name_1");
   });
 
   it("does not create new objects for already-valid names", () => {

--- a/src/agents/pi-embedded-runner/bedrock.test.ts
+++ b/src/agents/pi-embedded-runner/bedrock.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeBedrockToolName, sanitizeToolNamesForBedrock } from "./bedrock.js";
+
+describe("sanitizeBedrockToolName", () => {
+  it("keeps valid names unchanged", () => {
+    expect(sanitizeBedrockToolName("memory_search")).toBe("memory_search");
+    expect(sanitizeBedrockToolName("web-fetch")).toBe("web-fetch");
+    expect(sanitizeBedrockToolName("Read")).toBe("Read");
+  });
+
+  it("replaces invalid characters with underscore", () => {
+    expect(sanitizeBedrockToolName("tool.name")).toBe("tool_name");
+    expect(sanitizeBedrockToolName("tool name")).toBe("tool_name");
+    expect(sanitizeBedrockToolName("tool@name!")).toBe("tool_name_");
+  });
+
+  it("truncates names exceeding 64 characters", () => {
+    const longName = "a".repeat(100);
+    expect(sanitizeBedrockToolName(longName)).toHaveLength(64);
+  });
+
+  it("handles combined invalid chars and long names", () => {
+    const longInvalid = "tool.with.dots.".repeat(10);
+    const result = sanitizeBedrockToolName(longInvalid);
+    expect(result).toHaveLength(64);
+    expect(result).not.toMatch(/\./);
+  });
+});
+
+describe("sanitizeToolNamesForBedrock", () => {
+  const makeTool = (name: string) => ({
+    name,
+    description: "test",
+    parameters: {},
+    execute: async () => ({}),
+  });
+
+  it("skips non-bedrock providers", () => {
+    const tools = [makeTool("tool.name")];
+    const result = sanitizeToolNamesForBedrock({
+      tools,
+      provider: "anthropic",
+    });
+    expect(result[0].name).toBe("tool.name");
+  });
+
+  it("sanitizes for amazon-bedrock provider", () => {
+    const tools = [makeTool("tool.name")];
+    const result = sanitizeToolNamesForBedrock({
+      tools,
+      provider: "amazon-bedrock",
+    });
+    expect(result[0].name).toBe("tool_name");
+  });
+
+  it("sanitizes for bedrock-converse-stream model API", () => {
+    const tools = [makeTool("tool.name")];
+    const result = sanitizeToolNamesForBedrock({
+      tools,
+      provider: "openai",
+      modelApi: "bedrock-converse-stream",
+    });
+    expect(result[0].name).toBe("tool_name");
+  });
+
+  it("does not create new objects for already-valid names", () => {
+    const tools = [makeTool("valid_name")];
+    const result = sanitizeToolNamesForBedrock({
+      tools,
+      provider: "amazon-bedrock",
+    });
+    expect(result[0]).toBe(tools[0]);
+  });
+});

--- a/src/agents/pi-embedded-runner/bedrock.ts
+++ b/src/agents/pi-embedded-runner/bedrock.ts
@@ -32,19 +32,44 @@ export function sanitizeToolNamesForBedrock<
   if (params.provider !== "amazon-bedrock" && params.modelApi !== "bedrock-converse-stream") {
     return params.tools;
   }
-  return params.tools.map((tool) => {
+  const result = params.tools.map((tool) => {
     const sanitized = sanitizeBedrockToolName(tool.name);
     if (sanitized === tool.name) {
       return tool;
     }
     return { ...tool, name: sanitized };
   });
+  // Resolve collisions from sanitization (e.g. "tool.name" and "tool_name" both → "tool_name")
+  deduplicateToolNames(result);
+  return result;
 }
 
 export function sanitizeBedrockToolName(name: string): string {
+  if (!name) {
+    return "_"; // Bedrock requires at least 1 character
+  }
   const replaced = name.replace(BEDROCK_TOOL_NAME_INVALID_RE, "_");
   if (replaced.length <= BEDROCK_TOOL_NAME_MAX_LENGTH) {
     return replaced;
   }
   return replaced.slice(0, BEDROCK_TOOL_NAME_MAX_LENGTH);
+}
+
+/**
+ * Detect and resolve duplicate tool names that may arise from sanitization.
+ * Appends a numeric suffix to disambiguate collisions.
+ */
+function deduplicateToolNames<TSchemaType, TResult>(
+  tools: Array<{ name: string } & Record<string, unknown>>,
+): void {
+  const seen = new Map<string, number>();
+  for (const tool of tools) {
+    const count = seen.get(tool.name) ?? 0;
+    if (count > 0) {
+      const suffix = `_${count}`;
+      const maxBase = BEDROCK_TOOL_NAME_MAX_LENGTH - suffix.length;
+      tool.name = tool.name.slice(0, maxBase) + suffix;
+    }
+    seen.set(tool.name, count + 1);
+  }
 }

--- a/src/agents/pi-embedded-runner/bedrock.ts
+++ b/src/agents/pi-embedded-runner/bedrock.ts
@@ -59,9 +59,7 @@ export function sanitizeBedrockToolName(name: string): string {
  * Detect and resolve duplicate tool names that may arise from sanitization.
  * Appends a numeric suffix to disambiguate collisions.
  */
-function deduplicateToolNames<TSchemaType, TResult>(
-  tools: Array<{ name: string } & Record<string, unknown>>,
-): void {
+function deduplicateToolNames(tools: Array<{ name: string } & Record<string, unknown>>): void {
   const seen = new Map<string, number>();
   for (const tool of tools) {
     const count = seen.get(tool.name) ?? 0;

--- a/src/agents/pi-embedded-runner/bedrock.ts
+++ b/src/agents/pi-embedded-runner/bedrock.ts
@@ -1,0 +1,50 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { TSchema } from "@sinclair/typebox";
+
+/**
+ * Bedrock Converse API constraints for tool names:
+ * - Max 64 characters
+ * - Only [a-zA-Z0-9_-] allowed
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolSpecification.html
+ */
+const BEDROCK_TOOL_NAME_MAX_LENGTH = 64;
+const BEDROCK_TOOL_NAME_INVALID_RE = /[^a-zA-Z0-9_-]/g;
+
+/**
+ * Sanitize tool names for AWS Bedrock Converse API compatibility (#12892).
+ *
+ * Bedrock rejects tool names that contain invalid characters (like `.`) or
+ * exceed 64 characters. This function replaces invalid characters with `_`
+ * and truncates to the max length.
+ *
+ * Only applies when the provider is `amazon-bedrock` or the model API is
+ * `bedrock-converse-stream`.
+ */
+export function sanitizeToolNamesForBedrock<
+  TSchemaType extends TSchema = TSchema,
+  TResult = unknown,
+>(params: {
+  tools: AgentTool<TSchemaType, TResult>[];
+  provider: string;
+  modelApi?: string;
+}): AgentTool<TSchemaType, TResult>[] {
+  if (params.provider !== "amazon-bedrock" && params.modelApi !== "bedrock-converse-stream") {
+    return params.tools;
+  }
+  return params.tools.map((tool) => {
+    const sanitized = sanitizeBedrockToolName(tool.name);
+    if (sanitized === tool.name) {
+      return tool;
+    }
+    return { ...tool, name: sanitized };
+  });
+}
+
+export function sanitizeBedrockToolName(name: string): string {
+  const replaced = name.replace(BEDROCK_TOOL_NAME_INVALID_RE, "_");
+  if (replaced.length <= BEDROCK_TOOL_NAME_MAX_LENGTH) {
+    return replaced;
+  }
+  return replaced.slice(0, BEDROCK_TOOL_NAME_MAX_LENGTH);
+}

--- a/src/agents/pi-embedded-runner/bedrock.ts
+++ b/src/agents/pi-embedded-runner/bedrock.ts
@@ -59,7 +59,7 @@ export function sanitizeBedrockToolName(name: string): string {
  * Detect and resolve duplicate tool names that may arise from sanitization.
  * Appends a numeric suffix to disambiguate collisions.
  */
-function deduplicateToolNames(tools: Array<{ name: string } & Record<string, unknown>>): void {
+function deduplicateToolNames(tools: Array<{ name: string }>): void {
   const seen = new Map<string, number>();
   for (const tool of tools) {
     const count = seen.get(tool.name) ?? 0;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -55,6 +55,7 @@ import {
   type SkillSnapshot,
 } from "../skills.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
+import { sanitizeToolNamesForBedrock } from "./bedrock.js";
 import { buildEmbeddedExtensionPaths } from "./extensions.js";
 import {
   logToolSchemasForGoogle,
@@ -240,7 +241,12 @@ export async function compactEmbeddedPiSessionDirect(
       modelId,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config),
     });
-    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider });
+    const googleSanitized = sanitizeToolsForGoogle({ tools: toolsRaw, provider });
+    const tools = sanitizeToolNamesForBedrock({
+      tools: googleSanitized,
+      provider,
+      modelApi: model?.api,
+    });
     logToolSchemasForGoogle({ tools, provider });
     const machineName = await getMachineDisplayName();
     const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -62,6 +62,7 @@ import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
+import { sanitizeToolNamesForBedrock } from "../bedrock.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
@@ -245,7 +246,12 @@ export async function runEmbeddedAttempt(
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
         });
-    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
+    const googleSanitized = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
+    const tools = sanitizeToolNamesForBedrock({
+      tools: googleSanitized,
+      provider: params.provider,
+      modelApi: params.model?.api,
+    });
     logToolSchemasForGoogle({ tools, provider: params.provider });
 
     const machineName = await getMachineDisplayName();


### PR DESCRIPTION
## Summary

Fixes Bedrock models failing with validation errors when tool names contain invalid characters (like `.`) or exceed 64 characters.

## Problem

AWS Bedrock Converse API requires tool names to match `[a-zA-Z0-9_-]+` and be ≤64 chars. OpenClaw passes tool names as-is, causing:
```
Value at '...toolUse.name' failed to satisfy constraint:
Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+
```

## Changes

**`src/agents/pi-embedded-runner/bedrock.ts`** (new)
- `sanitizeBedrockToolName()` — replaces invalid chars with `_`, truncates to 64
- `sanitizeToolNamesForBedrock()` — applies only for `amazon-bedrock` provider or `bedrock-converse-stream` API

**`src/agents/pi-embedded-runner/run/attempt.ts`**
- Added Bedrock sanitization after existing Google sanitization

**`src/agents/pi-embedded-runner/compact.ts`**
- Same Bedrock sanitization for compaction path

**`src/agents/pi-embedded-runner/bedrock.test.ts`** (new)
- 8 tests covering: valid names unchanged, invalid char replacement, truncation, provider gating, object identity preservation

## Testing

- All 8 bedrock tests pass ✅
- 🤖 AI-assisted (Claude) — fully tested

Closes #12892

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Bedrock-specific tool-name sanitization for the Converse API constraints (allowed chars + 64-char max), and wires it into both the main embedded attempt path and the compaction path right after existing Google tool sanitization.

The new `sanitizeToolNamesForBedrock()`/`sanitizeBedrockToolName()` utilities rewrite tool names only when running against the `amazon-bedrock` provider or the `bedrock-converse-stream` model API, and new unit tests cover basic replacement/truncation and provider/model gating.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of correctness edge cases that can break Bedrock tool calling.
- The core sanitization logic and wiring look straightforward and well-tested for basic cases, but it currently doesn’t guarantee uniqueness after sanitization/truncation and can pass through empty names, both of which can cause Bedrock validation failures or ambiguous tool dispatch in practice.
- src/agents/pi-embedded-runner/bedrock.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->