### PR TITLE
add Infoflow(More than 50,000 users) channel support #16153

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -109,6 +109,11 @@
       - any-glob-to-any-file:
           - "extensions/zalouser/**"
           - "docs/channels/zalouser.md"
+"channel: infoflow":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/infoflow/**"
+          - "docs/channels/infoflow.md"
 
 "app: android":
   - changed-files:

--- a/extensions/infoflow/README.md
+++ b/extensions/infoflow/README.md
@@ -1,0 +1,70 @@
+# @openclaw/infoflow
+
+Baidu Infoflow (如流) channel plugin for OpenClaw.
+
+## Install (local checkout)
+
+```bash
+openclaw plugins install ./extensions/infoflow
+```
+
+## Install (npm)
+
+```bash
+openclaw plugins install @openclaw/infoflow
+```
+
+## Config
+
+```json5
+{
+  channels: {
+    infoflow: {
+      enabled: true,
+      apiHost: "https://api.infoflow.baidu.com",
+      check_token: "your-check-token",
+      encodingAESKey: "your-encoding-aes-key",
+      appKey: "your-app-key",
+      appSecret: "your-app-secret",
+      dmPolicy: "open", // "open" | "pairing" | "allowlist"
+      groupPolicy: "open", // "open" | "allowlist" | "disabled"
+      requireMention: true, // Bot only responds when @mentioned in groups
+      robotName: "YourBotName", // Required for @mention detection
+    },
+  },
+}
+```
+
+## Multi-account support
+
+```json5
+{
+  channels: {
+    infoflow: {
+      enabled: true,
+      accounts: {
+        work: {
+          check_token: "token-1",
+          encodingAESKey: "key-1",
+          appKey: "app-key-1",
+          appSecret: "secret-1",
+        },
+        personal: {
+          check_token: "token-2",
+          encodingAESKey: "key-2",
+          appKey: "app-key-2",
+          appSecret: "secret-2",
+        },
+      },
+      defaultAccount: "work",
+    },
+  },
+}
+```
+
+## Webhook
+
+Configure your Infoflow bot webhook URL to:
+`https://your-domain/webhook/infoflow`
+
+Restart the gateway after config changes.

--- a/extensions/infoflow/README.md
+++ b/extensions/infoflow/README.md
@@ -21,8 +21,8 @@ openclaw plugins install @openclaw/infoflow
   channels: {
     infoflow: {
       enabled: true,
-      apiHost: "https://api.infoflow.baidu.com",
-      check_token: "your-check-token",
+      apiHost: "https://apiin.im.baidu.com",
+      checkToken: "your-check-token",
       encodingAESKey: "your-encoding-aes-key",
       appKey: "your-app-key",
       appSecret: "your-app-secret",
@@ -44,13 +44,13 @@ openclaw plugins install @openclaw/infoflow
       enabled: true,
       accounts: {
         work: {
-          check_token: "token-1",
+          checkToken: "token-1",
           encodingAESKey: "key-1",
           appKey: "app-key-1",
           appSecret: "secret-1",
         },
         personal: {
-          check_token: "token-2",
+          checkToken: "token-2",
           encodingAESKey: "key-2",
           appKey: "app-key-2",
           appSecret: "secret-2",

--- a/extensions/infoflow/index.ts
+++ b/extensions/infoflow/index.ts
@@ -1,0 +1,18 @@
+import { emptyPluginConfigSchema, type OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { infoflowPlugin } from "./src/channel.js";
+import { handleInfoflowWebhookRequest } from "./src/monitor.js";
+import { setInfoflowRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "infoflow",
+  name: "Infoflow",
+  description: "OpenClaw Infoflow channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setInfoflowRuntime(api.runtime);
+    api.registerChannel({ plugin: infoflowPlugin });
+    api.registerHttpHandler(handleInfoflowWebhookRequest);
+  },
+};
+
+export default plugin;

--- a/extensions/infoflow/openclaw.plugin.json
+++ b/extensions/infoflow/openclaw.plugin.json
@@ -1,0 +1,44 @@
+{
+  "id": "infoflow",
+  "channels": ["infoflow"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiHost": { "type": "string" },
+      "enabled": { "type": "boolean" },
+      "name": { "type": "string" },
+      "check_token": { "type": "string" },
+      "encodingAESKey": { "type": "string" },
+      "appKey": { "type": "string" },
+      "appSecret": { "type": "string" },
+      "robotName": { "type": "string" },
+      "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist"] },
+      "allowFrom": { "type": "array", "items": { "type": "string" } },
+      "groupPolicy": { "type": "string", "enum": ["open", "allowlist", "disabled"] },
+      "groupAllowFrom": { "type": "array", "items": { "type": "string" } },
+      "requireMention": { "type": "boolean" },
+      "accounts": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "name": { "type": "string" },
+            "check_token": { "type": "string" },
+            "encodingAESKey": { "type": "string" },
+            "appKey": { "type": "string" },
+            "appSecret": { "type": "string" },
+            "robotName": { "type": "string" },
+            "dmPolicy": { "type": "string", "enum": ["open", "pairing", "allowlist"] },
+            "allowFrom": { "type": "array", "items": { "type": "string" } },
+            "groupPolicy": { "type": "string", "enum": ["open", "allowlist", "disabled"] },
+            "groupAllowFrom": { "type": "array", "items": { "type": "string" } },
+            "requireMention": { "type": "boolean" }
+          }
+        }
+      },
+      "defaultAccount": { "type": "string" }
+    }
+  }
+}

--- a/extensions/infoflow/openclaw.plugin.json
+++ b/extensions/infoflow/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "apiHost": { "type": "string" },
       "enabled": { "type": "boolean" },
       "name": { "type": "string" },
-      "check_token": { "type": "string" },
+      "checkToken": { "type": "string" },
       "encodingAESKey": { "type": "string" },
       "appKey": { "type": "string" },
       "appSecret": { "type": "string" },
@@ -25,7 +25,7 @@
           "properties": {
             "enabled": { "type": "boolean" },
             "name": { "type": "string" },
-            "check_token": { "type": "string" },
+            "checkToken": { "type": "string" },
             "encodingAESKey": { "type": "string" },
             "appKey": { "type": "string" },
             "appSecret": { "type": "string" },

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openclaw/infoflow",
+  "version": "2026.2.9",
+  "description": "OpenClaw Infoflow channel plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "infoflow",
+      "label": "Infoflow",
+      "selectionLabel": "Infoflow (如流)",
+      "docsPath": "/channels/infoflow",
+      "blurb": "Baidu Infoflow messaging platform.",
+      "order": 40
+    },
+    "install": {
+      "npmSpec": "@openclaw/infoflow",
+      "localPath": "extensions/infoflow",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/infoflow",
-  "version": "2026.2.13",
+  "version": "2026.2.15",
   "description": "OpenClaw Infoflow channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/infoflow",
-  "version": "2026.2.17",
+  "version": "2026.2.18",
   "description": "OpenClaw Infoflow channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/infoflow",
-  "version": "2026.2.15",
+  "version": "2026.2.16",
   "description": "OpenClaw Infoflow channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/infoflow",
-  "version": "2026.2.9",
+  "version": "2026.2.10",
   "description": "OpenClaw Infoflow channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/infoflow",
-  "version": "2026.2.10",
+  "version": "2026.2.13",
   "description": "OpenClaw Infoflow channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/infoflow",
-  "version": "2026.2.16",
+  "version": "2026.2.17",
   "description": "OpenClaw Infoflow channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/infoflow",
-  "version": "2026.2.18",
+  "version": "2026.2.23",
   "description": "OpenClaw Infoflow channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/infoflow/package.json
+++ b/extensions/infoflow/package.json
@@ -3,9 +3,7 @@
   "version": "2026.2.23",
   "description": "OpenClaw Infoflow channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
-  },
+  "devDependencies": {},
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/infoflow/src/accounts.ts
+++ b/extensions/infoflow/src/accounts.ts
@@ -108,7 +108,8 @@ export function resolveInfoflowAccount(params: {
   const encodingAESKey = merged.encodingAESKey ?? "";
   const appKey = merged.appKey ?? "";
   const appSecret = merged.appSecret ?? "";
-  const configured = Boolean(checkToken) && Boolean(appKey) && Boolean(appSecret);
+  const configured =
+    Boolean(checkToken) && Boolean(encodingAESKey) && Boolean(appKey) && Boolean(appSecret);
 
   return {
     accountId,

--- a/extensions/infoflow/src/accounts.ts
+++ b/extensions/infoflow/src/accounts.ts
@@ -1,0 +1,130 @@
+/**
+ * Infoflow account resolution and configuration helpers.
+ * Handles multi-account support with config merging.
+ */
+
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId, type OpenClawConfig } from "openclaw/plugin-sdk";
+import type { InfoflowAccountConfig, ResolvedInfoflowAccount } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Config Access Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the raw Infoflow channel section from config.
+ */
+export function getChannelSection(cfg: OpenClawConfig): InfoflowAccountConfig | undefined {
+  return cfg.channels?.["infoflow"] as InfoflowAccountConfig | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Account ID Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * List all configured Infoflow account IDs.
+ * Returns [DEFAULT_ACCOUNT_ID] if no accounts are configured (backward compatibility).
+ */
+export function listInfoflowAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = getChannelSection(cfg)?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  const ids = Object.keys(accounts).filter(Boolean);
+  return ids.length === 0 ? [DEFAULT_ACCOUNT_ID] : ids.toSorted((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Resolve the default account ID for Infoflow.
+ */
+export function resolveDefaultInfoflowAccountId(cfg: OpenClawConfig): string {
+  const channel = getChannelSection(cfg);
+  if (channel?.defaultAccount?.trim()) {
+    return channel.defaultAccount.trim();
+  }
+  const ids = listInfoflowAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+// ---------------------------------------------------------------------------
+// Config Merging
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge top-level Infoflow config with account-specific overrides.
+ * Account fields override base fields.
+ */
+function mergeInfoflowAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): {
+  apiHost: string;
+  checkToken: string;
+  encodingAESKey: string;
+  appKey: string;
+  appSecret: string;
+  enabled?: boolean;
+  name?: string;
+  robotName?: string;
+  requireMention?: boolean;
+} {
+  const raw = getChannelSection(cfg) ?? {};
+  const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
+  const account = raw.accounts?.[accountId] ?? {};
+  return { ...base, ...account } as {
+    apiHost: string;
+    checkToken: string;
+    encodingAESKey: string;
+    appKey: string;
+    appSecret: string;
+    enabled?: boolean;
+    name?: string;
+    robotName?: string;
+    requireMention?: boolean;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Account Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a complete Infoflow account with merged config.
+ */
+export function resolveInfoflowAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedInfoflowAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const baseEnabled = getChannelSection(params.cfg)?.enabled !== false;
+  const merged = mergeInfoflowAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const apiHost = merged.apiHost ?? "";
+  const checkToken = merged.checkToken ?? "";
+  const encodingAESKey = merged.encodingAESKey ?? "";
+  const appKey = merged.appKey ?? "";
+  const appSecret = merged.appSecret ?? "";
+  const configured = Boolean(checkToken) && Boolean(appKey) && Boolean(appSecret);
+
+  return {
+    accountId,
+    name: merged.name?.trim() || undefined,
+    enabled,
+    configured,
+    config: {
+      enabled: merged.enabled,
+      name: merged.name,
+      apiHost,
+      checkToken,
+      encodingAESKey,
+      appKey,
+      appSecret,
+      robotName: merged.robotName?.trim() || undefined,
+      requireMention: merged.requireMention,
+    },
+  };
+}

--- a/extensions/infoflow/src/bot.test.ts
+++ b/extensions/infoflow/src/bot.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { _checkBotMentioned as checkBotMentioned } from "./bot.js";
+
+describe("checkBotMentioned", () => {
+  // Case 1: Missing robotName should return false
+  it("returns false when robotName is undefined", () => {
+    const bodyItems = [{ type: "AT", name: "TestBot" }];
+    expect(checkBotMentioned(bodyItems, undefined)).toBe(false);
+  });
+
+  it("returns false when robotName is empty string", () => {
+    const bodyItems = [{ type: "AT", name: "TestBot" }];
+    expect(checkBotMentioned(bodyItems, "")).toBe(false);
+  });
+
+  // Case 2: Empty body array should return false
+  it("returns false when body array is empty", () => {
+    expect(checkBotMentioned([], "TestBot")).toBe(false);
+  });
+
+  // Case 3: Case-insensitive matching
+  it("matches robotName case-insensitively (lowercase input)", () => {
+    const bodyItems = [{ type: "AT", name: "testbot" }];
+    expect(checkBotMentioned(bodyItems, "TestBot")).toBe(true);
+  });
+
+  it("matches robotName case-insensitively (uppercase input)", () => {
+    const bodyItems = [{ type: "AT", name: "TESTBOT" }];
+    expect(checkBotMentioned(bodyItems, "TestBot")).toBe(true);
+  });
+
+  it("matches robotName case-insensitively (mixed case)", () => {
+    const bodyItems = [{ type: "AT", name: "TeStBoT" }];
+    expect(checkBotMentioned(bodyItems, "testbot")).toBe(true);
+  });
+
+  // Case 4: Exact match
+  it("returns true for exact name match", () => {
+    const bodyItems = [{ type: "AT", name: "MyBot" }];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(true);
+  });
+
+  // Case 5: No match
+  it("returns false when AT name does not match robotName", () => {
+    const bodyItems = [{ type: "AT", name: "OtherBot" }];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(false);
+  });
+
+  // Case 6: Multiple items in body
+  it("returns true when one of multiple items matches", () => {
+    const bodyItems = [
+      { type: "TEXT", content: "Hello" },
+      { type: "AT", name: "OtherUser" },
+      { type: "AT", name: "MyBot" },
+      { type: "TEXT", content: "world" },
+    ];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(true);
+  });
+
+  it("returns false when no AT items match in multiple items", () => {
+    const bodyItems = [
+      { type: "TEXT", content: "Hello" },
+      { type: "AT", name: "OtherUser" },
+      { type: "LINK", label: "example.com" },
+    ];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(false);
+  });
+
+  // Case 7: AT item without name field
+  it("returns false when AT item has no name", () => {
+    const bodyItems = [{ type: "AT", robotid: 123 }];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(false);
+  });
+
+  it("returns false when AT item has empty name", () => {
+    const bodyItems = [{ type: "AT", name: "" }];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(false);
+  });
+
+  // Case 8: Non-AT types should be ignored
+  it("ignores TEXT type items", () => {
+    const bodyItems = [{ type: "TEXT", content: "MyBot" }];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(false);
+  });
+
+  it("ignores LINK type items", () => {
+    const bodyItems = [{ type: "LINK", label: "MyBot" }];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(false);
+  });
+
+  // Case 9: Partial match should not count
+  it("returns false for partial name match", () => {
+    const bodyItems = [{ type: "AT", name: "MyBotHelper" }];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(false);
+  });
+
+  it("returns false when robotName is substring of AT name", () => {
+    const bodyItems = [{ type: "AT", name: "Bot" }];
+    expect(checkBotMentioned(bodyItems, "MyBot")).toBe(false);
+  });
+});

--- a/extensions/infoflow/src/bot.ts
+++ b/extensions/infoflow/src/bot.ts
@@ -1,0 +1,374 @@
+import type {
+  InfoflowChatType,
+  InfoflowMessageEvent,
+  HandleInfoflowMessageParams,
+  HandlePrivateChatParams,
+  HandleGroupChatParams,
+} from "./types.js";
+import { resolveInfoflowAccount } from "./channel.js";
+import { createInfoflowReplyDispatcher } from "./reply-dispatcher.js";
+import { getInfoflowRuntime } from "./runtime.js";
+
+// Re-export types for external consumers
+export type { InfoflowChatType, InfoflowMessageEvent } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// @mention detection types and helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Body item in Infoflow group message, supporting TEXT, AT, LINK types.
+ */
+type InfoflowBodyItem = {
+  type?: string;
+  content?: string;
+  label?: string;
+  /** Robot ID when type is AT */
+  robotid?: number;
+  /** Robot/user name when type is AT */
+  name?: string;
+};
+
+/**
+ * Check if the bot was @mentioned in the message body.
+ * Matches configured robotName against AT elements (case-insensitive).
+ */
+function checkBotMentioned(bodyItems: InfoflowBodyItem[], robotName?: string): boolean {
+  if (!robotName) {
+    return false; // Cannot detect mentions without configured robotName
+  }
+  const normalizedRobotName = robotName.toLowerCase();
+  for (const item of bodyItems) {
+    if (item.type === "AT" && item.name) {
+      if (item.name.toLowerCase() === normalizedRobotName) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Handles an incoming private chat message from Infoflow.
+ * Receives the raw decrypted message data and dispatches to the agent.
+ */
+export async function handlePrivateChatMessage(params: HandlePrivateChatParams): Promise<void> {
+  const { cfg, msgData, accountId, statusSink } = params;
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+
+  if (verbose) {
+    console.log("[infoflow] Received private chat message:", JSON.stringify(msgData, null, 2));
+  }
+
+  // Extract sender and content from msgData (flexible field names)
+  const fromuser = String(msgData.FromUserId ?? msgData.fromuserid ?? msgData.from ?? "");
+  const mes = String(msgData.Content ?? msgData.content ?? msgData.text ?? msgData.mes ?? "");
+
+  // Extract sender name (FromUserName is more human-readable than FromUserId)
+  const senderName = String(msgData.FromUserName ?? msgData.username ?? fromuser);
+
+  // Extract message ID for dedup tracking
+  const messageId = msgData.MsgId ?? msgData.msgid ?? msgData.messageid;
+  const messageIdStr = messageId != null ? String(messageId) : undefined;
+
+  // Extract timestamp (CreateTime is in seconds, convert to milliseconds)
+  const createTime = msgData.CreateTime ?? msgData.createtime;
+  const timestamp = createTime != null ? Number(createTime) * 1000 : Date.now();
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Private chat extracted: fromuser=${fromuser}, senderName=${senderName}, mes=${mes.slice(0, 50)}...`,
+    );
+  }
+
+  if (!fromuser || !mes.trim()) {
+    if (verbose) {
+      console.log(`[infoflow] Private chat skipped: missing fromuser or empty message`);
+    }
+    return;
+  }
+
+  // Delegate to the common message handler (private chat)
+  await handleInfoflowMessage({
+    cfg,
+    event: {
+      fromuser,
+      mes,
+      chatType: "direct",
+      senderName,
+      messageId: messageIdStr,
+      timestamp,
+    },
+    accountId,
+    statusSink,
+  });
+}
+
+/**
+ * Handles an incoming group chat message from Infoflow.
+ * Receives the raw decrypted message data and dispatches to the agent.
+ */
+export async function handleGroupChatMessage(params: HandleGroupChatParams): Promise<void> {
+  const { cfg, msgData, accountId, statusSink } = params;
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+
+  if (verbose) {
+    console.log("[infoflow] Received group chat message:", JSON.stringify(msgData, null, 2));
+  }
+
+  // Extract sender from nested structure or flat fields
+  const header = (msgData.message as Record<string, unknown>)?.header as
+    | Record<string, unknown>
+    | undefined;
+  const fromuser = String(header?.fromuserid ?? msgData.fromuserid ?? msgData.from ?? "");
+
+  // Extract message ID (priority: header.messageid > header.msgid > MsgId)
+  const messageId = header?.messageid ?? header?.msgid ?? msgData.MsgId;
+  const messageIdStr = messageId != null ? String(messageId) : undefined;
+
+  const rawGroupId = msgData.groupid ?? header?.groupid;
+  const groupid =
+    typeof rawGroupId === "number" ? rawGroupId : rawGroupId ? Number(rawGroupId) : undefined;
+
+  // Extract timestamp (time is in milliseconds)
+  const rawTime = msgData.time ?? header?.servertime;
+  const timestamp = rawTime != null ? Number(rawTime) : Date.now();
+
+  if (verbose) {
+    console.log(`[infoflow] Group chat extracted: fromuser=${fromuser}, groupid=${groupid}`);
+  }
+
+  if (!fromuser) {
+    if (verbose) {
+      console.log(`[infoflow] Group chat skipped: missing fromuser`);
+    }
+    return;
+  }
+
+  // Extract message content from body array or flat content field
+  const message = msgData.message as Record<string, unknown> | undefined;
+  const bodyItems = (message?.body ?? msgData.body ?? []) as InfoflowBodyItem[];
+
+  // Resolve account to get robotName for mention detection
+  const account = resolveInfoflowAccount({ cfg, accountId });
+  const robotName = account.config.robotName;
+
+  // Check if bot was @mentioned
+  const wasMentioned = checkBotMentioned(bodyItems, robotName);
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Group chat mention check: robotName=${robotName ?? "not configured"}, wasMentioned=${wasMentioned}`,
+    );
+  }
+
+  // Build two versions: mes (for CommandBody, no @xxx) and rawMes (for RawBody, with @xxx)
+  let textContent = "";
+  let rawTextContent = "";
+  if (Array.isArray(bodyItems)) {
+    for (const item of bodyItems) {
+      if (item.type === "TEXT") {
+        textContent += item.content ?? "";
+        rawTextContent += item.content ?? "";
+      } else if (item.type === "LINK") {
+        const label = item.label ?? "";
+        if (label) {
+          textContent += ` ${label} `;
+          rawTextContent += ` ${label} `;
+        }
+      } else if (item.type === "AT") {
+        // AT elements only go into rawTextContent, not textContent
+        const name = item.name ?? "";
+        if (name) {
+          rawTextContent += `@${name} `;
+        }
+      }
+    }
+  }
+
+  const mes = textContent.trim() || String(msgData.content ?? msgData.text ?? "");
+  const rawMes = rawTextContent.trim() || mes;
+
+  if (!mes) {
+    if (verbose) {
+      console.log(`[infoflow] Group chat skipped: empty message content`);
+    }
+    return;
+  }
+
+  // Extract sender name from header or fallback to fromuser
+  const senderName = String(header?.username ?? header?.nickname ?? msgData.username ?? fromuser);
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Group chat content: senderName=${senderName}, mes=${mes.slice(0, 50)}...`,
+    );
+  }
+
+  // Delegate to the common message handler (group chat)
+  await handleInfoflowMessage({
+    cfg,
+    event: {
+      fromuser,
+      mes,
+      rawMes,
+      chatType: "group",
+      groupId: groupid,
+      senderName,
+      wasMentioned,
+      messageId: messageIdStr,
+      timestamp,
+    },
+    accountId,
+    statusSink,
+  });
+}
+
+/**
+ * Resolves route, builds envelope, records session meta, and dispatches reply for one incoming Infoflow message.
+ * Called from monitor after webhook request is validated.
+ */
+export async function handleInfoflowMessage(params: HandleInfoflowMessageParams): Promise<void> {
+  const { cfg, event, accountId, statusSink } = params;
+  const { fromuser, mes, chatType, groupId, senderName } = event;
+
+  const account = resolveInfoflowAccount({ cfg, accountId });
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+
+  if (verbose) {
+    console.log(
+      `[infoflow] handleInfoflowMessage: chatType=${chatType}, fromuser=${fromuser}, groupId=${groupId || "N/A"}`,
+    );
+  }
+
+  const isGroup = chatType === "group";
+  // Convert groupId (number) to string for peerId since routing expects string
+  const peerId = isGroup ? (groupId !== undefined ? String(groupId) : fromuser) : fromuser;
+
+  // Resolve route based on chat type
+  const route = core.channel.routing.resolveAgentRoute({
+    cfg,
+    channel: "infoflow",
+    accountId: account.accountId,
+    peer: {
+      kind: isGroup ? "group" : "direct",
+      id: peerId,
+    },
+  });
+
+  const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+    agentId: route.agentId,
+  });
+  const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
+  const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+
+  // Build conversation label and from address based on chat type
+  const fromLabel = isGroup ? `group:${groupId}` : senderName || fromuser;
+  const fromAddress = isGroup ? `infoflow:group:${groupId}` : `infoflow:${fromuser}`;
+  const toAddress = isGroup ? `infoflow:${groupId}` : `infoflow:${account.accountId}`;
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Route resolved: agentId=${route.agentId}, sessionKey=${route.sessionKey}`,
+    );
+    console.log(`[infoflow] Address: From=${fromAddress}, To=${toAddress}`);
+  }
+
+  const body = core.channel.reply.formatAgentEnvelope({
+    channel: "Infoflow",
+    from: fromLabel,
+    timestamp: Date.now(),
+    previousTimestamp,
+    envelope: envelopeOptions,
+    body: mes,
+  });
+
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: body,
+    RawBody: event.rawMes ?? mes,
+    CommandBody: mes,
+    From: fromAddress,
+    To: toAddress,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: chatType,
+    ConversationLabel: fromLabel,
+    GroupSubject: isGroup ? `group:${groupId}` : undefined,
+    SenderName: senderName || fromuser,
+    SenderId: fromuser,
+    Provider: "infoflow",
+    Surface: "infoflow",
+    MessageSid: event.messageId ?? `${Date.now()}`,
+    Timestamp: event.timestamp ?? Date.now(),
+    OriginatingChannel: "infoflow",
+    OriginatingTo: toAddress,
+    WasMentioned: isGroup ? event.wasMentioned : undefined,
+    CommandAuthorized: true,
+  });
+
+  if (verbose) {
+    console.log("======ctxPayload======");
+    console.log(ctxPayload);
+  }
+  // Record session using recordInboundSession for proper session tracking
+  await core.channel.session.recordInboundSession({
+    storePath,
+    sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+    ctx: ctxPayload,
+    onRecordError: (err) => {
+      if (verbose) {
+        console.error(`[infoflow] failed updating session meta: ${String(err)}`);
+      }
+    },
+  });
+
+  // Mention gating: skip reply if requireMention is enabled and bot was not mentioned
+  // Session is already recorded above for context history
+  if (isGroup) {
+    const requireMention = account.config.requireMention !== false;
+    const canDetectMention = Boolean(account.config.robotName);
+    const wasMentioned = event.wasMentioned === true;
+
+    if (requireMention && canDetectMention && !wasMentioned) {
+      if (verbose) {
+        console.log(
+          `[infoflow] Group message recorded but reply skipped: requireMention=true, wasMentioned=false`,
+        );
+      }
+      return;
+    }
+  }
+
+  const { dispatcherOptions, replyOptions } = createInfoflowReplyDispatcher({
+    cfg,
+    agentId: route.agentId,
+    accountId: account.accountId,
+    fromuser,
+    chatType,
+    groupId,
+    statusSink,
+  });
+
+  if (verbose) {
+    console.log(
+      `[infoflow] Dispatching to OpenClaw: agentId=${route.agentId}, Body=${ctxPayload.Body?.slice(0, 100)}...`,
+    );
+  }
+
+  await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    ctx: ctxPayload,
+    cfg,
+    dispatcherOptions,
+    replyOptions,
+  });
+
+  if (verbose) {
+    console.log(`[infoflow] Dispatch completed for ${chatType} message from ${fromuser}`);
+  }
+}

