### PR TITLE
docs(system-prompt): clarify memory file injection behavior

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,6 +59,12 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
+- `MEMORY.md` (optional)
+- `memory.md` (optional fallback when `MEMORY.md` is absent)
+
+`memory/*.md` daily files are **not** auto-injected into the base system prompt.
+Those are typically accessed via `memory_search` / `memory_get` (or explicit
+`read` calls).
 
 Large files are truncated with a marker. The max per-file size is controlled by
 `agents.defaults.bootstrapMaxChars` (default: 20000). Missing files inject a


### PR DESCRIPTION
## Summary
Clarify memory file injection behavior in system prompt docs.

- Add `MEMORY.md` and `memory.md` to the injected workspace bootstrap file list.
- Clarify that `memory/*.md` daily files are **not** auto-injected into the base system prompt.
- Clarify that daily memory notes are typically accessed through `memory_search` / `memory_get` (or explicit `read`).

Closes #12909.

## Why
The current page can be read as if memory files are not injected. In practice, `MEMORY.md` / `memory.md` are injected in bootstrap context, while `memory/*.md` is not.

## Testing
- Docs-only change; validated against current runtime behavior and workspace bootstrap file loading.

## AI assistance
- [x] AI-assisted
- [x] Verified content against source implementation before opening this PR

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/concepts/system-prompt.md` to clarify how workspace memory files are injected into the system prompt: `MEMORY.md` (or `memory.md` fallback) can be included in the bootstrap context, while `memory/*.md` daily notes are not automatically injected and are typically accessed via `memory_search`/`memory_get`.

The new statements match the current implementation in `src/agents/workspace.ts` (bootstrap loader only considers fixed bootstrap files plus optional `MEMORY.md`/`memory.md`).

One follow-up is needed for doc consistency: the generated `docs/zh-CN/concepts/system-prompt.md` translation is now stale relative to the updated English source and should be regenerated/updated.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after updating generated docs output
- The English doc changes match the current bootstrap injection implementation, but the generated zh-CN translation is now stale and should be regenerated/updated to avoid publishing inconsistent documentation.
- docs/zh-CN/concepts/system-prompt.md (regenerate via docs i18n pipeline)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->