### PR TITLE
fix: resolve llm-task module import for global installs

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.test.ts
+++ b/extensions/llm-task/src/llm-task-tool.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("../../../src/agents/pi-embedded-runner.js", () => {
+vi.mock("openclaw/plugin-sdk", async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>();
   return {
+    ...original,
     runEmbeddedPiAgent: vi.fn(async () => ({
       meta: { startedAt: Date.now() },
       payloads: [{ text: "{}" }],
@@ -9,7 +11,7 @@ vi.mock("../../../src/agents/pi-embedded-runner.js", () => {
   };
 });
 
-import { runEmbeddedPiAgent } from "../../../src/agents/pi-embedded-runner.js";
+import { runEmbeddedPiAgent } from "openclaw/plugin-sdk";
 import { createLlmTaskTool } from "./llm-task-tool.js";
 
 function fakeApi(overrides: any = {}) {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -369,5 +369,8 @@ export {
 } from "../line/markdown-to-line.js";
 export type { ProcessedLineMessage } from "../line/markdown-to-line.js";
 
+// Agent runner (used by llm-task extension)
+export { runEmbeddedPiAgent } from "../agents/pi-embedded-runner.js";
+
 // Media utilities
 export { loadWebMedia, type WebMediaResult } from "../web/media.js";


### PR DESCRIPTION
## Summary

- Export `runEmbeddedPiAgent` from `openclaw/plugin-sdk` so the llm-task extension can import it via the stable SDK seam
- Replace fragile relative path imports (`../../../src/agents/pi-embedded-runner.js` with dev/dist fallback) with a single `import { runEmbeddedPiAgent } from "openclaw/plugin-sdk"`
- Fixes llm-task failing with `Cannot find module` in Homebrew and npm global installs where the bundled chunk layout differs from the source tree

## Changes

- `src/plugin-sdk/index.ts` — added `runEmbeddedPiAgent` export
- `extensions/llm-task/src/llm-task-tool.ts` — replaced dynamic loader with direct SDK import (-22 lines)
- `extensions/llm-task/src/llm-task-tool.test.ts` — updated mock to use new import path

Net: 3 files, -19 lines.

## Test plan

- [x] `pnpm vitest run extensions/llm-task/src/llm-task-tool.test.ts` — 8/8 passing
- [x] `pnpm build` — clean
- [x] `pnpm check` — lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `llm-task` failing to load `runEmbeddedPiAgent` in global/bundled installs by moving the import onto the stable `openclaw/plugin-sdk` seam.

Changes:
- `src/plugin-sdk/index.ts` now re-exports `runEmbeddedPiAgent`, making it available via `openclaw/plugin-sdk`.
- `extensions/llm-task/src/llm-task-tool.ts` replaces the previous relative-path/dynamic import fallback logic with a direct SDK import.
- `extensions/llm-task/src/llm-task-tool.test.ts` updates the mock to intercept `openclaw/plugin-sdk` and preserve other SDK exports via `importOriginal()`.

Integration-wise, this aligns the extension with the package’s `exports` mapping to `dist/plugin-sdk/index.js`, avoiding assumptions about bundled chunk layout.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to rerouting an internal import through the published plugin-sdk export surface. The new export is a value export (not type-only), and package exports map `openclaw/plugin-sdk` to the built `dist/plugin-sdk/index.js`, so the runtime symbol should exist in global installs. Tests were updated accordingly and remain focused on behavior, not module layout.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->