### PR TITLE
docs(system-prompt): warn against using exec for gateway restart

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -418,7 +418,7 @@ export function buildAgentSystemPrompt(params: {
     "- openclaw gateway status",
     "- openclaw gateway start",
     "- openclaw gateway stop",
-    "- openclaw gateway restart",
+    "- openclaw gateway restart (WARNING: does not preserve session context; prefer 'gateway' tool)",
     "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
     "",
     ...skillsSection,


### PR DESCRIPTION
## Issue Description
Currently, the System Prompt lists `openclaw gateway restart` as a valid command in the "OpenClaw CLI Quick Reference" section without any caveats.

However, using `exec` to run `openclaw gateway restart` performs a hard restart of the service, bypassing the OpenClaw Gateway Tool's state preservation logic (the "Restart Sentinel"). This causes the agent to lose context of the current session and fail to resume the conversation after the restart.

The proper way for an agent to restart the gateway is to use the `gateway` tool (e.g., `gateway(action="restart")`), which writes a sentinel file to disk before restarting, allowing the new process to wake up and reply to the user.

## Proposed Change
Add a warning to the System Prompt in `src/agents/system-prompt.ts` explicitly advising against `exec` usage for restarts when session continuity is desired.

**Before:**
`"- openclaw gateway restart",`

**After:**
`"- openclaw gateway restart (WARNING: does not preserve session context; prefer 'gateway' tool)",`

## Impact
- **Positive**: Reduces the likelihood of agents accidentally "killing themselves" mid-task without a way to report back completion.
- **Negative**: None. The command remains available for emergency use if the agent explicitly decides to use it.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

The PR updates the system prompt’s “OpenClaw CLI Quick Reference” to add an explicit warning that `openclaw gateway restart` does not preserve session context when invoked via `exec`, and to prefer using the `gateway` tool for restarts that need continuity.

Change is localized to `src/agents/system-prompt.ts` and does not affect runtime logic; existing tests that check for the presence of `openclaw gateway restart` still pass because the substring remains present.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-string docs-only change in the system prompt; no behavioral code paths altered. Existing prompt tests continue to pass because they match a substring that remains unchanged.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->