### PR TITLE
feat(slack): Add channel name resolution with TTL cache

### DIFF
--- a/src/slack/channel-cache.test.ts
+++ b/src/slack/channel-cache.test.ts
@@ -52,7 +52,7 @@ describe("SlackChannelCache", () => {
       };
 
       // Second call should use cache, not call API
-      const channels = await slackChannelCache.getChannels(mockToken, freshMock as any);
+      const channels = await slackChannelCache.getChannels(mockToken, freshMock as WebClient);
       expect(channels).toHaveLength(4);
       expect(freshMock.conversations.list).not.toHaveBeenCalled();
     });
@@ -73,7 +73,7 @@ describe("SlackChannelCache", () => {
         },
       };
 
-      const channels = await slackChannelCache.getChannels(mockToken, paginatedClient as any);
+      const channels = await slackChannelCache.getChannels(mockToken, paginatedClient as WebClient);
       expect(channels).toHaveLength(4);
     });
   });
@@ -177,7 +177,7 @@ describe("SlackChannelCache", () => {
       slackChannelCache.clearCache();
       const map = await slackChannelCache.getChannelsByName(
         "xoxb-duplicate-test",
-        duplicateClient as any,
+        duplicateClient as WebClient,
       );
 
       // Should prefer C200 (non-archived) over C100 (archived)
@@ -201,7 +201,7 @@ describe("SlackChannelCache", () => {
       slackChannelCache.clearCache();
       const map = await slackChannelCache.getChannelsByName(
         "xoxb-dup-both-active",
-        duplicateClient as any,
+        duplicateClient as WebClient,
       );
 
       // Should keep first one since both are non-archived

--- a/src/slack/channel-cache.test.ts
+++ b/src/slack/channel-cache.test.ts
@@ -1,0 +1,193 @@
+import type { WebClient } from "@slack/web-api";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { slackChannelCache } from "./channel-cache.js";
+
+describe("SlackChannelCache", () => {
+  const mockToken = "xoxb-test-token-123456";
+  const mockChannels = [
+    { id: "C001", name: "general", is_archived: false, is_private: false },
+    { id: "C002", name: "random", is_archived: false, is_private: false },
+    { id: "C003", name: "archived-chan", is_archived: true, is_private: false },
+    { id: "C004", name: "private-chan", is_archived: false, is_private: true },
+  ];
+
+  let mockClient: Partial<WebClient>;
+
+  beforeEach(() => {
+    slackChannelCache.clearCache();
+    mockClient = {
+      conversations: {
+        list: vi.fn().mockResolvedValue({
+          channels: mockChannels,
+          response_metadata: { next_cursor: "" },
+        }),
+      },
+    };
+  });
+
+  describe("getChannels", () => {
+    it("should fetch channels from Slack API", async () => {
+      const channels = await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      expect(channels).toHaveLength(4);
+      expect(channels[0]).toEqual({
+        id: "C001",
+        name: "general",
+        archived: false,
+        isPrivate: false,
+      });
+    });
+
+    it("should cache channels and not refetch within TTL", async () => {
+      // First call populates cache
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+
+      // Create a fresh mock to verify no new calls are made
+      const freshMock = {
+        conversations: {
+          list: vi.fn().mockResolvedValue({
+            channels: mockChannels,
+            response_metadata: { next_cursor: "" },
+          }),
+        },
+      };
+
+      // Second call should use cache, not call API
+      const channels = await slackChannelCache.getChannels(mockToken, freshMock as any);
+      expect(channels).toHaveLength(4);
+      expect(freshMock.conversations.list).not.toHaveBeenCalled();
+    });
+
+    it("should handle pagination", async () => {
+      const paginatedClient = {
+        conversations: {
+          list: vi
+            .fn()
+            .mockResolvedValueOnce({
+              channels: mockChannels.slice(0, 2),
+              response_metadata: { next_cursor: "cursor123" },
+            })
+            .mockResolvedValueOnce({
+              channels: mockChannels.slice(2),
+              response_metadata: { next_cursor: "" },
+            }),
+        },
+      };
+
+      const channels = await slackChannelCache.getChannels(mockToken, paginatedClient as any);
+      expect(channels).toHaveLength(4);
+    });
+  });
+
+  describe("resolveChannel", () => {
+    it("should resolve channel by ID", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      const channel = await slackChannelCache.resolveChannel(
+        mockToken,
+        "C001",
+        mockClient as WebClient,
+      );
+      expect(channel?.name).toBe("general");
+    });
+
+    it("should resolve channel by name", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      const channel = await slackChannelCache.resolveChannel(
+        mockToken,
+        "random",
+        mockClient as WebClient,
+      );
+      expect(channel?.id).toBe("C002");
+    });
+
+    it("should handle case-insensitive name matching", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      const channel = await slackChannelCache.resolveChannel(
+        mockToken,
+        "GENERAL",
+        mockClient as WebClient,
+      );
+      expect(channel?.id).toBe("C001");
+    });
+
+    it("should prefer non-archived channels", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      const channel = await slackChannelCache.resolveChannel(
+        mockToken,
+        "archived-chan",
+        mockClient as WebClient,
+      );
+      expect(channel?.name).toBe("archived-chan");
+      expect(channel?.archived).toBe(true);
+    });
+
+    it("should handle Slack mentions", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      const channel = await slackChannelCache.resolveChannel(
+        mockToken,
+        "<#C002|random>",
+        mockClient as WebClient,
+      );
+      expect(channel?.id).toBe("C002");
+    });
+
+    it("should handle # prefix", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      const channel = await slackChannelCache.resolveChannel(
+        mockToken,
+        "#general",
+        mockClient as WebClient,
+      );
+      expect(channel?.id).toBe("C001");
+    });
+
+    it("should return undefined for unknown channel", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      const channel = await slackChannelCache.resolveChannel(
+        mockToken,
+        "unknown",
+        mockClient as WebClient,
+      );
+      expect(channel).toBeUndefined();
+    });
+  });
+
+  describe("getChannelsByName", () => {
+    it("should return map of channels by lowercase name", async () => {
+      const map = await slackChannelCache.getChannelsByName(mockToken, mockClient as WebClient);
+      expect(map.get("general")?.id).toBe("C001");
+      expect(map.get("random")?.id).toBe("C002");
+      expect(map.size).toBe(4);
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear cache for specific token", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      slackChannelCache.clearCache(mockToken);
+
+      const spy = vi.spyOn(mockClient.conversations!, "list");
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it("should clear all caches when no token provided", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      slackChannelCache.clearCache();
+
+      const spy = vi.spyOn(mockClient.conversations!, "list");
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe("getStats", () => {
+    it("should return cache statistics", async () => {
+      await slackChannelCache.getChannels(mockToken, mockClient as WebClient);
+      const stats = slackChannelCache.getStats();
+
+      expect(stats.size).toBe(1);
+      expect(stats.tokens).toBe(1);
+      expect(stats.oldestEntryAge).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/src/slack/channel-cache.ts
+++ b/src/slack/channel-cache.ts
@@ -1,0 +1,197 @@
+import type { WebClient } from "@slack/web-api";
+import { createSlackWebClient } from "./client.js";
+
+export type CachedSlackChannel = {
+  id: string;
+  name: string;
+  archived: boolean;
+  isPrivate: boolean;
+};
+
+type CacheEntry<T> = {
+  data: T;
+  timestamp: number;
+};
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * SlackChannelCache - In-memory cache for Slack channel listings
+ * Provides name → ID resolution with automatic expiration
+ */
+class SlackChannelCache {
+  private cache: Map<string, CacheEntry<CachedSlackChannel[]>> = new Map();
+  private lastRefresh: Map<string, number> = new Map();
+
+  /**
+   * Get cached channels for an account, refreshing if needed
+   */
+  async getChannels(token: string, client?: WebClient): Promise<CachedSlackChannel[]> {
+    const key = this.getAccountKey(token);
+    const cached = this.cache.get(key);
+    const now = Date.now();
+
+    if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+      return cached.data;
+    }
+
+    const slackClient = client ?? createSlackWebClient(token);
+    const channels = await this.fetchChannels(slackClient);
+    this.cache.set(key, { data: channels, timestamp: now });
+    this.lastRefresh.set(key, now);
+
+    return channels;
+  }
+
+  /**
+   * Resolve a channel name or ID to channel info
+   */
+  async resolveChannel(
+    token: string,
+    input: string,
+    client?: WebClient,
+  ): Promise<CachedSlackChannel | undefined> {
+    const channels = await this.getChannels(token, client);
+    const normalized = this.normalizeInput(input);
+
+    // Try exact ID match first
+    if (normalized.id) {
+      return channels.find((c) => c.id === normalized.id);
+    }
+
+    // Try name match (prefer non-archived)
+    if (normalized.name) {
+      const target = normalized.name.toLowerCase();
+      const matches = channels.filter((c) => c.name.toLowerCase() === target);
+      if (matches.length === 0) {
+        return undefined;
+      }
+      // Prefer non-archived channel
+      const active = matches.find((c) => !c.archived);
+      return active ?? matches[0];
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Get all channels by name (convenient lookup)
+   */
+  async getChannelsByName(
+    token: string,
+    client?: WebClient,
+  ): Promise<Map<string, CachedSlackChannel>> {
+    const channels = await this.getChannels(token, client);
+    const map = new Map<string, CachedSlackChannel>();
+    for (const channel of channels) {
+      map.set(channel.name.toLowerCase(), channel);
+    }
+    return map;
+  }
+
+  /**
+   * Clear cache for a specific account (or all if no token provided)
+   */
+  clearCache(token?: string): void {
+    if (token) {
+      const key = this.getAccountKey(token);
+      this.cache.delete(key);
+      this.lastRefresh.delete(key);
+    } else {
+      this.cache.clear();
+      this.lastRefresh.clear();
+    }
+  }
+
+  /**
+   * Get cache stats for monitoring
+   */
+  getStats(): { size: number; tokens: number; oldestEntryAge: number } {
+    const now = Date.now();
+    const ages = Array.from(this.lastRefresh.values()).map((ts) => now - ts);
+    return {
+      size: this.cache.size,
+      tokens: this.lastRefresh.size,
+      oldestEntryAge: ages.length > 0 ? Math.max(...ages) : 0,
+    };
+  }
+
+  // ============ Private methods ============
+
+  private getAccountKey(token: string): string {
+    // Use first 16 chars of token as key (safe identifier)
+    return token.slice(0, 16);
+  }
+
+  private normalizeInput(input: string): {
+    id?: string;
+    name?: string;
+  } {
+    const trimmed = input.trim();
+
+    // Handle Slack mentions: <#C123456|channel-name>
+    const mention = trimmed.match(/^<#([A-Z0-9]+)(?:\|([^>]+))?>$/i);
+    if (mention) {
+      return {
+        id: mention[1]?.toUpperCase(),
+        name: mention[2]?.trim(),
+      };
+    }
+
+    // Handle prefixed IDs: slack:C123456, channel:C123456
+    // Real Slack IDs start with C/G and contain at least one digit (e.g., C03M3H7K4R7)
+    // This prevents matching words like "GENERAL" which start with G
+    const prefixed = trimmed.replace(/^(slack:|channel:)/i, "");
+    if (/^[CG](?=[A-Z0-9]*[0-9])[A-Z0-9]+$/i.test(prefixed)) {
+      return { id: prefixed.toUpperCase() };
+    }
+
+    // Handle channel names: #channel-name or just channel-name
+    const name = prefixed.replace(/^#/, "").trim();
+    return name ? { name } : {};
+  }
+
+  private async fetchChannels(client: WebClient): Promise<CachedSlackChannel[]> {
+    const channels: CachedSlackChannel[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const res = (await client.conversations.list({
+        types: "public_channel,private_channel",
+        exclude_archived: false,
+        limit: 1000,
+        cursor,
+      })) as {
+        channels?: Array<{
+          id?: string;
+          name?: string;
+          is_archived?: boolean;
+          is_private?: boolean;
+        }>;
+        response_metadata?: { next_cursor?: string };
+      };
+
+      for (const channel of res.channels ?? []) {
+        const id = channel.id?.trim();
+        const name = channel.name?.trim();
+        if (!id || !name) {
+          continue;
+        }
+        channels.push({
+          id,
+          name,
+          archived: Boolean(channel.is_archived),
+          isPrivate: Boolean(channel.is_private),
+        });
+      }
+
+      const next = res.response_metadata?.next_cursor?.trim();
+      cursor = next ? next : undefined;
+    } while (cursor);
+
+    return channels;
+  }
+}
+
+// Global singleton instance
+export const slackChannelCache = new SlackChannelCache();


### PR DESCRIPTION
# PR: feat(slack): Add channel name resolution with TTL cache

## Summary

Adds `SlackChannelCache` module for efficient Slack channel lookups with automatic caching.

## What

New `src/slack/channel-cache.ts` module providing:

- **In-memory cache** with 1-hour TTL for channel listings per workspace
- **Name → ID resolution** with case-insensitive matching
- **Multiple input format support:**
  - Channel names: `#general`, `general`, `GENERAL`
  - Slack mentions: `<#C123456|channel-name>`
  - Prefixed IDs: `slack:C123456`, `channel:C123456`
  - Raw IDs: `C123456`, `G789012`
- **Pagination support** for workspaces with 1000+ channels
- **Preference for non-archived** channels when duplicates exist
- **Cache statistics** for monitoring (`getStats()`)

## Why

Currently, resolving a channel name to ID requires API calls on every request. This adds:
1. **Latency** - each message send needs to resolve the target
2. **API rate limit pressure** - unnecessary `conversations.list` calls
3. **Complexity** - each caller reimplements resolution logic

With this cache:
- First call per workspace fetches and caches all channels
- Subsequent calls use cached data (1-hour TTL)
- Natural channel name usage in message tool (`target: "#general"`)
- Handles all Slack channel reference formats uniformly

## Usage Example

```typescript
import { slackChannelCache } from "./channel-cache.js";

// Resolve channel by name (case-insensitive)
const channel = await slackChannelCache.resolveChannel(token, "#general");
// { id: "C03M3H7K4R7", name: "general", archived: false, isPrivate: false }

// Or by Slack mention format
const channel2 = await slackChannelCache.resolveChannel(token, "<#C03M3H7K4R7|general>");

// Get all channels as name→info map
const channelMap = await slackChannelCache.getChannelsByName(token);
// Map { "general" => {...}, "random" => {...}, ... }

// Clear cache (e.g., after channel created/renamed)
slackChannelCache.clearCache(token);

// Monitor cache health
const stats = slackChannelCache.getStats();
// { size: 1, tokens: 1, oldestEntryAge: 300000 }
```

## Test Coverage

- **14 tests**, all passing
- Tests cover:
  - Basic channel fetching
  - Cache TTL behavior (no refetch within TTL)
  - Pagination handling
  - All input format variations
  - Case-insensitive matching
  - Archived channel handling
  - Cache clear operations
  - Statistics reporting

```
✓ src/slack/channel-cache.test.ts (14 tests) 4ms
```

## Breaking Changes

None. This is a new additive module with no changes to existing code.

## Dependencies

- Only depends on `@slack/web-api` (already a project dependency)
- Uses existing `createSlackWebClient()` from `./client.js`

## Files Changed

- `src/slack/channel-cache.ts` (new - 195 lines)
- `src/slack/channel-cache.test.ts` (new - 195 lines)

## PR Metadata

- **Title:** `feat(slack): Add channel name resolution with TTL cache`
- **Branch:** `feature/slack-channel-name-resolution`
- **Base:** `main`
- **Labels:** `enhancement`, `slack`

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass (`npm test -- channel-cache`)
- [x] All 145 Slack tests pass (`npm test -- src/slack/`)
- [x] No breaking changes
- [x] Self-contained (no fork-specific dependencies)
- [x] Documentation included in this PR description

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `src/slack/channel-cache.ts` singleton (`slackChannelCache`) that fetches Slack channel listings via `conversations.list`, caches them in-memory with a 1-hour TTL per account, and provides helpers to resolve a variety of channel reference formats (IDs, `#name`, `<#id|name>`, etc.). It also adds a Vitest suite covering fetching, caching, pagination, resolution, cache clearing, and stats.

The module fits alongside existing Slack helpers (e.g., `src/slack/resolve-channels.ts`) by centralizing channel listing/resolution logic and reducing repeated API calls for name→ID lookups.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after fixing the cache keying and duplicate-name map behavior to avoid incorrect cross-token/channel resolutions.
- Core logic is straightforward and tests cover basic behaviors, but the current cache key derivation can collide across tokens and `getChannelsByName` can return the wrong channel when duplicate names exist, which would cause incorrect routing in real use.
- src/slack/channel-cache.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->