### PR TITLE
fix(gateway): implement explicit channel isolation and heartbeat filtering

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -11,347 +11,6 @@ public enum ErrorCode: String, Codable, Sendable {
     case unavailable = "UNAVAILABLE"
 }
 
-public struct ConnectParams: Codable, Sendable {
-    public let minprotocol: Int
-    public let maxprotocol: Int
-    public let client: [String: AnyCodable]
-    public let caps: [String]?
-    public let commands: [String]?
-    public let permissions: [String: AnyCodable]?
-    public let pathenv: String?
-    public let role: String?
-    public let scopes: [String]?
-    public let device: [String: AnyCodable]?
-    public let auth: [String: AnyCodable]?
-    public let locale: String?
-    public let useragent: String?
-
-    public init(
-        minprotocol: Int,
-        maxprotocol: Int,
-        client: [String: AnyCodable],
-        caps: [String]?,
-        commands: [String]?,
-        permissions: [String: AnyCodable]?,
-        pathenv: String?,
-        role: String?,
-        scopes: [String]?,
-        device: [String: AnyCodable]?,
-        auth: [String: AnyCodable]?,
-        locale: String?,
-        useragent: String?
-    ) {
-        self.minprotocol = minprotocol
-        self.maxprotocol = maxprotocol
-        self.client = client
-        self.caps = caps
-        self.commands = commands
-        self.permissions = permissions
-        self.pathenv = pathenv
-        self.role = role
-        self.scopes = scopes
-        self.device = device
-        self.auth = auth
-        self.locale = locale
-        self.useragent = useragent
-    }
-    private enum CodingKeys: String, CodingKey {
-        case minprotocol = "minProtocol"
-        case maxprotocol = "maxProtocol"
-        case client
-        case caps
-        case commands
-        case permissions
-        case pathenv = "pathEnv"
-        case role
-        case scopes
-        case device
-        case auth
-        case locale
-        case useragent = "userAgent"
-    }
-}
-
-public struct HelloOk: Codable, Sendable {
-    public let type: String
-    public let _protocol: Int
-    public let server: [String: AnyCodable]
-    public let features: [String: AnyCodable]
-    public let snapshot: Snapshot
-    public let canvashosturl: String?
-    public let auth: [String: AnyCodable]?
-    public let policy: [String: AnyCodable]
-
-    public init(
-        type: String,
-        _protocol: Int,
-        server: [String: AnyCodable],
-        features: [String: AnyCodable],
-        snapshot: Snapshot,
-        canvashosturl: String?,
-        auth: [String: AnyCodable]?,
-        policy: [String: AnyCodable]
-    ) {
-        self.type = type
-        self._protocol = _protocol
-        self.server = server
-        self.features = features
-        self.snapshot = snapshot
-        self.canvashosturl = canvashosturl
-        self.auth = auth
-        self.policy = policy
-    }
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case _protocol = "protocol"
-        case server
-        case features
-        case snapshot
-        case canvashosturl = "canvasHostUrl"
-        case auth
-        case policy
-    }
-}
-
-public struct RequestFrame: Codable, Sendable {
-    public let type: String
-    public let id: String
-    public let method: String
-    public let params: AnyCodable?
-
-    public init(
-        type: String,
-        id: String,
-        method: String,
-        params: AnyCodable?
-    ) {
-        self.type = type
-        self.id = id
-        self.method = method
-        self.params = params
-    }
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case id
-        case method
-        case params
-    }
-}
-
-public struct ResponseFrame: Codable, Sendable {
-    public let type: String
-    public let id: String
-    public let ok: Bool
-    public let payload: AnyCodable?
-    public let error: [String: AnyCodable]?
-
-    public init(
-        type: String,
-        id: String,
-        ok: Bool,
-        payload: AnyCodable?,
-        error: [String: AnyCodable]?
-    ) {
-        self.type = type
-        self.id = id
-        self.ok = ok
-        self.payload = payload
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case id
-        case ok
-        case payload
-        case error
-    }
-}
-
-public struct EventFrame: Codable, Sendable {
-    public let type: String
-    public let event: String
-    public let payload: AnyCodable?
-    public let seq: Int?
-    public let stateversion: [String: AnyCodable]?
-
-    public init(
-        type: String,
-        event: String,
-        payload: AnyCodable?,
-        seq: Int?,
-        stateversion: [String: AnyCodable]?
-    ) {
-        self.type = type
-        self.event = event
-        self.payload = payload
-        self.seq = seq
-        self.stateversion = stateversion
-    }
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case event
-        case payload
-        case seq
-        case stateversion = "stateVersion"
-    }
-}
-
-public struct PresenceEntry: Codable, Sendable {
-    public let host: String?
-    public let ip: String?
-    public let version: String?
-    public let platform: String?
-    public let devicefamily: String?
-    public let modelidentifier: String?
-    public let mode: String?
-    public let lastinputseconds: Int?
-    public let reason: String?
-    public let tags: [String]?
-    public let text: String?
-    public let ts: Int
-    public let deviceid: String?
-    public let roles: [String]?
-    public let scopes: [String]?
-    public let instanceid: String?
-
-    public init(
-        host: String?,
-        ip: String?,
-        version: String?,
-        platform: String?,
-        devicefamily: String?,
-        modelidentifier: String?,
-        mode: String?,
-        lastinputseconds: Int?,
-        reason: String?,
-        tags: [String]?,
-        text: String?,
-        ts: Int,
-        deviceid: String?,
-        roles: [String]?,
-        scopes: [String]?,
-        instanceid: String?
-    ) {
-        self.host = host
-        self.ip = ip
-        self.version = version
-        self.platform = platform
-        self.devicefamily = devicefamily
-        self.modelidentifier = modelidentifier
-        self.mode = mode
-        self.lastinputseconds = lastinputseconds
-        self.reason = reason
-        self.tags = tags
-        self.text = text
-        self.ts = ts
-        self.deviceid = deviceid
-        self.roles = roles
-        self.scopes = scopes
-        self.instanceid = instanceid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case host
-        case ip
-        case version
-        case platform
-        case devicefamily = "deviceFamily"
-        case modelidentifier = "modelIdentifier"
-        case mode
-        case lastinputseconds = "lastInputSeconds"
-        case reason
-        case tags
-        case text
-        case ts
-        case deviceid = "deviceId"
-        case roles
-        case scopes
-        case instanceid = "instanceId"
-    }
-}
-
-public struct StateVersion: Codable, Sendable {
-    public let presence: Int
-    public let health: Int
-
-    public init(
-        presence: Int,
-        health: Int
-    ) {
-        self.presence = presence
-        self.health = health
-    }
-    private enum CodingKeys: String, CodingKey {
-        case presence
-        case health
-    }
-}
-
-public struct Snapshot: Codable, Sendable {
-    public let presence: [PresenceEntry]
-    public let health: AnyCodable
-    public let stateversion: StateVersion
-    public let uptimems: Int
-    public let configpath: String?
-    public let statedir: String?
-    public let sessiondefaults: [String: AnyCodable]?
-
-    public init(
-        presence: [PresenceEntry],
-        health: AnyCodable,
-        stateversion: StateVersion,
-        uptimems: Int,
-        configpath: String?,
-        statedir: String?,
-        sessiondefaults: [String: AnyCodable]?
-    ) {
-        self.presence = presence
-        self.health = health
-        self.stateversion = stateversion
-        self.uptimems = uptimems
-        self.configpath = configpath
-        self.statedir = statedir
-        self.sessiondefaults = sessiondefaults
-    }
-    private enum CodingKeys: String, CodingKey {
-        case presence
-        case health
-        case stateversion = "stateVersion"
-        case uptimems = "uptimeMs"
-        case configpath = "configPath"
-        case statedir = "stateDir"
-        case sessiondefaults = "sessionDefaults"
-    }
-}
-
-public struct ErrorShape: Codable, Sendable {
-    public let code: String
-    public let message: String
-    public let details: AnyCodable?
-    public let retryable: Bool?
-    public let retryafterms: Int?
-
-    public init(
-        code: String,
-        message: String,
-        details: AnyCodable?,
-        retryable: Bool?,
-        retryafterms: Int?
-    ) {
-        self.code = code
-        self.message = message
-        self.details = details
-        self.retryable = retryable
-        self.retryafterms = retryafterms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case code
-        case message
-        case details
-        case retryable
-        case retryafterms = "retryAfterMs"
-    }
-}
-
 public struct AgentEvent: Codable, Sendable {
     public let runid: String
     public let seq: Int
@@ -381,89 +40,45 @@ public struct AgentEvent: Codable, Sendable {
     }
 }
 
-public struct SendParams: Codable, Sendable {
-    public let to: String
-    public let message: String
-    public let mediaurl: String?
-    public let mediaurls: [String]?
-    public let gifplayback: Bool?
-    public let channel: String?
-    public let accountid: String?
+public struct AgentIdentityParams: Codable, Sendable {
+    public let agentid: String?
     public let sessionkey: String?
-    public let idempotencykey: String
 
     public init(
-        to: String,
-        message: String,
-        mediaurl: String?,
-        mediaurls: [String]?,
-        gifplayback: Bool?,
-        channel: String?,
-        accountid: String?,
-        sessionkey: String?,
-        idempotencykey: String
+        agentid: String?,
+        sessionkey: String?
     ) {
-        self.to = to
-        self.message = message
-        self.mediaurl = mediaurl
-        self.mediaurls = mediaurls
-        self.gifplayback = gifplayback
-        self.channel = channel
-        self.accountid = accountid
+        self.agentid = agentid
         self.sessionkey = sessionkey
-        self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
-        case to
-        case message
-        case mediaurl = "mediaUrl"
-        case mediaurls = "mediaUrls"
-        case gifplayback = "gifPlayback"
-        case channel
-        case accountid = "accountId"
+        case agentid = "agentId"
         case sessionkey = "sessionKey"
-        case idempotencykey = "idempotencyKey"
     }
 }
 
-public struct PollParams: Codable, Sendable {
-    public let to: String
-    public let question: String
-    public let options: [String]
-    public let maxselections: Int?
-    public let durationhours: Int?
-    public let channel: String?
-    public let accountid: String?
-    public let idempotencykey: String
+public struct AgentIdentityResult: Codable, Sendable {
+    public let agentid: String
+    public let name: String?
+    public let avatar: String?
+    public let emoji: String?
 
     public init(
-        to: String,
-        question: String,
-        options: [String],
-        maxselections: Int?,
-        durationhours: Int?,
-        channel: String?,
-        accountid: String?,
-        idempotencykey: String
+        agentid: String,
+        name: String?,
+        avatar: String?,
+        emoji: String?
     ) {
-        self.to = to
-        self.question = question
-        self.options = options
-        self.maxselections = maxselections
-        self.durationhours = durationhours
-        self.channel = channel
-        self.accountid = accountid
-        self.idempotencykey = idempotencykey
+        self.agentid = agentid
+        self.name = name
+        self.avatar = avatar
+        self.emoji = emoji
     }
     private enum CodingKeys: String, CodingKey {
-        case to
-        case question
-        case options
-        case maxselections = "maxSelections"
-        case durationhours = "durationHours"
-        case channel
-        case accountid = "accountId"
-        case idempotencykey = "idempotencyKey"
+        case agentid = "agentId"
+        case name
+        case avatar
+        case emoji
     }
 }
 
@@ -568,1027 +183,6 @@ public struct AgentParams: Codable, Sendable {
     }
 }
 
-public struct AgentIdentityParams: Codable, Sendable {
-    public let agentid: String?
-    public let sessionkey: String?
-
-    public init(
-        agentid: String?,
-        sessionkey: String?
-    ) {
-        self.agentid = agentid
-        self.sessionkey = sessionkey
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-        case sessionkey = "sessionKey"
-    }
-}
-
-public struct AgentIdentityResult: Codable, Sendable {
-    public let agentid: String
-    public let name: String?
-    public let avatar: String?
-    public let emoji: String?
-
-    public init(
-        agentid: String,
-        name: String?,
-        avatar: String?,
-        emoji: String?
-    ) {
-        self.agentid = agentid
-        self.name = name
-        self.avatar = avatar
-        self.emoji = emoji
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-        case name
-        case avatar
-        case emoji
-    }
-}
-
-public struct AgentWaitParams: Codable, Sendable {
-    public let runid: String
-    public let timeoutms: Int?
-
-    public init(
-        runid: String,
-        timeoutms: Int?
-    ) {
-        self.runid = runid
-        self.timeoutms = timeoutms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case runid = "runId"
-        case timeoutms = "timeoutMs"
-    }
-}
-
-public struct WakeParams: Codable, Sendable {
-    public let mode: AnyCodable
-    public let text: String
-
-    public init(
-        mode: AnyCodable,
-        text: String
-    ) {
-        self.mode = mode
-        self.text = text
-    }
-    private enum CodingKeys: String, CodingKey {
-        case mode
-        case text
-    }
-}
-
-public struct NodePairRequestParams: Codable, Sendable {
-    public let nodeid: String
-    public let displayname: String?
-    public let platform: String?
-    public let version: String?
-    public let coreversion: String?
-    public let uiversion: String?
-    public let devicefamily: String?
-    public let modelidentifier: String?
-    public let caps: [String]?
-    public let commands: [String]?
-    public let remoteip: String?
-    public let silent: Bool?
-
-    public init(
-        nodeid: String,
-        displayname: String?,
-        platform: String?,
-        version: String?,
-        coreversion: String?,
-        uiversion: String?,
-        devicefamily: String?,
-        modelidentifier: String?,
-        caps: [String]?,
-        commands: [String]?,
-        remoteip: String?,
-        silent: Bool?
-    ) {
-        self.nodeid = nodeid
-        self.displayname = displayname
-        self.platform = platform
-        self.version = version
-        self.coreversion = coreversion
-        self.uiversion = uiversion
-        self.devicefamily = devicefamily
-        self.modelidentifier = modelidentifier
-        self.caps = caps
-        self.commands = commands
-        self.remoteip = remoteip
-        self.silent = silent
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case displayname = "displayName"
-        case platform
-        case version
-        case coreversion = "coreVersion"
-        case uiversion = "uiVersion"
-        case devicefamily = "deviceFamily"
-        case modelidentifier = "modelIdentifier"
-        case caps
-        case commands
-        case remoteip = "remoteIp"
-        case silent
-    }
-}
-
-public struct NodePairListParams: Codable, Sendable {
-}
-
-public struct NodePairApproveParams: Codable, Sendable {
-    public let requestid: String
-
-    public init(
-        requestid: String
-    ) {
-        self.requestid = requestid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case requestid = "requestId"
-    }
-}
-
-public struct NodePairRejectParams: Codable, Sendable {
-    public let requestid: String
-
-    public init(
-        requestid: String
-    ) {
-        self.requestid = requestid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case requestid = "requestId"
-    }
-}
-
-public struct NodePairVerifyParams: Codable, Sendable {
-    public let nodeid: String
-    public let token: String
-
-    public init(
-        nodeid: String,
-        token: String
-    ) {
-        self.nodeid = nodeid
-        self.token = token
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case token
-    }
-}
-
-public struct NodeRenameParams: Codable, Sendable {
-    public let nodeid: String
-    public let displayname: String
-
-    public init(
-        nodeid: String,
-        displayname: String
-    ) {
-        self.nodeid = nodeid
-        self.displayname = displayname
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case displayname = "displayName"
-    }
-}
-
-public struct NodeListParams: Codable, Sendable {
-}
-
-public struct NodeDescribeParams: Codable, Sendable {
-    public let nodeid: String
-
-    public init(
-        nodeid: String
-    ) {
-        self.nodeid = nodeid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-    }
-}
-
-public struct NodeInvokeParams: Codable, Sendable {
-    public let nodeid: String
-    public let command: String
-    public let params: AnyCodable?
-    public let timeoutms: Int?
-    public let idempotencykey: String
-
-    public init(
-        nodeid: String,
-        command: String,
-        params: AnyCodable?,
-        timeoutms: Int?,
-        idempotencykey: String
-    ) {
-        self.nodeid = nodeid
-        self.command = command
-        self.params = params
-        self.timeoutms = timeoutms
-        self.idempotencykey = idempotencykey
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case command
-        case params
-        case timeoutms = "timeoutMs"
-        case idempotencykey = "idempotencyKey"
-    }
-}
-
-public struct NodeInvokeResultParams: Codable, Sendable {
-    public let id: String
-    public let nodeid: String
-    public let ok: Bool
-    public let payload: AnyCodable?
-    public let payloadjson: String?
-    public let error: [String: AnyCodable]?
-
-    public init(
-        id: String,
-        nodeid: String,
-        ok: Bool,
-        payload: AnyCodable?,
-        payloadjson: String?,
-        error: [String: AnyCodable]?
-    ) {
-        self.id = id
-        self.nodeid = nodeid
-        self.ok = ok
-        self.payload = payload
-        self.payloadjson = payloadjson
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case nodeid = "nodeId"
-        case ok
-        case payload
-        case payloadjson = "payloadJSON"
-        case error
-    }
-}
-
-public struct NodeEventParams: Codable, Sendable {
-    public let event: String
-    public let payload: AnyCodable?
-    public let payloadjson: String?
-
-    public init(
-        event: String,
-        payload: AnyCodable?,
-        payloadjson: String?
-    ) {
-        self.event = event
-        self.payload = payload
-        self.payloadjson = payloadjson
-    }
-    private enum CodingKeys: String, CodingKey {
-        case event
-        case payload
-        case payloadjson = "payloadJSON"
-    }
-}
-
-public struct NodeInvokeRequestEvent: Codable, Sendable {
-    public let id: String
-    public let nodeid: String
-    public let command: String
-    public let paramsjson: String?
-    public let timeoutms: Int?
-    public let idempotencykey: String?
-
-    public init(
-        id: String,
-        nodeid: String,
-        command: String,
-        paramsjson: String?,
-        timeoutms: Int?,
-        idempotencykey: String?
-    ) {
-        self.id = id
-        self.nodeid = nodeid
-        self.command = command
-        self.paramsjson = paramsjson
-        self.timeoutms = timeoutms
-        self.idempotencykey = idempotencykey
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case nodeid = "nodeId"
-        case command
-        case paramsjson = "paramsJSON"
-        case timeoutms = "timeoutMs"
-        case idempotencykey = "idempotencyKey"
-    }
-}
-
-public struct SessionsListParams: Codable, Sendable {
-    public let limit: Int?
-    public let activeminutes: Int?
-    public let includeglobal: Bool?
-    public let includeunknown: Bool?
-    public let includederivedtitles: Bool?
-    public let includelastmessage: Bool?
-    public let label: String?
-    public let spawnedby: String?
-    public let agentid: String?
-    public let search: String?
-
-    public init(
-        limit: Int?,
-        activeminutes: Int?,
-        includeglobal: Bool?,
-        includeunknown: Bool?,
-        includederivedtitles: Bool?,
-        includelastmessage: Bool?,
-        label: String?,
-        spawnedby: String?,
-        agentid: String?,
-        search: String?
-    ) {
-        self.limit = limit
-        self.activeminutes = activeminutes
-        self.includeglobal = includeglobal
-        self.includeunknown = includeunknown
-        self.includederivedtitles = includederivedtitles
-        self.includelastmessage = includelastmessage
-        self.label = label
-        self.spawnedby = spawnedby
-        self.agentid = agentid
-        self.search = search
-    }
-    private enum CodingKeys: String, CodingKey {
-        case limit
-        case activeminutes = "activeMinutes"
-        case includeglobal = "includeGlobal"
-        case includeunknown = "includeUnknown"
-        case includederivedtitles = "includeDerivedTitles"
-        case includelastmessage = "includeLastMessage"
-        case label
-        case spawnedby = "spawnedBy"
-        case agentid = "agentId"
-        case search
-    }
-}
-
-public struct SessionsPreviewParams: Codable, Sendable {
-    public let keys: [String]
-    public let limit: Int?
-    public let maxchars: Int?
-
-    public init(
-        keys: [String],
-        limit: Int?,
-        maxchars: Int?
-    ) {
-        self.keys = keys
-        self.limit = limit
-        self.maxchars = maxchars
-    }
-    private enum CodingKeys: String, CodingKey {
-        case keys
-        case limit
-        case maxchars = "maxChars"
-    }
-}
-
-public struct SessionsResolveParams: Codable, Sendable {
-    public let key: String?
-    public let sessionid: String?
-    public let label: String?
-    public let agentid: String?
-    public let spawnedby: String?
-    public let includeglobal: Bool?
-    public let includeunknown: Bool?
-
-    public init(
-        key: String?,
-        sessionid: String?,
-        label: String?,
-        agentid: String?,
-        spawnedby: String?,
-        includeglobal: Bool?,
-        includeunknown: Bool?
-    ) {
-        self.key = key
-        self.sessionid = sessionid
-        self.label = label
-        self.agentid = agentid
-        self.spawnedby = spawnedby
-        self.includeglobal = includeglobal
-        self.includeunknown = includeunknown
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case sessionid = "sessionId"
-        case label
-        case agentid = "agentId"
-        case spawnedby = "spawnedBy"
-        case includeglobal = "includeGlobal"
-        case includeunknown = "includeUnknown"
-    }
-}
-
-public struct SessionsPatchParams: Codable, Sendable {
-    public let key: String
-    public let label: AnyCodable?
-    public let thinkinglevel: AnyCodable?
-    public let verboselevel: AnyCodable?
-    public let reasoninglevel: AnyCodable?
-    public let responseusage: AnyCodable?
-    public let elevatedlevel: AnyCodable?
-    public let exechost: AnyCodable?
-    public let execsecurity: AnyCodable?
-    public let execask: AnyCodable?
-    public let execnode: AnyCodable?
-    public let model: AnyCodable?
-    public let spawnedby: AnyCodable?
-    public let sendpolicy: AnyCodable?
-    public let groupactivation: AnyCodable?
-
-    public init(
-        key: String,
-        label: AnyCodable?,
-        thinkinglevel: AnyCodable?,
-        verboselevel: AnyCodable?,
-        reasoninglevel: AnyCodable?,
-        responseusage: AnyCodable?,
-        elevatedlevel: AnyCodable?,
-        exechost: AnyCodable?,
-        execsecurity: AnyCodable?,
-        execask: AnyCodable?,
-        execnode: AnyCodable?,
-        model: AnyCodable?,
-        spawnedby: AnyCodable?,
-        sendpolicy: AnyCodable?,
-        groupactivation: AnyCodable?
-    ) {
-        self.key = key
-        self.label = label
-        self.thinkinglevel = thinkinglevel
-        self.verboselevel = verboselevel
-        self.reasoninglevel = reasoninglevel
-        self.responseusage = responseusage
-        self.elevatedlevel = elevatedlevel
-        self.exechost = exechost
-        self.execsecurity = execsecurity
-        self.execask = execask
-        self.execnode = execnode
-        self.model = model
-        self.spawnedby = spawnedby
-        self.sendpolicy = sendpolicy
-        self.groupactivation = groupactivation
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case label
-        case thinkinglevel = "thinkingLevel"
-        case verboselevel = "verboseLevel"
-        case reasoninglevel = "reasoningLevel"
-        case responseusage = "responseUsage"
-        case elevatedlevel = "elevatedLevel"
-        case exechost = "execHost"
-        case execsecurity = "execSecurity"
-        case execask = "execAsk"
-        case execnode = "execNode"
-        case model
-        case spawnedby = "spawnedBy"
-        case sendpolicy = "sendPolicy"
-        case groupactivation = "groupActivation"
-    }
-}
-
-public struct SessionsResetParams: Codable, Sendable {
-    public let key: String
-
-    public init(
-        key: String
-    ) {
-        self.key = key
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-    }
-}
-
-public struct SessionsDeleteParams: Codable, Sendable {
-    public let key: String
-    public let deletetranscript: Bool?
-
-    public init(
-        key: String,
-        deletetranscript: Bool?
-    ) {
-        self.key = key
-        self.deletetranscript = deletetranscript
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case deletetranscript = "deleteTranscript"
-    }
-}
-
-public struct SessionsCompactParams: Codable, Sendable {
-    public let key: String
-    public let maxlines: Int?
-
-    public init(
-        key: String,
-        maxlines: Int?
-    ) {
-        self.key = key
-        self.maxlines = maxlines
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case maxlines = "maxLines"
-    }
-}
-
-public struct SessionsUsageParams: Codable, Sendable {
-    public let key: String?
-    public let startdate: String?
-    public let enddate: String?
-    public let limit: Int?
-    public let includecontextweight: Bool?
-
-    public init(
-        key: String?,
-        startdate: String?,
-        enddate: String?,
-        limit: Int?,
-        includecontextweight: Bool?
-    ) {
-        self.key = key
-        self.startdate = startdate
-        self.enddate = enddate
-        self.limit = limit
-        self.includecontextweight = includecontextweight
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case startdate = "startDate"
-        case enddate = "endDate"
-        case limit
-        case includecontextweight = "includeContextWeight"
-    }
-}
-
-public struct ConfigGetParams: Codable, Sendable {
-}
-
-public struct ConfigSetParams: Codable, Sendable {
-    public let raw: String
-    public let basehash: String?
-
-    public init(
-        raw: String,
-        basehash: String?
-    ) {
-        self.raw = raw
-        self.basehash = basehash
-    }
-    private enum CodingKeys: String, CodingKey {
-        case raw
-        case basehash = "baseHash"
-    }
-}
-
-public struct ConfigApplyParams: Codable, Sendable {
-    public let raw: String
-    public let basehash: String?
-    public let sessionkey: String?
-    public let note: String?
-    public let restartdelayms: Int?
-
-    public init(
-        raw: String,
-        basehash: String?,
-        sessionkey: String?,
-        note: String?,
-        restartdelayms: Int?
-    ) {
-        self.raw = raw
-        self.basehash = basehash
-        self.sessionkey = sessionkey
-        self.note = note
-        self.restartdelayms = restartdelayms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case raw
-        case basehash = "baseHash"
-        case sessionkey = "sessionKey"
-        case note
-        case restartdelayms = "restartDelayMs"
-    }
-}
-
-public struct ConfigPatchParams: Codable, Sendable {
-    public let raw: String
-    public let basehash: String?
-    public let sessionkey: String?
-    public let note: String?
-    public let restartdelayms: Int?
-
-    public init(
-        raw: String,
-        basehash: String?,
-        sessionkey: String?,
-        note: String?,
-        restartdelayms: Int?
-    ) {
-        self.raw = raw
-        self.basehash = basehash
-        self.sessionkey = sessionkey
-        self.note = note
-        self.restartdelayms = restartdelayms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case raw
-        case basehash = "baseHash"
-        case sessionkey = "sessionKey"
-        case note
-        case restartdelayms = "restartDelayMs"
-    }
-}
-
-public struct ConfigSchemaParams: Codable, Sendable {
-}
-
-public struct ConfigSchemaResponse: Codable, Sendable {
-    public let schema: AnyCodable
-    public let uihints: [String: AnyCodable]
-    public let version: String
-    public let generatedat: String
-
-    public init(
-        schema: AnyCodable,
-        uihints: [String: AnyCodable],
-        version: String,
-        generatedat: String
-    ) {
-        self.schema = schema
-        self.uihints = uihints
-        self.version = version
-        self.generatedat = generatedat
-    }
-    private enum CodingKeys: String, CodingKey {
-        case schema
-        case uihints = "uiHints"
-        case version
-        case generatedat = "generatedAt"
-    }
-}
-
-public struct WizardStartParams: Codable, Sendable {
-    public let mode: AnyCodable?
-    public let workspace: String?
-
-    public init(
-        mode: AnyCodable?,
-        workspace: String?
-    ) {
-        self.mode = mode
-        self.workspace = workspace
-    }
-    private enum CodingKeys: String, CodingKey {
-        case mode
-        case workspace
-    }
-}
-
-public struct WizardNextParams: Codable, Sendable {
-    public let sessionid: String
-    public let answer: [String: AnyCodable]?
-
-    public init(
-        sessionid: String,
-        answer: [String: AnyCodable]?
-    ) {
-        self.sessionid = sessionid
-        self.answer = answer
-    }
-    private enum CodingKeys: String, CodingKey {
-        case sessionid = "sessionId"
-        case answer
-    }
-}
-
-public struct WizardCancelParams: Codable, Sendable {
-    public let sessionid: String
-
-    public init(
-        sessionid: String
-    ) {
-        self.sessionid = sessionid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case sessionid = "sessionId"
-    }
-}
-
-public struct WizardStatusParams: Codable, Sendable {
-    public let sessionid: String
-
-    public init(
-        sessionid: String
-    ) {
-        self.sessionid = sessionid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case sessionid = "sessionId"
-    }
-}
-
-public struct WizardStep: Codable, Sendable {
-    public let id: String
-    public let type: AnyCodable
-    public let title: String?
-    public let message: String?
-    public let options: [[String: AnyCodable]]?
-    public let initialvalue: AnyCodable?
-    public let placeholder: String?
-    public let sensitive: Bool?
-    public let executor: AnyCodable?
-
-    public init(
-        id: String,
-        type: AnyCodable,
-        title: String?,
-        message: String?,
-        options: [[String: AnyCodable]]?,
-        initialvalue: AnyCodable?,
-        placeholder: String?,
-        sensitive: Bool?,
-        executor: AnyCodable?
-    ) {
-        self.id = id
-        self.type = type
-        self.title = title
-        self.message = message
-        self.options = options
-        self.initialvalue = initialvalue
-        self.placeholder = placeholder
-        self.sensitive = sensitive
-        self.executor = executor
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case type
-        case title
-        case message
-        case options
-        case initialvalue = "initialValue"
-        case placeholder
-        case sensitive
-        case executor
-    }
-}
-
-public struct WizardNextResult: Codable, Sendable {
-    public let done: Bool
-    public let step: [String: AnyCodable]?
-    public let status: AnyCodable?
-    public let error: String?
-
-    public init(
-        done: Bool,
-        step: [String: AnyCodable]?,
-        status: AnyCodable?,
-        error: String?
-    ) {
-        self.done = done
-        self.step = step
-        self.status = status
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case done
-        case step
-        case status
-        case error
-    }
-}
-
-public struct WizardStartResult: Codable, Sendable {
-    public let sessionid: String
-    public let done: Bool
-    public let step: [String: AnyCodable]?
-    public let status: AnyCodable?
-    public let error: String?
-
-    public init(
-        sessionid: String,
-        done: Bool,
-        step: [String: AnyCodable]?,
-        status: AnyCodable?,
-        error: String?
-    ) {
-        self.sessionid = sessionid
-        self.done = done
-        self.step = step
-        self.status = status
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case sessionid = "sessionId"
-        case done
-        case step
-        case status
-        case error
-    }
-}
-
-public struct WizardStatusResult: Codable, Sendable {
-    public let status: AnyCodable
-    public let error: String?
-
-    public init(
-        status: AnyCodable,
-        error: String?
-    ) {
-        self.status = status
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case status
-        case error
-    }
-}
-
-public struct TalkModeParams: Codable, Sendable {
-    public let enabled: Bool
-    public let phase: String?
-
-    public init(
-        enabled: Bool,
-        phase: String?
-    ) {
-        self.enabled = enabled
-        self.phase = phase
-    }
-    private enum CodingKeys: String, CodingKey {
-        case enabled
-        case phase
-    }
-}
-
-public struct ChannelsStatusParams: Codable, Sendable {
-    public let probe: Bool?
-    public let timeoutms: Int?
-
-    public init(
-        probe: Bool?,
-        timeoutms: Int?
-    ) {
-        self.probe = probe
-        self.timeoutms = timeoutms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case probe
-        case timeoutms = "timeoutMs"
-    }
-}
-
-public struct ChannelsStatusResult: Codable, Sendable {
-    public let ts: Int
-    public let channelorder: [String]
-    public let channellabels: [String: AnyCodable]
-    public let channeldetaillabels: [String: AnyCodable]?
-    public let channelsystemimages: [String: AnyCodable]?
-    public let channelmeta: [[String: AnyCodable]]?
-    public let channels: [String: AnyCodable]
-    public let channelaccounts: [String: AnyCodable]
-    public let channeldefaultaccountid: [String: AnyCodable]
-
-    public init(
-        ts: Int,
-        channelorder: [String],
-        channellabels: [String: AnyCodable],
-        channeldetaillabels: [String: AnyCodable]?,
-        channelsystemimages: [String: AnyCodable]?,
-        channelmeta: [[String: AnyCodable]]?,
-        channels: [String: AnyCodable],
-        channelaccounts: [String: AnyCodable],
-        channeldefaultaccountid: [String: AnyCodable]
-    ) {
-        self.ts = ts
-        self.channelorder = channelorder
-        self.channellabels = channellabels
-        self.channeldetaillabels = channeldetaillabels
-        self.channelsystemimages = channelsystemimages
-        self.channelmeta = channelmeta
-        self.channels = channels
-        self.channelaccounts = channelaccounts
-        self.channeldefaultaccountid = channeldefaultaccountid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case ts
-        case channelorder = "channelOrder"
-        case channellabels = "channelLabels"
-        case channeldetaillabels = "channelDetailLabels"
-        case channelsystemimages = "channelSystemImages"
-        case channelmeta = "channelMeta"
-        case channels
-        case channelaccounts = "channelAccounts"
-        case channeldefaultaccountid = "channelDefaultAccountId"
-    }
-}
-
-public struct ChannelsLogoutParams: Codable, Sendable {
-    public let channel: String
-    public let accountid: String?
-
-    public init(
-        channel: String,
-        accountid: String?
-    ) {
-        self.channel = channel
-        self.accountid = accountid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case channel
-        case accountid = "accountId"
-    }
-}
-
-public struct WebLoginStartParams: Codable, Sendable {
-    public let force: Bool?
-    public let timeoutms: Int?
-    public let verbose: Bool?
-    public let accountid: String?
-
-    public init(
-        force: Bool?,
-        timeoutms: Int?,
-        verbose: Bool?,
-        accountid: String?
-    ) {
-        self.force = force
-        self.timeoutms = timeoutms
-        self.verbose = verbose
-        self.accountid = accountid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case force
-        case timeoutms = "timeoutMs"
-        case verbose
-        case accountid = "accountId"
-    }
-}
-
-public struct WebLoginWaitParams: Codable, Sendable {
-    public let timeoutms: Int?
-    public let accountid: String?
-
-    public init(
-        timeoutms: Int?,
-        accountid: String?
-    ) {
-        self.timeoutms = timeoutms
-        self.accountid = accountid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case timeoutms = "timeoutMs"
-        case accountid = "accountId"
-    }
-}
-
-public struct AgentSummary: Codable, Sendable {
-    public let id: String
-    public let name: String?
-    public let identity: [String: AnyCodable]?
-
-    public init(
-        id: String,
-        name: String?,
-        identity: [String: AnyCodable]?
-    ) {
-        self.id = id
-        self.name = name
-        self.identity = identity
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case name
-        case identity
-    }
-}
-
 public struct AgentsCreateParams: Codable, Sendable {
     public let name: String
     public let workspace: String
@@ -1636,52 +230,6 @@ public struct AgentsCreateResult: Codable, Sendable {
         case agentid = "agentId"
         case name
         case workspace
-    }
-}
-
-public struct AgentsUpdateParams: Codable, Sendable {
-    public let agentid: String
-    public let name: String?
-    public let workspace: String?
-    public let model: String?
-    public let avatar: String?
-
-    public init(
-        agentid: String,
-        name: String?,
-        workspace: String?,
-        model: String?,
-        avatar: String?
-    ) {
-        self.agentid = agentid
-        self.name = name
-        self.workspace = workspace
-        self.model = model
-        self.avatar = avatar
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-        case name
-        case workspace
-        case model
-        case avatar
-    }
-}
-
-public struct AgentsUpdateResult: Codable, Sendable {
-    public let ok: Bool
-    public let agentid: String
-
-    public init(
-        ok: Bool,
-        agentid: String
-    ) {
-        self.ok = ok
-        self.agentid = agentid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case agentid = "agentId"
     }
 }
 
@@ -1756,40 +304,6 @@ public struct AgentsFileEntry: Codable, Sendable {
     }
 }
 
