### PR TITLE
security: add --ignore-scripts to npm install during plugin/hook installation

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -172,7 +172,7 @@ Plugins run **in-process** with the Gateway. Treat them as trusted code:
 - Restart the Gateway after plugin changes.
 - If you install plugins from npm (`openclaw plugins install <npm-spec>`), treat it like running untrusted code:
   - The install path is `~/.openclaw/extensions/<pluginId>/` (or `$OPENCLAW_STATE_DIR/extensions/<pluginId>/`).
-  - OpenClaw uses `npm pack` and then runs `npm install --omit=dev` in that directory (npm lifecycle scripts can execute code during install).
+  - OpenClaw uses `npm pack` and then runs `npm install --omit=dev --ignore-scripts` in that directory (npm lifecycle scripts are blocked by default).
   - Prefer pinned, exact versions (`@scope/pkg@1.2.3`), and inspect the unpacked code on disk before enabling.
 
 Details: [Plugins](/tools/plugin)

--- a/docs/zh-CN/gateway/security/index.md
+++ b/docs/zh-CN/gateway/security/index.md
@@ -166,7 +166,7 @@ OpenClaw 的立场：
 - 在插件更改后重启 Gateway 网关。
 - 如果你从 npm 安装插件（`openclaw plugins install <npm-spec>`），将其视为运行不受信任的代码：
   - 安装路径是 `~/.openclaw/extensions/<pluginId>/`（或 `$OPENCLAW_STATE_DIR/extensions/<pluginId>/`）。
-  - OpenClaw 使用 `npm pack` 然后在该目录中运行 `npm install --omit=dev`（npm 生命周期脚本可以在安装期间执行代码）。
+  - OpenClaw 使用 `npm pack` 然后在该目录中运行 `npm install --omit=dev --ignore-scripts`（npm 生命周期脚本默认被阻止）。
   - 优先使用固定的精确版本（`@scope/pkg@1.2.3`），并在启用之前检查磁盘上解压的代码。
 
 详情：[插件](/tools/plugin)

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -40,7 +40,7 @@ export async function ensureMatrixSdkInstalled(params: {
   const root = resolvePluginRoot();
   const command = fs.existsSync(path.join(root, "pnpm-lock.yaml"))
     ? ["pnpm", "install"]
-    : ["npm", "install", "--omit=dev", "--silent"];
+    : ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"];
   params.runtime.log?.(`matrix: installing dependencies via ${command[0]} (${root})…`);
   const result = await getMatrixRuntime().system.runCommandWithTimeout(command, {
     cwd: root,

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -234,10 +234,13 @@ async function installHookPackageFromDir(params: {
   const hasDeps = Object.keys(deps).length > 0;
   if (hasDeps) {
     logger.info?.("Installing hook pack dependencies…");
-    const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent"], {
-      timeoutMs: Math.max(timeoutMs, 300_000),
-      cwd: targetDir,
-    });
+    const npmRes = await runCommandWithTimeout(
+      ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"],
+      {
+        timeoutMs: Math.max(timeoutMs, 300_000),
+        cwd: targetDir,
+      },
+    );
     if (npmRes.code !== 0) {
       if (backupDir) {
         await fs.rm(targetDir, { recursive: true, force: true }).catch(() => undefined);

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -278,10 +278,13 @@ async function installPluginFromPackageDir(params: {
   const hasDeps = Object.keys(deps).length > 0;
   if (hasDeps) {
     logger.info?.("Installing plugin dependencies…");
-    const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent"], {
-      timeoutMs: Math.max(timeoutMs, 300_000),
-      cwd: targetDir,
-    });
+    const npmRes = await runCommandWithTimeout(
+      ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"],
+      {
+        timeoutMs: Math.max(timeoutMs, 300_000),
+        cwd: targetDir,
+      },
+    );
     if (npmRes.code !== 0) {
       if (backupDir) {
         await fs.rm(targetDir, { recursive: true, force: true }).catch(() => undefined);


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to all `npm install` invocations during plugin, hook pack, and extension dependency installation
- Update security docs (EN + zh-CN) to reflect that lifecycle scripts are now blocked by default

## Problem
When installing plugins or hook packs with npm dependencies, `npm install` runs without `--ignore-scripts`. This means a malicious package's `postinstall` (or `preinstall`, `install`) lifecycle scripts execute arbitrary code on the host machine *before* any code safety review.

## Fix
Added `--ignore-scripts` to the npm install argument array in all three locations:

1. `src/plugins/install.ts` — plugin dependency installation
2. `src/hooks/install.ts` — hook pack dependency installation
3. `extensions/matrix/src/matrix/deps.ts` — Matrix extension on-demand dependency installation

Also updated the security documentation in both English and Chinese to reflect that npm lifecycle scripts are now blocked by default.

## Files Changed
- `src/plugins/install.ts` — Added `--ignore-scripts` flag
- `src/hooks/install.ts` — Added `--ignore-scripts` flag
- `extensions/matrix/src/matrix/deps.ts` — Added `--ignore-scripts` flag
- `docs/gateway/security/index.md` — Updated docs
- `docs/zh-CN/gateway/security/index.md` — Updated Chinese docs

## Test plan
- [x] TypeScript compiles cleanly (no new errors)
- [x] Lint passes
- [x] No test changes needed — existing plugin/hook install tests don't exercise the npm install path (test plugins have no `dependencies`)
- [x] Legitimate plugins should not rely on `postinstall` scripts; if a native addon needs compilation, users can manually run `npm rebuild`

Closes #13132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens dependency installation paths by adding `--ignore-scripts` to `npm install` when installing plugin dependencies (`src/plugins/install.ts`), hook pack dependencies (`src/hooks/install.ts`), and Matrix extension on-demand deps (`extensions/matrix/src/matrix/deps.ts`). It also updates the Gateway security documentation (EN + zh-CN) to reflect that npm lifecycle scripts are now blocked by default during these installs.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one security hardening gap remains for pnpm installs in the Matrix extension path.
- The npm install paths are consistently updated to block lifecycle scripts, aligning with the stated security goal. However, the Matrix dependency installer still runs `pnpm install` without an ignore-scripts equivalent when a pnpm lockfile is present, leaving an execution path for lifecycle scripts in that environment.
- extensions/matrix/src/matrix/deps.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->