### PR TITLE
matrix: optionally include media metadata in message.read

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -11,6 +11,23 @@ import { resolveMatrixAccount } from "./matrix/accounts.js";
 import { handleMatrixAction } from "./tool-actions.js";
 import type { CoreConfig } from "./types.js";
 
+function readBooleanParam(params: Record<string, unknown>, key: string): boolean | undefined {
+  const raw = params[key];
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed === "true") {
+      return true;
+    }
+    if (trimmed === "false") {
+      return false;
+    }
+  }
+  return undefined;
+}
+
 export const matrixMessageActions: ChannelMessageActionAdapter = {
   listActions: ({ cfg }) => {
     const account = resolveMatrixAccount({ cfg: cfg as CoreConfig });
@@ -114,6 +131,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "read") {
       const limit = readNumberParam(params, "limit", { integer: true });
+      const includeMedia = readBooleanParam(params, "includeMedia");
       return await handleMatrixAction(
         {
           action: "readMessages",
@@ -121,6 +139,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           limit,
           before: readStringParam(params, "before"),
           after: readStringParam(params, "after"),
+          includeMedia,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -10,23 +10,7 @@ import {
 import { resolveMatrixAccount } from "./matrix/accounts.js";
 import { handleMatrixAction } from "./tool-actions.js";
 import type { CoreConfig } from "./types.js";
-
-function readBooleanParam(params: Record<string, unknown>, key: string): boolean | undefined {
-  const raw = params[key];
-  if (typeof raw === "boolean") {
-    return raw;
-  }
-  if (typeof raw === "string") {
-    const trimmed = raw.trim().toLowerCase();
-    if (trimmed === "true") {
-      return true;
-    }
-    if (trimmed === "false") {
-      return false;
-    }
-  }
-  return undefined;
-}
+import { readBooleanParam } from "./utils.js";
 
 export const matrixMessageActions: ChannelMessageActionAdapter = {
   listActions: ({ cfg }) => {

--- a/extensions/matrix/src/matrix/actions/messages.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventType, type MatrixRawEvent } from "./types.js";
+
+const resolveActionClientMock = vi.fn();
+const resolveMatrixRoomIdMock = vi.fn(async (_client: unknown, roomId: string) => roomId);
+
+vi.mock("./client.js", () => ({
+  resolveActionClient: (...args: unknown[]) => resolveActionClientMock(...args),
+}));
+
+vi.mock("../send.js", () => ({
+  resolveMatrixRoomId: (...args: unknown[]) => resolveMatrixRoomIdMock(...args),
+  sendMessageMatrix: vi.fn(),
+}));
+
+import { readMatrixMessages } from "./messages.js";
+
+describe("readMatrixMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns media metadata when includeMedia=true", async () => {
+    const event: MatrixRawEvent = {
+      event_id: "$audio",
+      sender: "@alice:example.org",
+      type: EventType.RoomMessage,
+      origin_server_ts: 1700000000000,
+      content: {
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        url: "mxc://example.org/audio",
+        info: {
+          mimetype: "audio/ogg",
+          size: 42,
+        },
+      },
+    };
+
+    const client = {
+      doRequest: vi.fn().mockResolvedValue({
+        chunk: [event],
+        start: "start-token",
+        end: "end-token",
+      }),
+      mxcToHttp: vi
+        .fn()
+        .mockReturnValue("https://matrix.example.org/_matrix/media/v3/download/example.org/audio"),
+      stop: vi.fn(),
+    };
+
+    resolveActionClientMock.mockResolvedValue({
+      client,
+      stopOnDone: false,
+    });
+
+    const result = await readMatrixMessages("!room:example.org", {
+      includeMedia: true,
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.media).toEqual({
+      mxcUrl: "mxc://example.org/audio",
+      downloadUrl: "https://matrix.example.org/_matrix/media/v3/download/example.org/audio",
+      encrypted: false,
+      contentType: "audio/ogg",
+      sizeBytes: 42,
+      durationMs: undefined,
+    });
+  });
+
+  it("preserves old response shape by default", async () => {
+    const event: MatrixRawEvent = {
+      event_id: "$audio2",
+      sender: "@alice:example.org",
+      type: EventType.RoomMessage,
+      origin_server_ts: 1700000001000,
+      content: {
+        msgtype: "m.audio",
+        body: "voice2.ogg",
+        url: "mxc://example.org/audio2",
+      },
+    };
+
+    const client = {
+      doRequest: vi.fn().mockResolvedValue({
+        chunk: [event],
+        start: "start-token",
+        end: "end-token",
+      }),
+      mxcToHttp: vi.fn(),
+      stop: vi.fn(),
+    };
+
+    resolveActionClientMock.mockResolvedValue({
+      client,
+      stopOnDone: false,
+    });
+
+    const result = await readMatrixMessages("!room:example.org");
+
+    expect(result.messages[0]?.body).toBe("voice2.ogg");
+    expect(result.messages[0]?.msgtype).toBe("m.audio");
+    expect(result.messages[0]?.media).toBeUndefined();
+    expect(client.mxcToHttp).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -87,6 +87,7 @@ export async function readMatrixMessages(
     limit?: number;
     before?: string;
     after?: string;
+    includeMedia?: boolean;
   } = {},
 ): Promise<{
   messages: MatrixMessageSummary[];
@@ -112,7 +113,12 @@ export async function readMatrixMessages(
     const messages = res.chunk
       .filter((event) => event.type === EventType.RoomMessage)
       .filter((event) => !event.unsigned?.redacted_because)
-      .map(summarizeMatrixRawEvent);
+      .map((event) =>
+        summarizeMatrixRawEvent(event, {
+          includeMedia: opts.includeMedia,
+          client,
+        }),
+      );
     return {
       messages,
       nextBatch: res.end ?? null,

--- a/extensions/matrix/src/matrix/actions/summary.test.ts
+++ b/extensions/matrix/src/matrix/actions/summary.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { summarizeMatrixRawEvent } from "./summary.js";
+import { EventType, type MatrixRawEvent } from "./types.js";
+
+describe("summarizeMatrixRawEvent", () => {
+  it("keeps legacy payload when includeMedia is omitted", () => {
+    const event: MatrixRawEvent = {
+      event_id: "$event1",
+      sender: "@alice:example.org",
+      type: EventType.RoomMessage,
+      origin_server_ts: 1700000000000,
+      content: {
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        url: "mxc://example.org/audio1",
+      },
+    };
+
+    const summary = summarizeMatrixRawEvent(event);
+    expect(summary.media).toBeUndefined();
+    expect(summary.body).toBe("voice.ogg");
+    expect(summary.msgtype).toBe("m.audio");
+  });
+
+  it("includes mxc and downloadable url when includeMedia=true", () => {
+    const event: MatrixRawEvent = {
+      event_id: "$event2",
+      sender: "@alice:example.org",
+      type: EventType.RoomMessage,
+      origin_server_ts: 1700000001000,
+      content: {
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        url: "mxc://example.org/audio2",
+        info: {
+          mimetype: "audio/ogg",
+          size: 12345,
+          duration: 6789,
+        },
+      },
+    };
+
+    const mxcToHttp = vi
+      .fn()
+      .mockReturnValue("https://matrix.example.org/_matrix/media/v3/download/example.org/audio2");
+
+    const summary = summarizeMatrixRawEvent(event, {
+      includeMedia: true,
+      client: { mxcToHttp },
+    });
+
+    expect(summary.media).toEqual({
+      mxcUrl: "mxc://example.org/audio2",
+      downloadUrl: "https://matrix.example.org/_matrix/media/v3/download/example.org/audio2",
+      encrypted: false,
+      contentType: "audio/ogg",
+      sizeBytes: 12345,
+      durationMs: 6789,
+    });
+    expect(mxcToHttp).toHaveBeenCalledWith("mxc://example.org/audio2");
+  });
+
+  it("extracts encrypted media url from content.file", () => {
+    const event: MatrixRawEvent = {
+      event_id: "$event3",
+      sender: "@alice:example.org",
+      type: EventType.RoomMessage,
+      origin_server_ts: 1700000002000,
+      content: {
+        msgtype: "m.audio",
+        body: "secret.ogg",
+        file: {
+          url: "mxc://example.org/encrypted-audio",
+          iv: "x",
+        },
+      },
+    };
+
+    const summary = summarizeMatrixRawEvent(event, {
+      includeMedia: true,
+      client: { mxcToHttp: (mxc) => `https://download/${mxc}` },
+    });
+
+    expect(summary.media?.mxcUrl).toBe("mxc://example.org/encrypted-audio");
+    expect(summary.media?.encrypted).toBe(true);
+    expect(summary.media?.downloadUrl).toBe("https://download/mxc://example.org/encrypted-audio");
+  });
+});

--- a/extensions/matrix/src/matrix/actions/summary.test.ts
+++ b/extensions/matrix/src/matrix/actions/summary.test.ts
@@ -85,4 +85,30 @@ describe("summarizeMatrixRawEvent", () => {
     expect(summary.media?.encrypted).toBe(true);
     expect(summary.media?.downloadUrl).toBe("https://download/mxc://example.org/encrypted-audio");
   });
+
+  it("prioritizes plain mxc if both present, setting encrypted=false", () => {
+    const event: MatrixRawEvent = {
+      event_id: "$event4",
+      sender: "@bob:example.org",
+      type: EventType.RoomMessage,
+      origin_server_ts: 1700000003000,
+      content: {
+        msgtype: "m.image",
+        body: "image.png",
+        url: "mxc://example.org/plain-image",
+        file: {
+          url: "mxc://example.org/encrypted-image",
+          iv: "y",
+        },
+      },
+    };
+
+    const summary = summarizeMatrixRawEvent(event, {
+      includeMedia: true,
+      client: { mxcToHttp: (mxc) => `https://download/${mxc}` },
+    });
+
+    expect(summary.media?.mxcUrl).toBe("mxc://example.org/plain-image");
+    expect(summary.media?.encrypted).toBe(false);
+  });
 });

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -7,7 +7,15 @@ import {
   type RoomPinnedEventsEventContent,
 } from "./types.js";
 
-export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSummary {
+type EventSummaryOptions = {
+  includeMedia?: boolean;
+  client?: Pick<MatrixClient, "mxcToHttp">;
+};
+
+export function summarizeMatrixRawEvent(
+  event: MatrixRawEvent,
+  opts: EventSummaryOptions = {},
+): MatrixMessageSummary {
   const content = event.content as RoomMessageEventContent;
   const relates = content["m.relates_to"];
   let relType: string | undefined;
@@ -27,12 +35,40 @@ export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSum
           eventId,
         }
       : undefined;
+
+  let media: MatrixMessageSummary["media"];
+  if (opts.includeMedia) {
+    const plainMxc = typeof content.url === "string" ? content.url : undefined;
+    const encryptedFile =
+      content.file && typeof content.file === "object"
+        ? (content.file as { url?: unknown })
+        : undefined;
+    const encryptedMxc =
+      encryptedFile && typeof encryptedFile.url === "string" ? encryptedFile.url : undefined;
+    const mxcUrl = plainMxc ?? encryptedMxc;
+    if (mxcUrl) {
+      const info =
+        content.info && typeof content.info === "object"
+          ? (content.info as { mimetype?: unknown; size?: unknown; duration?: unknown })
+          : undefined;
+      media = {
+        mxcUrl,
+        downloadUrl: opts.client?.mxcToHttp(mxcUrl),
+        encrypted: Boolean(encryptedMxc),
+        contentType: typeof info?.mimetype === "string" ? info.mimetype : undefined,
+        sizeBytes: typeof info?.size === "number" ? info.size : undefined,
+        durationMs: typeof info?.duration === "number" ? info.duration : undefined,
+      };
+    }
+  }
+
   return {
     eventId: event.event_id,
     sender: event.sender,
     body: content.body,
     msgtype: content.msgtype,
     timestamp: event.origin_server_ts,
+    media,
     relatesTo,
   };
 }

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -12,6 +12,12 @@ type EventSummaryOptions = {
   client?: Pick<MatrixClient, "mxcToHttp">;
 };
 
+/**
+ * Summarizes a raw Matrix event into a simplified structure.
+ *
+ * CAUTION: This function must remain synchronous to be used in array.map()
+ * within readMatrixMessages. Do not introduce async calls here.
+ */
 export function summarizeMatrixRawEvent(
   event: MatrixRawEvent,
   opts: EventSummaryOptions = {},
@@ -54,7 +60,7 @@ export function summarizeMatrixRawEvent(
       media = {
         mxcUrl,
         downloadUrl: opts.client?.mxcToHttp(mxcUrl),
-        encrypted: Boolean(encryptedMxc),
+        encrypted: mxcUrl === encryptedMxc,
         contentType: typeof info?.mimetype === "string" ? info.mimetype : undefined,
         sizeBytes: typeof info?.size === "number" ? info.size : undefined,
         durationMs: typeof info?.duration === "number" ? info.duration : undefined,

--- a/extensions/matrix/src/matrix/actions/types.ts
+++ b/extensions/matrix/src/matrix/actions/types.ts
@@ -19,6 +19,17 @@ export const EventType = {
 export type RoomMessageEventContent = {
   msgtype: string;
   body: string;
+  url?: string;
+  file?: {
+    url?: string;
+    [key: string]: unknown;
+  };
+  info?: {
+    mimetype?: string;
+    size?: number;
+    duration?: number;
+    [key: string]: unknown;
+  };
   "m.new_content"?: RoomMessageEventContent;
   "m.relates_to"?: {
     rel_type?: string;
@@ -66,6 +77,14 @@ export type MatrixMessageSummary = {
   body?: string;
   msgtype?: string;
   timestamp?: number;
+  media?: {
+    mxcUrl?: string;
+    downloadUrl?: string;
+    encrypted?: boolean;
+    contentType?: string;
+    sizeBytes?: number;
+    durationMs?: number;
+  };
   relatesTo?: {
     relType?: string;
     eventId?: string;

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -26,6 +26,23 @@ const messageActions = new Set(["sendMessage", "editMessage", "deleteMessage", "
 const reactionActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
 
+function readBooleanParam(params: Record<string, unknown>, key: string): boolean | undefined {
+  const raw = params[key];
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed === "true") {
+      return true;
+    }
+    if (trimmed === "false") {
+      return false;
+    }
+  }
+  return undefined;
+}
+
 function readRoomId(params: Record<string, unknown>, required = true): string {
   const direct = readStringParam(params, "roomId") ?? readStringParam(params, "channelId");
   if (direct) {
@@ -108,10 +125,12 @@ export async function handleMatrixAction(
         const limit = readNumberParam(params, "limit", { integer: true });
         const before = readStringParam(params, "before");
         const after = readStringParam(params, "after");
+        const includeMedia = readBooleanParam(params, "includeMedia");
         const result = await readMatrixMessages(roomId, {
           limit: limit ?? undefined,
           before: before ?? undefined,
           after: after ?? undefined,
+          includeMedia: includeMedia ?? undefined,
         });
         return jsonResult({ ok: true, ...result });
       }

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -21,27 +21,11 @@ import {
 } from "./matrix/actions.js";
 import { reactMatrixMessage } from "./matrix/send.js";
 import type { CoreConfig } from "./types.js";
+import { readBooleanParam } from "./utils.js";
 
 const messageActions = new Set(["sendMessage", "editMessage", "deleteMessage", "readMessages"]);
 const reactionActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
-
-function readBooleanParam(params: Record<string, unknown>, key: string): boolean | undefined {
-  const raw = params[key];
-  if (typeof raw === "boolean") {
-    return raw;
-  }
-  if (typeof raw === "string") {
-    const trimmed = raw.trim().toLowerCase();
-    if (trimmed === "true") {
-      return true;
-    }
-    if (trimmed === "false") {
-      return false;
-    }
-  }
-  return undefined;
-}
 
 function readRoomId(params: Record<string, unknown>, required = true): string {
   const direct = readStringParam(params, "roomId") ?? readStringParam(params, "channelId");

--- a/extensions/matrix/src/utils.ts
+++ b/extensions/matrix/src/utils.ts
@@ -1,0 +1,19 @@
+export function readBooleanParam(
+  params: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const raw = params[key];
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed === "true") {
+      return true;
+    }
+    if (trimmed === "false") {
+      return false;
+    }
+  }
+  return undefined;
+}

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -255,6 +255,12 @@ function buildFetchSchema() {
     around: Type.Optional(Type.String()),
     fromMe: Type.Optional(Type.Boolean()),
     includeArchived: Type.Optional(Type.Boolean()),
+    includeMedia: Type.Optional(
+      Type.Boolean({
+        description:
+          "Include provider-specific media fields in read results (for Matrix: mxcUrl/downloadUrl).",
+      }),
+    ),
   };
 }
 

--- a/src/cli/program/message/register.read-edit-delete.ts
+++ b/src/cli/program/message/register.read-edit-delete.ts
@@ -16,6 +16,7 @@ export function registerMessageReadEditDeleteCommands(
     .option("--after <id>", "Read/search after id")
     .option("--around <id>", "Read around id")
     .option("--include-thread", "Include thread replies (Discord)", false)
+    .option("--include-media", "Include provider media metadata in read results", false)
     .action(async (opts) => {
       await helpers.runMessageAction("read", opts);
     });


### PR DESCRIPTION
## Summary
- add an optional `includeMedia` flag to Matrix `message.read` actions
- when enabled, include media metadata (`mxcUrl`, `downloadUrl`, content type, size, duration, encrypted flag) in read results
- keep default behavior unchanged to preserve compatibility
- expose the new option through the message tool schema and CLI
- add unit tests for both legacy and includeMedia paths

## Why
`message.read` was returning only simplified fields (e.g. body/msgtype), which dropped media URLs needed for Matrix voice workflows. This patch keeps existing defaults while enabling explicit media retrieval when needed.

## Testing
- `pnpm vitest extensions/matrix/src/matrix/actions --run`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `includeMedia` flag to Matrix `message.read`/`readMessages` so callers can request media-related metadata (mxc URL, downloadable URL via `mxcToHttp`, content type, size, duration, and an `encrypted` indicator derived from the selected URL source). The option is plumbed through the Matrix message action adapter (`extensions/matrix/src/actions.ts`), the Matrix tool-action handler (`extensions/matrix/src/tool-actions.ts`), and exposed in the global message tool schema and CLI (`src/agents/tools/message-tool.ts`, `src/cli/program/message/register.read-edit-delete.ts`).

Core behavior remains backward compatible by default: `summarizeMatrixRawEvent` only adds the `media` field when `includeMedia` is true, and tests cover both legacy and includeMedia paths, including the plaintext-vs-encrypted URL precedence logic.

<h3>Confidence Score: 4/5</h3>

- This PR appears safe to merge; changes are localized and maintain backward-compatible defaults.
- Review of the full diff shows the new `includeMedia` option is consistently threaded through adapter/tool-action layers into Matrix message summarization. Tests cover legacy behavior and media extraction (including encrypted-vs-plain URL selection), and there are no new callers that would break existing response consumers since `media` is optional. Unable to run tests in this environment due to missing Node/pnpm, so score is slightly reduced.
- extensions/matrix/src/matrix/actions/summary.ts (media extraction contract)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## AI-assisted disclosure

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing (lightly tested)
- [x] Include prompts or session logs if possible
- [x] Confirm you understand what the code does

**Testing degree:** Lightly tested (targeted Matrix action tests: `pnpm vitest extensions/matrix/src/matrix/actions --run`).

**Prompt/session log (summary):**
- "Add optional `includeMedia` support for Matrix `message.read` while preserving backward compatibility by default."
- "Thread the option through tool schema/CLI and add tests for legacy vs includeMedia paths."

**Confirmation:** I reviewed the final diff and understand the new optional media metadata behavior and compatibility impact.