-public struct AgentsFilesListParams: Codable, Sendable {
-    public let agentid: String
-
-    public init(
-        agentid: String
-    ) {
-        self.agentid = agentid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-    }
-}
-
-public struct AgentsFilesListResult: Codable, Sendable {
-    public let agentid: String
-    public let workspace: String
-    public let files: [AgentsFileEntry]
-
-    public init(
-        agentid: String,
-        workspace: String,
-        files: [AgentsFileEntry]
-    ) {
-        self.agentid = agentid
-        self.workspace = workspace
-        self.files = files
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-        case workspace
-        case files
-    }
-}
-
 public struct AgentsFilesGetParams: Codable, Sendable {
     public let agentid: String
     public let name: String
@@ -1825,6 +339,40 @@ public struct AgentsFilesGetResult: Codable, Sendable {
         case agentid = "agentId"
         case workspace
         case file
+    }
+}
+
+public struct AgentsFilesListParams: Codable, Sendable {
+    public let agentid: String
+
+    public init(
+        agentid: String
+    ) {
+        self.agentid = agentid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+    }
+}
+
+public struct AgentsFilesListResult: Codable, Sendable {
+    public let agentid: String
+    public let workspace: String
+    public let files: [AgentsFileEntry]
+
+    public init(
+        agentid: String,
+        workspace: String,
+        files: [AgentsFileEntry]
+    ) {
+        self.agentid = agentid
+        self.workspace = workspace
+        self.files = files
+    }
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case workspace
+        case files
     }
 }
 
@@ -1902,123 +450,515 @@ public struct AgentsListResult: Codable, Sendable {
     }
 }
 
