### PR TITLE
Changelog: add entry for #9564

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: render forwarded commands in monospace for safer approval scanning. (#11937) Thanks @sebslight.
 - Config: clamp `maxTokens` to `contextWindow` to prevent invalid model configs. (#5516) Thanks @lailoo.
 - Thinking: allow xhigh for `github-copilot/gpt-5.2-codex` and `github-copilot/gpt-5.2`. (#11646) Thanks @LatencyTDH.
+- Thinking: honor `/think off` for reasoning-capable models. (#9564) Thanks @liuy.
 - Discord: support forum/media thread-create starter messages, wire `message thread create --message`, and harden routing. (#10062) Thanks @jarvis89757.
 - Paths: structurally resolve `OPENCLAW_HOME`-derived home paths and fix Windows drive-letter handling in tool meta shortening. (#12125) Thanks @mcaxtr.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.


### PR DESCRIPTION
Adds a missing changelog bullet for #9564 (thanks @liuy).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a missing changelog bullet acknowledging #9564 (crediting @liuy) in `CHANGELOG.md`. The change is documentation-only and fits the repo’s release-notes workflow by ensuring the changelog reflects the previously merged functional/test changes related to honoring `/think off`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Only a changelog entry is modified; no code paths, tests, or build outputs are affected, so the likelihood of introducing regressions is negligible.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->