### PR TITLE
fix: intermittent (no output) reported by users

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -4,6 +4,7 @@ import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
+  formatRawAssistantErrorForUi,
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
@@ -232,6 +233,15 @@ export function handleMessageEnd(
       cleanedText = parsedFallback.text ?? rawCandidate;
       mediaUrls = parsedFallback.mediaUrls;
       hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
+    }
+  }
+  if (!cleanedText && !hasMedia) {
+    const stopReason =
+      typeof assistantMessage.stopReason === "string" ? assistantMessage.stopReason : "";
+    const errorMessage =
+      typeof assistantMessage.errorMessage === "string" ? assistantMessage.errorMessage.trim() : "";
+    if (stopReason === "error" && errorMessage) {
+      cleanedText = formatRawAssistantErrorForUi(errorMessage);
     }
   }
 

--- a/src/agents/pi-embedded-utils.e2e.test.ts
+++ b/src/agents/pi-embedded-utils.e2e.test.ts
@@ -92,6 +92,17 @@ describe("extractAssistantText", () => {
     expect(result).toBe("HTTP 500: Internal Server Error");
   });
 
+  it("extracts output_text blocks as assistant text", () => {
+    const msg: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "output_text", text: "Output text block" }],
+      timestamp: Date.now(),
+    };
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Output text block");
+  });
+
   it("strips Minimax tool invocations with extra attributes", () => {
     const msg: AssistantMessage = {
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -202,12 +202,13 @@ export function stripThinkingTagsFromText(text: string): string {
 }
 
 export function extractAssistantText(msg: AssistantMessage): string {
-  const isTextBlock = (block: unknown): block is { type: "text"; text: string } => {
+  const isTextBlock = (block: unknown): block is { type: "text" | "output_text"; text: string } => {
     if (!block || typeof block !== "object") {
       return false;
     }
     const rec = block as Record<string, unknown>;
-    return rec.type === "text" && typeof rec.text === "string";
+    const type = rec.type;
+    return (type === "text" || type === "output_text") && typeof rec.text === "string";
   };
 
   const blocks = Array.isArray(msg.content)

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -93,9 +93,7 @@ export type HeartbeatSummary = {
 
 const DEFAULT_HEARTBEAT_TARGET = "last";
 
-// Prompt used when an async exec has completed and the result should be relayed to the user.
-// This overrides the standard heartbeat prompt to ensure the model responds with the exec result
-// instead of just "HEARTBEAT_OK".
+// Prompt used when async exec completes; overrides standard heartbeat prompt so model relays exec result instead of only "HEARTBEAT_OK".
 const EXEC_EVENT_PROMPT =
   "An async command you ran earlier has completed. The result is shown in the system messages above. " +
   "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -88,6 +88,15 @@ describe("extractContentFromMessage", () => {
     expect(text).toBe("hello");
   });
 
+  it("collects output_text blocks", () => {
+    const text = extractContentFromMessage({
+      role: "assistant",
+      content: [{ type: "output_text", text: "hello from output_text" }],
+    });
+
+    expect(text).toBe("hello from output_text");
+  });
+
   it("renders error text when stopReason is error and content is not an array", () => {
     const text = extractContentFromMessage({
       role: "assistant",
@@ -104,5 +113,19 @@ describe("isCommandMessage", () => {
     expect(isCommandMessage({ command: true })).toBe(true);
     expect(isCommandMessage({ command: false })).toBe(false);
     expect(isCommandMessage({})).toBe(false);
+  });
+});
+
+describe("extractTextFromMessage block variants", () => {
+  it("joins input_text and output_text blocks", () => {
+    const text = extractTextFromMessage({
+      role: "assistant",
+      content: [
+        { type: "input_text", text: "prompt echo" },
+        { type: "output_text", text: "assistant output" },
+      ],
+    });
+
+    expect(text).toBe("prompt echo\nassistant output");
   });
 });

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -96,7 +96,7 @@ export function extractContentFromMessage(message: unknown): string {
       continue;
     }
     const rec = block as Record<string, unknown>;
-    if (rec.type === "text" && typeof rec.text === "string") {
+    if ((rec.type === "text" || rec.type === "output_text") && typeof rec.text === "string") {
       parts.push(rec.text);
     }
   }
@@ -129,7 +129,10 @@ function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean 
       continue;
     }
     const record = block as Record<string, unknown>;
-    if (record.type === "text" && typeof record.text === "string") {
+    if (
+      (record.type === "text" || record.type === "output_text" || record.type === "input_text") &&
+      typeof record.text === "string"
+    ) {
       textParts.push(record.text);
     }
     if (


### PR DESCRIPTION
This addresses intermittent "(no output)" reports by preserving assistant-visible text in finalization paths.
The goal is to avoid empty chat finals when providers emit non-text block shapes or error-only assistant completions.

Issue 1 is a run-finalization gap between the agent pipeline and the gateway chat stream: once a run is marked as agent-started, `chat.send` no longer uses its local final-text fallback, and the gateway emits `chat.state="final"` from the streamed assistant buffer only. If that buffer is empty (for example when the assistant ends with an error-only message, tool-only behavior, or no emitted assistant delta), the final chat event has no `message`, and the TUI resolves that to `(no output)`. This explains the intermittent “works sometimes” pattern and why restarting can appear to help without fixing root behavior.

Issue 2 is content-shape mismatch in text extraction: several extraction paths only read blocks with `type: "text"` and ignore other valid text-like formats such as `output_text`. When a provider/model returns content in those alternate shapes, the system can treat a real answer as empty, which again feeds into the same “no output” symptom. This aligns with reports that it happens across specific providers/models and can look inconsistent across channels.

- Fixes #5030

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change set attempts to eliminate intermittent “(no output)” finals in the TUI by (1) preserving assistant-visible text through agent run finalization paths, and (2) expanding text extraction to handle alternate provider content shapes (e.g., `output_text`) so the gateway/TUI final message buffer isn’t empty.

The updates span the embedded PI agent pipeline (message handling + final-output suppression filtering), shared embedded utilities (text extraction), heartbeat runner (finalization behavior), and TUI formatters + tests (rendering/formatting when the final message is missing or non-text). Overall, the intent is to ensure that when providers emit tool-only/error-only/non-`text` blocks, user-facing final events still contain assistant-readable content or a safe fallback rather than resolving to `(no output)`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly focused on text extraction/finalization edge-cases and are backed by targeted tests across the agent embedded utilities and TUI formatting paths; I did not find any new logic that would break normal streaming or introduce security concerns.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->