### PR TITLE
feat(doctor): add memory search embeddings provider health check

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -364,6 +364,10 @@
       "destination": "/gateway/heartbeat"
     },
     {
+      "source": "/hooks",
+      "destination": "/automation/hooks"
+    },
+    {
       "source": "/hubs",
       "destination": "/start/hubs"
     },

--- a/src/commands/doctor-memory.test.ts
+++ b/src/commands/doctor-memory.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import * as noteModule from "../terminal/note.js";
+import { noteMemorySearchHealth } from "./doctor-memory.js";
+
+vi.mock("../terminal/note.js", () => ({
+  note: vi.fn(),
+}));
+
+describe("noteMemorySearchHealth", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should not warn when memory search is explicitly disabled", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).not.toHaveBeenCalled();
+  });
+
+  it("should warn when memory search is enabled with provider=auto but no API keys or local model", () => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "auto",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).toHaveBeenCalledWith(
+      expect.stringContaining("Memory search is enabled but no embeddings provider is configured"),
+      "Memory Search",
+    );
+  });
+
+  it("should not warn when OPENAI_API_KEY is set with provider=auto", () => {
+    process.env.OPENAI_API_KEY = "sk-test123";
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "auto",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).not.toHaveBeenCalled();
+  });
+
+  it("should not warn when GEMINI_API_KEY is set with provider=auto", () => {
+    process.env.GEMINI_API_KEY = "test-gemini-key";
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "auto",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).not.toHaveBeenCalled();
+  });
+
+  it("should not warn when VOYAGE_API_KEY is set with provider=auto", () => {
+    process.env.VOYAGE_API_KEY = "test-voyage-key";
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "auto",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).not.toHaveBeenCalled();
+  });
+
+  it("should not warn when local model path is configured with provider=auto", () => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "auto",
+            local: {
+              modelPath: "/path/to/model.gguf",
+            },
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).not.toHaveBeenCalled();
+  });
+
+  it("should warn when provider=openai but OPENAI_API_KEY is missing", () => {
+    delete process.env.OPENAI_API_KEY;
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "openai",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).toHaveBeenCalledWith(
+      expect.stringContaining('provider is set to "openai" but OPENAI_API_KEY is not configured'),
+      "Memory Search",
+    );
+  });
+
+  it("should not warn when provider=openai and OPENAI_API_KEY is set", () => {
+    process.env.OPENAI_API_KEY = "sk-test123";
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "openai",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).not.toHaveBeenCalled();
+  });
+
+  it("should warn when provider=gemini but GEMINI_API_KEY is missing", () => {
+    delete process.env.GEMINI_API_KEY;
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "gemini",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).toHaveBeenCalledWith(
+      expect.stringContaining('provider is set to "gemini" but GEMINI_API_KEY is not configured'),
+      "Memory Search",
+    );
+  });
+
+  it("should warn when provider=voyage but VOYAGE_API_KEY is missing", () => {
+    delete process.env.VOYAGE_API_KEY;
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "voyage",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).toHaveBeenCalledWith(
+      expect.stringContaining('provider is set to "voyage" but VOYAGE_API_KEY is not configured'),
+      "Memory Search",
+    );
+  });
+
+  it("should warn when provider=local but no model path is configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "local",
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).toHaveBeenCalledWith(
+      expect.stringContaining('provider is set to "local" but no model path is configured'),
+      "Memory Search",
+    );
+  });
+
+  it("should not warn when provider=local and model path is configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "local",
+            local: {
+              modelPath: "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf",
+            },
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).not.toHaveBeenCalled();
+  });
+
+  it("should warn when memory search is implicitly enabled (no config) and no providers available", () => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {},
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).toHaveBeenCalledWith(
+      expect.stringContaining("Memory search is enabled but no embeddings provider is configured"),
+      "Memory Search",
+    );
+  });
+
+  it("should not warn when empty local model path (treated as not configured)", () => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+            provider: "auto",
+            local: {
+              modelPath: "  ", // whitespace only
+            },
+          },
+        },
+      },
+    };
+
+    noteMemorySearchHealth(cfg);
+
+    expect(noteModule.note).toHaveBeenCalledWith(
+      expect.stringContaining("Memory search is enabled but no embeddings provider is configured"),
+      "Memory Search",
+    );
+  });
+});