--- a/extensions/infoflow/src/bot.ts
+++ b/extensions/infoflow/src/bot.ts
@@ -172,12 +172,6 @@ export async function handleGroupChatMessage(params: HandleGroupChatParams): Pro
   // Extract sender name from header or fallback to fromuser
   const senderName = String(header?.username ?? header?.nickname ?? msgData.username ?? fromuser);
 
-  if (verbose) {
-    console.log(
-      `[infoflow] group chat: fromuser=${fromuser}, groupid=${groupid}, wasMentioned=${wasMentioned}`,
-    );
-  }
-
   // Delegate to the common message handler (group chat)
   await handleInfoflowMessage({
     cfg,
@@ -208,6 +202,19 @@ export async function handleInfoflowMessage(params: HandleInfoflowMessageParams)
   const account = resolveInfoflowAccount({ cfg, accountId });
   const core = getInfoflowRuntime();
   const verbose = core.logging.shouldLogVerbose();
+
+  if (verbose) {
+    console.log(`[infoflow] handleInfoflowMessage invoked:`, {
+      accountId,
+      chatType: event.chatType,
+      fromuser: event.fromuser,
+      groupId: event.groupId,
+      senderName: event.senderName,
+      messageId: event.messageId,
+      timestamp: event.timestamp,
+      wasMentioned: event.wasMentioned,
+    });
+  }
 
   const isGroup = chatType === "group";
   // Convert groupId (number) to string for peerId since routing expects string

--- a/extensions/infoflow/src/bot.ts
+++ b/extensions/infoflow/src/bot.ts
@@ -1,3 +1,7 @@
+import { resolveInfoflowAccount } from "./accounts.js";
+import { getInfoflowBotLog } from "./logging.js";
+import { createInfoflowReplyDispatcher } from "./reply-dispatcher.js";
+import { getInfoflowRuntime } from "./runtime.js";
 import type {
   InfoflowChatType,
   InfoflowMessageEvent,
@@ -5,10 +9,6 @@ import type {
   HandlePrivateChatParams,
   HandleGroupChatParams,
 } from "./types.js";
-import { resolveInfoflowAccount } from "./accounts.js";
-import { getInfoflowBotLog } from "./logging.js";
-import { createInfoflowReplyDispatcher } from "./reply-dispatcher.js";
-import { getInfoflowRuntime } from "./runtime.js";
 
 // Re-export types for external consumers
 export type { InfoflowChatType, InfoflowMessageEvent } from "./types.js";

--- a/extensions/infoflow/src/bot.ts
+++ b/extensions/infoflow/src/bot.ts
@@ -323,3 +323,10 @@ export async function handleInfoflowMessage(params: HandleInfoflowMessageParams)
     getInfoflowBotLog().debug?.(`[infoflow] dispatch complete: ${chatType} from ${fromuser}`);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Test-only exports (@internal)
+// ---------------------------------------------------------------------------
+
+/** @internal — Check if bot was mentioned in message body. Only exported for tests. */
+export const _checkBotMentioned = checkBotMentioned;

--- a/extensions/infoflow/src/bot.ts
+++ b/extensions/infoflow/src/bot.ts
@@ -6,6 +6,7 @@ import type {
   HandleGroupChatParams,
 } from "./types.js";
 import { resolveInfoflowAccount } from "./accounts.js";
+import { getInfoflowBotLog } from "./logging.js";
 import { createInfoflowReplyDispatcher } from "./reply-dispatcher.js";
 import { getInfoflowRuntime } from "./runtime.js";
 
@@ -73,7 +74,9 @@ export async function handlePrivateChatMessage(params: HandlePrivateChatParams):
   const timestamp = createTime != null ? Number(createTime) * 1000 : Date.now();
 
   if (verbose) {
-    console.log(`[infoflow] private chat: fromuser=${fromuser}, senderName=${senderName}`);
+    getInfoflowBotLog().debug?.(
+      `[infoflow] private chat: fromuser=${fromuser}, senderName=${senderName}`,
+    );
   }
 
   if (!fromuser || !mes.trim()) {
@@ -204,16 +207,9 @@ export async function handleInfoflowMessage(params: HandleInfoflowMessageParams)
   const verbose = core.logging.shouldLogVerbose();
 
   if (verbose) {
-    console.log(`[infoflow] handleInfoflowMessage invoked:`, {
-      accountId,
-      chatType: event.chatType,
-      fromuser: event.fromuser,
-      groupId: event.groupId,
-      senderName: event.senderName,
-      messageId: event.messageId,
-      timestamp: event.timestamp,
-      wasMentioned: event.wasMentioned,
-    });
+    getInfoflowBotLog().debug?.(
+      `[infoflow] handleInfoflowMessage invoked: accountId=${accountId}, chatType=${event.chatType}, fromuser=${event.fromuser}, groupId=${event.groupId}`,
+    );
   }
 
   const isGroup = chatType === "group";
@@ -246,7 +242,9 @@ export async function handleInfoflowMessage(params: HandleInfoflowMessageParams)
   const toAddress = isGroup ? `infoflow:${groupId}` : `infoflow:${account.accountId}`;
 
   if (verbose) {
-    console.log(`[infoflow] dispatch: chatType=${chatType}, agentId=${route.agentId}`);
+    getInfoflowBotLog().debug?.(
+      `[infoflow] dispatch: chatType=${chatType}, agentId=${route.agentId}`,
+    );
   }
 
   const body = core.channel.reply.formatAgentEnvelope({
@@ -287,7 +285,7 @@ export async function handleInfoflowMessage(params: HandleInfoflowMessageParams)
     sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
     ctx: ctxPayload,
     onRecordError: (err) => {
-      console.error(`[infoflow] failed updating session meta: ${String(err)}`);
+      getInfoflowBotLog().error(`[infoflow] failed updating session meta: ${String(err)}`);
     },
   });
 
@@ -322,6 +320,6 @@ export async function handleInfoflowMessage(params: HandleInfoflowMessageParams)
   });
 
   if (verbose) {
-    console.log(`[infoflow] dispatch complete: ${chatType} from ${fromuser}`);
+    getInfoflowBotLog().debug?.(`[infoflow] dispatch complete: ${chatType} from ${fromuser}`);
   }
 }

--- a/extensions/infoflow/src/bot.ts
+++ b/extensions/infoflow/src/bot.ts
@@ -5,7 +5,7 @@ import type {
   HandlePrivateChatParams,
   HandleGroupChatParams,
 } from "./types.js";
-import { resolveInfoflowAccount } from "./channel.js";
+import { resolveInfoflowAccount } from "./accounts.js";
 import { createInfoflowReplyDispatcher } from "./reply-dispatcher.js";
 import { getInfoflowRuntime } from "./runtime.js";
 
@@ -296,13 +296,14 @@ export async function handleInfoflowMessage(params: HandleInfoflowMessageParams)
     }
   }
 
+  // Build unified target: "group:<id>" for group chat, username for private chat
+  const to = isGroup && groupId !== undefined ? `group:${groupId}` : fromuser;
+
   const { dispatcherOptions, replyOptions } = createInfoflowReplyDispatcher({
     cfg,
     agentId: route.agentId,
     accountId: account.accountId,
-    fromuser,
-    chatType,
-    groupId,
+    to,
     statusSink,
   });
 

--- a/extensions/infoflow/src/bot.ts
+++ b/extensions/infoflow/src/bot.ts
@@ -75,7 +75,7 @@ export async function handlePrivateChatMessage(params: HandlePrivateChatParams):
 
   if (verbose) {
     getInfoflowBotLog().debug?.(
-      `[infoflow] private chat: fromuser=${fromuser}, senderName=${senderName}`,
+      `[infoflow] private chat: fromuser=${fromuser}, senderName=${senderName}, raw msgData: ${JSON.stringify(msgData)}`,
     );
   }
 
@@ -125,6 +125,12 @@ export async function handleGroupChatMessage(params: HandleGroupChatParams): Pro
   // Extract timestamp (time is in milliseconds)
   const rawTime = msgData.time ?? header?.servertime;
   const timestamp = rawTime != null ? Number(rawTime) : Date.now();
