### PR TITLE
Docker: include A2UI sources for bundle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,3 +46,15 @@ Swabble/
 Core/
 Users/
 vendor/
+
+# Needed for building the Canvas A2UI bundle during Docker image builds.
+# Keep the rest of apps/ and vendor/ excluded to avoid a large build context.
+!apps/shared/
+!apps/shared/OpenClawKit/
+!apps/shared/OpenClawKit/Tools/
+!apps/shared/OpenClawKit/Tools/CanvasA2UI/
+!apps/shared/OpenClawKit/Tools/CanvasA2UI/**
+!vendor/a2ui/
+!vendor/a2ui/renderers/
+!vendor/a2ui/renderers/lit/
+!vendor/a2ui/renderers/lit/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY scripts ./scripts
 RUN pnpm install --frozen-lockfile
 
 COPY . .
-RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
+RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build

--- a/scripts/bundle-a2ui.sh
+++ b/scripts/bundle-a2ui.sh
@@ -14,10 +14,14 @@ A2UI_RENDERER_DIR="$ROOT_DIR/vendor/a2ui/renderers/lit"
 A2UI_APP_DIR="$ROOT_DIR/apps/shared/OpenClawKit/Tools/CanvasA2UI"
 
 # Docker builds exclude vendor/apps via .dockerignore.
-# In that environment we must keep the prebuilt bundle.
+# In that environment we can keep a prebuilt bundle only if it exists.
 if [[ ! -d "$A2UI_RENDERER_DIR" || ! -d "$A2UI_APP_DIR" ]]; then
-  echo "A2UI sources missing; keeping prebuilt bundle."
-  exit 0
+  if [[ -f "$OUTPUT_FILE" ]]; then
+    echo "A2UI sources missing; keeping prebuilt bundle."
+    exit 0
+  fi
+  echo "A2UI sources missing and no prebuilt bundle found at: $OUTPUT_FILE" >&2
+  exit 1
 fi
 
 INPUT_PATHS=(


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/12878.

Problem:
- Docker builds were excluding `apps/` and `vendor/`, so `scripts/bundle-a2ui.sh` skipped bundling.
- `Dockerfile` set `OPENCLAW_A2UI_SKIP_MISSING=1`, so the build succeeded while silently shipping without `a2ui.bundle.js`.

Changes:
- Update `.dockerignore` to re-include only the A2UI bundle inputs:
  - `apps/shared/OpenClawKit/Tools/CanvasA2UI/**`
  - `vendor/a2ui/renderers/lit/**`
- Remove `OPENCLAW_A2UI_SKIP_MISSING=1` from the Docker build step so regressions fail fast.

Testing:
- `pnpm build`
- `pnpm check`
- `pnpm test src/canvas-host/server.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Docker build context to include the Canvas A2UI bundle inputs (specific `apps/shared/OpenClawKit/Tools/CanvasA2UI/**` and `vendor/a2ui/renderers/lit/**` paths) and removes `OPENCLAW_A2UI_SKIP_MISSING=1` from the `pnpm build` step to avoid silently shipping without the A2UI bundle.

However, as written, the `.dockerignore` negations likely don’t take effect because `apps/` and `vendor/` remain ignored, and the bundling script itself exits successfully when those sources are missing. As a result, Docker builds can still proceed without actually bundling A2UI, undermining the “fail fast” goal.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because it likely does not achieve its stated Docker bundling guarantees.
- The `.dockerignore` changes appear to still exclude the required A2UI source directories due to parent directory ignores, and `scripts/bundle-a2ui.sh` exits 0 when sources are missing, so removing `OPENCLAW_A2UI_SKIP_MISSING=1` doesn’t enforce a fail-fast build.
- .dockerignore, Dockerfile (and `scripts/bundle-a2ui.sh` behavior as it affects Docker builds)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->