### PR TITLE
fix: prevent cooldown pollution across different models on the same provider

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -180,6 +180,66 @@ describe("runWithModelFallback", () => {
     }
   });
 
+  it("does not skip different model on same provider due to cooldown from first model", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
+    const provider = `cooldown-cross-model-${crypto.randomUUID()}`;
+    const profileId = `${provider}:default`;
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider,
+          key: "test-key",
+        },
+      },
+      usageStats: {
+        [profileId]: {
+          cooldownUntil: Date.now() + 60_000,
+        },
+      },
+    };
+
+    saveAuthProfileStore(store, tempDir);
+
+    // Primary: provider/model-a, fallback: same provider but different model-b
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: `${provider}/model-a`,
+            fallbacks: [`${provider}/model-b`],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockImplementation(async (providerId, modelId) => {
+      if (providerId === provider && modelId === "model-b") {
+        return "ok";
+      }
+      throw new Error(`unexpected call: ${providerId}/${modelId}`);
+    });
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider,
+        model: "model-a",
+        agentDir: tempDir,
+        run,
+      });
+
+      // model-a should be skipped (cooldown), but model-b on same provider should be attempted
+      expect(result.result).toBe("ok");
+      expect(run.mock.calls).toEqual([[provider, "model-b"]]);
+      expect(result.attempts[0]?.reason).toBe("rate_limit");
+      expect(result.attempts[0]?.model).toBe("model-a");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not skip when any profile is available", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
     const provider = `cooldown-mixed-${crypto.randomUUID()}`;

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -237,6 +237,13 @@ export async function runWithModelFallback<T>(params: {
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
 
+  // Track providers where we've already performed a cooldown pre-check.
+  // Cooldown is per-profile, not per-model. Different models on the same
+  // provider may use independent quota pools (e.g. Claude vs Gemini on
+  // google-antigravity), so cooldown from one model should not block
+  // fallback attempts with a different model on the same provider.
+  const cooldownCheckedProviders = new Set<string>();
+
   for (let i = 0; i < candidates.length; i += 1) {
     const candidate = candidates[i];
     if (authStore) {
@@ -245,17 +252,21 @@ export async function runWithModelFallback<T>(params: {
         store: authStore,
         provider: candidate.provider,
       });
-      const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
 
-      if (profileIds.length > 0 && !isAnyProfileAvailable) {
-        // All profiles for this provider are in cooldown; skip without attempting
-        attempts.push({
-          provider: candidate.provider,
-          model: candidate.model,
-          error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
-          reason: "rate_limit",
-        });
-        continue;
+      if (!cooldownCheckedProviders.has(candidate.provider)) {
+        cooldownCheckedProviders.add(candidate.provider);
+        const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+
+        if (profileIds.length > 0 && !isAnyProfileAvailable) {
+          // All profiles for this provider are in cooldown; skip without attempting
+          attempts.push({
+            provider: candidate.provider,
+            model: candidate.model,
+            error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
+            reason: "rate_limit",
+          });
+          continue;
+        }
       }
     }
     try {


### PR DESCRIPTION
## Summary

When model fallback iterates candidates on the same provider but different models (e.g. Claude → Gemini on google-antigravity), cooldown set by the first model incorrectly blocks attempts with subsequent models. This happens because cooldown is tracked per-profile (not per-model), and the pre-flight check skips **all** candidates on a provider once any cooldown is active — even though different models may use entirely independent quota pools.

## Problem

```
Claude 4.6 rate-limited → profile enters cooldown
→ fallback to Gemini Pro (same provider) → cooldown check sees same profile in cooldown → skips
→ Gemini Pro quota is full but never tried
```

The same issue affects any provider with multiple model tiers (e.g. Flash ↔ Pro fallbacks).

## Fix

Track which providers have already been cooldown-checked during the fallback loop. Only perform the cooldown pre-check on the **first** candidate for each provider. Subsequent candidates on the same provider (with a different model) skip the pre-check and proceed to attempt execution directly.

This is the minimal, conservative fix — it doesn't alter cooldown state or profile tracking, just prevents the pre-flight check from blocking unrelated models.

## Test

Added test: `"does not skip different model on same provider due to cooldown from first model"` — verifies that when `provider/model-a` profiles are in cooldown, a fallback to `provider/model-b` is still attempted and succeeds.

All existing cooldown tests continue to pass (the cross-provider cooldown skip behavior is unchanged).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `runWithModelFallback` to avoid “cooldown pollution” when iterating multiple model candidates on the same provider by only performing the provider-wide cooldown pre-check once per provider, rather than once per candidate. It also adds a regression test to ensure a fallback to a different model on the same provider is still attempted.

The change fits into the existing model-fallback flow by adjusting the early “skip provider if all profiles are in cooldown” gate, without changing how failover errors are normalized/recorded, and without changing auth store semantics.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but may change runtime behavior in cases where a provider has no available profiles.
- The new provider-level cooldown check suppression can cause `params.run` to be called for models on a provider even when all profiles are still in cooldown, which can regress previous skip behavior depending on how credentials are selected. The added test currently doesn’t exercise real credential availability, so it may not protect against that regression.
- src/agents/model-fallback.ts, src/agents/model-fallback.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->