+
+  if (verbose) {
+    getInfoflowBotLog().debug?.(
+      `[infoflow] group chat: fromuser=${fromuser}, groupid=${groupid}, raw msgData: ${JSON.stringify(msgData)}`,
+    );
+  }
 
   if (!fromuser) {
     return;

--- a/extensions/infoflow/src/channel.ts
+++ b/extensions/infoflow/src/channel.ts
@@ -16,6 +16,7 @@ import {
   resolveDefaultInfoflowAccountId,
   resolveInfoflowAccount,
 } from "./accounts.js";
+import { getInfoflowSendLog } from "./logging.js";
 import { startInfoflowMonitor } from "./monitor.js";
 import { getInfoflowRuntime } from "./runtime.js";
 import { sendInfoflowMessage } from "./send.js";
@@ -201,7 +202,7 @@ export const infoflowPlugin: ChannelPlugin<ResolvedInfoflowAccount> = {
     sendText: async ({ cfg, to, text, accountId }) => {
       const verbose = getInfoflowRuntime().logging.shouldLogVerbose();
       if (verbose) {
-        console.log(`[infoflow:sendText] to=${to}, accountId=${accountId}`);
+        getInfoflowSendLog().debug?.(`[infoflow:sendText] to=${to}, accountId=${accountId}`);
       }
       // Use "markdown" type even though param is named `text`: LLM outputs are often markdown,
       // and Infoflow's markdown type handles both plain text and markdown seamlessly.
@@ -219,7 +220,9 @@ export const infoflowPlugin: ChannelPlugin<ResolvedInfoflowAccount> = {
     sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
       const verbose = getInfoflowRuntime().logging.shouldLogVerbose();
       if (verbose) {
-        console.log(`[infoflow:sendMedia] to=${to}, accountId=${accountId}, mediaUrl=${mediaUrl}`);
+        getInfoflowSendLog().debug?.(
+          `[infoflow:sendMedia] to=${to}, accountId=${accountId}, mediaUrl=${mediaUrl}`,
+        );
       }
 
       // Build contents array: text (if provided) + link for media URL

--- a/extensions/infoflow/src/channel.ts
+++ b/extensions/infoflow/src/channel.ts
@@ -1,0 +1,504 @@
+import {
+  applyAccountNameToChannelSection,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  migrateBaseNameToDefaultAccount,
+  normalizeAccountId,
+  setAccountEnabledInConfigSection,
+  type ChannelPlugin,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk";
+import type { InfoflowAccountConfig, InfoflowAtOptions, ResolvedInfoflowAccount } from "./types.js";
+import { startInfoflowMonitor } from "./monitor.js";
+import { getInfoflowRuntime } from "./runtime.js";
+import { sendInfoflowPrivateMessage, sendInfoflowGroupMessage } from "./send.js";
+import { normalizeInfoflowTarget, looksLikeInfoflowId } from "./targets.js";
+
+// Re-export types for external consumers
+export type { InfoflowAccountConfig, ResolvedInfoflowAccount } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Account resolution helpers
+// ---------------------------------------------------------------------------
+
+function getChannelSection(cfg: OpenClawConfig): InfoflowAccountConfig | undefined {
+  return cfg.channels?.["infoflow"] as InfoflowAccountConfig | undefined;
+}
+
+function listInfoflowAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = getChannelSection(cfg)?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  const ids = Object.keys(accounts).filter(Boolean);
+  return ids.length === 0 ? [DEFAULT_ACCOUNT_ID] : ids.toSorted((a, b) => a.localeCompare(b));
+}
+
+function resolveDefaultInfoflowAccountId(cfg: OpenClawConfig): string {
+  const channel = getChannelSection(cfg);
+  if (channel?.defaultAccount?.trim()) {
+    return channel.defaultAccount.trim();
+  }
+  const ids = listInfoflowAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function mergeInfoflowAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): {
+  apiHost: string;
+  check_token: string;
+  encodingAESKey: string;
+  appKey: string;
+  appSecret: string;
+  enabled?: boolean;
+  name?: string;
+  robotName?: string;
+  requireMention?: boolean;
+} {
+  const raw = getChannelSection(cfg) ?? {};
+  const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
+  const account = raw.accounts?.[accountId] ?? {};
+  return { ...base, ...account } as {
+    apiHost: string;
+    check_token: string;
+    encodingAESKey: string;
+    appKey: string;
+    appSecret: string;
+    enabled?: boolean;
+    name?: string;
+    robotName?: string;
+    requireMention?: boolean;
+  };
+}
+
+export function resolveInfoflowAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedInfoflowAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const baseEnabled = getChannelSection(params.cfg)?.enabled !== false;
+  const merged = mergeInfoflowAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const apiHost = merged.apiHost ?? "";
+  const check_token = merged.check_token ?? "";
+  const encodingAESKey = merged.encodingAESKey ?? "";
+  const appKey = merged.appKey ?? "";
+  const appSecret = merged.appSecret ?? "";
+  const configured = Boolean(check_token) && Boolean(appKey) && Boolean(appSecret);
+
+  return {
+    accountId,
+    name: merged.name?.trim() || undefined,
+    enabled,
+    configured,
+    config: {
+      enabled: merged.enabled,
+      name: merged.name,
+      apiHost,
+      check_token,
+      encodingAESKey,
+      appKey,
+      appSecret,
+      robotName: merged.robotName?.trim() || undefined,
+      requireMention: merged.requireMention,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Channel plugin
+// ---------------------------------------------------------------------------
+
+export const infoflowPlugin: ChannelPlugin<ResolvedInfoflowAccount> = {
+  id: "infoflow",
+  meta: {
+    id: "infoflow",
+    label: "Infoflow",
+    selectionLabel: "Infoflow (如流)",
+    docsPath: "/channels/infoflow",
+    blurb: "Baidu Infoflow enterprise messaging platform.",
+    showConfigured: true,
+  },
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    nativeCommands: true,
+  },
+  reload: { configPrefixes: ["channels.infoflow"] },
+  config: {
+    listAccountIds: (cfg) => listInfoflowAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveInfoflowAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultInfoflowAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "infoflow",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "infoflow",
+        accountId,
+        clearBaseFields: ["check_token", "encodingAESKey", "appKey", "appSecret", "name"],
+      }),
+    isConfigured: (account) => account.configured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+    }),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const channelCfg = getChannelSection(cfg);
+      const useAccountPath = Boolean(channelCfg?.accounts?.[resolvedAccountId]);
+      const basePath = useAccountPath
+        ? `channels.infoflow.accounts.${resolvedAccountId}.`
+        : "channels.infoflow.";
+
+      return {
+        policy: ((account.config as Record<string, unknown>).dmPolicy as string) ?? "open",
+        allowFrom: ((account.config as Record<string, unknown>).allowFrom as string[]) ?? [],
+        policyPath: `${basePath}dmPolicy`,
+        allowFromPath: basePath,
+        approveHint: formatPairingApproveHint("infoflow"),
+        normalizeEntry: (raw: string) => raw.replace(/^infoflow:/i, ""),
+      };
+    },
+    collectWarnings: ({ account, cfg }) => {
+      const warnings: string[] = [];
+      const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
+      const groupPolicy =
+        ((account.config as Record<string, unknown>).groupPolicy as string) ??
+        defaultGroupPolicy ??
+        "open";
+
+      if (groupPolicy === "open") {
+        warnings.push(
+          `- Infoflow groups: groupPolicy="open" allows any group to trigger. Consider setting channels.infoflow.groupPolicy="allowlist".`,
+        );
+      }
+      return warnings;
+    },
+  },
+  groups: {
+    resolveRequireMention: ({ cfg, accountId }) => {
+      const channelCfg = getChannelSection(cfg);
+      const accountCfg =
+        accountId && accountId !== DEFAULT_ACCOUNT_ID
+          ? channelCfg?.accounts?.[accountId]
+          : channelCfg;
+      return (accountCfg as Record<string, unknown> | undefined)?.requireMention !== false;
+    },
+    resolveToolPolicy: () => {
+      // Return undefined to use global policy
+      return undefined;
+    },
+  },
+  messaging: {
+    normalizeTarget: (raw) => normalizeInfoflowTarget(raw),
+    targetResolver: {
+      looksLikeId: looksLikeInfoflowId,
+      hint: "<username|group:groupId>",
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "infoflow",
+        accountId,
+        name,
+      }),
+    validateInput: ({ input }) => {
+      if (!input.token) {
+        return "Infoflow requires --token (check_token).";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "infoflow",
+        accountId,
+        name: input.name,
+      });
+      const next =
+        accountId !== DEFAULT_ACCOUNT_ID
+          ? migrateBaseNameToDefaultAccount({ cfg: namedConfig, channelKey: "infoflow" })
+          : namedConfig;
+
+      const patch: Record<string, unknown> = {};
+      if (input.token) {
+        patch.check_token = input.token;
+      }
+
+      const existing = (next.channels?.["infoflow"] ?? {}) as Record<string, unknown>;
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            infoflow: {
+              ...existing,
+              enabled: true,
+              ...patch,
+            },
+          },
+        } as OpenClawConfig;
+      }
+      const existingAccounts = (existing.accounts ?? {}) as Record<string, Record<string, unknown>>;
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          infoflow: {
+            ...existing,
+            enabled: true,
+            accounts: {
+              ...existingAccounts,
+              [accountId]: {
+                ...existingAccounts[accountId],
+                enabled: true,
+                ...patch,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunkerMode: "text",
+    textChunkLimit: 4000,
+    chunker: (text, limit) => getInfoflowRuntime().channel.text.chunkText(text, limit),
+    sendText: async ({ cfg, to, text, accountId }) => {
+      const verbose = getInfoflowRuntime().logging.shouldLogVerbose();
+      if (verbose) {
+        console.log(`[infoflow:sendText] start: to=${to}, accountId=${accountId}, text=${text}`);
+      }
+
+      const account = resolveInfoflowAccount({ cfg, accountId });
+      const { apiHost, appKey, appSecret } = account.config;
+
+      if (!appKey || !appSecret) {
+        console.error(`[infoflow:sendText] error: appKey/appSecret not configured`);
+        throw new Error("Infoflow appKey/appSecret not configured.");
+      }
+
+      const target = to.replace(/^infoflow:/i, "");
+      if (verbose) {
+        console.log(`[infoflow:sendText] resolved target=${target}, apiHost=${apiHost}`);
+      }
+
+      // Check if target is a group (format: group:123 or group:123?at=user1,user2 or group:123?atall=true)
+      const groupMatch = target.match(/^group:(\d+)/i);
+      if (groupMatch) {
+        const groupId = Number(groupMatch[1]);
+
+        // Parse AT options from query string
+        let atOptions: InfoflowAtOptions | undefined;
+        const atAllMatch = target.match(/[?&]atall=true/i);
+        const atMatch = target.match(/[?&]at=([^&]+)/);
+        if (atAllMatch) {
+          atOptions = { atAll: true };
+        } else if (atMatch) {
+          const atUserIds = atMatch[1]
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          if (atUserIds.length > 0) {
+            atOptions = { atUserIds };
+          }
+        }
+
+        if (verbose) {
+          console.log(
+            `[infoflow:sendText] sending group message: groupId=${groupId}, atOptions=${JSON.stringify(atOptions)}`,
+          );
+        }
+
+        const result = await sendInfoflowGroupMessage({
+          apiHost,
+          appKey,
+          appSecret,
+          groupId,
+          content: text,
+          atOptions,
+        });
+
+        if (verbose) {
+          console.log(
+            `[infoflow:sendText] group message result: ok=${result.ok}, messageId=${result.messageid}, error=${result.error}`,
+          );
+        }
+
+        return {
+          channel: "infoflow",
+          messageId: result.ok ? (result.messageid ?? "sent") : "failed",
+        };
+      }
+
+      // Private message (DM)
+      if (verbose) {
+        console.log(`[infoflow:sendText] sending private message: touser=${target}`);
+      }
+
+      const result = await sendInfoflowPrivateMessage({
+        apiHost,
+        appKey,
+        appSecret,
+        touser: target,
+        content: text,
+      });
+
+      if (verbose) {
+        console.log(
+          `[infoflow:sendText] private message result: ok=${result.ok}, msgkey=${result.msgkey}, error=${result.error}`,
+        );
+      }
+
+      return { channel: "infoflow", messageId: result.ok ? (result.msgkey ?? "sent") : "failed" };
+    },
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+      const verbose = getInfoflowRuntime().logging.shouldLogVerbose();
+      if (verbose) {
+        console.log(
+          `[infoflow:sendMedia] start: to=${to}, accountId=${accountId}, textLen=${text?.length ?? 0}, mediaUrl=${mediaUrl}`,
+        );
+      }
+
+      // Infoflow currently only supports text messages.
+      // Fallback: send media URL as a text link with optional caption.
+      const account = resolveInfoflowAccount({ cfg, accountId });
+      const { apiHost, appKey, appSecret } = account.config;
+
+      if (!appKey || !appSecret) {
+        console.error(`[infoflow:sendMedia] error: appKey/appSecret not configured`);
+        throw new Error("Infoflow appKey/appSecret not configured.");
+      }
+
+      // Build message: caption + media URL
+      const messageText = text?.trim() ? `${text.trim()}\n\n📎 ${mediaUrl}` : `📎 ${mediaUrl}`;
+      if (verbose) {
+        console.log(
+          `[infoflow:sendMedia] built messageText (len=${messageText.length}), using text fallback for media`,
+        );
+      }
+
+      const target = to.replace(/^infoflow:/i, "");
+      if (verbose) {
+        console.log(`[infoflow:sendMedia] resolved target=${target}, apiHost=${apiHost}`);
+      }
+
+      // Check if target is a group
+      const groupMatch = target.match(/^group:(\d+)/i);
+      if (groupMatch) {
+        const groupId = Number(groupMatch[1]);
+        if (verbose) {
+          console.log(`[infoflow:sendMedia] sending group message: groupId=${groupId}`);
+        }
+
+        const result = await sendInfoflowGroupMessage({
+          apiHost,
+          appKey,
+          appSecret,
+          groupId,
+          content: messageText,
+        });
+
+        if (verbose) {
+          console.log(
+            `[infoflow:sendMedia] group message result: ok=${result.ok}, messageId=${result.messageid}, error=${result.error}`,
+          );
+        }
+
+        return {
+          channel: "infoflow",
+          messageId: result.ok ? (result.messageid ?? "sent") : "failed",
+        };
+      }
+
+      // Private message (DM)
+      if (verbose) {
+        console.log(`[infoflow:sendMedia] sending private message: touser=${target}`);
+      }
+
+      const result = await sendInfoflowPrivateMessage({
+        apiHost,
+        appKey,
+        appSecret,
+        touser: target,
+        content: messageText,
+      });
+
+      if (verbose) {
+        console.log(
+          `[infoflow:sendMedia] private message result: ok=${result.ok}, msgkey=${result.msgkey}, error=${result.error}`,
+        );
+      }
+
+      return { channel: "infoflow", messageId: result.ok ? (result.msgkey ?? "sent") : "failed" };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    buildAccountSnapshot: ({ account, runtime }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+    }),
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.log?.info(`[${account.accountId}] starting Infoflow webhook`);
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: true,
+        lastStartAt: Date.now(),
+      });
+      const unregister = await startInfoflowMonitor({
+        account,
+        config: ctx.cfg,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
+      });
+      return () => {
+        unregister?.();
+        ctx.setStatus({
+          accountId: account.accountId,
+          running: false,
+          lastStopAt: Date.now(),
+        });
+      };
+    },
+  },
+};

