### PR TITLE
docs(readme): use --target for message send example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ openclaw onboard --install-daemon
 openclaw gateway --port 18789 --verbose
 
 # Send a message
-openclaw message send --to +1234567890 --message "Hello from OpenClaw"
+openclaw message send --target +1234567890 --message "Hello from OpenClaw"
 
 # Talk to the assistant (optionally deliver back to any connected channel: WhatsApp/Telegram/Slack/Discord/Google Chat/Signal/iMessage/BlueBubbles/Microsoft Teams/Matrix/Zalo/Zalo Personal/WebChat)
 openclaw agent --message "Ship checklist" --thinking high


### PR DESCRIPTION
## Summary
Update README `openclaw message send` example to use `--target` instead of deprecated `--to`.

Closes #10458.

## Why
Current docs show `--to`, but the command now uses `--target`.

## Testing
- Docs-only change.
- Verified updated snippet renders correctly in README.

## AI assistance
- [x] AI-assisted
- [x] Verified manually

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the README quick-start snippet to use `openclaw message send --target ...` instead of the deprecated `--to` flag, aligning the documentation with the current CLI option name.

Change is isolated to the `README.md` quick start example and doesn’t affect runtime code paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Docs-only change updates a single CLI flag in README; diff is small, consistent, and doesn’t introduce build/runtime impact.
- No files require special attention.

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->