### PR TITLE
fix: pass agentId to loadCostUsageSummary in /usage cost command

### DIFF
--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -6,6 +6,7 @@ import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
 import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import { parseActivationCommand } from "../group-activation.js";
 import { parseSendPolicyCommand } from "../send-policy.js";
@@ -162,13 +163,16 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
   const rawArgs = normalized === "/usage" ? "" : normalized.slice("/usage".length).trim();
   const requested = rawArgs ? normalizeUsageDisplay(rawArgs) : undefined;
   if (rawArgs.toLowerCase().startsWith("cost")) {
+    const agentId = params.sessionKey
+      ? resolveAgentIdFromSessionKey(params.sessionKey)
+      : undefined;
     const sessionSummary = await loadSessionCostSummary({
       sessionId: params.sessionEntry?.sessionId,
       sessionEntry: params.sessionEntry,
       sessionFile: params.sessionEntry?.sessionFile,
       config: params.cfg,
     });
-    const summary = await loadCostUsageSummary({ days: 30, config: params.cfg });
+    const summary = await loadCostUsageSummary({ days: 30, config: params.cfg, agentId });
 
     const sessionCost = formatUsd(sessionSummary?.totalCost);
     const sessionTokens = sessionSummary?.totalTokens


### PR DESCRIPTION
## Problem

When using named agents (not `main`), the `/usage cost` command shows **$0 for all time ranges** because `loadCostUsageSummary()` defaults to `agentId="main"` and scans `~/.openclaw/agents/main/sessions/` instead of the correct agent folder.

## Root Cause

In `src/auto-reply/reply/commands-session.ts`, the `/usage cost` handler calls:
```typescript
const summary = await loadCostUsageSummary({ days: 30, config: params.cfg });
```

Without passing `agentId`, `loadCostUsageSummary` defaults to `main` (line 399 in `src/infra/session-cost-usage.ts`):
```typescript
const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
```

## Solution

Resolve `agentId` from `params.sessionKey` before calling `loadCostUsageSummary`:
```typescript
const agentId = params.sessionKey
  ? resolveAgentIdFromSessionKey(params.sessionKey)
  : undefined;
const summary = await loadCostUsageSummary({ days: 30, config: params.cfg, agentId });
```

## Impact

✅ **Fixes**:
- `/usage cost` now shows correct totals for non-main agents
- 1-day, 7-day, 30-day ranges all work correctly
- Dashboard cost panel displays accurate usage

✅ **Unchanged**:
- Per-session cost already worked (uses direct file path)
- Global `usage.cost` gateway handler intentionally unchanged (may aggregate across all agents)

## Testing

- [x] Code follows project style
- [ ] Tested with custom agent name (requires non-main agent setup)
- [ ] Verified cost totals match transcript JSONL files

## References

Fixes #13173

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `/usage cost` for non-`main` agents by resolving the agent id from `params.sessionKey` and passing it into `loadCostUsageSummary()`, so the cost scan reads from the correct agent’s sessions directory. The change is localized to the command handler and aligns with the existing default behavior in `loadCostUsageSummary` (still defaults to `main` when `agentId` is omitted/undefined), keeping the gateway/global usage handler behavior unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and uses existing sessionKey parsing/normalization utilities; it preserves default behavior when sessionKey is absent and does not affect other `loadCostUsageSummary` call sites.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->