--- a/extensions/infoflow/src/channel.ts
+++ b/extensions/infoflow/src/channel.ts
@@ -9,7 +9,6 @@ import {
   type ChannelPlugin,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk";
-import type { InfoflowMessageContentItem, ResolvedInfoflowAccount } from "./types.js";
 import {
   getChannelSection,
   listInfoflowAccountIds,
@@ -21,6 +20,7 @@ import { startInfoflowMonitor } from "./monitor.js";
 import { getInfoflowRuntime } from "./runtime.js";
 import { sendInfoflowMessage } from "./send.js";
 import { normalizeInfoflowTarget, looksLikeInfoflowId } from "./targets.js";
+import type { InfoflowMessageContentItem, ResolvedInfoflowAccount } from "./types.js";
 
 // Re-export types and account functions for external consumers
 export type { InfoflowAccountConfig, ResolvedInfoflowAccount } from "./types.js";

--- a/extensions/infoflow/src/infoflow-req-parse.test.ts
+++ b/extensions/infoflow/src/infoflow-req-parse.test.ts
@@ -1,0 +1,168 @@
+import { createCipheriv } from "node:crypto";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  _extractDedupeKey,
+  _isDuplicateMessage,
+  _base64UrlSafeDecode,
+  _decryptMessage,
+  _parseXmlMessage,
+  _resetMessageCache,
+  recordSentMessageId,
+} from "./infoflow-req-parse.js";
+
+// ---------------------------------------------------------------------------
+// AES test helpers
+// ---------------------------------------------------------------------------
+
+function aesEcbEncrypt(plaintext: string, keyBytes: Buffer): string {
+  const algo =
+    keyBytes.length === 16 ? "aes-128-ecb" : keyBytes.length === 24 ? "aes-192-ecb" : "aes-256-ecb";
+  const cipher = createCipheriv(algo, keyBytes, null);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return toUrlSafeBase64(encrypted);
+}
+
+function toUrlSafeBase64(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+const KEY_32 = Buffer.from("0123456789abcdef0123456789abcdef"); // 32 bytes → AES-256
+
+// ============================================================================
+// extractDedupeKey
+// ============================================================================
+
+describe("extractDedupeKey", () => {
+  it("returns header.messageid when present", () => {
+    expect(_extractDedupeKey({ message: { header: { messageid: "msg-001" } } })).toBe("msg-001");
+  });
+
+  it("builds composite key from fromuserid + groupid + ctime", () => {
+    expect(
+      _extractDedupeKey({
+        message: { header: { fromuserid: "user1", groupid: "g1", ctime: 12345 } },
+      }),
+    ).toBe("user1_g1_12345");
+  });
+
+  it("Date.now() fallback when ctime is missing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00.000Z"));
+    try {
+      const key = _extractDedupeKey({ message: { header: { fromuserid: "user1" } } });
+      expect(key).toBe(`user1_dm_${Date.now()}`);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns null when no extractable data", () => {
+    expect(_extractDedupeKey({})).toBeNull();
+  });
+});
+
+// ============================================================================
+// isDuplicateMessage
+// ============================================================================
+
+describe("isDuplicateMessage", () => {
+  beforeEach(() => {
+    _resetMessageCache();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("first-seen → false, duplicate → true", () => {
+    const msg = { message: { header: { messageid: "msg-1" } } };
+    expect(_isDuplicateMessage(msg)).toBe(false);
+    expect(_isDuplicateMessage(msg)).toBe(true);
+  });
+
+  it("returns false after TTL expires", () => {
+    const msg = { message: { header: { messageid: "msg-1" } } };
+    _isDuplicateMessage(msg);
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    expect(_isDuplicateMessage(msg)).toBe(false);
+  });
+
+  it("recordSentMessageId prevents echo-back", () => {
+    recordSentMessageId("sent-1");
+    expect(_isDuplicateMessage({ message: { header: { messageid: "sent-1" } } })).toBe(true);
+  });
+});
+
+// ============================================================================
+// base64UrlSafeDecode
+// ============================================================================
+
+describe("base64UrlSafeDecode", () => {
+  it("decodes URL-safe characters (- and _)", () => {
+    const original = Buffer.from([0xfb, 0xef, 0xbe]);
+    const urlSafe = original
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(_base64UrlSafeDecode(urlSafe)).toEqual(original);
+  });
+
+  it("auto-pads missing = characters", () => {
+    expect(_base64UrlSafeDecode("SGVsbG8").toString("utf8")).toBe("Hello");
+  });
+});
+
+// ============================================================================
+// decryptMessage
+// ============================================================================
+
+describe("decryptMessage", () => {
+  it("round-trips AES-256-ECB", () => {
+    const plaintext = '{"fromuser":"bob","content":"hi"}';
+    const encrypted = aesEcbEncrypt(plaintext, KEY_32);
+    expect(_decryptMessage(encrypted, toUrlSafeBase64(KEY_32))).toBe(plaintext);
+  });
+
+  it("throws on invalid key length", () => {
+    const badKey = Buffer.alloc(15, 0x41);
+    const encrypted = aesEcbEncrypt("test", KEY_32);
+    expect(() => _decryptMessage(encrypted, toUrlSafeBase64(badKey))).toThrow(
+      /Invalid AES key length/,
+    );
+  });
+
+  it("round-trips Unicode content", () => {
+    const plaintext = "你好世界 🌍";
+    const encrypted = aesEcbEncrypt(plaintext, KEY_32);
+    expect(_decryptMessage(encrypted, toUrlSafeBase64(KEY_32))).toBe(plaintext);
+  });
+});
+
+// ============================================================================
+// parseXmlMessage
+// ============================================================================
+
+describe("parseXmlMessage", () => {
+  it("parses simple XML tags", () => {
+    expect(_parseXmlMessage("<xml><Name>test</Name></xml>")).toEqual({ Name: "test" });
+  });
+
+  it("parses CDATA sections", () => {
+    expect(_parseXmlMessage("<xml><Content><![CDATA[hello world]]></Content></xml>")).toEqual({
+      Content: "hello world",
+    });
+  });
+
+  it("returns null for empty string", () => {
+    expect(_parseXmlMessage("")).toBeNull();
+  });
+
+  it("handles CDATA containing XML-like content", () => {
+    expect(_parseXmlMessage("<xml><Content><![CDATA[<b>bold</b>]]></Content></xml>")).toEqual({
+      Content: "<b>bold</b>",
+    });
+  });
+});

--- a/extensions/infoflow/src/infoflow-req-parse.ts
+++ b/extensions/infoflow/src/infoflow-req-parse.ts
@@ -1,12 +1,12 @@
+import { createHash, createDecipheriv } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { createHash, createDecipheriv } from "node:crypto";
 import { createDedupeCache } from "openclaw/plugin-sdk";
-import type { ResolvedInfoflowAccount } from "./channel.js";
 // ---------------------------------------------------------------------------
 // Message deduplication
 // ---------------------------------------------------------------------------
 import { handlePrivateChatMessage, handleGroupChatMessage } from "./bot.js";
+import type { ResolvedInfoflowAccount } from "./channel.js";
 import { getInfoflowParseLog } from "./logging.js";
 
 const DEDUP_TTL_MS = 5 * 60 * 1000; // 5 minutes

--- a/extensions/infoflow/src/infoflow-req-parse.ts
+++ b/extensions/infoflow/src/infoflow-req-parse.ts
@@ -1,4 +1,4 @@
-import { createHash, createDecipheriv } from "node:crypto";
+import { createHash, createDecipheriv, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { createDedupeCache } from "openclaw/plugin-sdk";
@@ -241,7 +241,10 @@ export async function parseAndDispatchInfoflowRequest(
         const expectedSig = createHash("md5")
           .update(`${rn}${timestamp}${checkToken}`)
           .digest("hex");
-        if (signature === expectedSig) {
+        if (
+          signature.length === expectedSig.length &&
+          timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSig))
+        ) {
           if (verbose) {
             getInfoflowParseLog().debug?.(`[infoflow] echostr verified successfully`);
           }

--- a/extensions/infoflow/src/infoflow-req-parse.ts
+++ b/extensions/infoflow/src/infoflow-req-parse.ts
@@ -245,9 +245,6 @@ export async function parseAndDispatchInfoflowRequest(
           signature.length === expectedSig.length &&
           timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSig))
         ) {
-          if (verbose) {
-            getInfoflowParseLog().debug?.(`[infoflow] echostr verified successfully`);
-          }
           return { handled: true, statusCode: 200, body: echostr };
         }
       }
@@ -305,12 +302,6 @@ function tryDecryptAndDispatch(params: DecryptDispatchParams): ParseResult {
   if (!encryptedContent.trim()) {
     getInfoflowParseLog().error(`[infoflow] ${chatType}: empty encrypted content`);
     return { handled: true, statusCode: 400, body: "empty content" };
-  }
-
-  if (verbose) {
-    getInfoflowParseLog().debug?.(
-      `[infoflow] ${chatType}: trying ${targets.length} account(s) for decryption`,
-    );
   }
 
   for (const target of targets) {

--- a/extensions/infoflow/src/infoflow_req_parse.ts
+++ b/extensions/infoflow/src/infoflow_req_parse.ts
@@ -1,0 +1,534 @@
+import type { IncomingMessage } from "node:http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { createHash, createDecipheriv } from "node:crypto";
+import type { ResolvedInfoflowAccount } from "./channel.js";
+import { handlePrivateChatMessage, handleGroupChatMessage } from "./bot.js";
+
+// ---------------------------------------------------------------------------
+// Message deduplication
+// ---------------------------------------------------------------------------
+
+const DEDUP_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const DEDUP_MAX_SIZE = 1000;
+
+const messageCache = new Map<string, number>(); // key → timestamp
+
+/**
+ * Extracts a dedup key from the decrypted message data.
+ *
+ * Priority:
+ *   1. message.header.messageid || message.header.msgid || MsgId
+ *   2. fallback: "{fromuserid}_{groupid}_{ctime}"
+ */
+function extractDedupeKey(msgData: Record<string, unknown>): string | null {
+  const message = msgData.message as Record<string, unknown> | undefined;
+  const header = (message?.header ?? {}) as Record<string, unknown>;
+
+  // Priority 1: explicit message ID
+  const msgId = header.messageid ?? header.msgid ?? msgData.MsgId;
+  if (msgId != null) {
+    return String(msgId);
+  }
+
+  // Priority 2: composite key
+  const fromuserid = header.fromuserid ?? msgData.FromUserId ?? msgData.fromuserid;
+  const groupid = msgData.groupid ?? header.groupid;
+  const ctime = header.ctime ?? Date.now();
+  if (fromuserid != null) {
+    return `${fromuserid}_${groupid ?? "dm"}_${ctime}`;
+  }
+
+  return null;
+}
+
+/**
+ * Returns true if the message is a duplicate (already seen within TTL).
+ * If new, records it in cache. Prunes expired + oversized entries.
+ */
+function isDuplicateMessage(msgData: Record<string, unknown>): boolean {
+  const key = extractDedupeKey(msgData);
+  if (!key) return false; // Cannot extract key, allow through
+
+  const now = Date.now();
+
+  // Check existing
+  const existing = messageCache.get(key);
+  if (existing !== undefined && now - existing < DEDUP_TTL_MS) {
+    return true;
+  }
+
+  // Record new
+  messageCache.delete(key); // Ensure insertion at Map tail
+  messageCache.set(key, now);
+
+  // Prune expired
+  for (const [k, ts] of messageCache) {
+    if (now - ts >= DEDUP_TTL_MS) {
+      messageCache.delete(k);
+    } else {
+      break; // Map is insertion-ordered, later entries are newer
+    }
+  }
+
+  // Prune oversized
+  while (messageCache.size > DEDUP_MAX_SIZE) {
+    const oldest = messageCache.keys().next().value;
+    if (oldest) messageCache.delete(oldest);
+    else break;
+  }
+
+  return false;
+}
+
+/**
+ * Records a sent message ID in the dedup cache.
+ * Called after successfully sending a message to prevent
+ * the bot from processing its own outbound messages as inbound.
+ */
+export function recordSentMessageId(messageId: string | number): void {
+  if (messageId == null) return;
+  const key = String(messageId);
+  const now = Date.now();
+
+  messageCache.delete(key);
+  messageCache.set(key, now);
+
+  // Prune oversized
+  while (messageCache.size > DEDUP_MAX_SIZE) {
+    const oldest = messageCache.keys().next().value;
+    if (oldest) messageCache.delete(oldest);
+    else break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AES-ECB Decryption Utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Decodes a Base64 URLSafe encoded string to a Buffer.
+ * Handles the URL-safe alphabet (- → +, _ → /) and auto-pads with '='.
+ */
+function base64UrlSafeDecode(s: string): Buffer {
+  const base64 = s.replace(/-/g, "+").replace(/_/g, "/");
+  const padLen = (4 - (base64.length % 4)) % 4;
+  return Buffer.from(base64 + "=".repeat(padLen), "base64");
+}
+
+/**
+ * Decrypts an AES-ECB encrypted message.
+ * @param encryptedMsg - Base64 URLSafe encoded ciphertext
+ * @param encodingAESKey - Base64 URLSafe encoded AES key (supports 16/24/32 byte keys)
+ * @returns Decrypted UTF-8 string
+ */
+function decryptMessage(encryptedMsg: string, encodingAESKey: string): string {
+  const aesKey = base64UrlSafeDecode(encodingAESKey);
+  const cipherText = base64UrlSafeDecode(encryptedMsg);
+
+  // Select AES algorithm based on key length
+  let algorithm: string;
+  switch (aesKey.length) {
+    case 16:
+      algorithm = "aes-128-ecb";
+      break;
+    case 24:
+      algorithm = "aes-192-ecb";
+      break;
+    case 32:
+      algorithm = "aes-256-ecb";
+      break;
+    default:
+      throw new Error(`Invalid AES key length: ${aesKey.length} bytes (expected 16, 24, or 32)`);
+  }
+
+  // ECB mode does not use an IV (pass null)
+  const decipher = createDecipheriv(algorithm, aesKey, null);
+  const decrypted = Buffer.concat([decipher.update(cipherText), decipher.final()]);
+  return decrypted.toString("utf8");
+}
+
+/**
+ * Parses an XML message string into a key-value object.
+ * Handles simple XML structures like <xml><Tag>value</Tag></xml>.
+ */
+function parseXmlMessage(xmlString: string): Record<string, string> | null {
+  try {
+    const result: Record<string, string> = {};
+    // Match <TagName>content</TagName> patterns
+    const tagRegex = /<(\w+)>(?:<!\[CDATA\[([\s\S]*?)\]\]>|([^<]*))<\/\1>/g;
+    let match;
+    while ((match = tagRegex.exec(xmlString)) !== null) {
+      const tagName = match[1];
+      // CDATA content or plain text content
+      const content = match[2] ?? match[3] ?? "";
+      result[tagName] = content.trim();
+    }
+    return Object.keys(result).length > 0 ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type InfoflowCoreRuntime = {
+  logging: { shouldLogVerbose(): boolean };
+};
+
+export type WebhookTarget = {
+  account: ResolvedInfoflowAccount;
+  config: OpenClawConfig;
+  core: InfoflowCoreRuntime;
+  path: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+export type ParsedInfoflowMessage = {
+  fromuser: string;
+  mes: string;
+  chatType: "direct" | "group";
+};
+
+export type ParseResult = { handled: true; statusCode: number; body: string } | { handled: false };
+
+// ---------------------------------------------------------------------------
+// Body readers
+// ---------------------------------------------------------------------------
+
+const MAX_BODY_SIZE = 20 * 1024 * 1024; // 20 MB
+
+/** Load raw body as a string from the request stream; enforces max size. */
+export async function loadRawBody(
+  req: IncomingMessage,
+  maxBytes = MAX_BODY_SIZE,
+): Promise<{ ok: true; raw: string } | { ok: false; error: string }> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let done = false;
+  return await new Promise((resolve) => {
+    req.on("data", (chunk: Buffer) => {
+      if (done) return;
+      total += chunk.length;
+      if (total > maxBytes) {
+        done = true;
+        resolve({ ok: false, error: "payload too large" });
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (done) return;
+      done = true;
+      const raw = Buffer.concat(chunks).toString("utf8");
+      resolve({ ok: true, raw });
+    });
+    req.on("error", (err) => {
+      if (done) return;
+      done = true;
+      resolve({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses and dispatches an incoming Infoflow webhook request.
+ *
+ * 1. Parses Content-Type header once.
+ * 2. form-urlencoded:
+ *    - echostr present → signature verification → 200/403
+ *    - messageJson present → private chat (dm) handling
+ * 3. text/plain → group chat handling (raw body is encrypted ciphertext)
+ * 4. Other Content-Type → 400
+ *
+ * Returns a ParseResult indicating whether the request was handled and the response to send.
+ */
+export async function parseAndDispatchInfoflowRequest(
+  req: IncomingMessage,
+  rawBody: string,
+  targets: WebhookTarget[],
+): Promise<ParseResult> {
+  const verbose = targets[0]?.core?.logging?.shouldLogVerbose?.() ?? false;
+
+  // --- 1. Parse all needed headers once ---
+  const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
+
+  if (verbose) {
+    console.log(
+      `[infoflow] parseAndDispatch: contentType=${contentType}, bodyLen=${rawBody.length}`,
+    );
+  }
+
+  // --- 2. form-urlencoded: echostr verification + private chat ---
+  if (contentType.startsWith("application/x-www-form-urlencoded")) {
+    if (verbose) {
+      console.log(`[infoflow] handling form-urlencoded request`);
+    }
+    const form = new URLSearchParams(rawBody);
+
+    // 2a. echostr signature verification (try all accounts' tokens for multi-account support)
+    const echostr = form.get("echostr") ?? "";
+    if (echostr) {
+      if (verbose) {
+        console.log(`[infoflow] echostr verification request`);
+      }
+      const signature = form.get("signature") ?? "";
+      const timestamp = form.get("timestamp") ?? "";
+      const rn = form.get("rn") ?? "";
+      for (const target of targets) {
+        const checkToken = target.account.config.check_token ?? "";
+        if (!checkToken) continue;
+        const expectedSig = createHash("md5")
+          .update(`${rn}${timestamp}${checkToken}`)
+          .digest("hex");
+        if (signature === expectedSig) {
+          if (verbose) {
+            console.log(`[infoflow] echostr verified, returning echostr`);
+          }
+          return { handled: true, statusCode: 200, body: echostr };
+        }
+      }
+      console.error(`[infoflow] echostr signature mismatch`);
+      return { handled: true, statusCode: 403, body: "Invalid signature" };
+    }
+
+    // 2b. private chat message (messageJson field in form)
+    const messageJsonStr = form.get("messageJson") ?? "";
+    if (messageJsonStr) {
+      if (verbose) {
+        console.log(`[infoflow] private chat message detected, dispatching...`);
+      }
+      return handlePrivateMessage(messageJsonStr, targets, verbose);
+    }
+
+    console.error(`[infoflow] form-urlencoded but missing echostr or messageJson`);
+    return { handled: true, statusCode: 400, body: "missing echostr or messageJson" };
+  }
+
+  // --- 3. text/plain: group chat ---
+  if (contentType.startsWith("text/plain")) {
+    if (verbose) {
+      console.log(`[infoflow] group chat message detected, dispatching...`);
+    }
+    return handleGroupMessage(rawBody, targets, verbose);
+  }
+
+  // --- 4. unsupported Content-Type ---
+  console.error(`[infoflow] unsupported contentType: ${contentType}`);
+  return { handled: true, statusCode: 400, body: "unsupported content type" };
+}
+
+// ---------------------------------------------------------------------------
+// Private chat handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles a private (dm) chat message.
+ *
+ * messageJsonStr is the value of the `messageJson` form field,
+ * a JSON string in the shape `{ Encrypt: "..." }`.
+ *
+ * Decrypts the Encrypt field with encodingAESKey (AES-ECB),
+ * parses the decrypted content, then dispatches to bot.ts.
+ */
+function handlePrivateMessage(
+  messageJsonStr: string,
+  targets: WebhookTarget[],
+  verbose: boolean,
+): ParseResult {
+  if (targets.length === 0) {
+    console.error(`[infoflow] private: no target configured`);
+    return { handled: true, statusCode: 500, body: "no target configured" };
+  }
+
+  let messageJson: Record<string, unknown>;
+  try {
+    messageJson = JSON.parse(messageJsonStr) as Record<string, unknown>;
+  } catch {
+    console.error(`[infoflow] private: invalid messageJson`);
+    return { handled: true, statusCode: 400, body: "invalid messageJson" };
+  }
+
+  const encrypt = typeof messageJson.Encrypt === "string" ? messageJson.Encrypt : "";
+  if (!encrypt) {
+    console.error(`[infoflow] private: missing Encrypt field`);
+    return { handled: true, statusCode: 400, body: "missing Encrypt field in messageJson" };
+  }
+
+  if (verbose) {
+    console.log(`[infoflow] private: trying ${targets.length} account(s) for decryption`);
+  }
+
+  // Try each account's key until decryption succeeds (multi-account support)
+  for (const target of targets) {
+    const { encodingAESKey } = target.account.config;
+    if (!encodingAESKey) {
+      if (verbose) {
+        console.log(`[infoflow] private: account ${target.account.accountId} has no AES key, skip`);
+      }
+      continue;
+    }
+
+    let decryptedContent: string;
+    try {
+      decryptedContent = decryptMessage(encrypt, encodingAESKey);
+      if (verbose) {
+        console.log(
+          `[infoflow] private: decryption success for account ${target.account.accountId}`,
+        );
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(
+          `[infoflow] private: decryption failed for account ${target.account.accountId}: ${String(err)}`,
+        );
+      }
+      continue; // Try next account
+    }
+
+    // Parse decrypted content as JSON or XML
+    let msgData: Record<string, unknown> | null = null;
+    try {
+      msgData = JSON.parse(decryptedContent) as Record<string, unknown>;
+      if (verbose) {
+        console.log(`[infoflow] private: parsed as JSON`);
+      }
+    } catch {
+      msgData = parseXmlMessage(decryptedContent);
+      if (verbose) {
+        console.log(`[infoflow] private: parsed as XML, result=${msgData ? "ok" : "null"}`);
+      }
+    }
+
+    if (msgData && Object.keys(msgData).length > 0) {
+      if (isDuplicateMessage(msgData)) {
+        if (verbose) {
+          console.log(`[infoflow] private: duplicate message, skipping`);
+        }
+        return { handled: true, statusCode: 200, body: "success" };
+      }
+
+      if (verbose) {
+        console.log(`[infoflow] private: dispatching to handlePrivateChatMessage`);
+      }
+
+      target.statusSink?.({ lastInboundAt: Date.now() });
+
+      void handlePrivateChatMessage({
+        cfg: target.config,
+        msgData,
+        accountId: target.account.accountId,
+        statusSink: target.statusSink,
+      });
+
+      return { handled: true, statusCode: 200, body: "success" };
+    }
+  }
+
+  console.error(`[infoflow] private: decryption failed for all accounts`);
+  return { handled: true, statusCode: 500, body: "decryption failed for all accounts" };
+}
+
+// ---------------------------------------------------------------------------
+// Group chat handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles a group chat message.
+ *
+ * The rawBody itself is an AES-encrypted ciphertext (Base64URLSafe encoded).
+ * After decryption it yields a JSON object with group message fields.
+ *
+ * Decrypts rawBody with encodingAESKey (AES-ECB),
+ * parses the result, then dispatches to bot.ts.
+ */
+function handleGroupMessage(
+  rawBody: string,
+  targets: WebhookTarget[],
+  verbose: boolean,
+): ParseResult {
+  if (targets.length === 0) {
+    console.error(`[infoflow] group: no target configured`);
+    return { handled: true, statusCode: 500, body: "no target configured" };
+  }
+  if (!rawBody.trim()) {
+    console.error(`[infoflow] group: empty body`);
+    return { handled: true, statusCode: 400, body: "empty body" };
+  }
+
+  if (verbose) {
+    console.log(`[infoflow] group: trying ${targets.length} account(s) for decryption`);
+  }
+
+  // Try each account's key until decryption succeeds (multi-account support)
+  for (const target of targets) {
+    const { encodingAESKey } = target.account.config;
+    if (!encodingAESKey) {
+      if (verbose) {
+        console.log(`[infoflow] group: account ${target.account.accountId} has no AES key, skip`);
+      }
+      continue;
+    }
+
+    let decryptedContent: string;
+    try {
+      decryptedContent = decryptMessage(rawBody, encodingAESKey);
+      if (verbose) {
+        console.log(`[infoflow] group: decryption success for account ${target.account.accountId}`);
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(
+          `[infoflow] group: decryption failed for account ${target.account.accountId}: ${String(err)}`,
+        );
+      }
+      continue; // Try next account
+    }
+
+    let msgData: Record<string, unknown>;
+    try {
+      msgData = JSON.parse(decryptedContent) as Record<string, unknown>;
+      if (verbose) {
+        console.log(`[infoflow] group: parsed JSON successfully`);
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(`[infoflow] group: JSON parse failed: ${String(err)}`);
+      }
+      continue; // Try next account
+    }
+
+    if (msgData && Object.keys(msgData).length > 0) {
+      if (isDuplicateMessage(msgData)) {
+        if (verbose) {
+          console.log(`[infoflow] group: duplicate message, skipping`);
+        }
+        return { handled: true, statusCode: 200, body: "success" };
+      }
+
+      if (verbose) {
+        console.log(`[infoflow] group: dispatching to handleGroupChatMessage`);
+      }
+
+      target.statusSink?.({ lastInboundAt: Date.now() });
+
+      void handleGroupChatMessage({
+        cfg: target.config,
+        msgData,
+        accountId: target.account.accountId,
+        statusSink: target.statusSink,
+      });
+
+      return { handled: true, statusCode: 200, body: "success" };
+    }
+  }
+
+  console.error(`[infoflow] group: decryption failed for all accounts`);
+  return { handled: true, statusCode: 500, body: "decryption failed for all accounts" };
+}

--- a/extensions/infoflow/src/logging.ts
+++ b/extensions/infoflow/src/logging.ts
@@ -1,0 +1,115 @@
+/**
+ * Structured logging module for Infoflow extension.
+ * Provides consistent logging interface across all Infoflow modules.
+ */
+
+import type { RuntimeLogger } from "openclaw/plugin-sdk";
+import { getInfoflowRuntime } from "./runtime.js";
+
+// ---------------------------------------------------------------------------
+// Logger Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a child logger with infoflow-specific bindings.
+ * Uses the PluginRuntime logging system for structured output.
+ */
+function createInfoflowLogger(module?: string): RuntimeLogger {
+  const runtime = getInfoflowRuntime();
+  const bindings: Record<string, unknown> = { subsystem: "gateway/channels/infoflow" };
+  if (module) {
+    bindings.module = module;
+  }
+  return runtime.logging.getChildLogger(bindings);
+}
+
+// ---------------------------------------------------------------------------
+// Module-specific Loggers (lazy initialization)
+// ---------------------------------------------------------------------------
+
+let _sendLog: RuntimeLogger | null = null;
+let _webhookLog: RuntimeLogger | null = null;
+let _botLog: RuntimeLogger | null = null;
+let _parseLog: RuntimeLogger | null = null;
+
+/**
+ * Logger for send operations (private/group message sending).
+ */
+export function getInfoflowSendLog(): RuntimeLogger {
+  if (!_sendLog) {
+    _sendLog = createInfoflowLogger("send");
+  }
+  return _sendLog;
+}
+
+/**
+ * Logger for webhook/monitor operations.
+ */
+export function getInfoflowWebhookLog(): RuntimeLogger {
+  if (!_webhookLog) {
+    _webhookLog = createInfoflowLogger("webhook");
+  }
+  return _webhookLog;
+}
+
+/**
+ * Logger for bot/message processing operations.
+ */
+export function getInfoflowBotLog(): RuntimeLogger {
+  if (!_botLog) {
+    _botLog = createInfoflowLogger("bot");
+  }
+  return _botLog;
+}
+
+/**
+ * Logger for request parsing operations.
+ */
+export function getInfoflowParseLog(): RuntimeLogger {
+  if (!_parseLog) {
+    _parseLog = createInfoflowLogger("parse");
+  }
+  return _parseLog;
+}
+
+// ---------------------------------------------------------------------------
+// Utility Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Format error message for logging.
+ */
+export function formatInfoflowError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Log an API error with operation context.
+ * @param operation - The API operation name (e.g., "sendPrivate", "getToken")
+ * @param error - The error to log
+ * @param logger - Optional logger to use (defaults to send logger)
+ */
+export function logInfoflowApiError(
+  operation: string,
+  error: unknown,
+  logger?: RuntimeLogger,
+): void {
+  const log = logger ?? getInfoflowSendLog();
+  const errMsg = formatInfoflowError(error);
+  log.error(`[infoflow:${operation}] ${errMsg}`);
+}
+
+// ---------------------------------------------------------------------------
+// Test-only exports (@internal)
+// ---------------------------------------------------------------------------
+
+/** @internal — Reset all cached loggers. Only use in tests. */
+export function _resetLoggers(): void {
+  _sendLog = null;
+  _webhookLog = null;
+  _botLog = null;
+  _parseLog = null;
+}

--- a/extensions/infoflow/src/monitor.ts
+++ b/extensions/infoflow/src/monitor.ts
@@ -1,0 +1,187 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ResolvedInfoflowAccount } from "./channel.js";
+import {
+  parseAndDispatchInfoflowRequest,
+  loadRawBody,
+  type WebhookTarget,
+} from "./infoflow_req_parse.js";
+import { getInfoflowRuntime } from "./runtime.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type InfoflowCoreRuntime = ReturnType<typeof getInfoflowRuntime>;
+
+export type InfoflowMonitorOptions = {
+  account: ResolvedInfoflowAccount;
+  config: OpenClawConfig;
+  runtime: unknown;
+  abortSignal: AbortSignal;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** webhook path for Infoflow. */
+const INFOFLOW_WEBHOOK_PATH = "/webhook/infoflow";
+
+// ---------------------------------------------------------------------------
+// Webhook target registry
+// ---------------------------------------------------------------------------
+
+const webhookTargets = new Map<string, WebhookTarget[]>();
+
+/** Normalizes a webhook path: trim, ensure leading slash, strip trailing slash (except "/"). */
+function normalizeWebhookPath(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "/";
+  }
+  const withSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  if (withSlash.length > 1 && withSlash.endsWith("/")) {
+    return withSlash.slice(0, -1);
+  }
+  return withSlash;
+}
+
+/** Registers a webhook target for a path. Returns an unregister function to remove it. */
+function registerInfoflowWebhookTarget(target: WebhookTarget): () => void {
+  const key = normalizeWebhookPath(target.path);
+  const normalizedTarget = { ...target, path: key };
+  const existing = webhookTargets.get(key) ?? [];
+  const next = [...existing, normalizedTarget];
+  webhookTargets.set(key, next);
+  return () => {
+    const updated = (webhookTargets.get(key) ?? []).filter((entry) => entry !== normalizedTarget);
+    if (updated.length > 0) {
+      webhookTargets.set(key, updated);
+    } else {
+      webhookTargets.delete(key);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler (registered via api.registerHttpHandler)
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks if the request path matches a registered Infoflow webhook path.
+ */
+function isInfoflowPath(requestPath: string): boolean {
+  const normalized = normalizeWebhookPath(requestPath);
+  return webhookTargets.has(normalized);
+}
+
+/**
+ * Handles incoming Infoflow webhook HTTP requests.
+ *
+ * - Routes by path to registered targets (supports exact and suffix match).
+ * - Only allows POST.
+ * - Delegates body reading, echostr verification, authentication,
+ *   and message dispatch to infoflow_req_parse.
+ */
+export async function handleInfoflowWebhookRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const requestPath = normalizeWebhookPath(url.pathname);
+
+  if (verbose) {
+    console.log(`[infoflow] webhook request: method=${req.method}, path=${requestPath}`);
+  }
+
+  // Check if path matches Infoflow webhook pattern
+  if (!isInfoflowPath(requestPath)) {
+    if (verbose) {
+      console.log(`[infoflow] path not matched, skipping`);
+    }
+    return false;
+  }
+
+  // Get registered targets for the actual request path
+  const targets = webhookTargets.get(requestPath);
+  if (!targets || targets.length === 0) {
+    if (verbose) {
+      console.log(`[infoflow] no targets registered for path=${requestPath}`);
+    }
+    return false;
+  }
+
+  if (verbose) {
+    console.log(`[infoflow] found ${targets.length} target(s) for path=${requestPath}`);
+  }
+
+  if (req.method !== "POST") {
+    if (verbose) {
+      console.log(`[infoflow] rejected: method ${req.method} not allowed`);
+    }
+    res.statusCode = 405;
+    res.setHeader("Allow", "POST");
+    res.end("Method Not Allowed");
+    return true;
+  }
+
+  // Load raw body once
+  if (verbose) {
+    console.log(`[infoflow] reading request body...`);
+  }
+  const bodyResult = await loadRawBody(req);
+  if (!bodyResult.ok) {
+    console.error(`[infoflow] failed to read body: ${bodyResult.error}`);
+    res.statusCode = bodyResult.error === "payload too large" ? 413 : 400;
+    res.end(bodyResult.error);
+    return true;
+  }
+
+  if (verbose) {
+    console.log(`[infoflow] body read success, length=${bodyResult.raw.length}, dispatching...`);
+  }
+
+  const result = await parseAndDispatchInfoflowRequest(req, bodyResult.raw, targets);
+
+  if (verbose) {
+    console.log(
+      `[infoflow] dispatch result: handled=${result.handled}, status=${result.handled ? result.statusCode : "N/A"}`,
+    );
+  }
+
+  if (result.handled) {
+    if (result.body.startsWith("{")) {
+      res.setHeader("Content-Type", "application/json");
+    }
+    res.statusCode = result.statusCode;
+    res.end(result.body);
+  } else {
+    res.statusCode = 200;
+    res.end("OK");
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Monitor lifecycle
+// ---------------------------------------------------------------------------
+
+/** Registers this account's webhook target and returns an unregister (stop) function. */
+export async function startInfoflowMonitor(options: InfoflowMonitorOptions): Promise<() => void> {
+  const core = getInfoflowRuntime();
+
+  const unregister = registerInfoflowWebhookTarget({
+    account: options.account,
+    config: options.config,
+    core,
+    path: INFOFLOW_WEBHOOK_PATH,
+    statusSink: options.statusSink,
+  });
+
+  return unregister;
+}

--- a/extensions/infoflow/src/monitor.ts
+++ b/extensions/infoflow/src/monitor.ts
@@ -95,7 +95,7 @@ export async function handleInfoflowWebhookRequest(
   const requestPath = normalizeWebhookPath(url.pathname);
 
   if (verbose) {
-    // 记录url全部内容
+    // Log the full request URL
     getInfoflowWebhookLog().debug?.(`[infoflow] request: url=${url}`);
   }
 

--- a/extensions/infoflow/src/monitor.ts
+++ b/extensions/infoflow/src/monitor.ts
@@ -5,7 +5,7 @@ import {
   parseAndDispatchInfoflowRequest,
   loadRawBody,
   type WebhookTarget,
-} from "./infoflow_req_parse.js";
+} from "./infoflow-req-parse.js";
 import { getInfoflowRuntime } from "./runtime.js";
 
 // ---------------------------------------------------------------------------

--- a/extensions/infoflow/src/reply-dispatcher.test.ts
+++ b/extensions/infoflow/src/reply-dispatcher.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("./runtime.js", () => ({
+  getInfoflowRuntime: vi.fn(() => ({
+    logging: { shouldLogVerbose: () => false },
+    channel: {
+      text: {
+        chunkText: (text: string, limit: number) => {
+          // Simple chunking for tests
+          const chunks: string[] = [];
+          for (let i = 0; i < text.length; i += limit) {
+            chunks.push(text.slice(i, i + limit));
+          }
+          return chunks.length ? chunks : [text];
+        },
+      },
+    },
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  createReplyPrefixOptions: vi.fn(() => ({
+    onModelSelected: vi.fn(),
+    responsePrefix: undefined,
+  })),
+}));
+
+const mockSendInfoflowMessage = vi.hoisted(() => vi.fn());
+vi.mock("./send.js", () => ({
+  sendInfoflowMessage: mockSendInfoflowMessage,
+}));
+
+import { createInfoflowReplyDispatcher } from "./reply-dispatcher.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createInfoflowReplyDispatcher", () => {
+  beforeEach(() => {
+    mockSendInfoflowMessage.mockReset();
+    mockSendInfoflowMessage.mockResolvedValue({ ok: true, messageId: "msg-1" });
+  });
+
+  it("returns dispatcherOptions with deliver and onError", () => {
+    const result = createInfoflowReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "acc-1",
+      to: "user1",
+    });
+
+    expect(result.dispatcherOptions).toBeDefined();
+    expect(typeof result.dispatcherOptions.deliver).toBe("function");
+    expect(typeof result.dispatcherOptions.onError).toBe("function");
+    expect(result.replyOptions).toBeDefined();
+  });
+
+  it("deliver sends message via sendInfoflowMessage", async () => {
+    const statusSink = vi.fn();
+    const { dispatcherOptions } = createInfoflowReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "acc-1",
+      to: "user1",
+      statusSink,
+    });
+
+    await dispatcherOptions.deliver({ text: "Hello world" });
+
+    expect(mockSendInfoflowMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendInfoflowMessage).toHaveBeenCalledWith({
+      cfg: {},
+      to: "user1",
+      contents: [{ type: "markdown", content: "Hello world" }],
+      accountId: "acc-1",
+    });
+    expect(statusSink).toHaveBeenCalledWith({ lastOutboundAt: expect.any(Number) });
+  });
+
+  it("deliver skips empty text", async () => {
+    const { dispatcherOptions } = createInfoflowReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "acc-1",
+      to: "user1",
+    });
+
+    await dispatcherOptions.deliver({ text: "" });
+    await dispatcherOptions.deliver({ text: "   " });
+
+    expect(mockSendInfoflowMessage).not.toHaveBeenCalled();
+  });
+
+  it("deliver adds AT content for group messages (first chunk only)", async () => {
+    const { dispatcherOptions } = createInfoflowReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "acc-1",
+      to: "group:12345",
+      atOptions: { atUserIds: ["user1", "user2"] },
+    });
+
+    await dispatcherOptions.deliver({ text: "Hello" });
+
+    expect(mockSendInfoflowMessage).toHaveBeenCalledWith({
+      cfg: {},
+      to: "group:12345",
+      contents: [
+        { type: "markdown", content: "Hello" },
+        { type: "at", content: "user1,user2" },
+      ],
+      accountId: "acc-1",
+    });
+
+    // Test atAll variant
+    mockSendInfoflowMessage.mockClear();
+    const { dispatcherOptions: opts2 } = createInfoflowReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "acc-1",
+      to: "group:99999",
+      atOptions: { atAll: true },
+    });
+
+    await opts2.deliver({ text: "Announcement" });
+
+    expect(mockSendInfoflowMessage).toHaveBeenCalledWith({
+      cfg: {},
+      to: "group:99999",
+      contents: [
+        { type: "markdown", content: "Announcement" },
+        { type: "at", content: "all" },
+      ],
+      accountId: "acc-1",
+    });
+  });
+});

--- a/extensions/infoflow/src/reply-dispatcher.ts
+++ b/extensions/infoflow/src/reply-dispatcher.ts
@@ -4,6 +4,7 @@ import {
   type ReplyPayload,
 } from "openclaw/plugin-sdk";
 import type { InfoflowAtOptions, InfoflowMessageContentItem } from "./types.js";
+import { getInfoflowSendLog } from "./logging.js";
 import { getInfoflowRuntime } from "./runtime.js";
 import { sendInfoflowMessage } from "./send.js";
 
@@ -65,13 +66,13 @@ export function createInfoflowReplyDispatcher(params: CreateInfoflowReplyDispatc
       if (result.ok) {
         statusSink?.({ lastOutboundAt: Date.now() });
       } else if (result.error) {
-        console.error(`[infoflow] Failed to send message: ${result.error}`);
+        getInfoflowSendLog().error(`[infoflow] Failed to send message: ${result.error}`);
       }
     }
   };
 
   const onError = (err: unknown) => {
-    console.error(`[infoflow] reply failed: ${String(err)}`);
+    getInfoflowSendLog().error(`[infoflow] reply failed: ${String(err)}`);
   };
 
   return {

--- a/extensions/infoflow/src/reply-dispatcher.ts
+++ b/extensions/infoflow/src/reply-dispatcher.ts
@@ -3,10 +3,10 @@ import {
   type OpenClawConfig,
   type ReplyPayload,
 } from "openclaw/plugin-sdk";
-import type { InfoflowAtOptions, InfoflowMessageContentItem } from "./types.js";
 import { getInfoflowSendLog } from "./logging.js";
 import { getInfoflowRuntime } from "./runtime.js";
 import { sendInfoflowMessage } from "./send.js";
+import type { InfoflowAtOptions, InfoflowMessageContentItem } from "./types.js";
 
 export type CreateInfoflowReplyDispatcherParams = {
   cfg: OpenClawConfig;

--- a/extensions/infoflow/src/reply-dispatcher.ts
+++ b/extensions/infoflow/src/reply-dispatcher.ts
@@ -1,0 +1,111 @@
+import { createReplyPrefixOptions, type OpenClawConfig } from "openclaw/plugin-sdk";
+import type { InfoflowAtOptions } from "./types.js";
+import { resolveInfoflowAccount } from "./channel.js";
+import { getInfoflowRuntime } from "./runtime.js";
+import { sendInfoflowPrivateMessage, sendInfoflowGroupMessage } from "./send.js";
+
+export type CreateInfoflowReplyDispatcherParams = {
+  cfg: OpenClawConfig;
+  agentId: string;
+  accountId: string;
+  fromuser: string;
+  chatType: "direct" | "group";
+  groupId?: number;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  /** AT options for @mentioning members in group messages */
+  atOptions?: InfoflowAtOptions;
+};
+
+/**
+ * Builds dispatcherOptions and replyOptions for dispatchReplyWithBufferedBlockDispatcher.
+ * Encapsulates prefix options, chunked deliver (send via Infoflow API + statusSink), and onError.
+ */
+export function createInfoflowReplyDispatcher(params: CreateInfoflowReplyDispatcherParams) {
+  const { cfg, agentId, accountId, fromuser, chatType, groupId, statusSink, atOptions } = params;
+  const core = getInfoflowRuntime();
+  const verbose = core.logging.shouldLogVerbose();
+  const account = resolveInfoflowAccount({ cfg, accountId });
+
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg,
+    agentId,
+    channel: "infoflow",
+    accountId,
+  });
+
+  const deliver = async (payload: { text?: string; mediaUrl?: string; mediaUrls?: string[] }) => {
+    const { apiHost, appKey, appSecret } = account.config;
+
+    if (!appKey || !appSecret) {
+      console.error(`[infoflow] Missing appKey or appSecret for account ${accountId}`);
+      return;
+    }
+
+    if (payload.text) {
+      // Chunk text to 4000 chars max (Infoflow limit)
+      const chunks = core.channel.text.chunkText(payload.text, 4000);
+
+      for (const chunk of chunks) {
+        let result: { ok: boolean; error?: string; messageid?: string; msgkey?: string };
+
+        if (chatType === "group" && groupId) {
+          // Send to group
+          if (verbose) {
+            console.log(`[infoflow] Delivering group message to ${groupId}`);
+          }
+          result = await sendInfoflowGroupMessage({
+            apiHost,
+            appKey,
+            appSecret,
+            groupId,
+            content: chunk,
+            msgtype: "markdown",
+            atOptions,
+          });
+        } else {
+          // Send private message (DM)
+          if (verbose) {
+            console.log(`[infoflow] Delivering private message to ${fromuser}`);
+          }
+          result = await sendInfoflowPrivateMessage({
+            apiHost,
+            appKey,
+            appSecret,
+            touser: fromuser,
+            content: chunk,
+            msgtype: "markdown",
+          });
+        }
+
+        if (result.ok) {
+          statusSink?.({ lastOutboundAt: Date.now() });
+          // Dedup is handled in send.ts (recordSentMessageId called after successful send)
+        } else if (result.error) {
+          console.error(`[infoflow] Failed to send message: ${result.error}`);
+        }
+      }
+    }
+
+    // TODO: Handle media attachments if needed
+    if (payload.mediaUrl || payload.mediaUrls?.length) {
+      if (verbose) {
+        console.log(`[infoflow] Media attachments not yet supported`);
+      }
+    }
+  };
+
+  const onError = (err: unknown) => {
+    console.error(`[infoflow] reply failed: ${String(err)}`);
+  };
+
+  return {
+    dispatcherOptions: {
+      ...prefixOptions,
+      deliver,
+      onError,
+    },
+    replyOptions: {
+      onModelSelected,
+    },
+  };
+}

--- a/extensions/infoflow/src/runtime.ts
+++ b/extensions/infoflow/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setInfoflowRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getInfoflowRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Infoflow runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/infoflow/src/send.test.ts
+++ b/extensions/infoflow/src/send.test.ts
@@ -52,6 +52,166 @@ afterEach(() => {
 // getAppAccessToken
 // ============================================================================
 
+// ============================================================================
+// sendInfoflowMessage
+// ============================================================================
+
+vi.mock("./accounts.js", () => ({
+  resolveInfoflowAccount: vi.fn(({ accountId }: { accountId?: string }) => ({
+    accountId: accountId ?? "default",
+    config: {
+      apiHost: "https://api.example.com",
+      appKey: "test-key",
+      appSecret: "test-secret",
+    },
+  })),
+}));
+
+import { sendInfoflowMessage } from "./send.js";
+
+describe("sendInfoflowMessage", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("returns error when contents array is empty", async () => {
+    const result = await sendInfoflowMessage({
+      cfg: {} as never,
+      to: "user1",
+      contents: [],
+    });
+    expect(result).toEqual({ ok: false, error: "contents array is empty" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("routes to private message for username target", async () => {
+    // Mock token + private send
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-1")).mockResolvedValueOnce({
+      ok: true,
+      text: () =>
+        Promise.resolve(JSON.stringify({ code: "ok", data: { errcode: 0, msgkey: "msg-123" } })),
+    });
+
+    const result = await sendInfoflowMessage({
+      cfg: {} as never,
+      to: "chengbo05",
+      contents: [{ type: "text", content: "hello" }],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.messageId).toBe("msg-123");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("routes to group message for group:123 target", async () => {
+    // Mock token + group send
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-1")).mockResolvedValueOnce({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({ code: "ok", data: { errcode: 0, data: { messageid: "grp-456" } } }),
+        ),
+    });
+
+    const result = await sendInfoflowMessage({
+      cfg: {} as never,
+      to: "group:12345",
+      contents: [{ type: "markdown", content: "# Title" }],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.messageId).toBe("grp-456");
+  });
+
+  it("sends private message with link using richtext format", async () => {
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-1")).mockResolvedValueOnce({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({ code: "ok", data: { errcode: 0, msgkey: "msg-link-123" } }),
+        ),
+    });
+
+    const result = await sendInfoflowMessage({
+      cfg: {} as never,
+      to: "user1",
+      contents: [
+        { type: "text", content: "Check this link:" },
+        { type: "link", content: "[Example]https://example.com" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.messageId).toBe("msg-link-123");
+
+    // Verify richtext payload
+    const [, opts] = mockFetch.mock.calls[1] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body.msgtype).toBe("richtext");
+    expect(body.richtext).toEqual({
+      content: [
+        { type: "text", text: "Check this link:" },
+        { type: "a", href: "https://example.com", label: "Example" },
+      ],
+    });
+  });
+
+  it("sends private link with href only (no label)", async () => {
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-1")).mockResolvedValueOnce({
+      ok: true,
+      text: () =>
+        Promise.resolve(JSON.stringify({ code: "ok", data: { errcode: 0, msgkey: "msg-456" } })),
+    });
+
+    await sendInfoflowMessage({
+      cfg: {} as never,
+      to: "user1",
+      contents: [{ type: "link", content: "https://example.com" }],
+    });
+
+    const [, opts] = mockFetch.mock.calls[1] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body.msgtype).toBe("richtext");
+    expect(body.richtext).toEqual({
+      content: [{ type: "a", href: "https://example.com", label: "https://example.com" }],
+    });
+  });
+
+  it("sends group message with link in body", async () => {
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-1")).mockResolvedValueOnce({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({ code: "ok", data: { errcode: 0, data: { messageid: "grp-link-789" } } }),
+        ),
+    });
+
+    const result = await sendInfoflowMessage({
+      cfg: {} as never,
+      to: "group:12345",
+      contents: [
+        { type: "text", content: "Visit:" },
+        { type: "link", content: "[Docs]https://docs.example.com" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.messageId).toBe("grp-link-789");
+
+    // Verify group message body includes LINK item
+    const [, opts] = mockFetch.mock.calls[1] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string) as { message: { body: unknown[] } };
+    expect(body.message.body).toEqual([
+      { type: "TEXT", content: "Visit:" },
+      { type: "LINK", href: "https://docs.example.com" },
+    ]);
+  });
+});
+
+// ============================================================================
+// getAppAccessToken
+// ============================================================================
+
 describe("getAppAccessToken", () => {
   it("fetches token on cache miss", async () => {
     mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-abc"));

--- a/extensions/infoflow/src/send.test.ts
+++ b/extensions/infoflow/src/send.test.ts
@@ -1,0 +1,108 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./runtime.js", () => ({
+  getInfoflowRuntime: vi.fn(() => ({
+    logging: { shouldLogVerbose: () => false },
+  })),
+}));
+
+vi.mock("./infoflow-req-parse.js", () => ({
+  recordSentMessageId: vi.fn(),
+}));
+
+import { getAppAccessToken, _resetTokenCache } from "./send.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+
+function mockTokenResponse(token: string, expiresIn = 7200) {
+  return {
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        errcode: 0,
+        data: { app_access_token: token, expires_in: expiresIn },
+      }),
+  };
+}
+
+const BASE_PARAMS = {
+  apiHost: "https://api.example.com",
+  appKey: "test-key",
+  appSecret: "test-secret",
+};
+
+beforeEach(() => {
+  _resetTokenCache();
+  vi.stubGlobal("fetch", mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+// ============================================================================
+// getAppAccessToken
+// ============================================================================
+
+describe("getAppAccessToken", () => {
+  it("fetches token on cache miss", async () => {
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-abc"));
+    const result = await getAppAccessToken(BASE_PARAMS);
+    expect(result).toEqual({ ok: true, token: "tok-abc" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends MD5-hashed appSecret in request body", async () => {
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-1"));
+    await getAppAccessToken(BASE_PARAMS);
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string) as Record<string, string>;
+    const expectedMd5 = createHash("md5").update("test-secret").digest("hex").toLowerCase();
+    expect(body.app_secret).toBe(expectedMd5);
+  });
+
+  it("returns cached token on second call", async () => {
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-cached"));
+    await getAppAccessToken(BASE_PARAMS);
+    const result = await getAppAccessToken(BASE_PARAMS);
+    expect(result).toEqual({ ok: true, token: "tok-cached" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after cache expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-1", 600));
+    await getAppAccessToken(BASE_PARAMS);
+    vi.advanceTimersByTime(301 * 1000); // past (600-300)s buffer
+    mockFetch.mockResolvedValueOnce(mockTokenResponse("tok-2", 600));
+    const result = await getAppAccessToken(BASE_PARAMS);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.token).toBe("tok-2");
+  });
+
+  it("isolates cache by appKey (multi-account)", async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockTokenResponse("tok-A"))
+      .mockResolvedValueOnce(mockTokenResponse("tok-B"));
+    const resultA = await getAppAccessToken({ ...BASE_PARAMS, appKey: "key-A" });
+    const resultB = await getAppAccessToken({ ...BASE_PARAMS, appKey: "key-B" });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(resultA.token).toBe("tok-A");
+    expect(resultB.token).toBe("tok-B");
+  });
+
+  it("handles network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const result = await getAppAccessToken(BASE_PARAMS);
+    expect(result).toEqual({ ok: false, error: "ECONNREFUSED" });
+  });
+});

--- a/extensions/infoflow/src/send.ts
+++ b/extensions/infoflow/src/send.ts
@@ -3,17 +3,17 @@
  * Supports both private (DM) and group chat messages.
  */
 
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { createHash } from "node:crypto";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { resolveInfoflowAccount } from "./accounts.js";
+import { recordSentMessageId } from "./infoflow-req-parse.js";
+import { getInfoflowSendLog } from "./logging.js";
+import { getInfoflowRuntime } from "./runtime.js";
 import type {
   InfoflowGroupMessageBodyItem,
   InfoflowMessageContentItem,
   ResolvedInfoflowAccount,
 } from "./types.js";
-import { resolveInfoflowAccount } from "./accounts.js";
-import { recordSentMessageId } from "./infoflow-req-parse.js";
-import { getInfoflowSendLog } from "./logging.js";
-import { getInfoflowRuntime } from "./runtime.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000; // 30 seconds
 

--- a/extensions/infoflow/src/send.ts
+++ b/extensions/infoflow/src/send.ts
@@ -358,7 +358,7 @@ export async function sendInfoflowGroupMessage(params: {
     } else if (type === "md" || type === "markdown") {
       body.push({ type: "MD", content: item.content });
       hasMarkdown = true;
-    } else if (item.type === "at") {
+    } else if (type === "at") {
       // Parse AT content: "all" means atall, otherwise comma-separated user IDs
       if (item.content === "all") {
         body.push({ type: "AT", atall: true, atuserids: [] });

--- a/extensions/infoflow/src/send.ts
+++ b/extensions/infoflow/src/send.ts
@@ -12,6 +12,7 @@ import type {
 } from "./types.js";
 import { resolveInfoflowAccount } from "./accounts.js";
 import { recordSentMessageId } from "./infoflow-req-parse.js";
+import { getInfoflowSendLog } from "./logging.js";
 import { getInfoflowRuntime } from "./runtime.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000; // 30 seconds
@@ -198,7 +199,7 @@ export async function sendInfoflowPrivateMessage(params: {
   // Get token first
   const tokenResult = await getAppAccessToken({ apiHost, appKey, appSecret, timeoutMs });
   if (!tokenResult.ok || !tokenResult.token) {
-    console.error(`[infoflow:sendPrivate] token error: ${tokenResult.error}`);
+    getInfoflowSendLog().error(`[infoflow:sendPrivate] token error: ${tokenResult.error}`);
     return { ok: false, error: tokenResult.error ?? "failed to get token" };
   }
 
@@ -287,7 +288,7 @@ export async function sendInfoflowPrivateMessage(params: {
     const code = typeof data.code === "string" ? data.code : "";
     if (code !== "ok") {
       const errMsg = String(data.message ?? data.errmsg ?? `code=${code || "unknown"}`);
-      console.error(`[infoflow:sendPrivate] failed: ${errMsg}`);
+      getInfoflowSendLog().error(`[infoflow:sendPrivate] failed: ${errMsg}`);
       return { ok: false, error: errMsg };
     }
 
@@ -296,7 +297,7 @@ export async function sendInfoflowPrivateMessage(params: {
     const errcode = innerData?.errcode;
     if (errcode != null && errcode !== 0) {
       const errMsg = String(innerData?.errmsg ?? `errcode ${errcode}`);
-      console.error(`[infoflow:sendPrivate] failed: ${errMsg}`);
+      getInfoflowSendLog().error(`[infoflow:sendPrivate] failed: ${errMsg}`);
       return {
         ok: false,
         error: errMsg,
@@ -313,7 +314,7 @@ export async function sendInfoflowPrivateMessage(params: {
     return { ok: true, invaliduser: innerData?.invaliduser as string | undefined, msgkey };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
-    console.error(`[infoflow:sendPrivate] <<< EXCEPTION: ${errMsg}`);
+    getInfoflowSendLog().error(`[infoflow:sendPrivate] exception: ${errMsg}`);
     return { ok: false, error: errMsg };
   }
 }
@@ -384,7 +385,7 @@ export async function sendInfoflowGroupMessage(params: {
   // Get token first
   const tokenResult = await getAppAccessToken({ apiHost, appKey, appSecret, timeoutMs });
   if (!tokenResult.ok || !tokenResult.token) {
-    console.error(`[infoflow:sendGroup] token error: ${tokenResult.error}`);
+    getInfoflowSendLog().error(`[infoflow:sendGroup] token error: ${tokenResult.error}`);
     return { ok: false, error: tokenResult.error ?? "failed to get token" };
   }
 
@@ -428,7 +429,7 @@ export async function sendInfoflowGroupMessage(params: {
     const code = typeof data.code === "string" ? data.code : "";
     if (code !== "ok") {
       const errMsg = String(data.message ?? data.errmsg ?? `code=${code || "unknown"}`);
-      console.error(`[infoflow:sendGroup] failed: ${errMsg}`);
+      getInfoflowSendLog().error(`[infoflow:sendGroup] failed: ${errMsg}`);
       return { ok: false, error: errMsg };
     }
 
@@ -437,7 +438,7 @@ export async function sendInfoflowGroupMessage(params: {
     const errcode = innerData?.errcode;
     if (errcode != null && errcode !== 0) {
       const errMsg = String(innerData?.errmsg ?? `errcode ${errcode}`);
-      console.error(`[infoflow:sendGroup] failed: ${errMsg}`);
+      getInfoflowSendLog().error(`[infoflow:sendGroup] failed: ${errMsg}`);
       return { ok: false, error: errMsg };
     }
 
@@ -451,7 +452,7 @@ export async function sendInfoflowGroupMessage(params: {
     return { ok: true, messageid };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
-    console.error(`[infoflow:sendGroup] exception: ${errMsg}`);
+    getInfoflowSendLog().error(`[infoflow:sendGroup] exception: ${errMsg}`);
     return { ok: false, error: errMsg };
   }
 }

--- a/extensions/infoflow/src/send.ts
+++ b/extensions/infoflow/src/send.ts
@@ -121,9 +121,10 @@ export async function getAppAccessToken(params: {
     return { ok: true, token: cached.token };
   }
 
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     // app_secret needs to be MD5 hashed (lowercase)
     const md5Secret = createHash("md5").update(appSecret).digest("hex").toLowerCase();
@@ -134,8 +135,6 @@ export async function getAppAccessToken(params: {
       body: JSON.stringify({ app_key: appKey, app_secret: md5Secret }),
       signal: controller.signal,
     });
-
-    clearTimeout(timeout);
 
     if (!res.ok) {
       return { ok: false, error: `HTTP ${res.status}` };
@@ -166,6 +165,8 @@ export async function getAppAccessToken(params: {
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     return { ok: false, error: errMsg };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -203,9 +204,10 @@ export async function sendInfoflowPrivateMessage(params: {
     return { ok: false, error: tokenResult.error ?? "failed to get token" };
   }
 
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     let payload: Record<string, unknown>;
 
@@ -280,8 +282,6 @@ export async function sendInfoflowPrivateMessage(params: {
       signal: controller.signal,
     });
 
-    clearTimeout(timeout);
-
     const data = JSON.parse(await res.text()) as Record<string, unknown>;
 
     // Check outer code first
@@ -316,6 +316,8 @@ export async function sendInfoflowPrivateMessage(params: {
     const errMsg = err instanceof Error ? err.message : String(err);
     getInfoflowSendLog().error(`[infoflow:sendPrivate] exception: ${errMsg}`);
     return { ok: false, error: errMsg };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -389,9 +391,10 @@ export async function sendInfoflowGroupMessage(params: {
     return { ok: false, error: tokenResult.error ?? "failed to get token" };
   }
 
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     const payload = {
       message: {
@@ -420,8 +423,6 @@ export async function sendInfoflowGroupMessage(params: {
       body: JSON.stringify(payload),
       signal: controller.signal,
     });
-
-    clearTimeout(timeout);
 
     const data = JSON.parse(await res.text()) as Record<string, unknown>;
 
@@ -454,6 +455,8 @@ export async function sendInfoflowGroupMessage(params: {
     const errMsg = err instanceof Error ? err.message : String(err);
     getInfoflowSendLog().error(`[infoflow:sendGroup] exception: ${errMsg}`);
     return { ok: false, error: errMsg };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/extensions/infoflow/src/send.ts
+++ b/extensions/infoflow/src/send.ts
@@ -1,0 +1,433 @@
+/**
+ * Outbound send API: POST messages to the Infoflow service.
+ * Supports both private (DM) and group chat messages.
+ */
+
+import { createHash } from "node:crypto";
+import type { InfoflowAtOptions, InfoflowGroupMessageBodyItem } from "./types.js";
+import { recordSentMessageId } from "./infoflow_req_parse.js";
+import { getInfoflowRuntime } from "./runtime.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000; // 30 seconds
+
+/**
+ * Ensures apiHost uses HTTPS for security (secrets in transit).
+ * Allows HTTP only for localhost/127.0.0.1 (local development).
+ */
+function ensureHttps(apiHost: string): string {
+  if (apiHost.startsWith("http://")) {
+    const url = new URL(apiHost);
+    const isLocal = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+    if (!isLocal) {
+      return apiHost.replace(/^http:/, "https:");
+    }
+  }
+  return apiHost;
+}
+
+// Infoflow API paths (host is configured via apiHost in config)
+const INFOFLOW_AUTH_PATH = "/api/v1/auth/app_access_token";
+const INFOFLOW_PRIVATE_SEND_PATH = "/api/v1/app/message/send";
+const INFOFLOW_GROUP_SEND_PATH = "/api/v1/robot/msg/groupmsgsend";
+
+// Token cache to avoid fetching token for every message
+// Use Map keyed by appKey to support multi-account isolation
+const tokenCacheMap = new Map<string, { token: string; expiresAt: number }>();
+
+// ---------------------------------------------------------------------------
+// Helper Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts message ID from Infoflow API response data.
+ * Handles different response formats:
+ * - Private: data.msgkey
+ * - Group: data.data.messageid or data.data.msgid (nested)
+ * - Fallback: data.messageid or data.msgid (flat)
+ */
+function extractMessageId(data: Record<string, unknown>): string | undefined {
+  // Try data.msgkey (private message format)
+  if (data.msgkey != null) {
+    return String(data.msgkey);
+  }
+
+  // Try nested data.data structure (group message format)
+  const innerData = data.data as Record<string, unknown> | undefined;
+  if (innerData && typeof innerData === "object") {
+    // Try data.data.messageid
+    if (innerData.messageid != null) {
+      return String(innerData.messageid);
+    }
+    // Try data.data.msgid
+    if (innerData.msgid != null) {
+      return String(innerData.msgid);
+    }
+  }
+
+  // Fallback: try flat structure
+  if (data.messageid != null) {
+    return String(data.messageid);
+  }
+  if (data.msgid != null) {
+    return String(data.msgid);
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Token Management
+// ---------------------------------------------------------------------------
+
+/**
+ * Gets the app access token from Infoflow API.
+ * Token is cached and reused until expiry.
+ */
+export async function getAppAccessToken(params: {
+  apiHost: string;
+  appKey: string;
+  appSecret: string;
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; token?: string; error?: string }> {
+  const { apiHost, appKey, appSecret, timeoutMs = DEFAULT_TIMEOUT_MS } = params;
+
+  // Check cache first (by appKey for multi-account isolation)
+  const cached = tokenCacheMap.get(appKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return { ok: true, token: cached.token };
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    // app_secret needs to be MD5 hashed (lowercase)
+    const md5Secret = createHash("md5").update(appSecret).digest("hex").toLowerCase();
+
+    const res = await fetch(`${ensureHttps(apiHost)}${INFOFLOW_AUTH_PATH}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ app_key: appKey, app_secret: md5Secret }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!res.ok) {
+      return { ok: false, error: `HTTP ${res.status}` };
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+
+    if (data.errcode && data.errcode !== 0) {
+      const errMsg = String(data.errmsg ?? `errcode ${data.errcode}`);
+      return { ok: false, error: errMsg };
+    }
+
+    const dataField = data.data as { app_access_token?: string; expires_in?: number } | undefined;
+    const token = dataField?.app_access_token;
+    const expiresIn = dataField?.expires_in ?? 7200; // default 2 hours
+
+    if (!token) {
+      return { ok: false, error: "no token in response" };
+    }
+
+    // Cache token by appKey (with 5 minute buffer before expiry)
+    tokenCacheMap.set(appKey, {
+      token,
+      expiresAt: Date.now() + (expiresIn - 300) * 1000,
+    });
+
+    return { ok: true, token };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: errMsg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private Chat (DM) Message Sending
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends a private (DM) message to a user.
+ * @param touser - Recipient's uuapName (email prefix), multiple users separated by |
+ * @param content - Message content
+ */
+export async function sendInfoflowPrivateMessage(params: {
+  apiHost: string;
+  appKey: string;
+  appSecret: string;
+  touser: string;
+  content: string;
+  msgtype?: "text" | "markdown";
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; error?: string; invaliduser?: string; msgkey?: string }> {
+  const {
+    apiHost,
+    appKey,
+    appSecret,
+    touser,
+    content,
+    msgtype = "text",
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = params;
+
+  // Get verbose state once at start
+  let verbose = false;
+  try {
+    verbose = getInfoflowRuntime().logging.shouldLogVerbose();
+  } catch {
+    // runtime not available, keep verbose = false
+  }
+
+  if (verbose) {
+    console.log(
+      `[infoflow:sendPrivate] >>> START: touser=${touser}, content=${content}, msgtype=${msgtype}`,
+    );
+  }
+
+  // Get token first
+  const tokenResult = await getAppAccessToken({ apiHost, appKey, appSecret, timeoutMs });
+  if (!tokenResult.ok || !tokenResult.token) {
+    console.error(`[infoflow:sendPrivate] <<< FAILED: token error: ${tokenResult.error}`);
+    return { ok: false, error: tokenResult.error ?? "failed to get token" };
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    // Build payload based on message type
+    // Private message format: msgtype="text" with text.content, or msgtype="md" with md.content
+    const apiMsgtype = msgtype === "markdown" ? "md" : "text";
+    const payload: Record<string, unknown> = {
+      touser,
+      msgtype: apiMsgtype,
+    };
+    if (apiMsgtype === "text") {
+      payload.text = { content };
+    } else if (apiMsgtype === "md") {
+      payload.md = { content };
+    }
+
+    // Build headers with authorization
+    const headers = {
+      Authorization: `Bearer-${tokenResult.token}`,
+      "Content-Type": "application/json; charset=utf-8",
+      LOGID: String(Date.now() * 1000 + Math.floor(Math.random() * 1000)),
+    };
+
+    const requestUrl = `${ensureHttps(apiHost)}${INFOFLOW_PRIVATE_SEND_PATH}`;
+    const requestBody = JSON.stringify(payload);
+    if (verbose) {
+      console.log(`[infoflow:sendPrivate] REQUEST: url=${requestUrl}`);
+      console.log(`[infoflow:sendPrivate] REQUEST BODY: ${requestBody}`);
+    }
+
+    const res = await fetch(requestUrl, {
+      method: "POST",
+      headers,
+      body: requestBody,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    const rawResponse = await res.text();
+    if (verbose) {
+      console.log(`[infoflow:sendPrivate] RESPONSE STATUS: ${res.status}`);
+      console.log(`[infoflow:sendPrivate] RESPONSE RAW: ${rawResponse}`);
+    }
+
+    const data = JSON.parse(rawResponse) as Record<string, unknown>;
+
+    // Check outer code first
+    const code = typeof data.code === "string" ? data.code : "";
+    if (code !== "ok") {
+      const errMsg = String(data.message ?? data.errmsg ?? `code=${code || "unknown"}`);
+      console.error(`[infoflow:sendPrivate] <<< FAILED: outer code error: ${errMsg}`);
+      return { ok: false, error: errMsg };
+    }
+
+    // Check inner data.errcode
+    const innerData = data.data as Record<string, unknown> | undefined;
+    const errcode = innerData?.errcode;
+    if (errcode != null && errcode !== 0) {
+      const errMsg = String(innerData?.errmsg ?? `errcode ${errcode}`);
+      console.error(
+        `[infoflow:sendPrivate] <<< FAILED: ${errMsg}, invaliduser=${innerData?.invaliduser}`,
+      );
+      return {
+        ok: false,
+        error: errMsg,
+        invaliduser: innerData?.invaliduser as string | undefined,
+      };
+    }
+
+    // Extract message ID and record for dedup
+    const msgkey = extractMessageId(innerData ?? {});
+    if (msgkey) {
+      recordSentMessageId(msgkey);
+    }
+
+    if (verbose) {
+      console.log(`[infoflow:sendPrivate] <<< SUCCESS: msgkey=${msgkey}`);
+    }
+    return { ok: true, invaliduser: innerData?.invaliduser as string | undefined, msgkey };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    console.error(`[infoflow:sendPrivate] <<< EXCEPTION: ${errMsg}`);
+    return { ok: false, error: errMsg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Group Chat Message Sending
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends a group chat message.
+ * @param groupId - Target group ID (numeric)
+ * @param content - Message content
+ * @param msgtype - Message type: "text" or "markdown"
+ */
+export async function sendInfoflowGroupMessage(params: {
+  apiHost: string;
+  appKey: string;
+  appSecret: string;
+  groupId: number;
+  content: string;
+  msgtype?: "text" | "markdown";
+  atOptions?: InfoflowAtOptions;
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; error?: string; messageid?: string }> {
+  const {
+    apiHost,
+    appKey,
+    appSecret,
+    groupId,
+    content,
+    msgtype = "text",
+    atOptions,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = params;
+
+  // Get verbose state once at start
+  let verbose = false;
+  try {
+    verbose = getInfoflowRuntime().logging.shouldLogVerbose();
+  } catch {
+    // runtime not available, keep verbose = false
+  }
+
+  if (verbose) {
+    console.log(
+      `[infoflow:sendGroup] >>> START: groupId=${groupId}, contentLen=${content.length}, msgtype=${msgtype}, atOptions=${JSON.stringify(atOptions)}`,
+    );
+  }
+
+  // Get token first
+  const tokenResult = await getAppAccessToken({ apiHost, appKey, appSecret, timeoutMs });
+  if (!tokenResult.ok || !tokenResult.token) {
+    console.error(`[infoflow:sendGroup] <<< FAILED: token error: ${tokenResult.error}`);
+    return { ok: false, error: tokenResult.error ?? "failed to get token" };
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    // Build group message body
+    // Group message format: header.msgtype="MIXED", body[].type="MD" or "TEXT"
+    const bodyType = msgtype === "markdown" ? "MD" : "TEXT";
+    const body: InfoflowGroupMessageBodyItem[] = [{ type: bodyType, content }];
+
+    // Add AT element if atOptions is provided
+    if (atOptions?.atAll || (atOptions?.atUserIds && atOptions.atUserIds.length > 0)) {
+      body.push({
+        type: "AT",
+        atuserids: atOptions.atUserIds ?? [],
+        ...(atOptions.atAll && { atall: true }),
+      });
+    }
+
+    // Build group message payload (nested structure)
+    // header.msgtype is always "MIXED" for group messages
+    const payload = {
+      message: {
+        header: {
+          toid: groupId,
+          totype: "GROUP",
+          msgtype: bodyType,
+          clientmsgid: Date.now(),
+          role: "robot",
+        },
+        body,
+      },
+    };
+
+    // Build headers with authorization
+    const headers = {
+      Authorization: `Bearer-${tokenResult.token}`,
+      "Content-Type": "application/json",
+    };
+
+    const requestUrl = `${ensureHttps(apiHost)}${INFOFLOW_GROUP_SEND_PATH}`;
+    const requestBody = JSON.stringify(payload);
+    if (verbose) {
+      console.log(`[infoflow:sendGroup] REQUEST: url=${requestUrl}`);
+      console.log(`[infoflow:sendGroup] REQUEST BODY: ${requestBody}`);
+    }
+
+    const res = await fetch(requestUrl, {
+      method: "POST",
+      headers,
+      body: requestBody,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    const rawResponse = await res.text();
+    if (verbose) {
+      console.log(`[infoflow:sendGroup] RESPONSE STATUS: ${res.status}`);
+      console.log(`[infoflow:sendGroup] RESPONSE RAW: ${rawResponse}`);
+    }
+
+    const data = JSON.parse(rawResponse) as Record<string, unknown>;
+
+    // Check outer code first
+    const code = typeof data.code === "string" ? data.code : "";
+    if (code !== "ok") {
+      const errMsg = String(data.message ?? data.errmsg ?? `code=${code || "unknown"}`);
+      console.error(`[infoflow:sendGroup] <<< FAILED: outer code error: ${errMsg}`);
+      return { ok: false, error: errMsg };
+    }
+
+    // Check inner data.errcode
+    const innerData = data.data as Record<string, unknown> | undefined;
+    const errcode = innerData?.errcode;
+    if (errcode != null && errcode !== 0) {
+      const errMsg = String(innerData?.errmsg ?? `errcode ${errcode}`);
+      console.error(`[infoflow:sendGroup] <<< FAILED: ${errMsg}`);
+      return { ok: false, error: errMsg };
+    }
+
+    // Extract message ID from nested data.data structure and record for dedup
+    const nestedData = innerData?.data as Record<string, unknown> | undefined;
+    const messageid = extractMessageId(nestedData ?? innerData ?? {});
+    if (messageid) {
+      recordSentMessageId(messageid);
+    }
+
+    if (verbose) {
+      console.log(`[infoflow:sendGroup] <<< SUCCESS: messageid=${messageid}`);
+    }
+    return { ok: true, messageid };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    console.error(`[infoflow:sendGroup] <<< EXCEPTION: ${errMsg}`);
+    return { ok: false, error: errMsg };
+  }
+}

--- a/extensions/infoflow/src/send.ts
+++ b/extensions/infoflow/src/send.ts
@@ -3,7 +3,7 @@
  * Supports both private (DM) and group chat messages.
  */
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { resolveInfoflowAccount } from "./accounts.js";
 import { recordSentMessageId } from "./infoflow-req-parse.js";
@@ -272,7 +272,7 @@ export async function sendInfoflowPrivateMessage(params: {
     const headers = {
       Authorization: `Bearer-${tokenResult.token}`,
       "Content-Type": "application/json; charset=utf-8",
-      LOGID: String(Date.now() * 1000 + Math.floor(Math.random() * 1000)),
+      LOGID: randomUUID(),
     };
 
     const res = await fetch(`${ensureHttps(apiHost)}${INFOFLOW_PRIVATE_SEND_PATH}`, {

--- a/extensions/infoflow/src/targets.test.ts
+++ b/extensions/infoflow/src/targets.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./runtime.js", () => ({
+  getInfoflowRuntime: vi.fn(() => ({
+    logging: { shouldLogVerbose: () => false },
+  })),
+}));
+
+import { normalizeInfoflowTarget, looksLikeInfoflowId } from "./targets.js";
+
+// ============================================================================
+// normalizeInfoflowTarget
+// ============================================================================
+
+describe("normalizeInfoflowTarget", () => {
+  it("strips infoflow: prefix", () => {
+    expect(normalizeInfoflowTarget("infoflow:chengbo05")).toBe("chengbo05");
+  });
+
+  it("strips user: prefix", () => {
+    expect(normalizeInfoflowTarget("user:chengbo05")).toBe("chengbo05");
+  });
+
+  it("keeps group: prefix", () => {
+    expect(normalizeInfoflowTarget("group:123456")).toBe("group:123456");
+  });
+
+  it("converts pure digits to group:", () => {
+    expect(normalizeInfoflowTarget("123456")).toBe("group:123456");
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(normalizeInfoflowTarget("")).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// looksLikeInfoflowId
+// ============================================================================
+
+describe("looksLikeInfoflowId", () => {
+  it("accepts group: prefix", () => {
+    expect(looksLikeInfoflowId("group:123")).toBe(true);
+  });
+
+  it("accepts pure digits", () => {
+    expect(looksLikeInfoflowId("12345")).toBe(true);
+  });
+
+  it("accepts alphanumeric starting with letter", () => {
+    expect(looksLikeInfoflowId("chengbo05")).toBe(true);
+  });
+
+  it("rejects special characters", () => {
+    expect(looksLikeInfoflowId("user@domain.com")).toBe(false);
+  });
+});

--- a/extensions/infoflow/src/targets.ts
+++ b/extensions/infoflow/src/targets.ts
@@ -3,6 +3,7 @@
  * Handles user and group ID formats for message targeting.
  */
 
+import { getInfoflowSendLog } from "./logging.js";
 import { getInfoflowRuntime } from "./runtime.js";
 
 // ---------------------------------------------------------------------------
@@ -41,13 +42,13 @@ export function normalizeInfoflowTarget(raw: string): string | undefined {
   }
 
   if (verbose) {
-    console.log(`[infoflow:normalizeTarget] input: "${raw}"`);
+    getInfoflowSendLog().debug?.(`[infoflow:normalizeTarget] input: "${raw}"`);
   }
 
   const trimmed = raw.trim();
   if (!trimmed) {
     if (verbose) {
-      console.log(`[infoflow:normalizeTarget] empty input, returning undefined`);
+      getInfoflowSendLog().debug?.(`[infoflow:normalizeTarget] empty input, returning undefined`);
     }
     return undefined;
   }
@@ -63,7 +64,7 @@ export function normalizeInfoflowTarget(raw: string): string | undefined {
   // Keep group: prefix as-is
   if (target.toLowerCase().startsWith(GROUP_PREFIX)) {
     if (verbose) {
-      console.log(`[infoflow:normalizeTarget] output: "${target}" (group)`);
+      getInfoflowSendLog().debug?.(`[infoflow:normalizeTarget] output: "${target}" (group)`);
     }
     return target;
   }
@@ -72,14 +73,16 @@ export function normalizeInfoflowTarget(raw: string): string | undefined {
   if (/^\d+$/.test(target)) {
     const result = `${GROUP_PREFIX}${target}`;
     if (verbose) {
-      console.log(`[infoflow:normalizeTarget] output: "${result}" (digits -> group)`);
+      getInfoflowSendLog().debug?.(
+        `[infoflow:normalizeTarget] output: "${result}" (digits -> group)`,
+      );
     }
     return result;
   }
 
   // Otherwise it's a username
   if (verbose) {
-    console.log(`[infoflow:normalizeTarget] output: "${target}" (username)`);
+    getInfoflowSendLog().debug?.(`[infoflow:normalizeTarget] output: "${target}" (username)`);
   }
   return target;
 }

--- a/extensions/infoflow/src/targets.ts
+++ b/extensions/infoflow/src/targets.ts
@@ -1,0 +1,149 @@
+/**
+ * Infoflow target resolution utilities.
+ * Handles user and group ID formats for message targeting.
+ */
+
+import { getInfoflowRuntime } from "./runtime.js";
+
+// ---------------------------------------------------------------------------
+// Target Format Constants
+// ---------------------------------------------------------------------------
+
+/** Prefix for group targets: "group:123456" */
+const GROUP_PREFIX = "group:";
+
+/** Prefix for user targets (optional): "user:chengbo05" */
+const USER_PREFIX = "user:";
+
+// ---------------------------------------------------------------------------
+// Target Normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalizes an Infoflow target string.
+ * Strips channel prefix and normalizes format.
+ *
+ * Examples:
+ *   "infoflow:chengbo05" -> "chengbo05"
+ *   "infoflow:group:123456" -> "group:123456"
+ *   "user:chengbo05" -> "chengbo05"
+ *   "group:123456" -> "group:123456"
+ *   "chengbo05" -> "chengbo05"
+ *   "123456" -> "group:123456" (pure digits treated as group)
+ */
+export function normalizeInfoflowTarget(raw: string): string | undefined {
+  // Get verbose state once at start
+  let verbose = false;
+  try {
+    verbose = getInfoflowRuntime().logging.shouldLogVerbose();
+  } catch {
+    // runtime not available, keep verbose = false
+  }
+
+  if (verbose) {
+    console.log(`[infoflow:normalizeTarget] input: "${raw}"`);
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    if (verbose) {
+      console.log(`[infoflow:normalizeTarget] empty input, returning undefined`);
+    }
+    return undefined;
+  }
+
+  // Strip infoflow: prefix
+  let target = trimmed.replace(/^infoflow:/i, "");
+
+  // Strip user: prefix (normalize to plain username)
+  if (target.toLowerCase().startsWith(USER_PREFIX)) {
+    target = target.slice(USER_PREFIX.length);
+  }
+
+  // Keep group: prefix as-is
+  if (target.toLowerCase().startsWith(GROUP_PREFIX)) {
+    if (verbose) {
+      console.log(`[infoflow:normalizeTarget] output: "${target}" (group)`);
+    }
+    return target;
+  }
+
+  // Pure digits -> treat as group ID
+  if (/^\d+$/.test(target)) {
+    const result = `${GROUP_PREFIX}${target}`;
+    if (verbose) {
+      console.log(`[infoflow:normalizeTarget] output: "${result}" (digits -> group)`);
+    }
+    return result;
+  }
+
+  // Otherwise it's a username
+  if (verbose) {
+    console.log(`[infoflow:normalizeTarget] output: "${target}" (username)`);
+  }
+  return target;
+}
+
+// ---------------------------------------------------------------------------
+// Target ID Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks if the input looks like a valid Infoflow target ID.
+ * Returns true if the system should use this value directly without directory lookup.
+ *
+ * Valid formats:
+ * - group:123456 (group ID with prefix)
+ * - user:chengbo05 (user ID with prefix)
+ * - 123456789 (pure digits = group ID)
+ * - chengbo05 (alphanumeric starting with letter = username/uuapName)
+ */
+export function looksLikeInfoflowId(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  // Strip infoflow: prefix for checking
+  const target = trimmed.replace(/^infoflow:/i, "");
+
+  // Explicit prefixes are always valid
+  if (/^(group|user):/i.test(target)) {
+    return true;
+  }
+
+  // Pure digits (group ID)
+  if (/^\d+$/.test(target)) {
+    return true;
+  }
+
+  // Alphanumeric starting with letter (username/uuapName)
+  // e.g., chengbo05, zhangsan, user123
+  if (/^[a-zA-Z][a-zA-Z0-9_]*$/.test(target)) {
+    return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Target Formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats an Infoflow target for display.
+ * Used in UI and logs to show human-readable target info.
+ */
+export function formatInfoflowTarget(target: string): string {
+  const normalized = normalizeInfoflowTarget(target);
+  if (!normalized) {
+    return target;
+  }
+
+  if (normalized.startsWith(GROUP_PREFIX)) {
+    const groupId = normalized.slice(GROUP_PREFIX.length);
+    return `Group ${groupId}`;
+  }
+
+  return `User ${normalized}`;
+}

--- a/extensions/infoflow/src/targets.ts
+++ b/extensions/infoflow/src/targets.ts
@@ -125,25 +125,3 @@ export function looksLikeInfoflowId(raw: string): boolean {
 
   return false;
 }
-
-// ---------------------------------------------------------------------------
-// Target Formatting
-// ---------------------------------------------------------------------------
-
-/**
- * Formats an Infoflow target for display.
- * Used in UI and logs to show human-readable target info.
- */
-export function formatInfoflowTarget(target: string): string {
-  const normalized = normalizeInfoflowTarget(target);
-  if (!normalized) {
-    return target;
-  }
-
-  if (normalized.startsWith(GROUP_PREFIX)) {
-    const groupId = normalized.slice(GROUP_PREFIX.length);
-    return `Group ${groupId}`;
-  }
-
-  return `User ${normalized}`;
-}

--- a/extensions/infoflow/src/types.ts
+++ b/extensions/infoflow/src/types.ts
@@ -26,7 +26,14 @@ export type InfoflowAtOptions = {
 export type InfoflowGroupMessageBodyItem =
   | { type: "TEXT"; content: string }
   | { type: "MD"; content: string }
-  | { type: "AT"; atall?: boolean; atuserids: string[] };
+  | { type: "AT"; atall?: boolean; atuserids: string[] }
+  | { type: "LINK"; href: string };
+
+/** Content item for sendInfoflowMessage */
+export type InfoflowMessageContentItem = {
+  type: "text" | "markdown" | "at" | "link";
+  content: string;
+};
 
 // ---------------------------------------------------------------------------
 // Account configuration
@@ -36,7 +43,7 @@ export type InfoflowAccountConfig = {
   enabled?: boolean;
   name?: string;
   apiHost?: string;
-  check_token?: string;
+  checkToken?: string;
   encodingAESKey?: string;
   appKey?: string;
   appSecret?: string;
@@ -60,7 +67,7 @@ export type ResolvedInfoflowAccount = {
     enabled?: boolean;
     name?: string;
     apiHost: string;
-    check_token: string;
+    checkToken: string;
     encodingAESKey: string;
     appKey: string;
     appSecret: string;
@@ -92,15 +99,6 @@ export type InfoflowMessageEvent = {
   timestamp?: number;
   /** Raw message text preserving @mentions (for RawBody) */
   rawMes?: string;
-};
-
-export type InfoflowSendResult = {
-  ok: boolean;
-  error?: string;
-  messageId?: string;
-  msgkey?: string;
-  messageid?: string;
-  invaliduser?: string;
 };
 
 // ---------------------------------------------------------------------------

--- a/extensions/infoflow/src/types.ts
+++ b/extensions/infoflow/src/types.ts
@@ -1,0 +1,129 @@
+/**
+ * Infoflow channel type definitions.
+ */
+
+// ---------------------------------------------------------------------------
+// Policy types
+// ---------------------------------------------------------------------------
+
+export type InfoflowDmPolicy = "open" | "pairing" | "allowlist";
+export type InfoflowGroupPolicy = "open" | "allowlist" | "disabled";
+export type InfoflowChatType = "direct" | "group";
+
+// ---------------------------------------------------------------------------
+// AT mention types
+// ---------------------------------------------------------------------------
+
+/** AT mention options for @mentioning members in group messages */
+export type InfoflowAtOptions = {
+  /** @all members; when true, atUserIds is ignored */
+  atAll?: boolean;
+  /** List of user IDs (uuapName) to @mention */
+  atUserIds?: string[];
+};
+
+/** Group message body item type */
+export type InfoflowGroupMessageBodyItem =
+  | { type: "TEXT"; content: string }
+  | { type: "MD"; content: string }
+  | { type: "AT"; atall?: boolean; atuserids: string[] };
+
+// ---------------------------------------------------------------------------
+// Account configuration
+// ---------------------------------------------------------------------------
+
+export type InfoflowAccountConfig = {
+  enabled?: boolean;
+  name?: string;
+  apiHost?: string;
+  check_token?: string;
+  encodingAESKey?: string;
+  appKey?: string;
+  appSecret?: string;
+  dmPolicy?: InfoflowDmPolicy;
+  allowFrom?: string[];
+  groupPolicy?: InfoflowGroupPolicy;
+  groupAllowFrom?: string[];
+  requireMention?: boolean;
+  /** Robot name for matching @mentions in group messages */
+  robotName?: string;
+  accounts?: Record<string, InfoflowAccountConfig>;
+  defaultAccount?: string;
+};
+
+export type ResolvedInfoflowAccount = {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  configured: boolean;
+  config: {
+    enabled?: boolean;
+    name?: string;
+    apiHost: string;
+    check_token: string;
+    encodingAESKey: string;
+    appKey: string;
+    appSecret: string;
+    dmPolicy?: InfoflowDmPolicy;
+    allowFrom?: string[];
+    groupPolicy?: InfoflowGroupPolicy;
+    groupAllowFrom?: string[];
+    requireMention?: boolean;
+    /** Robot name for matching @mentions in group messages */
+    robotName?: string;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Message types
+// ---------------------------------------------------------------------------
+
+export type InfoflowMessageEvent = {
+  fromuser: string;
+  mes: string;
+  chatType: InfoflowChatType;
+  groupId?: number;
+  senderName?: string;
+  /** Whether the bot was @mentioned in the message */
+  wasMentioned?: boolean;
+  /** Original message ID from Infoflow */
+  messageId?: string;
+  /** Unix millisecond timestamp of the message */
+  timestamp?: number;
+  /** Raw message text preserving @mentions (for RawBody) */
+  rawMes?: string;
+};
+
+export type InfoflowSendResult = {
+  ok: boolean;
+  error?: string;
+  messageId?: string;
+  msgkey?: string;
+  messageid?: string;
+  invaliduser?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Handler parameter types
+// ---------------------------------------------------------------------------
+
+export type HandleInfoflowMessageParams = {
+  cfg: import("openclaw/plugin-sdk").OpenClawConfig;
+  event: InfoflowMessageEvent;
+  accountId: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+export type HandlePrivateChatParams = {
+  cfg: import("openclaw/plugin-sdk").OpenClawConfig;
+  msgData: Record<string, unknown>;
+  accountId: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+export type HandleGroupChatParams = {
+  cfg: import("openclaw/plugin-sdk").OpenClawConfig;
+  msgData: Record<string, unknown>;
+  accountId: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,8 @@ importers:
   extensions/imessage: {}
 
   extensions/irc: {}
+	
+  extensions/infoflow: {}
 
   extensions/line: {}
 


### PR DESCRIPTION
add Baidu Infoflow channel support

[Infoflow](https://infoflow.baidu.com)

Greptile Overview
Greptile Summary
PR adds a new extensions/infoflow extension that implements a “Baidu Infoflow” channel. The change includes a plugin manifest (openclaw.plugin.json), TypeScript entrypoint (index.ts), and a set of runtime modules (src/*) for parsing incoming Infoflow requests, managing a bot/channel abstraction, dispatching replies, sending messages, and monitoring.

This fits into the repo’s extension architecture by registering a new channel implementation packaged as its own extension with its own dependencies and build artifacts tracked in pnpm-lock.yaml.

Confidence Score: 5/5
This PR appears safe to merge with minimal risk.
Changes are additive (new extension) and don’t appear to modify shared core behavior outside adding dependency lock entries; review did not surface definite runtime-breaking issues that must be fixed before merge.
No files require special attention

<!-- greptile_comment -->