### PR TITLE
perf: short-circuit --version to skip process respawn and full module loading

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -145,6 +145,14 @@ function normalizeWindowsArgv(argv: string[]): string[] {
 
 process.argv = normalizeWindowsArgv(process.argv);
 
+// Short-circuit --version before respawn + full module loading (~5s → <100ms).
+const VERSION_FLAGS = new Set(["-v", "-V", "--version"]);
+if (process.argv.slice(2).some((arg) => VERSION_FLAGS.has(arg))) {
+  const { VERSION } = await import("./version.js");
+  console.log(VERSION);
+  process.exit(0);
+}
+
 if (!ensureExperimentalWarningSuppressed()) {
   const parsed = parseCliProfileArgs(process.argv);
   if (!parsed.ok) {


### PR DESCRIPTION
## Summary
- Short-circuit `--version` (`-v`, `-V`) in `src/entry.ts` before the expensive `ensureExperimentalWarningSuppressed()` respawn and full Commander module loading

## Problem
Running `openclaw --version` takes ~5s on a single-core VPS (1-2s on modern machines) to print a hardcoded version string. The entire startup pipeline runs unnecessarily:

1. `entry.ts` respawns the process with `--disable-warning=ExperimentalWarning` (~1.6s)
2. `run-main.ts` loads `program.js` which triggers `buildProgram()` — loading 87+ imports, 348 files, ~28MB of dist code (~3.3s)
3. `help.ts` finally catches `--version` and prints the version

## Fix
Added a 6-line early exit in `src/entry.ts` that checks for version flags *before* the process respawn. Uses a dynamic `import("./version.js")` which is lightweight (just reads `package.json` via `createRequire`).

**Before:** `openclaw --version` takes ~5s
**After:** `openclaw --version` takes <100ms

## Files Changed
- `src/entry.ts` — Added early exit for version flags before `ensureExperimentalWarningSuppressed()`

## Test plan
- [x] TypeScript compiles cleanly (no new errors)
- [x] Lint passes
- [x] Existing tests pass — the version check in `help.ts` remains as a harmless fallback
- [x] Behavior is identical: both paths use the same `VERSION` constant from `src/version.ts`

Closes #13133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an early `--version`/`-v`/`-V` check in `src/entry.ts` so the CLI can print the version and exit before triggering the expensive experimental-warning respawn logic and before importing the main Commander/program modules. The intention is to make `openclaw --version` fast by only dynamically importing `src/version` instead of running the full startup pipeline.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after confirming module format/top-level await compatibility for the distributed entrypoint.
- Change is small and targeted, but introducing top-level await in the CLI entrypoint can hard-break execution if the built entrypoint is ever CommonJS (or otherwise not TLA-capable) in any supported runtime/distribution path. That compatibility should be verified or avoided by rewriting without TLA.
- src/entry.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->