-public struct ModelChoice: Codable, Sendable {
+public struct AgentSummary: Codable, Sendable {
     public let id: String
-    public let name: String
-    public let provider: String
-    public let contextwindow: Int?
-    public let reasoning: Bool?
+    public let name: String?
+    public let identity: [String: AnyCodable]?
 
     public init(
         id: String,
-        name: String,
-        provider: String,
-        contextwindow: Int?,
-        reasoning: Bool?
+        name: String?,
+        identity: [String: AnyCodable]?
     ) {
         self.id = id
         self.name = name
-        self.provider = provider
-        self.contextwindow = contextwindow
-        self.reasoning = reasoning
+        self.identity = identity
     }
     private enum CodingKeys: String, CodingKey {
         case id
         case name
-        case provider
-        case contextwindow = "contextWindow"
-        case reasoning
+        case identity
     }
 }
 
-public struct ModelsListParams: Codable, Sendable {
-}
-
-public struct ModelsListResult: Codable, Sendable {
-    public let models: [ModelChoice]
+public struct AgentsUpdateParams: Codable, Sendable {
+    public let agentid: String
+    public let name: String?
+    public let workspace: String?
+    public let model: String?
+    public let avatar: String?
 
     public init(
-        models: [ModelChoice]
+        agentid: String,
+        name: String?,
+        workspace: String?,
+        model: String?,
+        avatar: String?
     ) {
-        self.models = models
+        self.agentid = agentid
+        self.name = name
+        self.workspace = workspace
+        self.model = model
+        self.avatar = avatar
     }
     private enum CodingKeys: String, CodingKey {
-        case models
+        case agentid = "agentId"
+        case name
+        case workspace
+        case model
+        case avatar
     }
 }
 
-public struct SkillsStatusParams: Codable, Sendable {
-    public let agentid: String?
+public struct AgentsUpdateResult: Codable, Sendable {
+    public let ok: Bool
+    public let agentid: String
 
     public init(
-        agentid: String?
+        ok: Bool,
+        agentid: String
     ) {
+        self.ok = ok
         self.agentid = agentid
     }
     private enum CodingKeys: String, CodingKey {
+        case ok
         case agentid = "agentId"
     }
 }
 
-public struct SkillsBinsParams: Codable, Sendable {
-}
-
-public struct SkillsBinsResult: Codable, Sendable {
-    public let bins: [String]
-
-    public init(
-        bins: [String]
-    ) {
-        self.bins = bins
-    }
-    private enum CodingKeys: String, CodingKey {
-        case bins
-    }
-}
-
-public struct SkillsInstallParams: Codable, Sendable {
-    public let name: String
-    public let installid: String
+public struct AgentWaitParams: Codable, Sendable {
+    public let runid: String
     public let timeoutms: Int?
 
     public init(
-        name: String,
-        installid: String,
+        runid: String,
         timeoutms: Int?
     ) {
-        self.name = name
-        self.installid = installid
+        self.runid = runid
         self.timeoutms = timeoutms
     }
     private enum CodingKeys: String, CodingKey {
-        case name
-        case installid = "installId"
+        case runid = "runId"
         case timeoutms = "timeoutMs"
     }
 }
 
-public struct SkillsUpdateParams: Codable, Sendable {
-    public let skillkey: String
-    public let enabled: Bool?
-    public let apikey: String?
-    public let env: [String: AnyCodable]?
+public struct ChannelsLogoutParams: Codable, Sendable {
+    public let channel: String
+    public let accountid: String?
 
     public init(
-        skillkey: String,
-        enabled: Bool?,
-        apikey: String?,
-        env: [String: AnyCodable]?
+        channel: String,
+        accountid: String?
     ) {
-        self.skillkey = skillkey
-        self.enabled = enabled
-        self.apikey = apikey
-        self.env = env
+        self.channel = channel
+        self.accountid = accountid
     }
     private enum CodingKeys: String, CodingKey {
-        case skillkey = "skillKey"
+        case channel
+        case accountid = "accountId"
+    }
+}
+
+public struct ChannelsStatusParams: Codable, Sendable {
+    public let probe: Bool?
+    public let timeoutms: Int?
+
+    public init(
+        probe: Bool?,
+        timeoutms: Int?
+    ) {
+        self.probe = probe
+        self.timeoutms = timeoutms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case probe
+        case timeoutms = "timeoutMs"
+    }
+}
+
+public struct ChannelsStatusResult: Codable, Sendable {
+    public let ts: Int
+    public let channelorder: [String]
+    public let channellabels: [String: AnyCodable]
+    public let channeldetaillabels: [String: AnyCodable]?
+    public let channelsystemimages: [String: AnyCodable]?
+    public let channelmeta: [[String: AnyCodable]]?
+    public let channels: [String: AnyCodable]
+    public let channelaccounts: [String: AnyCodable]
+    public let channeldefaultaccountid: [String: AnyCodable]
+
+    public init(
+        ts: Int,
+        channelorder: [String],
+        channellabels: [String: AnyCodable],
+        channeldetaillabels: [String: AnyCodable]?,
+        channelsystemimages: [String: AnyCodable]?,
+        channelmeta: [[String: AnyCodable]]?,
+        channels: [String: AnyCodable],
+        channelaccounts: [String: AnyCodable],
+        channeldefaultaccountid: [String: AnyCodable]
+    ) {
+        self.ts = ts
+        self.channelorder = channelorder
+        self.channellabels = channellabels
+        self.channeldetaillabels = channeldetaillabels
+        self.channelsystemimages = channelsystemimages
+        self.channelmeta = channelmeta
+        self.channels = channels
+        self.channelaccounts = channelaccounts
+        self.channeldefaultaccountid = channeldefaultaccountid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case ts
+        case channelorder = "channelOrder"
+        case channellabels = "channelLabels"
+        case channeldetaillabels = "channelDetailLabels"
+        case channelsystemimages = "channelSystemImages"
+        case channelmeta = "channelMeta"
+        case channels
+        case channelaccounts = "channelAccounts"
+        case channeldefaultaccountid = "channelDefaultAccountId"
+    }
+}
+
+public struct ChatAbortParams: Codable, Sendable {
+    public let sessionkey: String
+    public let runid: String?
+
+    public init(
+        sessionkey: String,
+        runid: String?
+    ) {
+        self.sessionkey = sessionkey
+        self.runid = runid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case runid = "runId"
+    }
+}
+
+public struct ChatEvent: Codable, Sendable {
+    public let runid: String
+    public let sessionkey: String
+    public let seq: Int
+    public let state: AnyCodable
+    public let message: AnyCodable?
+    public let errormessage: String?
+    public let usage: AnyCodable?
+    public let stopreason: String?
+
+    public init(
+        runid: String,
+        sessionkey: String,
+        seq: Int,
+        state: AnyCodable,
+        message: AnyCodable?,
+        errormessage: String?,
+        usage: AnyCodable?,
+        stopreason: String?
+    ) {
+        self.runid = runid
+        self.sessionkey = sessionkey
+        self.seq = seq
+        self.state = state
+        self.message = message
+        self.errormessage = errormessage
+        self.usage = usage
+        self.stopreason = stopreason
+    }
+    private enum CodingKeys: String, CodingKey {
+        case runid = "runId"
+        case sessionkey = "sessionKey"
+        case seq
+        case state
+        case message
+        case errormessage = "errorMessage"
+        case usage
+        case stopreason = "stopReason"
+    }
+}
+
+public struct ChatHistoryParams: Codable, Sendable {
+    public let sessionkey: String
+    public let limit: Int?
+
+    public init(
+        sessionkey: String,
+        limit: Int?
+    ) {
+        self.sessionkey = sessionkey
+        self.limit = limit
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case limit
+    }
+}
+
+public struct ChatInjectParams: Codable, Sendable {
+    public let sessionkey: String
+    public let message: String
+    public let label: String?
+
+    public init(
+        sessionkey: String,
+        message: String,
+        label: String?
+    ) {
+        self.sessionkey = sessionkey
+        self.message = message
+        self.label = label
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case message
+        case label
+    }
+}
+
+public struct ChatSendParams: Codable, Sendable {
+    public let sessionkey: String
+    public let message: String
+    public let thinking: String?
+    public let deliver: Bool?
+    public let attachments: [AnyCodable]?
+    public let timeoutms: Int?
+    public let idempotencykey: String
+
+    public init(
+        sessionkey: String,
+        message: String,
+        thinking: String?,
+        deliver: Bool?,
+        attachments: [AnyCodable]?,
+        timeoutms: Int?,
+        idempotencykey: String
+    ) {
+        self.sessionkey = sessionkey
+        self.message = message
+        self.thinking = thinking
+        self.deliver = deliver
+        self.attachments = attachments
+        self.timeoutms = timeoutms
+        self.idempotencykey = idempotencykey
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case message
+        case thinking
+        case deliver
+        case attachments
+        case timeoutms = "timeoutMs"
+        case idempotencykey = "idempotencyKey"
+    }
+}
+
+public struct ConfigApplyParams: Codable, Sendable {
+    public let raw: String
+    public let basehash: String?
+    public let sessionkey: String?
+    public let note: String?
+    public let restartdelayms: Int?
+
+    public init(
+        raw: String,
+        basehash: String?,
+        sessionkey: String?,
+        note: String?,
+        restartdelayms: Int?
+    ) {
+        self.raw = raw
+        self.basehash = basehash
+        self.sessionkey = sessionkey
+        self.note = note
+        self.restartdelayms = restartdelayms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case raw
+        case basehash = "baseHash"
+        case sessionkey = "sessionKey"
+        case note
+        case restartdelayms = "restartDelayMs"
+    }
+}
+
+public struct ConfigGetParams: Codable, Sendable {
+}
+
+public struct ConfigPatchParams: Codable, Sendable {
+    public let raw: String
+    public let basehash: String?
+    public let sessionkey: String?
+    public let note: String?
+    public let restartdelayms: Int?
+
+    public init(
+        raw: String,
+        basehash: String?,
+        sessionkey: String?,
+        note: String?,
+        restartdelayms: Int?
+    ) {
+        self.raw = raw
+        self.basehash = basehash
+        self.sessionkey = sessionkey
+        self.note = note
+        self.restartdelayms = restartdelayms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case raw
+        case basehash = "baseHash"
+        case sessionkey = "sessionKey"
+        case note
+        case restartdelayms = "restartDelayMs"
+    }
+}
+
+public struct ConfigSchemaParams: Codable, Sendable {
+}
+
+public struct ConfigSchemaResponse: Codable, Sendable {
+    public let schema: AnyCodable
+    public let uihints: [String: AnyCodable]
+    public let version: String
+    public let generatedat: String
+
+    public init(
+        schema: AnyCodable,
+        uihints: [String: AnyCodable],
+        version: String,
+        generatedat: String
+    ) {
+        self.schema = schema
+        self.uihints = uihints
+        self.version = version
+        self.generatedat = generatedat
+    }
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case uihints = "uiHints"
+        case version
+        case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSetParams: Codable, Sendable {
+    public let raw: String
+    public let basehash: String?
+
+    public init(
+        raw: String,
+        basehash: String?
+    ) {
+        self.raw = raw
+        self.basehash = basehash
+    }
+    private enum CodingKeys: String, CodingKey {
+        case raw
+        case basehash = "baseHash"
+    }
+}
+
+public struct ConnectParams: Codable, Sendable {
+    public let minprotocol: Int
+    public let maxprotocol: Int
+    public let client: [String: AnyCodable]
+    public let caps: [String]?
+    public let commands: [String]?
+    public let permissions: [String: AnyCodable]?
+    public let pathenv: String?
+    public let role: String?
+    public let scopes: [String]?
+    public let device: [String: AnyCodable]?
+    public let auth: [String: AnyCodable]?
+    public let locale: String?
+    public let useragent: String?
+
+    public init(
+        minprotocol: Int,
+        maxprotocol: Int,
+        client: [String: AnyCodable],
+        caps: [String]?,
+        commands: [String]?,
+        permissions: [String: AnyCodable]?,
+        pathenv: String?,
+        role: String?,
+        scopes: [String]?,
+        device: [String: AnyCodable]?,
+        auth: [String: AnyCodable]?,
+        locale: String?,
+        useragent: String?
+    ) {
+        self.minprotocol = minprotocol
+        self.maxprotocol = maxprotocol
+        self.client = client
+        self.caps = caps
+        self.commands = commands
+        self.permissions = permissions
+        self.pathenv = pathenv
+        self.role = role
+        self.scopes = scopes
+        self.device = device
+        self.auth = auth
+        self.locale = locale
+        self.useragent = useragent
+    }
+    private enum CodingKeys: String, CodingKey {
+        case minprotocol = "minProtocol"
+        case maxprotocol = "maxProtocol"
+        case client
+        case caps
+        case commands
+        case permissions
+        case pathenv = "pathEnv"
+        case role
+        case scopes
+        case device
+        case auth
+        case locale
+        case useragent = "userAgent"
+    }
+}
+
+public struct CronAddParams: Codable, Sendable {
+    public let name: String
+    public let agentid: AnyCodable?
+    public let description: String?
+    public let enabled: Bool?
+    public let deleteafterrun: Bool?
+    public let schedule: AnyCodable
+    public let sessiontarget: AnyCodable
+    public let wakemode: AnyCodable
+    public let payload: AnyCodable
+    public let delivery: [String: AnyCodable]?
+
+    public init(
+        name: String,
+        agentid: AnyCodable?,
+        description: String?,
+        enabled: Bool?,
+        deleteafterrun: Bool?,
+        schedule: AnyCodable,
+        sessiontarget: AnyCodable,
+        wakemode: AnyCodable,
+        payload: AnyCodable,
+        delivery: [String: AnyCodable]?
+    ) {
+        self.name = name
+        self.agentid = agentid
+        self.description = description
+        self.enabled = enabled
+        self.deleteafterrun = deleteafterrun
+        self.schedule = schedule
+        self.sessiontarget = sessiontarget
+        self.wakemode = wakemode
+        self.payload = payload
+        self.delivery = delivery
+    }
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case agentid = "agentId"
+        case description
         case enabled
-        case apikey = "apiKey"
-        case env
+        case deleteafterrun = "deleteAfterRun"
+        case schedule
+        case sessiontarget = "sessionTarget"
+        case wakemode = "wakeMode"
+        case payload
+        case delivery
     }
 }
 
@@ -2100,58 +1040,6 @@ public struct CronListParams: Codable, Sendable {
     }
 }
 
-public struct CronStatusParams: Codable, Sendable {
-}
-
-public struct CronAddParams: Codable, Sendable {
-    public let name: String
-    public let agentid: AnyCodable?
-    public let description: String?
-    public let enabled: Bool?
-    public let deleteafterrun: Bool?
-    public let schedule: AnyCodable
-    public let sessiontarget: AnyCodable
-    public let wakemode: AnyCodable
-    public let payload: AnyCodable
-    public let delivery: [String: AnyCodable]?
-
-    public init(
-        name: String,
-        agentid: AnyCodable?,
-        description: String?,
-        enabled: Bool?,
-        deleteafterrun: Bool?,
-        schedule: AnyCodable,
-        sessiontarget: AnyCodable,
-        wakemode: AnyCodable,
-        payload: AnyCodable,
-        delivery: [String: AnyCodable]?
-    ) {
-        self.name = name
-        self.agentid = agentid
-        self.description = description
-        self.enabled = enabled
-        self.deleteafterrun = deleteafterrun
-        self.schedule = schedule
-        self.sessiontarget = sessiontarget
-        self.wakemode = wakemode
-        self.payload = payload
-        self.delivery = delivery
-    }
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case agentid = "agentId"
-        case description
-        case enabled
-        case deleteafterrun = "deleteAfterRun"
-        case schedule
-        case sessiontarget = "sessionTarget"
-        case wakemode = "wakeMode"
-        case payload
-        case delivery
-    }
-}
-
 public struct CronRunLogEntry: Codable, Sendable {
     public let ts: Int
     public let jobid: String
@@ -2205,206 +1093,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     }
 }
 
-public struct LogsTailParams: Codable, Sendable {
-    public let cursor: Int?
-    public let limit: Int?
-    public let maxbytes: Int?
-
-    public init(
-        cursor: Int?,
-        limit: Int?,
-        maxbytes: Int?
-    ) {
-        self.cursor = cursor
-        self.limit = limit
-        self.maxbytes = maxbytes
-    }
-    private enum CodingKeys: String, CodingKey {
-        case cursor
-        case limit
-        case maxbytes = "maxBytes"
-    }
-}
-
-public struct LogsTailResult: Codable, Sendable {
-    public let file: String
-    public let cursor: Int
-    public let size: Int
-    public let lines: [String]
-    public let truncated: Bool?
-    public let reset: Bool?
-
-    public init(
-        file: String,
-        cursor: Int,
-        size: Int,
-        lines: [String],
-        truncated: Bool?,
-        reset: Bool?
-    ) {
-        self.file = file
-        self.cursor = cursor
-        self.size = size
-        self.lines = lines
-        self.truncated = truncated
-        self.reset = reset
-    }
-    private enum CodingKeys: String, CodingKey {
-        case file
-        case cursor
-        case size
-        case lines
-        case truncated
-        case reset
-    }
-}
-
-public struct ExecApprovalsGetParams: Codable, Sendable {
-}
-
-public struct ExecApprovalsSetParams: Codable, Sendable {
-    public let file: [String: AnyCodable]
-    public let basehash: String?
-
-    public init(
-        file: [String: AnyCodable],
-        basehash: String?
-    ) {
-        self.file = file
-        self.basehash = basehash
-    }
-    private enum CodingKeys: String, CodingKey {
-        case file
-        case basehash = "baseHash"
-    }
-}
-
-public struct ExecApprovalsNodeGetParams: Codable, Sendable {
-    public let nodeid: String
-
-    public init(
-        nodeid: String
-    ) {
-        self.nodeid = nodeid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-    }
-}
-
-public struct ExecApprovalsNodeSetParams: Codable, Sendable {
-    public let nodeid: String
-    public let file: [String: AnyCodable]
-    public let basehash: String?
-
-    public init(
-        nodeid: String,
-        file: [String: AnyCodable],
-        basehash: String?
-    ) {
-        self.nodeid = nodeid
-        self.file = file
-        self.basehash = basehash
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case file
-        case basehash = "baseHash"
-    }
-}
-
-public struct ExecApprovalsSnapshot: Codable, Sendable {
-    public let path: String
-    public let exists: Bool
-    public let hash: String
-    public let file: [String: AnyCodable]
-
-    public init(
-        path: String,
-        exists: Bool,
-        hash: String,
-        file: [String: AnyCodable]
-    ) {
-        self.path = path
-        self.exists = exists
-        self.hash = hash
-        self.file = file
-    }
-    private enum CodingKeys: String, CodingKey {
-        case path
-        case exists
-        case hash
-        case file
-    }
-}
-
-public struct ExecApprovalRequestParams: Codable, Sendable {
-    public let id: String?
-    public let command: String
-    public let cwd: AnyCodable?
-    public let host: AnyCodable?
-    public let security: AnyCodable?
-    public let ask: AnyCodable?
-    public let agentid: AnyCodable?
-    public let resolvedpath: AnyCodable?
-    public let sessionkey: AnyCodable?
-    public let timeoutms: Int?
-
-    public init(
-        id: String?,
-        command: String,
-        cwd: AnyCodable?,
-        host: AnyCodable?,
-        security: AnyCodable?,
-        ask: AnyCodable?,
-        agentid: AnyCodable?,
-        resolvedpath: AnyCodable?,
-        sessionkey: AnyCodable?,
-        timeoutms: Int?
-    ) {
-        self.id = id
-        self.command = command
-        self.cwd = cwd
-        self.host = host
-        self.security = security
-        self.ask = ask
-        self.agentid = agentid
-        self.resolvedpath = resolvedpath
-        self.sessionkey = sessionkey
-        self.timeoutms = timeoutms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case command
-        case cwd
-        case host
-        case security
-        case ask
-        case agentid = "agentId"
-        case resolvedpath = "resolvedPath"
-        case sessionkey = "sessionKey"
-        case timeoutms = "timeoutMs"
-    }
-}
-
-public struct ExecApprovalResolveParams: Codable, Sendable {
-    public let id: String
-    public let decision: String
-
-    public init(
-        id: String,
-        decision: String
-    ) {
-        self.id = id
-        self.decision = decision
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case decision
-    }
-}
-
-public struct DevicePairListParams: Codable, Sendable {
+public struct CronStatusParams: Codable, Sendable {
 }
 
 public struct DevicePairApproveParams: Codable, Sendable {
@@ -2420,6 +1109,9 @@ public struct DevicePairApproveParams: Codable, Sendable {
     }
 }
 
+public struct DevicePairListParams: Codable, Sendable {
+}
+
 public struct DevicePairRejectParams: Codable, Sendable {
     public let requestid: String
 
@@ -2430,44 +1122,6 @@ public struct DevicePairRejectParams: Codable, Sendable {
     }
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
-    }
-}
-
-public struct DeviceTokenRotateParams: Codable, Sendable {
-    public let deviceid: String
-    public let role: String
-    public let scopes: [String]?
-
-    public init(
-        deviceid: String,
-        role: String,
-        scopes: [String]?
-    ) {
-        self.deviceid = deviceid
-        self.role = role
-        self.scopes = scopes
-    }
-    private enum CodingKeys: String, CodingKey {
-        case deviceid = "deviceId"
-        case role
-        case scopes
-    }
-}
-
-public struct DeviceTokenRevokeParams: Codable, Sendable {
-    public let deviceid: String
-    public let role: String
-
-    public init(
-        deviceid: String,
-        role: String
-    ) {
-        self.deviceid = deviceid
-        self.role = role
-    }
-    private enum CodingKeys: String, CodingKey {
-        case deviceid = "deviceId"
-        case role
     }
 }
 
@@ -2561,136 +1215,1277 @@ public struct DevicePairResolvedEvent: Codable, Sendable {
     }
 }
 
-public struct ChatHistoryParams: Codable, Sendable {
-    public let sessionkey: String
-    public let limit: Int?
+public struct DeviceTokenRevokeParams: Codable, Sendable {
+    public let deviceid: String
+    public let role: String
 
     public init(
-        sessionkey: String,
-        limit: Int?
+        deviceid: String,
+        role: String
     ) {
-        self.sessionkey = sessionkey
-        self.limit = limit
+        self.deviceid = deviceid
+        self.role = role
     }
     private enum CodingKeys: String, CodingKey {
-        case sessionkey = "sessionKey"
-        case limit
+        case deviceid = "deviceId"
+        case role
     }
 }
 
-public struct ChatSendParams: Codable, Sendable {
-    public let sessionkey: String
+public struct DeviceTokenRotateParams: Codable, Sendable {
+    public let deviceid: String
+    public let role: String
+    public let scopes: [String]?
+
+    public init(
+        deviceid: String,
+        role: String,
+        scopes: [String]?
+    ) {
+        self.deviceid = deviceid
+        self.role = role
+        self.scopes = scopes
+    }
+    private enum CodingKeys: String, CodingKey {
+        case deviceid = "deviceId"
+        case role
+        case scopes
+    }
+}
+
+public struct ErrorShape: Codable, Sendable {
+    public let code: String
     public let message: String
-    public let thinking: String?
-    public let deliver: Bool?
-    public let attachments: [AnyCodable]?
+    public let details: AnyCodable?
+    public let retryable: Bool?
+    public let retryafterms: Int?
+
+    public init(
+        code: String,
+        message: String,
+        details: AnyCodable?,
+        retryable: Bool?,
+        retryafterms: Int?
+    ) {
+        self.code = code
+        self.message = message
+        self.details = details
+        self.retryable = retryable
+        self.retryafterms = retryafterms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case message
+        case details
+        case retryable
+        case retryafterms = "retryAfterMs"
+    }
+}
+
+public struct EventFrame: Codable, Sendable {
+    public let type: String
+    public let event: String
+    public let payload: AnyCodable?
+    public let seq: Int?
+    public let stateversion: [String: AnyCodable]?
+
+    public init(
+        type: String,
+        event: String,
+        payload: AnyCodable?,
+        seq: Int?,
+        stateversion: [String: AnyCodable]?
+    ) {
+        self.type = type
+        self.event = event
+        self.payload = payload
+        self.seq = seq
+        self.stateversion = stateversion
+    }
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case event
+        case payload
+        case seq
+        case stateversion = "stateVersion"
+    }
+}
+
+public struct ExecApprovalRequestParams: Codable, Sendable {
+    public let id: String?
+    public let command: String
+    public let cwd: AnyCodable?
+    public let host: AnyCodable?
+    public let security: AnyCodable?
+    public let ask: AnyCodable?
+    public let agentid: AnyCodable?
+    public let resolvedpath: AnyCodable?
+    public let sessionkey: AnyCodable?
+    public let timeoutms: Int?
+
+    public init(
+        id: String?,
+        command: String,
+        cwd: AnyCodable?,
+        host: AnyCodable?,
+        security: AnyCodable?,
+        ask: AnyCodable?,
+        agentid: AnyCodable?,
+        resolvedpath: AnyCodable?,
+        sessionkey: AnyCodable?,
+        timeoutms: Int?
+    ) {
+        self.id = id
+        self.command = command
+        self.cwd = cwd
+        self.host = host
+        self.security = security
+        self.ask = ask
+        self.agentid = agentid
+        self.resolvedpath = resolvedpath
+        self.sessionkey = sessionkey
+        self.timeoutms = timeoutms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case command
+        case cwd
+        case host
+        case security
+        case ask
+        case agentid = "agentId"
+        case resolvedpath = "resolvedPath"
+        case sessionkey = "sessionKey"
+        case timeoutms = "timeoutMs"
+    }
+}
+
+public struct ExecApprovalResolveParams: Codable, Sendable {
+    public let id: String
+    public let decision: String
+
+    public init(
+        id: String,
+        decision: String
+    ) {
+        self.id = id
+        self.decision = decision
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case decision
+    }
+}
+
+public struct ExecApprovalsGetParams: Codable, Sendable {
+}
+
+public struct ExecApprovalsNodeGetParams: Codable, Sendable {
+    public let nodeid: String
+
+    public init(
+        nodeid: String
+    ) {
+        self.nodeid = nodeid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+    }
+}
+
+public struct ExecApprovalsNodeSetParams: Codable, Sendable {
+    public let nodeid: String
+    public let file: [String: AnyCodable]
+    public let basehash: String?
+
+    public init(
+        nodeid: String,
+        file: [String: AnyCodable],
+        basehash: String?
+    ) {
+        self.nodeid = nodeid
+        self.file = file
+        self.basehash = basehash
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case file
+        case basehash = "baseHash"
+    }
+}
+
+public struct ExecApprovalsSetParams: Codable, Sendable {
+    public let file: [String: AnyCodable]
+    public let basehash: String?
+
+    public init(
+        file: [String: AnyCodable],
+        basehash: String?
+    ) {
+        self.file = file
+        self.basehash = basehash
+    }
+    private enum CodingKeys: String, CodingKey {
+        case file
+        case basehash = "baseHash"
+    }
+}
+
+public struct ExecApprovalsSnapshot: Codable, Sendable {
+    public let path: String
+    public let exists: Bool
+    public let hash: String
+    public let file: [String: AnyCodable]
+
+    public init(
+        path: String,
+        exists: Bool,
+        hash: String,
+        file: [String: AnyCodable]
+    ) {
+        self.path = path
+        self.exists = exists
+        self.hash = hash
+        self.file = file
+    }
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case exists
+        case hash
+        case file
+    }
+}
+
+public struct HelloOk: Codable, Sendable {
+    public let type: String
+    public let _protocol: Int
+    public let server: [String: AnyCodable]
+    public let features: [String: AnyCodable]
+    public let snapshot: Snapshot
+    public let canvashosturl: String?
+    public let auth: [String: AnyCodable]?
+    public let policy: [String: AnyCodable]
+
+    public init(
+        type: String,
+        _protocol: Int,
+        server: [String: AnyCodable],
+        features: [String: AnyCodable],
+        snapshot: Snapshot,
+        canvashosturl: String?,
+        auth: [String: AnyCodable]?,
+        policy: [String: AnyCodable]
+    ) {
+        self.type = type
+        self._protocol = _protocol
+        self.server = server
+        self.features = features
+        self.snapshot = snapshot
+        self.canvashosturl = canvashosturl
+        self.auth = auth
+        self.policy = policy
+    }
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case _protocol = "protocol"
+        case server
+        case features
+        case snapshot
+        case canvashosturl = "canvasHostUrl"
+        case auth
+        case policy
+    }
+}
+
+public struct LogsTailParams: Codable, Sendable {
+    public let cursor: Int?
+    public let limit: Int?
+    public let maxbytes: Int?
+
+    public init(
+        cursor: Int?,
+        limit: Int?,
+        maxbytes: Int?
+    ) {
+        self.cursor = cursor
+        self.limit = limit
+        self.maxbytes = maxbytes
+    }
+    private enum CodingKeys: String, CodingKey {
+        case cursor
+        case limit
+        case maxbytes = "maxBytes"
+    }
+}
+
+public struct LogsTailResult: Codable, Sendable {
+    public let file: String
+    public let cursor: Int
+    public let size: Int
+    public let lines: [String]
+    public let truncated: Bool?
+    public let reset: Bool?
+
+    public init(
+        file: String,
+        cursor: Int,
+        size: Int,
+        lines: [String],
+        truncated: Bool?,
+        reset: Bool?
+    ) {
+        self.file = file
+        self.cursor = cursor
+        self.size = size
+        self.lines = lines
+        self.truncated = truncated
+        self.reset = reset
+    }
+    private enum CodingKeys: String, CodingKey {
+        case file
+        case cursor
+        case size
+        case lines
+        case truncated
+        case reset
+    }
+}
+
+public struct ModelChoice: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let provider: String
+    public let contextwindow: Int?
+    public let reasoning: Bool?
+
+    public init(
+        id: String,
+        name: String,
+        provider: String,
+        contextwindow: Int?,
+        reasoning: Bool?
+    ) {
+        self.id = id
+        self.name = name
+        self.provider = provider
+        self.contextwindow = contextwindow
+        self.reasoning = reasoning
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case provider
+        case contextwindow = "contextWindow"
+        case reasoning
+    }
+}
+
+public struct ModelsListParams: Codable, Sendable {
+}
+
+public struct ModelsListResult: Codable, Sendable {
+    public let models: [ModelChoice]
+
+    public init(
+        models: [ModelChoice]
+    ) {
+        self.models = models
+    }
+    private enum CodingKeys: String, CodingKey {
+        case models
+    }
+}
+
+public struct NodeDescribeParams: Codable, Sendable {
+    public let nodeid: String
+
+    public init(
+        nodeid: String
+    ) {
+        self.nodeid = nodeid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+    }
+}
+
+public struct NodeEventParams: Codable, Sendable {
+    public let event: String
+    public let payload: AnyCodable?
+    public let payloadjson: String?
+
+    public init(
+        event: String,
+        payload: AnyCodable?,
+        payloadjson: String?
+    ) {
+        self.event = event
+        self.payload = payload
+        self.payloadjson = payloadjson
+    }
+    private enum CodingKeys: String, CodingKey {
+        case event
+        case payload
+        case payloadjson = "payloadJSON"
+    }
+}
+
+public struct NodeInvokeParams: Codable, Sendable {
+    public let nodeid: String
+    public let command: String
+    public let params: AnyCodable?
     public let timeoutms: Int?
     public let idempotencykey: String
 
     public init(
-        sessionkey: String,
-        message: String,
-        thinking: String?,
-        deliver: Bool?,
-        attachments: [AnyCodable]?,
+        nodeid: String,
+        command: String,
+        params: AnyCodable?,
         timeoutms: Int?,
         idempotencykey: String
     ) {
-        self.sessionkey = sessionkey
-        self.message = message
-        self.thinking = thinking
-        self.deliver = deliver
-        self.attachments = attachments
+        self.nodeid = nodeid
+        self.command = command
+        self.params = params
         self.timeoutms = timeoutms
         self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
-        case sessionkey = "sessionKey"
-        case message
-        case thinking
-        case deliver
-        case attachments
+        case nodeid = "nodeId"
+        case command
+        case params
         case timeoutms = "timeoutMs"
         case idempotencykey = "idempotencyKey"
     }
 }
 
-public struct ChatAbortParams: Codable, Sendable {
-    public let sessionkey: String
-    public let runid: String?
+public struct NodeInvokeRequestEvent: Codable, Sendable {
+    public let id: String
+    public let nodeid: String
+    public let command: String
+    public let paramsjson: String?
+    public let timeoutms: Int?
+    public let idempotencykey: String?
 
     public init(
-        sessionkey: String,
-        runid: String?
+        id: String,
+        nodeid: String,
+        command: String,
+        paramsjson: String?,
+        timeoutms: Int?,
+        idempotencykey: String?
     ) {
-        self.sessionkey = sessionkey
-        self.runid = runid
+        self.id = id
+        self.nodeid = nodeid
+        self.command = command
+        self.paramsjson = paramsjson
+        self.timeoutms = timeoutms
+        self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
-        case sessionkey = "sessionKey"
-        case runid = "runId"
+        case id
+        case nodeid = "nodeId"
+        case command
+        case paramsjson = "paramsJSON"
+        case timeoutms = "timeoutMs"
+        case idempotencykey = "idempotencyKey"
     }
 }
 
-public struct ChatInjectParams: Codable, Sendable {
-    public let sessionkey: String
+public struct NodeInvokeResultParams: Codable, Sendable {
+    public let id: String
+    public let nodeid: String
+    public let ok: Bool
+    public let payload: AnyCodable?
+    public let payloadjson: String?
+    public let error: [String: AnyCodable]?
+
+    public init(
+        id: String,
+        nodeid: String,
+        ok: Bool,
+        payload: AnyCodable?,
+        payloadjson: String?,
+        error: [String: AnyCodable]?
+    ) {
+        self.id = id
+        self.nodeid = nodeid
+        self.ok = ok
+        self.payload = payload
+        self.payloadjson = payloadjson
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case nodeid = "nodeId"
+        case ok
+        case payload
+        case payloadjson = "payloadJSON"
+        case error
+    }
+}
+
+public struct NodeListParams: Codable, Sendable {
+}
+
+public struct NodePairApproveParams: Codable, Sendable {
+    public let requestid: String
+
+    public init(
+        requestid: String
+    ) {
+        self.requestid = requestid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case requestid = "requestId"
+    }
+}
+
+public struct NodePairListParams: Codable, Sendable {
+}
+
+public struct NodePairRejectParams: Codable, Sendable {
+    public let requestid: String
+
+    public init(
+        requestid: String
+    ) {
+        self.requestid = requestid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case requestid = "requestId"
+    }
+}
+
+public struct NodePairRequestParams: Codable, Sendable {
+    public let nodeid: String
+    public let displayname: String?
+    public let platform: String?
+    public let version: String?
+    public let coreversion: String?
+    public let uiversion: String?
+    public let devicefamily: String?
+    public let modelidentifier: String?
+    public let caps: [String]?
+    public let commands: [String]?
+    public let remoteip: String?
+    public let silent: Bool?
+
+    public init(
+        nodeid: String,
+        displayname: String?,
+        platform: String?,
+        version: String?,
+        coreversion: String?,
+        uiversion: String?,
+        devicefamily: String?,
+        modelidentifier: String?,
+        caps: [String]?,
+        commands: [String]?,
+        remoteip: String?,
+        silent: Bool?
+    ) {
+        self.nodeid = nodeid
+        self.displayname = displayname
+        self.platform = platform
+        self.version = version
+        self.coreversion = coreversion
+        self.uiversion = uiversion
+        self.devicefamily = devicefamily
+        self.modelidentifier = modelidentifier
+        self.caps = caps
+        self.commands = commands
+        self.remoteip = remoteip
+        self.silent = silent
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case displayname = "displayName"
+        case platform
+        case version
+        case coreversion = "coreVersion"
+        case uiversion = "uiVersion"
+        case devicefamily = "deviceFamily"
+        case modelidentifier = "modelIdentifier"
+        case caps
+        case commands
+        case remoteip = "remoteIp"
+        case silent
+    }
+}
+
+public struct NodePairVerifyParams: Codable, Sendable {
+    public let nodeid: String
+    public let token: String
+
+    public init(
+        nodeid: String,
+        token: String
+    ) {
+        self.nodeid = nodeid
+        self.token = token
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case token
+    }
+}
+
+public struct NodeRenameParams: Codable, Sendable {
+    public let nodeid: String
+    public let displayname: String
+
+    public init(
+        nodeid: String,
+        displayname: String
+    ) {
+        self.nodeid = nodeid
+        self.displayname = displayname
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case displayname = "displayName"
+    }
+}
+
+public struct PollParams: Codable, Sendable {
+    public let to: String
+    public let question: String
+    public let options: [String]
+    public let maxselections: Int?
+    public let durationhours: Int?
+    public let channel: String?
+    public let accountid: String?
+    public let idempotencykey: String
+
+    public init(
+        to: String,
+        question: String,
+        options: [String],
+        maxselections: Int?,
+        durationhours: Int?,
+        channel: String?,
+        accountid: String?,
+        idempotencykey: String
+    ) {
+        self.to = to
+        self.question = question
+        self.options = options
+        self.maxselections = maxselections
+        self.durationhours = durationhours
+        self.channel = channel
+        self.accountid = accountid
+        self.idempotencykey = idempotencykey
+    }
+    private enum CodingKeys: String, CodingKey {
+        case to
+        case question
+        case options
+        case maxselections = "maxSelections"
+        case durationhours = "durationHours"
+        case channel
+        case accountid = "accountId"
+        case idempotencykey = "idempotencyKey"
+    }
+}
+
+public struct PresenceEntry: Codable, Sendable {
+    public let host: String?
+    public let ip: String?
+    public let version: String?
+    public let platform: String?
+    public let devicefamily: String?
+    public let modelidentifier: String?
+    public let mode: String?
+    public let lastinputseconds: Int?
+    public let reason: String?
+    public let tags: [String]?
+    public let text: String?
+    public let ts: Int
+    public let deviceid: String?
+    public let roles: [String]?
+    public let scopes: [String]?
+    public let instanceid: String?
+
+    public init(
+        host: String?,
+        ip: String?,
+        version: String?,
+        platform: String?,
+        devicefamily: String?,
+        modelidentifier: String?,
+        mode: String?,
+        lastinputseconds: Int?,
+        reason: String?,
+        tags: [String]?,
+        text: String?,
+        ts: Int,
+        deviceid: String?,
+        roles: [String]?,
+        scopes: [String]?,
+        instanceid: String?
+    ) {
+        self.host = host
+        self.ip = ip
+        self.version = version
+        self.platform = platform
+        self.devicefamily = devicefamily
+        self.modelidentifier = modelidentifier
+        self.mode = mode
+        self.lastinputseconds = lastinputseconds
+        self.reason = reason
+        self.tags = tags
+        self.text = text
+        self.ts = ts
+        self.deviceid = deviceid
+        self.roles = roles
+        self.scopes = scopes
+        self.instanceid = instanceid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case host
+        case ip
+        case version
+        case platform
+        case devicefamily = "deviceFamily"
+        case modelidentifier = "modelIdentifier"
+        case mode
+        case lastinputseconds = "lastInputSeconds"
+        case reason
+        case tags
+        case text
+        case ts
+        case deviceid = "deviceId"
+        case roles
+        case scopes
+        case instanceid = "instanceId"
+    }
+}
+
+public struct RequestFrame: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let method: String
+    public let params: AnyCodable?
+
+    public init(
+        type: String,
+        id: String,
+        method: String,
+        params: AnyCodable?
+    ) {
+        self.type = type
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case id
+        case method
+        case params
+    }
+}
+
+public struct ResponseFrame: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let ok: Bool
+    public let payload: AnyCodable?
+    public let error: [String: AnyCodable]?
+
+    public init(
+        type: String,
+        id: String,
+        ok: Bool,
+        payload: AnyCodable?,
+        error: [String: AnyCodable]?
+    ) {
+        self.type = type
+        self.id = id
+        self.ok = ok
+        self.payload = payload
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case id
+        case ok
+        case payload
+        case error
+    }
+}
+
+public struct SendParams: Codable, Sendable {
+    public let to: String
     public let message: String
-    public let label: String?
+    public let mediaurl: String?
+    public let mediaurls: [String]?
+    public let gifplayback: Bool?
+    public let channel: String?
+    public let accountid: String?
+    public let sessionkey: String?
+    public let idempotencykey: String
 
     public init(
-        sessionkey: String,
+        to: String,
         message: String,
-        label: String?
+        mediaurl: String?,
+        mediaurls: [String]?,
+        gifplayback: Bool?,
+        channel: String?,
+        accountid: String?,
+        sessionkey: String?,
+        idempotencykey: String
     ) {
-        self.sessionkey = sessionkey
+        self.to = to
         self.message = message
-        self.label = label
+        self.mediaurl = mediaurl
+        self.mediaurls = mediaurls
+        self.gifplayback = gifplayback
+        self.channel = channel
+        self.accountid = accountid
+        self.sessionkey = sessionkey
+        self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
-        case sessionkey = "sessionKey"
+        case to
         case message
-        case label
+        case mediaurl = "mediaUrl"
+        case mediaurls = "mediaUrls"
+        case gifplayback = "gifPlayback"
+        case channel
+        case accountid = "accountId"
+        case sessionkey = "sessionKey"
+        case idempotencykey = "idempotencyKey"
     }
 }
 
