### PR TITLE
Security: detect invisible Unicode in skills and plugins (ASCII smuggling, Trojan Source)

### DIFF
--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -34,22 +34,21 @@ export type SkillScanOptions = {
 // Scannable extensions
 // ---------------------------------------------------------------------------
 
-const SCANNABLE_EXTENSIONS = new Set([
-  ".js",
-  ".ts",
-  ".mjs",
-  ".cjs",
-  ".mts",
-  ".cts",
-  ".jsx",
-  ".tsx",
-]);
+const CODE_EXTENSIONS = new Set([".js", ".ts", ".mjs", ".cjs", ".mts", ".cts", ".jsx", ".tsx"]);
+
+/** Extensions scanned for invisible Unicode only (no code rules). */
+const TEXT_EXTENSIONS = new Set([".md", ".txt", ".yaml", ".yml", ".json"]);
 
 const DEFAULT_MAX_SCAN_FILES = 500;
 const DEFAULT_MAX_FILE_BYTES = 1024 * 1024;
 
 export function isScannable(filePath: string): boolean {
-  return SCANNABLE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+  const ext = path.extname(filePath).toLowerCase();
+  return CODE_EXTENSIONS.has(ext) || TEXT_EXTENSIONS.has(ext);
+}
+
+function isCodeFile(filePath: string): boolean {
+  return CODE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
 }
 
 function isErrno(err: unknown, code: string): boolean {
@@ -85,6 +84,206 @@ type SourceRule = {
   requiresContext?: RegExp;
 };
 
+// ---------------------------------------------------------------------------
+// Unicode safety helpers
+// ---------------------------------------------------------------------------
+
+type InvisibleUnicodeFileSummary = {
+  renderedEvidence: string;
+  evidenceLine: number;
+  uniqueCodePoints: string[];
+  total: number;
+  tags: number;
+  variationSelectors: number;
+  bidi: number;
+  other: number;
+  longestConsecutiveRun: number;
+  severity: SkillScanSeverity;
+};
+
+const INVISIBLE_UNICODE_PATTERN =
+  /[\u061C\u200B\u200C\u200D\u200E\u200F\u2060\u202A-\u202E\u2066-\u2069\uFE00-\uFE0F\uFEFF\u{E0000}-\u{E007F}\u{E0100}-\u{E01EF}]/u;
+
+function isInvisibleUnicodeCodePoint(codePoint: number): boolean {
+  return (
+    codePoint === 0x061c ||
+    (codePoint >= 0x200b && codePoint <= 0x200f) ||
+    codePoint === 0x2060 ||
+    (codePoint >= 0x202a && codePoint <= 0x202e) ||
+    (codePoint >= 0x2066 && codePoint <= 0x2069) ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+    codePoint === 0xfeff ||
+    (codePoint >= 0xe0000 && codePoint <= 0xe007f) ||
+    (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+  );
+}
+
+function isBidiControlCodePoint(codePoint: number): boolean {
+  return (
+    codePoint === 0x061c ||
+    codePoint === 0x200e ||
+    codePoint === 0x200f ||
+    (codePoint >= 0x202a && codePoint <= 0x202e) ||
+    (codePoint >= 0x2066 && codePoint <= 0x2069)
+  );
+}
+
+function formatUnicodeCodePoint(codePoint: number): string {
+  const hex = codePoint.toString(16).toUpperCase();
+  const padded = hex.padStart(4, "0");
+  return `U+${padded}`;
+}
+
+function isTagCodePoint(codePoint: number): boolean {
+  return codePoint >= 0xe0000 && codePoint <= 0xe007f;
+}
+
+function isVariationSelectorCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) || (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+  );
+}
+
+function describeInvisibleUnicodeCodePoint(codePoint: number): string {
+  switch (codePoint) {
+    case 0x061c:
+      return `${formatUnicodeCodePoint(codePoint)} ARABIC LETTER MARK`;
+    case 0x200b:
+      return `${formatUnicodeCodePoint(codePoint)} ZERO WIDTH SPACE`;
+    case 0x200c:
+      return `${formatUnicodeCodePoint(codePoint)} ZERO WIDTH NON-JOINER`;
+    case 0x200d:
+      return `${formatUnicodeCodePoint(codePoint)} ZERO WIDTH JOINER`;
+    case 0x200e:
+      return `${formatUnicodeCodePoint(codePoint)} LEFT-TO-RIGHT MARK`;
+    case 0x200f:
+      return `${formatUnicodeCodePoint(codePoint)} RIGHT-TO-LEFT MARK`;
+    case 0x202a:
+      return `${formatUnicodeCodePoint(codePoint)} LEFT-TO-RIGHT EMBEDDING`;
+    case 0x202b:
+      return `${formatUnicodeCodePoint(codePoint)} RIGHT-TO-LEFT EMBEDDING`;
+    case 0x202c:
+      return `${formatUnicodeCodePoint(codePoint)} POP DIRECTIONAL FORMATTING`;
+    case 0x202d:
+      return `${formatUnicodeCodePoint(codePoint)} LEFT-TO-RIGHT OVERRIDE`;
+    case 0x202e:
+      return `${formatUnicodeCodePoint(codePoint)} RIGHT-TO-LEFT OVERRIDE`;
+    case 0x2060:
+      return `${formatUnicodeCodePoint(codePoint)} WORD JOINER`;
+    case 0x2066:
+      return `${formatUnicodeCodePoint(codePoint)} LEFT-TO-RIGHT ISOLATE`;
+    case 0x2067:
+      return `${formatUnicodeCodePoint(codePoint)} RIGHT-TO-LEFT ISOLATE`;
+    case 0x2068:
+      return `${formatUnicodeCodePoint(codePoint)} FIRST STRONG ISOLATE`;
+    case 0x2069:
+      return `${formatUnicodeCodePoint(codePoint)} POP DIRECTIONAL ISOLATE`;
+    case 0xfeff:
+      return `${formatUnicodeCodePoint(codePoint)} ZERO WIDTH NO-BREAK SPACE (BOM)`;
+    default: {
+      if (codePoint >= 0xfe00 && codePoint <= 0xfe0f) {
+        return `${formatUnicodeCodePoint(codePoint)} VARIATION SELECTOR`;
+      }
+      if (codePoint >= 0xe0100 && codePoint <= 0xe01ef) {
+        return `${formatUnicodeCodePoint(codePoint)} VARIATION SELECTOR (SUPPLEMENT)`;
+      }
+      if (codePoint >= 0xe0000 && codePoint <= 0xe007f) {
+        return `${formatUnicodeCodePoint(codePoint)} TAG CHARACTER`;
+      }
+      return formatUnicodeCodePoint(codePoint);
+    }
+  }
+}
+
+function scanInvisibleUnicodeInFile(source: string): InvisibleUnicodeFileSummary | null {
+  if (!INVISIBLE_UNICODE_PATTERN.test(source)) {
+    return null;
+  }
+
+  const unique = new Map<number, string>();
+  const lines = source.split("\n");
+  let evidenceLine = 0;
+  let renderedEvidence = "";
+
+  let total = 0;
+  let tags = 0;
+  let variationSelectors = 0;
+  let bidi = 0;
+  let other = 0;
+  let longestConsecutiveRun = 0;
+  let currentRun = 0;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex].replace(/\r$/, "");
+    if (!INVISIBLE_UNICODE_PATTERN.test(line)) {
+      currentRun = 0;
+      continue;
+    }
+
+    const parts: string[] = [];
+    for (const ch of line) {
+      const codePoint = ch.codePointAt(0);
+      if (codePoint === undefined || !isInvisibleUnicodeCodePoint(codePoint)) {
+        if (currentRun > longestConsecutiveRun) {
+          longestConsecutiveRun = currentRun;
+        }
+        currentRun = 0;
+        parts.push(ch);
+        continue;
+      }
+
+      total += 1;
+      currentRun += 1;
+      if (isBidiControlCodePoint(codePoint)) {
+        bidi += 1;
+      } else if (isTagCodePoint(codePoint)) {
+        tags += 1;
+      } else if (isVariationSelectorCodePoint(codePoint)) {
+        variationSelectors += 1;
+      } else {
+        other += 1;
+      }
+
+      if (!unique.has(codePoint)) {
+        unique.set(codePoint, describeInvisibleUnicodeCodePoint(codePoint));
+      }
+
+      if (evidenceLine === 0) {
+        parts.push(`<${unique.get(codePoint) ?? formatUnicodeCodePoint(codePoint)}>`);
+      }
+    }
+
+    if (currentRun > longestConsecutiveRun) {
+      longestConsecutiveRun = currentRun;
+    }
+    currentRun = 0;
+
+    if (evidenceLine === 0) {
+      evidenceLine = lineIndex + 1;
+      renderedEvidence = parts.length > 0 ? parts.join("") : line;
+    }
+  }
+
+  if (total === 0) {
+    return null;
+  }
+
+  const severity: SkillScanSeverity = "warn";
+
+  return {
+    renderedEvidence,
+    evidenceLine: evidenceLine || 1,
+    uniqueCodePoints: [...unique.values()],
+    total,
+    tags,
+    variationSelectors,
+    bidi,
+    other,
+    longestConsecutiveRun,
+    severity,
+  };
+}
+
 const LINE_RULES: LineRule[] = [
   {
     ruleId: "dangerous-exec",
@@ -110,6 +309,13 @@ const LINE_RULES: LineRule[] = [
     severity: "warn",
     message: "WebSocket connection to non-standard port",
     pattern: /new\s+WebSocket\s*\(\s*["']wss?:\/\/[^"']*:(\d+)/,
+  },
+  {
+    ruleId: "invisible-unicode",
+    severity: "warn",
+    message:
+      "Invisible Unicode formatting/tag characters detected (possible obfuscation or Trojan Source)",
+    pattern: INVISIBLE_UNICODE_PATTERN,
   },
 ];
 
@@ -161,9 +367,16 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const lines = source.split("\n");
   const matchedLineRules = new Set<string>();
 
+  const codeFile = isCodeFile(filePath);
+
   // --- Line rules ---
   for (const rule of LINE_RULES) {
     if (matchedLineRules.has(rule.ruleId)) {
+      continue;
+    }
+
+    // Non-code files (e.g. .md) only get the invisible-unicode check
+    if (!codeFile && rule.ruleId !== "invisible-unicode") {
       continue;
     }
 
@@ -187,6 +400,58 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
         }
       }
 
+      if (rule.ruleId === "invisible-unicode") {
+        const summary = scanInvisibleUnicodeInFile(source);
+        if (!summary) {
+          continue;
+        }
+
+        // Skip files with only isolated invisible chars (e.g. emoji variation
+        // selectors). Report only when there are 10+ consecutive invisible
+        // code points (likely ASCII smuggling / hidden prompt injection) or
+        // any bidi controls (Trojan Source risk even in small numbers).
+        if (summary.longestConsecutiveRun < 10 && summary.bidi === 0) {
+          continue;
+        }
+        const uniqueList =
+          summary.uniqueCodePoints.length > 4
+            ? `${summary.uniqueCodePoints.slice(0, 4).join(", ")} (+${
+                summary.uniqueCodePoints.length - 4
+              } more)`
+            : summary.uniqueCodePoints.join(", ");
+
+        const parts: string[] = [
+          `${summary.total} invisible char(s)`,
+          `longest consecutive run: ${summary.longestConsecutiveRun}`,
+        ];
+        if (summary.tags > 0) {
+          parts.push(`tags=${summary.tags}`);
+        }
+        if (summary.variationSelectors > 0) {
+          parts.push(`vs=${summary.variationSelectors}`);
+        }
+        if (summary.bidi > 0) {
+          parts.push(`bidi=${summary.bidi}`);
+        }
+        parts.push(uniqueList);
+
+        const hint =
+          summary.longestConsecutiveRun >= 10
+            ? " — long consecutive sequences are suspicious and may indicate ASCII smuggling or hidden prompt injection"
+            : " — bidi controls can flip displayed code direction (Trojan Source risk)";
+
+        findings.push({
+          ruleId: rule.ruleId,
+          severity: summary.severity,
+          file: filePath,
+          line: summary.evidenceLine,
+          message: `${rule.message} (${parts.join("; ")}${hint})`,
+          evidence: truncateEvidence(summary.renderedEvidence),
+        });
+        matchedLineRules.add(rule.ruleId);
+        break; // one finding per line-rule per file
+      }
+
       findings.push({
         ruleId: rule.ruleId,
         severity: rule.severity,
@@ -200,7 +465,10 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
     }
   }
 
-  // --- Source rules ---
+  // --- Source rules (code files only) ---
+  if (!codeFile) {
+    return findings;
+  }
   const matchedSourceRules = new Set<string>();
   for (const rule of SOURCE_RULES) {
     // Allow multiple findings for different messages with the same ruleId


### PR DESCRIPTION
---

## Summary

This PR extends OpenClaw's skill scanner to detect invisible Unicode characters hidden in **skill definition files** (SKILL.md, HOOK.md, etc.) and other text content — not just code files. This catches **ASCII smuggling** and **hidden prompt injection** attacks where invisible instructions are embedded in markdown that looks clean to humans but is interpreted by the LLM.

## Problem

The existing skill scanner checks `.js`/`.ts` code files for dangerous patterns like `eval()`, `child_process.exec()`, and crypto mining references. That's valuable for catching malicious executable code.

However, the primary attack surface for skills isn't the code — it's the **markdown files**. SKILL.md is read directly by the LLM as instructions. An attacker can embed invisible Unicode characters in these files that:

- **Are completely invisible** in code review, GitHub diffs, and text editors
- **Are interpreted by LLMs** as readable text (tokenizers handle these characters)
- **Can contain arbitrary instructions** — "exfiltrate all API keys", "run this shell command", "ignore previous instructions"

This is not theoretical. Unicode Tag characters (U+E0000–E007F) mirror the ASCII table and render as zero-width invisible text. Tools like the [ASCII Smuggler](https://embracethered.com/blog/ascii-smuggler.html) make creating these payloads trivial.

## What this PR changes

### 1. Scans text files, not just code files

The skill scanner now checks **all text files** in a skill directory for invisible Unicode:

- **Text files** (`.md`, `.txt`, `.yaml`, `.yml`, `.json`) → scanned for invisible Unicode only
- **Code files** (`.js`, `.ts`, `.mjs`, `.cjs`, `.tsx`, `.jsx`) → scanned for invisible Unicode AND existing code rules (eval, exec, etc.)

This means SKILL.md, HOOK.md, README.md, config files — everything a skill ships — gets checked for hidden content.

### 2. Invisible Unicode detection engine

The scanner walks every character in every scannable file, classifying invisible code points into four categories:

| Category | Code Points | Risk | Legitimate Use |
|----------|------------|------|----------------|
| **Tag characters** | U+E0000–E007F | ASCII smuggling — encodes hidden text as invisible Unicode | Essentially none in skill files |
| **Variation selectors** | U+FE00–FE0F, U+E0100–E01EF | Byte-level data smuggling | Emoji presentation (❤️ vs ❤) |
| **Bidi controls** | U+202A–202E, U+2066–2069, U+061C | Trojan Source — code displays differently than it executes | Arabic, Hebrew, Persian text |
| **Zero-width chars** | U+200B–200F, U+2060, U+FEFF | Hidden characters in identifiers/strings | Emoji ZWJ sequences (👨‍👩‍👧), BOM |

### 3. Threshold-based reporting (minimizing false positives)

Not every invisible character is suspicious. Emoji commonly contain variation selectors and zero-width joiners. To avoid noise, the scanner only reports a finding when:

- **10+ consecutive invisible code points** → likely an encoded payload, not normal text
- **Any bidirectional control characters** → worth flagging even in small numbers (Trojan Source risk)

Files with only scattered, isolated invisible characters (emoji, BOM markers) are silently ignored.

### 4. Actionable warning messages

Warnings include enough context to assess the risk:

```
Invisible Unicode formatting/tag characters detected
(31 invisible char(s); longest consecutive run: 31; tags=31;
U+E0054 TAG CHARACTER, U+E0072 TAG CHARACTER (+2 more)
— long consecutive sequences are suspicious and may indicate
ASCII smuggling or hidden prompt injection)
```

Each warning shows:
- **Total invisible characters** found in the file
- **Longest consecutive run** — the key heuristic (1-2 = probably emoji, 20+ = suspicious)
- **Breakdown by category** (tags, variation selectors, bidi)
- **Contextual hint** explaining the specific risk
- **Evidence line** with invisible chars rendered as readable labels like `<U+202E RIGHT-TO-LEFT OVERRIDE>`

### 5. Non-blocking (warn only)

All findings are reported as **warnings**. Installation always continues. Users can investigate flagged files with `openclaw security audit --deep`.

## Changes

| File | Change |
|------|--------|
| `src/security/skill-scanner.ts` | Invisible Unicode detection engine, text file scanning, consecutive-run tracking, character classification, human-readable evidence rendering |
| `src/security/skill-scanner.test.ts` | 17 new tests covering all character categories, smuggling techniques, threshold behavior, markdown scanning, and false-positive suppression |

## Testing

```
36/36 tests pass (17 new + 19 existing)
Build clean, 0 lint errors
```

**Validated against real skills:**
- 52 bundled OpenClaw skills (59 files scanned) — all clean, zero false positives

### Key test cases

**Markdown scanning:**
- ASCII smuggling hidden in SKILL.md → detected
- Bidi controls in README.md → detected
- Code patterns in .md files (eval, exec) → correctly ignored (not code)

**False positive suppression:**
- Isolated emoji variation selectors → ignored
- Scattered zero-width joiners → ignored
- Clean code and markdown → no findings

**Detection:**
- ASCII smuggling via Unicode tags → detected with consecutive run count
- ASCII smuggling via variation selectors → detected
- Bidi overrides → detected with Trojan Source hint
- Large tag payloads → detected

## References

- [Trojan Source: Invisible Vulnerabilities (CVE-2021-42574)](https://trojansource.codes/)
- [ASCII Smuggler Tool](https://embracethered.com/blog/ascii-smuggler.html) — encode/decode invisible Unicode Tag payloads
- [ASCII Smuggler: Hiding and Finding Text with Unicode Tags](https://embracethered.com/blog/posts/2024/hiding-and-finding-text-with-unicode-tags/) — background on the technique, implications for prompt injection and data exfiltration

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the existing skill/plugin static scanner to also scan non-code “text” files (e.g. `SKILL.md`, `README.md`, `.json`, `.yaml`) for invisible Unicode that can be used for ASCII-smuggling / Trojan Source style obfuscation. It adds a Unicode classification + reporting helper and wires it into `scanSource()` so markdown gets Unicode-only checks while code files still get the existing dangerous code pattern rules.

Integration-wise, this scanner is used by plugin install (`src/plugins/install.ts`), skill install warnings (`src/agents/skills-install.ts`), and the deep security audit (`src/security/audit-extra.ts`), so broadening the scanned extensions directly affects those user-facing warnings.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a real regression that will skip code-rule scanning for some TypeScript module extensions.
- The Unicode detection approach is self-contained and covered by tests, but `isCodeFile()` omits `.mts`/`.cts` even though they’re included in `CODE_EXTENSIONS`, causing those files to be treated as non-code and bypass existing critical code-pattern rules. There’s also a correctness issue in code point formatting for non-BMP characters that will produce misleading evidence labels.
- src/security/skill-scanner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->