### PR TITLE
fix(docs): add redirect from /hooks to /automation/hooks

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -364,6 +364,10 @@
       "destination": "/gateway/heartbeat"
     },
     {
+      "source": "/hooks",
+      "destination": "/automation/hooks"
+    },
+    {
       "source": "/hubs",
       "destination": "/start/hubs"
     },


### PR DESCRIPTION
Fixes #13017

## Summary

The "Learn more" link in the Hooks setup screen pointed to `/hooks`, which incorrectly redirected to `/hooks/soul-evil` (a specific hook page) instead of the general hooks overview at `/automation/hooks`.

## Changes

Added a redirect entry in `docs/docs.json`:
```json
{
  "source": "/hooks",
  "destination": "/automation/hooks"
}
```

## Testing

- ✅ Verified JSON syntax is valid
- ✅ Redirect follows the existing pattern in docs.json
- ✅ Target page (`/automation/hooks`) exists and contains the general hooks documentation

## Impact

Users clicking "Learn more" in the Hooks setup flow will now land on the correct general hooks documentation page instead of the specific SOUL Evil Hook page.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a Mintlify docs redirect entry in `docs/docs.json` to route `/hooks` to the general hooks overview page at `/automation/hooks`, fixing the incorrect redirect behavior where `/hooks` led to a specific hook page. The change fits into the existing docs redirect list used by the Mintlify site configuration to maintain stable URLs and correct navigation destinations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted docs-site redirect addition that matches existing redirect patterns, does not affect runtime code, and introduces no conflicting entries in the current redirects list.
- docs/docs.json

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->