### PR TITLE
perf(gateway): reduce idle CPU by increasing config and manifest cache TTL

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -561,7 +561,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 // NOTE: These wrappers intentionally do *not* cache the resolved config path at
 // module scope. `OPENCLAW_CONFIG_PATH` (and friends) are expected to work even
 // when set after the module has been imported (tests, one-off scripts, etc.).
-const DEFAULT_CONFIG_CACHE_MS = 200;
+const DEFAULT_CONFIG_CACHE_MS = 5000;
 let configCache: {
   configPath: string;
   expiresAt: number;

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -32,7 +32,7 @@ export type PluginManifestRegistry = {
 
 const registryCache = new Map<string, { expiresAt: number; registry: PluginManifestRegistry }>();
 
-const DEFAULT_MANIFEST_CACHE_MS = 200;
+const DEFAULT_MANIFEST_CACHE_MS = 5000;
 
 function resolveManifestCacheMs(env: NodeJS.ProcessEnv): number {
   const raw = env.OPENCLAW_PLUGIN_MANIFEST_CACHE_MS?.trim();


### PR DESCRIPTION
# Problem
The Gateway periodically checks for configuration and plugin manifest changes.
The default cache TTL of 200ms caused excessive disk I/O (up to 5 stat calls/sec)
even when the system was completely idle, leading to unnecessary CPU overhead.

# Changes
- Increased 'DEFAULT_CONFIG_CACHE_MS' to 5000ms in 'src/config/io.ts'.
- Increased 'DEFAULT_MANIFEST_CACHE_MS' to 5000ms in 'src/plugins/manifest-registry.ts'.

# Validation
- Verified TTL increase via code audit.
- Ensured no regressions in configuration loading logic via 'pnpm tsgo'.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reduces idle Gateway CPU/disk activity by increasing the default TTLs used for caching configuration reads and plugin manifest registry discovery.

Changes are limited to bumping the module-level defaults that back `OPENCLAW_CONFIG_CACHE_MS` (in `src/config/io.ts`) and `OPENCLAW_PLUGIN_MANIFEST_CACHE_MS` (in `src/plugins/manifest-registry.ts`) from 200ms to 5000ms. The caching behavior and env overrides remain unchanged; callers can still disable caching via the existing `OPENCLAW_DISABLE_*_CACHE` flags or by setting the TTL env vars to `0`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change only increases two default cache TTL constants (200ms → 5000ms) without altering cache logic, keying, invalidation, or env overrides. No call sites or behavior contracts appear to rely on the prior 200ms default, and both caches can still be disabled via existing environment flags or by setting TTL to 0.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->