### PR TITLE
docs(system-prompt): include MEMORY bootstrap injection details

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,6 +59,8 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
+- `MEMORY.md` (optional, when present)
+- `memory.md` (optional fallback when `MEMORY.md` is absent)
 
 Large files are truncated with a marker. The max per-file size is controlled by
 `agents.defaults.bootstrapMaxChars` (default: 20000). Missing files inject a
@@ -66,6 +68,8 @@ short missing-file marker.
 
 Internal hooks can intercept this step via `agent:bootstrap` to mutate or replace
 the injected bootstrap files (for example swapping `SOUL.md` for an alternate persona).
+
+For sub-agent sessions, injection is intentionally reduced to `AGENTS.md` + `TOOLS.md` only.
 
 To inspect how much each injected file contributes (raw vs injected, truncation, plus tool schema overhead), use `/context list` or `/context detail`. See [Context](/concepts/context).
 


### PR DESCRIPTION
## Summary
Clarify `System Prompt` docs to reflect actual bootstrap-file injection behavior for memory files.

### Changes
- In `docs/concepts/system-prompt.md` (**Workspace bootstrap injection**):
  - add `MEMORY.md` as an optional injected bootstrap file when present
  - add `memory.md` as optional fallback when `MEMORY.md` is absent
- Add explicit note that sub-agent sessions reduce injection to `AGENTS.md` + `TOOLS.md` only.

Closes #12909.

## Why
Current docs omit memory bootstrap files in this section, which can imply they are not part of injected project context. Runtime behavior includes them when present.

## Testing
- Docs-only change; verified wording against current runtime behavior in `src/agents/workspace.ts`.

## AI assistance
- [x] AI-assisted
- [x] Manually reviewed for correctness

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/concepts/system-prompt.md` to document additional workspace bootstrap files injected into the system prompt (notably memory bootstrap files) and to clarify that sub-agent sessions use a reduced bootstrap set.

The change aligns the docs more closely with the runtime bootstrap assembly in `src/agents/workspace.ts` (where bootstrap files are loaded and then filtered for subagent sessions), but there is one behavioral mismatch called out in review comments regarding how `MEMORY.md` vs `memory.md` are actually selected.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix a docs/runtime mismatch first.
- Docs-only change with a single factual mismatch: the docs claim `memory.md` is a fallback when `MEMORY.md` is absent, but the runtime can inject both when both exist (deduping only when they resolve to the same path).
- docs/concepts/system-prompt.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->