-public struct ChatEvent: Codable, Sendable {
-    public let runid: String
-    public let sessionkey: String
-    public let seq: Int
-    public let state: AnyCodable
-    public let message: AnyCodable?
-    public let errormessage: String?
-    public let usage: AnyCodable?
-    public let stopreason: String?
+public struct SessionsCompactParams: Codable, Sendable {
+    public let key: String
+    public let maxlines: Int?
 
     public init(
-        runid: String,
-        sessionkey: String,
-        seq: Int,
-        state: AnyCodable,
-        message: AnyCodable?,
-        errormessage: String?,
-        usage: AnyCodable?,
-        stopreason: String?
+        key: String,
+        maxlines: Int?
     ) {
-        self.runid = runid
-        self.sessionkey = sessionkey
-        self.seq = seq
-        self.state = state
-        self.message = message
-        self.errormessage = errormessage
-        self.usage = usage
-        self.stopreason = stopreason
+        self.key = key
+        self.maxlines = maxlines
     }
     private enum CodingKeys: String, CodingKey {
-        case runid = "runId"
-        case sessionkey = "sessionKey"
-        case seq
-        case state
-        case message
-        case errormessage = "errorMessage"
-        case usage
-        case stopreason = "stopReason"
+        case key
+        case maxlines = "maxLines"
+    }
+}
+
+public struct SessionsDeleteParams: Codable, Sendable {
+    public let key: String
+    public let deletetranscript: Bool?
+
+    public init(
+        key: String,
+        deletetranscript: Bool?
+    ) {
+        self.key = key
+        self.deletetranscript = deletetranscript
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case deletetranscript = "deleteTranscript"
+    }
+}
+
+public struct SessionsListParams: Codable, Sendable {
+    public let limit: Int?
+    public let activeminutes: Int?
+    public let includeglobal: Bool?
+    public let includeunknown: Bool?
+    public let includederivedtitles: Bool?
+    public let includelastmessage: Bool?
+    public let label: String?
+    public let spawnedby: String?
+    public let agentid: String?
+    public let search: String?
+
+    public init(
+        limit: Int?,
+        activeminutes: Int?,
+        includeglobal: Bool?,
+        includeunknown: Bool?,
+        includederivedtitles: Bool?,
+        includelastmessage: Bool?,
+        label: String?,
+        spawnedby: String?,
+        agentid: String?,
+        search: String?
+    ) {
+        self.limit = limit
+        self.activeminutes = activeminutes
+        self.includeglobal = includeglobal
+        self.includeunknown = includeunknown
+        self.includederivedtitles = includederivedtitles
+        self.includelastmessage = includelastmessage
+        self.label = label
+        self.spawnedby = spawnedby
+        self.agentid = agentid
+        self.search = search
+    }
+    private enum CodingKeys: String, CodingKey {
+        case limit
+        case activeminutes = "activeMinutes"
+        case includeglobal = "includeGlobal"
+        case includeunknown = "includeUnknown"
+        case includederivedtitles = "includeDerivedTitles"
+        case includelastmessage = "includeLastMessage"
+        case label
+        case spawnedby = "spawnedBy"
+        case agentid = "agentId"
+        case search
+    }
+}
+
+public struct SessionsPatchParams: Codable, Sendable {
+    public let key: String
+    public let label: AnyCodable?
+    public let thinkinglevel: AnyCodable?
+    public let verboselevel: AnyCodable?
+    public let reasoninglevel: AnyCodable?
+    public let responseusage: AnyCodable?
+    public let elevatedlevel: AnyCodable?
+    public let exechost: AnyCodable?
+    public let execsecurity: AnyCodable?
+    public let execask: AnyCodable?
+    public let execnode: AnyCodable?
+    public let model: AnyCodable?
+    public let spawnedby: AnyCodable?
+    public let sendpolicy: AnyCodable?
+    public let groupactivation: AnyCodable?
+
+    public init(
+        key: String,
+        label: AnyCodable?,
+        thinkinglevel: AnyCodable?,
+        verboselevel: AnyCodable?,
+        reasoninglevel: AnyCodable?,
+        responseusage: AnyCodable?,
+        elevatedlevel: AnyCodable?,
+        exechost: AnyCodable?,
+        execsecurity: AnyCodable?,
+        execask: AnyCodable?,
+        execnode: AnyCodable?,
+        model: AnyCodable?,
+        spawnedby: AnyCodable?,
+        sendpolicy: AnyCodable?,
+        groupactivation: AnyCodable?
+    ) {
+        self.key = key
+        self.label = label
+        self.thinkinglevel = thinkinglevel
+        self.verboselevel = verboselevel
+        self.reasoninglevel = reasoninglevel
+        self.responseusage = responseusage
+        self.elevatedlevel = elevatedlevel
+        self.exechost = exechost
+        self.execsecurity = execsecurity
+        self.execask = execask
+        self.execnode = execnode
+        self.model = model
+        self.spawnedby = spawnedby
+        self.sendpolicy = sendpolicy
+        self.groupactivation = groupactivation
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case label
+        case thinkinglevel = "thinkingLevel"
+        case verboselevel = "verboseLevel"
+        case reasoninglevel = "reasoningLevel"
+        case responseusage = "responseUsage"
+        case elevatedlevel = "elevatedLevel"
+        case exechost = "execHost"
+        case execsecurity = "execSecurity"
+        case execask = "execAsk"
+        case execnode = "execNode"
+        case model
+        case spawnedby = "spawnedBy"
+        case sendpolicy = "sendPolicy"
+        case groupactivation = "groupActivation"
+    }
+}
+
+public struct SessionsPreviewParams: Codable, Sendable {
+    public let keys: [String]
+    public let limit: Int?
+    public let maxchars: Int?
+
+    public init(
+        keys: [String],
+        limit: Int?,
+        maxchars: Int?
+    ) {
+        self.keys = keys
+        self.limit = limit
+        self.maxchars = maxchars
+    }
+    private enum CodingKeys: String, CodingKey {
+        case keys
+        case limit
+        case maxchars = "maxChars"
+    }
+}
+
+public struct SessionsResetParams: Codable, Sendable {
+    public let key: String
+
+    public init(
+        key: String
+    ) {
+        self.key = key
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+    }
+}
+
+public struct SessionsResolveParams: Codable, Sendable {
+    public let key: String?
+    public let sessionid: String?
+    public let label: String?
+    public let agentid: String?
+    public let spawnedby: String?
+    public let includeglobal: Bool?
+    public let includeunknown: Bool?
+
+    public init(
+        key: String?,
+        sessionid: String?,
+        label: String?,
+        agentid: String?,
+        spawnedby: String?,
+        includeglobal: Bool?,
+        includeunknown: Bool?
+    ) {
+        self.key = key
+        self.sessionid = sessionid
+        self.label = label
+        self.agentid = agentid
+        self.spawnedby = spawnedby
+        self.includeglobal = includeglobal
+        self.includeunknown = includeunknown
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case sessionid = "sessionId"
+        case label
+        case agentid = "agentId"
+        case spawnedby = "spawnedBy"
+        case includeglobal = "includeGlobal"
+        case includeunknown = "includeUnknown"
+    }
+}
+
+public struct SessionsUsageParams: Codable, Sendable {
+    public let key: String?
+    public let startdate: String?
+    public let enddate: String?
+    public let limit: Int?
+    public let includecontextweight: Bool?
+
+    public init(
+        key: String?,
+        startdate: String?,
+        enddate: String?,
+        limit: Int?,
+        includecontextweight: Bool?
+    ) {
+        self.key = key
+        self.startdate = startdate
+        self.enddate = enddate
+        self.limit = limit
+        self.includecontextweight = includecontextweight
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case startdate = "startDate"
+        case enddate = "endDate"
+        case limit
+        case includecontextweight = "includeContextWeight"
+    }
+}
+
+public struct ShutdownEvent: Codable, Sendable {
+    public let reason: String
+    public let restartexpectedms: Int?
+
+    public init(
+        reason: String,
+        restartexpectedms: Int?
+    ) {
+        self.reason = reason
+        self.restartexpectedms = restartexpectedms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case reason
+        case restartexpectedms = "restartExpectedMs"
+    }
+}
+
+public struct SkillsBinsParams: Codable, Sendable {
+}
+
+public struct SkillsBinsResult: Codable, Sendable {
+    public let bins: [String]
+
+    public init(
+        bins: [String]
+    ) {
+        self.bins = bins
+    }
+    private enum CodingKeys: String, CodingKey {
+        case bins
+    }
+}
+
+public struct SkillsInstallParams: Codable, Sendable {
+    public let name: String
+    public let installid: String
+    public let timeoutms: Int?
+
+    public init(
+        name: String,
+        installid: String,
+        timeoutms: Int?
+    ) {
+        self.name = name
+        self.installid = installid
+        self.timeoutms = timeoutms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case installid = "installId"
+        case timeoutms = "timeoutMs"
+    }
+}
+
+public struct SkillsStatusParams: Codable, Sendable {
+    public let agentid: String?
+
+    public init(
+        agentid: String?
+    ) {
+        self.agentid = agentid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+    }
+}
+
+public struct SkillsUpdateParams: Codable, Sendable {
+    public let skillkey: String
+    public let enabled: Bool?
+    public let apikey: String?
+    public let env: [String: AnyCodable]?
+
+    public init(
+        skillkey: String,
+        enabled: Bool?,
+        apikey: String?,
+        env: [String: AnyCodable]?
+    ) {
+        self.skillkey = skillkey
+        self.enabled = enabled
+        self.apikey = apikey
+        self.env = env
+    }
+    private enum CodingKeys: String, CodingKey {
+        case skillkey = "skillKey"
+        case enabled
+        case apikey = "apiKey"
+        case env
+    }
+}
+
+public struct Snapshot: Codable, Sendable {
+    public let presence: [PresenceEntry]
+    public let health: AnyCodable
+    public let stateversion: StateVersion
+    public let uptimems: Int
+    public let configpath: String?
+    public let statedir: String?
+    public let sessiondefaults: [String: AnyCodable]?
+
+    public init(
+        presence: [PresenceEntry],
+        health: AnyCodable,
+        stateversion: StateVersion,
+        uptimems: Int,
+        configpath: String?,
+        statedir: String?,
+        sessiondefaults: [String: AnyCodable]?
+    ) {
+        self.presence = presence
+        self.health = health
+        self.stateversion = stateversion
+        self.uptimems = uptimems
+        self.configpath = configpath
+        self.statedir = statedir
+        self.sessiondefaults = sessiondefaults
+    }
+    private enum CodingKeys: String, CodingKey {
+        case presence
+        case health
+        case stateversion = "stateVersion"
+        case uptimems = "uptimeMs"
+        case configpath = "configPath"
+        case statedir = "stateDir"
+        case sessiondefaults = "sessionDefaults"
+    }
+}
+
+public struct StateVersion: Codable, Sendable {
+    public let presence: Int
+    public let health: Int
+
+    public init(
+        presence: Int,
+        health: Int
+    ) {
+        self.presence = presence
+        self.health = health
+    }
+    private enum CodingKeys: String, CodingKey {
+        case presence
+        case health
+    }
+}
+
+public struct TalkModeParams: Codable, Sendable {
+    public let enabled: Bool
+    public let phase: String?
+
+    public init(
+        enabled: Bool,
+        phase: String?
+    ) {
+        self.enabled = enabled
+        self.phase = phase
+    }
+    private enum CodingKeys: String, CodingKey {
+        case enabled
+        case phase
+    }
+}
+
+public struct TickEvent: Codable, Sendable {
+    public let ts: Int
+
+    public init(
+        ts: Int
+    ) {
+        self.ts = ts
+    }
+    private enum CodingKeys: String, CodingKey {
+        case ts
     }
 }
 
@@ -2719,33 +2514,238 @@ public struct UpdateRunParams: Codable, Sendable {
     }
 }
 
-public struct TickEvent: Codable, Sendable {
-    public let ts: Int
+public struct WakeParams: Codable, Sendable {
+    public let mode: AnyCodable
+    public let text: String
 
     public init(
-        ts: Int
+        mode: AnyCodable,
+        text: String
     ) {
-        self.ts = ts
+        self.mode = mode
+        self.text = text
     }
     private enum CodingKeys: String, CodingKey {
-        case ts
+        case mode
+        case text
     }
 }
 
-public struct ShutdownEvent: Codable, Sendable {
-    public let reason: String
-    public let restartexpectedms: Int?
+public struct WebLoginStartParams: Codable, Sendable {
+    public let force: Bool?
+    public let timeoutms: Int?
+    public let verbose: Bool?
+    public let accountid: String?
 
     public init(
-        reason: String,
-        restartexpectedms: Int?
+        force: Bool?,
+        timeoutms: Int?,
+        verbose: Bool?,
+        accountid: String?
     ) {
-        self.reason = reason
-        self.restartexpectedms = restartexpectedms
+        self.force = force
+        self.timeoutms = timeoutms
+        self.verbose = verbose
+        self.accountid = accountid
     }
     private enum CodingKeys: String, CodingKey {
-        case reason
-        case restartexpectedms = "restartExpectedMs"
+        case force
+        case timeoutms = "timeoutMs"
+        case verbose
+        case accountid = "accountId"
+    }
+}
+
+public struct WebLoginWaitParams: Codable, Sendable {
+    public let timeoutms: Int?
+    public let accountid: String?
+
+    public init(
+        timeoutms: Int?,
+        accountid: String?
+    ) {
+        self.timeoutms = timeoutms
+        self.accountid = accountid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case timeoutms = "timeoutMs"
+        case accountid = "accountId"
+    }
+}
+
+public struct WizardCancelParams: Codable, Sendable {
+    public let sessionid: String
+
+    public init(
+        sessionid: String
+    ) {
+        self.sessionid = sessionid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionid = "sessionId"
+    }
+}
+
+public struct WizardNextParams: Codable, Sendable {
+    public let sessionid: String
+    public let answer: [String: AnyCodable]?
+
+    public init(
+        sessionid: String,
+        answer: [String: AnyCodable]?
+    ) {
+        self.sessionid = sessionid
+        self.answer = answer
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionid = "sessionId"
+        case answer
+    }
+}
+
+public struct WizardNextResult: Codable, Sendable {
+    public let done: Bool
+    public let step: [String: AnyCodable]?
+    public let status: AnyCodable?
+    public let error: String?
+
+    public init(
+        done: Bool,
+        step: [String: AnyCodable]?,
+        status: AnyCodable?,
+        error: String?
+    ) {
+        self.done = done
+        self.step = step
+        self.status = status
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case done
+        case step
+        case status
+        case error
+    }
+}
+
+public struct WizardStartParams: Codable, Sendable {
+    public let mode: AnyCodable?
+    public let workspace: String?
+
+    public init(
+        mode: AnyCodable?,
+        workspace: String?
+    ) {
+        self.mode = mode
+        self.workspace = workspace
+    }
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case workspace
+    }
+}
+
+public struct WizardStartResult: Codable, Sendable {
+    public let sessionid: String
+    public let done: Bool
+    public let step: [String: AnyCodable]?
+    public let status: AnyCodable?
+    public let error: String?
+
+    public init(
+        sessionid: String,
+        done: Bool,
+        step: [String: AnyCodable]?,
+        status: AnyCodable?,
+        error: String?
+    ) {
+        self.sessionid = sessionid
+        self.done = done
+        self.step = step
+        self.status = status
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionid = "sessionId"
+        case done
+        case step
+        case status
+        case error
+    }
+}
+
+public struct WizardStatusParams: Codable, Sendable {
+    public let sessionid: String
+
+    public init(
+        sessionid: String
+    ) {
+        self.sessionid = sessionid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionid = "sessionId"
+    }
+}
+
+public struct WizardStatusResult: Codable, Sendable {
+    public let status: AnyCodable
+    public let error: String?
+
+    public init(
+        status: AnyCodable,
+        error: String?
+    ) {
+        self.status = status
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case error
+    }
+}
+
+public struct WizardStep: Codable, Sendable {
+    public let id: String
+    public let type: AnyCodable
+    public let title: String?
+    public let message: String?
+    public let options: [[String: AnyCodable]]?
+    public let initialvalue: AnyCodable?
+    public let placeholder: String?
+    public let sensitive: Bool?
+    public let executor: AnyCodable?
+
+    public init(
+        id: String,
+        type: AnyCodable,
+        title: String?,
+        message: String?,
+        options: [[String: AnyCodable]]?,
+        initialvalue: AnyCodable?,
+        placeholder: String?,
+        sensitive: Bool?,
+        executor: AnyCodable?
+    ) {
+        self.id = id
+        self.type = type
+        self.title = title
+        self.message = message
+        self.options = options
+        self.initialvalue = initialvalue
+        self.placeholder = placeholder
+        self.sensitive = sensitive
+        self.executor = executor
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case title
+        case message
+        case options
+        case initialvalue = "initialValue"
+        case placeholder
+        case sensitive
+        case executor
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -11,347 +11,6 @@ public enum ErrorCode: String, Codable, Sendable {
     case unavailable = "UNAVAILABLE"
 }
 
-public struct ConnectParams: Codable, Sendable {
-    public let minprotocol: Int
-    public let maxprotocol: Int
-    public let client: [String: AnyCodable]
-    public let caps: [String]?
-    public let commands: [String]?
-    public let permissions: [String: AnyCodable]?
-    public let pathenv: String?
-    public let role: String?
-    public let scopes: [String]?
-    public let device: [String: AnyCodable]?
-    public let auth: [String: AnyCodable]?
-    public let locale: String?
-    public let useragent: String?
-
-    public init(
-        minprotocol: Int,
-        maxprotocol: Int,
-        client: [String: AnyCodable],
-        caps: [String]?,
-        commands: [String]?,
-        permissions: [String: AnyCodable]?,
-        pathenv: String?,
-        role: String?,
-        scopes: [String]?,
-        device: [String: AnyCodable]?,
-        auth: [String: AnyCodable]?,
-        locale: String?,
-        useragent: String?
-    ) {
-        self.minprotocol = minprotocol
-        self.maxprotocol = maxprotocol
-        self.client = client
-        self.caps = caps
-        self.commands = commands
-        self.permissions = permissions
-        self.pathenv = pathenv
-        self.role = role
-        self.scopes = scopes
-        self.device = device
-        self.auth = auth
-        self.locale = locale
-        self.useragent = useragent
-    }
-    private enum CodingKeys: String, CodingKey {
-        case minprotocol = "minProtocol"
-        case maxprotocol = "maxProtocol"
-        case client
-        case caps
-        case commands
-        case permissions
-        case pathenv = "pathEnv"
-        case role
-        case scopes
-        case device
-        case auth
-        case locale
-        case useragent = "userAgent"
-    }
-}
-
-public struct HelloOk: Codable, Sendable {
-    public let type: String
-    public let _protocol: Int
-    public let server: [String: AnyCodable]
-    public let features: [String: AnyCodable]
-    public let snapshot: Snapshot
-    public let canvashosturl: String?
-    public let auth: [String: AnyCodable]?
-    public let policy: [String: AnyCodable]
-
-    public init(
-        type: String,
-        _protocol: Int,
-        server: [String: AnyCodable],
-        features: [String: AnyCodable],
-        snapshot: Snapshot,
-        canvashosturl: String?,
-        auth: [String: AnyCodable]?,
-        policy: [String: AnyCodable]
-    ) {
-        self.type = type
-        self._protocol = _protocol
-        self.server = server
-        self.features = features
-        self.snapshot = snapshot
-        self.canvashosturl = canvashosturl
-        self.auth = auth
-        self.policy = policy
-    }
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case _protocol = "protocol"
-        case server
-        case features
-        case snapshot
-        case canvashosturl = "canvasHostUrl"
-        case auth
-        case policy
-    }
-}
-
-public struct RequestFrame: Codable, Sendable {
-    public let type: String
-    public let id: String
-    public let method: String
-    public let params: AnyCodable?
-
-    public init(
-        type: String,
-        id: String,
-        method: String,
-        params: AnyCodable?
-    ) {
-        self.type = type
-        self.id = id
-        self.method = method
-        self.params = params
-    }
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case id
-        case method
-        case params
-    }
-}
-
-public struct ResponseFrame: Codable, Sendable {
-    public let type: String
-    public let id: String
-    public let ok: Bool
-    public let payload: AnyCodable?
-    public let error: [String: AnyCodable]?
-
-    public init(
-        type: String,
-        id: String,
-        ok: Bool,
-        payload: AnyCodable?,
-        error: [String: AnyCodable]?
-    ) {
-        self.type = type
-        self.id = id
-        self.ok = ok
-        self.payload = payload
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case id
-        case ok
-        case payload
-        case error
-    }
-}
-
-public struct EventFrame: Codable, Sendable {
-    public let type: String
-    public let event: String
-    public let payload: AnyCodable?
-    public let seq: Int?
-    public let stateversion: [String: AnyCodable]?
-
-    public init(
-        type: String,
-        event: String,
-        payload: AnyCodable?,
-        seq: Int?,
-        stateversion: [String: AnyCodable]?
-    ) {
-        self.type = type
-        self.event = event
-        self.payload = payload
-        self.seq = seq
-        self.stateversion = stateversion
-    }
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case event
-        case payload
-        case seq
-        case stateversion = "stateVersion"
-    }
-}
-
-public struct PresenceEntry: Codable, Sendable {
-    public let host: String?
-    public let ip: String?
-    public let version: String?
-    public let platform: String?
-    public let devicefamily: String?
-    public let modelidentifier: String?
-    public let mode: String?
-    public let lastinputseconds: Int?
-    public let reason: String?
-    public let tags: [String]?
-    public let text: String?
-    public let ts: Int
-    public let deviceid: String?
-    public let roles: [String]?
-    public let scopes: [String]?
-    public let instanceid: String?
-
-    public init(
-        host: String?,
-        ip: String?,
-        version: String?,
-        platform: String?,
-        devicefamily: String?,
-        modelidentifier: String?,
-        mode: String?,
-        lastinputseconds: Int?,
-        reason: String?,
-        tags: [String]?,
-        text: String?,
-        ts: Int,
-        deviceid: String?,
-        roles: [String]?,
-        scopes: [String]?,
-        instanceid: String?
-    ) {
-        self.host = host
-        self.ip = ip
-        self.version = version
-        self.platform = platform
-        self.devicefamily = devicefamily
-        self.modelidentifier = modelidentifier
-        self.mode = mode
-        self.lastinputseconds = lastinputseconds
-        self.reason = reason
-        self.tags = tags
-        self.text = text
-        self.ts = ts
-        self.deviceid = deviceid
-        self.roles = roles
-        self.scopes = scopes
-        self.instanceid = instanceid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case host
-        case ip
-        case version
-        case platform
-        case devicefamily = "deviceFamily"
-        case modelidentifier = "modelIdentifier"
-        case mode
-        case lastinputseconds = "lastInputSeconds"
-        case reason
-        case tags
-        case text
-        case ts
-        case deviceid = "deviceId"
-        case roles
-        case scopes
-        case instanceid = "instanceId"
-    }
-}
-
-public struct StateVersion: Codable, Sendable {
-    public let presence: Int
-    public let health: Int
-
-    public init(
-        presence: Int,
-        health: Int
-    ) {
-        self.presence = presence
-        self.health = health
-    }
-    private enum CodingKeys: String, CodingKey {
-        case presence
-        case health
-    }
-}
-
-public struct Snapshot: Codable, Sendable {
-    public let presence: [PresenceEntry]
-    public let health: AnyCodable
-    public let stateversion: StateVersion
-    public let uptimems: Int
-    public let configpath: String?
-    public let statedir: String?
-    public let sessiondefaults: [String: AnyCodable]?
-
-    public init(
-        presence: [PresenceEntry],
-        health: AnyCodable,
-        stateversion: StateVersion,
-        uptimems: Int,
-        configpath: String?,
-        statedir: String?,
-        sessiondefaults: [String: AnyCodable]?
-    ) {
-        self.presence = presence
-        self.health = health
-        self.stateversion = stateversion
-        self.uptimems = uptimems
-        self.configpath = configpath
-        self.statedir = statedir
-        self.sessiondefaults = sessiondefaults
-    }
-    private enum CodingKeys: String, CodingKey {
-        case presence
-        case health
-        case stateversion = "stateVersion"
-        case uptimems = "uptimeMs"
-        case configpath = "configPath"
-        case statedir = "stateDir"
-        case sessiondefaults = "sessionDefaults"
-    }
-}
-
-public struct ErrorShape: Codable, Sendable {
-    public let code: String
-    public let message: String
-    public let details: AnyCodable?
-    public let retryable: Bool?
-    public let retryafterms: Int?
-
-    public init(
-        code: String,
-        message: String,
-        details: AnyCodable?,
-        retryable: Bool?,
-        retryafterms: Int?
-    ) {
-        self.code = code
-        self.message = message
-        self.details = details
-        self.retryable = retryable
-        self.retryafterms = retryafterms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case code
-        case message
-        case details
-        case retryable
-        case retryafterms = "retryAfterMs"
-    }
-}
-
 public struct AgentEvent: Codable, Sendable {
     public let runid: String
     public let seq: Int
@@ -381,89 +40,45 @@ public struct AgentEvent: Codable, Sendable {
     }
 }
 
