### PR TITLE
feat(hooks): add agent:reply internal hook event (AI-assisted)

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -233,6 +233,7 @@ Triggered when agent commands are issued:
 ### Agent Events
 
 - **`agent:bootstrap`**: Before workspace bootstrap files are injected (hooks may mutate `context.bootstrapFiles`)
+- **`agent:reply`**: After an agent turn completes. Context includes `replyText` (joined assistant text) and `toolMetas` (tools executed during the turn), plus optional routing metadata like `channel`/`to` and model/provider info.
 
 ### Gateway Events
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -856,6 +856,7 @@ export async function runEmbeddedPiAgent(
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             messagingToolSentTexts: attempt.messagingToolSentTexts,
             messagingToolSentTargets: attempt.messagingToolSentTargets,
+            toolMetas: attempt.toolMetas.length > 0 ? attempt.toolMetas : undefined,
           };
         }
       } finally {

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -50,6 +50,8 @@ export type EmbeddedPiRunResult = {
   messagingToolSentTexts?: string[];
   // Messaging tool targets that successfully sent a message during the run.
   messagingToolSentTargets?: MessagingToolSend[];
+  /** Tools executed during this run (name + optional meta string). */
+  toolMetas?: Array<{ toolName: string; meta?: string }>;
 };
 
 export type EmbeddedPiCompactResult = {

--- a/src/hooks/emit-agent-reply.ts
+++ b/src/hooks/emit-agent-reply.ts
@@ -1,0 +1,38 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+
+/**
+ * Emit an `agent:reply` hook event after an agent turn completes.
+ * Shared across all code paths (auto-reply, CLI, cron, subagent).
+ * Returns any messages pushed by hook handlers.
+ */
+export async function emitAgentReplyHook(opts: {
+  cfg: OpenClawConfig;
+  replyText: string;
+  sessionKey: string;
+  sessionId: string;
+  channel?: string;
+  to?: string;
+  model?: string;
+  provider?: string;
+  toolMetas?: Array<{ toolName: string; meta?: string }>;
+}): Promise<string[]> {
+  if (!opts.cfg.hooks?.internal?.enabled) {
+    return [];
+  }
+  try {
+    const hookEvent = createInternalHookEvent("agent", "reply", opts.sessionKey, {
+      replyText: opts.replyText,
+      sessionId: opts.sessionId,
+      channel: opts.channel,
+      to: opts.to,
+      model: opts.model,
+      provider: opts.provider,
+      toolMetas: opts.toolMetas ?? [],
+    });
+    await triggerInternalHook(hookEvent);
+    return hookEvent.messages;
+  } catch {
+    return [];
+  }
+}

--- a/src/hooks/emit-agent-reply.ts
+++ b/src/hooks/emit-agent-reply.ts
@@ -32,7 +32,10 @@ export async function emitAgentReplyHook(opts: {
     });
     await triggerInternalHook(hookEvent);
     return hookEvent.messages;
-  } catch {
+  } catch (err) {
+    // triggerInternalHook already logs per-handler errors, but log here too in case
+    // loading/dispatch fails (misconfig, bad module, etc.).
+    console.error(`[hooks] agent:reply hook failed: ${String(err)}`);
     return [];
   }
 }


### PR DESCRIPTION
## What
Adds a new internal hooks event `agent:reply` that fires after an agent turn completes (auto-reply, CLI `openclaw agent`, and cron isolated agent turns).

Context includes:
- `replyText`: joined assistant text for the turn
- `toolMetas`: tools executed during the turn
- optional routing/model metadata (`channel`, `to`, `sessionId`, `model`, `provider`)

## Why
Enables lightweight workspace hooks to do post-turn structural automation (e.g. promise verification / follow-up scheduling) without needing a full plugin.

## Testing
- Fully tested: `pnpm build && pnpm check && pnpm test`

## Notes
- AI-assisted (Codex/Claude).
- This PR documents the new event in `docs/automation/hooks.md`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new internal hook event `agent:reply`, emitted after an agent turn completes across the auto-reply runner, CLI `openclaw agent`, and cron isolated agent turns. It adds a shared emitter (`src/hooks/emit-agent-reply.ts`) that packages `replyText`, `toolMetas`, and optional routing/model metadata into an internal hook event (`type: "agent"`, `action: "reply"`). The docs are updated to mention the new event, and tests are added to verify handler registration/dispatch and that hooks can push messages back via `event.messages`.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of correctness/semantics issues around what `replyText` contains and how hook failures are handled.
- The new `agent:reply` emission is wired into all intended code paths and has test coverage for hook dispatch, but the auto-reply path currently feeds the hook a `replyText` that can include verbose/usage/system hint lines (not just assistant text), and the shared emitter suppresses all errors without logging, which will make hook-driven automation brittle to debug.
- src/auto-reply/reply/agent-runner.ts, src/hooks/emit-agent-reply.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->