### PR TITLE
feat: Add support for custom Telegram Bot API server URL via apiRoot option

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -781,6 +781,7 @@ Provider options:
 - `channels.telegram.mediaMaxMb`: inbound/outbound media cap (MB).
 - `channels.telegram.retry`: retry policy for outbound Telegram API calls (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to disabled on Node 22 to avoid Happy Eyeballs timeouts.
+- `channels.telegram.apiRoot`: custom Telegram Bot API server URL (e.g., `http://localhost:8081` for local Bot API server or custom proxy). Defaults to `https://api.telegram.org`.
 - `channels.telegram.proxy`: proxy URL for Bot API calls (SOCKS/HTTP).
 - `channels.telegram.webhookUrl`: enable webhook mode (requires `channels.telegram.webhookSecret`).
 - `channels.telegram.webhookSecret`: webhook secret (required when webhookUrl is set).

--- a/docs/zh-CN/channels/telegram.md
+++ b/docs/zh-CN/channels/telegram.md
@@ -732,6 +732,7 @@ Telegram 反应作为**单独的 `message_reaction` 事件**到达，而不是�
 - `channels.telegram.mediaMaxMb`：入站/出站媒体上限（MB）。
 - `channels.telegram.retry`：出站 Telegram API 调用的重试策略（attempts、minDelayMs、maxDelayMs、jitter）。
 - `channels.telegram.network.autoSelectFamily`：覆盖 Node autoSelectFamily（true=启用，false=禁用）。在 Node 22 上默认禁用以避免 Happy Eyeballs 超时。
+- `channels.telegram.apiRoot`：自定义 Telegram Bot API 服务器 URL（例如，`http://localhost:8081` 用于本地 Bot API 服务器或自定义代理）。默认为 `https://api.telegram.org`。
 - `channels.telegram.proxy`：Bot API 调用的代理 URL（SOCKS/HTTP）。
 - `channels.telegram.webhookUrl`：启用 webhook 模式（需要 `channels.telegram.webhookSecret`）。
 - `channels.telegram.webhookSecret`：webhook 密钥（设置 webhookUrl 时必需）。

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -105,6 +105,8 @@ export type TelegramAccountConfig = {
   retry?: OutboundRetryConfig;
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
+  /** Optional custom Telegram Bot API server URL (e.g., for local Bot API server or proxy). */
+  apiRoot?: string;
   proxy?: string;
   webhookUrl?: string;
   webhookSecret?: string;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -135,11 +135,13 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+  const apiRoot = telegramCfg?.apiRoot;
   const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
+    shouldProvideFetch || timeoutSeconds || apiRoot
       ? {
           ...(shouldProvideFetch && fetchImpl ? { fetch: fetchForClient } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
 


### PR DESCRIPTION
add apiRoot and docs

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an `apiRoot` option to Telegram account configuration and wires it into the grammY `Bot` client options, allowing the Telegram channel to target a custom Telegram Bot API base URL (e.g., local Bot API server or proxy). It also updates the English and zh-CN Telegram docs to document the new `channels.telegram.apiRoot` setting and its default (`https://api.telegram.org`).

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are small, isolated to Telegram config/types, bot client construction, and docs. The new option is optional and only affects behavior when explicitly set, so default behavior remains unchanged.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->