### PR TITLE
Add project.yml to fix clawdbot/moltbot package action runtime for de…

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,11 @@
+# Deployment project configuration (used when building/deploying this repo).
+# The build system discovers actions from packages (e.g. clawdbot/index, clawdbot/scripts,
+# clawdbot/package). The "package" action corresponds to the package manifest; without
+# an explicit runtime it fails with "runtime type could not be determined".
+# This file defines runtime for those actions so the build succeeds.
+
+actions:
+  clawdbot/package:
+    runtime: node
+  moltbot/package:
+    runtime: node


### PR DESCRIPTION
…ploy

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a root-level `project.yml` deployment configuration defining explicit `node` runtimes for the `clawdbot/package` and `moltbot/package` actions. This is intended to fix deploy/build discovery where the package action’s runtime can’t be inferred from the manifest, causing builds to fail with “runtime type could not be determined.”

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to adding a small declarative config file; it doesn’t alter runtime code paths and is consistent with the stated deploy failure it addresses.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->