### PR TITLE
feat: Add China LLM Gateway (CN-LLM) skill for unified access to Qwen, DeepSeek, and Chinese LLMs

### DIFF
--- a/skills/cn-llm/SKILL.md
+++ b/skills/cn-llm/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: cn-llm
+description: "China LLM Gateway - Unified interface for Chinese LLMs including Qwen, DeepSeek, GLM, Baichuan. OpenAI compatible, one API Key for all models."
+homepage: https://openclaw.ai
+metadata: {"openclaw":{"emoji":"🐉","requires":{"bins":["curl","python3"],"env":["AISA_API_KEY"]},"primaryEnv":"AISA_API_KEY"}}
+---
+
+# OpenClaw CN-LLM 🐉
+
+**China LLM Unified Gateway. Powered by AIsa.**
+
+One API Key to access all Chinese LLMs. OpenAI compatible interface.
+
+Qwen, DeepSeek, GLM, Baichuan, Moonshot, and more - unified API access.
+
+## 🔥 What You Can Do
+
+### Intelligent Chat
+```
+"Use Qwen to answer Chinese questions, use DeepSeek for coding"
+```
+
+### Deep Reasoning
+```
+"Use DeepSeek-R1 for complex reasoning tasks"
+```
+
+### Code Generation
+```
+"Use DeepSeek-Coder to generate Python code with explanations"
+```
+
+### Long Text Processing
+```
+"Use Qwen-Long for ultra-long document summarization"
+```
+
+### Model Comparison
+```
+"Compare response quality between Qwen-Max and DeepSeek-V3"
+```
+
+## Supported Models
+
+### Qwen (Alibaba)
+
+| Model | Input Price | Output Price | Features |
+|-----|---------|---------|------|
+| qwen3-max | $1.37/M | $5.48/M | Most powerful general model |
+| qwen3-max-2026-01-23 | $1.37/M | $5.48/M | Latest version |
+| qwen3-coder-plus | $2.86/M | $28.60/M | Enhanced code generation |
+| qwen3-coder-flash | $0.72/M | $3.60/M | Fast code generation |
+| qwen3-coder-480b-a35b-instruct | $2.15/M | $8.60/M | 480B large model |
+| qwen3-vl-plus | $0.43/M | $4.30/M | Vision-language model |
+| qwen3-vl-flash | $0.86/M | $0.86/M | Fast vision model |
+| qwen3-omni-flash | $4.00/M | $16.00/M | Multimodal model |
+| qwen-vl-max | $0.23/M | $0.57/M | Vision-language |
+| qwen-plus-2025-12-01 | $1.26/M | $12.60/M | Plus version |
+| qwen-mt-flash | $0.168/M | $0.514/M | Fast machine translation |
+| qwen-mt-lite | $0.13/M | $0.39/M | Lite machine translation |
+
+### DeepSeek
+
+| Model | Input Price | Output Price | Features |
+|-----|---------|---------|------|
+| deepseek-r1 | $2.00/M | $8.00/M | Reasoning model, supports Tools |
+| deepseek-v3 | $1.00/M | $4.00/M | General chat, 671B parameters |
+| deepseek-v3-0324 | $1.20/M | $4.80/M | V3 stable version |
+| deepseek-v3.1 | $4.00/M | $12.00/M | Latest Terminus version |
+
+> **Note**: Prices are in M (million tokens). Model availability may change, see [marketplace.aisa.one/pricing](https://marketplace.aisa.one/pricing) for the latest list.
+
+## Quick Start
+
+```bash
+export AISA_API_KEY="your-key"
+```
+
+## API Endpoints
+
+### OpenAI Compatible Interface
+
+```
+POST https://api.aisa.one/v1/chat/completions
+```
+
+#### Qwen Example
+
+```bash
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-max",
+    "messages": [
+      {"role": "system", "content": "You are a professional Chinese assistant."},
+      {"role": "user", "content": "Please explain what a large language model is?"}
+    ],
+    "temperature": 0.7,
+    "max_tokens": 1000
+  }'
+```
+
+#### DeepSeek Example
+
+```bash
+# DeepSeek-V3 general chat (671B parameters)
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-v3",
+    "messages": [{"role": "user", "content": "Write a quicksort algorithm in Python"}],
+    "temperature": 0.3
+  }'
+
+# DeepSeek-R1 deep reasoning (supports Tools)
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-r1",
+    "messages": [{"role": "user", "content": "A farmer needs to cross a river with a wolf, a sheep, and a cabbage. The boat can only carry the farmer and one item at a time. If the farmer is not present, the wolf will eat the sheep, and the sheep will eat the cabbage. How can the farmer safely cross?"}]
+  }'
+
+# DeepSeek-V3.1 Terminus latest version
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-v3.1",
+    "messages": [{"role": "user", "content": "Implement an LRU cache with get and put operations"}]
+  }'
+```
+
+#### Qwen3 Code Generation Example
+
+```bash
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-coder-plus",
+    "messages": [{"role": "user", "content": "Implement a thread-safe Map in Go"}]
+  }'
+```
+
+#### Parameter Reference
+
+| Parameter | Type | Required | Description |
+|-----|------|-----|------|
+| `model` | string | Yes | Model identifier |
+| `messages` | array | Yes | Message list |
+| `temperature` | number | No | Randomness (0-2, default 1) |
+| `max_tokens` | integer | No | Maximum tokens to generate |
+| `stream` | boolean | No | Stream output (default false) |
+| `top_p` | number | No | Nucleus sampling parameter (0-1) |
+
+#### Response Format
+
+```json
+{
+  "id": "chatcmpl-xxx",
+  "object": "chat.completion",
+  "created": 1234567890,
+  "model": "qwen-max",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "A large language model (LLM) is a deep learning-based..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 30,
+    "completion_tokens": 150,
+    "total_tokens": 180,
+    "cost": 0.001
+  }
+}
+```
+
+### Streaming Output
+
+```bash
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen-plus",
+    "messages": [{"role": "user", "content": "Tell a Chinese folk story"}],
+    "stream": true
+  }'
+```
+
+Returns Server-Sent Events (SSE) format:
+
+```
+data: {"id":"chatcmpl-xxx","choices":[{"delta":{"content":"Once"}}]}
+data: {"id":"chatcmpl-xxx","choices":[{"delta":{"content":" upon"}}]}
+...
+data: [DONE]
+```
+
+## Python Client
+
+### CLI Usage
+
+```bash
+# Qwen chat
+python3 {baseDir}/scripts/cn_llm_client.py chat --model qwen3-max --message "Hello, please introduce yourself"
+
+# Qwen3 code generation
+python3 {baseDir}/scripts/cn_llm_client.py chat --model qwen3-coder-plus --message "Write a binary search algorithm"
+
+# DeepSeek-R1 reasoning
+python3 {baseDir}/scripts/cn_llm_client.py chat --model deepseek-r1 --message "Which is larger, 9.9 or 9.11? Please reason in detail"
+
+# DeepSeek-V3 chat
+python3 {baseDir}/scripts/cn_llm_client.py chat --model deepseek-v3 --message "Tell a story" --stream
+
+# With system prompt
+python3 {baseDir}/scripts/cn_llm_client.py chat --model qwen3-max --system "You are a classical poetry expert" --message "Write a poem about plum blossoms"
+
+# Model comparison
+python3 {baseDir}/scripts/cn_llm_client.py compare --models "qwen3-max,deepseek-v3" --message "What is quantum computing?"
+
+# List supported models
+python3 {baseDir}/scripts/cn_llm_client.py models
+```
+
+### Python SDK Usage
+
+```python
+from cn_llm_client import CNLLMClient
+
+client = CNLLMClient()  # Uses AISA_API_KEY environment variable
+
+# Qwen chat
+response = client.chat(
+    model="qwen3-max",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response["choices"][0]["message"]["content"])
+
+# Qwen3 code generation
+response = client.chat(
+    model="qwen3-coder-plus",
+    messages=[
+        {"role": "system", "content": "You are a professional programmer."},
+        {"role": "user", "content": "Implement a singleton pattern in Python"}
+    ],
+    temperature=0.3
+)
+
+# Streaming output
+for chunk in client.chat_stream(
+    model="deepseek-v3",
+    messages=[{"role": "user", "content": "Tell a story about an idiom"}]
+):
+    print(chunk, end="", flush=True)
+
+# Model comparison
+results = client.compare_models(
+    models=["qwen3-max", "deepseek-v3", "deepseek-r1"],
+    message="Explain what machine learning is"
+)
+for model, result in results.items():
+    print(f"{model}: {result['response'][:100]}...")
+```
+
+## Use Cases
+
+### 1. Chinese Content Generation
+
+```python
+# Copywriting
+response = client.chat(
+    model="qwen3-max",
+    messages=[
+        {"role": "system", "content": "You are a professional copywriter."},
+        {"role": "user", "content": "Write a product introduction for a smart watch"}
+    ]
+)
+```
+
+### 2. Code Development
+
+```python
+# Code generation and explanation
+response = client.chat(
+    model="qwen3-coder-plus",
+    messages=[{"role": "user", "content": "Implement a thread-safe Map in Go"}]
+)
+```
+
+### 3. Complex Reasoning
+
+```python
+# Mathematical reasoning
+response = client.chat(
+    model="deepseek-r1",
+    messages=[{"role": "user", "content": "Prove: For any positive integer n, n³-n is divisible by 6"}]
+)
+```
+
+### 4. Visual Understanding
+
+```python
+# Image understanding
+response = client.chat(
+    model="qwen3-vl-plus",
+    messages=[
+        {"role": "user", "content": [
+            {"type": "text", "text": "Describe the content of this image"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+        ]}
+    ]
+)
+```
+
+### 5. Model Routing Strategy
+
+```python
+MODEL_MAP = {
+    "chat": "qwen3-max",           # General chat
+    "code": "qwen3-coder-plus",    # Code generation
+    "reasoning": "deepseek-r1",    # Complex reasoning
+    "vision": "qwen3-vl-plus",     # Visual understanding
+    "fast": "qwen3-coder-flash",   # Fast response
+    "translate": "qwen-mt-flash"   # Machine translation
+}
+
+def route_by_task(task_type: str, message: str) -> str:
+    model = MODEL_MAP.get(task_type, "qwen3-max")
+    return client.chat(model=model, messages=[{"role": "user", "content": message}])
+```
+
+## Error Handling
+
+Errors return JSON with `error` field:
+
+```json
+{
+  "error": {
+    "code": "model_not_found",
+    "message": "Model 'xxx' is not available"
+  }
+}
+```
+
+Common error codes:
+- `401` - Invalid or missing API Key
+- `402` - Insufficient balance
+- `404` - Model not found
+- `429` - Rate limit exceeded
+- `500` - Server error
+
+## Pricing
+
+| Model | Input ($/M) | Output ($/M) |
+|-----|-----------|-----------|
+| qwen3-max | $1.37 | $5.48 |
+| qwen3-coder-plus | $2.86 | $28.60 |
+| qwen3-coder-flash | $0.72 | $3.60 |
+| qwen3-vl-plus | $0.43 | $4.30 |
+| deepseek-v3 | $1.00 | $4.00 |
+| deepseek-r1 | $2.00 | $8.00 |
+| deepseek-v3.1 | $4.00 | $12.00 |
+
+> Price unit: $ per Million tokens. Each response includes `usage.cost` and `usage.credits_remaining`.
+
+## Get Started
+
+1. Register at [aisa.one](https://aisa.one)
+2. Get API Key
+3. Top up (pay-as-you-go)
+4. Set environment variable: `export AISA_API_KEY="your-key"`
+
+## Full API Reference
+
+See [API Reference](https://aisa.mintlify.app/api-reference/introduction) for complete endpoint documentation.

--- a/skills/cn-llm/scripts/cn_llm_client.py
+++ b/skills/cn-llm/scripts/cn_llm_client.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+CN-LLM - China LLM Unified Gateway Client
+Access Chinese LLMs including Qwen, DeepSeek, GLM, Baichuan, Moonshot via AIsa API.
+
+Usage:
+    python cn_llm_client.py chat --model <model> --message <message> [--stream]
+    python cn_llm_client.py chat --model <model> --messages <json_array>
+    python cn_llm_client.py compare --models <model1,model2,...> --message <message>
+    python cn_llm_client.py models
+"""
+
+import argparse
+import io
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from typing import Any, Dict, Generator, List, Optional
+
+# Ensure UTF-8 output on Windows
+if sys.platform == "win32":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
+
+class CNLLMClient:
+    """China LLM Unified Gateway Client."""
+
+    BASE_URL = "https://api.aisa.one/v1"
+
+    # Supported Chinese LLMs (from marketplace.aisa.one/pricing)
+    SUPPORTED_MODELS = {
+        "Qwen3 (Alibaba)": [
+            "qwen3-max",
+            "qwen3-max-2026-01-23",
+            "qwen3-coder-plus",
+            "qwen3-coder-flash",
+            "qwen3-coder-480b-a35b-instruct",
+            "qwen3-vl-plus",
+            "qwen3-vl-plus-2025-12-19",
+            "qwen3-vl-flash",
+            "qwen3-vl-flash-2025-10-15",
+            "qwen3-omni-flash",
+            "qwen3-omni-flash-2025-12-01"
+        ],
+        "Qwen (Alibaba)": [
+            "qwen-vl-max",
+            "qwen-plus-2025-12-01",
+            "qwen-mt-flash",
+            "qwen-mt-lite"
+        ],
+        "DeepSeek": [
+            "deepseek-r1",
+            "deepseek-v3",
+            "deepseek-v3-0324",
+            "deepseek-v3.1"
+        ]
+    }
+
+    def __init__(self, api_key: Optional[str] = None):
+        """Initialize the client."""
+        self.api_key = api_key or os.environ.get("AISA_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "AISA_API_KEY required. Set environment variable or pass to constructor."
+            )
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        data: Optional[Dict[str, Any]] = None,
+        stream: bool = False
+    ) -> Any:
+        """Send HTTP request to AIsa API."""
+        url = f"{self.BASE_URL}{endpoint}"
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "OpenClaw-CNLLM/1.0",
+            "Accept": "application/json"
+        }
+
+        request_data = None
+        if data:
+            request_data = json.dumps(data).encode("utf-8")
+
+        req = urllib.request.Request(url, data=request_data, headers=headers, method=method)
+
+        try:
+            response = urllib.request.urlopen(req, timeout=120)
+
+            if stream:
+                return self._handle_stream(response)
+            else:
+                return json.loads(response.read().decode("utf-8"))
+
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8")
+            try:
+                return json.loads(error_body)
+            except json.JSONDecodeError:
+                return {"error": {"code": str(e.code), "message": error_body}}
+        except urllib.error.URLError as e:
+            return {"error": {"code": "NETWORK_ERROR", "message": str(e.reason)}}
+
+    def _handle_stream(self, response) -> Generator[str, None, None]:
+        """Handle streaming response (SSE)."""
+        for line in response:
+            line = line.decode("utf-8").strip()
+            if line.startswith("data: "):
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                    if "choices" in chunk and chunk["choices"]:
+                        delta = chunk["choices"][0].get("delta", {})
+                        content = delta.get("content", "")
+                        if content:
+                            yield content
+                except json.JSONDecodeError:
+                    continue
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        top_p: Optional[float] = None,
+        stream: bool = False,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """
+        Create a chat completion.
+
+        Args:
+            model: Model identifier (e.g., qwen-max, deepseek-v3)
+            messages: Message list containing 'role' and 'content'
+            temperature: Sampling temperature (0-2)
+            max_tokens: Maximum tokens to generate
+            top_p: Nucleus sampling parameter
+            stream: Enable streaming output
+            **kwargs: Additional parameters
+
+        Returns:
+            Chat completion response
+        """
+        payload = {
+            "model": model,
+            "messages": messages,
+            "stream": stream
+        }
+
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if top_p is not None:
+            payload["top_p"] = top_p
+
+        payload.update(kwargs)
+
+        return self._request("POST", "/chat/completions", data=payload, stream=stream)
+
+    def chat_stream(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        **kwargs
+    ) -> Generator[str, None, None]:
+        """
+        Create a streaming chat completion.
+
+        Yields generated content chunk by chunk.
+        """
+        return self.chat(model=model, messages=messages, stream=True, **kwargs)
+
+    def compare_models(
+        self,
+        models: List[str],
+        message: str,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """
+        Compare responses from multiple models.
+
+        Args:
+            models: List of model identifiers
+            message: Message to send to each model
+
+        Returns:
+            Dictionary with model names as keys and results as values
+        """
+        import time
+
+        results = {}
+        for model in models:
+            start = time.time()
+            try:
+                response = self.chat(
+                    model=model,
+                    messages=[{"role": "user", "content": message}],
+                    **kwargs
+                )
+                elapsed = time.time() - start
+
+                if "error" in response:
+                    results[model] = {
+                        "success": False,
+                        "error": response["error"],
+                        "latency": elapsed
+                    }
+                else:
+                    content = response.get("choices", [{}])[0].get("message", {}).get("content", "")
+                    usage = response.get("usage", {})
+                    results[model] = {
+                        "success": True,
+                        "response": content,
+                        "latency": elapsed,
+                        "tokens": usage.get("total_tokens", 0),
+                        "cost": usage.get("cost", 0)
+                    }
+            except Exception as e:
+                results[model] = {
+                    "success": False,
+                    "error": str(e),
+                    "latency": time.time() - start
+                }
+
+        return results
+
+    def list_models(self) -> Dict[str, List[str]]:
+        """List supported Chinese LLMs."""
+        return self.SUPPORTED_MODELS
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="CN-LLM - China LLM Unified Gateway",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    %(prog)s chat --model qwen-max --message "Hello!"
+    %(prog)s chat --model deepseek-coder --message "Write a quicksort"
+    %(prog)s chat --model deepseek-r1 --message "Which is larger, 9.9 or 9.11?"
+    %(prog)s chat --model qwen-plus --message "Tell a story" --stream
+    %(prog)s chat --model glm-4 --system "You are a poet" --message "Write a poem about spring"
+    %(prog)s compare --models "qwen-max,deepseek-v3" --message "What is AI?"
+    %(prog)s models
+        """
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Commands")
+
+    # Chat command
+    chat_parser = subparsers.add_parser("chat", help="Send chat request")
+    chat_parser.add_argument("--model", "-m", required=True, help="Model identifier")
+    chat_parser.add_argument("--message", help="User message")
+    chat_parser.add_argument("--messages", help="Full message array (JSON format)")
+    chat_parser.add_argument("--system", "-s", help="System prompt")
+    chat_parser.add_argument("--temperature", "-t", type=float, help="Temperature (0-2)")
+    chat_parser.add_argument("--max-tokens", type=int, help="Maximum tokens to generate")
+    chat_parser.add_argument("--stream", action="store_true", help="Streaming output")
+
+    # Compare command
+    compare_parser = subparsers.add_parser("compare", help="Compare multiple models")
+    compare_parser.add_argument("--models", required=True, help="Comma-separated model list")
+    compare_parser.add_argument("--message", "-m", required=True, help="Message to send")
+    compare_parser.add_argument("--temperature", "-t", type=float, help="Temperature")
+    compare_parser.add_argument("--max-tokens", type=int, help="Maximum tokens")
+
+    # Models command
+    subparsers.add_parser("models", help="List supported models")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    # Models command doesn't require API Key
+    if args.command == "models":
+        print(json.dumps(CNLLMClient.SUPPORTED_MODELS, indent=2, ensure_ascii=False))
+        sys.exit(0)
+
+    try:
+        client = CNLLMClient()
+    except ValueError as e:
+        print(json.dumps({"error": {"code": "AUTH_ERROR", "message": str(e)}}, ensure_ascii=False))
+        sys.exit(1)
+
+    result = None
+
+    if args.command == "chat":
+        # Build messages
+        if args.messages:
+            messages = json.loads(args.messages)
+        elif args.message:
+            messages = []
+            if args.system:
+                messages.append({"role": "system", "content": args.system})
+            messages.append({"role": "user", "content": args.message})
+        else:
+            print(json.dumps({"error": {"code": "INVALID_INPUT", "message": "Requires --message or --messages parameter"}}, ensure_ascii=False))
+            sys.exit(1)
+
+        kwargs = {}
+        if args.temperature is not None:
+            kwargs["temperature"] = args.temperature
+        if args.max_tokens is not None:
+            kwargs["max_tokens"] = args.max_tokens
+
+        if args.stream:
+            # Streaming mode
+            try:
+                for chunk in client.chat_stream(model=args.model, messages=messages, **kwargs):
+                    print(chunk, end="", flush=True)
+                print()  # Final newline
+                sys.exit(0)
+            except Exception as e:
+                print(json.dumps({"error": {"code": "STREAM_ERROR", "message": str(e)}}, ensure_ascii=False))
+                sys.exit(1)
+        else:
+            result = client.chat(model=args.model, messages=messages, **kwargs)
+
+    elif args.command == "compare":
+        models = [m.strip() for m in args.models.split(",")]
+        kwargs = {}
+        if args.temperature is not None:
+            kwargs["temperature"] = args.temperature
+        if args.max_tokens is not None:
+            kwargs["max_tokens"] = args.max_tokens
+        result = client.compare_models(models=models, message=args.message, **kwargs)
+
+    if result:
+        output = json.dumps(result, indent=2, ensure_ascii=False)
+        try:
+            print(output)
+        except UnicodeEncodeError:
+            print(json.dumps(result, indent=2, ensure_ascii=True))
+
+        # Return error code if result contains error
+        if isinstance(result, dict) and "error" in result:
+            sys.exit(1)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## CN-LLM 🐉 - China LLM Unified Gateway

### Overview
CN-LLM provides unified access to Chinese Large Language Models through a single OpenAI-compatible API endpoint, powered by AIsa. One API key to access Qwen3, DeepSeek, GLM, Baichuan, and other major Chinese LLMs.

### Key Features
- **🇨🇳 Unified Chinese LLM Access**: Single interface for Qwen, DeepSeek, GLM, Baichuan, Moonshot
- **🤖 OpenAI Compatible**: Drop-in replacement for OpenAI SDK
- **📊 Model Comparison Tool**: Compare responses from multiple models side-by-side
- **⚡ Streaming Support**: Real-time response streaming with SSE
- **💰 Transparent Pricing**: Pay-per-use with detailed cost breakdowns

### Supported Models

#### Qwen3 Series (Alibaba)
- **General Purpose**: qwen3-max, qwen3-max-2026-01-23
- **Code Generation**: qwen3-coder-plus, qwen3-coder-flash, qwen3-coder-480b-a35b-instruct
- **Vision-Language**: qwen3-vl-plus, qwen3-vl-flash, qwen3-omni-flash
- **Machine Translation**: qwen-mt-flash, qwen-mt-lite

#### DeepSeek Series
- **Deep Reasoning**: deepseek-r1 (supports Tools, reasoning tasks)
- **General Chat**: deepseek-v3 (671B parameters)
- **Latest Versions**: deepseek-v3-0324, deepseek-v3.1 (Terminus)

### Files Included

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `cn-llm` skill with documentation (`skills/cn-llm/SKILL.md`) and a Python CLI/SDK client (`skills/cn-llm/scripts/cn_llm_client.py`) for calling the AIsa OpenAI-compatible `/v1/chat/completions` endpoint across multiple Chinese LLMs (Qwen/DeepSeek, etc.), including a simple model comparison mode and optional SSE streaming.

The main integration surface is the skill README/frontmatter (for OpenClaw’s skill loader) plus the standalone Python script that users run to talk to the remote API using `AISA_API_KEY`.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a real correctness issue in the streaming CLI error path.
- The changes are isolated to a new skill doc + a standalone Python client, but the streaming mode currently mishandles network/HTTP errors by iterating a dict as if it were a stream, which can silently mask failures (printing keys and exiting successfully).
- skills/cn-llm/scripts/cn_llm_client.py

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->