### PR TITLE
fix(ui): prioritize displayName over label in webchat session picker

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -5,7 +5,7 @@ import { resolveSessionDisplayName } from "./app-render.helpers.ts";
 type SessionRow = SessionsListResult["sessions"][number];
 
 function row(overrides: Partial<SessionRow> & { key: string }): SessionRow {
-  return { kind: "direct", updatedAt: Date.now(), ...overrides };
+  return { kind: "direct", updatedAt: 0, ...overrides };
 }
 
 describe("resolveSessionDisplayName", () => {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { SessionsListResult } from "./types.ts";
+import { resolveSessionDisplayName } from "./app-render.helpers.ts";
+
+type SessionRow = SessionsListResult["sessions"][number];
+
+function row(overrides: Partial<SessionRow> & { key: string }): SessionRow {
+  return { kind: "direct", updatedAt: Date.now(), ...overrides };
+}
+
+describe("resolveSessionDisplayName", () => {
+  it("returns key when no row is provided", () => {
+    expect(resolveSessionDisplayName("agent:main:main")).toBe("agent:main:main");
+  });
+
+  it("returns key when row has no label or displayName", () => {
+    expect(resolveSessionDisplayName("agent:main:main", row({ key: "agent:main:main" }))).toBe(
+      "agent:main:main",
+    );
+  });
+
+  it("returns key when displayName matches key", () => {
+    expect(resolveSessionDisplayName("mykey", row({ key: "mykey", displayName: "mykey" }))).toBe(
+      "mykey",
+    );
+  });
+
+  it("returns key when label matches key", () => {
+    expect(resolveSessionDisplayName("mykey", row({ key: "mykey", label: "mykey" }))).toBe("mykey");
+  });
+
+  it("uses displayName prominently when available", () => {
+    expect(
+      resolveSessionDisplayName(
+        "discord:123:456",
+        row({ key: "discord:123:456", displayName: "My Chat" }),
+      ),
+    ).toBe("My Chat (discord:123:456)");
+  });
+
+  it("falls back to label when displayName is absent", () => {
+    expect(
+      resolveSessionDisplayName(
+        "discord:123:456",
+        row({ key: "discord:123:456", label: "General" }),
+      ),
+    ).toBe("General (discord:123:456)");
+  });
+
+  it("prefers displayName over label when both are present", () => {
+    expect(
+      resolveSessionDisplayName(
+        "discord:123:456",
+        row({ key: "discord:123:456", displayName: "My Chat", label: "General" }),
+      ),
+    ).toBe("My Chat (discord:123:456)");
+  });
+
+  it("ignores whitespace-only displayName", () => {
+    expect(
+      resolveSessionDisplayName(
+        "discord:123:456",
+        row({ key: "discord:123:456", displayName: "   ", label: "General" }),
+      ),
+    ).toBe("General (discord:123:456)");
+  });
+
+  it("ignores whitespace-only label", () => {
+    expect(
+      resolveSessionDisplayName("discord:123:456", row({ key: "discord:123:456", label: "   " })),
+    ).toBe("discord:123:456");
+  });
+
+  it("trims displayName and label", () => {
+    expect(resolveSessionDisplayName("k", row({ key: "k", displayName: "  My Chat  " }))).toBe(
+      "My Chat (k)",
+    );
+  });
+});

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -219,14 +219,17 @@ function resolveMainSessionKey(
   return null;
 }
 
-function resolveSessionDisplayName(key: string, row?: SessionsListResult["sessions"][number]) {
-  const label = row?.label?.trim() || "";
+export function resolveSessionDisplayName(
+  key: string,
+  row?: SessionsListResult["sessions"][number],
+) {
   const displayName = row?.displayName?.trim() || "";
+  const label = row?.label?.trim() || "";
+  if (displayName && displayName !== key) {
+    return `${displayName} (${key})`;
+  }
   if (label && label !== key) {
     return `${label} (${key})`;
-  }
-  if (displayName && displayName !== key) {
-    return `${key} (${displayName})`;
   }
   return key;
 }


### PR DESCRIPTION
## Summary

- **Fix**: `resolveSessionDisplayName()` in `app-render.helpers.ts` checked `label` before `displayName` and formatted displayName entries as `key (displayName)` instead of `displayName (key)`, causing the session picker dropdown to show raw session keys prominently instead of human-readable names.
- **Change**: Swap priority so `displayName` is checked first, and use a consistent `humanName (key)` format for both `displayName` and `label` fallbacks.
- **Tests**: 10 new unit tests covering all fallback combinations (displayName, label, both, neither, whitespace, key-matching, trimming).

## Test plan

- [x] All 10 new tests fail before the fix, pass after (TDD)
- [x] `pnpm build` passes
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] CI passes

Fixes #6645

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `resolveSessionDisplayName()` in `ui/src/ui/app-render.helpers.ts` so the session picker renders a human-friendly `displayName` ahead of `label`, and formats both as `"<name> (<key>)"` when the name differs from the raw session key. It also adds a focused node-only Vitest suite (`ui/src/ui/app-render.helpers.node.test.ts`) covering fallback/whitespace/trim/key-match cases to lock in the intended dropdown display behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is localized to string selection/formatting for session dropdown labels, with deterministic unit tests covering key edge cases (missing values, key matches, whitespace trimming). No other consumers parse this string, and the session row type matches the test fixture shape.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->