### PR TITLE
feat(infra): add systemd WatchdogSec integration

### DIFF
--- a/docs/systemd-service-example.md
+++ b/docs/systemd-service-example.md
@@ -27,6 +27,6 @@ WantedBy=multi-user.target
 
 ## How it works
 
-1.  **Readiness**: When the gateway finishes starting up and is ready to accept connections, it sends `READY=1` to systemd.
-2.  **Watchdog**: Every time the internal maintenance timer "ticks" (configured by `TICK_INTERVAL_MS`), the gateway sends `WATCHDOG=1` to systemd to reset the watchdog timer.
-3.  **Automatic Restart**: If the gateway process hangs (e.g., event loop starvation) and fails to send the watchdog signal within the `WatchdogSec` interval, systemd will kill and restart the service.
+1. **Readiness**: When the gateway finishes starting up and is ready to accept connections, it sends `READY=1` to systemd.
+2. **Watchdog**: Every time the internal maintenance timer "ticks" (configured by `TICK_INTERVAL_MS`), the gateway sends `WATCHDOG=1` to systemd to reset the watchdog timer.
+3. **Automatic Restart**: If the gateway process hangs (e.g., event loop starvation) and fails to send the watchdog signal within the `WatchdogSec` interval, systemd will kill and restart the service.

