### PR TITLE
feat(feishu): skip reply-to in DM conversations

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1160,6 +1160,7 @@ export async function handleFeishuMessage(params: {
       runtime: runtime as RuntimeEnv,
       chatId: ctx.chatId,
       replyToMessageId: ctx.messageId,
+      skipReplyToInMessages: !isGroup,
       replyInThread,
       rootId: ctx.rootId,
       mentionTargets: ctx.mentionTargets,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -28,6 +28,8 @@ export type CreateFeishuReplyDispatcherParams = {
   runtime: RuntimeEnv;
   chatId: string;
   replyToMessageId?: string;
+  /** When true, preserve typing indicator on reply target but send messages without reply metadata */
+  skipReplyToInMessages?: boolean;
   replyInThread?: boolean;
   rootId?: string;
   mentionTargets?: MentionTarget[];
@@ -41,11 +43,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     agentId,
     chatId,
     replyToMessageId,
+    skipReplyToInMessages,
     replyInThread,
     rootId,
     mentionTargets,
     accountId,
   } = params;
+  const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const account = resolveFeishuAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
@@ -189,7 +193,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   cfg,
                   to: chatId,
                   mediaUrl,
-                  replyToMessageId,
+                  replyToMessageId: sendReplyToMessageId,
                   replyInThread,
                   accountId,
                 });
@@ -209,7 +213,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 cfg,
                 to: chatId,
                 text: chunk,
-                replyToMessageId,
+                replyToMessageId: sendReplyToMessageId,
                 replyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
@@ -227,7 +231,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 cfg,
                 to: chatId,
                 text: chunk,
-                replyToMessageId,
+                replyToMessageId: sendReplyToMessageId,
                 replyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
@@ -243,7 +247,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               cfg,
               to: chatId,
               mediaUrl,
-              replyToMessageId,
+              replyToMessageId: sendReplyToMessageId,
               replyInThread,
               accountId,
             });


### PR DESCRIPTION
## Problem

In Feishu DM (p2p) chats, every bot response shows a 'Reply to' quote referencing the user's last message. This is unnecessary in 1-on-1 conversations and clutters the chat interface.

## Root Cause

`createFeishuReplyDispatcher` in `bot.ts` always passes `replyToMessageId: ctx.messageId`, which causes `send.ts` to use the `im.message.reply()` API instead of `im.message.create()`. The reply API inherently adds the 'Reply to' reference.

## Fix

Only pass `replyToMessageId` in group chats where reply context is useful. In DMs, pass `undefined` so messages are sent via `im.message.create()` without reply references.

```typescript
// Before
replyToMessageId: ctx.messageId,

// After  
replyToMessageId: isGroup ? ctx.messageId : undefined,
```

Both call sites in `bot.ts` are updated (normal message dispatch and permission error dispatch).

## Testing

Tested in production Feishu DM — bot messages no longer show 'Reply to' in DMs while group chat behavior is preserved.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes Feishu reply dispatch so DMs no longer send via `im.message.reply()` (which shows a “Reply to” quote) by conditionally omitting `replyToMessageId` when `chat_type` is `p2p`. Group chats keep the existing reply behavior by still providing `replyToMessageId`.

The change is localized to `extensions/feishu/src/bot.ts` call sites of `createFeishuReplyDispatcher`, and relies on `extensions/feishu/src/send.ts`’s branching between `message.reply` vs `message.create` based on whether `replyToMessageId` is set.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but introduces a clear DM behavior regression for typing indicators.
- The core change (skipping reply-to in DMs) is small and consistent across both dispatcher call sites, but it interacts with existing typing-indicator logic that requires `replyToMessageId`, causing typing indicators to never start in DMs.
- extensions/feishu/src/reply-dispatcher.ts (typing indicator gating on replyToMessageId), extensions/feishu/src/bot.ts (DM replyToMessageId now undefined)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->