-public struct SendParams: Codable, Sendable {
-    public let to: String
-    public let message: String
-    public let mediaurl: String?
-    public let mediaurls: [String]?
-    public let gifplayback: Bool?
-    public let channel: String?
-    public let accountid: String?
+public struct AgentIdentityParams: Codable, Sendable {
+    public let agentid: String?
     public let sessionkey: String?
-    public let idempotencykey: String
 
     public init(
-        to: String,
-        message: String,
-        mediaurl: String?,
-        mediaurls: [String]?,
-        gifplayback: Bool?,
-        channel: String?,
-        accountid: String?,
-        sessionkey: String?,
-        idempotencykey: String
+        agentid: String?,
+        sessionkey: String?
     ) {
-        self.to = to
-        self.message = message
-        self.mediaurl = mediaurl
-        self.mediaurls = mediaurls
-        self.gifplayback = gifplayback
-        self.channel = channel
-        self.accountid = accountid
+        self.agentid = agentid
         self.sessionkey = sessionkey
-        self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
-        case to
-        case message
-        case mediaurl = "mediaUrl"
-        case mediaurls = "mediaUrls"
-        case gifplayback = "gifPlayback"
-        case channel
-        case accountid = "accountId"
+        case agentid = "agentId"
         case sessionkey = "sessionKey"
-        case idempotencykey = "idempotencyKey"
     }
 }
 
-public struct PollParams: Codable, Sendable {
-    public let to: String
-    public let question: String
-    public let options: [String]
-    public let maxselections: Int?
-    public let durationhours: Int?
-    public let channel: String?
-    public let accountid: String?
-    public let idempotencykey: String
+public struct AgentIdentityResult: Codable, Sendable {
+    public let agentid: String
+    public let name: String?
+    public let avatar: String?
+    public let emoji: String?
 
     public init(
-        to: String,
-        question: String,
-        options: [String],
-        maxselections: Int?,
-        durationhours: Int?,
-        channel: String?,
-        accountid: String?,
-        idempotencykey: String
+        agentid: String,
+        name: String?,
+        avatar: String?,
+        emoji: String?
     ) {
-        self.to = to
-        self.question = question
-        self.options = options
-        self.maxselections = maxselections
-        self.durationhours = durationhours
-        self.channel = channel
-        self.accountid = accountid
-        self.idempotencykey = idempotencykey
+        self.agentid = agentid
+        self.name = name
+        self.avatar = avatar
+        self.emoji = emoji
     }
     private enum CodingKeys: String, CodingKey {
-        case to
-        case question
-        case options
-        case maxselections = "maxSelections"
-        case durationhours = "durationHours"
-        case channel
-        case accountid = "accountId"
-        case idempotencykey = "idempotencyKey"
+        case agentid = "agentId"
+        case name
+        case avatar
+        case emoji
     }
 }
 
@@ -568,1027 +183,6 @@ public struct AgentParams: Codable, Sendable {
     }
 }
 
-public struct AgentIdentityParams: Codable, Sendable {
-    public let agentid: String?
-    public let sessionkey: String?
-
-    public init(
-        agentid: String?,
-        sessionkey: String?
-    ) {
-        self.agentid = agentid
-        self.sessionkey = sessionkey
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-        case sessionkey = "sessionKey"
-    }
-}
-
-public struct AgentIdentityResult: Codable, Sendable {
-    public let agentid: String
-    public let name: String?
-    public let avatar: String?
-    public let emoji: String?
-
-    public init(
-        agentid: String,
-        name: String?,
-        avatar: String?,
-        emoji: String?
-    ) {
-        self.agentid = agentid
-        self.name = name
-        self.avatar = avatar
-        self.emoji = emoji
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-        case name
-        case avatar
-        case emoji
-    }
-}
-
-public struct AgentWaitParams: Codable, Sendable {
-    public let runid: String
-    public let timeoutms: Int?
-
-    public init(
-        runid: String,
-        timeoutms: Int?
-    ) {
-        self.runid = runid
-        self.timeoutms = timeoutms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case runid = "runId"
-        case timeoutms = "timeoutMs"
-    }
-}
-
-public struct WakeParams: Codable, Sendable {
-    public let mode: AnyCodable
-    public let text: String
-
-    public init(
-        mode: AnyCodable,
-        text: String
-    ) {
-        self.mode = mode
-        self.text = text
-    }
-    private enum CodingKeys: String, CodingKey {
-        case mode
-        case text
-    }
-}
-
-public struct NodePairRequestParams: Codable, Sendable {
-    public let nodeid: String
-    public let displayname: String?
-    public let platform: String?
-    public let version: String?
-    public let coreversion: String?
-    public let uiversion: String?
-    public let devicefamily: String?
-    public let modelidentifier: String?
-    public let caps: [String]?
-    public let commands: [String]?
-    public let remoteip: String?
-    public let silent: Bool?
-
-    public init(
-        nodeid: String,
-        displayname: String?,
-        platform: String?,
-        version: String?,
-        coreversion: String?,
-        uiversion: String?,
-        devicefamily: String?,
-        modelidentifier: String?,
-        caps: [String]?,
-        commands: [String]?,
-        remoteip: String?,
-        silent: Bool?
-    ) {
-        self.nodeid = nodeid
-        self.displayname = displayname
-        self.platform = platform
-        self.version = version
-        self.coreversion = coreversion
-        self.uiversion = uiversion
-        self.devicefamily = devicefamily
-        self.modelidentifier = modelidentifier
-        self.caps = caps
-        self.commands = commands
-        self.remoteip = remoteip
-        self.silent = silent
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case displayname = "displayName"
-        case platform
-        case version
-        case coreversion = "coreVersion"
-        case uiversion = "uiVersion"
-        case devicefamily = "deviceFamily"
-        case modelidentifier = "modelIdentifier"
-        case caps
-        case commands
-        case remoteip = "remoteIp"
-        case silent
-    }
-}
-
-public struct NodePairListParams: Codable, Sendable {
-}
-
-public struct NodePairApproveParams: Codable, Sendable {
-    public let requestid: String
-
-    public init(
-        requestid: String
-    ) {
-        self.requestid = requestid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case requestid = "requestId"
-    }
-}
-
-public struct NodePairRejectParams: Codable, Sendable {
-    public let requestid: String
-
-    public init(
-        requestid: String
-    ) {
-        self.requestid = requestid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case requestid = "requestId"
-    }
-}
-
-public struct NodePairVerifyParams: Codable, Sendable {
-    public let nodeid: String
-    public let token: String
-
-    public init(
-        nodeid: String,
-        token: String
-    ) {
-        self.nodeid = nodeid
-        self.token = token
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case token
-    }
-}
-
-public struct NodeRenameParams: Codable, Sendable {
-    public let nodeid: String
-    public let displayname: String
-
-    public init(
-        nodeid: String,
-        displayname: String
-    ) {
-        self.nodeid = nodeid
-        self.displayname = displayname
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case displayname = "displayName"
-    }
-}
-
-public struct NodeListParams: Codable, Sendable {
-}
-
-public struct NodeDescribeParams: Codable, Sendable {
-    public let nodeid: String
-
-    public init(
-        nodeid: String
-    ) {
-        self.nodeid = nodeid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-    }
-}
-
-public struct NodeInvokeParams: Codable, Sendable {
-    public let nodeid: String
-    public let command: String
-    public let params: AnyCodable?
-    public let timeoutms: Int?
-    public let idempotencykey: String
-
-    public init(
-        nodeid: String,
-        command: String,
-        params: AnyCodable?,
-        timeoutms: Int?,
-        idempotencykey: String
-    ) {
-        self.nodeid = nodeid
-        self.command = command
-        self.params = params
-        self.timeoutms = timeoutms
-        self.idempotencykey = idempotencykey
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case command
-        case params
-        case timeoutms = "timeoutMs"
-        case idempotencykey = "idempotencyKey"
-    }
-}
-
-public struct NodeInvokeResultParams: Codable, Sendable {
-    public let id: String
-    public let nodeid: String
-    public let ok: Bool
-    public let payload: AnyCodable?
-    public let payloadjson: String?
-    public let error: [String: AnyCodable]?
-
-    public init(
-        id: String,
-        nodeid: String,
-        ok: Bool,
-        payload: AnyCodable?,
-        payloadjson: String?,
-        error: [String: AnyCodable]?
-    ) {
-        self.id = id
-        self.nodeid = nodeid
-        self.ok = ok
-        self.payload = payload
-        self.payloadjson = payloadjson
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case nodeid = "nodeId"
-        case ok
-        case payload
-        case payloadjson = "payloadJSON"
-        case error
-    }
-}
-
-public struct NodeEventParams: Codable, Sendable {
-    public let event: String
-    public let payload: AnyCodable?
-    public let payloadjson: String?
-
-    public init(
-        event: String,
-        payload: AnyCodable?,
-        payloadjson: String?
-    ) {
-        self.event = event
-        self.payload = payload
-        self.payloadjson = payloadjson
-    }
-    private enum CodingKeys: String, CodingKey {
-        case event
-        case payload
-        case payloadjson = "payloadJSON"
-    }
-}
-
-public struct NodeInvokeRequestEvent: Codable, Sendable {
-    public let id: String
-    public let nodeid: String
-    public let command: String
-    public let paramsjson: String?
-    public let timeoutms: Int?
-    public let idempotencykey: String?
-
-    public init(
-        id: String,
-        nodeid: String,
-        command: String,
-        paramsjson: String?,
-        timeoutms: Int?,
-        idempotencykey: String?
-    ) {
-        self.id = id
-        self.nodeid = nodeid
-        self.command = command
-        self.paramsjson = paramsjson
-        self.timeoutms = timeoutms
-        self.idempotencykey = idempotencykey
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case nodeid = "nodeId"
-        case command
-        case paramsjson = "paramsJSON"
-        case timeoutms = "timeoutMs"
-        case idempotencykey = "idempotencyKey"
-    }
-}
-
-public struct SessionsListParams: Codable, Sendable {
-    public let limit: Int?
-    public let activeminutes: Int?
-    public let includeglobal: Bool?
-    public let includeunknown: Bool?
-    public let includederivedtitles: Bool?
-    public let includelastmessage: Bool?
-    public let label: String?
-    public let spawnedby: String?
-    public let agentid: String?
-    public let search: String?
-
-    public init(
-        limit: Int?,
-        activeminutes: Int?,
-        includeglobal: Bool?,
-        includeunknown: Bool?,
-        includederivedtitles: Bool?,
-        includelastmessage: Bool?,
-        label: String?,
-        spawnedby: String?,
-        agentid: String?,
-        search: String?
-    ) {
-        self.limit = limit
-        self.activeminutes = activeminutes
-        self.includeglobal = includeglobal
-        self.includeunknown = includeunknown
-        self.includederivedtitles = includederivedtitles
-        self.includelastmessage = includelastmessage
-        self.label = label
-        self.spawnedby = spawnedby
-        self.agentid = agentid
-        self.search = search
-    }
-    private enum CodingKeys: String, CodingKey {
-        case limit
-        case activeminutes = "activeMinutes"
-        case includeglobal = "includeGlobal"
-        case includeunknown = "includeUnknown"
-        case includederivedtitles = "includeDerivedTitles"
-        case includelastmessage = "includeLastMessage"
-        case label
-        case spawnedby = "spawnedBy"
-        case agentid = "agentId"
-        case search
-    }
-}
-
-public struct SessionsPreviewParams: Codable, Sendable {
-    public let keys: [String]
-    public let limit: Int?
-    public let maxchars: Int?
-
-    public init(
-        keys: [String],
-        limit: Int?,
-        maxchars: Int?
-    ) {
-        self.keys = keys
-        self.limit = limit
-        self.maxchars = maxchars
-    }
-    private enum CodingKeys: String, CodingKey {
-        case keys
-        case limit
-        case maxchars = "maxChars"
-    }
-}
-
-public struct SessionsResolveParams: Codable, Sendable {
-    public let key: String?
-    public let sessionid: String?
-    public let label: String?
-    public let agentid: String?
-    public let spawnedby: String?
-    public let includeglobal: Bool?
-    public let includeunknown: Bool?
-
-    public init(
-        key: String?,
-        sessionid: String?,
-        label: String?,
-        agentid: String?,
-        spawnedby: String?,
-        includeglobal: Bool?,
-        includeunknown: Bool?
-    ) {
-        self.key = key
-        self.sessionid = sessionid
-        self.label = label
-        self.agentid = agentid
-        self.spawnedby = spawnedby
-        self.includeglobal = includeglobal
-        self.includeunknown = includeunknown
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case sessionid = "sessionId"
-        case label
-        case agentid = "agentId"
-        case spawnedby = "spawnedBy"
-        case includeglobal = "includeGlobal"
-        case includeunknown = "includeUnknown"
-    }
-}
-
-public struct SessionsPatchParams: Codable, Sendable {
-    public let key: String
-    public let label: AnyCodable?
-    public let thinkinglevel: AnyCodable?
-    public let verboselevel: AnyCodable?
-    public let reasoninglevel: AnyCodable?
-    public let responseusage: AnyCodable?
-    public let elevatedlevel: AnyCodable?
-    public let exechost: AnyCodable?
-    public let execsecurity: AnyCodable?
-    public let execask: AnyCodable?
-    public let execnode: AnyCodable?
-    public let model: AnyCodable?
-    public let spawnedby: AnyCodable?
-    public let sendpolicy: AnyCodable?
-    public let groupactivation: AnyCodable?
-
-    public init(
-        key: String,
-        label: AnyCodable?,
-        thinkinglevel: AnyCodable?,
-        verboselevel: AnyCodable?,
-        reasoninglevel: AnyCodable?,
-        responseusage: AnyCodable?,
-        elevatedlevel: AnyCodable?,
-        exechost: AnyCodable?,
-        execsecurity: AnyCodable?,
-        execask: AnyCodable?,
-        execnode: AnyCodable?,
-        model: AnyCodable?,
-        spawnedby: AnyCodable?,
-        sendpolicy: AnyCodable?,
-        groupactivation: AnyCodable?
-    ) {
-        self.key = key
-        self.label = label
-        self.thinkinglevel = thinkinglevel
-        self.verboselevel = verboselevel
-        self.reasoninglevel = reasoninglevel
-        self.responseusage = responseusage
-        self.elevatedlevel = elevatedlevel
-        self.exechost = exechost
-        self.execsecurity = execsecurity
-        self.execask = execask
-        self.execnode = execnode
-        self.model = model
-        self.spawnedby = spawnedby
-        self.sendpolicy = sendpolicy
-        self.groupactivation = groupactivation
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case label
-        case thinkinglevel = "thinkingLevel"
-        case verboselevel = "verboseLevel"
-        case reasoninglevel = "reasoningLevel"
-        case responseusage = "responseUsage"
-        case elevatedlevel = "elevatedLevel"
-        case exechost = "execHost"
-        case execsecurity = "execSecurity"
-        case execask = "execAsk"
-        case execnode = "execNode"
-        case model
-        case spawnedby = "spawnedBy"
-        case sendpolicy = "sendPolicy"
-        case groupactivation = "groupActivation"
-    }
-}
-
-public struct SessionsResetParams: Codable, Sendable {
-    public let key: String
-
-    public init(
-        key: String
-    ) {
-        self.key = key
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-    }
-}
-
-public struct SessionsDeleteParams: Codable, Sendable {
-    public let key: String
-    public let deletetranscript: Bool?
-
-    public init(
-        key: String,
-        deletetranscript: Bool?
-    ) {
-        self.key = key
-        self.deletetranscript = deletetranscript
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case deletetranscript = "deleteTranscript"
-    }
-}
-
-public struct SessionsCompactParams: Codable, Sendable {
-    public let key: String
-    public let maxlines: Int?
-
-    public init(
-        key: String,
-        maxlines: Int?
-    ) {
-        self.key = key
-        self.maxlines = maxlines
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case maxlines = "maxLines"
-    }
-}
-
-public struct SessionsUsageParams: Codable, Sendable {
-    public let key: String?
-    public let startdate: String?
-    public let enddate: String?
-    public let limit: Int?
-    public let includecontextweight: Bool?
-
-    public init(
-        key: String?,
-        startdate: String?,
-        enddate: String?,
-        limit: Int?,
-        includecontextweight: Bool?
-    ) {
-        self.key = key
-        self.startdate = startdate
-        self.enddate = enddate
-        self.limit = limit
-        self.includecontextweight = includecontextweight
-    }
-    private enum CodingKeys: String, CodingKey {
-        case key
-        case startdate = "startDate"
-        case enddate = "endDate"
-        case limit
-        case includecontextweight = "includeContextWeight"
-    }
-}
-
-public struct ConfigGetParams: Codable, Sendable {
-}
-
-public struct ConfigSetParams: Codable, Sendable {
-    public let raw: String
-    public let basehash: String?
-
-    public init(
-        raw: String,
-        basehash: String?
-    ) {
-        self.raw = raw
-        self.basehash = basehash
-    }
-    private enum CodingKeys: String, CodingKey {
-        case raw
-        case basehash = "baseHash"
-    }
-}
-
-public struct ConfigApplyParams: Codable, Sendable {
-    public let raw: String
-    public let basehash: String?
-    public let sessionkey: String?
-    public let note: String?
-    public let restartdelayms: Int?
-
-    public init(
-        raw: String,
-        basehash: String?,
-        sessionkey: String?,
-        note: String?,
-        restartdelayms: Int?
-    ) {
-        self.raw = raw
-        self.basehash = basehash
-        self.sessionkey = sessionkey
-        self.note = note
-        self.restartdelayms = restartdelayms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case raw
-        case basehash = "baseHash"
-        case sessionkey = "sessionKey"
-        case note
-        case restartdelayms = "restartDelayMs"
-    }
-}
-
-public struct ConfigPatchParams: Codable, Sendable {
-    public let raw: String
-    public let basehash: String?
-    public let sessionkey: String?
-    public let note: String?
-    public let restartdelayms: Int?
-
-    public init(
-        raw: String,
-        basehash: String?,
-        sessionkey: String?,
-        note: String?,
-        restartdelayms: Int?
-    ) {
-        self.raw = raw
-        self.basehash = basehash
-        self.sessionkey = sessionkey
-        self.note = note
-        self.restartdelayms = restartdelayms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case raw
-        case basehash = "baseHash"
-        case sessionkey = "sessionKey"
-        case note
-        case restartdelayms = "restartDelayMs"
-    }
-}
-
-public struct ConfigSchemaParams: Codable, Sendable {
-}
-
-public struct ConfigSchemaResponse: Codable, Sendable {
-    public let schema: AnyCodable
-    public let uihints: [String: AnyCodable]
-    public let version: String
-    public let generatedat: String
-
-    public init(
-        schema: AnyCodable,
-        uihints: [String: AnyCodable],
-        version: String,
-        generatedat: String
-    ) {
-        self.schema = schema
-        self.uihints = uihints
-        self.version = version
-        self.generatedat = generatedat
-    }
-    private enum CodingKeys: String, CodingKey {
-        case schema
-        case uihints = "uiHints"
-        case version
-        case generatedat = "generatedAt"
-    }
-}
-
-public struct WizardStartParams: Codable, Sendable {
-    public let mode: AnyCodable?
-    public let workspace: String?
-
-    public init(
-        mode: AnyCodable?,
-        workspace: String?
-    ) {
-        self.mode = mode
-        self.workspace = workspace
-    }
-    private enum CodingKeys: String, CodingKey {
-        case mode
-        case workspace
-    }
-}
-
-public struct WizardNextParams: Codable, Sendable {
-    public let sessionid: String
-    public let answer: [String: AnyCodable]?
-
-    public init(
-        sessionid: String,
-        answer: [String: AnyCodable]?
-    ) {
-        self.sessionid = sessionid
-        self.answer = answer
-    }
-    private enum CodingKeys: String, CodingKey {
-        case sessionid = "sessionId"
-        case answer
-    }
-}
-
-public struct WizardCancelParams: Codable, Sendable {
-    public let sessionid: String
-
-    public init(
-        sessionid: String
-    ) {
-        self.sessionid = sessionid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case sessionid = "sessionId"
-    }
-}
-
-public struct WizardStatusParams: Codable, Sendable {
-    public let sessionid: String
-
-    public init(
-        sessionid: String
-    ) {
-        self.sessionid = sessionid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case sessionid = "sessionId"
-    }
-}
-
-public struct WizardStep: Codable, Sendable {
-    public let id: String
-    public let type: AnyCodable
-    public let title: String?
-    public let message: String?
-    public let options: [[String: AnyCodable]]?
-    public let initialvalue: AnyCodable?
-    public let placeholder: String?
-    public let sensitive: Bool?
-    public let executor: AnyCodable?
-
-    public init(
-        id: String,
-        type: AnyCodable,
-        title: String?,
-        message: String?,
-        options: [[String: AnyCodable]]?,
-        initialvalue: AnyCodable?,
-        placeholder: String?,
-        sensitive: Bool?,
-        executor: AnyCodable?
-    ) {
-        self.id = id
-        self.type = type
-        self.title = title
-        self.message = message
-        self.options = options
-        self.initialvalue = initialvalue
-        self.placeholder = placeholder
-        self.sensitive = sensitive
-        self.executor = executor
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case type
-        case title
-        case message
-        case options
-        case initialvalue = "initialValue"
-        case placeholder
-        case sensitive
-        case executor
-    }
-}
-
-public struct WizardNextResult: Codable, Sendable {
-    public let done: Bool
-    public let step: [String: AnyCodable]?
-    public let status: AnyCodable?
-    public let error: String?
-
-    public init(
-        done: Bool,
-        step: [String: AnyCodable]?,
-        status: AnyCodable?,
-        error: String?
-    ) {
-        self.done = done
-        self.step = step
-        self.status = status
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case done
-        case step
-        case status
-        case error
-    }
-}
-
-public struct WizardStartResult: Codable, Sendable {
-    public let sessionid: String
-    public let done: Bool
-    public let step: [String: AnyCodable]?
-    public let status: AnyCodable?
-    public let error: String?
-
-    public init(
-        sessionid: String,
-        done: Bool,
-        step: [String: AnyCodable]?,
-        status: AnyCodable?,
-        error: String?
-    ) {
-        self.sessionid = sessionid
-        self.done = done
-        self.step = step
-        self.status = status
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case sessionid = "sessionId"
-        case done
-        case step
-        case status
-        case error
-    }
-}
-
-public struct WizardStatusResult: Codable, Sendable {
-    public let status: AnyCodable
-    public let error: String?
-
-    public init(
-        status: AnyCodable,
-        error: String?
-    ) {
-        self.status = status
-        self.error = error
-    }
-    private enum CodingKeys: String, CodingKey {
-        case status
-        case error
-    }
-}
-
-public struct TalkModeParams: Codable, Sendable {
-    public let enabled: Bool
-    public let phase: String?
-
-    public init(
-        enabled: Bool,
-        phase: String?
-    ) {
-        self.enabled = enabled
-        self.phase = phase
-    }
-    private enum CodingKeys: String, CodingKey {
-        case enabled
-        case phase
-    }
-}
-
-public struct ChannelsStatusParams: Codable, Sendable {
-    public let probe: Bool?
-    public let timeoutms: Int?
-
-    public init(
-        probe: Bool?,
-        timeoutms: Int?
-    ) {
-        self.probe = probe
-        self.timeoutms = timeoutms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case probe
-        case timeoutms = "timeoutMs"
-    }
-}
-
-public struct ChannelsStatusResult: Codable, Sendable {
-    public let ts: Int
-    public let channelorder: [String]
-    public let channellabels: [String: AnyCodable]
-    public let channeldetaillabels: [String: AnyCodable]?
-    public let channelsystemimages: [String: AnyCodable]?
-    public let channelmeta: [[String: AnyCodable]]?
-    public let channels: [String: AnyCodable]
-    public let channelaccounts: [String: AnyCodable]
-    public let channeldefaultaccountid: [String: AnyCodable]
-
-    public init(
-        ts: Int,
-        channelorder: [String],
-        channellabels: [String: AnyCodable],
-        channeldetaillabels: [String: AnyCodable]?,
-        channelsystemimages: [String: AnyCodable]?,
-        channelmeta: [[String: AnyCodable]]?,
-        channels: [String: AnyCodable],
-        channelaccounts: [String: AnyCodable],
-        channeldefaultaccountid: [String: AnyCodable]
-    ) {
-        self.ts = ts
-        self.channelorder = channelorder
-        self.channellabels = channellabels
-        self.channeldetaillabels = channeldetaillabels
-        self.channelsystemimages = channelsystemimages
-        self.channelmeta = channelmeta
-        self.channels = channels
-        self.channelaccounts = channelaccounts
-        self.channeldefaultaccountid = channeldefaultaccountid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case ts
-        case channelorder = "channelOrder"
-        case channellabels = "channelLabels"
-        case channeldetaillabels = "channelDetailLabels"
-        case channelsystemimages = "channelSystemImages"
-        case channelmeta = "channelMeta"
-        case channels
-        case channelaccounts = "channelAccounts"
-        case channeldefaultaccountid = "channelDefaultAccountId"
-    }
-}
-
-public struct ChannelsLogoutParams: Codable, Sendable {
-    public let channel: String
-    public let accountid: String?
-
-    public init(
-        channel: String,
-        accountid: String?
-    ) {
-        self.channel = channel
-        self.accountid = accountid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case channel
-        case accountid = "accountId"
-    }
-}
-
-public struct WebLoginStartParams: Codable, Sendable {
-    public let force: Bool?
-    public let timeoutms: Int?
-    public let verbose: Bool?
-    public let accountid: String?
-
-    public init(
-        force: Bool?,
-        timeoutms: Int?,
-        verbose: Bool?,
-        accountid: String?
-    ) {
-        self.force = force
-        self.timeoutms = timeoutms
-        self.verbose = verbose
-        self.accountid = accountid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case force
-        case timeoutms = "timeoutMs"
-        case verbose
-        case accountid = "accountId"
-    }
-}
-
-public struct WebLoginWaitParams: Codable, Sendable {
-    public let timeoutms: Int?
-    public let accountid: String?
-
-    public init(
-        timeoutms: Int?,
-        accountid: String?
-    ) {
-        self.timeoutms = timeoutms
-        self.accountid = accountid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case timeoutms = "timeoutMs"
-        case accountid = "accountId"
-    }
-}
-
-public struct AgentSummary: Codable, Sendable {
-    public let id: String
-    public let name: String?
-    public let identity: [String: AnyCodable]?
-
-    public init(
-        id: String,
-        name: String?,
-        identity: [String: AnyCodable]?
-    ) {
-        self.id = id
-        self.name = name
-        self.identity = identity
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case name
-        case identity
-    }
-}
-
 public struct AgentsCreateParams: Codable, Sendable {
     public let name: String
     public let workspace: String
@@ -1636,52 +230,6 @@ public struct AgentsCreateResult: Codable, Sendable {
         case agentid = "agentId"
         case name
         case workspace
-    }
-}
-
-public struct AgentsUpdateParams: Codable, Sendable {
-    public let agentid: String
-    public let name: String?
-    public let workspace: String?
-    public let model: String?
-    public let avatar: String?
-
-    public init(
-        agentid: String,
-        name: String?,
-        workspace: String?,
-        model: String?,
-        avatar: String?
-    ) {
-        self.agentid = agentid
-        self.name = name
-        self.workspace = workspace
-        self.model = model
-        self.avatar = avatar
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-        case name
-        case workspace
-        case model
-        case avatar
-    }
-}
-
-public struct AgentsUpdateResult: Codable, Sendable {
-    public let ok: Bool
-    public let agentid: String
-
-    public init(
-        ok: Bool,
-        agentid: String
-    ) {
-        self.ok = ok
-        self.agentid = agentid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case agentid = "agentId"
     }
 }
 
@@ -1756,40 +304,6 @@ public struct AgentsFileEntry: Codable, Sendable {
     }
 }
 
