### PR TITLE
perf(logging): defer log pruning to setImmediate during startup

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -65,7 +65,7 @@ describe("logger helpers", () => {
     cleanup(logPath);
   });
 
-  it("uses daily rolling default log file and prunes old ones", () => {
+  it("uses daily rolling default log file and prunes old ones", async () => {
     resetLogger();
     setLoggerOverride({}); // force defaults regardless of user config
     const today = localDateString(new Date());
@@ -82,6 +82,9 @@ describe("logger helpers", () => {
 
     expect(fs.existsSync(todayPath)).toBe(true);
     expect(fs.readFileSync(todayPath, "utf-8")).toContain("roll-me");
+
+    // Pruning is deferred to setImmediate; wait for it to run.
+    await new Promise((resolve) => setImmediate(resolve));
     expect(fs.existsSync(oldPath)).toBe(false);
 
     cleanup(todayPath);

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -89,9 +89,10 @@ export function isFileLogLevelEnabled(level: LogLevel): boolean {
 
 function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   fs.mkdirSync(path.dirname(settings.file), { recursive: true });
-  // Clean up stale rolling logs when using a dated log filename.
+  // Defer log pruning to avoid blocking the event loop during startup.
   if (isRollingPath(settings.file)) {
-    pruneOldRollingLogs(path.dirname(settings.file));
+    const dir = path.dirname(settings.file);
+    setImmediate(() => pruneOldRollingLogs(dir));
   }
   const logger = new TsLogger<LogObj>({
     name: "openclaw",


### PR DESCRIPTION
## Summary

- Defer `pruneOldRollingLogs()` from synchronous execution during logger initialization to `setImmediate`, removing it from the critical startup path
- The test is updated to await the deferred tick before asserting the old log file was deleted

## Measurements

| Platform | Before | After | Savings |
|---|---|---|---|
| VPS (1 vCPU, 2GHz AMD, Node v22) | 6.38s | 4.20s | **2.18s (34%)** |
| Mac (M-series) | 1.26s | 0.80s | **0.46s (37%)** |

Individual contribution is small (log pruning is fast on most systems), but it removes unnecessary synchronous I/O from the startup hot path. Measurements are combined with #13194 and #13195.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] All 5635 tests pass (`pnpm test`)
- [x] Updated rolling log pruning test to await `setImmediate` tick
- [x] Verified log pruning still occurs (just deferred by one event loop tick)

AI-assisted (Claude Code). Fully tested, changes understood.