### PR TITLE
fix(gateway): defer seq increment until after dropIfSlow filtering

### DIFF
--- a/src/gateway/server-broadcast.test.ts
+++ b/src/gateway/server-broadcast.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
+import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 
 type TestSocket = {
   bufferedAmount: number;
@@ -57,5 +58,71 @@ describe("gateway broadcaster", () => {
     expect(readSocket.send).toHaveBeenCalledTimes(1);
     expect(approvalsSocket.send).toHaveBeenCalledTimes(1);
     expect(pairingSocket.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not increment seq when all clients are slow with dropIfSlow (#12895)", () => {
+    const slowSocket: TestSocket = {
+      bufferedAmount: MAX_BUFFERED_BYTES + 1,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+    const clients = new Set<GatewayWsClient>([
+      {
+        socket: slowSocket as unknown as GatewayWsClient["socket"],
+        connect: { role: "operator", scopes: [] } as GatewayWsClient["connect"],
+        connId: "c-slow",
+      },
+    ]);
+
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    // First broadcast: all clients slow + dropIfSlow → seq should NOT increment
+    broadcast("tick", { ts: 1 }, { dropIfSlow: true });
+    expect(slowSocket.send).not.toHaveBeenCalled();
+
+    // Make client fast again
+    slowSocket.bufferedAmount = 0;
+    broadcast("tick", { ts: 2 });
+
+    // The seq in the frame should be 1 (not 2), proving the slow-dropped
+    // broadcast did not consume a seq number.
+    const frame = JSON.parse((slowSocket.send as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(frame.seq).toBe(1);
+  });
+
+  it("delivers contiguous seq to fast clients when mixed with slow (#12895)", () => {
+    const fastSocket: TestSocket = {
+      bufferedAmount: 0,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+    const slowSocket: TestSocket = {
+      bufferedAmount: MAX_BUFFERED_BYTES + 1,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+    const clients = new Set<GatewayWsClient>([
+      {
+        socket: fastSocket as unknown as GatewayWsClient["socket"],
+        connect: { role: "operator", scopes: [] } as GatewayWsClient["connect"],
+        connId: "c-fast",
+      },
+      {
+        socket: slowSocket as unknown as GatewayWsClient["socket"],
+        connect: { role: "operator", scopes: [] } as GatewayWsClient["connect"],
+        connId: "c-slow",
+      },
+    ]);
+
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("tick", { ts: 1 }, { dropIfSlow: true });
+    broadcast("tick", { ts: 2 }, { dropIfSlow: true });
+
+    const calls = (fastSocket.send as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(2);
+    const seq1 = JSON.parse(calls[0][0]).seq;
+    const seq2 = JSON.parse(calls[1][0]).seq;
+    expect(seq2 - seq1).toBe(1);
   });
 });


### PR DESCRIPTION
## Problem
Dashboard shows recurring "event gap detected" errors because the broadcast `seq`
counter increments before the per-client send loop. When `dropIfSlow` skips slow
clients, the seq is consumed but the frame is never delivered, causing clients to
see non-contiguous sequence numbers. Fixes #12895

## Solution
Restructure `broadcastInternal()` into a two-pass approach:
1. **Pass 1**: Collect eligible recipients, closing slow consumers along the way
2. **Pass 2**: Only increment `seq` and serialize the frame if at least one client
   will receive it

The log metadata now distinguishes `"targeted"` (targeted events) from `"dropped"`
(broadcast with no eligible recipients) for better observability.

## Testing
- [ ] `pnpm build` passes
- [ ] `pnpm check` passes
- [ ] Added test: dropIfSlow does not increment seq when all clients are slow
- [ ] Added test: mixed fast/slow clients receive contiguous seq

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the gateway WebSocket broadcaster to avoid consuming a broadcast sequence number when no clients will actually receive the frame (e.g., when all recipients are filtered out by `dropIfSlow`). It does this by splitting `broadcastInternal()` into two passes: first selecting eligible recipients (and filtering/handling slow consumers), then allocating `seq` and serializing the frame only if at least one recipient exists. Tests were added to assert that `seq` is not incremented when all clients are slow with `dropIfSlow`, and that fast clients still observe contiguous `seq` values when mixed with slow clients.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but there is a behavior change around handling slow clients when dropIfSlow is enabled that should be confirmed/fixed before merging.
- The seq allocation change and added tests align with the stated bug. However, the new first-pass logic skips slow clients when `dropIfSlow` is true without closing them, whereas previously slow consumers were closed; if the prior behavior was relied on for backpressure enforcement, this is a functional regression. Tooling/tests were not runnable in this environment (pnpm unavailable), so confidence is reduced.
- src/gateway/server-broadcast.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->