--- a/src/commands/doctor-memory.ts
+++ b/src/commands/doctor-memory.ts
@@ -1,0 +1,110 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { note } from "../terminal/note.js";
+
+/**
+ * Check if memory search is likely to be non-functional due to missing embeddings provider.
+ * Returns diagnostic messages if issues are detected.
+ */
+export function noteMemorySearchHealth(cfg: OpenClawConfig): void {
+  const memoryConfig = cfg.agents?.defaults?.memorySearch;
+
+  // Memory search explicitly disabled - that's OK, no warning needed
+  if (memoryConfig?.enabled === false) {
+    return;
+  }
+
+  // Memory search is enabled (or default enabled) - check if embeddings provider is available
+  const provider = memoryConfig?.provider ?? "auto";
+  const warnings: string[] = [];
+
+  // Check if any API keys are configured
+  const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
+  const hasGemini = Boolean(process.env.GEMINI_API_KEY);
+  const hasVoyage = Boolean(process.env.VOYAGE_API_KEY);
+
+  // Check local model configuration
+  const localModelPath = memoryConfig?.local?.modelPath?.trim();
+  const hasLocalModel = localModelPath && localModelPath.length > 0;
+
+  if (provider === "auto") {
+    // Auto mode needs at least one provider available
+    if (!hasOpenAI && !hasGemini && !hasVoyage && !hasLocalModel) {
+      warnings.push(
+        "⚠️  Memory search is enabled but no embeddings provider is configured.",
+        "",
+        "Memory search requires semantic embeddings to work. Without a provider,",
+        "the memory_search tool will fail and your agent cannot recall information",
+        "from MEMORY.md or memory/*.md files.",
+        "",
+        "Fix options (choose one):",
+        "",
+        "1. Use OpenAI (recommended for most users):",
+        `   export OPENAI_API_KEY="sk-..."`,
+        `   Or run: ${formatCliCommand("openclaw configure")}`,
+        "",
+        "2. Use Google Gemini (free tier available):",
+        `   export GEMINI_API_KEY="..."`,
+        `   Or run: ${formatCliCommand("openclaw onboard --auth-choice gemini-api-key")}`,
+        "",
+        "3. Use Voyage AI:",
+        `   export VOYAGE_API_KEY="..."`,
+        "",
+        "4. Use local embeddings (requires node-llama-cpp):",
+        `   ${formatCliCommand('openclaw config set agents.defaults.memorySearch.provider "local"')}`,
+        `   ${formatCliCommand('openclaw config set agents.defaults.memorySearch.local.modelPath "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf"')}`,
+        "",
+        "5. Disable memory search if not needed:",
+        `   ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
+        "",
+        `Check current status: ${formatCliCommand("openclaw memory status --deep")}`,
+      );
+    }
+  } else if (provider === "openai") {
+    if (!hasOpenAI) {
+      warnings.push(
+        `⚠️  Memory search provider is set to "openai" but OPENAI_API_KEY is not configured.`,
+        "",
+        `Set your API key: export OPENAI_API_KEY="sk-..."`,
+        `Or switch to auto: ${formatCliCommand('openclaw config set agents.defaults.memorySearch.provider "auto"')}`,
+        `Or disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
+      );
+    }
+  } else if (provider === "gemini") {
+    if (!hasGemini) {
+      warnings.push(
+        `⚠️  Memory search provider is set to "gemini" but GEMINI_API_KEY is not configured.`,
+        "",
+        `Set your API key: export GEMINI_API_KEY="..."`,
+        `Or switch to auto: ${formatCliCommand('openclaw config set agents.defaults.memorySearch.provider "auto"')}`,
+        `Or disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
+      );
+    }
+  } else if (provider === "voyage") {
+    if (!hasVoyage) {
+      warnings.push(
+        `⚠️  Memory search provider is set to "voyage" but VOYAGE_API_KEY is not configured.`,
+        "",
+        `Set your API key: export VOYAGE_API_KEY="..."`,
+        `Or switch to auto: ${formatCliCommand('openclaw config set agents.defaults.memorySearch.provider "auto"')}`,
+        `Or disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
+      );
+    }
+  } else if (provider === "local") {
+    if (!hasLocalModel) {
+      warnings.push(
+        `⚠️  Memory search provider is set to "local" but no model path is configured.`,
+        "",
+        `Set a model path: ${formatCliCommand('openclaw config set agents.defaults.memorySearch.local.modelPath "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf"')}`,
+        `Or switch to auto: ${formatCliCommand('openclaw config set agents.defaults.memorySearch.provider "auto"')}`,
+        `Or disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
+        "",
+        "Note: Local embeddings require node-llama-cpp to be installed.",
+      );
+    }
+  }
+
+  if (warnings.length > 0) {
+    note(warnings.join("\n"), "Memory Search");
+  }
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -35,6 +35,7 @@ import {
   maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
 import { noteSourceInstallIssues } from "./doctor-install.js";
+import { noteMemorySearchHealth } from "./doctor-memory.js";
 import {
   noteMacLaunchAgentOverrides,
   noteMacLaunchctlGatewayEnvOverrides,
@@ -259,6 +260,9 @@ export async function doctorCommand(
   }
 
   noteWorkspaceStatus(cfg);
+
+  // Check memory search embeddings configuration
+  noteMemorySearchHealth(cfg);
 
   // Check and fix shell completion
   await doctorShellCompletion(runtime, prompter, {


### PR DESCRIPTION
## Summary

Adds diagnostic check in `openclaw doctor` to warn when memory search is enabled but no embeddings provider is configured.

## Problem (Issue #13027)

Users were experiencing silent memory recall failures because:
- Memory search was enabled by default
- No embeddings provider was configured (no API keys, no local model)
- The failure mode was subtle - agent simply couldn't recall from MEMORY.md
- Users blamed "AI forgot" instead of configuration issue
- No prominent warning during setup or at runtime

## Solution

Added `noteMemorySearchHealth()` check in doctor command that:
- Detects when memorySearch is enabled (or default enabled)
- Validates provider-specific requirements:
  - `auto`: checks for any available provider (OpenAI/Gemini/Voyage API keys or local model path)
  - `openai`: validates OPENAI_API_KEY
  - `gemini`: validates GEMINI_API_KEY
  - `voyage`: validates VOYAGE_API_KEY
  - `local`: validates model path is configured
- Provides actionable fix suggestions for each scenario
- References `openclaw memory status --deep` for verification

## Changes

- **src/commands/doctor-memory.ts** (new): Memory search health check logic
- **src/commands/doctor.ts**: Added call to `noteMemorySearchHealth()`
- **src/commands/doctor-memory.test.ts** (new): 14 comprehensive tests

## Testing

```bash
pnpm test doctor-memory
# ✓ 14 tests passing
```

Test coverage:
- Disabled memory search (no warning)
- Auto provider with/without API keys
- Specific providers with/without credentials
- Empty/whitespace model paths
- Implicit enabled state

## Example Output

When memory search is enabled but no provider is configured:

```
⚠️  Memory search is enabled but no embeddings provider is configured.

Memory search requires semantic embeddings to work. Without a provider,
the memory_search tool will fail and your agent cannot recall information
from MEMORY.md or memory/*.md files.

Fix options (choose one):

1. Use OpenAI (recommended for most users):
   export OPENAI_API_KEY="sk-..."
   Or run: openclaw configure

2. Use Google Gemini (free tier available):
   export GEMINI_API_KEY="..."
   Or run: openclaw onboard --auth-choice gemini-api-key

[... more options ...]
```

## Related

Closes #13027

---

This surfaces configuration issues early (during `openclaw doctor`) rather than at runtime when memory recall silently fails.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `noteMemorySearchHealth()` diagnostic that runs during `openclaw doctor` to warn when memory search is enabled but no embeddings provider appears to be configured (no relevant API keys and no local model path). It also adds a redirect entry in `docs/docs.json` and includes a Vitest suite covering common provider/config combinations.

The core change is wired into `src/commands/doctor.ts` so the warning is surfaced early during `doctor`, before users hit silent recall failures at runtime.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but the new tests’ env handling and the doctor warning gating should be adjusted to avoid flaky tests and false-positive warnings.
- Core implementation is straightforward and localized, but the Vitest suite reassigns `process.env` (can be flaky across Node/test runners) and the new doctor check currently warns even when memory search isn’t explicitly enabled in config, which may produce noise for some users/config shapes.
- src/commands/doctor-memory.test.ts, src/commands/doctor-memory.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->