### PR TITLE
fix: prevent redaction of non-secret fields like maxTokens

### DIFF
--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -12,7 +12,7 @@ export const REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
  * Patterns that identify sensitive config field names.
  * Aligned with the UI-hint logic in schema.ts.
  */
-const SENSITIVE_KEY_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+const SENSITIVE_KEY_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -775,7 +775,7 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "agents.list[].identity.avatar": "avatars/openclaw.png",
 };
 
-const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+const SENSITIVE_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 function isSensitivePath(path: string): boolean {
   return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));


### PR DESCRIPTION
## Summary

Fixes #13058

The `SENSITIVE_KEY_PATTERNS` regex `/token/i` in `redact-snapshot.ts` matched any config key **containing** "token" anywhere — including non-secret numeric fields like `maxTokens`, `inputTokens`, `outputTokens`, and `totalTokens`.

When `maxTokens: 8192` was redacted to `"__OPENCLAW_REDACTED__"`, the type changed from number to string, corrupting the config on round-trip through the Studio GUI.

### Root cause

`/token/i` is a substring match. `RegExp.test("maxTokens")` returns `true` because "token" appears inside "maxTokens".

### Fix

Changed the pattern from `/token/i` to `/token$/i` (end-of-string anchor). This preserves redaction for actual secret fields (`token`, `botToken`, `apiToken`, `accessToken`, `refreshToken`) while excluding non-secret fields where "Tokens" is a suffix (`maxTokens`, `inputTokens`, `outputTokens`, `totalTokens`).

## Test plan

- [x] New test: `maxTokens: 8192` is NOT redacted (preserves number value)
- [x] New test: `inputTokens`, `outputTokens`, `totalTokens` are NOT redacted
- [x] New test: `botToken`, `apiToken`, `accessToken` ARE still redacted (regression guard)
- [x] New test: `maxTokens` in raw JSON text is NOT redacted
- [x] All 4 new tests fail before fix, pass after (TDD)
- [x] All 24 existing tests continue to pass
- [x] `pnpm build && pnpm check` passes clean

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR narrows the sensitive-field matching used for snapshot redaction from a substring `token` match to an end-of-key match (`/token$/i`), preventing non-secret numeric fields like `maxTokens`/`inputTokens`/`outputTokens`/`totalTokens` from being redacted and type-corrupted on round-trip. It also adds regression tests covering both object-based redaction and raw JSON text redaction, and aligns the UI/schema hinting regex (`SENSITIVE_PATTERNS`) with the snapshot redaction regex to keep behavior consistent across the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped (regex anchor) with targeted regression tests, and the schema/UI sensitivity hints were updated to stay aligned with snapshot redaction. No other behavioral changes were introduced in the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->