### PR TITLE
feat(logging): Add session context and breadcrumbs to error logs

### DIFF
--- a/src/logging/error-context.test.ts
+++ b/src/logging/error-context.test.ts
@@ -9,6 +9,8 @@ import {
   createContextualError,
   formatContextualError,
   sanitizeContextualErrorForSlack,
+  runInContext,
+  runInContextAsync,
 } from "./error-context.js";
 
 describe("ErrorContext", () => {
@@ -18,70 +20,192 @@ describe("ErrorContext", () => {
 
   describe("operation stack", () => {
     it("should manage operation contexts", () => {
-      expect(getCurrentOperation()).toBeUndefined();
+      runInContext(() => {
+        expect(getCurrentOperation()).toBeUndefined();
 
-      pushOperation({ operation: "test-op", sessionKey: "sess-123" });
-      expect(getCurrentOperation()?.operation).toBe("test-op");
+        pushOperation({ operation: "test-op", sessionKey: "sess-123" });
+        expect(getCurrentOperation()?.operation).toBe("test-op");
 
-      pushOperation({ operation: "nested-op" });
-      expect(getCurrentOperation()?.operation).toBe("nested-op");
+        pushOperation({ operation: "nested-op" });
+        expect(getCurrentOperation()?.operation).toBe("nested-op");
 
-      popOperation();
-      expect(getCurrentOperation()?.operation).toBe("test-op");
+        popOperation();
+        expect(getCurrentOperation()?.operation).toBe("test-op");
 
-      popOperation();
-      expect(getCurrentOperation()).toBeUndefined();
+        popOperation();
+        expect(getCurrentOperation()).toBeUndefined();
+      });
     });
 
     it("should clear operation stack", () => {
-      pushOperation({ operation: "op1" });
-      pushOperation({ operation: "op2" });
-      clearOperationStack();
+      runInContext(() => {
+        pushOperation({ operation: "op1" });
+        pushOperation({ operation: "op2" });
+        clearOperationStack();
 
-      expect(getCurrentOperation()).toBeUndefined();
+        expect(getCurrentOperation()).toBeUndefined();
+      });
     });
 
     it("should track breadcrumbs", () => {
-      pushOperation({ operation: "test" });
-      addBreadcrumb("step 1");
-      addBreadcrumb("step 2");
+      runInContext(() => {
+        pushOperation({ operation: "test" });
+        addBreadcrumb("step 1");
+        addBreadcrumb("step 2");
 
-      const ctx = getCurrentOperation();
-      expect(ctx?.breadcrumbs).toHaveLength(2);
-      expect(ctx?.breadcrumbs?.[0]).toContain("step 1");
-      expect(ctx?.breadcrumbs?.[1]).toContain("step 2");
+        const ctx = getCurrentOperation();
+        expect(ctx?.breadcrumbs).toHaveLength(2);
+        expect(ctx?.breadcrumbs?.[0]).toContain("step 1");
+        expect(ctx?.breadcrumbs?.[1]).toContain("step 2");
+      });
+    });
+  });
+
+  describe("context isolation (AsyncLocalStorage)", () => {
+    it("should isolate contexts between concurrent sessions", async () => {
+      const results: string[] = [];
+
+      await Promise.all([
+        runInContextAsync(async () => {
+          pushOperation({ operation: "session-A", sessionKey: "key-A" });
+          await new Promise((r) => setTimeout(r, 10)); // Simulate async work
+          results.push(`A:${getCurrentOperation()?.operation}`);
+          addBreadcrumb("A completed");
+          results.push(`A-crumbs:${getCurrentOperation()?.breadcrumbs?.length}`);
+        }),
+        runInContextAsync(async () => {
+          pushOperation({ operation: "session-B", sessionKey: "key-B" });
+          await new Promise((r) => setTimeout(r, 5)); // Finishes before A
+          results.push(`B:${getCurrentOperation()?.operation}`);
+          addBreadcrumb("B completed");
+          results.push(`B-crumbs:${getCurrentOperation()?.breadcrumbs?.length}`);
+        }),
+      ]);
+
+      // Each session should see only its own operation
+      expect(results).toContain("A:session-A");
+      expect(results).toContain("B:session-B");
+      // Each session should have exactly 1 breadcrumb (its own)
+      expect(results).toContain("A-crumbs:1");
+      expect(results).toContain("B-crumbs:1");
+    });
+
+    it("should maintain separate stacks in nested contexts", () => {
+      runInContext(() => {
+        pushOperation({ operation: "outer" });
+
+        runInContext(() => {
+          // Inner context starts fresh
+          expect(getCurrentOperation()).toBeUndefined();
+          pushOperation({ operation: "inner" });
+          expect(getCurrentOperation()?.operation).toBe("inner");
+        });
+
+        // Outer context is unchanged
+        expect(getCurrentOperation()?.operation).toBe("outer");
+      });
     });
   });
 
   describe("sanitizeError", () => {
-    it("should return non-Error objects as strings", () => {
+    it("should return non-Error objects as strings without marking sanitized", () => {
       const result = sanitizeError("simple string");
       expect(result.message).toBe("simple string");
-      expect(result.sanitized).toBe(true);
+      // No actual sanitization happened, so sanitized should be false
+      expect(result.sanitized).toBe(false);
     });
 
-    it("should redact file paths", () => {
+    it("should redact file paths to sensitive files", () => {
       const err = new Error("Config loaded from /home/user/.openclawrc");
       const result = sanitizeError(err);
 
-      expect(result.message).toContain("[REDACTED_PATH]");
+      expect(result.message).toContain("[REDACTED]");
       expect(result.sanitized).toBe(true);
     });
 
-    it("should redact token-like strings", () => {
-      const err = new Error("Token: abcdef1234567890abcdef1234567890");
+    it("should redact .env file paths", () => {
+      const err = new Error("Error reading /app/.env.production");
       const result = sanitizeError(err);
 
-      expect(result.message).not.toContain("abcdef1234567890");
+      expect(result.message).toContain("[REDACTED]");
       expect(result.sanitized).toBe(true);
     });
 
-    it("should redact URLs with secrets", () => {
+    it("should redact OpenAI-style API keys", () => {
+      const err = new Error("Invalid key: sk-abc123def456ghi789jklmnopqrst");
+      const result = sanitizeError(err);
+
+      expect(result.message).not.toContain("sk-abc");
+      expect(result.message).toContain("[REDACTED]");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should redact GitHub tokens", () => {
+      const err = new Error("Auth failed with ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+      const result = sanitizeError(err);
+
+      expect(result.message).not.toContain("ghp_");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should redact Slack tokens", () => {
+      const err = new Error("Slack error: xoxb-123456789-abcdefghij");
+      const result = sanitizeError(err);
+
+      expect(result.message).not.toContain("xoxb-");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should redact JWTs", () => {
+      const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+      const err = new Error(`Token expired: ${jwt}`);
+      const result = sanitizeError(err);
+
+      expect(result.message).not.toContain("eyJ");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should redact URLs with secret query params", () => {
       const err = new Error("Failed at https://api.example.com?token=secret123");
       const result = sanitizeError(err);
 
-      expect(result.message).toContain("[REDACTED_URL]");
+      expect(result.message).toContain("[REDACTED]");
+      expect(result.message).not.toContain("secret123");
       expect(result.sanitized).toBe(true);
+    });
+
+    it("should redact password assignments", () => {
+      const err = new Error('Connection failed: password="super_secret_123"');
+      const result = sanitizeError(err);
+
+      expect(result.message).not.toContain("super_secret");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should NOT redact UUIDs (not secrets)", () => {
+      const err = new Error("Session: 550e8400-e29b-41d4-a716-446655440000");
+      const result = sanitizeError(err);
+
+      expect(result.message).toBe("Session: 550e8400-e29b-41d4-a716-446655440000");
+      expect(result.sanitized).toBe(false);
+    });
+
+    it("should NOT redact commit hashes (not secrets)", () => {
+      const err = new Error("Deployed from commit abc123def456789012345678901234567890abcd");
+      const result = sanitizeError(err);
+
+      // Commit hash should remain intact
+      expect(result.message).toContain("abc123def456789012345678901234567890abcd");
+      expect(result.sanitized).toBe(false);
+    });
+
+    it("should NOT redact session identifiers (not secrets)", () => {
+      const err = new Error("Session ID: agent:main:subagent:54d3d43a-596a");
+      const result = sanitizeError(err);
+
+      expect(result.message).toBe("Session ID: agent:main:subagent:54d3d43a-596a");
+      expect(result.sanitized).toBe(false);
     });
 
     it("should not modify clean errors", () => {
@@ -107,14 +231,16 @@ describe("ErrorContext", () => {
     });
 
     it("should inherit context from operation stack", () => {
-      pushOperation({ sessionKey: "sess-456", operation: "stack-op" });
-      addBreadcrumb("test breadcrumb");
+      runInContext(() => {
+        pushOperation({ sessionKey: "sess-456", operation: "stack-op" });
+        addBreadcrumb("test breadcrumb");
 
-      const err = createContextualError("inherited error");
+        const err = createContextualError("inherited error");
 
-      expect(err.context.sessionKey).toBe("sess-456");
-      expect(err.context.operation).toBe("stack-op");
-      expect(err.context.breadcrumbs).toHaveLength(1);
+        expect(err.context.sessionKey).toBe("sess-456");
+        expect(err.context.operation).toBe("stack-op");
+        expect(err.context.breadcrumbs).toHaveLength(1);
+      });
     });
 
     it("should preserve original error", () => {
@@ -144,36 +270,51 @@ describe("ErrorContext", () => {
     });
 
     it("should include breadcrumbs in formatted output", () => {
-      pushOperation({ operation: "test" });
-      addBreadcrumb("step 1");
-      addBreadcrumb("step 2");
+      runInContext(() => {
+        pushOperation({ operation: "test" });
+        addBreadcrumb("step 1");
+        addBreadcrumb("step 2");
 
-      const err = createContextualError("error with crumbs");
-      const formatted = formatContextualError(err);
+        const err = createContextualError("error with crumbs");
+        const formatted = formatContextualError(err);
 
-      expect(formatted).toContain("Breadcrumbs:");
-      expect(formatted).toContain("step 1");
-      expect(formatted).toContain("step 2");
+        expect(formatted).toContain("Breadcrumbs:");
+        expect(formatted).toContain("step 1");
+        expect(formatted).toContain("step 2");
+      });
     });
   });
 
   describe("sanitizeContextualErrorForSlack", () => {
-    it("should sanitize error message", () => {
-      const err = createContextualError("Token: abcdef1234567890abcdef1234567890");
+    it("should sanitize error message with secrets", () => {
+      const err = createContextualError("Token: sk-abcdef1234567890abcdef1234567890");
       const sanitized = sanitizeContextualErrorForSlack(err);
 
-      expect(sanitized.message).not.toContain("abcdef");
+      expect(sanitized.message).not.toContain("sk-abcdef");
       expect(sanitized.sanitized).toBe(true);
     });
 
-    it("should sanitize breadcrumbs", () => {
-      pushOperation({ operation: "test" });
-      addBreadcrumb("Auth failed at https://api.example.com?token=secret");
-
-      const err = createContextualError("error");
+    it("should NOT mark sanitized=true when no secrets present", () => {
+      const err = createContextualError("normal error message", {
+        context: { sessionKey: "sess-123" },
+      });
       const sanitized = sanitizeContextualErrorForSlack(err);
 
-      expect(sanitized.context.breadcrumbs?.[0]).toContain("[REDACTED_URL]");
+      expect(sanitized.message).toBe("normal error message");
+      expect(sanitized.sanitized).toBe(false);
+    });
+
+    it("should sanitize breadcrumbs with secrets", () => {
+      runInContext(() => {
+        pushOperation({ operation: "test" });
+        addBreadcrumb("Auth failed at https://api.example.com?token=secret");
+
+        const err = createContextualError("error");
+        const sanitized = sanitizeContextualErrorForSlack(err);
+
+        expect(sanitized.context.breadcrumbs?.[0]).toContain("[REDACTED]");
+        expect(sanitized.sanitized).toBe(true);
+      });
     });
 
     it("should preserve non-sensitive content", () => {

--- a/src/logging/error-context.test.ts
+++ b/src/logging/error-context.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  pushOperation,
+  popOperation,
+  getCurrentOperation,
+  clearOperationStack,
+  addBreadcrumb,
+  sanitizeError,
+  createContextualError,
+  formatContextualError,
+  sanitizeContextualErrorForSlack,
+} from "./error-context.js";
+
+describe("ErrorContext", () => {
+  beforeEach(() => {
+    clearOperationStack();
+  });
+
+  describe("operation stack", () => {
+    it("should manage operation contexts", () => {
+      expect(getCurrentOperation()).toBeUndefined();
+
+      pushOperation({ operation: "test-op", sessionKey: "sess-123" });
+      expect(getCurrentOperation()?.operation).toBe("test-op");
+
+      pushOperation({ operation: "nested-op" });
+      expect(getCurrentOperation()?.operation).toBe("nested-op");
+
+      popOperation();
+      expect(getCurrentOperation()?.operation).toBe("test-op");
+
+      popOperation();
+      expect(getCurrentOperation()).toBeUndefined();
+    });
+
+    it("should clear operation stack", () => {
+      pushOperation({ operation: "op1" });
+      pushOperation({ operation: "op2" });
+      clearOperationStack();
+
+      expect(getCurrentOperation()).toBeUndefined();
+    });
+
+    it("should track breadcrumbs", () => {
+      pushOperation({ operation: "test" });
+      addBreadcrumb("step 1");
+      addBreadcrumb("step 2");
+
+      const ctx = getCurrentOperation();
+      expect(ctx?.breadcrumbs).toHaveLength(2);
+      expect(ctx?.breadcrumbs?.[0]).toContain("step 1");
+      expect(ctx?.breadcrumbs?.[1]).toContain("step 2");
+    });
+  });
+
+  describe("sanitizeError", () => {
+    it("should return non-Error objects as strings", () => {
+      const result = sanitizeError("simple string");
+      expect(result.message).toBe("simple string");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should redact file paths", () => {
+      const err = new Error("Config loaded from /home/user/.openclawrc");
+      const result = sanitizeError(err);
+
+      expect(result.message).toContain("[REDACTED_PATH]");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should redact token-like strings", () => {
+      const err = new Error("Token: abcdef1234567890abcdef1234567890");
+      const result = sanitizeError(err);
+
+      expect(result.message).not.toContain("abcdef1234567890");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should redact URLs with secrets", () => {
+      const err = new Error("Failed at https://api.example.com?token=secret123");
+      const result = sanitizeError(err);
+
+      expect(result.message).toContain("[REDACTED_URL]");
+      expect(result.sanitized).toBe(true);
+    });
+
+    it("should not modify clean errors", () => {
+      const err = new Error("Something went wrong");
+      const result = sanitizeError(err);
+
+      expect(result.message).toBe("Something went wrong");
+      expect(result.sanitized).toBe(false);
+    });
+  });
+
+  describe("createContextualError", () => {
+    it("should create error with context", () => {
+      const err = createContextualError("test error", {
+        code: "TEST_ERROR",
+        context: { sessionKey: "sess-123", operation: "test" },
+      });
+
+      expect(err.message).toBe("test error");
+      expect(err.code).toBe("TEST_ERROR");
+      expect(err.context.sessionKey).toBe("sess-123");
+      expect(err.context.operation).toBe("test");
+    });
+
+    it("should inherit context from operation stack", () => {
+      pushOperation({ sessionKey: "sess-456", operation: "stack-op" });
+      addBreadcrumb("test breadcrumb");
+
+      const err = createContextualError("inherited error");
+
+      expect(err.context.sessionKey).toBe("sess-456");
+      expect(err.context.operation).toBe("stack-op");
+      expect(err.context.breadcrumbs).toHaveLength(1);
+    });
+
+    it("should preserve original error", () => {
+      const original = new Error("original");
+      const err = createContextualError("wrapper", { originalError: original });
+
+      expect(err.originalError).toBe(original);
+    });
+  });
+
+  describe("formatContextualError", () => {
+    it("should format error with all context", () => {
+      const err = createContextualError("test message", {
+        code: "CODE",
+        context: {
+          sessionKey: "sess-abc123def456",
+          operation: "my-operation",
+        },
+      });
+
+      const formatted = formatContextualError(err);
+
+      expect(formatted).toContain("[sess-ab");
+      expect(formatted).toContain("{my-operation}");
+      expect(formatted).toContain("ERR_CODE");
+      expect(formatted).toContain("test message");
+    });
+
+    it("should include breadcrumbs in formatted output", () => {
+      pushOperation({ operation: "test" });
+      addBreadcrumb("step 1");
+      addBreadcrumb("step 2");
+
+      const err = createContextualError("error with crumbs");
+      const formatted = formatContextualError(err);
+
+      expect(formatted).toContain("Breadcrumbs:");
+      expect(formatted).toContain("step 1");
+      expect(formatted).toContain("step 2");
+    });
+  });
+
+  describe("sanitizeContextualErrorForSlack", () => {
+    it("should sanitize error message", () => {
+      const err = createContextualError("Token: abcdef1234567890abcdef1234567890");
+      const sanitized = sanitizeContextualErrorForSlack(err);
+
+      expect(sanitized.message).not.toContain("abcdef");
+      expect(sanitized.sanitized).toBe(true);
+    });
+
+    it("should sanitize breadcrumbs", () => {
+      pushOperation({ operation: "test" });
+      addBreadcrumb("Auth failed at https://api.example.com?token=secret");
+
+      const err = createContextualError("error");
+      const sanitized = sanitizeContextualErrorForSlack(err);
+
+      expect(sanitized.context.breadcrumbs?.[0]).toContain("[REDACTED_URL]");
+    });
+
+    it("should preserve non-sensitive content", () => {
+      const err = createContextualError("normal error message", {
+        context: { sessionKey: "sess-123" },
+      });
+      const sanitized = sanitizeContextualErrorForSlack(err);
+
+      expect(sanitized.message).toBe("normal error message");
+      expect(sanitized.context.sessionKey).toBe("sess-123");
+    });
+  });
+});

--- a/src/logging/error-context.ts
+++ b/src/logging/error-context.ts
@@ -1,0 +1,180 @@
+/**
+ * Enhanced error context tracking
+ * Adds session key, operation trace, and structured error information
+ */
+
+export type OperationContext = {
+  sessionKey?: string;
+  operation?: string;
+  tool?: string;
+  timestamp?: number;
+  breadcrumbs?: string[];
+};
+
+export type ContextualError = {
+  message: string;
+  code?: string;
+  context: OperationContext;
+  originalError?: Error;
+  sanitized?: boolean;
+};
+
+const operationStack: OperationContext[] = [];
+
+/**
+ * Set the current operation context (for nested operations)
+ */
+export function pushOperation(ctx: Partial<OperationContext>): void {
+  operationStack.push({
+    sessionKey: ctx.sessionKey,
+    operation: ctx.operation,
+    tool: ctx.tool,
+    timestamp: ctx.timestamp ?? Date.now(),
+    breadcrumbs: ctx.breadcrumbs ?? [],
+  });
+}
+
+/**
+ * Pop the current operation context
+ */
+export function popOperation(): OperationContext | undefined {
+  return operationStack.pop();
+}
+
+/**
+ * Get the current operation context
+ */
+export function getCurrentOperation(): OperationContext | undefined {
+  return operationStack[operationStack.length - 1];
+}
+
+/**
+ * Clear all operation contexts
+ */
+export function clearOperationStack(): void {
+  operationStack.length = 0;
+}
+
+/**
+ * Add a breadcrumb to the current operation
+ */
+export function addBreadcrumb(message: string): void {
+  const current = getCurrentOperation();
+  if (current) {
+    current.breadcrumbs ??= [];
+    current.breadcrumbs.push(`[${new Date().toISOString()}] ${message}`);
+  }
+}
+
+/**
+ * Sanitize an error for safe transmission (e.g., to Slack)
+ */
+export function sanitizeError(err: Error | unknown): {
+  message: string;
+  sanitized: boolean;
+} {
+  if (!(err instanceof Error)) {
+    return {
+      message: String(err),
+      sanitized: true,
+    };
+  }
+
+  // Remove sensitive paths and keys from message
+  let message = err.message;
+
+  // Remove URLs with secrets (must run before file path redaction)
+  message = message.replace(/https?:\/\/[^\s]*(?:token|key|secret|auth)[^\s]*/gi, "[REDACTED_URL]");
+
+  // Remove file paths
+  message = message.replace(
+    /\/[^\s]*(\/\.openclawrc|\.env|secrets?|tokens?|keys?)[^\s]*/gi,
+    "[REDACTED_PATH]",
+  );
+
+  // Remove token-like strings (long hex/base64 sequences)
+  message = message.replace(/[a-zA-Z0-9]{32,}/g, "[REDACTED_TOKEN]");
+
+  const sanitized = message !== err.message;
+
+  return { message, sanitized };
+}
+
+/**
+ * Create a contextual error with session and operation information
+ */
+export function createContextualError(
+  message: string,
+  options?: {
+    code?: string;
+    context?: Partial<OperationContext>;
+    originalError?: Error;
+  },
+): ContextualError {
+  const currentOperation = getCurrentOperation();
+  const context: OperationContext = {
+    sessionKey: options?.context?.sessionKey ?? currentOperation?.sessionKey,
+    operation: options?.context?.operation ?? currentOperation?.operation,
+    tool: options?.context?.tool ?? currentOperation?.tool,
+    timestamp: options?.context?.timestamp ?? Date.now(),
+    breadcrumbs: options?.context?.breadcrumbs ?? [...(currentOperation?.breadcrumbs ?? [])],
+  };
+
+  return {
+    message,
+    code: options?.code,
+    context,
+    originalError: options?.originalError,
+    sanitized: false,
+  };
+}
+
+/**
+ * Format a contextual error for logging
+ */
+export function formatContextualError(err: ContextualError): string {
+  const parts: string[] = [];
+
+  if (err.context.sessionKey) {
+    parts.push(`[${err.context.sessionKey.slice(0, 8)}]`);
+  }
+
+  if (err.context.operation) {
+    parts.push(`{${err.context.operation}}`);
+  }
+
+  if (err.code) {
+    parts.push(`ERR_${err.code}`);
+  }
+
+  parts.push(err.message);
+
+  if (err.context.breadcrumbs && err.context.breadcrumbs.length > 0) {
+    parts.push(`\nBreadcrumbs:\n${err.context.breadcrumbs.join("\n")}`);
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Sanitize a contextual error for safe Slack delivery
+ */
+export function sanitizeContextualErrorForSlack(err: ContextualError): ContextualError {
+  const { message } = sanitizeError(new Error(err.message));
+
+  // Also sanitize breadcrumbs
+  const sanitizedBreadcrumbs = (err.context.breadcrumbs ?? []).map((crumb) => {
+    const { message: sanitizedMessage } = sanitizeError(new Error(crumb));
+    return sanitizedMessage;
+  });
+
+  return {
+    ...err,
+    message,
+    sanitized: true,
+    context: {
+      ...err.context,
+      breadcrumbs: sanitizedBreadcrumbs,
+    },
+  };
+}

--- a/src/logging/error-context.ts
+++ b/src/logging/error-context.ts
@@ -129,7 +129,7 @@ const SECRET_PATTERNS = [
  * Sanitize an error for safe transmission (e.g., to Slack)
  * Only redacts actual secrets, not general identifiers like UUIDs or session keys.
  */
-export function sanitizeError(err: Error | unknown): {
+export function sanitizeError(err: unknown): {
   message: string;
   sanitized: boolean;
 } {


### PR DESCRIPTION
# PR: feat(logging): Add session context and breadcrumbs to error logs

## Summary

Adds enhanced error context tracking for better debugging in multi-session and multi-agent setups. This module provides structured error context with session correlation, operation tracing, and automatic sanitization.

## Motivation

In multi-agent or multi-session deployments, errors can be difficult to trace back to their source. This feature adds:
- **Session keys** to correlate errors to specific sessions
- **Breadcrumbs** to trace the path leading to an error
- **Automatic sanitization** to safely transmit errors without leaking secrets

## Features

### Operation Context Stack
```typescript
import { pushOperation, popOperation, addBreadcrumb } from './error-context.js';

// Track operation context
pushOperation({ sessionKey: 'sess-abc123', operation: 'tool-exec', tool: 'exec' });
addBreadcrumb('Starting command execution');
addBreadcrumb('Command completed, parsing output');
// ... error occurs ...
popOperation();
```

### Contextual Errors
```typescript
import { createContextualError, formatContextualError } from './error-context.js';

const err = createContextualError('Tool execution failed', {
  code: 'TOOL_EXEC_FAIL',
  context: { sessionKey: 'sess-abc123', operation: 'exec' }
});

console.log(formatContextualError(err));
// Output: [sess-abc] {exec} ERR_TOOL_EXEC_FAIL Tool execution failed
// Breadcrumbs:
// [2026-02-09T00:00:00.000Z] Starting command execution
// [2026-02-09T00:00:01.000Z] Command completed, parsing output
```

### Automatic Sanitization
```typescript
import { sanitizeError, sanitizeContextualErrorForSlack } from './error-context.js';

// Redacts tokens, secret URLs, and sensitive file paths
const result = sanitizeError(new Error('Failed with token abc123...def456'));
// result.message: "Failed with token [REDACTED_TOKEN]"

// Safe for external delivery (Slack, webhooks, etc.)
const safeErr = sanitizeContextualErrorForSlack(contextualError);
```

## API

| Function | Description |
|----------|-------------|
| `pushOperation(ctx)` | Push operation context onto stack |
| `popOperation()` | Pop current operation context |
| `getCurrentOperation()` | Get current operation context |
| `clearOperationStack()` | Clear all operation contexts |
| `addBreadcrumb(message)` | Add breadcrumb to current operation |
| `sanitizeError(err)` | Sanitize error for safe transmission |
| `createContextualError(msg, opts)` | Create error with context |
| `formatContextualError(err)` | Format error for human-readable logs |
| `sanitizeContextualErrorForSlack(err)` | Sanitize contextual error for external delivery |

## Types

```typescript
type OperationContext = {
  sessionKey?: string;
  operation?: string;
  tool?: string;
  timestamp?: number;
  breadcrumbs?: string[];
};

type ContextualError = {
  message: string;
  code?: string;
  context: OperationContext;
  originalError?: Error;
  sanitized?: boolean;
};
```

## Benefits

1. **Debugging**: Easily correlate errors to specific sessions in multi-agent deployments
2. **Tracing**: Follow operation chains with breadcrumb trails
3. **Security**: Automatic redaction prevents secret leakage in error reports
4. **Flexibility**: Works standalone or integrates with existing logging

## Performance

- **Negligible overhead**: Simple array operations for context stack
- **No async operations**: Purely synchronous, no event loop impact
- **Memory efficient**: Breadcrumbs are timestamp-prefixed strings

## Test Coverage

16 test cases covering:
- Operation stack management (push/pop/clear)
- Breadcrumb tracking
- Token/URL/path sanitization
- Context inheritance from stack
- Formatted output generation
- Slack-safe sanitization

## Backward Compatibility

- **No breaking changes**: New standalone module
- **No dependencies**: Zero imports, self-contained
- **Optional adoption**: Consumers can gradually integrate

## Files Changed

- `src/logging/error-context.ts` - Main module (156 lines)
- `src/logging/error-context.test.ts` - Tests (189 lines)

## Branch

`feature/enhanced-error-context` based on `upstream/main`

## PR Metadata

- **Title**: feat(logging): Add session context and breadcrumbs to error logs
- **Labels**: enhancement, logging, debugging
- **Reviewers**: (maintainers)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `src/logging/error-context.ts` module plus unit tests to support attaching session/operation context and breadcrumb trails to errors, formatting those contextual errors for logs, and sanitizing error messages/breadcrumbs for external delivery (e.g., Slack).

The module is currently standalone and not wired into any existing logging pipeline in `src/`, so its impact depends on follow-up integration. The core API (push/pop stack, breadcrumb capture, contextual error creation/formatting, and sanitization) is straightforward, but there are a couple of correctness issues around concurrency/isolation and sanitization behavior that should be addressed before merging.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to incorrect context isolation across concurrent operations.
- The module uses a process-global mutable stack for operation context, which will produce wrong/merged context in real multi-session or overlapping async usage. Additionally, sanitization behavior is currently overly broad (redacting many non-secret identifiers) and reports inconsistent sanitized status for non-Error inputs, making downstream behavior hard to trust.
- src/logging/error-context.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->