### PR TITLE
fix: add forward-compat for google-antigravity claude-opus-4-6 models

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -114,6 +114,70 @@ function resolveAnthropicOpus46ForwardCompatModel(
   return undefined;
 }
 
+// google-antigravity OAuth provider wraps Anthropic/Gemini models via Google's API.
+// When antigravity updates their model catalog (e.g., claude-opus-4-6-thinking),
+// OpenClaw's pi-ai registry may not have the new ID yet. This fallback maps new
+// claude-opus-4-6 variants to their claude-opus-4-5 equivalents for forward-compat.
+function resolveAntigravityOpus46ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (normalizedProvider !== "google-antigravity") {
+    return undefined;
+  }
+
+  const trimmedModelId = modelId.trim();
+  const lower = trimmedModelId.toLowerCase();
+
+  // Match claude-opus-4-6, claude-opus-4-6-thinking, claude-opus-4.6, etc.
+  const isOpus46 =
+    lower === ANTHROPIC_OPUS_46_MODEL_ID ||
+    lower === ANTHROPIC_OPUS_46_DOT_MODEL_ID ||
+    lower.startsWith(`${ANTHROPIC_OPUS_46_MODEL_ID}-`) ||
+    lower.startsWith(`${ANTHROPIC_OPUS_46_DOT_MODEL_ID}-`);
+  if (!isOpus46) {
+    return undefined;
+  }
+
+  // Build candidate template IDs by replacing 4-6 with 4-5
+  const templateIds: string[] = [];
+  if (lower.startsWith(ANTHROPIC_OPUS_46_MODEL_ID)) {
+    templateIds.push(lower.replace(ANTHROPIC_OPUS_46_MODEL_ID, "claude-opus-4-5"));
+  }
+  if (lower.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID)) {
+    templateIds.push(lower.replace(ANTHROPIC_OPUS_46_DOT_MODEL_ID, "claude-opus-4.5"));
+  }
+  templateIds.push(...ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS);
+
+  // Try to find a template model in the registry for google-antigravity
+  for (const templateId of [...new Set(templateIds)].filter(Boolean)) {
+    const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
+    if (template) {
+      return normalizeModelCompat({
+        ...template,
+        id: trimmedModelId,
+        name: trimmedModelId,
+      } as Model<Api>);
+    }
+  }
+
+  // If no template found in registry, create a synthetic model definition
+  // google-antigravity uses anthropic-messages API for Claude models
+  return normalizeModelCompat({
+    id: trimmedModelId,
+    name: trimmedModelId,
+    api: "anthropic-messages",
+    provider: normalizedProvider,
+    reasoning: lower.includes("thinking"),
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_TOKENS,
+    maxTokens: DEFAULT_CONTEXT_TOKENS,
+  } as Model<Api>);
+}
+
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
 ): InlineModelEntry[] {
@@ -198,6 +262,14 @@ export function resolveModel(
     );
     if (anthropicForwardCompat) {
       return { model: anthropicForwardCompat, authStorage, modelRegistry };
+    }
+    const antigravityForwardCompat = resolveAntigravityOpus46ForwardCompatModel(
+      provider,
+      modelId,
+      modelRegistry,
+    );
+    if (antigravityForwardCompat) {
+      return { model: antigravityForwardCompat, authStorage, modelRegistry };
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {


### PR DESCRIPTION
## Summary

When antigravity updates their model catalog to include `claude-opus-4-6-thinking`, OpenClaw's pi-ai registry may not have the new ID yet, causing "Unknown model: google-antigravity/claude-opus-4-6-thinking" errors.

This adds a forward-compat fallback that maps `claude-opus-4-6` variants to their `claude-opus-4-5` equivalents for the `google-antigravity` provider, similar to the existing `anthropic` provider handling in `resolveAnthropicOpus46ForwardCompatModel`.

## Changes

- Added `resolveAntigravityOpus46ForwardCompatModel()` function that:
  - Detects claude-opus-4-6 model IDs for google-antigravity provider
  - Maps them to claude-opus-4-5 equivalents in the registry
  - Falls back to synthetic model definition if no template found
  - Properly sets `reasoning: true` for `-thinking` variants

## Models Fixed

- `google-antigravity/claude-opus-4-6`
- `google-antigravity/claude-opus-4-6-thinking`
- `google-antigravity/claude-opus-4.6`

## Test Plan

- [ ] Verify `google-antigravity/claude-opus-4-6-thinking` resolves without "Unknown model" error
- [ ] Verify model inherits correct settings from claude-opus-4-5-thinking template
- [ ] Verify `-thinking` variants have `reasoning: true`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a `google-antigravity`-specific forward-compat resolver in `src/agents/pi-embedded-runner/model.ts` that detects `claude-opus-4-6` / `claude-opus-4.6` (and `-thinking` variants) and maps them to `claude-opus-4-5` / `claude-opus-4.5` template models from the pi-ai registry when available. If no template exists, it synthesizes a minimal `anthropic-messages` model definition, setting `reasoning: true` when the requested model id contains `thinking`.

The resolver is wired into `resolveModel()` alongside the existing OpenAI Codex and Anthropic Opus forward-compat fallbacks, so users won’t hit `Unknown model: google-antigravity/...` when antigravity’s catalog updates faster than the local registry.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to model resolution fallback logic, follows the existing forward-compat pattern used for other providers, and only activates for the `google-antigravity` provider with specific `claude-opus-4-6` model id patterns. No functional regressions were identified in the surrounding call sites.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->