### PR TITLE
perf(cli): short-circuit --version in entry bootstrap

### DIFF
--- a/src/cli/banner.ts
+++ b/src/cli/banner.ts
@@ -31,7 +31,7 @@ function splitGraphemes(value: string): string[] {
 const hasJsonFlag = (argv: string[]) =>
   argv.some((arg) => arg === "--json" || arg.startsWith("--json="));
 
-const hasVersionFlag = (argv: string[]) =>
+const hasBannerVersionFlag = (argv: string[]) =>
   argv.some((arg) => arg === "--version" || arg === "-V" || arg === "-v");
 
 export function formatCliBannerLine(version: string, options: BannerOptions = {}): string {
@@ -119,7 +119,7 @@ export function emitCliBanner(version: string, options: BannerOptions = {}) {
   if (hasJsonFlag(argv)) {
     return;
   }
-  if (hasVersionFlag(argv)) {
+  if (hasBannerVersionFlag(argv)) {
     return;
   }
   const line = formatCliBannerLine(version, options);

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -6,6 +6,18 @@ import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
 import { installProcessWarningFilter } from "./infra/warning-filter.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
+import { VERSION } from "./version.js";
+
+const VERSION_FLAGS = new Set(["-v", "-V", "--version"]);
+
+export function hasVersionFlag(argv: string[]): boolean {
+  return argv.some((arg) => VERSION_FLAGS.has(arg));
+}
+
+if (hasVersionFlag(process.argv)) {
+  console.log(VERSION);
+  process.exit(0);
+}
 
 process.title = "openclaw";
 installProcessWarningFilter();

--- a/src/entry.version-flag.test.ts
+++ b/src/entry.version-flag.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { hasVersionFlag } from "./entry.js";
+
+describe("entry version short-circuit", () => {
+  it("detects global version flags", () => {
+    expect(hasVersionFlag(["node", "openclaw", "--version"])).toBe(true);
+    expect(hasVersionFlag(["node", "openclaw", "-V"])).toBe(true);
+    expect(hasVersionFlag(["node", "openclaw", "-v"])).toBe(true);
+  });
+
+  it("ignores argv without version flags", () => {
+    expect(hasVersionFlag(["node", "openclaw", "status"])).toBe(false);
+    expect(hasVersionFlag(["node", "openclaw", "gateway", "--port", "18789"])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- short-circuit --version/-V/-v in src/entry.ts before runtime/bootstrap initialization
- print VERSION and exit immediately for version-only invocations
- add focused unit tests for version-flag detection

## Why
- keeps `openclaw --version` fast and side-effect free
- avoids unnecessary initialization work for a pure metadata command

## AI assistance
- AI-assisted: implemented with Codex

## Testing
- Degree: lightly tested
- `pnpm vitest src/entry.version-flag.test.ts --run`
- Note: repository-wide `tsc` currently fails due to unrelated pre-existing errors in `src/commands/skill-audit.ts`

Refs #13133

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an early-exit path in `src/entry.ts` to print `VERSION` and `process.exit(0)` when `-v`/`-V`/`--version` is present, plus a small unit test for version-flag detection.

Key concern is that the new test imports `src/entry.ts` directly, which is the real CLI entrypoint and executes bootstrap side effects at module evaluation time. Additionally, the new version-flag detection logic does not respect the `--` argument terminator and differs from existing argv parsing helpers in `src/cli/argv.ts`, which can change behavior for commands that pass `-v` through after `--`.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge until bootstrap side effects are removed from the unit test import and version-flag parsing matches existing argv semantics.
- The functional change is small, but the test currently imports the CLI entrypoint (triggering top-level bootstrap) and the new flag detection can incorrectly exit for args after `--`, which is a behavior regression for pass-through invocations.
- src/entry.ts, src/entry.version-flag.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->