### PR TITLE
fix: dedup mapped hook dispatches to prevent Gmail Pub/Sub retries

### DIFF
--- a/src/gateway/server-http-hooks-dedupe.test.ts
+++ b/src/gateway/server-http-hooks-dedupe.test.ts
@@ -1,0 +1,168 @@
+import { type IncomingMessage, type ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { resolveHookMappings } from "./hooks-mapping.js";
+import { createHooksRequestHandler } from "./server-http.js";
+
+function fakeReq(opts: {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}): IncomingMessage {
+  const chunks: Buffer[] = [];
+  const bodyStr = opts.body ? JSON.stringify(opts.body) : "";
+  if (bodyStr) {
+    chunks.push(Buffer.from(bodyStr, "utf-8"));
+  }
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    authorization: "Bearer test-token",
+    ...opts.headers,
+  };
+  return {
+    url: opts.url,
+    method: opts.method ?? "POST",
+    headers,
+    on(event: string, cb: (...args: unknown[]) => void) {
+      if (event === "data") {
+        for (const chunk of chunks) {
+          cb(chunk);
+        }
+      }
+      if (event === "end") {
+        cb();
+      }
+      return this;
+    },
+    removeListener() {
+      return this;
+    },
+  } as unknown as IncomingMessage;
+}
+
+function fakeRes(): ServerResponse & { _status: number; _body: string } {
+  const res = {
+    _status: 0,
+    _body: "",
+    _headers: {} as Record<string, string>,
+    statusCode: 200,
+    headersSent: false,
+    setHeader(key: string, value: string) {
+      res._headers[key.toLowerCase()] = value;
+    },
+    end(body?: string) {
+      res._status = res.statusCode;
+      res._body = body ?? "";
+    },
+  };
+  return res as unknown as ServerResponse & { _status: number; _body: string };
+}
+
+describe("hooks request handler dedup", () => {
+  const gmailMappings = resolveHookMappings({
+    presets: ["gmail"],
+  });
+
+  function makeHandler() {
+    const dispatched: Array<{ message: string; sessionKey: string }> = [];
+    const dispatchAgentHook = vi.fn((value: { message: string; sessionKey: string }) => {
+      dispatched.push(value);
+      return `run-${dispatched.length}`;
+    });
+    const dispatchWakeHook = vi.fn();
+    const handler = createHooksRequestHandler({
+      getHooksConfig: () => ({
+        basePath: "/hooks",
+        token: "test-token",
+        maxBodyBytes: 1_000_000,
+        mappings: gmailMappings,
+      }),
+      bindHost: "127.0.0.1",
+      port: 18789,
+      logHooks: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        verbose: () => {},
+      } as any,
+      dispatchAgentHook: dispatchAgentHook as any,
+      dispatchWakeHook: dispatchWakeHook as any,
+    });
+    return { handler, dispatchAgentHook, dispatched };
+  }
+
+  it("dispatches the first hook request", async () => {
+    const { handler, dispatchAgentHook } = makeHandler();
+    const req = fakeReq({
+      url: "/hooks/gmail",
+      body: {
+        messages: [
+          {
+            id: "msg-123",
+            from: "alice@test.com",
+            subject: "Hello",
+            snippet: "Hi",
+            body: "Hi there",
+          },
+        ],
+      },
+    });
+    const res = fakeRes();
+    const handled = await handler(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(202);
+    expect(dispatchAgentHook).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates the same hook payload within TTL", async () => {
+    const { handler, dispatchAgentHook } = makeHandler();
+    const body = {
+      messages: [
+        { id: "msg-456", from: "bob@test.com", subject: "Dup", snippet: "...", body: "body" },
+      ],
+    };
+
+    // First request — should dispatch
+    const req1 = fakeReq({ url: "/hooks/gmail", body });
+    const res1 = fakeRes();
+    await handler(req1, res1);
+    expect(res1._status).toBe(202);
+    expect(dispatchAgentHook).toHaveBeenCalledTimes(1);
+
+    // Second request with same payload — should be deduped
+    const req2 = fakeReq({ url: "/hooks/gmail", body });
+    const res2 = fakeRes();
+    await handler(req2, res2);
+    expect(res2._status).toBe(200);
+    expect(dispatchAgentHook).toHaveBeenCalledTimes(1); // Still 1, not 2
+    const parsed = JSON.parse(res2._body);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.duplicate).toBe(true);
+  });
+
+  it("allows different message IDs through", async () => {
+    const { handler, dispatchAgentHook } = makeHandler();
+
+    const req1 = fakeReq({
+      url: "/hooks/gmail",
+      body: {
+        messages: [{ id: "msg-a", from: "a@test.com", subject: "A", snippet: "", body: "" }],
+      },
+    });
+    const res1 = fakeRes();
+    await handler(req1, res1);
+
+    const req2 = fakeReq({
+      url: "/hooks/gmail",
+      body: {
+        messages: [{ id: "msg-b", from: "b@test.com", subject: "B", snippet: "", body: "" }],
+      },
+    });
+    const res2 = fakeRes();
+    await handler(req2, res2);
+
+    expect(dispatchAgentHook).toHaveBeenCalledTimes(2);
+    expect(res1._status).toBe(202);
+    expect(res2._status).toBe(202);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a TTL-based dedup cache (5 min, 500 entries) to the hooks request handler
- When a mapped hook resolves with a session key that was already seen within TTL, return `200 {ok: true, duplicate: true}` instead of dispatching a new agent run
- Prevents at-least-once delivery systems like Gmail Pub/Sub from triggering duplicate agent runs for the same email notification

## Root Cause

Google Pub/Sub uses at-least-once delivery — the same notification can arrive multiple times. The hook handler in `server-http.ts` dispatched `dispatchAgentHook()` for every matching request without checking if that exact session key was already processed. The Gmail preset uses `hook:gmail:{{messages[0].id}}` as the session key, providing a natural dedup key.

## Changes

- `src/gateway/server-http.ts` — added `createDedupeCache` import and dedup check before mapped hook dispatch (+13 lines)
- `src/gateway/server-http-hooks-dedupe.test.ts` — 3 tests covering dispatch, dedup, and different IDs (new file)

## Test plan

- [x] `pnpm vitest run src/gateway/server-http-hooks-dedupe.test.ts` — 3/3 passing
- [x] `pnpm vitest run src/gateway/hooks-mapping.test.ts` — 7/7 passing (no regression)
- [x] `pnpm build` — clean
- [x] `pnpm check` — lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a TTL-based in-memory dedupe cache to the gateway hooks HTTP handler so mapped hook dispatches (not `/hooks/agent`) are suppressed when the same `sessionKey` repeats within a 5 minute window. It returns `200 { ok: true, duplicate: true }` for duplicates instead of dispatching a new agent run, and includes a new Vitest file covering first-dispatch vs duplicate vs different IDs for the Gmail preset mapping.

The change is localized to `createHooksRequestHandler` in `src/gateway/server-http.ts`, leveraging a shared `createDedupeCache` utility from `src/infra/dedupe.ts`, and it interacts with the existing hook mapping system (`applyHookMappings` / Gmail preset `sessionKey`).

<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge, but the dedupe flow can drop events if dispatch fails after marking a key as seen.
- The core change is small and covered by tests, but the current `check()`-then-dispatch ordering means a transient dispatch failure can cause subsequent retries to be treated as duplicates (no agent run), which is a correctness issue for at-least-once delivery sources.
- src/gateway/server-http.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->