### PR TITLE
fix(gateway): implement explicit channel isolation and heartbeat filtering

### DIFF
--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -14,8 +14,11 @@ import {
 } from "../gateway/protocol/client-info.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 
-export const INTERNAL_MESSAGE_CHANNEL = "webchat" as const;
+export const INTERNAL_MESSAGE_CHANNEL = "internal" as const;
 export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL;
+
+export const WEBCHAT_MESSAGE_CHANNEL = "webchat" as const;
+export type WebchatMessageChannel = typeof WEBCHAT_MESSAGE_CHANNEL;
 
 const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([
   "slack",
@@ -24,6 +27,7 @@ const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([
   "discord",
   "googlechat",
   "tui",
+  WEBCHAT_MESSAGE_CHANNEL,
   INTERNAL_MESSAGE_CHANNEL,
 ]);
 
@@ -44,6 +48,18 @@ export function isInternalMessageChannel(raw?: string | null): raw is InternalMe
   return normalizeMessageChannel(raw) === INTERNAL_MESSAGE_CHANNEL;
 }
 
+export function isWebchatMessageChannel(raw?: string | null): raw is WebchatMessageChannel {
+  return normalizeMessageChannel(raw) === WEBCHAT_MESSAGE_CHANNEL;
+}
+
+/** Returns true if the channel is 'webchat' or 'internal' (gateway client channels). */
+export function isClientMessageChannel(
+  raw?: string | null,
+): raw is WebchatMessageChannel | InternalMessageChannel {
+  const normalized = normalizeMessageChannel(raw);
+  return normalized === WEBCHAT_MESSAGE_CHANNEL || normalized === INTERNAL_MESSAGE_CHANNEL;
+}
+
 export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean {
   const mode = normalizeGatewayClientMode(client?.mode);
   if (mode === GATEWAY_CLIENT_MODES.WEBCHAT) {
@@ -59,6 +75,9 @@ export function normalizeMessageChannel(raw?: string | null): string | undefined
   }
   if (normalized === INTERNAL_MESSAGE_CHANNEL) {
     return INTERNAL_MESSAGE_CHANNEL;
+  }
+  if (normalized === WEBCHAT_MESSAGE_CHANNEL) {
+    return WEBCHAT_MESSAGE_CHANNEL;
   }
   const builtIn = normalizeChatChannelId(normalized);
   if (builtIn) {
@@ -97,11 +116,15 @@ export const listDeliverableMessageChannels = (): ChannelId[] =>
 
 export type DeliverableMessageChannel = ChannelId;
 
-export type GatewayMessageChannel = DeliverableMessageChannel | InternalMessageChannel;
+export type GatewayMessageChannel =
+  | DeliverableMessageChannel
+  | InternalMessageChannel
+  | WebchatMessageChannel;
 
 export const listGatewayMessageChannels = (): GatewayMessageChannel[] => [
   ...listDeliverableMessageChannels(),
   INTERNAL_MESSAGE_CHANNEL,
+  WEBCHAT_MESSAGE_CHANNEL,
 ];
 
 export const listGatewayAgentChannelAliases = (): string[] =>


### PR DESCRIPTION
# Problem
The 'INTERNAL_MESSAGE_CHANNEL' was incorrectly aliased to "webchat", causing
internal system messages (heartbeats) to pollute real browser chat history.
Additionally, 'chat.send' lacked propagation of the effective channel, leading
to incorrect message prefixing.

# Changes
- Defined separate "internal" and "webchat" channel IDs in 'message-channel.ts'.
- Implemented 'isHeartbeatAckMessage' utility to identify system acknowledgments.
- Refactored 'chat.history' to prune heartbeats when 'channels.defaults.heartbeat.showOk' is false.
- Fixed 'chat.send' to propagate the derived 'effectiveChannel' to dispatcher options.

# Validation
- Verified channel isolation via 'pnpm tsgo'.
- Confirmed 'HEARTBEAT_OK' filtering logic passes type-aware linting.
- Executed 'pnpm build' to ensure no regressions in build artifacts.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR splits the previously-aliased internal/webchat message channels by changing `INTERNAL_MESSAGE_CHANNEL` to `"internal"` and introducing `WEBCHAT_MESSAGE_CHANNEL = "webchat"`. It also updates gateway chat handling to (a) propagate the derived effective channel through `chat.send` so reply prefixing and dispatcher behavior match the connection type, and (b) filter heartbeat OK/ACK messages from `chat.history` when configured.

The changes integrate at the gateway request handler layer (handlers receive `isWebchatConnect`) and in channel normalization/type helpers under `src/utils/message-channel.ts`.

Issues to fix before merge:
- `chat.history` heartbeat filtering logic currently only filters for webchat clients, even though the PR description/comment imply filtering should be controlled by `channels.defaults.heartbeat.showOk` generally.
- `resolveOutboundTarget()` still emits an error message referencing WebChat when rejecting `INTERNAL_MESSAGE_CHANNEL`, but that constant is now `"internal"`.
- A direct handler invocation in `chat.inject.parentid.test.ts` does not conform to the `GatewayRequestHandlerOptions` shape and is fragile against handler signature/destructuring changes.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but has a couple correctness issues to address before merge.
- Channel separation and propagation changes are localized and consistent, but there are two confirmed correctness problems: (1) heartbeat filtering in `chat.history` doesn’t match the stated/configured behavior (filters only for webchat), and (2) an internal-channel error message now references WebChat after the constant change. There’s also a confirmed fragile test harness direct-call that doesn’t match the handler option shape.
- src/gateway/server-methods/chat.ts and src/infra/outbound/targets.ts (plus src/gateway/server-methods/chat.inject.parentid.test.ts for the direct handler call).

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->