### PR TITLE
fix(tui): sanitize non-printable characters to prevent binary data crash

### DIFF
--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -1,5 +1,6 @@
 import { Container, Spacer, Text } from "@mariozechner/pi-tui";
 import { theme } from "../theme/theme.js";
+import { sanitizeForDisplay } from "../tui-formatters.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
 import { UserMessageComponent } from "./user-message.js";
@@ -17,11 +18,11 @@ export class ChatLog extends Container {
 
   addSystem(text: string) {
     this.addChild(new Spacer(1));
-    this.addChild(new Text(theme.system(text), 1, 0));
+    this.addChild(new Text(theme.system(sanitizeForDisplay(text)), 1, 0));
   }
 
   addUser(text: string) {
-    this.addChild(new UserMessageComponent(text));
+    this.addChild(new UserMessageComponent(sanitizeForDisplay(text)));
   }
 
   private resolveRunId(runId?: string) {
@@ -29,7 +30,8 @@ export class ChatLog extends Container {
   }
 
   startAssistant(text: string, runId?: string) {
-    const component = new AssistantMessageComponent(text);
+    const safe = sanitizeForDisplay(text);
+    const component = new AssistantMessageComponent(safe);
     this.streamingRuns.set(this.resolveRunId(runId), component);
     this.addChild(component);
     return component;
@@ -42,18 +44,19 @@ export class ChatLog extends Container {
       this.startAssistant(text, runId);
       return;
     }
-    existing.setText(text);
+    existing.setText(sanitizeForDisplay(text));
   }
 
   finalizeAssistant(text: string, runId?: string) {
+    const safe = sanitizeForDisplay(text);
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (existing) {
-      existing.setText(text);
+      existing.setText(safe);
       this.streamingRuns.delete(effectiveRunId);
       return;
     }
-    this.addChild(new AssistantMessageComponent(text));
+    this.addChild(new AssistantMessageComponent(safe));
   }
 
   dropAssistant(runId?: string) {

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -4,6 +4,7 @@ import {
   extractTextFromMessage,
   extractThinkingFromMessage,
   isCommandMessage,
+  resolveFinalAssistantText,
   sanitizeForDisplay,
 } from "./tui-formatters.js";
 
@@ -58,6 +59,31 @@ describe("extractTextFromMessage", () => {
     );
 
     expect(text).toBe("[thinking]\nponder\n\nhello");
+  });
+});
+
+describe("resolveFinalAssistantText", () => {
+  it("falls through to '(no output)' when finalText is purely binary", () => {
+    const text = resolveFinalAssistantText({
+      finalText: "\x00\x01\x02\x80\x9F",
+      streamedText: null,
+    });
+    expect(text).toBe("(no output)");
+  });
+
+  it("falls through to streamedText when finalText is purely binary", () => {
+    const text = resolveFinalAssistantText({
+      finalText: "\x00\x01\x02",
+      streamedText: "fallback content",
+    });
+    expect(text).toBe("fallback content");
+  });
+
+  it("sanitizes finalText before returning", () => {
+    const text = resolveFinalAssistantText({
+      finalText: "hello\x00world",
+    });
+    expect(text).toBe("helloworld");
   });
 });
 

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -4,6 +4,7 @@ import {
   extractTextFromMessage,
   extractThinkingFromMessage,
   isCommandMessage,
+  sanitizeForDisplay,
 } from "./tui-formatters.js";
 
 describe("extractTextFromMessage", () => {
@@ -96,6 +97,74 @@ describe("extractContentFromMessage", () => {
     });
 
     expect(text).toContain("HTTP 429");
+  });
+});
+
+describe("sanitizeForDisplay", () => {
+  it("strips control characters from text", () => {
+    // Simulate binary data that leaked into a text field
+    const binaryText = "hello\x00\x01\x02\x03\x04\x05\x06\x07\x08world";
+    const result = sanitizeForDisplay(binaryText);
+    expect(result).toBe("helloworld");
+  });
+
+  it("strips C1 control codes (0x80-0x9F)", () => {
+    const c1Text = "data\x80\x81\x8F\x9Fmore";
+    const result = sanitizeForDisplay(c1Text);
+    expect(result).toBe("datamore");
+  });
+
+  it("strips DELETE character (0x7F)", () => {
+    const text = "before\x7Fafter";
+    const result = sanitizeForDisplay(text);
+    expect(result).toBe("beforeafter");
+  });
+
+  it("preserves normal whitespace (newline, tab, carriage return)", () => {
+    const text = "line1\nline2\ttabbed\rcarriage";
+    const result = sanitizeForDisplay(text);
+    expect(result).toBe("line1\nline2\ttabbed\rcarriage");
+  });
+
+  it("preserves Unicode printable characters", () => {
+    const text = "café résumé 日本語 한국어 Привет";
+    const result = sanitizeForDisplay(text);
+    expect(result).toBe("café résumé 日本語 한국어 Привет");
+  });
+
+  it("returns empty string for purely binary content", () => {
+    // Simulate raw PDF header bytes as a string
+    const binary = String.fromCharCode(0x00, 0x01, 0x02, 0x80, 0x90, 0x9f, 0x7f);
+    const result = sanitizeForDisplay(binary);
+    expect(result).toBe("");
+  });
+});
+
+describe("extractTextFromMessage — binary sanitization", () => {
+  it("strips binary data from text content blocks", () => {
+    const text = extractTextFromMessage({
+      role: "user",
+      content: [{ type: "text", text: "hello\x00\x01\x02 world\x80\x9F" }],
+    });
+    expect(text).toBe("hello world");
+  });
+
+  it("strips binary data from string content", () => {
+    const text = extractTextFromMessage({
+      role: "user",
+      content: "message\x00\x01with\x7Fbinary",
+    });
+    expect(text).toBe("messagewithbinary");
+  });
+});
+
+describe("extractContentFromMessage — binary sanitization", () => {
+  it("strips binary data from text content blocks", () => {
+    const text = extractContentFromMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "response\x00\x03\x80data" }],
+    });
+    expect(text).toBe("responsedata");
   });
 });
 

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -74,6 +74,15 @@ describe("extractThinkingFromMessage", () => {
 
     expect(text).toBe("alpha\nbeta");
   });
