### PR TITLE
fix(signal): enforce mention gating for group messages

### DIFF
--- a/src/signal/monitor/event-handler.mention-gating.test.ts
+++ b/src/signal/monitor/event-handler.mention-gating.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+
+let capturedCtx: MsgContext | undefined;
+
+vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../auto-reply/dispatch.js")>();
+  const dispatchInboundMessage = vi.fn(async (params: { ctx: MsgContext }) => {
+    capturedCtx = params.ctx;
+    return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+  });
+  return {
+    ...actual,
+    dispatchInboundMessage,
+    dispatchInboundMessageWithDispatcher: dispatchInboundMessage,
+    dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessage,
+  };
+});
+
+import { createSignalEventHandler } from "./event-handler.js";
+
+function createBaseDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    runtime: { log: () => {}, error: () => {} } as any,
+    baseUrl: "http://localhost",
+    accountId: "default",
+    historyLimit: 5,
+    groupHistories: new Map(),
+    textLimit: 4000,
+    dmPolicy: "open" as const,
+    allowFrom: ["*"],
+    groupAllowFrom: ["*"],
+    groupPolicy: "open" as const,
+    reactionMode: "off" as const,
+    reactionAllowlist: [],
+    mediaMaxBytes: 1024,
+    ignoreAttachments: true,
+    sendReadReceipts: false,
+    readReceiptsViaDaemon: false,
+    fetchAttachment: async () => null,
+    deliverReplies: async () => {},
+    resolveSignalReactionTargets: () => [],
+    // oxlint-disable-next-line typescript/no-explicit-any
+    isSignalReactionMessage: () => false as any,
+    shouldEmitSignalReactionNotification: () => false,
+    buildSignalReactionSystemEventText: () => "reaction",
+    ...overrides,
+  };
+}
+
+function makeGroupEvent(message: string) {
+  return {
+    event: "receive",
+    data: JSON.stringify({
+      envelope: {
+        sourceNumber: "+15550001111",
+        sourceName: "Alice",
+        timestamp: 1700000000000,
+        dataMessage: {
+          message,
+          attachments: [],
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      },
+    }),
+  };
+}
+
+describe("signal mention gating", () => {
+  it("drops group messages without mention when requireMention is configured", async () => {
+    capturedCtx = undefined;
+    const handler = createSignalEventHandler(
+      createBaseDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 }, groupChat: { mentionPatterns: ["@bot"] } },
+          channels: { signal: { groups: { "*": { requireMention: true } } } },
+        },
+      }),
+    );
+
+    await handler(makeGroupEvent("hello everyone"));
+    expect(capturedCtx).toBeUndefined();
+  });
+
+  it("allows group messages with mention when requireMention is configured", async () => {
+    capturedCtx = undefined;
+    const handler = createSignalEventHandler(
+      createBaseDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 }, groupChat: { mentionPatterns: ["@bot"] } },
+          channels: { signal: { groups: { "*": { requireMention: true } } } },
+        },
+      }),
+    );
+
+    await handler(makeGroupEvent("hey @bot what's up"));
+    expect(capturedCtx).toBeTruthy();
+    expect(capturedCtx?.WasMentioned).toBe(true);
+  });
+
+  it("sets WasMentioned=false for group messages without mention when requireMention is off", async () => {
+    capturedCtx = undefined;
+    const handler = createSignalEventHandler(
+      createBaseDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 }, groupChat: { mentionPatterns: ["@bot"] } },
+          channels: { signal: { groups: { "*": { requireMention: false } } } },
+        },
+      }),
+    );
+
+    await handler(makeGroupEvent("hello everyone"));
+    expect(capturedCtx).toBeTruthy();
+    expect(capturedCtx?.WasMentioned).toBe(false);
+  });
+
+  it("records pending history for skipped group messages", async () => {
+    capturedCtx = undefined;
+    const groupHistories = new Map();
+    const handler = createSignalEventHandler(
+      createBaseDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 }, groupChat: { mentionPatterns: ["@bot"] } },
+          channels: { signal: { groups: { "*": { requireMention: true } } } },
+        },
+        historyLimit: 5,
+        groupHistories,
+      }),
+    );
+
+    await handler(makeGroupEvent("hello from alice"));
+    expect(capturedCtx).toBeUndefined();
+    const entries = groupHistories.get("g1");
+    expect(entries).toBeTruthy();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].sender).toBe("Alice");
+    expect(entries[0].body).toBe("hello from alice");
+  });
+
+  it("bypasses mention gating for authorized control commands", async () => {
+    capturedCtx = undefined;
+    const handler = createSignalEventHandler(
+      createBaseDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 }, groupChat: { mentionPatterns: ["@bot"] } },
+          channels: { signal: { groups: { "*": { requireMention: true } } } },
+        },
+      }),
+    );
+
+    await handler(makeGroupEvent("/help"));
+    expect(capturedCtx).toBeTruthy();
+  });
+});

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -14,14 +14,18 @@ import {
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
+  recordPendingHistoryEntryIfEnabled,
 } from "../../auto-reply/reply/history.js";
 import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.js";
