### PR TITLE
fix(usage): resolve cost summary agent from session/config

### DIFF
--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -2,6 +2,7 @@ import type { SessionEntry } from "../../config/sessions.js";
 import type { CommandHandler } from "./commands-types.js";
 import { abortEmbeddedPiRun } from "../../agents/pi-embedded.js";
 import { updateSessionStore } from "../../config/sessions.js";
+import { resolveAgentIdFromSessionKey } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
@@ -162,13 +163,14 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
   const rawArgs = normalized === "/usage" ? "" : normalized.slice("/usage".length).trim();
   const requested = rawArgs ? normalizeUsageDisplay(rawArgs) : undefined;
   if (rawArgs.toLowerCase().startsWith("cost")) {
+    const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
     const sessionSummary = await loadSessionCostSummary({
       sessionId: params.sessionEntry?.sessionId,
       sessionEntry: params.sessionEntry,
       sessionFile: params.sessionEntry?.sessionFile,
       config: params.cfg,
     });
-    const summary = await loadCostUsageSummary({ days: 30, config: params.cfg });
+    const summary = await loadCostUsageSummary({ days: 30, config: params.cfg, agentId });
 
     const sessionCost = formatUsd(sessionSummary?.totalCost);
     const sessionTokens = sessionSummary?.totalTokens

--- a/src/auto-reply/reply/commands-session.usage-cost.test.ts
+++ b/src/auto-reply/reply/commands-session.usage-cost.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../infra/session-cost-usage.js", () => ({
+  loadSessionCostSummary: vi.fn(async () => ({
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 10,
+    totalCost: 1.23,
+    inputCost: 0,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+  })),
+  loadCostUsageSummary: vi.fn(async () => ({
+    updatedAt: Date.now(),
+    days: 30,
+    daily: [],
+    totals: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 100,
+      totalCost: 12.3,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    },
+  })),
+}));
+
+import { loadCostUsageSummary } from "../../infra/session-cost-usage.js";
+import { handleUsageCommand } from "./commands-session.js";
+
+describe("handleUsageCommand /usage cost", () => {
+  it("passes agentId derived from sessionKey to loadCostUsageSummary", async () => {
+    const result = await handleUsageCommand(
+      {
+        cfg: {},
+        command: {
+          commandBodyNormalized: "/usage cost",
+          isAuthorizedSender: true,
+        },
+        sessionKey: "agent:ops:main",
+        sessionEntry: {
+          sessionId: "sess-1",
+        },
+      } as never,
+      true,
+    );
+
+    expect(vi.mocked(loadCostUsageSummary)).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "ops" }),
+    );
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Usage cost");
+  });
+});


### PR DESCRIPTION
## Summary
- fix `/usage cost` to resolve `agentId` from the current `sessionKey` and pass it into `loadCostUsageSummary`
- fix gateway `usage.cost` to resolve `agentId` from request params (`agentId`, `key`, `sessionKey`) and otherwise fall back to the configured default agent
- include `agentId` in usage-cost cache keys to avoid cross-agent cache contamination

## Why
For non-`main` agents, usage-cost summaries were reading the wrong session directory (`agents/main/sessions`) when callers omitted `agentId`, producing `$0` totals.

## AI assistance
- AI-assisted: implemented with Codex

## Testing
- Degree: fully tested for changed paths
- `pnpm vitest src/gateway/server-methods/usage.test.ts --run`
- `pnpm vitest src/auto-reply/reply/commands-session.usage-cost.test.ts --run`
- `pnpm vitest src/infra/session-cost-usage.test.ts --run`

Fixes #13173

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `/usage cost` and the gateway `usage.cost` handler to consistently resolve the correct `agentId` from the active `sessionKey` / request params, and threads that through to `loadCostUsageSummary` so cost summaries read from the right agent session directory.

It also updates the gateway-side in-memory cache key for cost usage summaries to include `agentId`, preventing cross-agent cache contamination when multiple agents request the same date range. Tests were added/updated to assert `agentId` resolution and that the correct value is passed through.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to agentId resolution and cache keying, with targeted unit tests covering the new behavior paths in both CLI command handling and gateway request handling.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->