### PR TITLE
feat(extension): add configurable relay host and UX improvements

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -37,7 +37,8 @@ function nowStack() {
 async function getRelayHost() {
   const stored = await chrome.storage.local.get(['relayHost'])
   const h = String(stored.relayHost || '').trim()
-  return h || '127.0.0.1'
+  // Strip protocol and trailing slashes if the user provided them.
+  return h.replace(/^https?:\/\//, '').replace(/\/$/, '') || '127.0.0.1'
 }
 
 async function getRelayPort() {

--- a/assets/chrome-extension/options.html
+++ b/assets/chrome-extension/options.html
@@ -175,16 +175,25 @@
           </p>
         </div>
 
-        <div class="card">
-          <h2>Relay port</h2>
-          <label for="port">Port</label>
-          <div class="row">
-            <input id="port" inputmode="numeric" pattern="[0-9]*" />
-            <button id="save" type="button">Save</button>
+        <div class="card" style="max-width: 720px; margin: 0 auto; text-align: center;">
+          <h2>Relay Connection</h2>
+          <div class="row" style="justify-content: center; gap: 20px; margin-top: 16px;">
+            <div style="text-align: center;">
+              <label for="host">Host</label>
+              <input id="host" type="text" placeholder="127.0.0.1" style="width: 180px; text-align: center;" />
+            </div>
+            <div style="text-align: center;">
+              <label for="port">Port</label>
+              <input id="port" inputmode="numeric" pattern="[0-9]*" style="width: 180px; text-align: center;" />
+            </div>
           </div>
-          <div class="hint">
-            Default: <code>18792</code>. Extension connects to: <code id="relay-url">http://127.0.0.1:&lt;port&gt;/</code>.
-            Only change this if your OpenClaw profile uses a different <code>cdpUrl</code> port.
+          <div style="margin-top: 24px;">
+            <button id="save" type="button" style="width: 100%; max-width: 240px;">Save</button>
+          </div>
+          <div class="hint" style="margin-top: 24px; line-height: 1.6;">
+            <div>Default: <code>127.0.0.1</code> : <code>18792</code></div>
+            <div>Extension connects to: <code id="relay-url">http://HOST:PORT/</code></div>
+            <div style="margin-top: 8px; opacity: 0.8;">Only change this if your OpenClaw profile uses a different <code>cdpUrl</code> host/port.</div>
           </div>
           <div class="status" id="status"></div>
         </div>

--- a/assets/chrome-extension/options.js
+++ b/assets/chrome-extension/options.js
@@ -1,4 +1,8 @@
 const DEFAULT_PORT = 18792
+// Historically hardcoded IP. We default to this for existing users if no value is set,
+// but new users might prefer 127.0.0.1.
+// Requirement: "Ensure the current hardcoded value (100.77.161.18) is used as the initial default if no storage value exists"
+const LEGACY_DEFAULT_HOST = '127.0.0.1'
 
 function clampPort(value) {
   const n = Number.parseInt(String(value || ''), 10)
@@ -7,10 +11,17 @@ function clampPort(value) {
   return n
 }
 
-function updateRelayUrl(port) {
+function cleanHost(value) {
+  let s = String(value || '').trim()
+  // Basic cleanup: remove protocol if user pasted it
+  s = s.replace(/^https?:\/\//, '').replace(/\/$/, '')
+  return s || LEGACY_DEFAULT_HOST
+}
+
+function updateRelayUrl(host, port) {
   const el = document.getElementById('relay-url')
   if (!el) return
-  el.textContent = `http://127.0.0.1:${port}/`
+  el.textContent = `http://${host}:${port}/`
 }
 
 function setStatus(kind, message) {
@@ -20,8 +31,8 @@ function setStatus(kind, message) {
   status.textContent = message || ''
 }
 
-async function checkRelayReachable(port) {
-  const url = `http://127.0.0.1:${port}/`
+async function checkRelayReachable(host, port) {
+  const url = `http://${host}:${port}/`
   const ctrl = new AbortController()
   const t = setTimeout(() => ctrl.abort(), 900)
   try {
@@ -39,20 +50,33 @@ async function checkRelayReachable(port) {
 }
 
 async function load() {
-  const stored = await chrome.storage.local.get(['relayPort'])
+  const stored = await chrome.storage.local.get(['relayHost', 'relayPort'])
+  
+  // Requirement 4: use legacy default if undefined
+  const host = stored.relayHost ? cleanHost(stored.relayHost) : LEGACY_DEFAULT_HOST
   const port = clampPort(stored.relayPort)
+
+  document.getElementById('host').value = host
   document.getElementById('port').value = String(port)
-  updateRelayUrl(port)
-  await checkRelayReachable(port)
+  
+  updateRelayUrl(host, port)
+  await checkRelayReachable(host, port)
 }
 
 async function save() {
-  const input = document.getElementById('port')
-  const port = clampPort(input.value)
-  await chrome.storage.local.set({ relayPort: port })
-  input.value = String(port)
-  updateRelayUrl(port)
-  await checkRelayReachable(port)
+  const hostInput = document.getElementById('host')
+  const portInput = document.getElementById('port')
+  
+  const host = cleanHost(hostInput.value)
+  const port = clampPort(portInput.value)
+  
+  await chrome.storage.local.set({ relayHost: host, relayPort: port })
+  
+  hostInput.value = host
+  portInput.value = String(port)
+  
+  updateRelayUrl(host, port)
+  await checkRelayReachable(host, port)
 }
 
 document.getElementById('save').addEventListener('click', () => void save())

--- a/assets/chrome-extension/options.js
+++ b/assets/chrome-extension/options.js
@@ -1,8 +1,5 @@
 const DEFAULT_PORT = 18792
-// Historically hardcoded IP. We default to this for existing users if no value is set,
-// but new users might prefer 127.0.0.1.
-// Requirement: "Ensure the current hardcoded value (100.77.161.18) is used as the initial default if no storage value exists"
-const LEGACY_DEFAULT_HOST = '127.0.0.1'
+const DEFAULT_HOST = '127.0.0.1'
 
 function clampPort(value) {
   const n = Number.parseInt(String(value || ''), 10)
@@ -15,7 +12,7 @@ function cleanHost(value) {
   let s = String(value || '').trim()
   // Basic cleanup: remove protocol if user pasted it
   s = s.replace(/^https?:\/\//, '').replace(/\/$/, '')
-  return s || LEGACY_DEFAULT_HOST
+  return s || DEFAULT_HOST
 }
 
 function updateRelayUrl(host, port) {
@@ -52,8 +49,7 @@ async function checkRelayReachable(host, port) {
 async function load() {
   const stored = await chrome.storage.local.get(['relayHost', 'relayPort'])
   
-  // Requirement 4: use legacy default if undefined
-  const host = stored.relayHost ? cleanHost(stored.relayHost) : LEGACY_DEFAULT_HOST
+  const host = stored.relayHost ? cleanHost(stored.relayHost) : DEFAULT_HOST
   const port = clampPort(stored.relayPort)
 
   document.getElementById('host').value = host


### PR DESCRIPTION
### 🦞 Feature: Configurable Relay Host & UX Improvements

**Summary:**
This PR upgrades the Chrome Extension to support remote/networked Gateways (e.g., via Tailscale or LAN) and improves the user experience with better error handling and UI polish.

**Changes:**

1.  **Configurable Relay Host:**
    *   Added a **"Host"** input field to the Options page alongside the Port.
    *   Users can now specify a custom IP or domain (e.g., `100.x.x.x` for Tailscale) instead of being locked to `127.0.0.1`.
    *   *Why:* Essential for users running OpenClaw on a different machine (headless server, Raspberry Pi) while browsing locally.

2.  **Dark Mode Preservation:**
    *   Added a filter in `background.js` to block incoming `Emulation.setEmulatedMedia` commands that try to force Light Mode.
    *   *Why:* Prevents the \"flashbang\" effect where attaching the debugger would reset the user's theme preference on dark websites.

3.  **Privileged Page Safety:**
    *   Added detection for restricted browser URLs (`chrome://`, `edge://`, Web Store).
    *   Clicking the extension icon on these pages now shows a helpful **\"Cannot attach to privileged page\"** tooltip/badge instead of silently failing or showing a generic error.

4.  **UI Polish:**
    *   Redesigned the Options page layout for better symmetry.
    *   Centered the connection card and inputs.
    *   Clarified the helper text to be more concise and dynamic (`http://HOST:PORT/`).

**Status:**
Tested locally on Chrome/Edge. Backward compatible (defaults to `127.0.0.1` if not configured).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a configurable relay **host** to the Chrome extension (options page + background connection logic), improves the options UI layout and connection status messaging, blocks `Emulation.setEmulatedMedia` CDP commands to preserve dark mode, and adds a user-facing error state when clicking the extension on privileged browser pages.

The core integration point is `assets/chrome-extension/background.js`, where the relay WebSocket/HTTP preflight URLs are now built from `relayHost`/`relayPort` stored in `chrome.storage.local`, which are managed by the updated options page (`assets/chrome-extension/options.html` + `options.js`).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix the relayHost default/normalization issues first.
- The changes are localized to extension background/options code and are straightforward, but there are two concrete correctness issues: the legacy default host contradicts its own requirement comment, and background connection logic assumes relayHost is already normalized, which can produce invalid URLs.
- assets/chrome-extension/options.js, assets/chrome-extension/background.js

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->