### PR TITLE
perf(cli): short-circuit --version in bootstrap

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -11,6 +11,35 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   }
 }
 
+// Fast-path: print version and exit without loading the full CLI module graph.
+// Avoids process respawn + 28MB dist import for a simple version query.
+// Scans top-level flags only — stops at the first non-flag arg (subcommand).
+let _versionFlag = false;
+for (let _i = 2; _i < process.argv.length; _i++) {
+  const _a = process.argv[_i];
+  if (_a === "--version" || _a === "-v" || _a === "-V") {
+    _versionFlag = true;
+    break;
+  }
+  if (!_a.startsWith("-")) {
+    break;
+  }
+  if (_a === "--profile") {
+    _i++;
+  } // skip --profile's value
+}
+if (_versionFlag) {
+  let _version = process.env.OPENCLAW_BUNDLED_VERSION;
+  if (!_version) {
+    try {
+      const _require = module.createRequire(import.meta.url);
+      _version = _require("./package.json").version;
+    } catch {}
+  }
+  console.log(_version || "0.0.0");
+  process.exit(0);
+}
+
 const isModuleNotFoundError = (err) =>
   err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND";
 

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -25,8 +25,11 @@ for (let _i = 2; _i < process.argv.length; _i++) {
     break;
   }
   if (_a === "--profile") {
-    _i++;
-  } // skip --profile's value
+    const _next = process.argv[_i + 1];
+    if (_next && !_next.startsWith("-")) {
+      _i++;
+    }
+  }
 }
 if (_versionFlag) {
   let _version = process.env.OPENCLAW_BUNDLED_VERSION;

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -21,7 +21,7 @@ for (let _i = 2; _i < process.argv.length; _i++) {
     _versionFlag = true;
     break;
   }
-  if (!_a.startsWith("-")) {
+  if (_a === "--" || !_a.startsWith("-")) {
     break;
   }
   if (_a === "--profile") {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -66,11 +66,22 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     outputError: (str, write) => write(theme.error(str)),
   });
 
-  if (
-    process.argv.includes("-V") ||
-    process.argv.includes("--version") ||
-    process.argv.includes("-v")
-  ) {
+  // Scan top-level flags for version request, stopping at the first subcommand.
+  let isVersionRequest = false;
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+    if (arg === "--version" || arg === "-v" || arg === "-V") {
+      isVersionRequest = true;
+      break;
+    }
+    if (!arg.startsWith("-")) {
+      break;
+    }
+    if (arg === "--profile") {
+      i++;
+    } // skip --profile's value
+  }
+  if (isVersionRequest) {
     console.log(ctx.programVersion);
     process.exit(0);
   }

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -74,7 +74,7 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
       isVersionRequest = true;
       break;
     }
-    if (!arg.startsWith("-")) {
+    if (arg === "--" || !arg.startsWith("-")) {
       break;
     }
     if (arg === "--profile") {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -78,8 +78,11 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
       break;
     }
     if (arg === "--profile") {
-      i++;
-    } // skip --profile's value
+      const next = process.argv[i + 1];
+      if (next && !next.startsWith("-")) {
+        i++;
+      }
+    }
   }
   if (isVersionRequest) {
     console.log(ctx.programVersion);


### PR DESCRIPTION
## Summary

- Add a fast-path in `openclaw.mjs` that checks for `--version` / `-v` / `-V` flags before importing the heavy dist bundle
- Reads version from `OPENCLAW_BUNDLED_VERSION` env var or `package.json` via `createRequire`, then exits immediately
- Bypasses the process respawn and full module graph load that currently happen for a simple version query
- Scans only top-level flags, stopping at the first non-flag arg (subcommand) to avoid `-v` collisions on subcommands

## Measurements

| Platform | Before | After | Savings |
|---|---|---|---|
| VPS (1 vCPU, 2GHz AMD, Node v22) | ~3.5s | ~44ms | **~3.5s (99%)** |

## Test plan

- [x] Verified `--version`, `-v`, `-V` all print correct version and exit immediately
- [x] Verified `openclaw --dev --version` works correctly (scans past global flags)
- [x] Verified `openclaw --profile foo --version` works correctly (skips --profile value)
- [x] Verified normal startup (`health --json`) is unaffected
- [x] Verified `OPENCLAW_BUNDLED_VERSION` env var is respected when set
- [x] `pnpm build && pnpm check && pnpm test` all pass (5635 tests)

AI-assisted (Claude Code). Fully tested, changes understood.

Closes #13133

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a lightweight `--version` fast-path in `openclaw.mjs` that scans only top-level flags (stopping at `--` or the first subcommand) and prints the version without importing the heavy dist entry. It also updates the runtime help/program setup (`src/cli/program/help.ts`) to use the same top-level scan so version requests exit immediately and consistently even when global flags like `--profile <name>` precede `--version`.

The new scanners align with existing argv semantics in `src/cli/argv.ts` (flag terminator handling and value-token consumption), and preserve subcommand `-v` usage by breaking at the first non-flag arg.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are narrowly scoped to version-flag detection, and the updated scans correctly respect the `--` terminator, stop at the first subcommand to avoid `-v` collisions, and avoid consuming `--version` as a missing `--profile` value. Behavior matches existing argv/profile parsing semantics verified in `src/cli/argv.ts` and `src/cli/profile.ts`.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->