### PR TITLE
fix(tools): correct Grok response parsing for xAI Responses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Auth: strip embedded line breaks from pasted API keys and tokens before storing/resolving credentials.
 - Web UI: make chat refresh smoothly scroll to the latest messages and suppress new-messages badge flash during manual refresh.
 - Tools/web_search: include provider-specific settings in the web search cache key, and pass `inlineCitations` for Grok. (#12419) Thanks @tmchow.
+- Tools/web_search: fix Grok response parsing for xAI Responses API output blocks. (#13049) Thanks @ereid7.
 - Tools/web_search: normalize direct Perplexity model IDs while keeping OpenRouter model IDs unchanged. (#12795) Thanks @cdorsey.
 - Model failover: treat HTTP 400 errors as failover-eligible, enabling automatic model fallback. (#1879) Thanks @orenyomtov.
 - Errors: prevent false positive context overflow detection when conversation mentions "context overflow" topic. (#2078) Thanks @sbking.

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -10,6 +10,7 @@ const {
   resolveGrokApiKey,
   resolveGrokModel,
   resolveGrokInlineCitations,
+  extractGrokContent,
 } = __testing;
 
 describe("web_search perplexity baseUrl defaults", () => {
@@ -140,5 +141,25 @@ describe("web_search grok config resolution", () => {
   it("respects inlineCitations config", () => {
     expect(resolveGrokInlineCitations({ inlineCitations: true })).toBe(true);
     expect(resolveGrokInlineCitations({ inlineCitations: false })).toBe(false);
+  });
+});
+
+describe("web_search grok response parsing", () => {
+  it("extracts content from Responses API output blocks", () => {
+    expect(
+      extractGrokContent({
+        output: [
+          {
+            content: [{ text: "hello from output" }],
+          },
+        ],
+      }),
+    ).toBe("hello from output");
+  });
+
+  it("falls back to deprecated output_text", () => {
+    expect(extractGrokContent({ output_text: "hello from output_text" })).toBe(
+      "hello from output_text",
+    );
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -131,6 +131,15 @@ type PerplexitySearchResponse = {
 
 type PerplexityBaseUrlHint = "direct" | "openrouter";
 
+function extractGrokContent(data: GrokSearchResponse): string | undefined {
+  // xAI Responses API format: output[0].content[0].text
+  const fromResponses = data.output?.[0]?.content?.[0]?.text;
+  if (typeof fromResponses === "string" && fromResponses) {
+    return fromResponses;
+  }
+  return typeof data.output_text === "string" ? data.output_text : undefined;
+}
+
 function resolveSearchConfig(cfg?: OpenClawConfig): WebSearchConfig {
   const search = cfg?.tools?.web?.search;
   if (!search || typeof search !== "object") {
@@ -484,8 +493,7 @@ async function runGrokSearch(params: {
   }
 
   const data = (await res.json()) as GrokSearchResponse;
-  // Extract content from xAI Responses API format: output[0].content[0].text
-  const content = data.output?.[0]?.content?.[0]?.text ?? data.output_text ?? "No response";
+  const content = extractGrokContent(data) ?? "No response";
   const citations = data.citations ?? [];
   const inlineCitations = data.inline_citations;
 
@@ -557,7 +565,7 @@ async function runWebSearch(params: {
       provider: params.provider,
       model: params.grokModel ?? DEFAULT_GROK_MODEL,
       tookMs: Date.now() - start,
-      content,
+      content: wrapWebContent(content),
       citations,
       inlineCitations,
     };
@@ -722,4 +730,5 @@ export const __testing = {
   resolveGrokApiKey,
   resolveGrokModel,
   resolveGrokInlineCitations,
+  extractGrokContent,
 } as const;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -103,7 +103,15 @@ type GrokConfig = {
 };
 
 type GrokSearchResponse = {
-  output_text?: string;
+  output?: Array<{
+    type?: string;
+    role?: string;
+    content?: Array<{
+      type?: string;
+      text?: string;
+    }>;
+  }>;
+  output_text?: string; // deprecated field - kept for backwards compatibility
   citations?: string[];
   inline_citations?: Array<{
     start_index: number;
@@ -476,7 +484,8 @@ async function runGrokSearch(params: {
   }
 
   const data = (await res.json()) as GrokSearchResponse;
-  const content = data.output_text ?? "No response";
+  // Extract content from xAI Responses API format: output[0].content[0].text
+  const content = data.output?.[0]?.content?.[0]?.text ?? data.output_text ?? "No response";
   const citations = data.citations ?? [];
   const inlineCitations = data.inline_citations;
 


### PR DESCRIPTION
## Summary
Grok web_search provider returns "No response" for all queries because the response parsing code expects "output_text" field, but xAI's Responses API returns content in "output[0].content[0].text".

## Changes
- Updated "GrokSearchResponse" type to match actual xAI API response structure
- Fixed "runGrokSearch" to extract content from the correct path: "output[0].content[0].text"
- Kept backwards compatibility with "output_text" field (optional fallback)

## Testing
Verified fix works with live xAI API:
- Query: "what is the capital of France"
- Result: "**Paris** is the capital of France..."

## Related
Fixes bug introduced in PR #12419

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code follows project style guidelines
- [x] Change is backwards compatible
- [x] Tested with live API

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends `web_search` to support Grok (xAI) and fixes Grok parsing by reading the xAI Responses API’s `output[0].content[0].text` (with a fallback to the legacy `output_text` field). It also adds Grok config resolution helpers (apiKey/model/inline citations), updates the tools config types + runtime zod schema to accept `provider: "grok"` and a `tools.web.search.grok` config block, and adds unit tests for the new Grok config resolution behavior.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a concrete sanitization inconsistency for Grok output that should be fixed first.
- Core change is a narrow parsing fix plus config/schema updates, and it aligns with the stated xAI Responses API structure. However, Grok’s `content` is returned without `wrapWebContent(...)` unlike the other providers, which can bypass existing external-content handling and affect downstream rendering/consumption.
- src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->