-public struct AgentsFilesListParams: Codable, Sendable {
-    public let agentid: String
-
-    public init(
-        agentid: String
-    ) {
-        self.agentid = agentid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-    }
-}
-
-public struct AgentsFilesListResult: Codable, Sendable {
-    public let agentid: String
-    public let workspace: String
-    public let files: [AgentsFileEntry]
-
-    public init(
-        agentid: String,
-        workspace: String,
-        files: [AgentsFileEntry]
-    ) {
-        self.agentid = agentid
-        self.workspace = workspace
-        self.files = files
-    }
-    private enum CodingKeys: String, CodingKey {
-        case agentid = "agentId"
-        case workspace
-        case files
-    }
-}
-
 public struct AgentsFilesGetParams: Codable, Sendable {
     public let agentid: String
     public let name: String
@@ -1825,6 +339,40 @@ public struct AgentsFilesGetResult: Codable, Sendable {
         case agentid = "agentId"
         case workspace
         case file
+    }
+}
+
+public struct AgentsFilesListParams: Codable, Sendable {
+    public let agentid: String
+
+    public init(
+        agentid: String
+    ) {
+        self.agentid = agentid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+    }
+}
+
+public struct AgentsFilesListResult: Codable, Sendable {
+    public let agentid: String
+    public let workspace: String
+    public let files: [AgentsFileEntry]
+
+    public init(
+        agentid: String,
+        workspace: String,
+        files: [AgentsFileEntry]
+    ) {
+        self.agentid = agentid
+        self.workspace = workspace
+        self.files = files
+    }
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case workspace
+        case files
     }
 }
 
@@ -1902,123 +450,515 @@ public struct AgentsListResult: Codable, Sendable {
     }
 }
 
-public struct ModelChoice: Codable, Sendable {
+public struct AgentSummary: Codable, Sendable {
     public let id: String
-    public let name: String
-    public let provider: String
-    public let contextwindow: Int?
-    public let reasoning: Bool?
+    public let name: String?
+    public let identity: [String: AnyCodable]?
 
     public init(
         id: String,
-        name: String,
-        provider: String,
-        contextwindow: Int?,
-        reasoning: Bool?
+        name: String?,
+        identity: [String: AnyCodable]?
     ) {
         self.id = id
         self.name = name
-        self.provider = provider
-        self.contextwindow = contextwindow
-        self.reasoning = reasoning
+        self.identity = identity
     }
     private enum CodingKeys: String, CodingKey {
         case id
         case name
-        case provider
-        case contextwindow = "contextWindow"
-        case reasoning
+        case identity
     }
 }
 
-public struct ModelsListParams: Codable, Sendable {
-}
-
-public struct ModelsListResult: Codable, Sendable {
-    public let models: [ModelChoice]
+public struct AgentsUpdateParams: Codable, Sendable {
+    public let agentid: String
+    public let name: String?
+    public let workspace: String?
+    public let model: String?
+    public let avatar: String?
 
     public init(
-        models: [ModelChoice]
+        agentid: String,
+        name: String?,
+        workspace: String?,
+        model: String?,
+        avatar: String?
     ) {
-        self.models = models
+        self.agentid = agentid
+        self.name = name
+        self.workspace = workspace
+        self.model = model
+        self.avatar = avatar
     }
     private enum CodingKeys: String, CodingKey {
-        case models
+        case agentid = "agentId"
+        case name
+        case workspace
+        case model
+        case avatar
     }
 }
 
-public struct SkillsStatusParams: Codable, Sendable {
-    public let agentid: String?
+public struct AgentsUpdateResult: Codable, Sendable {
+    public let ok: Bool
+    public let agentid: String
 
     public init(
-        agentid: String?
+        ok: Bool,
+        agentid: String
     ) {
+        self.ok = ok
         self.agentid = agentid
     }
     private enum CodingKeys: String, CodingKey {
+        case ok
         case agentid = "agentId"
     }
 }
 
-public struct SkillsBinsParams: Codable, Sendable {
-}
-
-public struct SkillsBinsResult: Codable, Sendable {
-    public let bins: [String]
-
-    public init(
-        bins: [String]
-    ) {
-        self.bins = bins
-    }
-    private enum CodingKeys: String, CodingKey {
-        case bins
-    }
-}
-
-public struct SkillsInstallParams: Codable, Sendable {
-    public let name: String
-    public let installid: String
+public struct AgentWaitParams: Codable, Sendable {
+    public let runid: String
     public let timeoutms: Int?
 
     public init(
-        name: String,
-        installid: String,
+        runid: String,
         timeoutms: Int?
     ) {
-        self.name = name
-        self.installid = installid
+        self.runid = runid
         self.timeoutms = timeoutms
     }
     private enum CodingKeys: String, CodingKey {
-        case name
-        case installid = "installId"
+        case runid = "runId"
         case timeoutms = "timeoutMs"
     }
 }
 
-public struct SkillsUpdateParams: Codable, Sendable {
-    public let skillkey: String
-    public let enabled: Bool?
-    public let apikey: String?
-    public let env: [String: AnyCodable]?
+public struct ChannelsLogoutParams: Codable, Sendable {
+    public let channel: String
+    public let accountid: String?
 
     public init(
-        skillkey: String,
-        enabled: Bool?,
-        apikey: String?,
-        env: [String: AnyCodable]?
+        channel: String,
+        accountid: String?
     ) {
-        self.skillkey = skillkey
-        self.enabled = enabled
-        self.apikey = apikey
-        self.env = env
+        self.channel = channel
+        self.accountid = accountid
     }
     private enum CodingKeys: String, CodingKey {
-        case skillkey = "skillKey"
+        case channel
+        case accountid = "accountId"
+    }
+}
+
+public struct ChannelsStatusParams: Codable, Sendable {
+    public let probe: Bool?
+    public let timeoutms: Int?
+
+    public init(
+        probe: Bool?,
+        timeoutms: Int?
+    ) {
+        self.probe = probe
+        self.timeoutms = timeoutms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case probe
+        case timeoutms = "timeoutMs"
+    }
+}
+
+public struct ChannelsStatusResult: Codable, Sendable {
+    public let ts: Int
+    public let channelorder: [String]
+    public let channellabels: [String: AnyCodable]
+    public let channeldetaillabels: [String: AnyCodable]?
+    public let channelsystemimages: [String: AnyCodable]?
+    public let channelmeta: [[String: AnyCodable]]?
+    public let channels: [String: AnyCodable]
+    public let channelaccounts: [String: AnyCodable]
+    public let channeldefaultaccountid: [String: AnyCodable]
+
+    public init(
+        ts: Int,
+        channelorder: [String],
+        channellabels: [String: AnyCodable],
+        channeldetaillabels: [String: AnyCodable]?,
+        channelsystemimages: [String: AnyCodable]?,
+        channelmeta: [[String: AnyCodable]]?,
+        channels: [String: AnyCodable],
+        channelaccounts: [String: AnyCodable],
+        channeldefaultaccountid: [String: AnyCodable]
+    ) {
+        self.ts = ts
+        self.channelorder = channelorder
+        self.channellabels = channellabels
+        self.channeldetaillabels = channeldetaillabels
+        self.channelsystemimages = channelsystemimages
+        self.channelmeta = channelmeta
+        self.channels = channels
+        self.channelaccounts = channelaccounts
+        self.channeldefaultaccountid = channeldefaultaccountid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case ts
+        case channelorder = "channelOrder"
+        case channellabels = "channelLabels"
+        case channeldetaillabels = "channelDetailLabels"
+        case channelsystemimages = "channelSystemImages"
+        case channelmeta = "channelMeta"
+        case channels
+        case channelaccounts = "channelAccounts"
+        case channeldefaultaccountid = "channelDefaultAccountId"
+    }
+}
+
+public struct ChatAbortParams: Codable, Sendable {
+    public let sessionkey: String
+    public let runid: String?
+
+    public init(
+        sessionkey: String,
+        runid: String?
+    ) {
+        self.sessionkey = sessionkey
+        self.runid = runid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case runid = "runId"
+    }
+}
+
+public struct ChatEvent: Codable, Sendable {
+    public let runid: String
+    public let sessionkey: String
+    public let seq: Int
+    public let state: AnyCodable
+    public let message: AnyCodable?
+    public let errormessage: String?
+    public let usage: AnyCodable?
+    public let stopreason: String?
+
+    public init(
+        runid: String,
+        sessionkey: String,
+        seq: Int,
+        state: AnyCodable,
+        message: AnyCodable?,
+        errormessage: String?,
+        usage: AnyCodable?,
+        stopreason: String?
+    ) {
+        self.runid = runid
+        self.sessionkey = sessionkey
+        self.seq = seq
+        self.state = state
+        self.message = message
+        self.errormessage = errormessage
+        self.usage = usage
+        self.stopreason = stopreason
+    }
+    private enum CodingKeys: String, CodingKey {
+        case runid = "runId"
+        case sessionkey = "sessionKey"
+        case seq
+        case state
+        case message
+        case errormessage = "errorMessage"
+        case usage
+        case stopreason = "stopReason"
+    }
+}
+
+public struct ChatHistoryParams: Codable, Sendable {
+    public let sessionkey: String
+    public let limit: Int?
+
+    public init(
+        sessionkey: String,
+        limit: Int?
+    ) {
+        self.sessionkey = sessionkey
+        self.limit = limit
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case limit
+    }
+}
+
+public struct ChatInjectParams: Codable, Sendable {
+    public let sessionkey: String
+    public let message: String
+    public let label: String?
+
+    public init(
+        sessionkey: String,
+        message: String,
+        label: String?
+    ) {
+        self.sessionkey = sessionkey
+        self.message = message
+        self.label = label
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case message
+        case label
+    }
+}
+
+public struct ChatSendParams: Codable, Sendable {
+    public let sessionkey: String
+    public let message: String
+    public let thinking: String?
+    public let deliver: Bool?
+    public let attachments: [AnyCodable]?
+    public let timeoutms: Int?
+    public let idempotencykey: String
+
+    public init(
+        sessionkey: String,
+        message: String,
+        thinking: String?,
+        deliver: Bool?,
+        attachments: [AnyCodable]?,
+        timeoutms: Int?,
+        idempotencykey: String
+    ) {
+        self.sessionkey = sessionkey
+        self.message = message
+        self.thinking = thinking
+        self.deliver = deliver
+        self.attachments = attachments
+        self.timeoutms = timeoutms
+        self.idempotencykey = idempotencykey
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case message
+        case thinking
+        case deliver
+        case attachments
+        case timeoutms = "timeoutMs"
+        case idempotencykey = "idempotencyKey"
+    }
+}
+
+public struct ConfigApplyParams: Codable, Sendable {
+    public let raw: String
+    public let basehash: String?
+    public let sessionkey: String?
+    public let note: String?
+    public let restartdelayms: Int?
+
+    public init(
+        raw: String,
+        basehash: String?,
+        sessionkey: String?,
+        note: String?,
+        restartdelayms: Int?
+    ) {
+        self.raw = raw
+        self.basehash = basehash
+        self.sessionkey = sessionkey
+        self.note = note
+        self.restartdelayms = restartdelayms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case raw
+        case basehash = "baseHash"
+        case sessionkey = "sessionKey"
+        case note
+        case restartdelayms = "restartDelayMs"
+    }
+}
+
+public struct ConfigGetParams: Codable, Sendable {
+}
+
+public struct ConfigPatchParams: Codable, Sendable {
+    public let raw: String
+    public let basehash: String?
+    public let sessionkey: String?
+    public let note: String?
+    public let restartdelayms: Int?
+
+    public init(
+        raw: String,
+        basehash: String?,
+        sessionkey: String?,
+        note: String?,
+        restartdelayms: Int?
+    ) {
+        self.raw = raw
+        self.basehash = basehash
+        self.sessionkey = sessionkey
+        self.note = note
+        self.restartdelayms = restartdelayms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case raw
+        case basehash = "baseHash"
+        case sessionkey = "sessionKey"
+        case note
+        case restartdelayms = "restartDelayMs"
+    }
+}
+
+public struct ConfigSchemaParams: Codable, Sendable {
+}
+
+public struct ConfigSchemaResponse: Codable, Sendable {
+    public let schema: AnyCodable
+    public let uihints: [String: AnyCodable]
+    public let version: String
+    public let generatedat: String
+
+    public init(
+        schema: AnyCodable,
+        uihints: [String: AnyCodable],
+        version: String,
+        generatedat: String
+    ) {
+        self.schema = schema
+        self.uihints = uihints
+        self.version = version
+        self.generatedat = generatedat
+    }
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case uihints = "uiHints"
+        case version
+        case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSetParams: Codable, Sendable {
+    public let raw: String
+    public let basehash: String?
+
+    public init(
+        raw: String,
+        basehash: String?
+    ) {
+        self.raw = raw
+        self.basehash = basehash
+    }
+    private enum CodingKeys: String, CodingKey {
+        case raw
+        case basehash = "baseHash"
+    }
+}
+
+public struct ConnectParams: Codable, Sendable {
+    public let minprotocol: Int
+    public let maxprotocol: Int
+    public let client: [String: AnyCodable]
+    public let caps: [String]?
+    public let commands: [String]?
+    public let permissions: [String: AnyCodable]?
+    public let pathenv: String?
+    public let role: String?
+    public let scopes: [String]?
+    public let device: [String: AnyCodable]?
+    public let auth: [String: AnyCodable]?
+    public let locale: String?
+    public let useragent: String?
+
+    public init(
+        minprotocol: Int,
+        maxprotocol: Int,
+        client: [String: AnyCodable],
+        caps: [String]?,
+        commands: [String]?,
+        permissions: [String: AnyCodable]?,
+        pathenv: String?,
+        role: String?,
+        scopes: [String]?,
+        device: [String: AnyCodable]?,
+        auth: [String: AnyCodable]?,
+        locale: String?,
+        useragent: String?
+    ) {
+        self.minprotocol = minprotocol
+        self.maxprotocol = maxprotocol
+        self.client = client
+        self.caps = caps
+        self.commands = commands
+        self.permissions = permissions
+        self.pathenv = pathenv
+        self.role = role
+        self.scopes = scopes
+        self.device = device
+        self.auth = auth
+        self.locale = locale
+        self.useragent = useragent
+    }
+    private enum CodingKeys: String, CodingKey {
+        case minprotocol = "minProtocol"
+        case maxprotocol = "maxProtocol"
+        case client
+        case caps
+        case commands
+        case permissions
+        case pathenv = "pathEnv"
+        case role
+        case scopes
+        case device
+        case auth
+        case locale
+        case useragent = "userAgent"
+    }
+}
+
+public struct CronAddParams: Codable, Sendable {
+    public let name: String
+    public let agentid: AnyCodable?
+    public let description: String?
+    public let enabled: Bool?
+    public let deleteafterrun: Bool?
+    public let schedule: AnyCodable
+    public let sessiontarget: AnyCodable
+    public let wakemode: AnyCodable
+    public let payload: AnyCodable
+    public let delivery: [String: AnyCodable]?
+
+    public init(
+        name: String,
+        agentid: AnyCodable?,
+        description: String?,
+        enabled: Bool?,
+        deleteafterrun: Bool?,
+        schedule: AnyCodable,
+        sessiontarget: AnyCodable,
+        wakemode: AnyCodable,
+        payload: AnyCodable,
+        delivery: [String: AnyCodable]?
+    ) {
+        self.name = name
+        self.agentid = agentid
+        self.description = description
+        self.enabled = enabled
+        self.deleteafterrun = deleteafterrun
+        self.schedule = schedule
+        self.sessiontarget = sessiontarget
+        self.wakemode = wakemode
+        self.payload = payload
+        self.delivery = delivery
+    }
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case agentid = "agentId"
+        case description
         case enabled
-        case apikey = "apiKey"
-        case env
+        case deleteafterrun = "deleteAfterRun"
+        case schedule
+        case sessiontarget = "sessionTarget"
+        case wakemode = "wakeMode"
+        case payload
+        case delivery
     }
 }
 
@@ -2100,58 +1040,6 @@ public struct CronListParams: Codable, Sendable {
     }
 }
 
-public struct CronStatusParams: Codable, Sendable {
-}
-
-public struct CronAddParams: Codable, Sendable {
-    public let name: String
-    public let agentid: AnyCodable?
-    public let description: String?
-    public let enabled: Bool?
-    public let deleteafterrun: Bool?
-    public let schedule: AnyCodable
-    public let sessiontarget: AnyCodable
-    public let wakemode: AnyCodable
-    public let payload: AnyCodable
-    public let delivery: [String: AnyCodable]?
-
-    public init(
-        name: String,
-        agentid: AnyCodable?,
-        description: String?,
-        enabled: Bool?,
-        deleteafterrun: Bool?,
-        schedule: AnyCodable,
-        sessiontarget: AnyCodable,
-        wakemode: AnyCodable,
-        payload: AnyCodable,
-        delivery: [String: AnyCodable]?
-    ) {
-        self.name = name
-        self.agentid = agentid
-        self.description = description
-        self.enabled = enabled
-        self.deleteafterrun = deleteafterrun
-        self.schedule = schedule
-        self.sessiontarget = sessiontarget
-        self.wakemode = wakemode
-        self.payload = payload
-        self.delivery = delivery
-    }
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case agentid = "agentId"
-        case description
-        case enabled
-        case deleteafterrun = "deleteAfterRun"
-        case schedule
-        case sessiontarget = "sessionTarget"
-        case wakemode = "wakeMode"
-        case payload
-        case delivery
-    }
-}
-
 public struct CronRunLogEntry: Codable, Sendable {
     public let ts: Int
     public let jobid: String
@@ -2205,206 +1093,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     }
 }
 
-public struct LogsTailParams: Codable, Sendable {
-    public let cursor: Int?
-    public let limit: Int?
-    public let maxbytes: Int?
-
-    public init(
-        cursor: Int?,
-        limit: Int?,
-        maxbytes: Int?
-    ) {
-        self.cursor = cursor
-        self.limit = limit
-        self.maxbytes = maxbytes
-    }
-    private enum CodingKeys: String, CodingKey {
-        case cursor
-        case limit
-        case maxbytes = "maxBytes"
-    }
-}
-
-public struct LogsTailResult: Codable, Sendable {
-    public let file: String
-    public let cursor: Int
-    public let size: Int
-    public let lines: [String]
-    public let truncated: Bool?
-    public let reset: Bool?
-
-    public init(
-        file: String,
-        cursor: Int,
-        size: Int,
-        lines: [String],
-        truncated: Bool?,
-        reset: Bool?
-    ) {
-        self.file = file
-        self.cursor = cursor
-        self.size = size
-        self.lines = lines
-        self.truncated = truncated
-        self.reset = reset
-    }
-    private enum CodingKeys: String, CodingKey {
-        case file
-        case cursor
-        case size
-        case lines
-        case truncated
-        case reset
-    }
-}
-
-public struct ExecApprovalsGetParams: Codable, Sendable {
-}
-
-public struct ExecApprovalsSetParams: Codable, Sendable {
-    public let file: [String: AnyCodable]
-    public let basehash: String?
-
-    public init(
-        file: [String: AnyCodable],
-        basehash: String?
-    ) {
-        self.file = file
-        self.basehash = basehash
-    }
-    private enum CodingKeys: String, CodingKey {
-        case file
-        case basehash = "baseHash"
-    }
-}
-
-public struct ExecApprovalsNodeGetParams: Codable, Sendable {
-    public let nodeid: String
-
-    public init(
-        nodeid: String
-    ) {
-        self.nodeid = nodeid
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-    }
-}
-
-public struct ExecApprovalsNodeSetParams: Codable, Sendable {
-    public let nodeid: String
-    public let file: [String: AnyCodable]
-    public let basehash: String?
-
-    public init(
-        nodeid: String,
-        file: [String: AnyCodable],
-        basehash: String?
-    ) {
-        self.nodeid = nodeid
-        self.file = file
-        self.basehash = basehash
-    }
-    private enum CodingKeys: String, CodingKey {
-        case nodeid = "nodeId"
-        case file
-        case basehash = "baseHash"
-    }
-}
-
-public struct ExecApprovalsSnapshot: Codable, Sendable {
-    public let path: String
-    public let exists: Bool
-    public let hash: String
-    public let file: [String: AnyCodable]
-
-    public init(
-        path: String,
-        exists: Bool,
-        hash: String,
-        file: [String: AnyCodable]
-    ) {
-        self.path = path
-        self.exists = exists
-        self.hash = hash
-        self.file = file
-    }
-    private enum CodingKeys: String, CodingKey {
-        case path
-        case exists
-        case hash
-        case file
-    }
-}
-
-public struct ExecApprovalRequestParams: Codable, Sendable {
-    public let id: String?
-    public let command: String
-    public let cwd: AnyCodable?
-    public let host: AnyCodable?
-    public let security: AnyCodable?
-    public let ask: AnyCodable?
-    public let agentid: AnyCodable?
-    public let resolvedpath: AnyCodable?
-    public let sessionkey: AnyCodable?
-    public let timeoutms: Int?
-
-    public init(
-        id: String?,
-        command: String,
-        cwd: AnyCodable?,
-        host: AnyCodable?,
-        security: AnyCodable?,
-        ask: AnyCodable?,
-        agentid: AnyCodable?,
-        resolvedpath: AnyCodable?,
-        sessionkey: AnyCodable?,
-        timeoutms: Int?
-    ) {
-        self.id = id
-        self.command = command
-        self.cwd = cwd
-        self.host = host
-        self.security = security
-        self.ask = ask
-        self.agentid = agentid
-        self.resolvedpath = resolvedpath
-        self.sessionkey = sessionkey
-        self.timeoutms = timeoutms
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case command
-        case cwd
-        case host
-        case security
-        case ask
-        case agentid = "agentId"
-        case resolvedpath = "resolvedPath"
-        case sessionkey = "sessionKey"
-        case timeoutms = "timeoutMs"
-    }
-}
-
-public struct ExecApprovalResolveParams: Codable, Sendable {
-    public let id: String
-    public let decision: String
-
-    public init(
-        id: String,
-        decision: String
-    ) {
-        self.id = id
-        self.decision = decision
-    }
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case decision
-    }
-}
-
-public struct DevicePairListParams: Codable, Sendable {
+public struct CronStatusParams: Codable, Sendable {
 }
 
 public struct DevicePairApproveParams: Codable, Sendable {
@@ -2420,6 +1109,9 @@ public struct DevicePairApproveParams: Codable, Sendable {
     }
 }
 
+public struct DevicePairListParams: Codable, Sendable {
+}
+
 public struct DevicePairRejectParams: Codable, Sendable {
     public let requestid: String
 
@@ -2430,44 +1122,6 @@ public struct DevicePairRejectParams: Codable, Sendable {
     }
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
-    }
-}
-
-public struct DeviceTokenRotateParams: Codable, Sendable {
-    public let deviceid: String
-    public let role: String
-    public let scopes: [String]?
-
-    public init(
-        deviceid: String,
-        role: String,
-        scopes: [String]?
-    ) {
-        self.deviceid = deviceid
-        self.role = role
-        self.scopes = scopes
-    }
-    private enum CodingKeys: String, CodingKey {
-        case deviceid = "deviceId"
-        case role
-        case scopes
-    }
-}
-
-public struct DeviceTokenRevokeParams: Codable, Sendable {
-    public let deviceid: String
-    public let role: String
-
-    public init(
-        deviceid: String,
-        role: String
-    ) {
-        self.deviceid = deviceid
-        self.role = role
-    }
-    private enum CodingKeys: String, CodingKey {
-        case deviceid = "deviceId"
-        case role
     }
 }
 
@@ -2561,136 +1215,1277 @@ public struct DevicePairResolvedEvent: Codable, Sendable {
     }
 }
 
