### PR TITLE
CI: extend stale timelines to be contributor-friendly

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/stale@v9
         with:
           repo-token: ${{ steps.app-token.outputs.token }}
-          days-before-issue-stale: 7
-          days-before-issue-close: 5
-          days-before-pr-stale: 5
-          days-before-pr-close: 3
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale


### PR DESCRIPTION
Extends stale automation timelines to be more contributor-friendly:

| | Before | After |
|---|---|---|
| **Issues** | 7 days stale → 5 days close (12 total) | 30 days stale → 14 days close (44 total) |
| **PRs** | 5 days stale → 3 days close (8 total) | 14 days stale → 7 days close (21 total) |

The original timelines were too aggressive for community contributors who may have vacations, busy periods, or need time to address feedback.

Exemptions remain unchanged: `maintainer`, `security`, `enhancement`, `pinned`, `no-stale`, and assigned items.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the GitHub Actions stale workflow (`.github/workflows/stale.yml`) to significantly relax the inactivity windows before labeling issues/PRs as `stale` and before auto-closing them.

The workflow continues to run on a daily schedule and uses the GitHub App token to apply labels/comments and close items, while keeping the same exemption rules (labels and assignees).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to numeric configuration values in a single GitHub Actions workflow and don’t affect application runtime behavior. The updated values are internally consistent (close-after is later than stale-after) and exemptions/config structure remain unchanged.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->