### PR TITLE
fix(provider): disable reasoning tags for gemini-3-pro variants to fix tool calls

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -24,6 +24,10 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
 
   // Handle google-antigravity and its model variations (e.g. google-antigravity/gemini-3)
   if (normalized.includes("google-antigravity")) {
+    // PATCH: Disable reasoning tags for gemini-3-pro-low due to tool call format issues
+    if (normalized.includes("gemini-3-pro-low") || normalized.includes("gemini-3-pro")) {
+      return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
fix:
[Historical context: a different model called tool "read" with arguments: {
"file_path"

https://github.com/openclaw/openclaw/issues/3344

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `isReasoningTagProvider` to return `false` for `google-antigravity` provider strings that include `gemini-3-pro` or `gemini-3-pro-low`, effectively disabling `<think>/<final>` reasoning-tag prompting for those Gemini variants to avoid malformed tool calls.

The change affects downstream behavior wherever `isReasoningTagProvider()` is used to decide whether to enforce a final tag or to include reasoning-tag hints in the system prompt (e.g., reply runner and embedded runner code paths).

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, with a small but real documentation/comment issue to fix.
- The functional change is narrowly scoped to a specific provider/model substring and is wired through existing helper usage. The main concrete issue is the placeholder issue URL (`issues/XXXXX`) in the code comment, which should be corrected before merging.
- src/utils/provider-utils.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->