### PR TITLE
add Baidu Infoflow channel support

### DIFF
--- a/extensions/infoflow/index.ts
+++ b/extensions/infoflow/index.ts
@@ -1,0 +1,18 @@
+import { emptyPluginConfigSchema, type OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { infoflowPlugin } from "./src/channel.js";
+import { handleInfoflowWebhookRequest } from "./src/monitor.js";
+import { setInfoflowRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "infoflow",
+  name: "Infoflow",
+  description: "OpenClaw Infoflow channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setInfoflowRuntime(api.runtime);
+    api.registerChannel({ plugin: infoflowPlugin });
+    api.registerHttpHandler(handleInfoflowWebhookRequest);
+  },
+};
+
+export default plugin;

--- a/extensions/infoflow/openclaw.plugin.json
+++ b/extensions/infoflow/openclaw.plugin.json
@@ -1,0 +1,44 @@
+{
+  "id": "infoflow",
+  "channels": ["infoflow"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiHost": { "type": "string" },
+      "enabled": { "type": "boolean" },
+      "name": { "type": "string" },
+      "check_token": { "type": "string" },
+      "encodingAESKey": { "type": "string" },
+      "appKey": { "type": "string" },
+      "appSecret": { "type": "string" },
+      "robotName": { "type": "string" },
+      "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist"] },
+      "allowFrom": { "type": "array", "items": { "type": "string" } },
+      "groupPolicy": { "type": "string", "enum": ["open", "allowlist", "disabled"] },
+      "groupAllowFrom": { "type": "array", "items": { "type": "string" } },
+      "requireMention": { "type": "boolean" },
+      "accounts": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "name": { "type": "string" },
+            "check_token": { "type": "string" },
+            "encodingAESKey": { "type": "string" },
+            "appKey": { "type": "string" },
+            "appSecret": { "type": "string" },
+            "robotName": { "type": "string" },
+            "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist"] },
+            "allowFrom": { "type": "array", "items": { "type": "string" } },
+            "groupPolicy": { "type": "string", "enum": ["open", "allowlist", "disabled"] },
+            "groupAllowFrom": { "type": "array", "items": { "type": "string" } },
+            "requireMention": { "type": "boolean" }
+          }
+        }
+      },
+      "defaultAccount": { "type": "string" }
+    }
+  }
+}

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openclaw/infoflow",
+  "version": "2026.2.6-3",
+  "description": "OpenClaw Infoflow channel plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "infoflow",
+      "label": "Infoflow",
+      "selectionLabel": "Infoflow (如流)",
+      "docsPath": "/channels/infoflow",
+      "blurb": "Baidu Infoflow messaging platform.",
+      "order": 40
+    },
+    "install": {
+      "npmSpec": "@openclaw/infoflow",
+      "localPath": "extensions/infoflow",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/infoflow/src/bot.ts
+++ b/extensions/infoflow/src/bot.ts
@@ -1,0 +1,374 @@
+import type {
+  InfoflowChatType,
+  InfoflowMessageEvent,
+  HandleInfoflowMessageParams,
+  HandlePrivateChatParams,
+  HandleGroupChatParams,
+} from "./types.js";
+import { resolveInfoflowAccount } from "./channel.js";
+import { createInfoflowReplyDispatcher } from "./reply-dispatcher.js";
+import { getInfoflowRuntime } from "./runtime.js";
+
+// Re-export types for external consumers
+export type { InfoflowChatType, InfoflowMessageEvent } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// @mention detection types and helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Body item in Infoflow group message, supporting TEXT, AT, LINK types.
+ */
+type InfoflowBodyItem = {
+  type?: string;
+  content?: string;
+  label?: string;
+  /** Robot ID when type is AT */
+  robotid?: number;
+  /** Robot/user name when type is AT */
+  name?: string;
+};
+
+/**
+ * Check if the bot was @mentioned in the message body.
+ * Matches configured robotName against AT elements (case-insensitive).
+ */
+function checkBotMentioned(bodyItems: InfoflowBodyItem[], robotName?: string): boolean {
+  if (!robotName) {
+    return false; // Cannot detect mentions without configured robotName
+  }
+  const normalizedRobotName = robotName.toLowerCase();
+  for (const item of bodyItems) {
+    if (item.type === "AT" && item.name) {
+      if (item.name.toLowerCase() === normalizedRobotName) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Handles an incoming private chat message from Infoflow.
+ * Receives the raw decrypted message data and dispatches to the agent.
+ */
+export async function handlePrivateChatMessage(params: HandlePrivateChatParams): Promise<void> {
+  const { cfg, msgData, accountId, statusSink } = params;
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+
+  if (verbose) {
+    console.log("[infoflow] Received private chat message:", JSON.stringify(msgData, null, 2));
+  }
+
+  // Extract sender and content from msgData (flexible field names)
+  const fromuser = String(msgData.FromUserId ?? msgData.fromuserid ?? msgData.from ?? "");
+  const mes = String(msgData.Content ?? msgData.content ?? msgData.text ?? msgData.mes ?? "");
+
+  // Extract sender name (FromUserName is more human-readable than FromUserId)
+  const senderName = String(msgData.FromUserName ?? msgData.username ?? fromuser);
+
+  // Extract message ID for dedup tracking
+  const messageId = msgData.MsgId ?? msgData.msgid ?? msgData.messageid;
+  const messageIdStr = messageId != null ? String(messageId) : undefined;
+
+  // Extract timestamp (CreateTime is in seconds, convert to milliseconds)
+  const createTime = msgData.CreateTime ?? msgData.createtime;
+  const timestamp = createTime != null ? Number(createTime) * 1000 : Date.now();
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Private chat extracted: fromuser=${fromuser}, senderName=${senderName}, mes=${mes.slice(0, 50)}...`,
+    );
+  }
+
+  if (!fromuser || !mes.trim()) {
+    if (verbose) {
+      console.log(`[infoflow] Private chat skipped: missing fromuser or empty message`);
+    }
+    return;
+  }
+
+  // Delegate to the common message handler (private chat)
+  await handleInfoflowMessage({
+    cfg,
+    event: {
+      fromuser,
+      mes,
+      chatType: "direct",
+      senderName,
+      messageId: messageIdStr,
+      timestamp,
+    },
+    accountId,
+    statusSink,
+  });
+}
+
+/**
+ * Handles an incoming group chat message from Infoflow.
+ * Receives the raw decrypted message data and dispatches to the agent.
+ */
+export async function handleGroupChatMessage(params: HandleGroupChatParams): Promise<void> {
+  const { cfg, msgData, accountId, statusSink } = params;
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+
+  if (verbose) {
+    console.log("[infoflow] Received group chat message:", JSON.stringify(msgData, null, 2));
+  }
+
+  // Extract sender from nested structure or flat fields
+  const header = (msgData.message as Record<string, unknown>)?.header as
+    | Record<string, unknown>
+    | undefined;
+  const fromuser = String(header?.fromuserid ?? msgData.fromuserid ?? msgData.from ?? "");
+
+  // Extract message ID (priority: header.messageid > header.msgid > MsgId)
+  const messageId = header?.messageid ?? header?.msgid ?? msgData.MsgId;
+  const messageIdStr = messageId != null ? String(messageId) : undefined;
+
+  const rawGroupId = msgData.groupid ?? header?.groupid;
+  const groupid =
+    typeof rawGroupId === "number" ? rawGroupId : rawGroupId ? Number(rawGroupId) : undefined;
+
+  // Extract timestamp (time is in milliseconds)
+  const rawTime = msgData.time ?? header?.servertime;
+  const timestamp = rawTime != null ? Number(rawTime) : Date.now();
+
+  if (verbose) {
+    console.log(`[infoflow] Group chat extracted: fromuser=${fromuser}, groupid=${groupid}`);
+  }
+
+  if (!fromuser) {
+    if (verbose) {
+      console.log(`[infoflow] Group chat skipped: missing fromuser`);
+    }
+    return;
+  }
+
+  // Extract message content from body array or flat content field
+  const message = msgData.message as Record<string, unknown> | undefined;
+  const bodyItems = (message?.body ?? msgData.body ?? []) as InfoflowBodyItem[];
+
+  // Resolve account to get robotName for mention detection
+  const account = resolveInfoflowAccount({ cfg, accountId });
+  const robotName = account.config.robotName;
+
+  // Check if bot was @mentioned
+  const wasMentioned = checkBotMentioned(bodyItems, robotName);
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Group chat mention check: robotName=${robotName ?? "not configured"}, wasMentioned=${wasMentioned}`,
+    );
+  }
+
+  // Build two versions: mes (for CommandBody, no @xxx) and rawMes (for RawBody, with @xxx)
+  let textContent = "";
+  let rawTextContent = "";
+  if (Array.isArray(bodyItems)) {
+    for (const item of bodyItems) {
+      if (item.type === "TEXT") {
+        textContent += item.content ?? "";
+        rawTextContent += item.content ?? "";
+      } else if (item.type === "LINK") {
+        const label = item.label ?? "";
+        if (label) {
+          textContent += ` ${label} `;
+          rawTextContent += ` ${label} `;
+        }
+      } else if (item.type === "AT") {
+        // AT elements only go into rawTextContent, not textContent
+        const name = item.name ?? "";
+        if (name) {
+          rawTextContent += `@${name} `;
+        }
+      }
+    }
+  }
+
+  const mes = textContent.trim() || String(msgData.content ?? msgData.text ?? "");
+  const rawMes = rawTextContent.trim() || mes;
+
+  if (!mes) {
+    if (verbose) {
+      console.log(`[infoflow] Group chat skipped: empty message content`);
+    }
+    return;
+  }
+
+  // Extract sender name from header or fallback to fromuser
+  const senderName = String(header?.username ?? header?.nickname ?? msgData.username ?? fromuser);
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Group chat content: senderName=${senderName}, mes=${mes.slice(0, 50)}...`,
+    );
+  }
+
+  // Delegate to the common message handler (group chat)
+  await handleInfoflowMessage({
+    cfg,
+    event: {
+      fromuser,
+      mes,
+      rawMes,
+      chatType: "group",
+      groupId: groupid,
+      senderName,
+      wasMentioned,
+      messageId: messageIdStr,
+      timestamp,
+    },
+    accountId,
+    statusSink,
+  });
+}
+
+/**
+ * Resolves route, builds envelope, records session meta, and dispatches reply for one incoming Infoflow message.
+ * Called from monitor after webhook request is validated.
+ */
+export async function handleInfoflowMessage(params: HandleInfoflowMessageParams): Promise<void> {
+  const { cfg, event, accountId, statusSink } = params;
+  const { fromuser, mes, chatType, groupId, senderName } = event;
+
+  const account = resolveInfoflowAccount({ cfg, accountId });
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+
+  if (verbose) {
+    console.log(
+      `[infoflow] handleInfoflowMessage: chatType=${chatType}, fromuser=${fromuser}, groupId=${groupId || "N/A"}`,
+    );
+  }
+
+  const isGroup = chatType === "group";
+  // Convert groupId (number) to string for peerId since routing expects string
+  const peerId = isGroup ? (groupId !== undefined ? String(groupId) : fromuser) : fromuser;
+
+  // Resolve route based on chat type
+  const route = core.channel.routing.resolveAgentRoute({
+    cfg,
+    channel: "infoflow",
+    accountId: account.accountId,
+    peer: {
+      kind: isGroup ? "group" : "dm",
+      id: peerId,
+    },
+  });
+
+  const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+    agentId: route.agentId,
+  });
+  const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
+  const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+
+  // Build conversation label and from address based on chat type
+  const fromLabel = isGroup ? `group:${groupId}` : senderName || fromuser;
+  const fromAddress = isGroup ? `infoflow:group:${groupId}` : `infoflow:${fromuser}`;
+  const toAddress = isGroup ? `infoflow:${groupId}` : `infoflow:${account.accountId}`;
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Route resolved: agentId=${route.agentId}, sessionKey=${route.sessionKey}`,
+    );
+    console.log(`[infoflow] Address: From=${fromAddress}, To=${toAddress}`);
+  }
+
+  const body = core.channel.reply.formatAgentEnvelope({
+    channel: "Infoflow",
+    from: fromLabel,
+    timestamp: Date.now(),
+    previousTimestamp,
+    envelope: envelopeOptions,
+    body: mes,
+  });
+
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: body,
+    RawBody: event.rawMes ?? mes,
+    CommandBody: mes,
+    From: fromAddress,
+    To: toAddress,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: chatType,
+    ConversationLabel: fromLabel,
+    GroupSubject: isGroup ? `group:${groupId}` : undefined,
+    SenderName: senderName || fromuser,
+    SenderId: fromuser,
+    Provider: "infoflow",
+    Surface: "infoflow",
+    MessageSid: event.messageId ?? `${Date.now()}`,
+    Timestamp: event.timestamp ?? Date.now(),
+    OriginatingChannel: "infoflow",
+    OriginatingTo: toAddress,
+    WasMentioned: isGroup ? event.wasMentioned : undefined,
+    CommandAuthorized: true,
+  });
+
+  if (verbose) {
+    console.log("======ctxPayload======");
+    console.log(ctxPayload);
+  }
+  // Record session using recordInboundSession for proper session tracking
+  await core.channel.session.recordInboundSession({
+    storePath,
+    sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+    ctx: ctxPayload,
+    onRecordError: (err) => {
+      if (verbose) {
+        console.error(`[infoflow] failed updating session meta: ${String(err)}`);
+      }
+    },
+  });
+
+  // Mention gating: skip reply if requireMention is enabled and bot was not mentioned
+  // Session is already recorded above for context history
+  if (isGroup) {
+    const requireMention = account.config.requireMention !== false;
+    const canDetectMention = Boolean(account.config.robotName);
+    const wasMentioned = event.wasMentioned === true;
+
+    if (requireMention && canDetectMention && !wasMentioned) {
+      if (verbose) {
+        console.log(
+          `[infoflow] Group message recorded but reply skipped: requireMention=true, wasMentioned=false`,
+        );
+      }
+      return;
+    }
+  }
+
+  const { dispatcherOptions, replyOptions } = createInfoflowReplyDispatcher({
+    cfg,
+    agentId: route.agentId,
+    accountId: account.accountId,
+    fromuser,
+    chatType,
+    groupId,
+    statusSink,
+  });
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Dispatching to OpenClaw: agentId=${route.agentId}, Body=${ctxPayload.Body?.slice(0, 100)}...`,
+    );
+  }
+
+  await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    ctx: ctxPayload,
+    cfg,
+    dispatcherOptions,
+    replyOptions,
+  });
+
+  if (verbose) {
+    console.log(`[infoflow] Dispatch completed for ${chatType} message from ${fromuser}`);
+  }
+}

--- a/extensions/infoflow/src/channel.ts
+++ b/extensions/infoflow/src/channel.ts
@@ -1,0 +1,381 @@
+import {
+  applyAccountNameToChannelSection,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  migrateBaseNameToDefaultAccount,
+  normalizeAccountId,
+  setAccountEnabledInConfigSection,
+  type ChannelPlugin,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk";
+import type { InfoflowAccountConfig, InfoflowAtOptions, ResolvedInfoflowAccount } from "./types.js";
+import { startInfoflowMonitor } from "./monitor.js";
+import { getInfoflowRuntime } from "./runtime.js";
+import { sendInfoflowPrivateMessage, sendInfoflowGroupMessage } from "./send.js";
+
+// Re-export types for external consumers
+export type { InfoflowAccountConfig, ResolvedInfoflowAccount } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Account resolution helpers
+// ---------------------------------------------------------------------------
+
+function getChannelSection(cfg: OpenClawConfig): InfoflowAccountConfig | undefined {
+  return cfg.channels?.["infoflow"] as InfoflowAccountConfig | undefined;
+}
+
+function listInfoflowAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = getChannelSection(cfg)?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  const ids = Object.keys(accounts).filter(Boolean);
+  return ids.length === 0 ? [DEFAULT_ACCOUNT_ID] : ids.toSorted((a, b) => a.localeCompare(b));
+}
+
+function resolveDefaultInfoflowAccountId(cfg: OpenClawConfig): string {
+  const channel = getChannelSection(cfg);
+  if (channel?.defaultAccount?.trim()) {
+    return channel.defaultAccount.trim();
+  }
+  const ids = listInfoflowAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function mergeInfoflowAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): {
+  apiHost: string;
+  check_token: string;
+  encodingAESKey: string;
+  appKey: string;
+  appSecret: string;
+  enabled?: boolean;
+  name?: string;
+  robotName?: string;
+  requireMention?: boolean;
+} {
+  const raw = getChannelSection(cfg) ?? {};
+  const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
+  const account = raw.accounts?.[accountId] ?? {};
+  return { ...base, ...account } as {
+    apiHost: string;
+    check_token: string;
+    encodingAESKey: string;
+    appKey: string;
+    appSecret: string;
+    enabled?: boolean;
+    name?: string;
+    robotName?: string;
+    requireMention?: boolean;
+  };
+}
+
+export function resolveInfoflowAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedInfoflowAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const baseEnabled = getChannelSection(params.cfg)?.enabled !== false;
+  const merged = mergeInfoflowAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const apiHost = merged.apiHost ?? "";
+  const check_token = merged.check_token ?? "";
+  const encodingAESKey = merged.encodingAESKey ?? "";
+  const appKey = merged.appKey ?? "";
+  const appSecret = merged.appSecret ?? "";
+  const configured = Boolean(check_token) && Boolean(appKey) && Boolean(appSecret);
+
+  return {
+    accountId,
+    name: merged.name?.trim() || undefined,
+    enabled,
+    configured,
+    config: {
+      enabled: merged.enabled,
+      name: merged.name,
+      apiHost,
+      check_token,
+      encodingAESKey,
+      appKey,
+      appSecret,
+      robotName: merged.robotName?.trim() || undefined,
+      requireMention: merged.requireMention,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Channel plugin
+// ---------------------------------------------------------------------------
+
+export const infoflowPlugin: ChannelPlugin<ResolvedInfoflowAccount> = {
+  id: "infoflow",
+  meta: {
+    id: "infoflow",
+    label: "Infoflow",
+    selectionLabel: "Infoflow (如流)",
+    docsPath: "/channels/infoflow",
+    blurb: "Baidu Infoflow enterprise messaging platform.",
+    showConfigured: true,
+  },
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    nativeCommands: true,
+  },
+  reload: { configPrefixes: ["channels.infoflow"] },
+  config: {
+    listAccountIds: (cfg) => listInfoflowAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveInfoflowAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultInfoflowAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "infoflow",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "infoflow",
+        accountId,
+        clearBaseFields: ["check_token", "encodingAESKey", "appKey", "appSecret", "name"],
+      }),
+    isConfigured: (account) => account.configured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+    }),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const channelCfg = getChannelSection(cfg);
+      const useAccountPath = Boolean(channelCfg?.accounts?.[resolvedAccountId]);
+      const basePath = useAccountPath
+        ? `channels.infoflow.accounts.${resolvedAccountId}.`
+        : "channels.infoflow.";
+
+      return {
+        policy: ((account.config as Record<string, unknown>).dmPolicy as string) ?? "open",
+        allowFrom: ((account.config as Record<string, unknown>).allowFrom as string[]) ?? [],
+        policyPath: `${basePath}dmPolicy`,
+        allowFromPath: basePath,
+        normalizeEntry: (raw: string) => raw.replace(/^infoflow:/i, ""),
+      };
+    },
+    collectWarnings: ({ account, cfg }) => {
+      const warnings: string[] = [];
+      const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
+      const groupPolicy =
+        ((account.config as Record<string, unknown>).groupPolicy as string) ??
+        defaultGroupPolicy ??
+        "open";
+
+      if (groupPolicy === "open") {
+        warnings.push(
+          `- Infoflow groups: groupPolicy="open" allows any group to trigger. Consider setting channels.infoflow.groupPolicy="allowlist".`,
+        );
+      }
+      return warnings;
+    },
+  },
+  groups: {
+    resolveRequireMention: ({ cfg, accountId }) => {
+      const channelCfg = getChannelSection(cfg);
+      const accountCfg =
+        accountId && accountId !== DEFAULT_ACCOUNT_ID
+          ? channelCfg?.accounts?.[accountId]
+          : channelCfg;
+      return (accountCfg as Record<string, unknown> | undefined)?.requireMention !== false;
+    },
+    resolveToolPolicy: () => {
+      // Return undefined to use global policy
+      return undefined;
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "infoflow",
+        accountId,
+        name,
+      }),
+    validateInput: ({ input }) => {
+      if (!input.token) {
+        return "Infoflow requires --token (check_token).";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "infoflow",
+        accountId,
+        name: input.name,
+      });
+      const next =
+        accountId !== DEFAULT_ACCOUNT_ID
+          ? migrateBaseNameToDefaultAccount({ cfg: namedConfig, channelKey: "infoflow" })
+          : namedConfig;
+
+      const patch: Record<string, unknown> = {};
+      if (input.token) {
+        patch.check_token = input.token;
+      }
+
+      const existing = (next.channels?.["infoflow"] ?? {}) as Record<string, unknown>;
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            infoflow: {
+              ...existing,
+              enabled: true,
+              ...patch,
+            },
+          },
+        } as OpenClawConfig;
+      }
+      const existingAccounts = (existing.accounts ?? {}) as Record<string, Record<string, unknown>>;
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          infoflow: {
+            ...existing,
+            enabled: true,
+            accounts: {
+              ...existingAccounts,
+              [accountId]: {
+                ...existingAccounts[accountId],
+                enabled: true,
+                ...patch,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunkerMode: "text",
+    textChunkLimit: 4000,
+    chunker: (text, limit) => getInfoflowRuntime().channel.text.chunkText(text, limit),
+    sendText: async ({ cfg, to, text, accountId }) => {
+      const account = resolveInfoflowAccount({ cfg, accountId });
+      const { apiHost, appKey, appSecret } = account.config;
+
+      if (!appKey || !appSecret) {
+        throw new Error("Infoflow appKey/appSecret not configured.");
+      }
+
+      const target = to.replace(/^infoflow:/i, "");
+
+      // Check if target is a group (format: group:123 or group:123?at=user1,user2 or group:123?atall=true)
+      const groupMatch = target.match(/^group:(\d+)/i);
+      if (groupMatch) {
+        const groupId = Number(groupMatch[1]);
+
+        // Parse AT options from query string
+        let atOptions: InfoflowAtOptions | undefined;
+        const atAllMatch = target.match(/[?&]atall=true/i);
+        const atMatch = target.match(/[?&]at=([^&]+)/);
+        if (atAllMatch) {
+          atOptions = { atAll: true };
+        } else if (atMatch) {
+          const atUserIds = atMatch[1]
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          if (atUserIds.length > 0) {
+            atOptions = { atUserIds };
+          }
+        }
+
+        const result = await sendInfoflowGroupMessage({
+          apiHost,
+          appKey,
+          appSecret,
+          groupId,
+          content: text,
+          atOptions,
+        });
+        return {
+          channel: "infoflow",
+          messageId: result.ok ? (result.messageid ?? "sent") : "failed",
+        };
+      }
+
+      // Private message (DM)
+      const result = await sendInfoflowPrivateMessage({
+        apiHost,
+        appKey,
+        appSecret,
+        touser: target,
+        content: text,
+      });
+      return { channel: "infoflow", messageId: result.ok ? (result.msgkey ?? "sent") : "failed" };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    buildAccountSnapshot: ({ account, runtime }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+    }),
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.log?.info(`[${account.accountId}] starting Infoflow webhook`);
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: true,
+        lastStartAt: Date.now(),
+      });
+      const unregister = await startInfoflowMonitor({
+        account,
+        config: ctx.cfg,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
+      });
+      return () => {
+        unregister?.();
+        ctx.setStatus({
+          accountId: account.accountId,
+          running: false,
+          lastStopAt: Date.now(),
+        });
+      };
+    },
+  },
+};

--- a/extensions/infoflow/src/infoflow_req_parse.ts
+++ b/extensions/infoflow/src/infoflow_req_parse.ts
@@ -1,0 +1,534 @@
+import type { IncomingMessage } from "node:http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { createHash, createDecipheriv } from "node:crypto";
+import type { ResolvedInfoflowAccount } from "./channel.js";
+import { handlePrivateChatMessage, handleGroupChatMessage } from "./bot.js";
+
+// ---------------------------------------------------------------------------
+// Message deduplication
+// ---------------------------------------------------------------------------
+
+const DEDUP_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const DEDUP_MAX_SIZE = 1000;
+
+const messageCache = new Map<string, number>(); // key → timestamp
+
+/**
+ * Extracts a dedup key from the decrypted message data.
+ *
+ * Priority:
+ *   1. message.header.messageid || message.header.msgid || MsgId
+ *   2. fallback: "{fromuserid}_{groupid}_{ctime}"
+ */
+function extractDedupeKey(msgData: Record<string, unknown>): string | null {
+  const message = msgData.message as Record<string, unknown> | undefined;
+  const header = (message?.header ?? {}) as Record<string, unknown>;
+
+  // Priority 1: explicit message ID
+  const msgId = header.messageid ?? header.msgid ?? msgData.MsgId;
+  if (msgId != null) {
+    return String(msgId);
+  }
+
+  // Priority 2: composite key
+  const fromuserid = header.fromuserid ?? msgData.FromUserId ?? msgData.fromuserid;
+  const groupid = msgData.groupid ?? header.groupid;
+  const ctime = header.ctime ?? Date.now();
+  if (fromuserid != null) {
+    return `${fromuserid}_${groupid ?? "dm"}_${ctime}`;
+  }
+
+  return null;
+}
+
+/**
+ * Returns true if the message is a duplicate (already seen within TTL).
+ * If new, records it in cache. Prunes expired + oversized entries.
+ */
+function isDuplicateMessage(msgData: Record<string, unknown>): boolean {
+  const key = extractDedupeKey(msgData);
+  if (!key) return false; // 无法提取 key 则放行
+
+  const now = Date.now();
+
+  // Check existing
+  const existing = messageCache.get(key);
+  if (existing !== undefined && now - existing < DEDUP_TTL_MS) {
+    return true;
+  }
+
+  // Record new
+  messageCache.delete(key); // 确保插入到 Map 尾部
+  messageCache.set(key, now);
+
+  // Prune expired
+  for (const [k, ts] of messageCache) {
+    if (now - ts >= DEDUP_TTL_MS) {
+      messageCache.delete(k);
+    } else {
+      break; // Map 按插入顺序，后面的更新
+    }
+  }
+
+  // Prune oversized
+  while (messageCache.size > DEDUP_MAX_SIZE) {
+    const oldest = messageCache.keys().next().value;
+    if (oldest) messageCache.delete(oldest);
+    else break;
+  }
+
+  return false;
+}
+
+/**
+ * Records a sent message ID in the dedup cache.
+ * Called after successfully sending a message to prevent
+ * the bot from processing its own outbound messages as inbound.
+ */
+export function recordSentMessageId(messageId: string | number): void {
+  if (messageId == null) return;
+  const key = String(messageId);
+  const now = Date.now();
+
+  messageCache.delete(key);
+  messageCache.set(key, now);
+
+  // Prune oversized
+  while (messageCache.size > DEDUP_MAX_SIZE) {
+    const oldest = messageCache.keys().next().value;
+    if (oldest) messageCache.delete(oldest);
+    else break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AES-ECB Decryption Utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Decodes a Base64 URLSafe encoded string to a Buffer.
+ * Handles the URL-safe alphabet (- → +, _ → /) and auto-pads with '='.
+ */
+function base64UrlSafeDecode(s: string): Buffer {
+  const base64 = s.replace(/-/g, "+").replace(/_/g, "/");
+  const padLen = (4 - (base64.length % 4)) % 4;
+  return Buffer.from(base64 + "=".repeat(padLen), "base64");
+}
+
+/**
+ * Decrypts an AES-ECB encrypted message.
+ * @param encryptedMsg - Base64 URLSafe encoded ciphertext
+ * @param encodingAESKey - Base64 URLSafe encoded AES key (supports 16/24/32 byte keys)
+ * @returns Decrypted UTF-8 string
+ */
+function decryptMessage(encryptedMsg: string, encodingAESKey: string): string {
+  const aesKey = base64UrlSafeDecode(encodingAESKey);
+  const cipherText = base64UrlSafeDecode(encryptedMsg);
+
+  // Select AES algorithm based on key length
+  let algorithm: string;
+  switch (aesKey.length) {
+    case 16:
+      algorithm = "aes-128-ecb";
+      break;
+    case 24:
+      algorithm = "aes-192-ecb";
+      break;
+    case 32:
+      algorithm = "aes-256-ecb";
+      break;
+    default:
+      throw new Error(`Invalid AES key length: ${aesKey.length} bytes (expected 16, 24, or 32)`);
+  }
+
+  // ECB mode does not use an IV (pass null)
+  const decipher = createDecipheriv(algorithm, aesKey, null);
+  const decrypted = Buffer.concat([decipher.update(cipherText), decipher.final()]);
+  return decrypted.toString("utf8");
+}
+
+/**
+ * Parses an XML message string into a key-value object.
+ * Handles simple XML structures like <xml><Tag>value</Tag></xml>.
+ */
+function parseXmlMessage(xmlString: string): Record<string, string> | null {
+  try {
+    const result: Record<string, string> = {};
+    // Match <TagName>content</TagName> patterns
+    const tagRegex = /<(\w+)>(?:<!\[CDATA\[([\s\S]*?)\]\]>|([^<]*))<\/\1>/g;
+    let match;
+    while ((match = tagRegex.exec(xmlString)) !== null) {
+      const tagName = match[1];
+      // CDATA content or plain text content
+      const content = match[2] ?? match[3] ?? "";
+      result[tagName] = content.trim();
+    }
+    return Object.keys(result).length > 0 ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type InfoflowCoreRuntime = {
+  logging: { shouldLogVerbose(): boolean };
+};
+
+export type WebhookTarget = {
+  account: ResolvedInfoflowAccount;
+  config: OpenClawConfig;
+  core: InfoflowCoreRuntime;
+  path: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+export type ParsedInfoflowMessage = {
+  fromuser: string;
+  mes: string;
+  chatType: "dm" | "group";
+};
+
+export type ParseResult = { handled: true; statusCode: number; body: string } | { handled: false };
+
+// ---------------------------------------------------------------------------
+// Body readers
+// ---------------------------------------------------------------------------
+
+const MAX_BODY_SIZE = 20 * 1024 * 1024; // 20 MB
+
+/** Reads raw body as a string from the request stream; enforces max size. */
+export async function readRawBody(
+  req: IncomingMessage,
+  maxBytes = MAX_BODY_SIZE,
+): Promise<{ ok: true; raw: string } | { ok: false; error: string }> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let done = false;
+  return await new Promise((resolve) => {
+    req.on("data", (chunk: Buffer) => {
+      if (done) return;
+      total += chunk.length;
+      if (total > maxBytes) {
+        done = true;
+        resolve({ ok: false, error: "payload too large" });
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (done) return;
+      done = true;
+      const raw = Buffer.concat(chunks).toString("utf8");
+      resolve({ ok: true, raw });
+    });
+    req.on("error", (err) => {
+      if (done) return;
+      done = true;
+      resolve({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses and dispatches an incoming Infoflow webhook request.
+ *
+ * 1. Parses Content-Type header once.
+ * 2. form-urlencoded:
+ *    - echostr present → signature verification → 200/403
+ *    - messageJson present → private chat (dm) handling
+ * 3. text/plain → group chat handling (raw body is encrypted ciphertext)
+ * 4. Other Content-Type → 400
+ *
+ * Returns a ParseResult indicating whether the request was handled and the response to send.
+ */
+export async function parseAndDispatchInfoflowRequest(
+  req: IncomingMessage,
+  rawBody: string,
+  targets: WebhookTarget[],
+): Promise<ParseResult> {
+  const verbose = targets[0]?.core?.logging?.shouldLogVerbose?.() ?? false;
+
+  // --- 1. Parse all needed headers once ---
+  const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
+
+  if (verbose) {
+    console.log(
+      `[infoflow] parseAndDispatch: contentType=${contentType}, bodyLen=${rawBody.length}`,
+    );
+  }
+
+  // --- 2. form-urlencoded: echostr verification + private chat ---
+  if (contentType.startsWith("application/x-www-form-urlencoded")) {
+    if (verbose) {
+      console.log(`[infoflow] handling form-urlencoded request`);
+    }
+    const form = new URLSearchParams(rawBody);
+
+    // 2a. echostr signature verification (try all accounts' tokens for multi-account support)
+    const echostr = form.get("echostr") ?? "";
+    if (echostr) {
+      if (verbose) {
+        console.log(`[infoflow] echostr verification request`);
+      }
+      const signature = form.get("signature") ?? "";
+      const timestamp = form.get("timestamp") ?? "";
+      const rn = form.get("rn") ?? "";
+      for (const target of targets) {
+        const checkToken = target.account.config.check_token ?? "";
+        if (!checkToken) continue;
+        const expectedSig = createHash("md5")
+          .update(`${rn}${timestamp}${checkToken}`)
+          .digest("hex");
+        if (signature === expectedSig) {
+          if (verbose) {
+            console.log(`[infoflow] echostr verified, returning echostr`);
+          }
+          return { handled: true, statusCode: 200, body: echostr };
+        }
+      }
+      console.error(`[infoflow] echostr signature mismatch`);
+      return { handled: true, statusCode: 403, body: "Invalid signature" };
+    }
+
+    // 2b. private chat message (messageJson field in form)
+    const messageJsonStr = form.get("messageJson") ?? "";
+    if (messageJsonStr) {
+      if (verbose) {
+        console.log(`[infoflow] private chat message detected, dispatching...`);
+      }
+      return handlePrivateMessage(messageJsonStr, targets, verbose);
+    }
+
+    console.error(`[infoflow] form-urlencoded but missing echostr or messageJson`);
+    return { handled: true, statusCode: 400, body: "missing echostr or messageJson" };
+  }
+
+  // --- 3. text/plain: group chat ---
+  if (contentType.startsWith("text/plain")) {
+    if (verbose) {
+      console.log(`[infoflow] group chat message detected, dispatching...`);
+    }
+    return handleGroupMessage(rawBody, targets, verbose);
+  }
+
+  // --- 4. unsupported Content-Type ---
+  console.error(`[infoflow] unsupported contentType: ${contentType}`);
+  return { handled: true, statusCode: 400, body: "unsupported content type" };
+}
+
+// ---------------------------------------------------------------------------
+// Private chat handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles a private (dm) chat message.
+ *
+ * messageJsonStr is the value of the `messageJson` form field,
+ * a JSON string in the shape `{ Encrypt: "..." }`.
+ *
+ * Decrypts the Encrypt field with encodingAESKey (AES-ECB),
+ * parses the decrypted content, then dispatches to bot.ts.
+ */
+function handlePrivateMessage(
+  messageJsonStr: string,
+  targets: WebhookTarget[],
+  verbose: boolean,
+): ParseResult {
+  if (targets.length === 0) {
+    console.error(`[infoflow] private: no target configured`);
+    return { handled: true, statusCode: 500, body: "no target configured" };
+  }
+
+  let messageJson: Record<string, unknown>;
+  try {
+    messageJson = JSON.parse(messageJsonStr) as Record<string, unknown>;
+  } catch {
+    console.error(`[infoflow] private: invalid messageJson`);
+    return { handled: true, statusCode: 400, body: "invalid messageJson" };
+  }
+
+  const encrypt = typeof messageJson.Encrypt === "string" ? messageJson.Encrypt : "";
+  if (!encrypt) {
+    console.error(`[infoflow] private: missing Encrypt field`);
+    return { handled: true, statusCode: 400, body: "missing Encrypt field in messageJson" };
+  }
+
+  if (verbose) {
+    console.log(`[infoflow] private: trying ${targets.length} account(s) for decryption`);
+  }
+
+  // Try each account's key until decryption succeeds (multi-account support)
+  for (const target of targets) {
+    const { encodingAESKey } = target.account.config;
+    if (!encodingAESKey) {
+      if (verbose) {
+        console.log(`[infoflow] private: account ${target.account.accountId} has no AES key, skip`);
+      }
+      continue;
+    }
+
+    let decryptedContent: string;
+    try {
+      decryptedContent = decryptMessage(encrypt, encodingAESKey);
+      if (verbose) {
+        console.log(
+          `[infoflow] private: decryption success for account ${target.account.accountId}`,
+        );
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(
+          `[infoflow] private: decryption failed for account ${target.account.accountId}: ${String(err)}`,
+        );
+      }
+      continue; // Try next account
+    }
+
+    // Parse decrypted content as JSON or XML
+    let msgData: Record<string, unknown> | null = null;
+    try {
+      msgData = JSON.parse(decryptedContent) as Record<string, unknown>;
+      if (verbose) {
+        console.log(`[infoflow] private: parsed as JSON`);
+      }
+    } catch {
+      msgData = parseXmlMessage(decryptedContent);
+      if (verbose) {
+        console.log(`[infoflow] private: parsed as XML, result=${msgData ? "ok" : "null"}`);
+      }
+    }
+
+    if (msgData && Object.keys(msgData).length > 0) {
+      if (isDuplicateMessage(msgData)) {
+        if (verbose) {
+          console.log(`[infoflow] private: duplicate message, skipping`);
+        }
+        return { handled: true, statusCode: 200, body: "success" };
+      }
+
+      if (verbose) {
+        console.log(`[infoflow] private: dispatching to handlePrivateChatMessage`);
+      }
+
+      target.statusSink?.({ lastInboundAt: Date.now() });
+
+      void handlePrivateChatMessage({
+        cfg: target.config,
+        msgData,
+        accountId: target.account.accountId,
+        statusSink: target.statusSink,
+      });
+
+      return { handled: true, statusCode: 200, body: "success" };
+    }
+  }
+
+  console.error(`[infoflow] private: decryption failed for all accounts`);
+  return { handled: true, statusCode: 500, body: "decryption failed for all accounts" };
+}
+
+// ---------------------------------------------------------------------------
+// Group chat handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles a group chat message.
+ *
+ * The rawBody itself is an AES-encrypted ciphertext (Base64URLSafe encoded).
+ * After decryption it yields a JSON object with group message fields.
+ *
+ * Decrypts rawBody with encodingAESKey (AES-ECB),
+ * parses the result, then dispatches to bot.ts.
+ */
+function handleGroupMessage(
+  rawBody: string,
+  targets: WebhookTarget[],
+  verbose: boolean,
+): ParseResult {
+  if (targets.length === 0) {
+    console.error(`[infoflow] group: no target configured`);
+    return { handled: true, statusCode: 500, body: "no target configured" };
+  }
+  if (!rawBody.trim()) {
+    console.error(`[infoflow] group: empty body`);
+    return { handled: true, statusCode: 400, body: "empty body" };
+  }
+
+  if (verbose) {
+    console.log(`[infoflow] group: trying ${targets.length} account(s) for decryption`);
+  }
+
+  // Try each account's key until decryption succeeds (multi-account support)
+  for (const target of targets) {
+    const { encodingAESKey } = target.account.config;
+    if (!encodingAESKey) {
+      if (verbose) {
+        console.log(`[infoflow] group: account ${target.account.accountId} has no AES key, skip`);
+      }
+      continue;
+    }
+
+    let decryptedContent: string;
+    try {
+      decryptedContent = decryptMessage(rawBody, encodingAESKey);
+      if (verbose) {
+        console.log(`[infoflow] group: decryption success for account ${target.account.accountId}`);
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(
+          `[infoflow] group: decryption failed for account ${target.account.accountId}: ${String(err)}`,
+        );
+      }
+      continue; // Try next account
+    }
+
+    let msgData: Record<string, unknown>;
+    try {
+      msgData = JSON.parse(decryptedContent) as Record<string, unknown>;
+      if (verbose) {
+        console.log(`[infoflow] group: parsed JSON successfully`);
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(`[infoflow] group: JSON parse failed: ${String(err)}`);
+      }
+      continue; // Try next account
+    }
+
+    if (msgData && Object.keys(msgData).length > 0) {
+      if (isDuplicateMessage(msgData)) {
+        if (verbose) {
+          console.log(`[infoflow] group: duplicate message, skipping`);
+        }
+        return { handled: true, statusCode: 200, body: "success" };
+      }
+
+      if (verbose) {
+        console.log(`[infoflow] group: dispatching to handleGroupChatMessage`);
+      }
+
+      target.statusSink?.({ lastInboundAt: Date.now() });
+
+      void handleGroupChatMessage({
+        cfg: target.config,
+        msgData,
+        accountId: target.account.accountId,
+        statusSink: target.statusSink,
+      });
+
+      return { handled: true, statusCode: 200, body: "success" };
+    }
+  }
+
+  console.error(`[infoflow] group: decryption failed for all accounts`);
+  return { handled: true, statusCode: 500, body: "decryption failed for all accounts" };
+}

--- a/extensions/infoflow/src/monitor.ts
+++ b/extensions/infoflow/src/monitor.ts
@@ -1,0 +1,184 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ResolvedInfoflowAccount } from "./channel.js";
+import {
+  parseAndDispatchInfoflowRequest,
+  loadRawBody,
+  type WebhookTarget,
+} from "./infoflow_req_parse.js";
+import { getInfoflowRuntime } from "./runtime.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type InfoflowCoreRuntime = ReturnType<typeof getInfoflowRuntime>;
+
+export type InfoflowMonitorOptions = {
+  account: ResolvedInfoflowAccount;
+  config: OpenClawConfig;
+  runtime: unknown;
+  abortSignal: AbortSignal;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** webhook path for Infoflow. */
+const INFOFLOW_WEBHOOK_PATH = "/webhook/infoflow";
+
+// ---------------------------------------------------------------------------
+// Webhook target registry
+// ---------------------------------------------------------------------------
+
+const webhookTargets = new Map<string, WebhookTarget[]>();
+
+/** Normalizes a webhook path: trim, ensure leading slash, strip trailing slash (except "/"). */
+function normalizeWebhookPath(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "/";
+  }
+  const withSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  if (withSlash.length > 1 && withSlash.endsWith("/")) {
+    return withSlash.slice(0, -1);
+  }
+  return withSlash;
+}
+
+/** Registers a webhook target for a path. Returns an unregister function to remove it. */
+function registerInfoflowWebhookTarget(target: WebhookTarget): () => void {
+  const key = normalizeWebhookPath(target.path);
+  const normalizedTarget = { ...target, path: key };
+  const existing = webhookTargets.get(key) ?? [];
+  const next = [...existing, normalizedTarget];
+  webhookTargets.set(key, next);
+  return () => {
+    const updated = (webhookTargets.get(key) ?? []).filter((entry) => entry !== normalizedTarget);
+    if (updated.length > 0) {
+      webhookTargets.set(key, updated);
+    } else {
+      webhookTargets.delete(key);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler (registered via api.registerHttpHandler)
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks if the request path matches a registered Infoflow webhook path.
+ */
+function isInfoflowPath(requestPath: string): boolean {
+  const normalized = normalizeWebhookPath(requestPath);
+  return webhookTargets.has(normalized);
+}
+
+/**
+ * Handles incoming Infoflow webhook HTTP requests.
+ *
+ * - Routes by path to registered targets (supports exact and suffix match).
+ * - Only allows POST.
+ * - Delegates body reading, echostr verification, authentication,
+ *   and message dispatch to infoflow_req_parse.
+ */
+export async function handleInfoflowWebhookRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const requestPath = normalizeWebhookPath(url.pathname);
+
+  if (verbose) {
+    console.log(`[infoflow] webhook request: method=${req.method}, path=${requestPath}`);
+  }
+
+  // Check if path matches Infoflow webhook pattern
+  if (!isInfoflowPath(requestPath)) {
+    if (verbose) {
+      console.log(`[infoflow] path not matched, skipping`);
+    }
+    return false;
+  }
+
+  // Get registered targets for the actual request path
+  const targets = webhookTargets.get(requestPath);
+  if (!targets || targets.length === 0) {
+    if (verbose) {
+      console.log(`[infoflow] no targets registered for path=${requestPath}`);
+    }
+    return false;
+  }
+
+  if (verbose) {
+    console.log(`[infoflow] found ${targets.length} target(s) for path=${requestPath}`);
+  }
+
+  if (req.method !== "POST") {
+    if (verbose) {
+      console.log(`[infoflow] rejected: method ${req.method} not allowed`);
+    }
+    res.statusCode = 405;
+    res.setHeader("Allow", "POST");
+    res.end("Method Not Allowed");
+    return true;
+  }
+
+  // Read raw body once
+  if (verbose) {
+    console.log(`[infoflow] reading request body...`);
+  }
+  const bodyResult = await loadRawBody(req);
+  if (!bodyResult.ok) {
+    console.error(`[infoflow] failed to read body: ${bodyResult.error}`);
+    res.statusCode = bodyResult.error === "payload too large" ? 413 : 400;
+    res.end(bodyResult.error);
+    return true;
+  }
+
+  if (verbose) {
+    console.log(`[infoflow] body read success, length=${bodyResult.raw.length}, dispatching...`);
+  }
+
+  const result = await parseAndDispatchInfoflowRequest(req, bodyResult.raw, targets);
+
+  if (verbose) {
+    console.log(
+      `[infoflow] dispatch result: handled=${result.handled}, status=${result.statusCode}`,
+    );
+  }
+
+  if (result.handled) {
+    res.statusCode = result.statusCode;
+    if (result.statusCode === 200 && result.body.startsWith("{")) {
+      res.setHeader("Content-Type", "application/json");
+    }
+    res.end(result.body);
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Monitor lifecycle
+// ---------------------------------------------------------------------------
+
+/** Registers this account's webhook target and returns an unregister (stop) function. */
+export async function startInfoflowMonitor(options: InfoflowMonitorOptions): Promise<() => void> {
+  const core = getInfoflowRuntime();
+
+  const unregister = registerInfoflowWebhookTarget({
+    account: options.account,
+    config: options.config,
+    core,
+    path: INFOFLOW_WEBHOOK_PATH,
+    statusSink: options.statusSink,
+  });
+
+  return unregister;
+}

--- a/extensions/infoflow/src/reply-dispatcher.ts
+++ b/extensions/infoflow/src/reply-dispatcher.ts
@@ -1,0 +1,114 @@
+import { createReplyPrefixOptions, type OpenClawConfig } from "openclaw/plugin-sdk";
+import type { InfoflowAtOptions } from "./types.js";
+import { resolveInfoflowAccount } from "./channel.js";
+import { recordSentMessageId } from "./infoflow_req_parse.js";
+import { getInfoflowRuntime } from "./runtime.js";
+import { sendInfoflowPrivateMessage, sendInfoflowGroupMessage } from "./send.js";
+
+export type CreateInfoflowReplyDispatcherParams = {
+  cfg: OpenClawConfig;
+  agentId: string;
+  accountId: string;
+  fromuser: string;
+  chatType: "direct" | "group";
+  groupId?: number;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  /** AT 选项，用于在群消息中 @成员 */
+  atOptions?: InfoflowAtOptions;
+};
+
+/**
+ * Builds dispatcherOptions and replyOptions for dispatchReplyWithBufferedBlockDispatcher.
+ * Encapsulates prefix options, chunked deliver (send via Infoflow API + statusSink), and onError.
+ */
+export function createInfoflowReplyDispatcher(params: CreateInfoflowReplyDispatcherParams) {
+  const { cfg, agentId, accountId, fromuser, chatType, groupId, statusSink, atOptions } = params;
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+  const account = resolveInfoflowAccount({ cfg, accountId });
+
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg,
+    agentId,
+    channel: "infoflow",
+    accountId,
+  });
+
+  const deliver = async (payload: { text?: string; mediaUrl?: string; mediaUrls?: string[] }) => {
+    const { apiHost, appKey, appSecret } = account.config;
+
+    if (!appKey || !appSecret) {
+      console.error(`[infoflow] Missing appKey or appSecret for account ${accountId}`);
+      return;
+    }
+
+    if (payload.text) {
+      // Chunk text to 4000 chars max (Infoflow limit)
+      const chunks = core.channel.text.chunkText(payload.text, 4000);
+
+      for (const chunk of chunks) {
+        let result: { ok: boolean; error?: string; messageid?: string; msgkey?: string };
+
+        if (chatType === "group" && groupId) {
+          // Send to group
+          if (verbose) {
+            console.log(`[infoflow] Delivering group message to ${groupId}`);
+          }
+          result = await sendInfoflowGroupMessage({
+            apiHost,
+            appKey,
+            appSecret,
+            groupId,
+            content: chunk,
+            atOptions,
+          });
+        } else {
+          // Send private message (DM)
+          if (verbose) {
+            console.log(`[infoflow] Delivering private message to ${fromuser}`);
+          }
+          result = await sendInfoflowPrivateMessage({
+            apiHost,
+            appKey,
+            appSecret,
+            touser: fromuser,
+            content: chunk,
+          });
+        }
+
+        if (result.ok) {
+          statusSink?.({ lastOutboundAt: Date.now() });
+          // Record sent message ID for dedup (prevent echo)
+          const sentId = result.messageid ?? result.msgkey;
+          if (sentId) {
+            recordSentMessageId(sentId);
+          }
+        } else if (result.error) {
+          console.error(`[infoflow] Failed to send message: ${result.error}`);
+        }
+      }
+    }
+
+    // TODO: Handle media attachments if needed
+    if (payload.mediaUrl || payload.mediaUrls?.length) {
+      if (verbose) {
+        console.log(`[infoflow] Media attachments not yet supported`);
+      }
+    }
+  };
+
+  const onError = (err: unknown) => {
+    console.error(`[infoflow] reply failed: ${String(err)}`);
+  };
+
+  return {
+    dispatcherOptions: {
+      ...prefixOptions,
+      deliver,
+      onError,
+    },
+    replyOptions: {
+      onModelSelected,
+    },
+  };
+}

--- a/extensions/infoflow/src/runtime.ts
+++ b/extensions/infoflow/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setInfoflowRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getInfoflowRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Infoflow runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/infoflow/src/send.ts
+++ b/extensions/infoflow/src/send.ts
@@ -1,0 +1,284 @@
+/**
+ * Outbound send API: POST messages to the Infoflow service.
+ * Supports both private (DM) and group chat messages.
+ */
+
+import { createHash } from "node:crypto";
+import type { InfoflowAtOptions, InfoflowGroupMessageBodyItem } from "./types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000; // 30 seconds
+
+/**
+ * Ensures apiHost uses HTTPS for security (secrets in transit).
+ * Allows HTTP only for localhost/127.0.0.1 (local development).
+ */
+function ensureHttps(apiHost: string): string {
+  if (apiHost.startsWith("http://")) {
+    const url = new URL(apiHost);
+    const isLocal = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+    if (!isLocal) {
+      return apiHost.replace(/^http:/, "https:");
+    }
+  }
+  return apiHost;
+}
+
+// Infoflow API paths (host is configured via apiHost in config)
+const INFOFLOW_AUTH_PATH = "/api/v1/auth/app_access_token";
+const INFOFLOW_PRIVATE_SEND_PATH = "/api/v1/app/message/send";
+const INFOFLOW_GROUP_SEND_PATH = "/api/v1/robot/msg/groupmsgsend";
+
+// Token cache to avoid fetching token for every message
+let tokenCache: { token: string; expiresAt: number } | null = null;
+
+// ---------------------------------------------------------------------------
+// Token Management
+// ---------------------------------------------------------------------------
+
+/**
+ * Gets the app access token from Infoflow API.
+ * Token is cached and reused until expiry.
+ */
+export async function getAppAccessToken(params: {
+  apiHost: string;
+  appKey: string;
+  appSecret: string;
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; token?: string; error?: string }> {
+  const { apiHost, appKey, appSecret, timeoutMs = DEFAULT_TIMEOUT_MS } = params;
+
+  // Check cache first
+  if (tokenCache && tokenCache.expiresAt > Date.now()) {
+    return { ok: true, token: tokenCache.token };
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    // app_secret needs to be MD5 hashed (lowercase)
+    const md5Secret = createHash("md5").update(appSecret).digest("hex").toLowerCase();
+
+    const res = await fetch(`${ensureHttps(apiHost)}${INFOFLOW_AUTH_PATH}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ app_key: appKey, app_secret: md5Secret }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!res.ok) {
+      return { ok: false, error: `HTTP ${res.status}` };
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+
+    if (data.errcode && data.errcode !== 0) {
+      const errMsg = String(data.errmsg ?? `errcode ${data.errcode}`);
+      return { ok: false, error: errMsg };
+    }
+
+    const dataField = data.data as { app_access_token?: string; expires_in?: number } | undefined;
+    const token = dataField?.app_access_token;
+    const expiresIn = dataField?.expires_in ?? 7200; // default 2 hours
+
+    if (!token) {
+      return { ok: false, error: "no token in response" };
+    }
+
+    // Cache token (with 5 minute buffer before expiry)
+    tokenCache = {
+      token,
+      expiresAt: Date.now() + (expiresIn - 300) * 1000,
+    };
+
+    return { ok: true, token };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: errMsg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private Chat (DM) Message Sending
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends a private (DM) message to a user.
+ * @param touser - Recipient's uuapName (email prefix), multiple users separated by |
+ * @param content - Message content
+ */
+export async function sendInfoflowPrivateMessage(params: {
+  apiHost: string;
+  appKey: string;
+  appSecret: string;
+  touser: string;
+  content: string;
+  msgtype?: "text" | "markdown";
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; error?: string; invaliduser?: string; msgkey?: string }> {
+  const {
+    apiHost,
+    appKey,
+    appSecret,
+    touser,
+    content,
+    msgtype = "text",
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = params;
+
+  // Get token first
+  const tokenResult = await getAppAccessToken({ apiHost, appKey, appSecret, timeoutMs });
+  if (!tokenResult.ok || !tokenResult.token) {
+    return { ok: false, error: tokenResult.error ?? "failed to get token" };
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    // Build payload based on message type
+    const payload: Record<string, unknown> = {
+      touser,
+      msgtype,
+    };
+    if (msgtype === "text") {
+      payload.text = { content };
+    } else if (msgtype === "markdown") {
+      payload.markdown = { content };
+    }
+
+    // Build headers with authorization
+    const headers = {
+      Authorization: `Bearer-${tokenResult.token}`,
+      "Content-Type": "application/json; charset=utf-8",
+      LOGID: String(Date.now() * 1000 + Math.floor(Math.random() * 1000)),
+    };
+
+    const res = await fetch(`${ensureHttps(apiHost)}${INFOFLOW_PRIVATE_SEND_PATH}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    const data = (await res.json()) as Record<string, unknown>;
+
+    // Check for error (errcode-based or code-based)
+    if (data.errcode && data.errcode !== 0) {
+      const errMsg = String(data.errmsg ?? `errcode ${data.errcode}`);
+      return { ok: false, error: errMsg, invaliduser: data.invaliduser as string | undefined };
+    }
+
+    const innerData = data.data as { msgkey?: number | string } | undefined;
+    const msgkey = innerData?.msgkey != null ? String(innerData.msgkey) : undefined;
+    return { ok: true, invaliduser: data.invaliduser as string | undefined, msgkey };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: errMsg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Group Chat Message Sending
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends a group chat message.
+ * @param groupId - Target group ID (numeric)
+ * @param content - Message content
+ */
+export async function sendInfoflowGroupMessage(params: {
+  apiHost: string;
+  appKey: string;
+  appSecret: string;
+  groupId: number;
+  content: string;
+  atOptions?: InfoflowAtOptions;
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; error?: string; messageid?: string }> {
+  const {
+    apiHost,
+    appKey,
+    appSecret,
+    groupId,
+    content,
+    atOptions,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = params;
+
+  // Get token first
+  const tokenResult = await getAppAccessToken({ apiHost, appKey, appSecret, timeoutMs });
+  if (!tokenResult.ok || !tokenResult.token) {
+    return { ok: false, error: tokenResult.error ?? "failed to get token" };
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    // Build group message body
+    const body: InfoflowGroupMessageBodyItem[] = [{ type: "TEXT", content }];
+
+    // Add AT element if atOptions is provided
+    if (atOptions?.atAll || (atOptions?.atUserIds && atOptions.atUserIds.length > 0)) {
+      body.push({
+        type: "AT",
+        atall: atOptions.atAll ?? false,
+        atuserids: atOptions.atUserIds ?? [],
+      });
+    }
+
+    // Build group message payload (nested structure)
+    const payload = {
+      message: {
+        header: {
+          toid: groupId,
+          totype: "GROUP",
+          msgtype: "TEXT",
+          clientmsgid: Date.now(),
+          role: "robot",
+        },
+        body,
+      },
+    };
+
+    // Build headers with authorization
+    const headers = {
+      Authorization: `Bearer-${tokenResult.token}`,
+      "Content-Type": "application/json",
+    };
+
+    const res = await fetch(`${ensureHttps(apiHost)}${INFOFLOW_GROUP_SEND_PATH}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    const data = (await res.json()) as Record<string, unknown>;
+
+    // Infoflow group API returns { "code": "ok" } on success
+    const code = typeof data.code === "string" ? data.code : "";
+    if (code !== "ok") {
+      const errMsg = String(data.message ?? data.errmsg ?? data.msg ?? `code=${code || "unknown"}`);
+      return { ok: false, error: errMsg };
+    }
+
+    // API may return 'messageid' or 'msgid' depending on version
+    const innerData = data.data as
+      | { messageid?: number | string; msgid?: number | string }
+      | undefined;
+    const rawMsgId = innerData?.messageid ?? innerData?.msgid;
+    const messageid = rawMsgId != null ? String(rawMsgId) : undefined;
+    return { ok: true, messageid };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: errMsg };
+  }
+}

--- a/extensions/infoflow/src/types.ts
+++ b/extensions/infoflow/src/types.ts
@@ -1,0 +1,128 @@
+/**
+ * Infoflow channel type definitions.
+ */
+
+// ---------------------------------------------------------------------------
+// Policy types
+// ---------------------------------------------------------------------------
+
+export type InfoflowDmPolicy = "open" | "pairing" | "allowlist";
+export type InfoflowGroupPolicy = "open" | "allowlist" | "disabled";
+export type InfoflowChatType = "direct" | "group";
+
+// ---------------------------------------------------------------------------
+// AT mention types
+// ---------------------------------------------------------------------------
+
+/** AT 功能选项，用于在群消息中 @成员 */
+export type InfoflowAtOptions = {
+  /** @全体成员，为 true 时 atUserIds 失效 */
+  atAll?: boolean;
+  /** 被 @ 的用户 ID 列表（uuapName） */
+  atUserIds?: string[];
+};
+
+/** 群消息 body 元素类型 */
+export type InfoflowGroupMessageBodyItem =
+  | { type: "TEXT"; content: string }
+  | { type: "AT"; atall: boolean; atuserids: string[] };
+
+// ---------------------------------------------------------------------------
+// Account configuration
+// ---------------------------------------------------------------------------
+
+export type InfoflowAccountConfig = {
+  enabled?: boolean;
+  name?: string;
+  apiHost?: string;
+  check_token?: string;
+  encodingAESKey?: string;
+  appKey?: string;
+  appSecret?: string;
+  dmPolicy?: InfoflowDmPolicy;
+  allowFrom?: string[];
+  groupPolicy?: InfoflowGroupPolicy;
+  groupAllowFrom?: string[];
+  requireMention?: boolean;
+  /** Robot name for matching @mentions in group messages */
+  robotName?: string;
+  accounts?: Record<string, InfoflowAccountConfig>;
+  defaultAccount?: string;
+};
+
+export type ResolvedInfoflowAccount = {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  configured: boolean;
+  config: {
+    enabled?: boolean;
+    name?: string;
+    apiHost: string;
+    check_token: string;
+    encodingAESKey: string;
+    appKey: string;
+    appSecret: string;
+    dmPolicy?: InfoflowDmPolicy;
+    allowFrom?: string[];
+    groupPolicy?: InfoflowGroupPolicy;
+    groupAllowFrom?: string[];
+    requireMention?: boolean;
+    /** Robot name for matching @mentions in group messages */
+    robotName?: string;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Message types
+// ---------------------------------------------------------------------------
+
+export type InfoflowMessageEvent = {
+  fromuser: string;
+  mes: string;
+  chatType: InfoflowChatType;
+  groupId?: number;
+  senderName?: string;
+  /** Whether the bot was @mentioned in the message */
+  wasMentioned?: boolean;
+  /** Original message ID from Infoflow */
+  messageId?: string;
+  /** Unix millisecond timestamp of the message */
+  timestamp?: number;
+  /** Raw message text preserving @mentions (for RawBody) */
+  rawMes?: string;
+};
+
+export type InfoflowSendResult = {
+  ok: boolean;
+  error?: string;
+  messageId?: string;
+  msgkey?: string;
+  messageid?: string;
+  invaliduser?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Handler parameter types
+// ---------------------------------------------------------------------------
+
+export type HandleInfoflowMessageParams = {
+  cfg: import("openclaw/plugin-sdk").OpenClawConfig;
+  event: InfoflowMessageEvent;
+  accountId: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+export type HandlePrivateChatParams = {
+  cfg: import("openclaw/plugin-sdk").OpenClawConfig;
+  msgData: Record<string, unknown>;
+  accountId: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+export type HandleGroupChatParams = {
+  cfg: import("openclaw/plugin-sdk").OpenClawConfig;
+  msgData: Record<string, unknown>;
+  accountId: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/infoflow:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/line:
     devDependencies:
       openclaw:


### PR DESCRIPTION
add Baidu Infoflow channel support

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `@openclaw/infoflow` extension that registers an Infoflow channel plugin plus an HTTP webhook handler. It includes inbound webhook parsing/decryption and outbound send APIs (DM + group), along with account resolution/config schema and reply dispatch plumbing.

Key integration points are `extensions/infoflow/index.ts` (plugin entry), `extensions/infoflow/src/channel.ts` (channel plugin + outbound send), `extensions/infoflow/src/monitor.ts` + `infoflow_req_parse.ts` (HTTP webhook routing + decrypt/dispatch), and `extensions/infoflow/src/send.ts` (Infoflow REST calls + token handling).

Blocking issues to address before merge: a build-breaking import mismatch in the webhook handler, a global token cache that breaks multi-account setups, and inconsistent group address formatting between inbound context and outbound send parsing. The account “configured” signal also ignores fields required for inbound/outbound to function (AES key / apiHost), which can misreport readiness.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge until a few blocking integration issues are fixed.
- Score reduced due to (1) a build-breaking import mismatch in the webhook handler, (2) a module-level token cache that will break multi-account configurations, and (3) inconsistent group address formatting that will route group replies as DMs. Once these are corrected, the rest of the extension wiring looks straightforward.
- extensions/infoflow/src/monitor.ts, extensions/infoflow/src/send.ts, extensions/infoflow/src/channel.ts, extensions/infoflow/src/bot.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->