### PR TITLE
security: enforce webhookSecret at runtime for Telegram webhook mode

### DIFF
--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -25,6 +25,12 @@ vi.mock("./bot.js", () => ({
 }));
 
 describe("startTelegramWebhook", () => {
+  it("throws when secret is missing", async () => {
+    await expect(startTelegramWebhook({ token: "tok", port: 0 })).rejects.toThrow(
+      "requires a secret token",
+    );
+  });
+
   it("starts server, registers webhook, and serves health", async () => {
     createTelegramBotSpy.mockClear();
     const abort = new AbortController();
@@ -34,6 +40,7 @@ describe("startTelegramWebhook", () => {
       accountId: "opie",
       config: cfg,
       port: 0, // random free port
+      secret: "test-secret",
       abortSignal: abort.signal,
     });
     expect(createTelegramBotSpy).toHaveBeenCalledWith(
@@ -65,6 +72,7 @@ describe("startTelegramWebhook", () => {
       accountId: "opie",
       config: cfg,
       port: 0,
+      secret: "test-secret",
       abortSignal: abort.signal,
       path: "/hook",
     });

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -30,6 +30,13 @@ export async function startTelegramWebhook(opts: {
   healthPath?: string;
   publicUrl?: string;
 }) {
+  if (!opts.secret) {
+    throw new Error(
+      "Telegram webhook mode requires a secret token. " +
+        "Set channels.telegram.webhookSecret in your config.",
+    );
+  }
+
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
   const port = opts.port ?? 8787;


### PR DESCRIPTION
## Summary
- Add a runtime guard in `startTelegramWebhook()` that throws if `secret` is missing, preventing unauthenticated webhook update injection

## Problem
While the Zod config schema validates that `webhookSecret` must be set when `webhookUrl` is configured, the runtime API surface (`startTelegramWebhook()`) accepts `secret` as optional. When `secret` is undefined, grammY's `webhookCallback` accepts *all* POST requests without authentication:

```javascript
// grammy/out/convenience/webhook.js
function compareSecretToken(header, token) {
    if (token === undefined) { return true; } // accepts everything
    ...
}
```

Since the webhook server binds to `0.0.0.0` by default, an attacker who can reach the webhook port could inject forged Telegram update payloads. This is particularly relevant for plugin/SDK consumers who may call `startTelegramWebhook()` directly, bypassing config-level validation.

## Fix
Added a fail-fast guard at the top of `startTelegramWebhook()`:

```typescript
if (!opts.secret) {
  throw new Error(
    "Telegram webhook mode requires a secret token. " +
      "Set channels.telegram.webhookSecret in your config.",
  );
}
```

Updated existing tests to pass a `secret` parameter and added a new test verifying that startup fails without a secret.

## Files Changed
- `src/telegram/webhook.ts` — Added runtime secret guard
- `src/telegram/webhook.test.ts` — Added missing-secret test, updated existing tests

## Test plan
- [x] New test: `throws when secret is missing` — verifies the guard works
- [x] Existing tests updated with `secret: "test-secret"` — all 3 tests pass
- [x] TypeScript compiles cleanly
- [x] Lint passes
- [x] No behavioral change for properly configured deployments (config schema already requires the secret)

Closes #13116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens Telegram webhook mode by adding a fail-fast runtime guard in `src/telegram/webhook.ts` so `startTelegramWebhook()` throws when `opts.secret` is missing, preventing grammY’s `webhookCallback` from accepting unauthenticated POSTs when `secretToken` is `undefined`. Tests in `src/telegram/webhook.test.ts` were updated to pass a secret and a new test asserts startup rejects without one.

This aligns the runtime API surface with existing config-level validation (`channels.telegram.webhookUrl` requires `channels.telegram.webhookSecret`) and closes the gap for SDK/plugin consumers who call `startTelegramWebhook()` directly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted runtime guard that matches the existing config invariants, and the accompanying tests cover the new failure mode plus existing webhook start paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->