### PR TITLE
fix(daemon): use execFileSync instead of execSync to prevent shell injection

### DIFF
--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -148,10 +148,10 @@ async function resolveNodePath(): Promise<string> {
 }
 
 async function resolveBinaryPath(binary: string): Promise<string> {
-  const { execSync } = await import("node:child_process");
+  const { execFileSync } = await import("node:child_process");
   const cmd = process.platform === "win32" ? "where" : "which";
   try {
-    const output = execSync(`${cmd} ${binary}`, { encoding: "utf8" }).trim();
+    const output = execFileSync(cmd, [binary], { encoding: "utf8" }).trim();
     const resolved = output.split(/\r?\n/)[0]?.trim();
     if (!resolved) {
       throw new Error("empty");


### PR DESCRIPTION
## Summary

- Replace `execSync` with `execFileSync` in `src/daemon/program-args.ts` to prevent shell injection when resolving binary paths.
- `execSync` passes the command through a shell, which could allow injection if the binary name were attacker-controlled. `execFileSync` invokes the target directly without a shell intermediary.

Supersedes #12253 (accidentally closed during fork maintenance).

## Test plan
- [ ] Verify `openclaw gateway start` still resolves binary paths correctly
- [ ] Verify `which`/`where` lookups work on Linux/macOS/Windows

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/daemon/program-args.ts` to resolve runtime binaries (`node`/`bun`) using `execFileSync(cmd, [binary])` instead of `execSync(`${cmd} ${binary}`)`. That keeps the `which`/`where` lookup behavior but avoids going through a shell, removing a straightforward command-injection vector if `binary` were ever influenced by untrusted input.

The change is localized to the daemon program-argument resolution path used by service install helpers (`src/commands/daemon-install-helpers.ts`, `src/commands/node-daemon-install-helpers.ts`) and should be behavior-preserving aside from the security hardening.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (one call site) and replaces shell-based execution with direct execution while preserving inputs/outputs, reducing injection risk without changing surrounding logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->