### PR TITLE
fix: guard .trim() calls on potentially undefined workspaceDir

### DIFF
--- a/src/agents/skills/plugin-skills.ts
+++ b/src/agents/skills/plugin-skills.ts
@@ -12,7 +12,7 @@ import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 const log = createSubsystemLogger("skills");
 
 export function resolvePluginSkillDirs(params: {
-  workspaceDir: string;
+  workspaceDir: string | undefined;
   config?: OpenClawConfig;
 }): string[] {
   const workspaceDir = (params.workspaceDir ?? "").trim();

--- a/src/agents/skills/plugin-skills.ts
+++ b/src/agents/skills/plugin-skills.ts
@@ -15,7 +15,7 @@ export function resolvePluginSkillDirs(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
 }): string[] {
-  const workspaceDir = params.workspaceDir.trim();
+  const workspaceDir = (params.workspaceDir ?? "").trim();
   if (!workspaceDir) {
     return [];
   }

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -15,9 +15,8 @@ describe("ensureSkillsWatcher", () => {
   it("does not crash when workspaceDir is undefined", async () => {
     const mod = await import("./refresh.js");
     // Should not throw TypeError: Cannot read properties of undefined (reading 'trim')
-    expect(() =>
-      mod.ensureSkillsWatcher({ workspaceDir: undefined as unknown as string }),
-    ).not.toThrow();
+    // Agent configs with workspace: null resolve to undefined (#12888)
+    expect(() => mod.ensureSkillsWatcher({ workspaceDir: undefined })).not.toThrow();
   });
 
   it("ignores node_modules, dist, .git, and Python venvs by default", async () => {

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -12,6 +12,14 @@ vi.mock("chokidar", () => {
 });
 
 describe("ensureSkillsWatcher", () => {
+  it("does not crash when workspaceDir is undefined", async () => {
+    const mod = await import("./refresh.js");
+    // Should not throw TypeError: Cannot read properties of undefined (reading 'trim')
+    expect(() =>
+      mod.ensureSkillsWatcher({ workspaceDir: undefined as unknown as string }),
+    ).not.toThrow();
+  });
+
   it("ignores node_modules, dist, .git, and Python venvs by default", async () => {
     const mod = await import("./refresh.js");
     mod.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -55,7 +55,7 @@ function emit(event: SkillsChangeEvent) {
   }
 }
 
-function resolveWatchPaths(workspaceDir: string, config?: OpenClawConfig): string[] {
+function resolveWatchPaths(workspaceDir: string | undefined, config?: OpenClawConfig): string[] {
   const paths: string[] = [];
   if ((workspaceDir ?? "").trim()) {
     paths.push(path.join(workspaceDir, "skills"));
@@ -106,7 +106,10 @@ export function getSkillsSnapshotVersion(workspaceDir?: string): number {
   return Math.max(globalVersion, local);
 }
 
-export function ensureSkillsWatcher(params: { workspaceDir: string; config?: OpenClawConfig }) {
+export function ensureSkillsWatcher(params: {
+  workspaceDir: string | undefined;
+  config?: OpenClawConfig;
+}) {
   const workspaceDir = (params.workspaceDir ?? "").trim();
   if (!workspaceDir) {
     return;

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -57,7 +57,7 @@ function emit(event: SkillsChangeEvent) {
 
 function resolveWatchPaths(workspaceDir: string, config?: OpenClawConfig): string[] {
   const paths: string[] = [];
-  if (workspaceDir.trim()) {
+  if ((workspaceDir ?? "").trim()) {
     paths.push(path.join(workspaceDir, "skills"));
   }
   paths.push(path.join(CONFIG_DIR, "skills"));
@@ -107,7 +107,7 @@ export function getSkillsSnapshotVersion(workspaceDir?: string): number {
 }
 
 export function ensureSkillsWatcher(params: { workspaceDir: string; config?: OpenClawConfig }) {
-  const workspaceDir = params.workspaceDir.trim();
+  const workspaceDir = (params.workspaceDir ?? "").trim();
   if (!workspaceDir) {
     return;
   }

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -58,7 +58,7 @@ function emit(event: SkillsChangeEvent) {
 function resolveWatchPaths(workspaceDir: string | undefined, config?: OpenClawConfig): string[] {
   const paths: string[] = [];
   if ((workspaceDir ?? "").trim()) {
-    paths.push(path.join(workspaceDir, "skills"));
+    paths.push(path.join(workspaceDir!, "skills"));
   }
   paths.push(path.join(CONFIG_DIR, "skills"));
   const extraDirsRaw = config?.skills?.load?.extraDirs ?? [];


### PR DESCRIPTION
## Summary

Fixes sub-agent spawning crashing with `TypeError: Cannot read properties of undefined (reading 'trim')` when agent config includes `workspace: null`.

## Problem

When an agent is configured with `workspace: null`, `resolveAgentConfig()` correctly resolves it to `undefined`. However, downstream functions in the skills subsystem call `.trim()` directly on the workspace string without null guards, causing a crash during sub-agent initialization.

## Changes

**`src/agents/skills/plugin-skills.ts`**
- `resolvePluginSkillDirs()`: `(params.workspaceDir ?? "").trim()`

**`src/agents/skills/refresh.ts`**
- `resolveWatchPaths()`: `(workspaceDir ?? "").trim()`
- `ensureSkillsWatcher()`: `(params.workspaceDir ?? "").trim()`

**`src/agents/skills/refresh.test.ts`**
- New test: verifies `ensureSkillsWatcher` doesn't crash with `undefined` workspaceDir

## Testing

- All 2 skills refresh tests pass ✅
- 🤖 AI-assisted (Claude) — fully tested

Closes #12888

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents crashes in the skills subsystem when an agent config resolves `workspace` to `undefined` by guarding `.trim()` calls in skills refresh and plugin skill directory resolution.

Changes are localized to the skills watcher setup (`src/agents/skills/refresh.ts`) and plugin skill dir resolution (`src/agents/skills/plugin-skills.ts`), plus a new Vitest case asserting `ensureSkillsWatcher` doesn’t throw when `workspaceDir` is undefined.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but the public function types no longer match the new optional-handling behavior.
- Runtime crash is addressed by null-guarding `.trim()`; however, keeping parameters typed as `string` while treating them as optional reduces compile-time protection and may allow similar bugs to recur without TypeScript catching them.
- src/agents/skills/refresh.ts, src/agents/skills/plugin-skills.ts, src/agents/skills/refresh.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->