### PR TITLE
pi-embedded: enable failover when per-agent fallbacks are configured

### DIFF
--- a/src/agents/pi-embedded-runner/run.fallback-config.test.ts
+++ b/src/agents/pi-embedded-runner/run.fallback-config.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+vi.mock("./run/attempt.js", () => ({
+  runEmbeddedAttempt: vi.fn(),
+}));
+
+vi.mock("../workspace-run.js", () => ({
+  redactRunIdentifier: (s: string) => s,
+  resolveRunWorkspaceDir: vi.fn(() => ({
+    workspaceDir: "/tmp/workspace",
+    usedFallback: false,
+    fallbackReason: "",
+    agentId: "main",
+  })),
+}));
+
+vi.mock("../../process/command-queue.js", () => ({
+  enqueueCommandInLane: vi.fn((_lane: string, task: () => unknown) => task()),
+}));
+
+vi.mock("../../utils/message-channel.js", () => ({
+  isMarkdownCapableMessageChannel: vi.fn(() => true),
+}));
+
+vi.mock("../agent-paths.js", () => ({
+  resolveOpenClawAgentDir: vi.fn(() => "/tmp/agent-dir"),
+}));
+
+vi.mock("../models-config.js", () => ({
+  ensureOpenClawModelsJson: vi.fn(async () => {}),
+}));
+
+vi.mock("../context-window-guard.js", () => ({
+  CONTEXT_WINDOW_HARD_MIN_TOKENS: 1000,
+  CONTEXT_WINDOW_WARN_BELOW_TOKENS: 5000,
+  evaluateContextWindowGuard: vi.fn(() => ({
+    shouldWarn: false,
+    shouldBlock: false,
+    tokens: 200000,
+    source: "model",
+  })),
+  resolveContextWindowInfo: vi.fn(() => ({
+    tokens: 200000,
+    source: "model",
+  })),
+}));
+
+vi.mock("../defaults.js", () => ({
+  DEFAULT_CONTEXT_TOKENS: 200000,
+  DEFAULT_MODEL: "test-model",
+  DEFAULT_PROVIDER: "opencode",
+}));
+
+vi.mock("../failover-error.js", () => ({
+  FailoverError: class FailoverError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = "FailoverError";
+    }
+  },
+  resolveFailoverStatus: vi.fn(() => 429),
+}));
+
+vi.mock("./lanes.js", () => ({
+  resolveSessionLane: vi.fn(() => "session-lane"),
+  resolveGlobalLane: vi.fn(() => "global-lane"),
+}));
+
+vi.mock("./logger.js", () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("./model.js", () => ({
+  resolveModel: vi.fn(() => ({
+    model: {
+      id: "test-model",
+      provider: "opencode",
+      contextWindow: 200000,
+      api: "openai-completions",
+    },
+    error: null,
+    authStorage: {
+      setRuntimeApiKey: vi.fn(),
+    },
+    modelRegistry: {},
+  })),
+}));
+
+vi.mock("../model-auth.js", () => ({
+  ensureAuthProfileStore: vi.fn(() => ({ profiles: {} })),
+  // Force API key resolution to fail so we go through throwAuthProfileFailover.
+  getApiKeyForModel: vi.fn(async () => {
+    throw new Error("no api key");
+  }),
+  resolveAuthProfileOrder: vi.fn(() => []),
+}));
+
+vi.mock("../model-selection.js", () => ({
+  normalizeProviderId: (p: string) => p,
+}));
+
+vi.mock("../auth-profiles.js", () => ({
+  isProfileInCooldown: vi.fn(() => false),
+  markAuthProfileFailure: vi.fn(async () => {}),
+  markAuthProfileGood: vi.fn(async () => {}),
+  markAuthProfileUsed: vi.fn(async () => {}),
+}));
+
+vi.mock("../usage.js", () => ({
+  normalizeUsage: vi.fn(() => undefined),
+}));
+
+vi.mock("./run/payloads.js", () => ({
+  buildEmbeddedRunPayloads: vi.fn(() => []),
+}));
+
+vi.mock("./compact.js", () => ({
+  compactEmbeddedPiSessionDirect: vi.fn(async () => ({
+    compacted: false,
+    compactedCount: 0,
+    durationMs: 0,
+  })),
+}));
+
+vi.mock("./tool-result-truncation.js", () => ({
+  truncateOversizedToolResultsInSession: vi.fn(async () => ({
+    truncated: false,
+    truncatedCount: 0,
+    reason: "none",
+  })),
+  sessionLikelyHasOversizedToolResults: vi.fn(() => false),
+}));
+
+vi.mock("./utils.js", () => ({
+  describeUnknownError: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+}));
+
+vi.mock("../pi-embedded-helpers.js", async () => ({
+  BILLING_ERROR_USER_MESSAGE: "billing",
+  classifyFailoverReason: vi.fn(() => "rate_limit"),
+  formatAssistantErrorText: vi.fn(() => ""),
+  isAuthAssistantError: vi.fn(() => false),
+  isBillingAssistantError: vi.fn(() => false),
+  isCompactionFailureError: vi.fn(() => false),
+  isContextOverflowError: vi.fn(() => false),
+  isFailoverAssistantError: vi.fn(() => false),
+  isFailoverErrorMessage: vi.fn(() => true),
+  isRateLimitAssistantError: vi.fn(() => true),
+  isTimeoutErrorMessage: vi.fn(() => false),
+  parseImageSizeError: vi.fn(() => null),
+  parseImageDimensionError: vi.fn(() => null),
+  pickFallbackThinkingLevel: vi.fn(() => null),
+}));
+
+import { runEmbeddedPiAgent } from "./run.js";
+
+const baseParams = {
+  sessionId: "test-session",
+  sessionKey: "agent:main:main",
+  sessionFile: "/tmp/session.json",
+  workspaceDir: "/tmp/workspace",
+  prompt: "hello",
+  timeoutMs: 30000,
+  runId: "run-1",
+  provider: "opencode",
+  model: "kimi-k2.5-free",
+};
+
+describe("runEmbeddedPiAgent fallback gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("treats per-agent fallbacks as enabling failover (even when defaults are empty)", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: null,
+        },
+        list: [
+          {
+            id: "main",
+            model: {
+              primary: "opencode/kimi-k2.5-free",
+              fallbacks: ["openai-codex/gpt-5.3-codex"],
+            },
+          },
+        ],
+      },
+    };
+
+    await expect(
+      runEmbeddedPiAgent({ ...baseParams, config: cfg as unknown as OpenClawConfig }),
+    ).rejects.toMatchObject({
+      name: "FailoverError",
+    });
+  });
+
+  it("does NOT enable failover when per-agent fallbacks are explicitly disabled", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: null,
+        },
+        list: [
+          {
+            id: "main",
+            model: {
+              primary: "opencode/kimi-k2.5-free",
+              fallbacks: [],
+            },
+          },
+        ],
+      },
+    };
+
+    try {
+      await runEmbeddedPiAgent({ ...baseParams, config: cfg as unknown as OpenClawConfig });
+      throw new Error("expected runEmbeddedPiAgent to throw");
+    } catch (err) {
+      expect(err).not.toMatchObject({ name: "FailoverError" });
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -5,6 +5,7 @@ import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
+import { resolveAgentModelFallbacksOverride } from "../agent-scope.js";
 import {
   isProfileInCooldown,
   markAuthProfileFailure,
@@ -176,8 +177,17 @@ export async function runEmbeddedPiAgent(
       const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
       const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
+
+      const agentFallbacksOverride = params.config
+        ? resolveAgentModelFallbacksOverride(params.config, workspaceResolution.agentId)
+        : undefined;
+      const defaultFallbacks = params.config?.agents?.defaults?.model?.fallbacks;
+
       const fallbackConfigured =
-        (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
+        agentFallbacksOverride !== undefined
+          ? agentFallbacksOverride.length > 0
+          : (defaultFallbacks?.length ?? 0) > 0;
+
       await ensureOpenClawModelsJson(params.config, agentDir);
 
       const { model, error, authStorage, modelRegistry } = resolveModel(


### PR DESCRIPTION
### Problem
When OpenClaw runs inbound messages via the embedded PI runner (e.g. Telegram), `runEmbeddedPiAgent()` decides whether to throw `FailoverError` (to let the outer `runWithModelFallback()` advance models) based only on `agents.defaults.model.fallbacks`.

If `agents.defaults.model` is unset/null but an agent has per-agent model fallbacks configured (`agents.list[].model.fallbacks`), embedded runs treat rate-limit/auth failures as non-failover and do not advance to the next model. This effectively disables per-agent fallbacks for embedded sessions.

### Change
Gate failover on **per-agent fallback override** when present:
- If `resolveAgentModelFallbacksOverride(cfg, agentId)` is defined, use its length to decide whether failover is enabled.
- Otherwise fall back to `agents.defaults.model.fallbacks`.

This preserves existing semantics and also honors explicit per-agent disable (`fallbacks: []`).

### Tests
Add `run.fallback-config.test.ts` to verify:
- Per-agent fallbacks enable FailoverError even if defaults are empty
- Per-agent fallbacks explicitly disabled do not enable failover

### Why
This makes embedded sessions behave consistently with gateway-level model fallback selection, and prevents surprising “stuck on primary model” behavior when only per-agent fallbacks are configured.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the embedded PI runner’s failover gating so that `runEmbeddedPiAgent()` treats per-agent model fallback overrides (`agents.list[].model.fallbacks`) as enabling failover (and respects an explicit disable via `fallbacks: []`) when defaults are unset. A new unit test exercises the two key behaviors: per-agent fallbacks enable throwing `FailoverError` on auth/rate-limit style failures even when defaults are empty, and explicitly-disabled per-agent fallbacks do not.

The change fits into the existing failover flow by only affecting the boolean `fallbackConfigured`, which is later used to decide whether to throw `FailoverError` (allowing `runWithModelFallback()` to advance models) vs rethrowing the underlying error during embedded runs.

<h3>Confidence Score: 3/5</h3>

- This PR is conceptually safe but the new test may not actually run in CI as added.
- The runtime change is small and uses an existing helper (`resolveAgentModelFallbacksOverride`) with well-defined semantics (undefined vs empty array). However, the new test heavily mocks internals and I couldn't validate execution here (no npm), so the main remaining risk is that the added test isn’t executed by the repo’s configured test runner/patterns.
- src/agents/pi-embedded-runner/run.fallback-config.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->