### PR TITLE
fix(telegram): use message_id instead of callback.id for inline button context

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -586,7 +586,7 @@ export const registerTelegramHandlers = ({
             storeAllowFrom,
             {
               forceWasMentioned: true,
-              messageIdOverride: callback.id,
+              messageIdOverride: String(callbackMessage.message_id),
             },
           );
           return;
@@ -606,7 +606,7 @@ export const registerTelegramHandlers = ({
       const getFile = typeof ctx.getFile === "function" ? ctx.getFile.bind(ctx) : async () => ({});
       await processMessage({ message: syntheticMessage, me: ctx.me, getFile }, [], storeAllowFrom, {
         forceWasMentioned: true,
-        messageIdOverride: callback.id,
+        messageIdOverride: String(callbackMessage.message_id),
       });
     } catch (err) {
       runtime.error?.(danger(`callback handler failed: ${String(err)}`));


### PR DESCRIPTION
## Problem
Telegram inline button callbacks use `callback.id` (callback query ID, a large
integer like `7433195443371913934`) as `messageIdOverride` instead of
`callbackMessage.message_id` (the real message ID like `1887`). This causes
`setMessageReaction()` to fail with `400: Bad Request: message to react not found`
because the callback query ID is not a valid message ID. Fixes #12886

## Solution
Replace `messageIdOverride: callback.id` with
`messageIdOverride: String(callbackMessage.message_id)` in both callback handler
paths (model selection at line 589 and generic callback data at line 609).

## Testing
- [ ] `pnpm build` passes
- [ ] `pnpm check` passes
- [ ] Inline button reactions target the correct message

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Telegram `callback_query` handler to use the *actual* Telegram message ID (`callbackMessage.message_id`) as the `messageIdOverride` when converting inline button callbacks into synthetic messages for processing. Previously it used the callback query ID (`callback.id`), which is not a valid message ID and breaks downstream operations that rely on `MessageSid` (notably reactions via `setMessageReaction`).

The change stays localized to `src/telegram/bot-handlers.ts` and flows into `buildTelegramMessageContext` where `MessageSid` is populated from `options.messageIdOverride` (`src/telegram/bot-message-context.ts:591`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff is small, changes only the identifier used for `messageIdOverride` in Telegram callback handling, and aligns it with how `MessageSid` is expected to map to real Telegram message IDs for downstream APIs like reactions. No other call sites or types are impacted.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->