-public struct ChatHistoryParams: Codable, Sendable {
-    public let sessionkey: String
-    public let limit: Int?
+public struct DeviceTokenRevokeParams: Codable, Sendable {
+    public let deviceid: String
+    public let role: String
 
     public init(
-        sessionkey: String,
-        limit: Int?
+        deviceid: String,
+        role: String
     ) {
-        self.sessionkey = sessionkey
-        self.limit = limit
+        self.deviceid = deviceid
+        self.role = role
     }
     private enum CodingKeys: String, CodingKey {
-        case sessionkey = "sessionKey"
-        case limit
+        case deviceid = "deviceId"
+        case role
     }
 }
 
-public struct ChatSendParams: Codable, Sendable {
-    public let sessionkey: String
+public struct DeviceTokenRotateParams: Codable, Sendable {
+    public let deviceid: String
+    public let role: String
+    public let scopes: [String]?
+
+    public init(
+        deviceid: String,
+        role: String,
+        scopes: [String]?
+    ) {
+        self.deviceid = deviceid
+        self.role = role
+        self.scopes = scopes
+    }
+    private enum CodingKeys: String, CodingKey {
+        case deviceid = "deviceId"
+        case role
+        case scopes
+    }
+}
+
+public struct ErrorShape: Codable, Sendable {
+    public let code: String
     public let message: String
-    public let thinking: String?
-    public let deliver: Bool?
-    public let attachments: [AnyCodable]?
+    public let details: AnyCodable?
+    public let retryable: Bool?
+    public let retryafterms: Int?
+
+    public init(
+        code: String,
+        message: String,
+        details: AnyCodable?,
+        retryable: Bool?,
+        retryafterms: Int?
+    ) {
+        self.code = code
+        self.message = message
+        self.details = details
+        self.retryable = retryable
+        self.retryafterms = retryafterms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case message
+        case details
+        case retryable
+        case retryafterms = "retryAfterMs"
+    }
+}
+
+public struct EventFrame: Codable, Sendable {
+    public let type: String
+    public let event: String
+    public let payload: AnyCodable?
+    public let seq: Int?
+    public let stateversion: [String: AnyCodable]?
+
+    public init(
+        type: String,
+        event: String,
+        payload: AnyCodable?,
+        seq: Int?,
+        stateversion: [String: AnyCodable]?
+    ) {
+        self.type = type
+        self.event = event
+        self.payload = payload
+        self.seq = seq
+        self.stateversion = stateversion
+    }
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case event
+        case payload
+        case seq
+        case stateversion = "stateVersion"
+    }
+}
+
+public struct ExecApprovalRequestParams: Codable, Sendable {
+    public let id: String?
+    public let command: String
+    public let cwd: AnyCodable?
+    public let host: AnyCodable?
+    public let security: AnyCodable?
+    public let ask: AnyCodable?
+    public let agentid: AnyCodable?
+    public let resolvedpath: AnyCodable?
+    public let sessionkey: AnyCodable?
+    public let timeoutms: Int?
+
+    public init(
+        id: String?,
+        command: String,
+        cwd: AnyCodable?,
+        host: AnyCodable?,
+        security: AnyCodable?,
+        ask: AnyCodable?,
+        agentid: AnyCodable?,
+        resolvedpath: AnyCodable?,
+        sessionkey: AnyCodable?,
+        timeoutms: Int?
+    ) {
+        self.id = id
+        self.command = command
+        self.cwd = cwd
+        self.host = host
+        self.security = security
+        self.ask = ask
+        self.agentid = agentid
+        self.resolvedpath = resolvedpath
+        self.sessionkey = sessionkey
+        self.timeoutms = timeoutms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case command
+        case cwd
+        case host
+        case security
+        case ask
+        case agentid = "agentId"
+        case resolvedpath = "resolvedPath"
+        case sessionkey = "sessionKey"
+        case timeoutms = "timeoutMs"
+    }
+}
+
+public struct ExecApprovalResolveParams: Codable, Sendable {
+    public let id: String
+    public let decision: String
+
+    public init(
+        id: String,
+        decision: String
+    ) {
+        self.id = id
+        self.decision = decision
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case decision
+    }
+}
+
+public struct ExecApprovalsGetParams: Codable, Sendable {
+}
+
+public struct ExecApprovalsNodeGetParams: Codable, Sendable {
+    public let nodeid: String
+
+    public init(
+        nodeid: String
+    ) {
+        self.nodeid = nodeid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+    }
+}
+
+public struct ExecApprovalsNodeSetParams: Codable, Sendable {
+    public let nodeid: String
+    public let file: [String: AnyCodable]
+    public let basehash: String?
+
+    public init(
+        nodeid: String,
+        file: [String: AnyCodable],
+        basehash: String?
+    ) {
+        self.nodeid = nodeid
+        self.file = file
+        self.basehash = basehash
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case file
+        case basehash = "baseHash"
+    }
+}
+
+public struct ExecApprovalsSetParams: Codable, Sendable {
+    public let file: [String: AnyCodable]
+    public let basehash: String?
+
+    public init(
+        file: [String: AnyCodable],
+        basehash: String?
+    ) {
+        self.file = file
+        self.basehash = basehash
+    }
+    private enum CodingKeys: String, CodingKey {
+        case file
+        case basehash = "baseHash"
+    }
+}
+
+public struct ExecApprovalsSnapshot: Codable, Sendable {
+    public let path: String
+    public let exists: Bool
+    public let hash: String
+    public let file: [String: AnyCodable]
+
+    public init(
+        path: String,
+        exists: Bool,
+        hash: String,
+        file: [String: AnyCodable]
+    ) {
+        self.path = path
+        self.exists = exists
+        self.hash = hash
+        self.file = file
+    }
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case exists
+        case hash
+        case file
+    }
+}
+
+public struct HelloOk: Codable, Sendable {
+    public let type: String
+    public let _protocol: Int
+    public let server: [String: AnyCodable]
+    public let features: [String: AnyCodable]
+    public let snapshot: Snapshot
+    public let canvashosturl: String?
+    public let auth: [String: AnyCodable]?
+    public let policy: [String: AnyCodable]
+
+    public init(
+        type: String,
+        _protocol: Int,
+        server: [String: AnyCodable],
+        features: [String: AnyCodable],
+        snapshot: Snapshot,
+        canvashosturl: String?,
+        auth: [String: AnyCodable]?,
+        policy: [String: AnyCodable]
+    ) {
+        self.type = type
+        self._protocol = _protocol
+        self.server = server
+        self.features = features
+        self.snapshot = snapshot
+        self.canvashosturl = canvashosturl
+        self.auth = auth
+        self.policy = policy
+    }
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case _protocol = "protocol"
+        case server
+        case features
+        case snapshot
+        case canvashosturl = "canvasHostUrl"
+        case auth
+        case policy
+    }
+}
+
+public struct LogsTailParams: Codable, Sendable {
+    public let cursor: Int?
+    public let limit: Int?
+    public let maxbytes: Int?
+
+    public init(
+        cursor: Int?,
+        limit: Int?,
+        maxbytes: Int?
+    ) {
+        self.cursor = cursor
+        self.limit = limit
+        self.maxbytes = maxbytes
+    }
+    private enum CodingKeys: String, CodingKey {
+        case cursor
+        case limit
+        case maxbytes = "maxBytes"
+    }
+}
+
+public struct LogsTailResult: Codable, Sendable {
+    public let file: String
+    public let cursor: Int
+    public let size: Int
+    public let lines: [String]
+    public let truncated: Bool?
+    public let reset: Bool?
+
+    public init(
+        file: String,
+        cursor: Int,
+        size: Int,
+        lines: [String],
+        truncated: Bool?,
+        reset: Bool?
+    ) {
+        self.file = file
+        self.cursor = cursor
+        self.size = size
+        self.lines = lines
+        self.truncated = truncated
+        self.reset = reset
+    }
+    private enum CodingKeys: String, CodingKey {
+        case file
+        case cursor
+        case size
+        case lines
+        case truncated
+        case reset
+    }
+}
+
+public struct ModelChoice: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let provider: String
+    public let contextwindow: Int?
+    public let reasoning: Bool?
+
+    public init(
+        id: String,
+        name: String,
+        provider: String,
+        contextwindow: Int?,
+        reasoning: Bool?
+    ) {
+        self.id = id
+        self.name = name
+        self.provider = provider
+        self.contextwindow = contextwindow
+        self.reasoning = reasoning
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case provider
+        case contextwindow = "contextWindow"
+        case reasoning
+    }
+}
+
+public struct ModelsListParams: Codable, Sendable {
+}
+
+public struct ModelsListResult: Codable, Sendable {
+    public let models: [ModelChoice]
+
+    public init(
+        models: [ModelChoice]
+    ) {
+        self.models = models
+    }
+    private enum CodingKeys: String, CodingKey {
+        case models
+    }
+}
+
+public struct NodeDescribeParams: Codable, Sendable {
+    public let nodeid: String
+
+    public init(
+        nodeid: String
+    ) {
+        self.nodeid = nodeid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+    }
+}
+
+public struct NodeEventParams: Codable, Sendable {
+    public let event: String
+    public let payload: AnyCodable?
+    public let payloadjson: String?
+
+    public init(
+        event: String,
+        payload: AnyCodable?,
+        payloadjson: String?
+    ) {
+        self.event = event
+        self.payload = payload
+        self.payloadjson = payloadjson
+    }
+    private enum CodingKeys: String, CodingKey {
+        case event
+        case payload
+        case payloadjson = "payloadJSON"
+    }
+}
+
+public struct NodeInvokeParams: Codable, Sendable {
+    public let nodeid: String
+    public let command: String
+    public let params: AnyCodable?
     public let timeoutms: Int?
     public let idempotencykey: String
 
     public init(
-        sessionkey: String,
-        message: String,
-        thinking: String?,
-        deliver: Bool?,
-        attachments: [AnyCodable]?,
+        nodeid: String,
+        command: String,
+        params: AnyCodable?,
         timeoutms: Int?,
         idempotencykey: String
     ) {
-        self.sessionkey = sessionkey
-        self.message = message
-        self.thinking = thinking
-        self.deliver = deliver
-        self.attachments = attachments
+        self.nodeid = nodeid
+        self.command = command
+        self.params = params
         self.timeoutms = timeoutms
         self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
-        case sessionkey = "sessionKey"
-        case message
-        case thinking
-        case deliver
-        case attachments
+        case nodeid = "nodeId"
+        case command
+        case params
         case timeoutms = "timeoutMs"
         case idempotencykey = "idempotencyKey"
     }
 }
 
-public struct ChatAbortParams: Codable, Sendable {
-    public let sessionkey: String
-    public let runid: String?
+public struct NodeInvokeRequestEvent: Codable, Sendable {
+    public let id: String
+    public let nodeid: String
+    public let command: String
+    public let paramsjson: String?
+    public let timeoutms: Int?
+    public let idempotencykey: String?
 
     public init(
-        sessionkey: String,
-        runid: String?
+        id: String,
+        nodeid: String,
+        command: String,
+        paramsjson: String?,
+        timeoutms: Int?,
+        idempotencykey: String?
     ) {
-        self.sessionkey = sessionkey
-        self.runid = runid
+        self.id = id
+        self.nodeid = nodeid
+        self.command = command
+        self.paramsjson = paramsjson
+        self.timeoutms = timeoutms
+        self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
-        case sessionkey = "sessionKey"
-        case runid = "runId"
+        case id
+        case nodeid = "nodeId"
+        case command
+        case paramsjson = "paramsJSON"
+        case timeoutms = "timeoutMs"
+        case idempotencykey = "idempotencyKey"
     }
 }
 
-public struct ChatInjectParams: Codable, Sendable {
-    public let sessionkey: String
+public struct NodeInvokeResultParams: Codable, Sendable {
+    public let id: String
+    public let nodeid: String
+    public let ok: Bool
+    public let payload: AnyCodable?
+    public let payloadjson: String?
+    public let error: [String: AnyCodable]?
+
+    public init(
+        id: String,
+        nodeid: String,
+        ok: Bool,
+        payload: AnyCodable?,
+        payloadjson: String?,
+        error: [String: AnyCodable]?
+    ) {
+        self.id = id
+        self.nodeid = nodeid
+        self.ok = ok
+        self.payload = payload
+        self.payloadjson = payloadjson
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case nodeid = "nodeId"
+        case ok
+        case payload
+        case payloadjson = "payloadJSON"
+        case error
+    }
+}
+
+public struct NodeListParams: Codable, Sendable {
+}
+
+public struct NodePairApproveParams: Codable, Sendable {
+    public let requestid: String
+
+    public init(
+        requestid: String
+    ) {
+        self.requestid = requestid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case requestid = "requestId"
+    }
+}
+
+public struct NodePairListParams: Codable, Sendable {
+}
+
+public struct NodePairRejectParams: Codable, Sendable {
+    public let requestid: String
+
+    public init(
+        requestid: String
+    ) {
+        self.requestid = requestid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case requestid = "requestId"
+    }
+}
+
+public struct NodePairRequestParams: Codable, Sendable {
+    public let nodeid: String
+    public let displayname: String?
+    public let platform: String?
+    public let version: String?
+    public let coreversion: String?
+    public let uiversion: String?
+    public let devicefamily: String?
+    public let modelidentifier: String?
+    public let caps: [String]?
+    public let commands: [String]?
+    public let remoteip: String?
+    public let silent: Bool?
+
+    public init(
+        nodeid: String,
+        displayname: String?,
+        platform: String?,
+        version: String?,
+        coreversion: String?,
+        uiversion: String?,
+        devicefamily: String?,
+        modelidentifier: String?,
+        caps: [String]?,
+        commands: [String]?,
+        remoteip: String?,
+        silent: Bool?
+    ) {
+        self.nodeid = nodeid
+        self.displayname = displayname
+        self.platform = platform
+        self.version = version
+        self.coreversion = coreversion
+        self.uiversion = uiversion
+        self.devicefamily = devicefamily
+        self.modelidentifier = modelidentifier
+        self.caps = caps
+        self.commands = commands
+        self.remoteip = remoteip
+        self.silent = silent
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case displayname = "displayName"
+        case platform
+        case version
+        case coreversion = "coreVersion"
+        case uiversion = "uiVersion"
+        case devicefamily = "deviceFamily"
+        case modelidentifier = "modelIdentifier"
+        case caps
+        case commands
+        case remoteip = "remoteIp"
+        case silent
+    }
+}
+
+public struct NodePairVerifyParams: Codable, Sendable {
+    public let nodeid: String
+    public let token: String
+
+    public init(
+        nodeid: String,
+        token: String
+    ) {
+        self.nodeid = nodeid
+        self.token = token
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case token
+    }
+}
+
+public struct NodeRenameParams: Codable, Sendable {
+    public let nodeid: String
+    public let displayname: String
+
+    public init(
+        nodeid: String,
+        displayname: String
+    ) {
+        self.nodeid = nodeid
+        self.displayname = displayname
+    }
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case displayname = "displayName"
+    }
+}
+
+public struct PollParams: Codable, Sendable {
+    public let to: String
+    public let question: String
+    public let options: [String]
+    public let maxselections: Int?
+    public let durationhours: Int?
+    public let channel: String?
+    public let accountid: String?
+    public let idempotencykey: String
+
+    public init(
+        to: String,
+        question: String,
+        options: [String],
+        maxselections: Int?,
+        durationhours: Int?,
+        channel: String?,
+        accountid: String?,
+        idempotencykey: String
+    ) {
+        self.to = to
+        self.question = question
+        self.options = options
+        self.maxselections = maxselections
+        self.durationhours = durationhours
+        self.channel = channel
+        self.accountid = accountid
+        self.idempotencykey = idempotencykey
+    }
+    private enum CodingKeys: String, CodingKey {
+        case to
+        case question
+        case options
+        case maxselections = "maxSelections"
+        case durationhours = "durationHours"
+        case channel
+        case accountid = "accountId"
+        case idempotencykey = "idempotencyKey"
+    }
+}
+
+public struct PresenceEntry: Codable, Sendable {
+    public let host: String?
+    public let ip: String?
+    public let version: String?
+    public let platform: String?
+    public let devicefamily: String?
+    public let modelidentifier: String?
+    public let mode: String?
+    public let lastinputseconds: Int?
+    public let reason: String?
+    public let tags: [String]?
+    public let text: String?
+    public let ts: Int
+    public let deviceid: String?
+    public let roles: [String]?
+    public let scopes: [String]?
+    public let instanceid: String?
+
+    public init(
+        host: String?,
+        ip: String?,
+        version: String?,
+        platform: String?,
+        devicefamily: String?,
+        modelidentifier: String?,
+        mode: String?,
+        lastinputseconds: Int?,
+        reason: String?,
+        tags: [String]?,
+        text: String?,
+        ts: Int,
+        deviceid: String?,
+        roles: [String]?,
+        scopes: [String]?,
+        instanceid: String?
+    ) {
+        self.host = host
+        self.ip = ip
+        self.version = version
+        self.platform = platform
+        self.devicefamily = devicefamily
+        self.modelidentifier = modelidentifier
+        self.mode = mode
+        self.lastinputseconds = lastinputseconds
+        self.reason = reason
+        self.tags = tags
+        self.text = text
+        self.ts = ts
+        self.deviceid = deviceid
+        self.roles = roles
+        self.scopes = scopes
+        self.instanceid = instanceid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case host
+        case ip
+        case version
+        case platform
+        case devicefamily = "deviceFamily"
+        case modelidentifier = "modelIdentifier"
+        case mode
+        case lastinputseconds = "lastInputSeconds"
+        case reason
+        case tags
+        case text
+        case ts
+        case deviceid = "deviceId"
+        case roles
+        case scopes
+        case instanceid = "instanceId"
+    }
+}
+
+public struct RequestFrame: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let method: String
+    public let params: AnyCodable?
+
+    public init(
+        type: String,
+        id: String,
+        method: String,
+        params: AnyCodable?
+    ) {
+        self.type = type
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case id
+        case method
+        case params
+    }
+}
+
+public struct ResponseFrame: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let ok: Bool
+    public let payload: AnyCodable?
+    public let error: [String: AnyCodable]?
+
+    public init(
+        type: String,
+        id: String,
+        ok: Bool,
+        payload: AnyCodable?,
+        error: [String: AnyCodable]?
+    ) {
+        self.type = type
+        self.id = id
+        self.ok = ok
+        self.payload = payload
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case id
+        case ok
+        case payload
+        case error
+    }
+}
+
+public struct SendParams: Codable, Sendable {
+    public let to: String
     public let message: String
-    public let label: String?
+    public let mediaurl: String?
+    public let mediaurls: [String]?
+    public let gifplayback: Bool?
+    public let channel: String?
+    public let accountid: String?
+    public let sessionkey: String?
+    public let idempotencykey: String
 
     public init(
-        sessionkey: String,
+        to: String,
         message: String,
-        label: String?
+        mediaurl: String?,
+        mediaurls: [String]?,
+        gifplayback: Bool?,
+        channel: String?,
+        accountid: String?,
+        sessionkey: String?,
+        idempotencykey: String
     ) {
-        self.sessionkey = sessionkey
+        self.to = to
         self.message = message
-        self.label = label
+        self.mediaurl = mediaurl
+        self.mediaurls = mediaurls
+        self.gifplayback = gifplayback
+        self.channel = channel
+        self.accountid = accountid
+        self.sessionkey = sessionkey
+        self.idempotencykey = idempotencykey
     }
     private enum CodingKeys: String, CodingKey {
-        case sessionkey = "sessionKey"
+        case to
         case message
-        case label
+        case mediaurl = "mediaUrl"
+        case mediaurls = "mediaUrls"
+        case gifplayback = "gifPlayback"
+        case channel
+        case accountid = "accountId"
+        case sessionkey = "sessionKey"
+        case idempotencykey = "idempotencyKey"
     }
 }
 
-public struct ChatEvent: Codable, Sendable {
-    public let runid: String
-    public let sessionkey: String
-    public let seq: Int
-    public let state: AnyCodable
-    public let message: AnyCodable?
-    public let errormessage: String?
-    public let usage: AnyCodable?
-    public let stopreason: String?
+public struct SessionsCompactParams: Codable, Sendable {
+    public let key: String
+    public let maxlines: Int?
 
     public init(
-        runid: String,
-        sessionkey: String,
-        seq: Int,
-        state: AnyCodable,
-        message: AnyCodable?,
-        errormessage: String?,
-        usage: AnyCodable?,
-        stopreason: String?
+        key: String,
+        maxlines: Int?
     ) {
-        self.runid = runid
-        self.sessionkey = sessionkey
-        self.seq = seq
-        self.state = state
-        self.message = message
-        self.errormessage = errormessage
-        self.usage = usage
-        self.stopreason = stopreason
+        self.key = key
+        self.maxlines = maxlines
     }
     private enum CodingKeys: String, CodingKey {
-        case runid = "runId"
-        case sessionkey = "sessionKey"
-        case seq
-        case state
-        case message
-        case errormessage = "errorMessage"
-        case usage
-        case stopreason = "stopReason"
+        case key
+        case maxlines = "maxLines"
+    }
+}
+
+public struct SessionsDeleteParams: Codable, Sendable {
+    public let key: String
+    public let deletetranscript: Bool?
+
+    public init(
+        key: String,
+        deletetranscript: Bool?
+    ) {
+        self.key = key
+        self.deletetranscript = deletetranscript
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case deletetranscript = "deleteTranscript"
+    }
+}
+
+public struct SessionsListParams: Codable, Sendable {
+    public let limit: Int?
+    public let activeminutes: Int?
+    public let includeglobal: Bool?
+    public let includeunknown: Bool?
+    public let includederivedtitles: Bool?
+    public let includelastmessage: Bool?
+    public let label: String?
+    public let spawnedby: String?
+    public let agentid: String?
+    public let search: String?
+
+    public init(
+        limit: Int?,
+        activeminutes: Int?,
+        includeglobal: Bool?,
+        includeunknown: Bool?,
+        includederivedtitles: Bool?,
+        includelastmessage: Bool?,
+        label: String?,
+        spawnedby: String?,
+        agentid: String?,
+        search: String?
+    ) {
+        self.limit = limit
+        self.activeminutes = activeminutes
+        self.includeglobal = includeglobal
+        self.includeunknown = includeunknown
+        self.includederivedtitles = includederivedtitles
+        self.includelastmessage = includelastmessage
+        self.label = label
+        self.spawnedby = spawnedby
+        self.agentid = agentid
+        self.search = search
+    }
+    private enum CodingKeys: String, CodingKey {
+        case limit
+        case activeminutes = "activeMinutes"
+        case includeglobal = "includeGlobal"
+        case includeunknown = "includeUnknown"
+        case includederivedtitles = "includeDerivedTitles"
+        case includelastmessage = "includeLastMessage"
+        case label
+        case spawnedby = "spawnedBy"
+        case agentid = "agentId"
+        case search
+    }
+}
+
+public struct SessionsPatchParams: Codable, Sendable {
+    public let key: String
+    public let label: AnyCodable?
+    public let thinkinglevel: AnyCodable?
+    public let verboselevel: AnyCodable?
+    public let reasoninglevel: AnyCodable?
+    public let responseusage: AnyCodable?
+    public let elevatedlevel: AnyCodable?
+    public let exechost: AnyCodable?
+    public let execsecurity: AnyCodable?
+    public let execask: AnyCodable?
+    public let execnode: AnyCodable?
+    public let model: AnyCodable?
+    public let spawnedby: AnyCodable?
+    public let sendpolicy: AnyCodable?
+    public let groupactivation: AnyCodable?
+
+    public init(
+        key: String,
+        label: AnyCodable?,
+        thinkinglevel: AnyCodable?,
+        verboselevel: AnyCodable?,
+        reasoninglevel: AnyCodable?,
+        responseusage: AnyCodable?,
+        elevatedlevel: AnyCodable?,
+        exechost: AnyCodable?,
+        execsecurity: AnyCodable?,
+        execask: AnyCodable?,
+        execnode: AnyCodable?,
+        model: AnyCodable?,
+        spawnedby: AnyCodable?,
+        sendpolicy: AnyCodable?,
+        groupactivation: AnyCodable?
+    ) {
+        self.key = key
+        self.label = label
+        self.thinkinglevel = thinkinglevel
+        self.verboselevel = verboselevel
+        self.reasoninglevel = reasoninglevel
+        self.responseusage = responseusage
+        self.elevatedlevel = elevatedlevel
+        self.exechost = exechost
+        self.execsecurity = execsecurity
+        self.execask = execask
+        self.execnode = execnode
+        self.model = model
+        self.spawnedby = spawnedby
+        self.sendpolicy = sendpolicy
+        self.groupactivation = groupactivation
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case label
+        case thinkinglevel = "thinkingLevel"
+        case verboselevel = "verboseLevel"
+        case reasoninglevel = "reasoningLevel"
+        case responseusage = "responseUsage"
+        case elevatedlevel = "elevatedLevel"
+        case exechost = "execHost"
+        case execsecurity = "execSecurity"
+        case execask = "execAsk"
+        case execnode = "execNode"
+        case model
+        case spawnedby = "spawnedBy"
+        case sendpolicy = "sendPolicy"
+        case groupactivation = "groupActivation"
+    }
+}
+
+public struct SessionsPreviewParams: Codable, Sendable {
+    public let keys: [String]
+    public let limit: Int?
+    public let maxchars: Int?
+
+    public init(
+        keys: [String],
+        limit: Int?,
+        maxchars: Int?
+    ) {
+        self.keys = keys
+        self.limit = limit
+        self.maxchars = maxchars
+    }
+    private enum CodingKeys: String, CodingKey {
+        case keys
+        case limit
+        case maxchars = "maxChars"
+    }
+}
+
+public struct SessionsResetParams: Codable, Sendable {
+    public let key: String
+
+    public init(
+        key: String
+    ) {
+        self.key = key
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+    }
+}
+
+public struct SessionsResolveParams: Codable, Sendable {
+    public let key: String?
+    public let sessionid: String?
+    public let label: String?
+    public let agentid: String?
+    public let spawnedby: String?
+    public let includeglobal: Bool?
+    public let includeunknown: Bool?
+
+    public init(
+        key: String?,
+        sessionid: String?,
+        label: String?,
+        agentid: String?,
+        spawnedby: String?,
+        includeglobal: Bool?,
+        includeunknown: Bool?
+    ) {
+        self.key = key
+        self.sessionid = sessionid
+        self.label = label
+        self.agentid = agentid
+        self.spawnedby = spawnedby
+        self.includeglobal = includeglobal
+        self.includeunknown = includeunknown
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case sessionid = "sessionId"
+        case label
+        case agentid = "agentId"
+        case spawnedby = "spawnedBy"
+        case includeglobal = "includeGlobal"
+        case includeunknown = "includeUnknown"
+    }
+}
+
+public struct SessionsUsageParams: Codable, Sendable {
+    public let key: String?
+    public let startdate: String?
+    public let enddate: String?
+    public let limit: Int?
+    public let includecontextweight: Bool?
+
+    public init(
+        key: String?,
+        startdate: String?,
+        enddate: String?,
+        limit: Int?,
+        includecontextweight: Bool?
+    ) {
+        self.key = key
+        self.startdate = startdate
+        self.enddate = enddate
+        self.limit = limit
+        self.includecontextweight = includecontextweight
+    }
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case startdate = "startDate"
+        case enddate = "endDate"
+        case limit
+        case includecontextweight = "includeContextWeight"
+    }
+}
+
+public struct ShutdownEvent: Codable, Sendable {
+    public let reason: String
+    public let restartexpectedms: Int?
+
+    public init(
+        reason: String,
+        restartexpectedms: Int?
+    ) {
+        self.reason = reason
+        self.restartexpectedms = restartexpectedms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case reason
+        case restartexpectedms = "restartExpectedMs"
+    }
+}
+
+public struct SkillsBinsParams: Codable, Sendable {
+}
+
+public struct SkillsBinsResult: Codable, Sendable {
+    public let bins: [String]
+
+    public init(
+        bins: [String]
+    ) {
+        self.bins = bins
+    }
+    private enum CodingKeys: String, CodingKey {
+        case bins
+    }
+}
+
+public struct SkillsInstallParams: Codable, Sendable {
+    public let name: String
+    public let installid: String
+    public let timeoutms: Int?
+
+    public init(
+        name: String,
+        installid: String,
+        timeoutms: Int?
+    ) {
+        self.name = name
+        self.installid = installid
+        self.timeoutms = timeoutms
+    }
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case installid = "installId"
+        case timeoutms = "timeoutMs"
+    }
+}
+
+public struct SkillsStatusParams: Codable, Sendable {
+    public let agentid: String?
+
+    public init(
+        agentid: String?
+    ) {
+        self.agentid = agentid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+    }
+}
+
+public struct SkillsUpdateParams: Codable, Sendable {
+    public let skillkey: String
+    public let enabled: Bool?
+    public let apikey: String?
+    public let env: [String: AnyCodable]?
+
+    public init(
+        skillkey: String,
+        enabled: Bool?,
+        apikey: String?,
+        env: [String: AnyCodable]?
+    ) {
+        self.skillkey = skillkey
+        self.enabled = enabled
+        self.apikey = apikey
+        self.env = env
+    }
+    private enum CodingKeys: String, CodingKey {
+        case skillkey = "skillKey"
+        case enabled
+        case apikey = "apiKey"
+        case env
+    }
+}
+
+public struct Snapshot: Codable, Sendable {
+    public let presence: [PresenceEntry]
+    public let health: AnyCodable
+    public let stateversion: StateVersion
+    public let uptimems: Int
+    public let configpath: String?
+    public let statedir: String?
+    public let sessiondefaults: [String: AnyCodable]?
+
+    public init(
+        presence: [PresenceEntry],
+        health: AnyCodable,
+        stateversion: StateVersion,
+        uptimems: Int,
+        configpath: String?,
+        statedir: String?,
+        sessiondefaults: [String: AnyCodable]?
+    ) {
+        self.presence = presence
+        self.health = health
+        self.stateversion = stateversion
+        self.uptimems = uptimems
+        self.configpath = configpath
+        self.statedir = statedir
+        self.sessiondefaults = sessiondefaults
+    }
+    private enum CodingKeys: String, CodingKey {
+        case presence
+        case health
+        case stateversion = "stateVersion"
+        case uptimems = "uptimeMs"
+        case configpath = "configPath"
+        case statedir = "stateDir"
+        case sessiondefaults = "sessionDefaults"
+    }
+}
+
+public struct StateVersion: Codable, Sendable {
+    public let presence: Int
+    public let health: Int
+
+    public init(
+        presence: Int,
+        health: Int
+    ) {
+        self.presence = presence
+        self.health = health
+    }
+    private enum CodingKeys: String, CodingKey {
+        case presence
+        case health
+    }
+}
+
+public struct TalkModeParams: Codable, Sendable {
+    public let enabled: Bool
+    public let phase: String?
+
+    public init(
+        enabled: Bool,
+        phase: String?
+    ) {
+        self.enabled = enabled
+        self.phase = phase
+    }
+    private enum CodingKeys: String, CodingKey {
+        case enabled
+        case phase
+    }
+}
+
+public struct TickEvent: Codable, Sendable {
+    public let ts: Int
+
+    public init(
+        ts: Int
+    ) {
+        self.ts = ts
+    }
+    private enum CodingKeys: String, CodingKey {
+        case ts
     }
 }
 
