### PR TITLE
fix: debounce subagent lifecycle events to prevent premature announce with stale data

### DIFF
--- a/src/agents/subagent-registry.lifecycle-debounce.test.ts
+++ b/src/agents/subagent-registry.lifecycle-debounce.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture the lifecycle event handler registered by ensureListener().
+let capturedEventHandler: ((evt: unknown) => void) | null = null;
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (req: unknown) => {
+    const typed = req as { method?: string };
+    // Simulate embedded run: agent.wait returns non-terminal status so
+    // waitForSubagentCompletion exits early without competing with the
+    // lifecycle listener path.
+    if (typed.method === "agent.wait") {
+      return { status: "pending" };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn((handler: (evt: unknown) => void) => {
+    capturedEventHandler = handler;
+    return () => {
+      capturedEventHandler = null;
+    };
+  }),
+}));
+
+const announceSpy = vi.fn(async () => true);
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: (...args: unknown[]) => announceSpy(...args),
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
+  saveSubagentRegistryToDisk: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    agents: {
+      defaults: {
+        subagents: { archiveAfterMinutes: 60 },
+      },
+    },
+  })),
+}));
+
+vi.mock("./timeout.js", () => ({
+  resolveAgentTimeoutMs: vi.fn(() => 60_000),
+}));
+
+vi.mock("../utils/delivery-context.js", () => ({
+  normalizeDeliveryContext: vi.fn((ctx: unknown) => ctx),
+}));
+
+describe("subagent lifecycle debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: 1000 });
+    vi.clearAllMocks();
+    capturedEventHandler = null;
+  });
+
+  afterEach(async () => {
+    // Reset modules first while fake timers are still active so any
+    // pending debounce timers are cleared deterministically before
+    // switching back to real timers.
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  async function setupAndRegister(overrides?: { runId?: string }) {
+    const mod = await import("./subagent-registry.js");
+    mod.registerSubagentRun({
+      runId: overrides?.runId ?? "run-retry",
+      childSessionKey: "agent:main:subagent:test",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "test task",
+      cleanup: "keep",
+    });
+    // Flush microtasks so waitForSubagentCompletion resolves (mocked as pending).
+    await vi.advanceTimersByTimeAsync(0);
+    return mod;
+  }
+
+  it("does not trigger announce immediately on first lifecycle end event", async () => {
+    await setupAndRegister();
+
+    // Simulate first attempt's agent_end
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 100 },
+    });
+
+    // Announce should NOT fire immediately
+    await vi.advanceTimersByTimeAsync(0);
+    expect(announceSpy).not.toHaveBeenCalled();
+  });
+
+  it("triggers announce after debounce when no retry starts", async () => {
+    await setupAndRegister();
+
+    // Simulate single attempt ending
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 5000 },
+    });
+
+    // Advance past debounce window (3 seconds)
+    await vi.advanceTimersByTimeAsync(3_500);
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const params = announceSpy.mock.calls[0]?.[0] as { endedAt?: number };
+    expect(params.endedAt).toBe(5000);
+  });
+
+  it("cancels pending announce when retry starts and announces with final data", async () => {
+    await setupAndRegister();
+
+    // First attempt ends (error at API level, but lifecycle phase is "end")
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 100 },
+    });
+
+    // Advance 1 second (within debounce window)
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(announceSpy).not.toHaveBeenCalled();
+
+    // Retry starts — should cancel the pending timer
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 200 },
+    });
+
+    // Retry completes with real output
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 60_000 },
+    });
+
+    // Still within new debounce window
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(announceSpy).not.toHaveBeenCalled();
+
+    // Advance past debounce
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    // NOW announce should fire with the RETRY's data
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const params = announceSpy.mock.calls[0]?.[0] as {
+      endedAt?: number;
+      outcome?: { status: string };
+    };
+    expect(params.endedAt).toBe(60_000);
+    expect(params.outcome?.status).toBe("ok");
+  });
+
+  it("preserves original startedAt across retry phase start events", async () => {
+    await setupAndRegister();
+
+    // The registration sets startedAt = Date.now() (which is 0 with fake timers).
+    // First attempt start (should NOT overwrite the registration startedAt)
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 500 },
+    });
+
+    // First attempt end
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 1000 },
+    });
+
+    // Retry start (should NOT overwrite startedAt)
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 2000 },
+    });
+
+    // Retry end
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 30_000 },
+    });
+
+    // Advance past debounce
+    await vi.advanceTimersByTimeAsync(3_500);
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const params = announceSpy.mock.calls[0]?.[0] as { startedAt?: number };
+    // startedAt should be the original registration time (1000), not overwritten
+    // by subsequent lifecycle start events (500 or 2000).
+    expect(params.startedAt).toBe(1000);
+  });
+
+  it("triggers immediately on run-level phase error without debounce", async () => {
+    await setupAndRegister();
+
+    // Simulate run-level error (emitted from agent-runner-execution.ts catch)
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "error", endedAt: 500, error: "run failed" },
+    });
+
+    // Should trigger immediately without waiting for debounce
+    await vi.advanceTimersByTimeAsync(0);
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const params = announceSpy.mock.calls[0]?.[0] as {
+      outcome?: { status: string; error?: string };
+    };
+    expect(params.outcome?.status).toBe("error");
+    expect(params.outcome?.error).toBe("run failed");
+  });
+
+  it("announce fires only once even with multiple rapid end events", async () => {
+    await setupAndRegister();
+
+    // Multiple rapid end events (e.g., both lifecycle listener and agent.wait)
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 1000 },
+    });
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 2000 },
+    });
+
+    await vi.advanceTimersByTimeAsync(3_500);
+
+    // Only one announce call (beginSubagentCleanup guard prevents second)
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    // Uses the latest endedAt
+    const params = announceSpy.mock.calls[0]?.[0] as { endedAt?: number };
+    expect(params.endedAt).toBe(2000);
+  });
+});

