### PR TITLE
fix(plugins): inject globalThis.require for CJS interop in jiti-loaded extensions

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1128,7 +1128,7 @@ describe("loadOpenClawPlugins", () => {
     );
 
     // Plugin that loads the CJS helper via globalThis.require and uses it during registration
-    writePlugin({
+    const cjsCompatPlugin = writePlugin({
       id: "cjs-compat",
       body: [
         `const helper = globalThis.require(${JSON.stringify(path.join(dir, "cjs-helper.cjs"))});`,
@@ -1148,15 +1148,14 @@ describe("loadOpenClawPlugins", () => {
       cache: false,
       config: {
         plugins: {
-          load: { paths: [path.join(dir, "cjs-compat.js")] },
+          load: { paths: [cjsCompatPlugin.file] },
           allow: ["cjs-compat"],
         },
       },
     });
 
-    const plugin = registry.plugins.find((entry) => entry.id === "cjs-compat");
+    const plugin = registry.plugins.find((entry) => entry.id === cjsCompatPlugin.id);
     expect(plugin?.status).toBe("loaded");
-  });
   });
 
   it("prefers dist plugin-sdk alias when loader runs from dist", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1100,6 +1100,65 @@ describe("loadOpenClawPlugins", () => {
     expect(record?.status).toBe("loaded");
   });
 
+  it("injects globalThis.require for CJS interop in jiti-loaded plugins", () => {
+    // The loader module must set globalThis.require so that CJS dependencies
+    // loaded by jiti can call require() at runtime (see #12854).
+    expect(typeof globalThis.require).toBe("function");
+    // Verify the shim actually resolves Node.js built-in modules
+    const resolved = globalThis.require("node:path");
+    expect(typeof resolved.join).toBe("function");
+  });
+
+  it("loads plugins whose CJS dependencies call require() at runtime", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+
+    const dir = makeTempDir();
+
+    // Create a CJS helper module that uses require() internally.
+    // This simulates a real CJS dependency (e.g. @vector-im/matrix-bot-sdk)
+    // whose internal code calls require("events"), require("htmlencode"), etc.
+    fs.writeFileSync(
+      path.join(dir, "cjs-helper.cjs"),
+      [
+        `"use strict";`,
+        `const nodePath = require("node:path");`,
+        `module.exports = { joined: nodePath.join("a", "b") };`,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    // Plugin that loads the CJS helper via globalThis.require and uses it during registration
+    writePlugin({
+      id: "cjs-compat",
+      body: [
+        `const helper = globalThis.require(${JSON.stringify(path.join(dir, "cjs-helper.cjs"))});`,
+        `export default {`,
+        `  id: "cjs-compat",`,
+        `  register() {`,
+        `    if (helper.joined !== ${JSON.stringify(path.join("a", "b"))}) {`,
+        `      throw new Error("CJS require interop failed");`,
+        `    }`,
+        `  },`,
+        `};`,
+      ].join("\n"),
+      dir,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [path.join(dir, "cjs-compat.js")] },
+          allow: ["cjs-compat"],
+        },
+      },
+    });
+
+    const plugin = registry.plugins.find((entry) => entry.id === "cjs-compat");
+    expect(plugin?.status).toBe("loaded");
+  });
+  });
+
   it("prefers dist plugin-sdk alias when loader runs from dist", () => {
     const { root, distFile } = createPluginSdkAliasFixture();
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -837,6 +837,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
   }
 
+  // Restore globalThis.require to a stable base anchored at the project root
+  // so runtime require() calls after loading resolve from a predictable path.
+  globalThis.require = createRequire(import.meta.url);
+
   if (typeof memorySlot === "string" && !memorySlotMatched) {
     registry.diagnostics.push({
       level: "warn",

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -601,6 +601,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   let selectedMemoryPluginId: string | null = null;
   let memorySlotMatched = false;
 
+  const savedRequire = globalThis.require;
+
   for (const candidate of discovery.candidates) {
     const manifestRecord = manifestByRoot.get(candidate.rootDir);
     if (!manifestRecord) {
@@ -837,9 +839,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
   }
 
-  // Restore globalThis.require to a stable base anchored at the project root
-  // so runtime require() calls after loading resolve from a predictable path.
-  globalThis.require = createRequire(import.meta.url);
+  // Restore the pre-existing require (or the module-level fallback) so runtime
+  // code that relied on the original require semantics is not broken.
+  globalThis.require = savedRequire;
 
   if (typeof memorySlot === "string" && !memorySlotMatched) {
     registry.diagnostics.push({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -707,6 +707,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     const safeSource = opened.path;
     fs.closeSync(opened.fd);
 
+    // Anchor require() resolution to the plugin's directory so its CJS
+    // dependencies resolve packages from the plugin's own node_modules.
+    globalThis.require = createRequire(candidate.source);
+
     let mod: OpenClawPluginModule | null = null;
     try {
       mod = getJiti()(safeSource) as OpenClawPluginModule;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,7 +1,15 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
+
+// Provide require() globally for CJS dependencies of jiti-loaded plugins (#12854).
+// jiti evaluates extensions in an ESM context where require is unavailable, causing
+// CJS packages that internally call require() to fail at runtime.
+if (typeof globalThis.require !== "function") {
+  globalThis.require = createRequire(import.meta.url);
+}
 import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";


### PR DESCRIPTION
## Summary

Fixes #12854

Extensions loaded via jiti run in an ESM context where `require` is unavailable. CJS dependencies that internally call `require()` (e.g. `@vector-im/matrix-bot-sdk` calling `require("events")`) crash at runtime with `ReferenceError: require is not defined`.

This PR:
- Injects a `globalThis.require` shim at module load time via `createRequire(import.meta.url)` so CJS packages always have a usable `require`
- Re-anchors `globalThis.require` to each plugin's source path before `jiti()` evaluates it, so CJS dependencies resolve from the plugin's own `node_modules`
- Saves/restores the pre-existing `globalThis.require` around the plugin loading loop so runtime code outside the loader is unaffected

## Test plan

- [x] New test: `injects globalThis.require for CJS interop in jiti-loaded plugins` — verifies the shim exists and resolves built-in modules
- [x] New test: `loads plugins whose CJS dependencies call require() at runtime` — creates a real CJS helper that calls `require("node:path")`, loads a plugin that depends on it, verifies `status === "loaded"`
- [x] All 16 loader tests pass (TDD: both new tests fail before the fix, pass after)
- [x] `pnpm build && pnpm check` clean

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adjusts the plugin loader so extensions evaluated via `jiti` (ESM context) have a `require` available for CommonJS interop. It injects a `globalThis.require` shim via `createRequire(import.meta.url)`, re-anchors `globalThis.require` to each plugin’s source path before `jiti()` evaluation so CJS dependencies resolve from the plugin’s own `node_modules`, and saves/restores any pre-existing `globalThis.require` around the plugin loading loop. Tests are added to verify the shim exists and can resolve built-in modules, and that plugins with CJS dependencies calling `require()` at runtime load successfully.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to plugin loading, adds targeted tests that exercise the new behavior (globalThis.require injection and per-plugin require anchoring), and does not introduce broader behavioral changes beyond the loader’s evaluation context.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->