--- a/docs/systemd-service-example.md
+++ b/docs/systemd-service-example.md
@@ -1,0 +1,32 @@
+# systemd WatchdogSec Integration
+
+OpenClaw supports systemd's `Type=notify` and `WatchdogSec` integration. This allows systemd to monitor the gateway's health and automatically restart it if it becomes unresponsive.
+
+## Systemd Service Configuration
+
+To enable this integration, add the following settings to your `openclaw.service` unit file:
+
+```ini
+[Unit]
+Description=OpenClaw Gateway
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/openclaw gateway start
+# Enable systemd notification support
+Type=notify
+# Restart the service if it doesn't send a watchdog heartbeats for 90 seconds
+WatchdogSec=90
+# Ensure the service can send notifications
+NotifyAccess=all
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## How it works
+
+1.  **Readiness**: When the gateway finishes starting up and is ready to accept connections, it sends `READY=1` to systemd.
+2.  **Watchdog**: Every time the internal maintenance timer "ticks" (configured by `TICK_INTERVAL_MS`), the gateway sends `WATCHDOG=1` to systemd to reset the watchdog timer.
+3.  **Automatic Restart**: If the gateway process hangs (e.g., event loop starvation) and fails to send the watchdog signal within the `WatchdogSec` interval, systemd will kill and restart the service.

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -1,5 +1,6 @@
 import type { HealthSummary } from "../commands/health.js";
 import { cleanOldMedia } from "../media/store.js";
+import { notifyWatchdog } from "../infra/systemd-notify.js";
 import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ChatRunEntry } from "./server-chat.js";
 import {
@@ -57,6 +58,7 @@ export function startGatewayMaintenanceTimers(params: {
 
   // periodic keepalive
   const tickInterval = setInterval(() => {
+    notifyWatchdog();
     const payload = { ts: Date.now() };
     params.broadcast("tick", payload, { dropIfSlow: true });
     params.nodeSendToAllSubscribed("tick", payload);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -41,6 +41,7 @@ import {
   setSkillsRemoteRegistry,
 } from "../infra/skills-remote.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import { notifyReady } from "../infra/systemd-notify.js";
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
@@ -910,6 +911,8 @@ export async function startGatewayServer(
         controlUiBasePath,
         logTailscale,
       });
+
+  notifyReady();
 
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
   if (!minimalTestGateway) {

--- a/src/infra/systemd-notify.test.ts
+++ b/src/infra/systemd-notify.test.ts
@@ -1,0 +1,74 @@
+import dgram from "node:dgram";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { sendNotification, notifyReady, notifyWatchdog } from "./systemd-notify.js";
+
+vi.mock("node:dgram", () => {
+  const mockSocket = {
+    send: vi.fn((buffer, offset, length, path, callback) => {
+      if (callback) callback();
+    }),
+    close: vi.fn(),
+  };
+  return {
+    default: {
+      createSocket: vi.fn(() => mockSocket),
+    },
+  };
+});
+
+describe("systemd-notify", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("should not send notification if NOTIFY_SOCKET is not set", () => {
+    delete process.env.NOTIFY_SOCKET;
+    sendNotification("READY=1");
+    expect(dgram.createSocket).not.toHaveBeenCalled();
+  });
+
+  it("should send notification if NOTIFY_SOCKET is set", () => {
+    process.env.NOTIFY_SOCKET = "/tmp/test.sock";
+    sendNotification("READY=1");
+
+    expect(dgram.createSocket).toHaveBeenCalledWith("unix_dgram");
+    const socket = dgram.createSocket("unix_dgram");
+    expect(socket.send).toHaveBeenCalled();
+    const [buffer, offset, length, path] = (socket.send as any).mock.calls[0];
+    expect(buffer.toString()).toBe("READY=1\n");
+    expect(path).toBe("/tmp/test.sock");
+  });
+
+  it("should handle abstract namespace sockets (starting with @)", () => {
+    process.env.NOTIFY_SOCKET = "@/test/abstract.sock";
+    sendNotification("READY=1");
+
+    const socket = dgram.createSocket("unix_dgram");
+    const [buffer, offset, length, path] = (socket.send as any).mock.calls[0];
+    expect(path).toBe("\0/test/abstract.sock");
+  });
+
+  it("notifyReady should send READY=1", () => {
+    process.env.NOTIFY_SOCKET = "/tmp/test.sock";
+    notifyReady();
+    const socket = dgram.createSocket("unix_dgram");
+    const [buffer] = (socket.send as any).mock.calls[0];
+    expect(buffer.toString()).toBe("READY=1\n");
+  });
+
+  it("notifyWatchdog should send WATCHDOG=1", () => {
+    process.env.NOTIFY_SOCKET = "/tmp/test.sock";
+    notifyWatchdog();
+    const socket = dgram.createSocket("unix_dgram");
+    const [buffer] = (socket.send as any).mock.calls[0];
+    expect(buffer.toString()).toBe("WATCHDOG=1\n");
+  });
+});

--- a/src/infra/systemd-notify.ts
+++ b/src/infra/systemd-notify.ts
@@ -1,0 +1,48 @@
+import dgram from "node:dgram";
+import fs from "node:fs";
+
+/**
+ * Sends a notification to systemd via the NOTIFY_SOCKET.
+ * @param state The state string to send (e.g., 'READY=1', 'WATCHDOG=1')
+ */
+export function sendNotification(state: string): void {
+  const socketPath = process.env.NOTIFY_SOCKET;
+  if (!socketPath) {
+    return;
+  }
+
+  // Handle abstract namespace sockets (starting with @)
+  const isAbstract = socketPath.startsWith("@");
+  const buffer = Buffer.from(state + "\n");
+
+  try {
+    const client = dgram.createSocket("unix_dgram");
+
+    // Abstract sockets need to be prefixed with \0
+    const finalPath = isAbstract ? "\0" + socketPath.slice(1) : socketPath;
+
+    client.send(buffer, 0, buffer.length, finalPath, (err) => {
+      client.close();
+      if (err) {
+        // We don't want to crash the process if notification fails
+        console.error("[systemd-notify] Failed to send notification:", err);
+      }
+    });
+  } catch (err) {
+    console.error("[systemd-notify] Error creating socket or sending notification:", err);
+  }
+}
+
+/**
+ * Notify systemd that the service is ready.
+ */
+export function notifyReady(): void {
+  sendNotification("READY=1");
+}
+
+/**
+ * Notify systemd watchdog to reset the timer.
+ */
+export function notifyWatchdog(): void {
+  sendNotification("WATCHDOG=1");
+}


### PR DESCRIPTION
Implements systemd WatchdogSec and Type=notify integration for OpenClaw. This allows systemd to monitor the gateway health and automatically restart it if it hangs.

Referencing GitHub Discussion #12026.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds systemd `Type=notify` / `WatchdogSec` integration by introducing `src/infra/systemd-notify.ts` (READY/WATCHDOG notifications via `NOTIFY_SOCKET`) and wiring it into gateway startup (`notifyReady()` in `src/gateway/server.impl.ts`) and the existing maintenance tick loop (`notifyWatchdog()` in `src/gateway/server-maintenance.ts`). It also adds docs with a sample unit file and new Vitest coverage.

Before merging, the new tests need to be made runnable: `src/infra/crypto-store.test.ts` currently imports a non-existent `./crypto-store.js`, and `src/infra/systemd-notify.ts` includes an unused `node:fs` import that is likely to trip CI lint/typecheck rules.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because CI is likely to fail due to a broken test import and an unused import.
- Core feature wiring is small and localized, but the added `crypto-store.test.ts` references a missing module (`./crypto-store.js`), which will fail module resolution, and `systemd-notify.ts` has an unused `fs` import that may fail lint/typecheck. Fixing these should make the PR much lower risk.
- src/infra/crypto-store.test.ts, src/infra/systemd-notify.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->