### PR TITLE
Fix matrix media attachments

### DIFF
--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -30,11 +30,13 @@ async function fetchMatrixMediaBuffer(params: {
   // Use the client's download method which handles auth
   try {
     const result = await params.client.downloadContent(params.mxcUrl);
-    const buffer = result.data;
+    const raw = result.data ?? result;
+    const buffer = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+
     if (buffer.byteLength > params.maxBytes) {
       throw new Error("Matrix media exceeds configured size limit");
     }
-    return { buffer: Buffer.from(buffer) };
+    return { buffer, headerType: result.contentType };
   } catch (err) {
     throw new Error(`Matrix media download failed: ${String(err)}`, { cause: err });
   }


### PR DESCRIPTION
## Summary

Fix inbound Matrix media downloads failing silently due to incorrect handling of `client.downloadContent()` return value.

## Problem

`client.downloadContent()` from `@vector-im/matrix-bot-sdk` returns `{ data: Buffer, contentType: string }`, but `fetchMatrixMediaBuffer()` in `media.ts` treats the entire return value as a raw Buffer:

```ts
const buffer = await params.client.downloadContent(params.mxcUrl);
if (buffer.byteLength > params.maxBytes) { ... }
return { buffer: Buffer.from(buffer) };
```

`Buffer.from()` receives an Object instead of a Buffer/ArrayBuffer, throwing:
```
ERR_INVALID_ARG_TYPE: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Object
```

This error is caught silently and only logged at verbose level, making it appear as though the download simply never happened. Messages arrive with the filename as body text but no `MediaPath` in the inbound context.

## Fix

Extract `.data` from the return value and handle both the `{data, contentType}` format and potential future changes where it might return a raw    

## Testing

- Verified `m.image` events contain correct `mxc://` URLs via Matrix client API
- After fix: images sent via Matrix are downloaded, saved to `~/.openclaw/media/inbound/`, and attached to inbound context with `MediaPath`/`MediaType`
- Tested with unencrypted room on self-hosted Synapse

## Related Issues

Fixes #7363 (also related to #3203 and #3499 )

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Matrix inbound media handling to correctly interpret `@vector-im/matrix-bot-sdk`’s `client.downloadContent()` return value. Instead of treating the return as a raw `Buffer`, the code now extracts the actual bytes (`.data`) and preserves the associated content type, preventing silent failures when attachments are downloaded and persisted for inbound context.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is tightly scoped to Matrix media download handling, aligns with the documented SDK return type, and resolves a deterministic runtime error that previously prevented attachments from being processed.
- extensions/matrix/src/matrix/monitor/media.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->