### PR TITLE
feat(hooks): add unified session:before_end hook event

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -231,6 +231,7 @@ export async function initSessionState(params: {
   let systemSent = false;
   let abortedLastRun = false;
   let resetTriggered = false;
+  let resetTriggerReason: "new" | "reset" | undefined;
 
   let persistedThinking: string | undefined;
   let persistedVerbose: string | undefined;
@@ -298,6 +299,7 @@ export async function initSessionState(params: {
       isNewSession = true;
       bodyStripped = "";
       resetTriggered = true;
+      resetTriggerReason = triggerLower.startsWith("/reset") ? "reset" : "new";
       break;
     }
     const triggerPrefixLower = `${triggerLower} `;
@@ -311,6 +313,7 @@ export async function initSessionState(params: {
       isNewSession = true;
       bodyStripped = strippedForReset.slice(trigger.length).trimStart();
       resetTriggered = true;
+      resetTriggerReason = triggerLower.startsWith("/reset") ? "reset" : "new";
       break;
     }
   }
@@ -363,6 +366,29 @@ export async function initSessionState(params: {
     sessionKey,
     previousSessionId: previousSessionEntry?.sessionId,
   });
+
+  const resetReason = resetTriggered ? (resetTriggerReason ?? "new") : "auto";
+  if ((isNewSession || !freshEntry) && entry && entry.sessionId) {
+    // Session is ending (either explicitly via /new or implicitly via auto-reset)
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("session_before_end")) {
+      void hookRunner
+        .runSessionBeforeEnd(
+          {
+            sessionId: entry.sessionId,
+            reason: resetReason,
+            messageCount: entry.messageCount ?? 0,
+          },
+          {
+            sessionId: entry.sessionId,
+            agentId,
+          },
+        )
+        .catch((err) => {
+          log.warn(`session_before_end hook failed: ${String(err)}`);
+        });
+    }
+  }
 
   if (!isNewSession && freshEntry) {
     sessionId = entry.sessionId;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -144,6 +144,7 @@ export type SessionEntry = {
   fallbackNoticeReason?: string;
   contextTokens?: number;
   compactionCount?: number;
+  messageCount?: number;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
   cliSessionIds?: Record<string, string>;

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -36,6 +36,7 @@ import type {
   PluginHookRegistration,
   PluginHookSessionContext,
   PluginHookSessionEndEvent,
+  PluginHookSessionBeforeEndEvent,
   PluginHookSessionStartEvent,
   PluginHookSubagentContext,
   PluginHookSubagentDeliveryTargetEvent,
@@ -84,6 +85,7 @@ export type {
   PluginHookSessionContext,
   PluginHookSessionStartEvent,
   PluginHookSessionEndEvent,
+  PluginHookSessionBeforeEndEvent,
   PluginHookSubagentContext,
   PluginHookSubagentDeliveryTargetEvent,
   PluginHookSubagentDeliveryTargetResult,
@@ -678,6 +680,17 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     return runVoidHook("subagent_ended", event, ctx);
   }
 
+  /**
+   * Run session_before_end hook.
+   * Runs sequentially to allow async work before session is cleared.
+   */
+  async function runSessionBeforeEnd(
+    event: PluginHookSessionBeforeEndEvent,
+    ctx: PluginHookSessionContext,
+  ): Promise<void> {
+    return runVoidHook("session_before_end", event, ctx);
+  }
+
   // =========================================================================
   // Gateway Hooks
   // =========================================================================
@@ -746,6 +759,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Session hooks
     runSessionStart,
     runSessionEnd,
+    runSessionBeforeEnd,
     runSubagentSpawning,
     runSubagentDeliveryTarget,
     runSubagentSpawned,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -622,3 +622,13 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     registerTypedHook,
   };
 }
+
+let SHARED_REGISTRY: PluginRegistry | null = null;
+
+export function setPluginRegistry(registry: PluginRegistry) {
+  SHARED_REGISTRY = registry;
+}
+
+export function getPluginRegistry(): PluginRegistry | null {
+  return SHARED_REGISTRY;
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -337,6 +337,7 @@ export type PluginHookName =
   | "before_message_write"
   | "session_start"
   | "session_end"
+  | "session_before_end"
   | "subagent_spawning"
   | "subagent_delivery_target"
   | "subagent_spawned"
@@ -768,6 +769,13 @@ export type PluginHookSubagentEndedEvent = {
   error?: string;
 };
 
+// session_before_end hook
+export type PluginHookSessionBeforeEndEvent = {
+  sessionId: string;
+  reason: "new" | "reset" | "compact" | "auto";
+  messageCount: number;
+};
+
 // Gateway context
 export type PluginHookGatewayContext = {
   port?: number;
@@ -852,6 +860,10 @@ export type PluginHookHandlerMap = {
   ) => Promise<void> | void;
   session_end: (
     event: PluginHookSessionEndEvent,
+    ctx: PluginHookSessionContext,
+  ) => Promise<void> | void;
+  session_before_end: (
+    event: PluginHookSessionBeforeEndEvent,
     ctx: PluginHookSessionContext,
   ) => Promise<void> | void;
   subagent_spawning: (


### PR DESCRIPTION
This PR adds a new `session:before_end` hook event that fires before a session is cleared (e.g., via `/new`, `/reset`, `/compact`, or auto-reset). 

This allows plugins to perform cleanup tasks like context summarization or memory flushing before the session transcript is lost.

Relates to Discussion #12164 and PR #12162.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new plugin hook event (`session_before_end`) intended to fire right before a session is cleared (manual compaction and session resets/auto-resets). It wires new hook runner entrypoints in `src/plugins/hooks.ts` and attempts to invoke the hook from the compaction command and from session initialization when a reset is detected.

Key issues to address before merge:
- The new shared plugin registry (`getPluginRegistry`) is never initialized (no call to `setPluginRegistry`), so the hook will never run.
- `session_before_end` is documented as sequential but is currently executed in parallel because it uses `runVoidHook`.
- The reset “reason” mapping misclassifies explicit resets (e.g. `/reset`) as `auto`.
- The hook is awaited during `initSessionState`, so a slow plugin can directly delay handling incoming messages (needs an explicit decision on timeout/backgrounding vs blocking semantics).

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge until the hook wiring and execution semantics are corrected.
- The `session_before_end` hook currently won’t fire at all due to an uninitialized shared registry, and the implementation contradicts its own sequential-execution contract (it runs handlers in parallel). Additionally, explicit reset reasons are misreported, and the hook can block session initialization with unbounded plugin runtime.
- src/plugins/registry.ts, src/plugins/hooks.ts, src/auto-reply/reply/session.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->