### PR TITLE
fix: Device-pair extension leaks gateway credentials in chat messages

### DIFF
--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -10,20 +10,11 @@ type DevicePairPluginConfig = {
 
 type SetupPayload = {
   url: string;
-  token?: string;
-  password?: string;
 };
 
 type ResolveUrlResult = {
   url?: string;
   source?: string;
-  error?: string;
-};
-
-type ResolveAuthResult = {
-  token?: string;
-  password?: string;
-  label?: string;
   error?: string;
 };
 
@@ -220,38 +211,6 @@ function parsePossiblyNoisyJsonObject(raw: string): Record<string, unknown> {
   }
 }
 
-function resolveAuth(cfg: OpenClawPluginApi["config"]): ResolveAuthResult {
-  const mode = cfg.gateway?.auth?.mode;
-  const token =
-    process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
-    process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
-    cfg.gateway?.auth?.token?.trim();
-  const password =
-    process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() ||
-    process.env.CLAWDBOT_GATEWAY_PASSWORD?.trim() ||
-    cfg.gateway?.auth?.password?.trim();
-
-  if (mode === "password") {
-    if (!password) {
-      return { error: "Gateway auth is set to password, but no password is configured." };
-    }
-    return { password, label: "password" };
-  }
-  if (mode === "token") {
-    if (!token) {
-      return { error: "Gateway auth is set to token, but no token is configured." };
-    }
-    return { token, label: "token" };
-  }
-  if (token) {
-    return { token, label: "token" };
-  }
-  if (password) {
-    return { password, label: "password" };
-  }
-  return { error: "Gateway auth is not configured (no token or password)." };
-}
-
 async function resolveGatewayUrl(api: OpenClawPluginApi): Promise<ResolveUrlResult> {
   const cfg = api.config;
   const pluginCfg = (api.pluginConfig ?? {}) as DevicePairPluginConfig;
@@ -320,20 +279,21 @@ function encodeSetupCode(payload: SetupPayload): string {
   return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
-function formatSetupReply(payload: SetupPayload, authLabel: string): string {
+function formatSetupReply(payload: SetupPayload): string {
   const setupCode = encodeSetupCode(payload);
   return [
     "Pairing setup code generated.",
     "",
     "1) Open the iOS app → Settings → Gateway",
-    "2) Paste the setup code below and tap Connect",
-    "3) Back here, run /pair approve",
+    "2) Paste the setup code below",
+    "3) Enter your gateway token/password in the app",
+    "4) Tap Connect, then back here run /pair approve",
     "",
     "Setup code:",
     setupCode,
     "",
     `Gateway: ${payload.url}`,
-    `Auth: ${authLabel}`,
+    "Auth: enter manually in app (token/password)",
   ].join("\n");
 }
 
@@ -342,8 +302,9 @@ function formatSetupInstructions(): string {
     "Pairing setup code generated.",
     "",
     "1) Open the iOS app → Settings → Gateway",
-    "2) Paste the setup code from my next message and tap Connect",
-    "3) Back here, run /pair approve",
+    "2) Paste the setup code from my next message",
+    "3) Enter your gateway token/password in the app",
+    "4) Tap Connect, then back here run /pair approve",
   ].join("\n");
 }
 
@@ -435,11 +396,6 @@ export default function register(api: OpenClawPluginApi) {
         return { text: `✅ Paired ${label}${platformLabel}.` };
       }
 
-      const auth = resolveAuth(api.config);
-      if (auth.error) {
-        return { text: `Error: ${auth.error}` };
-      }
-
       const urlResult = await resolveGatewayUrl(api);
       if (!urlResult.url) {
         return { text: `Error: ${urlResult.error ?? "Gateway URL unavailable."}` };
@@ -447,13 +403,10 @@ export default function register(api: OpenClawPluginApi) {
 
       const payload: SetupPayload = {
         url: urlResult.url,
-        token: auth.token,
-        password: auth.password,
       };
 
       const channel = ctx.channel;
       const target = ctx.senderId?.trim() || ctx.from?.trim() || ctx.to?.trim() || "";
-      const authLabel = auth.label ?? "auth";
 
       if (channel === "telegram" && target) {
         try {
@@ -492,7 +445,7 @@ export default function register(api: OpenClawPluginApi) {
       }
 
       return {
-        text: formatSetupReply(payload, authLabel),
+        text: formatSetupReply(payload),
       };
     },
   });


### PR DESCRIPTION
## Fix Summary
The device-pair extension's `/pair` command sends the gateway authentication credential (token or password) as a base64url-encoded chat message. Anyone with read access to the chat (group members, message backups, forwarded messages, or platform admins) can trivially decode the setup code and extract the full gateway credential, granting unauthorized gateway access with self-declared admin scopes.

## Issue Linkage
Fixes #13088

## Security Snapshot
- CVSS v3.1: 9.0 (Critical)
- CVSS v4.0: 9.4 (Critical)

## Implementation Details
### Files Changed
- `extensions/device-pair/index.ts` (+9/-56)

### Technical Analysis
The `/pair` command in `extensions/device-pair/index.ts` resolves the gateway auth credential (token or password) from configuration or environment variables via `resolveAuth()`, then constructs a `SetupPayload` containing the URL and credential. This payload is JSON-serialized and base64url-encoded by `encodeSetupCode()`, then sent as a plain-text chat message to the channel where `/pair` was invoked.

Base64 encoding is a reversible encoding, not encryption. Any observer who can read the chat message can decode it with a single `atob()` call or `echo <code> | base64 -d` to extract the raw gateway token or password.

The gateway's shared-auth path (token/password) allows connections to self-declare arbitrary scopes including `operator.admin` (see `message-handler.ts:359-367`). Scope enforcement only applies to device-paired connections, not shared-auth ones. This means the leaked credential grants full unrestricted administrative access to the gateway.

## Validation Evidence
- Command: `pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: GPT-5.3-Codex

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change removes gateway authentication credentials (token/password) from the `/pair` setup payload in `extensions/device-pair/index.ts`, so the generated base64url setup code no longer contains secrets that can be trivially decoded from chat history. The command output text/instructions are updated accordingly to require entering the gateway credential manually in the iOS app, while keeping the existing URL resolution behavior and Telegram “split send” flow.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to removing credentials from the pairing payload and adjusting user-facing instructions. I did not find any remaining code paths in this extension that include token/password in the encoded setup message, and the compilation surface area is small (single file, type changes align with usage).
- extensions/device-pair/index.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->