### PR TITLE
fix(onboarding): correct hooks Learn more docs URL

### DIFF
--- a/src/commands/onboard-hooks.test.ts
+++ b/src/commands/onboard-hooks.test.ts
@@ -236,6 +236,7 @@ describe("onboard-hooks", () => {
       // First note should explain what hooks are
       expect(noteCalls[0][0]).toContain("Hooks let you automate actions");
       expect(noteCalls[0][0]).toContain("automate actions");
+      expect(noteCalls[0][0]).toContain("https://docs.openclaw.ai/automation/hooks");
 
       // Second note should confirm configuration
       expect(noteCalls[1][0]).toContain("Enabled 1 hook: session-memory");

--- a/src/commands/onboard-hooks.ts
+++ b/src/commands/onboard-hooks.ts
@@ -15,7 +15,7 @@ export async function setupInternalHooks(
       "Hooks let you automate actions when agent commands are issued.",
       "Example: Save session context to memory when you issue /new.",
       "",
-      "Learn more: https://docs.openclaw.ai/hooks",
+      "Learn more: https://docs.openclaw.ai/automation/hooks",
     ].join("\n"),
     "Hooks",
   );


### PR DESCRIPTION
## Summary
Fix onboarding Hooks "Learn more" URL to point to the Hooks overview page.

- Replace `https://docs.openclaw.ai/hooks` with `https://docs.openclaw.ai/automation/hooks` in `setupInternalHooks`.
- Add/extend test assertion in `src/commands/onboard-hooks.test.ts` to verify the onboarding note includes the corrected URL.

Closes #13017.

## Why
The previous URL redirects to a specific hook page and not the general Hooks documentation users need during onboarding.

## Testing
- [x] `pnpm check`
- [x] `pnpm vitest run src/commands/onboard-hooks.test.ts`

## AI assistance
- [x] AI-assisted (implementation + test update)
- [x] I verified the code and test behavior locally

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the onboarding Hooks "Learn more" documentation link in `src/commands/onboard-hooks.ts` from `https://docs.openclaw.ai/hooks` to `https://docs.openclaw.ai/automation/hooks`, and extends `src/commands/onboard-hooks.test.ts` to assert the corrected URL is included in the first onboarding note. This keeps onboarding guidance aligned with the intended Hooks overview documentation and ensures it stays correct via a targeted test.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a simple string update to a user-facing docs URL plus a matching test assertion; no behavioral logic is modified and the test locks the expected output.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->