+
+  it("strips binary data from thinking blocks", () => {
+    const text = extractThinkingFromMessage({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "thought\x00\x01\x80process" }],
+    });
+
+    expect(text).toBe("thoughtprocess");
+  });
 });
 
 describe("extractContentFromMessage", () => {

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -22,13 +22,13 @@ export function resolveFinalAssistantText(params: {
   finalText?: string | null;
   streamedText?: string | null;
 }) {
-  const finalText = params.finalText ?? "";
+  const finalText = sanitizeForDisplay(params.finalText ?? "");
   if (finalText.trim()) {
-    return sanitizeForDisplay(finalText);
+    return finalText;
   }
-  const streamedText = params.streamedText ?? "";
+  const streamedText = sanitizeForDisplay(params.streamedText ?? "");
   if (streamedText.trim()) {
-    return sanitizeForDisplay(streamedText);
+    return streamedText;
   }
   return "(no output)";
 }

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -24,11 +24,11 @@ export function resolveFinalAssistantText(params: {
 }) {
   const finalText = params.finalText ?? "";
   if (finalText.trim()) {
-    return finalText;
+    return sanitizeForDisplay(finalText);
   }
   const streamedText = params.streamedText ?? "";
   if (streamedText.trim()) {
-    return streamedText;
+    return sanitizeForDisplay(streamedText);
   }
   return "(no output)";
 }

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -79,7 +79,7 @@ export function extractThinkingFromMessage(message: unknown): string {
       parts.push(rec.thinking);
     }
   }
-  return parts.join("\n").trim();
+  return sanitizeForDisplay(parts.join("\n").trim());
 }
 
 /**
@@ -102,7 +102,7 @@ export function extractContentFromMessage(message: unknown): string {
     const stopReason = typeof record.stopReason === "string" ? record.stopReason : "";
     if (stopReason === "error") {
       const errorMessage = typeof record.errorMessage === "string" ? record.errorMessage : "";
-      return formatRawAssistantErrorForUi(errorMessage);
+      return sanitizeForDisplay(formatRawAssistantErrorForUi(errorMessage));
     }
     return "";
   }
@@ -123,7 +123,7 @@ export function extractContentFromMessage(message: unknown): string {
     const stopReason = typeof record.stopReason === "string" ? record.stopReason : "";
     if (stopReason === "error") {
       const errorMessage = typeof record.errorMessage === "string" ? record.errorMessage : "";
-      return formatRawAssistantErrorForUi(errorMessage);
+      return sanitizeForDisplay(formatRawAssistantErrorForUi(errorMessage));
     }
   }
 
@@ -186,7 +186,7 @@ export function extractTextFromMessage(
   }
 
   const errorMessage = typeof record.errorMessage === "string" ? record.errorMessage : "";
-  return formatRawAssistantErrorForUi(errorMessage);
+  return sanitizeForDisplay(formatRawAssistantErrorForUi(errorMessage));
 }
 
 export function isCommandMessage(message: unknown): boolean {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -28,7 +28,7 @@ import { GatewayChatClient } from "./gateway-chat.js";
 import { editorTheme, theme } from "./theme/theme.js";
 import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
-import { formatTokens } from "./tui-formatters.js";
+import { formatTokens, sanitizeForDisplay } from "./tui-formatters.js";
 import { createLocalShellRunner } from "./tui-local-shell.js";
 import { createOverlayHandlers } from "./tui-overlays.js";
 import { createSessionActions } from "./tui-session-actions.js";
@@ -683,7 +683,7 @@ export async function runTui(opts: TuiOptions) {
     isConnected = false;
     wasDisconnected = true;
     historyLoaded = false;
-    const reasonLabel = reason?.trim() ? reason.trim() : "closed";
+    const reasonLabel = reason?.trim() ? sanitizeForDisplay(reason.trim()) : "closed";
     setConnectionStatus(`gateway disconnected: ${reasonLabel}`, 5000);
     setActivityStatus("idle");
     updateFooter();


### PR DESCRIPTION
Fixes #13007

## Problem

TUI crashes with `Rendered line X exceeds terminal width` when session history contains binary attachment data (e.g. from WhatsApp PDFs/images). Binary bytes leaked into message text fields produce non-printable characters that:

1. Create ultra-long lines (no newlines in binary data)
2. Cause `visibleWidth()` miscalculations in pi-tui
3. Crash the TUI renderer when a line exceeds terminal width

## Solution

Add a `sanitizeForDisplay()` function that strips non-printable characters before text reaches the Markdown rendering component:

- **Strips**: C0 control codes (0x00-0x08, 0x0B-0x0C, 0x0E-0x1F), DELETE (0x7F), C1 control codes (0x80-0x9F)
- **Preserves**: Tab, newline, carriage return, all printable ASCII, and Unicode above U+009F

Applied at four extraction points in `tui-formatters.ts`:
- `extractContentFromMessage()` — string content path and joined text blocks path
- `extractTextBlocks()` — string content path and composed thinking+content path

This ensures binary data is sanitized regardless of how it enters session history.

## Test Plan

TDD approach — all 9 new tests fail before, pass after:

- [x] `sanitizeForDisplay` strips C0 control characters (0x00-0x08)
- [x] `sanitizeForDisplay` strips C1 control codes (0x80-0x9F)
- [x] `sanitizeForDisplay` strips DELETE character (0x7F)
- [x] `sanitizeForDisplay` preserves normal whitespace (newline, tab, CR)
- [x] `sanitizeForDisplay` preserves Unicode printable characters (CJK, Cyrillic, accented)
- [x] `sanitizeForDisplay` returns empty string for purely binary content
- [x] `extractTextFromMessage` strips binary from text content blocks
- [x] `extractTextFromMessage` strips binary from string content
- [x] `extractContentFromMessage` strips binary from text content blocks
- [x] All 8 pre-existing tests continue to pass
- [x] `pnpm build` passes
- [x] `pnpm check` passes (format, typecheck, lint — 0 warnings, 0 errors)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `sanitizeForDisplay()` helper to strip C0/C1 control characters and applies it across TUI message formatting and display paths (formatters, chat log rendering, and disconnect reason rendering) to prevent pi-tui width-calculation crashes when binary bytes leak into message text. It also adds focused unit tests covering sanitization behavior and verifies assistant final text selection sanitizes before choosing fallbacks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to sanitizing display-bound strings and include comprehensive unit tests for the new behavior; integration points were traced through the TUI event/streaming/history paths and no regressions were found beyond previously discussed branch-selection semantics (already addressed in the latest commit).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->