### PR TITLE
fix: suggest /clear in context overflow error message

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -26,7 +26,7 @@ describe("sanitizeUserFacingText", () => {
   it("sanitizes direct context-overflow errors", () => {
     expect(
       sanitizeUserFacingText(
-        "Context overflow: prompt too large for the model. Try again with less input or a larger-context model.",
+        "Context overflow: prompt too large for the model. Try /clear to reset session history, or use a larger-context model.",
       ),
     ).toContain("Context overflow: prompt too large for the model.");
     expect(sanitizeUserFacingText("Request size exceeds model context window")).toContain(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -354,7 +354,7 @@ export function formatAssistantErrorText(
   if (isContextOverflowError(raw)) {
     return (
       "Context overflow: prompt too large for the model. " +
-      "Try again with less input or a larger-context model."
+      "Try /clear to reset session history, or use a larger-context model."
     );
   }
 
@@ -422,7 +422,7 @@ export function sanitizeUserFacingText(text: string): string {
   if (shouldRewriteContextOverflowText(trimmed)) {
     return (
       "Context overflow: prompt too large for the model. " +
-      "Try again with less input or a larger-context model."
+      "Try /clear to reset session history, or use a larger-context model."
     );
   }
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -580,7 +580,7 @@ export async function runEmbeddedPiAgent(
                 {
                   text:
                     "Context overflow: prompt too large for the model. " +
-                    "Try again with less input or a larger-context model.",
+                    "Try /clear to reset session history, or use a larger-context model.",
                   isError: true,
                 },
               ],


### PR DESCRIPTION
## Summary

Adds actionable recovery guidance to context overflow errors by suggesting `/clear` as an immediate fix.

Closes #12940

## Changes

Updated error message from:
```
Context overflow: prompt too large for the model. Try again with less input or a larger-context model.
```

To:
```
Context overflow: prompt too large for the model. Try /clear to reset session history, or use a larger-context model.
```

## Why

- Users hitting context overflow on messaging channels (Telegram, etc.) had no clear recovery path
- Gateway restarts don't help (session history persists)
- `/compact` fails when context is already overflowed
- `/clear` is the immediate fix that works

## Test plan

- [x] `pnpm vitest run src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts` → 10/10 pass
- [x] Updated test expectation to match new message

## AI Disclosure 🤖

Built with Claude Opus 4.5 as coding assistant. Lightly tested (unit tests pass). I understand the change: it's a simple string replacement in 3 locations with corresponding test update.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the user-facing “context overflow” recovery text in the embedded PI agent to recommend `/clear` as the immediate remediation, and adjusts the sanitizer unit test to match. The message is emitted from both the generic assistant-error formatting path (`src/agents/pi-embedded-helpers/errors.ts`) and the embedded runner’s context-overflow recovery flow (`src/agents/pi-embedded-runner/run.ts`), ensuring users see consistent guidance when the session history itself prevents retries/compaction.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are limited to updating a static, user-facing error message in three call sites plus a matching unit test expectation; no control flow or parsing logic was modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->