### PR TITLE
docs(system-prompt): clarify MEMORY.md vs memory/*.md injection

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,6 +59,12 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
+- `MEMORY.md` (optional)
+- `memory.md` (optional fallback when `MEMORY.md` is absent)
+
+`memory/*.md` daily files are **not** auto-injected into the base system prompt.
+Those are typically accessed via `memory_search` / `memory_get` (or explicit
+`read` calls).
 
 Large files are truncated with a marker. The max per-file size is controlled by
 `agents.defaults.bootstrapMaxChars` (default: 20000). Missing files inject a


### PR DESCRIPTION
## Summary
Clarify memory file injection behavior on the system prompt docs page.

### Changes
- In `docs/concepts/system-prompt.md` (Workspace bootstrap injection section), explicitly document that:
  - `MEMORY.md` is injected when present
  - `memory.md` is used as a fallback
  - `memory/*.md` daily files are **not** auto-injected into the base system prompt
- Keep existing guidance pointing users to `/context list` and `/context detail` for token impact inspection.

Closes #12909.

## Why
The current page did not clearly describe memory file injection behavior, which can lead to wrong assumptions about context usage.

## Testing
- Docs-only change; no runtime behavior changed.

## AI assistance
- [x] AI-assisted (drafting/editing)
- [x] Verified changed section against current docs structure and wording

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `docs/concepts/system-prompt.md` to explicitly document memory bootstrap injection behavior: `MEMORY.md` is injected when present, `memory.md` is used only as a fallback, and `memory/*.md` daily files are not automatically included in the base system prompt (they’re typically accessed via memory tools or explicit reads). This fits into the existing “Workspace bootstrap injection” section, alongside guidance on using `/context list` and `/context detail` to inspect token impact.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Docs-only change that clarifies existing behavior; diff is small, internally consistent with the surrounding section, and introduces no code/runtime changes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->