### PR TITLE
fix(heartbeat): ignore session modelOverride when heartbeat.model is configured

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -391,6 +391,7 @@ export async function resolveReplyDirectives(params: {
     provider,
     model,
     hasModelDirective: directives.hasModelDirective,
+    isHeartbeat: opts?.isHeartbeat,
   });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -271,6 +271,7 @@ export async function createModelSelectionState(params: {
   provider: string;
   model: string;
   hasModelDirective: boolean;
+  isHeartbeat?: boolean;
 }): Promise<ModelSelectionState> {
   const {
     cfg,
@@ -343,7 +344,8 @@ export async function createModelSelectionState(params: {
     sessionKey,
     parentSessionKey,
   });
-  if (storedOverride?.model) {
+  // Skip session model override for heartbeats (they use their own heartbeat.model config)
+  if (storedOverride?.model && !params.isHeartbeat) {
     const candidateProvider = storedOverride.provider || defaultProvider;
     const key = modelKey(candidateProvider, storedOverride.model);
     if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {


### PR DESCRIPTION
Fixes #13009

## Problem
Heartbeats were incorrectly using the session's `modelOverride` (set via `/model` in TUI) instead of their configured `agents.defaults.heartbeat.model`. This caused heartbeats to run on expensive models (e.g., Claude Opus) when they should run on cheaper ones (e.g., openrouter/auto).

## Root Cause
In `createModelSelectionState()`, the session's stored model override was applied unconditionally, without checking if this was a heartbeat call that should use its own configured model.

## Solution
- Added `isHeartbeat?: boolean` parameter to `createModelSelectionState()`
- Skip applying session `modelOverride` when `isHeartbeat === true`
- Pass `opts?.isHeartbeat` through from `resolveReplyDirectives()`

## Testing
- Added test case verifying heartbeats ignore session overrides
- All 314 existing tests in src/auto-reply/reply/ still pass
- Test covers both normal (applies override) and heartbeat (ignores override) behavior

## Changes
- `src/auto-reply/reply/model-selection.ts`: Added isHeartbeat parameter and guard
- `src/auto-reply/reply/get-reply-directives.ts`: Pass isHeartbeat flag
- `src/auto-reply/reply/model-selection.inherit-parent.test.ts`: Added test case

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads an `isHeartbeat` flag into the reply directive/model-selection pipeline so that `createModelSelectionState()` skips applying the session-stored `modelOverride` when the call is a heartbeat. It adds a focused regression test asserting the normal behavior (session override applied) vs heartbeat behavior (session override ignored), preventing heartbeats from inadvertently running on expensive user-selected models while preserving the existing per-session override semantics for regular replies.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (one conditional guard plus plumbing a boolean flag), preserves existing behavior for non-heartbeat calls, and includes a regression test covering both branches. I did not find any introduced runtime/type issues in the touched code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->