### PR TITLE
fix(security): clarify dmScope remediation path with explicit CLI command

### DIFF
--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -124,7 +124,9 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
 
     if (dmScope === "main" && isMultiUserDm) {
       warnings.push(
-        `- ${params.label} DMs: multiple senders share the main session; set session.dmScope="per-channel-peer" (or "per-account-channel-peer" for multi-account channels) to isolate sessions.`,
+        `- ${params.label} DMs: multiple senders share the main session; run: ` +
+          formatCliCommand('openclaw config set session.dmScope "per-channel-peer"') +
+          ' (or "per-account-channel-peer" for multi-account channels) to isolate sessions.',
       );
     }
   };

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -194,7 +194,9 @@ async function noteChannelPrimer(
       "DM security: default is pairing; unknown DMs get a pairing code.",
       `Approve with: ${formatCliCommand("openclaw pairing approve <channel> <code>")}`,
       'Public DMs require dmPolicy="open" + allowFrom=["*"].',
-      'Multi-user DMs: set session.dmScope="per-channel-peer" (or "per-account-channel-peer" for multi-account channels) to isolate sessions.',
+      "Multi-user DMs: run: " +
+        formatCliCommand('openclaw config set session.dmScope "per-channel-peer"') +
+        ' (or "per-account-channel-peer" for multi-account channels) to isolate sessions.',
       `Docs: ${formatDocsLink("/start/pairing", "start/pairing")}`,
       "",
       ...channelLines,
@@ -248,7 +250,9 @@ async function maybeConfigureDmPolicies(params: {
         `Approve: ${formatCliCommand(`openclaw pairing approve ${policy.channel} <code>`)}`,
         `Allowlist DMs: ${policy.policyKey}="allowlist" + ${policy.allowFromKey} entries.`,
         `Public DMs: ${policy.policyKey}="open" + ${policy.allowFromKey} includes "*".`,
-        'Multi-user DMs: set session.dmScope="per-channel-peer" (or "per-account-channel-peer" for multi-account channels) to isolate sessions.',
+        "Multi-user DMs: run: " +
+          formatCliCommand('openclaw config set session.dmScope "per-channel-peer"') +
+          ' (or "per-account-channel-peer" for multi-account channels) to isolate sessions.',
         `Docs: ${formatDocsLink("/start/pairing", "start/pairing")}`,
       ].join("\n"),
       `${policy.label} DM access`,

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -544,7 +544,9 @@ async function collectChannelSecurityFindings(params: {
         detail:
           "Multiple DM senders currently share the main session, which can leak context across users.",
         remediation:
-          'Set session.dmScope="per-channel-peer" (or "per-account-channel-peer" for multi-account channels) to isolate DM sessions per sender.',
+          "Run: " +
+          formatCliCommand('openclaw config set session.dmScope "per-channel-peer"') +
+          ' (or "per-account-channel-peer" for multi-account channels) to isolate DM sessions per sender.',
       });
     }
   };


### PR DESCRIPTION
# Problem
The security audit and onboarding screens suggested 'Set session.dmScope="..."'
for multi-user DM isolation. This led users to try setting the value in invalid
config paths (e.g., 'channels.imessage.dmScope').

# Changes
- Updated 'src/security/audit.ts' to use 'formatCliCommand' for dmScope remediation.
- Updated 'src/commands/doctor-security.ts' and 'src/commands/onboard-channels.ts'
  to use the explicit 'openclaw config set' command format.

# Validation
- Verified text alignment with 'pnpm tsgo'.
- Confirmed CLI command formatting remains consistent across modified files.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the DM isolation remediation messaging in the security audit, doctor-security, and onboarding flows to point users at an explicit `openclaw config set session.dmScope ...` command (formatted via `formatCliCommand`) rather than instructing them to manually set `session.dmScope="..."` in arbitrary config paths.

The change fits the existing CLI UX pattern by reusing the shared command formatter (which also injects `--profile` when applicable), improving copy/paste correctness for end users.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but needs a small output-format fix.
- Only string/message changes, but the current concatenation/indentation will introduce unintended whitespace in user-facing remediation text in multiple places.
- src/security/audit.ts, src/commands/doctor-security.ts, src/commands/onboard-channels.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->