### PR TITLE
feat(agents): dispatch Claude Code CLI runs as persistent, resumable subagents

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -38,6 +38,8 @@ export async function runCliAgent(params: {
   agentId?: string;
   sessionFile: string;
   workspaceDir: string;
+  /** Override the process working directory. Defaults to workspaceDir. */
+  cwd?: string;
   config?: OpenClawConfig;
   prompt: string;
   provider: string;
@@ -233,9 +235,10 @@ export async function runCliAgent(params: {
         await cleanupResumeProcesses(backend, cliSessionIdToSend);
       }
 
+      const processCwd = params.cwd?.trim() || workspaceDir;
       const result = await runCommandWithTimeout([backend.command, ...args], {
         timeoutMs: params.timeoutMs,
-        cwd: workspaceDir,
+        cwd: processCwd,
         env,
         input: stdinPayload,
       });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -415,6 +415,7 @@ export async function runEmbeddedPiAgent(
             hasRepliedRef: params.hasRepliedRef,
             sessionFile: params.sessionFile,
             workspaceDir: resolvedWorkspace,
+            cwd: params.cwd,
             agentDir,
             config: params.config,
             skillsSnapshot: params.skillsSnapshot,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -56,6 +56,8 @@ export type RunEmbeddedPiAgentParams = {
   disableMessageTool?: boolean;
   sessionFile: string;
   workspaceDir: string;
+  /** Override the process working directory. Defaults to workspaceDir. */
+  cwd?: string;
   agentDir?: string;
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -41,6 +41,8 @@ export type EmbeddedRunAttemptParams = {
   hasRepliedRef?: { value: boolean };
   sessionFile: string;
   workspaceDir: string;
+  /** Override the process working directory. Defaults to workspaceDir. */
+  cwd?: string;
   agentDir?: string;
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -311,6 +311,7 @@ export function buildSubagentSystemPrompt(params: {
   childSessionKey: string;
   label?: string;
   task?: string;
+  resumable?: boolean;
 }) {
   const taskText =
     typeof params.task === "string" && params.task.trim()
@@ -330,7 +331,9 @@ export function buildSubagentSystemPrompt(params: {
     "1. **Stay focused** - Do your assigned task, nothing else",
     "2. **Complete the task** - Your final message will be automatically reported to the main agent",
     "3. **Don't initiate** - No heartbeats, no proactive actions, no side quests",
-    "4. **Be ephemeral** - You may be terminated after task completion. That's fine.",
+    params.resumable
+      ? "4. **Resumable** - Your session persists after completion. You may receive follow-up messages."
+      : "4. **Be ephemeral** - You may be terminated after task completion. That's fine.",
     "",
     "## Output Format",
     "When complete, your final response should include:",
@@ -380,6 +383,7 @@ export async function runSubagentAnnounceFlow(params: {
   label?: string;
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
+  isFollowUp?: boolean;
 }): Promise<boolean> {
   let didAnnounce = false;
   let shouldDeleteChildSession = params.cleanup === "delete";
@@ -486,6 +490,14 @@ export async function runSubagentAnnounceFlow(params: {
     // Build instructional message for main agent
     const announceType = params.announceType ?? "subagent task";
     const taskLabel = params.label || params.task || "task";
+    const followUpHint =
+      params.cleanup === "keep" && !params.isFollowUp
+        ? [
+            "",
+            `Follow-up session key: ${params.childSessionKey}`,
+            "You can send follow-up messages to this subagent using sessions_send with the session key above, if needed.",
+          ]
+        : [];
     const triggerMessage = [
       `A ${announceType} "${taskLabel}" just ${statusLabel}.`,
       "",
@@ -493,9 +505,10 @@ export async function runSubagentAnnounceFlow(params: {
       reply || "(no output)",
       "",
       statsLine,
+      ...followUpHint,
       "",
       "Summarize this naturally for the user. Keep it brief (1-2 sentences). Flow it into the conversation naturally.",
-      `Do not mention technical details like tokens, stats, or that this was a ${announceType}.`,
+      `Do not mention technical details like tokens, stats, session keys, or that this was a ${announceType}.`,
       "You can respond with NO_REPLY if no announcement is needed (e.g., internal task with no user-facing result).",
     ].join("\n");
 

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -9,15 +9,18 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
 import {
   type GatewayMessageChannel,
   INTERNAL_MESSAGE_CHANNEL,
 } from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
+import { findSubagentRunByChildSessionKey, registerSubagentRun } from "../subagent-registry.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
   createAgentToAgentPolicy,
   extractAssistantText,
+  resolveDisplaySessionKey,
   resolveInternalSessionKey,
   resolveMainSessionAlias,
   resolveSessionReference,
@@ -289,7 +292,33 @@ export function createSessionsSendTool(opts?: {
           if (typeof response?.runId === "string" && response.runId) {
             runId = response.runId;
           }
-          startA2AFlow(undefined, runId);
+          if (isSubagentSessionKey(resolvedKey) && requesterInternalKey) {
+            // Register for lifecycle → announce delivery so the main agent
+            // gets the result back automatically, same as sessions_spawn.
+            // Preserve the original spawn's cleanup intent — fall back to
+            // "keep" since follow-ups only make sense for kept sessions.
+            const originalRun = findSubagentRunByChildSessionKey(resolvedKey);
+            const cleanup = originalRun?.cleanup ?? "keep";
+            registerSubagentRun({
+              runId,
+              childSessionKey: resolvedKey,
+              requesterSessionKey: requesterInternalKey,
+              requesterOrigin: normalizeDeliveryContext({
+                channel: opts?.agentChannel,
+              }),
+              requesterDisplayKey: resolveDisplaySessionKey({
+                key: requesterInternalKey,
+                alias,
+                mainKey,
+              }),
+              task: message,
+              cleanup,
+              label: labelParam,
+              isFollowUp: true,
+            });
+          } else {
+            startA2AFlow(undefined, runId);
+          }
           return jsonResult({
             runId,
             status: "accepted",
@@ -376,7 +405,9 @@ export function createSessionsSendTool(opts?: {
       const filtered = stripToolMessages(Array.isArray(history?.messages) ? history.messages : []);
       const last = filtered.length > 0 ? filtered[filtered.length - 1] : undefined;
       const reply = last ? extractAssistantText(last) : undefined;
-      startA2AFlow(reply ?? undefined);
+      if (!isSubagentSessionKey(resolvedKey)) {
+        startA2AFlow(reply ?? undefined);
+      }
 
       return jsonResult({
         runId,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -44,6 +44,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../config/sessions.js";
+import { callGateway } from "../gateway/call.js";
 import {
   clearAgentRunContext,
   emitAgentEvent,
@@ -397,6 +398,7 @@ export async function agentCommand(
               agentId: sessionAgentId,
               sessionFile,
               workspaceDir,
+              cwd: opts.cwd,
               config: cfg,
               prompt: body,
               provider: providerOverride,
@@ -431,6 +433,7 @@ export async function agentCommand(
             senderIsOwner: true,
             sessionFile,
             workspaceDir,
+            cwd: opts.cwd,
             config: cfg,
             skillsSnapshot,
             prompt: body,
@@ -468,6 +471,32 @@ export async function agentCommand(
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
       if (!lifecycleEnded) {
+        // CLI-backed runs don't write to the gateway chat store, so
+        // downstream consumers (readLatestAssistantReply, chat.history)
+        // find nothing. Inject the CLI output before emitting the
+        // lifecycle event so it's available by the time announce flows run.
+        // Cap at 100 KB to avoid bloating the session transcript.
+        const MAX_INJECT_BYTES = 100_000;
+        let cliReplyText = (result.payloads ?? [])
+          .map((p) => p.text)
+          .filter(Boolean)
+          .join("\n")
+          .trim();
+        if (cliReplyText.length > MAX_INJECT_BYTES) {
+          cliReplyText = `${cliReplyText.slice(0, MAX_INJECT_BYTES)}\n\n[truncated — output exceeded ${MAX_INJECT_BYTES} bytes]`;
+        }
+        if (cliReplyText && sessionKey) {
+          try {
+            await callGateway({
+              method: "chat.inject",
+              params: { sessionKey, message: cliReplyText },
+              timeoutMs: 5_000,
+            });
+          } catch {
+            // Best-effort; announce flow will fall back to "(no output)".
+          }
+        }
+
         emitAgentEvent({
           runId,
           stream: "lifecycle",

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -74,4 +74,8 @@ export type AgentCommandOpts = {
   extraSystemPrompt?: string;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;
+  /** Override the process working directory (cwd) for the spawned agent.
+   *  The agent's configured workspace is still used for memory/bootstrap files;
+   *  this only controls where the CLI/embedded process runs. */
+  cwd?: string;
 };

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -67,6 +67,7 @@ export const AgentParamsSchema = Type.Object(
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
     spawnedBy: Type.Optional(Type.String()),
+    cwd: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -85,6 +85,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       timeout?: number;
       label?: string;
       spawnedBy?: string;
+      cwd?: string;
     };
     const cfg = loadConfig();
     const idem = request.idempotencyKey;
@@ -400,6 +401,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         runId,
         lane: request.lane,
         extraSystemPrompt: request.extraSystemPrompt,
+        cwd: typeof request.cwd === "string" && request.cwd.trim() ? request.cwd.trim() : undefined,
       },
       defaultRuntime,
       context.deps,

--- a/src/gateway/server-methods/chat.inject.parentid.test.ts
+++ b/src/gateway/server-methods/chat.inject.parentid.test.ts
@@ -30,6 +30,8 @@ describe("gateway chat.inject transcript writes", () => {
       return {
         ...original,
         loadSessionEntry: () => ({
+          cfg: {},
+          canonicalKey: "k1",
           storePath: "/tmp/store.json",
           entry: {
             sessionId: "sess-1",

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -659,10 +659,26 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     // Load session to find transcript file
     const rawSessionKey = p.sessionKey;
-    const { storePath, entry } = loadSessionEntry(rawSessionKey);
+    const { cfg, storePath, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
     const sessionId = entry?.sessionId;
     if (!sessionId || !storePath) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "session not found"));
+      return;
+    }
+
+    const sendPolicy = resolveSendPolicy({
+      cfg,
+      entry,
+      sessionKey,
+      channel: entry?.channel,
+      chatType: entry?.chatType,
+    });
+    if (sendPolicy === "deny") {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
+      );
       return;
     }
 
@@ -672,7 +688,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionId,
       storePath,
       sessionFile: entry?.sessionFile,
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## feat(agents): dispatch Claude Code CLI runs as persistent, resumable subagents

### Summary

This PR enables a workflow for dispatching Claude Code CLI processes as kept subagents that run in specific project directories, pick up MCP tools via `.mcp.json`, and support iterative follow-up — all driven by the existing lifecycle/announce pipeline without cron or polling.

Spawn a subagent into a git worktree → it discovers project-specific MCP servers → it completes and announces its result → you follow up to refine → the cycle continues with full prior context.

### Motivation

The built-in subagent system and CLI backends (`claude-cli`) already support spawning headless Claude Code runs. With `cleanup: "keep"`, sessions persist and can be resumed. But two gaps prevented this from being useful for multi-turn coding workflows:

1. **No way to follow up.** The announce message didn't include the child session key, the subagent didn't expect follow-ups, and async sends silently dropped results. The main agent had no structured path to iterate on a subagent's work.

2. **No way to control where the process runs.** The CLI process always launched in the agent's configured workspace directory (`~/.openclaw/workspace` by default). If your project has a `.mcp.json` that provides MCP tools, the subagent never sees them — and telling it to `cd` to your project breaks MCP discovery since servers are initialized relative to the process `cwd` at startup.

### Changes

#### Working directory separation (`cwd`)

The `sessions_spawn` tool now accepts an optional `cwd` parameter that controls where the CLI/embedded process actually runs, independently from the agent's workspace directory.

- **`workspaceDir`** — the agent's home for memory, bootstrap files, skills, and state. Resolved from agent config as before.
- **`cwd`** — where the process runs. Defaults to `workspaceDir` when not specified. When set, only affects `spawn()` in the CLI runner and `process.chdir()` / `createAgentSession({ cwd })` in the embedded runner.

Nothing is written into the `cwd` directory by the agent framework — no `AGENTS.md`, `SOUL.md`, or other scaffolding. The typical workflow:

1. Create a git worktree for the task
2. Spawn a subagent with `cwd` pointing at the worktree
3. The Claude CLI process starts in the worktree, discovers `.mcp.json`, and gets project-specific MCP tools
4. Follow up as needed, clean up the worktree when done

**Files:** `sessions-spawn-tool.ts` (schema + passthrough), `agent.ts` (protocol schema), `server-methods/agent.ts` (handler), `agent/types.ts` (opts), `agent.ts` (command), `cli-runner.ts` (spawn), `pi-embedded-runner/run.ts` + `run/attempt.ts` + `run/params.ts` + `run/types.ts` (embedded runner)

#### Follow-up messaging to kept subagent sessions

When a subagent is spawned with `cleanup: "keep"`, the main agent can now send follow-up messages that build on the subagent's full prior context. Three things were missing:

**Announce message includes follow-up key** (`subagent-announce.ts`)

When `cleanup === "keep"`, the announce trigger now appends the child session key and a hint that `sessions_send` can continue the conversation.

**Subagent system prompt is context-aware** (`subagent-announce.ts`, `sessions-spawn-tool.ts`)

`buildSubagentSystemPrompt` gains an optional `resumable` parameter. When the spawn tool passes `resumable: true`, the subagent prompt swaps "Be ephemeral" for "Resumable — your session persists after completion. You may receive follow-up messages."

**Async follow-ups register for announce delivery** (`sessions-send-tool.ts`)

When `sessions_send` dispatches async (`timeoutSeconds: 0`) to a subagent session key, it now calls `registerSubagentRun` — the same registration that `sessions_spawn` uses. This wires follow-ups into the existing lifecycle → announce pipeline so results are delivered back automatically.

#### CLI output available for announce flows (`agent.ts`, `chat.ts`)

CLI-backed runs don't write to the gateway chat store, so `readLatestAssistantReply` returned nothing when the announce flow tried to read the subagent's output. Now, CLI output is injected via `chat.inject` before emitting the lifecycle event. The handler accepts `createIfMissing: true` so transcripts can be bootstrapped on first write.

### Design rationale

The `sessions_send` follow-up path reuses the full subagent lifecycle pipeline (`registerSubagentRun` → lifecycle listener → `runSubagentAnnounceFlow` → `finalizeSubagentCleanup`) rather than building a parallel delivery mechanism. Each follow-up generates a unique `runId`, so multiple concurrent follow-ups to different subagents are tracked independently.

The `cwd` / `workspaceDir` separation is intentionally minimal — `cwd` only affects the process working directory, not skills resolution, bootstrap file loading, or any other agent state. This keeps the security model intact: the operator controls the workspace via config, while `cwd` lets the orchestrating agent point tasks at specific project directories.

### Testing

```bash
pnpm build && pnpm check && pnpm test
```

Type-check clean, formatter clean, all 252 tests pass (41 test files).

**Verified manually:**

- `sessions_spawn` with `cleanup: "keep"` — announce message includes the follow-up session key
- `sessions_send` to the child session key — subagent resumes with full prior context
- `sessions_spawn` with `cwd` pointing at a project with `.mcp.json` — CLI process discovers MCP servers
- Spawning a *new* subagent and asking "What's the last thing I asked you?" — correctly reports no history, confirming session isolation
- Async `sessions_send` results announced back automatically via the lifecycle flow

### Sign-Off

- **AI-assisted**: Yes — developed collaboratively with Claude (Opus 4.6)
- **Testing**: Type-check clean, all existing tests pass, manual verification confirmed above
