### PR TITLE
harden archive extraction, auth tokens, hook transforms, and queue limits

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -112,6 +112,8 @@ export class GatewayClient {
       maxPayload: 25 * 1024 * 1024,
     };
     if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
+      // Self-signed certs require disabling CA chain validation; the pinned
+      // SHA-256 fingerprint serves as the sole trust anchor instead.
       wsOptions.rejectUnauthorized = false;
       wsOptions.checkServerIdentity = ((_host: string, cert: CertMeta) => {
         const fingerprintValue =

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -128,7 +128,7 @@ export function resolveHookMappings(hooks?: HooksConfig): HookMappingResolved[] 
 
   const configDir = path.dirname(CONFIG_PATH);
   const transformsDir = hooks?.transformsDir
-    ? resolvePath(configDir, hooks.transformsDir)
+    ? path.resolve(configDir, hooks.transformsDir)
     : configDir;
 
   return mappings.map((mapping, index) => normalizeHookMapping(mapping, index, transformsDir));

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -336,10 +336,15 @@ function resolvePath(baseDir: string, target: string): string {
   if (!target) {
     return baseDir;
   }
-  if (path.isAbsolute(target)) {
-    return target;
+  const resolved = path.isAbsolute(target) ? target : path.join(baseDir, target);
+  const normalized = path.resolve(resolved);
+  const normalizedBase = path.resolve(baseDir);
+  if (!normalized.startsWith(normalizedBase + path.sep) && normalized !== normalizedBase) {
+    throw new Error(
+      `hook transform path escapes base directory: ${target} (resolved to ${normalized})`,
+    );
   }
-  return path.join(baseDir, target);
+  return normalized;
 }
 
 function normalizeMatchPath(raw?: string): string | undefined {

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -339,7 +339,8 @@ function resolvePath(baseDir: string, target: string): string {
   const resolved = path.isAbsolute(target) ? target : path.join(baseDir, target);
   const normalized = path.resolve(resolved);
   const normalizedBase = path.resolve(baseDir);
-  if (!normalized.startsWith(normalizedBase + path.sep) && normalized !== normalizedBase) {
+  const rel = path.relative(normalizedBase, normalized);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
     throw new Error(
       `hook transform path escapes base directory: ${target} (resolved to ${normalized})`,
     );

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -19,7 +19,12 @@ import {
 } from "../canvas-host/a2ui.js";
 import { loadConfig } from "../config/config.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
-import { authorizeGatewayConnect, isLocalDirectRequest, type ResolvedGatewayAuth } from "./auth.js";
+import {
+  authorizeGatewayConnect,
+  isLocalDirectRequest,
+  type ResolvedGatewayAuth,
+} from "./auth.js";
+import { timingSafeEqual } from "node:crypto";
 import {
   handleControlUiAvatarRequest,
   handleControlUiHttpRequest,
@@ -157,7 +162,11 @@ export function createHooksRequestHandler(
     }
 
     const token = extractHookToken(req);
-    if (!token || token !== hooksConfig.token) {
+    if (
+      !token ||
+      token.length !== hooksConfig.token.length ||
+      !timingSafeEqual(Buffer.from(token), Buffer.from(hooksConfig.token))
+    ) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1,5 +1,6 @@
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
+import { timingSafeEqual } from "node:crypto";
 import {
   createServer as createHttpServer,
   type Server as HttpServer,
@@ -19,12 +20,7 @@ import {
 } from "../canvas-host/a2ui.js";
 import { loadConfig } from "../config/config.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
-import {
-  authorizeGatewayConnect,
-  isLocalDirectRequest,
-  type ResolvedGatewayAuth,
-} from "./auth.js";
-import { timingSafeEqual } from "node:crypto";
+import { authorizeGatewayConnect, isLocalDirectRequest, type ResolvedGatewayAuth } from "./auth.js";
 import {
   handleControlUiAvatarRequest,
   handleControlUiHttpRequest,

--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -108,8 +108,19 @@ export async function extractArchive(params: {
 
   const label = kind === "zip" ? "extract zip" : "extract tar";
   if (kind === "tar") {
+    const destDir = params.destDir;
     await withTimeout(
-      tar.x({ file: params.archivePath, cwd: params.destDir }),
+      tar.x({
+        file: params.archivePath,
+        cwd: destDir,
+        filter: (entryPath) => {
+          const resolved = path.resolve(destDir, entryPath);
+          if (!resolved.startsWith(destDir + path.sep) && resolved !== destDir) {
+            throw new Error(`tar entry escapes destination: ${entryPath}`);
+          }
+          return true;
+        },
+      }),
       params.timeoutMs,
       label,
     );

--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -116,7 +116,7 @@ export async function extractArchive(params: {
         filter: (entryPath) => {
           const resolved = path.resolve(destDir, entryPath);
           if (!resolved.startsWith(destDir + path.sep) && resolved !== destDir) {
-            throw new Error(`tar entry escapes destination: ${entryPath}`);
+            return false;
           }
           return true;
         },


### PR DESCRIPTION
1. Tar archive extraction path traversal (src/infra/archive.ts)
   - Added a `filter` callback to `tar.x()` that validates each entry path resolves within the destination directory before extraction. The zip extraction path already had this check; tar did not.

2. Hook token timing attack (src/gateway/server-http.ts)
   - Replaced plain `!==` string comparison of the webhook hook token with `crypto.timingSafeEqual`, preventing character-by-character brute-force via response-time measurement. The main gateway auth already used timing-safe comparison; the hook endpoint did not.

3. TLS fingerprint pinning clarity (src/gateway/client.ts)
   - Documented why `rejectUnauthorized: false` is required when using certificate fingerprint pinning with self-signed certificates generated by the gateway's auto-TLS feature.

4. Hook transform module path traversal (src/gateway/hooks-mapping.ts)
   - `resolvePath()` previously accepted absolute paths and `../` sequences, allowing a malicious config to load and execute arbitrary JS files via `import()`. Now validates that the resolved path stays within the transforms base directory.

5. Unbounded command queue DoS (src/process/command-queue.ts)
   - Added a per-lane max queue depth (default 1000). Enqueue attempts beyond this limit are rejected immediately with an error, preventing memory exhaustion from unbounded task accumulation.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes focus on hardening several security-sensitive areas:

- Adds a path containment check for tar extraction entries (matching existing zip behavior).
- Switches webhook hook token comparison to `timingSafeEqual`.
- Documents the trust model when using TLS fingerprint pinning with self-signed gateway certs.
- Restricts hook transform module resolution to remain within the configured transforms base directory.
- Adds a per-lane maximum queue depth to prevent unbounded command queue growth.

Overall, the PR moves multiple edge cases toward safer defaults, but there are a couple of correctness/portability issues in the new path and queue-limit checks that should be addressed before merging.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally good but has a few correctness/portability issues to address before merging.
- Security hardening changes are generally sound, but the new path containment check relies on string prefix logic that can misbehave on case-insensitive platforms, and the new queue limit semantics may not enforce the intended hard cap. These should be corrected to avoid false rejections or incomplete protection.
- src/gateway/hooks-mapping.ts, src/process/command-queue.ts, src/infra/archive.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->