--- a/src/agents/subagent-registry.lifecycle-debounce.test.ts
+++ b/src/agents/subagent-registry.lifecycle-debounce.test.ts
@@ -164,7 +164,7 @@ describe("subagent lifecycle debounce", () => {
   it("preserves original startedAt across retry phase start events", async () => {
     await setupAndRegister();
 
-    // The registration sets startedAt = Date.now() (which is 0 with fake timers).
+    // The registration sets startedAt = Date.now() (1000 with these fake timers).
     // First attempt start (should NOT overwrite the registration startedAt)
     capturedEventHandler?.({
       runId: "run-retry",

--- a/src/agents/subagent-registry.lifecycle-debounce.test.ts
+++ b/src/agents/subagent-registry.lifecycle-debounce.test.ts
@@ -25,9 +25,9 @@ vi.mock("../infra/agent-events.js", () => ({
   }),
 }));
 
-const announceSpy = vi.fn(async () => true);
+const announceSpy = vi.fn(async (_params: unknown) => true);
 vi.mock("./subagent-announce.js", () => ({
-  runSubagentAnnounceFlow: (...args: unknown[]) => announceSpy(...args),
+  runSubagentAnnounceFlow: (arg: unknown) => announceSpy(arg),
 }));
 
 vi.mock("./subagent-registry.store.js", () => ({

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -437,19 +437,24 @@ describe("subagent registry steer restarts", () => {
       cleanup: "keep",
     });
 
-    lifecycleHandler?.({
-      stream: "lifecycle",
-      runId: "run-parent",
-      data: { phase: "end" },
-    });
-    await flushAnnounce();
+    vi.useFakeTimers();
+    try {
+      lifecycleHandler?.({
+        stream: "lifecycle",
+        runId: "run-parent",
+        data: { phase: "end" },
+      });
+      await vi.advanceTimersByTimeAsync(3_001);
 
-    lifecycleHandler?.({
-      stream: "lifecycle",
-      runId: "run-child",
-      data: { phase: "end" },
-    });
-    await flushAnnounce();
+      lifecycleHandler?.({
+        stream: "lifecycle",
+        runId: "run-child",
+        data: { phase: "end" },
+      });
+      await vi.advanceTimersByTimeAsync(3_001);
+    } finally {
+      vi.useRealTimers();
+    }
 
     const childRunIds = announceSpy.mock.calls.map(
       (call) => ((call[0] ?? {}) as { childRunId?: string }).childRunId,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -112,6 +112,7 @@ function triggerCleanupAndAnnounce(runId: string) {
     requesterOrigin,
     requesterDisplayKey: entry.requesterDisplayKey,
     task: entry.task,
+    expectsCompletionMessage: entry.expectsCompletionMessage,
     timeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
     cleanup: entry.cleanup,
     waitForCompletion: false,
@@ -597,6 +598,11 @@ function retryDeferredCompletedAnnounces(excludeRunId?: string) {
       continue;
     }
     if (entry.cleanupCompletedAt || entry.cleanupHandled) {
+      continue;
+    }
+    // Skip entries with a pending debounce timer — they are awaiting retry
+    // and should not be announced until the timer fires (#13011).
+    if (pendingCleanupTimers.has(runId)) {
       continue;
     }
     if (suppressAnnounceForSteerRestart(entry)) {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -78,8 +78,60 @@ function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit" | "ex
   );
 }
 
+// Debounce cleanup to handle per-attempt lifecycle "end" events that fire before
+// retries. Without debouncing, the first attempt's agent_end triggers announce
+// with stale data before the retry can produce correct output (#13011).
+const pendingCleanupTimers = new Map<string, NodeJS.Timeout>();
+const LIFECYCLE_END_DEBOUNCE_MS = 3_000;
+
 function persistSubagentRuns() {
   persistSubagentRunsToDisk(subagentRuns);
+}
+
+function cancelPendingCleanupTimer(runId: string) {
+  const timer = pendingCleanupTimers.get(runId);
+  if (timer) {
+    clearTimeout(timer);
+    pendingCleanupTimers.delete(runId);
+  }
+}
+
+function triggerCleanupAndAnnounce(runId: string) {
+  const entry = subagentRuns.get(runId);
+  if (!entry) {
+    return;
+  }
+  if (!beginSubagentCleanup(runId)) {
+    return;
+  }
+  const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
+  void runSubagentAnnounceFlow({
+    childSessionKey: entry.childSessionKey,
+    childRunId: entry.runId,
+    requesterSessionKey: entry.requesterSessionKey,
+    requesterOrigin,
+    requesterDisplayKey: entry.requesterDisplayKey,
+    task: entry.task,
+    timeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
+    cleanup: entry.cleanup,
+    waitForCompletion: false,
+    startedAt: entry.startedAt,
+    endedAt: entry.endedAt,
+    label: entry.label,
+    outcome: entry.outcome,
+  }).then((didAnnounce) => {
+    finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
+  });
+}
+
+function scheduleDebouncedCleanup(runId: string) {
+  cancelPendingCleanupTimer(runId);
+  const timer = setTimeout(() => {
+    pendingCleanupTimers.delete(runId);
+    triggerCleanupAndAnnounce(runId);
+  }, LIFECYCLE_END_DEBOUNCE_MS);
+  timer.unref?.();
+  pendingCleanupTimers.set(runId, timer);
 }
 
 const resumedRuns = new Set<string>();
@@ -374,44 +426,55 @@ function ensureListener() {
   }
   listenerStarted = true;
   listenerStop = onAgentEvent((evt) => {
-    void (async () => {
-      if (!evt || evt.stream !== "lifecycle") {
-        return;
+    if (!evt || evt.stream !== "lifecycle") {
+      return;
+    }
+    const entry = subagentRuns.get(evt.runId);
+    if (!entry) {
+      return;
+    }
+    const phase = evt.data?.phase;
+    if (phase === "start") {
+      // Cancel any pending cleanup timer — a retry attempt is starting.
+      cancelPendingCleanupTimer(evt.runId);
+      // Preserve the original startedAt (set at registration) so total
+      // wall-clock runtime is reported correctly across retries.
+      const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
+      if (startedAt && !entry.startedAt) {
+        entry.startedAt = startedAt;
+        persistSubagentRuns();
       }
-      const entry = subagentRuns.get(evt.runId);
-      if (!entry) {
-        return;
-      }
-      const phase = evt.data?.phase;
-      if (phase === "start") {
-        const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
-        if (startedAt) {
-          entry.startedAt = startedAt;
-          persistSubagentRuns();
-        }
-        return;
-      }
-      if (phase !== "end" && phase !== "error") {
-        return;
-      }
-      const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
-      const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
-      const outcome: SubagentRunOutcome =
-        phase === "error"
-          ? { status: "error", error }
-          : evt.data?.aborted
-            ? { status: "timeout" }
-            : { status: "ok" };
-      await completeSubagentRun({
-        runId: evt.runId,
-        endedAt,
-        outcome,
-        reason: phase === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
-        sendFarewell: true,
-        accountId: entry.requesterOrigin?.accountId,
-        triggerCleanup: true,
-      });
-    })();
+      return;
+    }
+    if (phase !== "end" && phase !== "error") {
+      return;
+    }
+    const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+    const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+    if (phase === "error") {
+      entry.outcome = { status: "error", error };
+    } else if (evt.data?.aborted) {
+      entry.outcome = { status: "timeout" };
+    } else {
+      entry.outcome = { status: "ok" };
+    }
+    persistSubagentRuns();
+
+    if (suppressAnnounceForSteerRestart(entry)) {
+      return;
+    }
+
+    if (phase === "error") {
+      // Run-level errors (from agent-runner-execution catch blocks) are
+      // definitive — trigger cleanup immediately without debouncing.
+      cancelPendingCleanupTimer(evt.runId);
+      triggerCleanupAndAnnounce(evt.runId);
+    } else {
+      // Per-attempt "end" events fire after each API call, including
+      // intermediate attempts that will be retried. Debounce so we
+      // only announce after the final attempt settles (#13011).
+      scheduleDebouncedCleanup(evt.runId);
+    }
   });
 }
 
@@ -790,6 +853,10 @@ export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   endedHookInFlightRunIds.clear();
   resetAnnounceQueuesForTests();
   stopSweeper();
+  for (const timer of pendingCleanupTimers.values()) {
+    clearTimeout(timer);
+  }
+  pendingCleanupTimers.clear();
   restoreAttempted = false;
   if (listenerStop) {
     listenerStop();

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -121,7 +121,7 @@ function triggerCleanupAndAnnounce(runId: string) {
     label: entry.label,
     outcome: entry.outcome,
   }).then((didAnnounce) => {
-    finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
+    void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
   });
 }
 
@@ -450,7 +450,7 @@ function ensureListener() {
     if (phase !== "end" && phase !== "error") {
       return;
     }
-    const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+    entry.endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
     const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
     if (phase === "error") {
       entry.outcome = { status: "error", error };

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -873,6 +873,7 @@ export function addSubagentRunForTests(entry: SubagentRunRecord) {
 }
 
 export function releaseSubagentRun(runId: string) {
+  cancelPendingCleanupTimer(runId);
   const didDelete = subagentRuns.delete(runId);
   if (didDelete) {
     persistSubagentRuns();


### PR DESCRIPTION
## Summary

Fixes #13011

When a subagent's first API call fails and the embedded runner retries, the lifecycle listener in subagent-registry.ts fires on the first attempt's agent_end event, triggering the announce flow prematurely with stale data. The parent receives (no output), runtime 0s, and tokens n/a despite the retry completing successfully.

**Root cause:** The lifecycle listener treated every per-attempt phase end event as run-level completion, immediately triggering beginSubagentCleanup + runSubagentAnnounceFlow. Between retry attempts, isEmbeddedPiRunActive returns false (the session handle is cleared between subscriptions), so the announce flow's existing safeguards could not detect the in-progress retry.

**Fix:** Debounce lifecycle end events by 3 seconds before triggering announce. If a retry start event arrives during the debounce window, the pending timer is canceled. Only after the final attempt settles (no new lifecycle events for 3s) does the announce fire with the correct data. Run-level error events still trigger immediately without debounce.

Also preserves the original startedAt from registration time across retry start events so total wall-clock runtime is reported correctly.

## Changes

- src/agents/subagent-registry.ts: Added debounce logic for lifecycle end events; extracted triggerCleanupAndAnnounce helper; preserve startedAt across retries
- src/agents/subagent-registry.lifecycle-debounce.test.ts: 6 new tests covering: no immediate announce on first end, debounced announce after settle, timer cancellation on retry start, startedAt preservation, immediate error handling, dedup on rapid events

## Test plan

- [x] All 6 new tests fail before the fix, pass after
- [x] All 19 existing tests in subagent-registry.persistence.test.ts and subagent-announce.format.test.ts pass
- [x] pnpm build succeeds
- [x] pnpm check (format + lint) succeeds

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `src/agents/subagent-registry.ts` to prevent premature subagent “announce” runs when embedded subagent executions retry: lifecycle `end` events are now debounced (3s) so intermediate attempt completions don’t trigger cleanup/announce with stale `endedAt/outcome`. A new helper (`triggerCleanupAndAnnounce`) centralizes the cleanup + announce flow, and pending debounce timers are canceled on retry `start`, on `releaseSubagentRun`, and during test resets. A new Vitest suite (`src/agents/subagent-registry.lifecycle-debounce.test.ts`) exercises the debounce behavior, timer cancellation on retry start, startedAt preservation, immediate handling for run-level `error`, and de-duping rapid end events.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are scoped to subagent lifecycle handling and add deterministic debounce/timer-cancellation logic to avoid premature announce on retries; new targeted tests cover the key edge cases and cleanup paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->