### PR TITLE
docs(system-prompt): clarify MEMORY.md injection and memory/*.md behavior

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,6 +59,10 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
+- `MEMORY.md` (optional; injected when present)
+- `memory.md` (optional fallback when `MEMORY.md` is absent)
+
+`memory/*.md` daily files are **not** auto-injected into the system prompt. They are accessed via memory tools (`memory_search`, `memory_get`) and the memory index pipeline.
 
 Large files are truncated with a marker. The max per-file size is controlled by
 `agents.defaults.bootstrapMaxChars` (default: 20000). Missing files inject a


### PR DESCRIPTION
## Summary
Clarify memory-file injection behavior on the System Prompt docs page.

### Changes
- Document that `MEMORY.md` is injected when present.
- Document that `memory.md` is used as fallback when `MEMORY.md` is absent.
- Clarify that `memory/*.md` daily files are **not** auto-injected into the system prompt and are accessed via memory tools (`memory_search`, `memory_get`).

Closes #12909.

## Why
The docs currently imply/omit behavior in a way that can make users underestimate baseline context usage and misunderstand how memory files are loaded.

## Testing
- Docs-only change.

## AI assistance
- [x] AI-assisted (draft + edit)
- [x] Reviewed manually

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/concepts/system-prompt.md` to clarify which memory-related workspace files get injected into the generated system prompt. It adds `MEMORY.md` to the documented bootstrap injection list (injected when present), documents `memory.md` as the fallback when `MEMORY.md` is absent, and explicitly states that `memory/*.md` daily files are not auto-injected and are instead accessed via the memory tool/index pipeline.

This aligns the docs with the current implementation in `src/agents/workspace.ts` (optional `MEMORY.md` / `memory.md` bootstrap entries) and the system prompt’s memory guidance in `src/agents/system-prompt.ts` (which instructs using `memory_search` / `memory_get` against `MEMORY.md + memory/*.md`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Docs-only change that matches current code behavior: workspace bootstrap loads optional `MEMORY.md`/`memory.md` and daily `memory/*.md` are accessed through memory tools rather than auto-injection.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->