+import { buildMentionRegexes, matchesMentionPatterns } from "../../auto-reply/reply/mentions.js";
 import { createReplyDispatcherWithTyping } from "../../auto-reply/reply/reply-dispatcher.js";
 import { resolveControlCommandGate } from "../../channels/command-gating.js";
 import { logInboundDrop, logTypingFailure } from "../../channels/logging.js";
+import { resolveMentionGatingWithBypass } from "../../channels/mention-gating.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
 import { createTypingCallbacks } from "../../channels/typing.js";
+import { resolveChannelGroupRequireMention } from "../../config/group-policy.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -61,6 +65,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaPath?: string;
     mediaType?: string;
     commandAuthorized: boolean;
+    wasMentioned?: boolean;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -144,6 +149,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaPath: entry.mediaPath,
       MediaType: entry.mediaType,
       MediaUrl: entry.mediaPath,
+      WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
@@ -499,6 +505,61 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
+    const route = resolveAgentRoute({
+      cfg: deps.cfg,
+      channel: "signal",
+      accountId: deps.accountId,
+      peer: {
+        kind: isGroup ? "group" : "direct",
+        id: isGroup ? (groupId ?? "unknown") : senderPeerId,
+      },
+    });
+    const mentionRegexes = buildMentionRegexes(deps.cfg, route.agentId);
+    const wasMentioned = isGroup && matchesMentionPatterns(messageText, mentionRegexes);
+    const requireMention =
+      isGroup &&
+      resolveChannelGroupRequireMention({
+        cfg: deps.cfg,
+        channel: "signal",
+        groupId,
+        accountId: deps.accountId,
+      });
+    const canDetectMention = mentionRegexes.length > 0;
+    const mentionGate = resolveMentionGatingWithBypass({
+      isGroup,
+      requireMention: Boolean(requireMention),
+      canDetectMention,
+      wasMentioned,
+      implicitMention: false,
+      hasAnyMention: false,
+      allowTextCommands: true,
+      hasControlCommand: hasControlCommandInMessage,
+      commandAuthorized,
+    });
+    const effectiveWasMentioned = mentionGate.effectiveWasMentioned;
+    if (isGroup && requireMention && canDetectMention && mentionGate.shouldSkip) {
+      logInboundDrop({
+        log: logVerbose,
+        channel: "signal",
+        reason: "no mention",
+        target: senderDisplay,
+      });
+      const historyKey = groupId ?? "unknown";
+      recordPendingHistoryEntryIfEnabled({
+        historyMap: deps.groupHistories,
+        historyKey,
+        limit: deps.historyLimit,
+        entry: {
+          sender: envelope.sourceName ?? senderDisplay,
+          body: messageText,
+          timestamp: envelope.timestamp ?? undefined,
+          messageId:
+            typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined,
+        },
+      });
+      return;
+    }
+
     let mediaPath: string | undefined;
     let mediaType: string | undefined;
     let placeholder = "";
@@ -576,6 +637,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaPath,
       mediaType,
       commandAuthorized,
+      wasMentioned: effectiveWasMentioned,
     });
   };
 }


### PR DESCRIPTION
## Summary
Fixes #13106

Signal group messages bypassed mention gating (`requireMention` + `mentionPatterns`), causing the bot to reply to every group message even when mention gating was configured. This aligns Signal with Slack, Discord, Telegram, and iMessage which all enforce mention gating correctly.

## Changes
- Add mention gating logic to Signal event handler (`resolveMentionGatingWithBypass`, `buildMentionRegexes`, `matchesMentionPatterns`, `resolveChannelGroupRequireMention`)
- Drop unmentioned group messages when `requireMention` is enabled, with pending history recording for context
- Set `WasMentioned` on `ctxPayload` so downstream directive gating (elevated/exec) works correctly
- Allow authorized control commands to bypass mention gating (consistent with other channels)

## Test plan
- [x] Added 5 new tests covering:
  - Group messages without mention are dropped when `requireMention` is enabled
  - Group messages with mention are allowed through
  - `WasMentioned` is set correctly when `requireMention` is off
  - Pending history is recorded for skipped messages
  - Authorized control commands bypass mention gating
- [x] All 42 existing Signal tests pass (no regressions)
- [x] Mention gating unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds mention-gating enforcement to Signal group message handling so `requireMention` + `mentionPatterns` behave consistently with other channels. The Signal event handler now resolves the agent route, builds mention regexes, computes `wasMentioned`, applies `resolveMentionGatingWithBypass` (allowing authorized control commands through), records pending history for skipped group messages, and plumbs `WasMentioned` into the inbound context. New Vitest coverage exercises the drop/allow paths, pending history, and bypass behavior.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the mention-gating check uses the wrong message text in some cases and can incorrectly drop valid group messages.
- Core gating logic is consistent with existing shared helpers (`buildMentionRegexes`, `resolveMentionGatingWithBypass`) and tests cover main flows. However, gating/history currently key off `messageText` rather than the effective inbound `bodyText` (which can be quote/attachment placeholder), so behavior will be wrong for quote-only/attachment-only messages and pending history recording. Addressing that would raise confidence.
- src/signal/monitor/event-handler.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->