### PR TITLE
fix(signal): fall back to JSON-RPC for health check on signal-cli 0.13+

### DIFF
--- a/src/signal/client.test.ts
+++ b/src/signal/client.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock resolveFetch so we can control HTTP responses
+const mockFetch = vi.fn();
+vi.mock("../infra/fetch.js", () => ({
+  resolveFetch: () => mockFetch,
+}));
+
+import { signalCheck } from "./client.js";
+
+describe("signalCheck", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns ok when REST /api/v1/check succeeds", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+    const result = await signalCheck("http://127.0.0.1:8080", 1000);
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    // Should only call REST endpoint, not JSON-RPC
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toContain("/api/v1/check");
+  });
+
+  it("falls back to JSON-RPC when REST /api/v1/check returns non-ok", async () => {
+    // REST endpoint returns 404 (signal-cli 0.13+)
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    // JSON-RPC version call succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ jsonrpc: "2.0", result: { version: "0.13.23" }, id: "1" }),
+    });
+
+    const result = await signalCheck("http://127.0.0.1:8080", 1000);
+
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0][0]).toContain("/api/v1/check");
+    expect(mockFetch.mock.calls[1][0]).toContain("/api/v1/rpc");
+  });
+
+  it("falls back to JSON-RPC when REST /api/v1/check throws", async () => {
+    // REST endpoint throws (connection refused, etc.)
+    mockFetch.mockRejectedValueOnce(new Error("fetch failed"));
+    // JSON-RPC version call succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ jsonrpc: "2.0", result: { version: "0.13.23" }, id: "1" }),
+    });
+
+    const result = await signalCheck("http://127.0.0.1:8080", 1000);
+
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns error when both REST and JSON-RPC fail", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    mockFetch.mockRejectedValueOnce(new Error("connection refused"));
+
+    const result = await signalCheck("http://127.0.0.1:8080", 1000);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("connection refused");
+  });
+
+  it("returns error when both REST throws and JSON-RPC fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    mockFetch.mockRejectedValueOnce(new Error("rpc unavailable"));
+
+    const result = await signalCheck("http://127.0.0.1:8080", 1000);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("rpc unavailable");
+  });
+});

--- a/src/signal/client.ts
+++ b/src/signal/client.ts
@@ -92,6 +92,7 @@ export async function signalCheck(
 ): Promise<{ ok: boolean; status?: number | null; error?: string | null }> {
   const normalized = normalizeBaseUrl(baseUrl);
   // Try the REST health endpoint first (signal-cli <0.13)
+  let restStatus: number | null = null;
   try {
     const res = await fetchWithTimeout(
       `${normalized}/api/v1/check`,
@@ -99,11 +100,18 @@ export async function signalCheck(
       timeoutMs,
       getRequiredFetch(),
     );
+    restStatus = res.status;
     if (res.ok) {
       return { ok: true, status: res.status, error: null };
     }
   } catch {
-    // REST endpoint unavailable, try JSON-RPC below
+    // REST endpoint unavailable (connection refused, timeout, etc.)
+  }
+  // Only fall back to JSON-RPC when the REST endpoint is missing (404) or
+  // unreachable (network error). Other non-OK statuses (401, 500, 503) indicate
+  // the server is reachable but unhealthy — don't mask those with an RPC probe.
+  if (restStatus !== null && restStatus !== 404) {
+    return { ok: false, status: restStatus, error: `HTTP ${restStatus}` };
   }
   // Fall back to JSON-RPC "version" method (signal-cli 0.13+)
   try {
@@ -112,7 +120,7 @@ export async function signalCheck(
   } catch (err) {
     return {
       ok: false,
-      status: null,
+      status: restStatus,
       error: err instanceof Error ? err.message : String(err),
     };
   }


### PR DESCRIPTION
## Summary
Fixes `openclaw doctor` reporting Signal as `failed (unknown) - fetch failed` when using signal-cli 0.13.x, which removed the REST `/api/v1/check` endpoint.

Closes #12933

## Changes
- **`client.ts`**: `signalCheck()` now tries REST `/api/v1/check` first, then falls back to a JSON-RPC `version` call at `/api/v1/rpc` if REST fails. Works with both old (<0.13) and new (0.13+) signal-cli versions.

## Testing
- Added 5 new tests in `client.test.ts` covering:
  - REST success (no fallback needed)
  - REST 404 → JSON-RPC fallback succeeds
  - REST throws → JSON-RPC fallback succeeds  
  - Both REST and JSON-RPC fail → returns error
  - Both throw → returns error
- All 42 existing signal tests pass

🤖 Generated with Claude (AI-assisted)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Signal health check to be compatible with signal-cli 0.13+ by attempting the legacy REST endpoint (`/api/v1/check`) first and falling back to a JSON-RPC `version` request against `/api/v1/rpc` when the REST check fails.

The change lives in `src/signal/client.ts` (`signalCheck`) and is exercised by a new `src/signal/client.test.ts` suite. `signalCheck` is used by `probeSignal` and the Signal monitor check path, so its success/failure semantics directly affect `openclaw doctor` and runtime health reporting.

Main concern: the fallback currently triggers on *any* non-OK REST response, which can mask genuine errors from the REST endpoint on older signal-cli versions (e.g., 401/403/5xx) if JSON-RPC happens to respond. Tests cover the 404/throw scenarios but don’t guard against this behavior change for other statuses.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but the new fallback logic can change health-check semantics in a way that masks real failures.
- The implementation achieves the intended compatibility, but `signalCheck` now treats any non-OK REST response as a reason to fall back and potentially report success if JSON-RPC works, which is a behavioral regression for older signal-cli setups and is not covered by tests.
- src/signal/client.ts; src/signal/client.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->