@@ -2719,33 +2514,238 @@ public struct UpdateRunParams: Codable, Sendable {
     }
 }
 
-public struct TickEvent: Codable, Sendable {
-    public let ts: Int
+public struct WakeParams: Codable, Sendable {
+    public let mode: AnyCodable
+    public let text: String
 
     public init(
-        ts: Int
+        mode: AnyCodable,
+        text: String
     ) {
-        self.ts = ts
+        self.mode = mode
+        self.text = text
     }
     private enum CodingKeys: String, CodingKey {
-        case ts
+        case mode
+        case text
     }
 }
 
-public struct ShutdownEvent: Codable, Sendable {
-    public let reason: String
-    public let restartexpectedms: Int?
+public struct WebLoginStartParams: Codable, Sendable {
+    public let force: Bool?
+    public let timeoutms: Int?
+    public let verbose: Bool?
+    public let accountid: String?
 
     public init(
-        reason: String,
-        restartexpectedms: Int?
+        force: Bool?,
+        timeoutms: Int?,
+        verbose: Bool?,
+        accountid: String?
     ) {
-        self.reason = reason
-        self.restartexpectedms = restartexpectedms
+        self.force = force
+        self.timeoutms = timeoutms
+        self.verbose = verbose
+        self.accountid = accountid
     }
     private enum CodingKeys: String, CodingKey {
-        case reason
-        case restartexpectedms = "restartExpectedMs"
+        case force
+        case timeoutms = "timeoutMs"
+        case verbose
+        case accountid = "accountId"
+    }
+}
+
+public struct WebLoginWaitParams: Codable, Sendable {
+    public let timeoutms: Int?
+    public let accountid: String?
+
+    public init(
+        timeoutms: Int?,
+        accountid: String?
+    ) {
+        self.timeoutms = timeoutms
+        self.accountid = accountid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case timeoutms = "timeoutMs"
+        case accountid = "accountId"
+    }
+}
+
+public struct WizardCancelParams: Codable, Sendable {
+    public let sessionid: String
+
+    public init(
+        sessionid: String
+    ) {
+        self.sessionid = sessionid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionid = "sessionId"
+    }
+}
+
+public struct WizardNextParams: Codable, Sendable {
+    public let sessionid: String
+    public let answer: [String: AnyCodable]?
+
+    public init(
+        sessionid: String,
+        answer: [String: AnyCodable]?
+    ) {
+        self.sessionid = sessionid
+        self.answer = answer
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionid = "sessionId"
+        case answer
+    }
+}
+
+public struct WizardNextResult: Codable, Sendable {
+    public let done: Bool
+    public let step: [String: AnyCodable]?
+    public let status: AnyCodable?
+    public let error: String?
+
+    public init(
+        done: Bool,
+        step: [String: AnyCodable]?,
+        status: AnyCodable?,
+        error: String?
+    ) {
+        self.done = done
+        self.step = step
+        self.status = status
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case done
+        case step
+        case status
+        case error
+    }
+}
+
+public struct WizardStartParams: Codable, Sendable {
+    public let mode: AnyCodable?
+    public let workspace: String?
+
+    public init(
+        mode: AnyCodable?,
+        workspace: String?
+    ) {
+        self.mode = mode
+        self.workspace = workspace
+    }
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case workspace
+    }
+}
+
+public struct WizardStartResult: Codable, Sendable {
+    public let sessionid: String
+    public let done: Bool
+    public let step: [String: AnyCodable]?
+    public let status: AnyCodable?
+    public let error: String?
+
+    public init(
+        sessionid: String,
+        done: Bool,
+        step: [String: AnyCodable]?,
+        status: AnyCodable?,
+        error: String?
+    ) {
+        self.sessionid = sessionid
+        self.done = done
+        self.step = step
+        self.status = status
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionid = "sessionId"
+        case done
+        case step
+        case status
+        case error
+    }
+}
+
+public struct WizardStatusParams: Codable, Sendable {
+    public let sessionid: String
+
+    public init(
+        sessionid: String
+    ) {
+        self.sessionid = sessionid
+    }
+    private enum CodingKeys: String, CodingKey {
+        case sessionid = "sessionId"
+    }
+}
+
+public struct WizardStatusResult: Codable, Sendable {
+    public let status: AnyCodable
+    public let error: String?
+
+    public init(
+        status: AnyCodable,
+        error: String?
+    ) {
+        self.status = status
+        self.error = error
+    }
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case error
+    }
+}
+
+public struct WizardStep: Codable, Sendable {
+    public let id: String
+    public let type: AnyCodable
+    public let title: String?
+    public let message: String?
+    public let options: [[String: AnyCodable]]?
+    public let initialvalue: AnyCodable?
+    public let placeholder: String?
+    public let sensitive: Bool?
+    public let executor: AnyCodable?
+
+    public init(
+        id: String,
+        type: AnyCodable,
+        title: String?,
+        message: String?,
+        options: [[String: AnyCodable]]?,
+        initialvalue: AnyCodable?,
+        placeholder: String?,
+        sensitive: Bool?,
+        executor: AnyCodable?
+    ) {
+        self.id = id
+        self.type = type
+        self.title = title
+        self.message = message
+        self.options = options
+        self.initialvalue = initialvalue
+        self.placeholder = placeholder
+        self.sensitive = sensitive
+        self.executor = executor
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case title
+        case message
+        case options
+        case initialvalue = "initialValue"
+        case placeholder
+        case sensitive
+        case executor
     }
 }
 

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -208,7 +208,9 @@ function emitGatewayFrame(): string {
 }
 
 async function generate() {
-  const definitions = Object.entries(ProtocolSchemas) as Array<[string, JsonSchema]>;
+  const definitions = (Object.entries(ProtocolSchemas) as Array<[string, JsonSchema]>).toSorted(
+    ([a], [b]) => a.localeCompare(b),
+  );
 
   for (const [name, schema] of definitions) {
     schemaNameByObject.set(schema as object, name);
@@ -230,10 +232,10 @@ async function generate() {
   // Frame enum must come after payload structs
   parts.push(emitGatewayFrame());
 
-  const content = parts.join("\n");
+  const content = parts.join("\n").replace(/\r\n/g, "\n");
   for (const outPath of outPaths) {
     await fs.mkdir(path.dirname(outPath), { recursive: true });
-    await fs.writeFile(outPath, content);
+    await fs.writeFile(outPath, content, "utf8");
     console.log(`wrote ${outPath}`);
   }
 }

--- a/scripts/protocol-gen.ts
+++ b/scripts/protocol-gen.ts
@@ -8,7 +8,8 @@ const repoRoot = path.resolve(__dirname, "..");
 
 async function writeJsonSchema() {
   const definitions: Record<string, unknown> = {};
-  for (const [name, schema] of Object.entries(ProtocolSchemas)) {
+  const entries = Object.entries(ProtocolSchemas).toSorted(([a], [b]) => a.localeCompare(b));
+  for (const [name, schema] of entries) {
     definitions[name] = schema;
   }
 
@@ -36,9 +37,10 @@ async function writeJsonSchema() {
   const distDir = path.join(repoRoot, "dist");
   await fs.mkdir(distDir, { recursive: true });
   const jsonSchemaPath = path.join(distDir, "protocol.schema.json");
-  await fs.writeFile(jsonSchemaPath, JSON.stringify(rootSchema, null, 2));
+  const content = JSON.stringify(rootSchema, null, 2).replace(/\r\n/g, "\n");
+  await fs.writeFile(jsonSchemaPath, content, "utf8");
   console.log(`wrote ${jsonSchemaPath}`);
-  return { jsonSchemaPath, schemaString: JSON.stringify(rootSchema) };
+  return { jsonSchemaPath, schemaString: content };
 }
 
 async function main() {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -474,7 +474,7 @@ describe("sessions tools", () => {
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
-        channel: "webchat",
+        channel: "internal",
       });
     }
     expect(
@@ -651,7 +651,7 @@ describe("sessions tools", () => {
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
-        channel: "webchat",
+        channel: "internal",
       });
     }
 

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -4,7 +4,7 @@ import { logVerbose } from "../../globals.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
-  isInternalMessageChannel,
+  isSystemMessageChannel,
 } from "../../utils/message-channel.js";
 
 const COMMAND = "/approve";
@@ -86,7 +86,7 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
     return { shouldContinue: false, reply: { text: parsed.error } };
   }
 
-  if (isInternalMessageChannel(params.command.channel)) {
+  if (isSystemMessageChannel(params.command.channel)) {
     const scopes = params.ctx.GatewayClientScopes ?? [];
     const hasApprovals = scopes.includes("operator.approvals") || scopes.includes("operator.admin");
     if (!hasApprovals) {

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -3,7 +3,7 @@ import type { GroupKeyResolution, SessionEntry } from "../../config/sessions.js"
 import type { TemplateContext } from "../templating.js";
 import { getChannelDock } from "../../channels/dock.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
-import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { isSystemMessageChannel } from "../../utils/message-channel.js";
 import { normalizeGroupActivation } from "../group-activation.js";
 
 function extractGroupId(raw: string | undefined | null): string | undefined {
@@ -77,7 +77,7 @@ export function buildGroupIntro(params: {
     if (!providerKey) {
       return "chat";
     }
-    if (isInternalMessageChannel(providerKey)) {
+    if (isSystemMessageChannel(providerKey)) {
       return "WebChat";
     }
     if (providerId) {

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -13,7 +13,12 @@ import type { ReplyPayload } from "../types.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
-import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
+import {
+  type InternalMessageChannel,
+  type WebchatMessageChannel,
+  isSystemMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 
 export type RouteReplyParams = {
@@ -91,7 +96,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     return { ok: true };
   }
 
-  if (channel === INTERNAL_MESSAGE_CHANNEL) {
+  if (isSystemMessageChannel(channel)) {
     return {
       ok: false,
       error: "Webchat routing not supported for queued replies",
@@ -154,8 +159,8 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
  */
 export function isRoutableChannel(
   channel: OriginatingChannelType | undefined,
-): channel is Exclude<OriginatingChannelType, typeof INTERNAL_MESSAGE_CHANNEL> {
-  if (!channel || channel === INTERNAL_MESSAGE_CHANNEL) {
+): channel is Exclude<OriginatingChannelType, InternalMessageChannel | WebchatMessageChannel> {
+  if (!channel || isSystemMessageChannel(channel)) {
     return false;
   }
   return normalizeChannelId(channel) !== null;

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -99,7 +99,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
   if (isSystemMessageChannel(channel)) {
     return {
       ok: false,
-      error: "Webchat routing not supported for queued replies",
+      error: "System channel routing not supported for queued replies",
     };
   }
 

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -4,11 +4,11 @@ import type {
   MediaUnderstandingOutput,
 } from "../media-understanding/types.js";
 import type { StickerMetadata } from "../telegram/bot/types.js";
-import type { InternalMessageChannel } from "../utils/message-channel.js";
+import type { InternalMessageChannel, WebchatMessageChannel } from "../utils/message-channel.js";
 import type { CommandArgs } from "./commands-registry.types.js";
 
 /** Valid message channels for routing. */
-export type OriginatingChannelType = ChannelId | InternalMessageChannel;
+export type OriginatingChannelType = ChannelId | InternalMessageChannel | WebchatMessageChannel;
 
 export type MsgContext = {
   Body?: string;

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -17,7 +17,7 @@ import {
   normalizeOutboundPayloads,
   normalizeOutboundPayloadsForJson,
 } from "../../infra/outbound/payloads.js";
-import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { isSystemMessageChannel } from "../../utils/message-channel.js";
 
 type RunResult = Awaited<
   ReturnType<(typeof import("../../agents/pi-embedded.js"))["runEmbeddedPiAgent"]>
@@ -79,12 +79,11 @@ export async function deliverAgentCommandResult(params: {
   });
   const deliveryChannel = deliveryPlan.resolvedChannel;
   // Channel docking: delivery channels are resolved via plugin registry.
-  const deliveryPlugin = !isInternalMessageChannel(deliveryChannel)
+  const deliveryPlugin = !isSystemMessageChannel(deliveryChannel)
     ? getChannelPlugin(normalizeChannelId(deliveryChannel) ?? deliveryChannel)
     : undefined;
 
-  const isDeliveryChannelKnown =
-    isInternalMessageChannel(deliveryChannel) || Boolean(deliveryPlugin);
+  const isDeliveryChannelKnown = isSystemMessageChannel(deliveryChannel) || Boolean(deliveryPlugin);
 
   const targetMode =
     opts.deliveryTargetMode ??
@@ -176,7 +175,7 @@ export async function deliverAgentCommandResult(params: {
       logPayload(payload);
     }
   }
-  if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {
+  if (deliver && deliveryChannel && !isSystemMessageChannel(deliveryChannel)) {
     if (deliveryTarget) {
       await deliverOutboundPayloads({
         cfg,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -20,9 +20,9 @@ import { defaultRuntime } from "../../runtime.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import {
-  INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
+  isSystemMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
@@ -344,7 +344,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
+    const deliver = request.deliver === true && !isSystemMessageChannel(resolvedChannel);
 
     const accepted = {
       runId,

--- a/src/infra/heartbeat-visibility.test.ts
+++ b/src/infra/heartbeat-visibility.test.ts
@@ -248,7 +248,7 @@ describe("resolveHeartbeatVisibility", () => {
     });
   });
 
-  it("webchat uses channel defaults only (no per-channel config)", () => {
+  it("system channels use channel defaults only (no per-channel config)", () => {
     const cfg = {
       channels: {
         defaults: {
@@ -261,28 +261,33 @@ describe("resolveHeartbeatVisibility", () => {
       },
     } as OpenClawConfig;
 
-    const result = resolveHeartbeatVisibility({ cfg, channel: "webchat" });
+    const webchatResult = resolveHeartbeatVisibility({ cfg, channel: "webchat" });
+    const internalResult = resolveHeartbeatVisibility({ cfg, channel: "internal" });
 
-    expect(result).toEqual({
+    expect(webchatResult).toEqual({
       showOk: true,
       showAlerts: false,
       useIndicator: false,
     });
+    expect(internalResult).toEqual(webchatResult);
   });
 
-  it("webchat returns defaults when no channel defaults configured", () => {
+  it("system channels return defaults when no channel defaults configured", () => {
     const cfg = {} as OpenClawConfig;
 
-    const result = resolveHeartbeatVisibility({ cfg, channel: "webchat" });
+    const webchatResult = resolveHeartbeatVisibility({ cfg, channel: "webchat" });
+    const internalResult = resolveHeartbeatVisibility({ cfg, channel: "internal" });
 
-    expect(result).toEqual({
+    const expected = {
       showOk: false,
       showAlerts: true,
       useIndicator: true,
-    });
+    };
+    expect(webchatResult).toEqual(expected);
+    expect(internalResult).toEqual(expected);
   });
 
-  it("webchat ignores accountId (only uses defaults)", () => {
+  it("system channels ignore accountId (only uses defaults)", () => {
     const cfg = {
       channels: {
         defaults: {

--- a/src/infra/heartbeat-visibility.ts
+++ b/src/infra/heartbeat-visibility.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { ChannelHeartbeatVisibilityConfig } from "../config/types.channels.js";
-import type { GatewayMessageChannel } from "../utils/message-channel.js";
+import { type GatewayMessageChannel, isSystemMessageChannel } from "../utils/message-channel.js";
 
 export type ResolvedHeartbeatVisibility = {
   showOk: boolean;
@@ -26,8 +26,8 @@ export function resolveHeartbeatVisibility(params: {
 }): ResolvedHeartbeatVisibility {
   const { cfg, channel, accountId } = params;
 
-  // Webchat uses channel defaults only (no per-channel or per-account config)
-  if (channel === "webchat") {
+  // Webchat/Internal uses channel defaults only (no per-channel or per-account config)
+  if (isSystemMessageChannel(channel)) {
     const channelDefaults = cfg.channels?.defaults?.heartbeat;
     return {
       showOk: channelDefaults?.showOk ?? DEFAULT_VISIBILITY.showOk,

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -6,8 +6,10 @@ import { DEFAULT_CHAT_CHANNEL } from "../../channels/registry.js";
 import { normalizeAccountId } from "../../utils/account-id.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
+  WEBCHAT_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
+  isSystemMessageChannel,
   normalizeMessageChannel,
   type GatewayMessageChannel,
 } from "../../utils/message-channel.js";
@@ -46,7 +48,7 @@ export function resolveAgentDeliveryPlan(params: {
 
   const baseDelivery = resolveSessionDeliveryTarget({
     entry: params.sessionEntry,
-    requestedChannel: requestedChannel === INTERNAL_MESSAGE_CHANNEL ? "last" : requestedChannel,
+    requestedChannel: isSystemMessageChannel(requestedChannel) ? "last" : requestedChannel,
     explicitTo,
     explicitThreadId: params.explicitThreadId,
   });
@@ -55,8 +57,11 @@ export function resolveAgentDeliveryPlan(params: {
     if (requestedChannel === INTERNAL_MESSAGE_CHANNEL) {
       return INTERNAL_MESSAGE_CHANNEL;
     }
+    if (requestedChannel === WEBCHAT_MESSAGE_CHANNEL) {
+      return WEBCHAT_MESSAGE_CHANNEL;
+    }
     if (requestedChannel === "last") {
-      if (baseDelivery.channel && baseDelivery.channel !== INTERNAL_MESSAGE_CHANNEL) {
+      if (baseDelivery.channel && !isSystemMessageChannel(baseDelivery.channel)) {
         return baseDelivery.channel;
       }
       return params.wantsDelivery ? DEFAULT_CHAT_CHANNEL : INTERNAL_MESSAGE_CHANNEL;
@@ -66,7 +71,7 @@ export function resolveAgentDeliveryPlan(params: {
       return requestedChannel;
     }
 
-    if (baseDelivery.channel && baseDelivery.channel !== INTERNAL_MESSAGE_CHANNEL) {
+    if (baseDelivery.channel && !isSystemMessageChannel(baseDelivery.channel)) {
       return baseDelivery.channel;
     }
     return params.wantsDelivery ? DEFAULT_CHAT_CHANNEL : INTERNAL_MESSAGE_CHANNEL;

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -104,6 +104,14 @@ describe("resolveOutboundTarget", () => {
       expect(res.error.message).toContain("WebChat");
     }
   });
+
+  it("rejects internal delivery", () => {
+    const res = resolveOutboundTarget({ channel: "internal", to: "x" });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.message).toContain("WebChat");
+    }
+  });
 });
 
 describe("resolveSessionDeliveryTarget", () => {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -11,8 +11,8 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { deliveryContextFromSession } from "../../utils/delivery-context.js";
 import {
-  INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
+  isSystemMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { missingTargetError } from "./target-errors.js";
@@ -124,7 +124,7 @@ export function resolveOutboundTarget(params: {
   accountId?: string | null;
   mode?: ChannelOutboundTargetMode;
 }): OutboundTargetResolution {
-  if (params.channel === INTERNAL_MESSAGE_CHANNEL) {
+  if (isSystemMessageChannel(params.channel)) {
     return {
       ok: false,
       error: new Error(


### PR DESCRIPTION
# Problem
The 'INTERNAL_MESSAGE_CHANNEL' was incorrectly aliased to "webchat", causing
internal system messages (heartbeats) to pollute real browser chat history.
Additionally, 'chat.send' lacked propagation of the effective channel, leading
to incorrect message prefixing.

# Changes
- Defined separate "internal" and "webchat" channel IDs in 'message-channel.ts'.
- Implemented 'isHeartbeatAckMessage' utility to identify system acknowledgments.
- Refactored 'chat.history' to prune heartbeats when 'channels.defaults.heartbeat.showOk' is false.
- Fixed 'chat.send' to propagate the derived 'effectiveChannel' to dispatcher options.

# Validation
- Verified channel isolation via 'pnpm tsgo'.
- Confirmed 'HEARTBEAT_OK' filtering logic passes type-aware linting.
- Executed 'pnpm build' to ensure no regressions in build artifacts.

Fixes：#11630
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR separates gateway client channel identifiers by changing `INTERNAL_MESSAGE_CHANNEL` from `"webchat"` to `"internal"` and adding an explicit `WEBCHAT_MESSAGE_CHANNEL` constant. It also updates `chat.send` to propagate the derived effective channel into the message context/prefixing, and adds heartbeat-ack filtering in `chat.history`.

Key integration points are the channel normalization helpers in `src/utils/message-channel.ts` (which now recognize both `internal` and `webchat` as gateway channels) and the gateway RPC handlers in `src/gateway/server-methods/chat.ts` (which now choose the effective channel based on whether the connection is webchat).

Before merging, ensure the rest of the codebase no longer relies on `INTERNAL_MESSAGE_CHANNEL` being the webchat sentinel; otherwise delivery/routing decisions can silently flip as a result of the constant’s semantic change.

<h3>Confidence Score: 3/5</h3>

- This PR has clear correctness risks due to a channel sentinel semantic change affecting routing/delivery logic.
- The change to `INTERNAL_MESSAGE_CHANNEL` meaning requires coordinated updates across callers; at least one existing routing guard still keys off `INTERNAL_MESSAGE_CHANNEL`, and heartbeat filtering behavior in `chat.history` doesn’t match the stated config semantics. These are behavior-level issues that can affect message delivery and history contents.
- src/utils/message-channel.ts, src/gateway/server-methods/chat.ts, and any routing/delivery logic using INTERNAL_MESSAGE_CHANNEL (e.g. src/auto-reply/reply/route-reply.ts, src/gateway/server-methods/agent.ts).

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->