### PR TITLE
feat(discord): add role-based agent routing

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -47,6 +47,8 @@ export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist
 export type DiscordGuildEntry = {
   slug?: string;
   requireMention?: boolean;
+  /** Optional per-guild role→agent routing overrides (roleId -> agentId). */
+  roleBindings?: Record<string, string>;
   /** Optional tool policy overrides for this guild (used when channel override is missing). */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -245,6 +245,7 @@ export const DiscordGuildSchema = z
   .object({
     slug: z.string().optional(),
     requireMention: z.boolean().optional(),
+    roleBindings: z.record(z.string(), z.string()).optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -20,6 +20,7 @@ export type DiscordGuildEntryResolved = {
   id?: string;
   slug?: string;
   requireMention?: boolean;
+  roleBindings?: Record<string, string>;
   reactionNotifications?: "off" | "own" | "all" | "allowlist";
   users?: Array<string | number>;
   channels?: Record<

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -219,12 +219,21 @@ export async function preflightDiscordMessage(
     earlyThreadParentType = parentInfo.type;
   }
 
+  const guildInfo = isGuildMessage
+    ? resolveDiscordGuildEntry({
+        guild: params.data.guild ?? undefined,
+        guildEntries: params.guildEntries,
+      })
+    : null;
+
   // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const route = resolveAgentRoute({
     cfg: loadConfig(),
     channel: "discord",
     accountId: params.accountId,
     guildId: params.data.guild_id ?? undefined,
+    mentionedRoleIds: message.mentionedRoles,
+    roleBindings: guildInfo?.roleBindings,
     peer: {
       kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
       id: isDirectMessage ? author.id : message.channelId,
@@ -274,12 +283,6 @@ export async function preflightDiscordMessage(
     return null;
   }
 
-  const guildInfo = isGuildMessage
-    ? resolveDiscordGuildEntry({
-        guild: params.data.guild ?? undefined,
-        guildEntries: params.guildEntries,
-      })
-    : null;
   if (
     isGuildMessage &&
     params.guildEntries &&

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -457,13 +457,16 @@ export async function preflightDiscordMessage(
   }
 
   const canDetectMention = Boolean(botId) || mentionRegexes.length > 0;
+  // Role-based routing should satisfy the mention gate — the user explicitly
+  // mentioned an agent role, which is equivalent to mentioning the bot.
+  const roleRouted = route.matchedBy === "binding.role";
   const mentionGate = resolveMentionGatingWithBypass({
     isGroup: isGuildMessage,
     requireMention: Boolean(shouldRequireMention),
     canDetectMention,
-    wasMentioned,
+    wasMentioned: wasMentioned || roleRouted,
     implicitMention,
-    hasAnyMention,
+    hasAnyMention: hasAnyMention || roleRouted,
     allowTextCommands,
     hasControlCommand: hasControlCommandInMessage,
     commandAuthorized,

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -471,6 +471,40 @@ describe("discord role mention routing", () => {
     expect(route.matchedBy).toBe("binding.peer");
   });
 
+  test("parent peer binding still wins over role mention", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "storm",
+          match: {
+            channel: "discord",
+            peer: { kind: "channel", id: "storm-chat" },
+          },
+        },
+        {
+          agentId: "guild-fallback",
+          match: {
+            channel: "discord",
+            guildId: "g1",
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      guildId: "g1",
+      peer: { kind: "channel", id: "thread-1" },
+      parentPeer: { kind: "channel", id: "storm-chat" },
+      mentionedRoleIds: ["r-hunter"],
+      roleBindings: {
+        "r-hunter": "hunter",
+      },
+    });
+    expect(route.agentId).toBe("storm");
+    expect(route.matchedBy).toBe("binding.peer.parent");
+  });
+
   test("role mention wins over guild fallback when peer is not bound", () => {
     const cfg: OpenClawConfig = {
       bindings: [

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -238,12 +238,18 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   if (input.mentionedRoleIds?.length) {
     const roleBindings = input.roleBindings;
     if (roleBindings) {
+      // Normalize roleBindings keys once for reliable lookup
+      const normalizedBindings = new Map<string, string>();
+      for (const [key, value] of Object.entries(roleBindings)) {
+        const nk = normalizeId(key);
+        if (nk && value) normalizedBindings.set(nk, value);
+      }
       for (const roleId of input.mentionedRoleIds) {
         const normalizedRoleId = normalizeId(roleId);
         if (!normalizedRoleId) {
           continue;
         }
-        const agentId = roleBindings[normalizedRoleId];
+        const agentId = normalizedBindings.get(normalizedRoleId);
         if (agentId) {
           return choose(agentId, "binding.role");
         }

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -242,7 +242,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       const normalizedBindings = new Map<string, string>();
       for (const [key, value] of Object.entries(roleBindings)) {
         const nk = normalizeId(key);
-        if (nk && value) normalizedBindings.set(nk, value);
+        if (nk && value) {
+          normalizedBindings.set(nk, value);
+        }
       }
       for (const roleId of input.mentionedRoleIds) {
         const normalizedRoleId = normalizeId(roleId);


### PR DESCRIPTION
## Summary

Adds role-based routing for Discord messages. When a message contains a role mention (e.g. `@Storm`), OpenClaw can route it to the correct agent based on a new `roleBindings` config — regardless of which channel the message was sent in.

## Problem

OpenClaw routes Discord messages to agents based on channel bindings. All agents share one bot account (Clawd). When someone @mentions an agent's Discord role in a different channel, the message routes to the channel owner — not the mentioned agent.

Example: `@Storm` mentioned in `#hunter-chat` → routes to Hunter (channel owner), not Storm.

## Solution

Add `roleBindings` to the Discord guild config:

```json
{
  "channels": {
    "discord": {
      "guilds": {
        "GUILD_ID": {
          "roleBindings": {
            "STORM_ROLE_ID": "storm",
            "HUNTER_ROLE_ID": "hunter"
          }
        }
      }
    }
  }
}
```

### Routing Priority (updated cascade)
1. `binding.peer` — exact channel match
2. `binding.peer.parent` — thread parent channel match
3. **`binding.role` — role mention match (NEW)**
4. `binding.guild` — guild-level binding
5. `binding.team` — team-level binding
6. `binding.account` / `binding.channel` — account fallback
7. `default` — default agent

### Key Design Decisions
- Role routing has **lower** priority than peer (channel) binding — if you're in `#storm-chat` and mention `@Hunter`, it still goes to Storm (channel owner is intentional)
- Role routing has **higher** priority than guild/team fallback — if you're in an unbound channel and mention `@Storm`, it routes to Storm
- If multiple roles are mentioned, first match wins
- Role bindings are per-guild (different servers can have different mappings)

## Files Changed
- `src/config/types.discord.ts` — added `roleBindings` to guild config type
- `src/config/zod-schema.providers-core.ts` — added zod validation for roleBindings
- `src/routing/resolve-route.ts` — added role routing to cascade + `binding.role` matchedBy type
- `src/discord/monitor/message-handler.preflight.ts` — passes mentionedRoles + roleBindings to resolveAgentRoute
- `src/discord/monitor/allow-list.ts` — role mention allowlist support
- `src/routing/resolve-route.test.ts` — 163 lines of new tests covering role routing

## Use Case
Multi-agent Discord servers where each agent has a Discord role. Users and agents can @mention each other across channels, and messages route to the correct agent session.

## Testing
- Added comprehensive tests for role-based routing
- Tests cover: basic role routing, peer binding precedence over roles, parent-peer precedence, multiple role mentions, unknown roles fallback to default

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Discord routing so that, for guild messages, role mentions can influence agent resolution via a new per-guild `roleBindings` config (roleId → agentId). The routing cascade in `src/routing/resolve-route.ts` now checks (1) peer binding, (2) parent-peer binding (thread parent), then (3) first mentioned role that maps in `roleBindings`, before falling back to guild/team/account/default bindings. Discord preflight is updated to pass `message.mentionedRoles` and the resolved guild’s `roleBindings` into `resolveAgentRoute`, and tests were added to cover precedence and fallback behavior.

Primary issue to address before merge: role mention routing normalizes incoming role IDs but does not normalize the configured `roleBindings` keys, so minor formatting differences in config (e.g., whitespace) will cause routing to fail unexpectedly.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the roleBindings normalization edge case is addressed.
- Changes are localized and covered by new routing tests, but the new config-driven role routing path can fail unexpectedly if roleBindings keys aren’t normalized consistently with incoming role IDs.
- src/routing/resolve-route.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->