### PR TITLE
add agent system prompt builder with configurable sections and prompt modes.

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -208,7 +208,7 @@ describe("buildAgentSystemPrompt", () => {
   // Agents should use session_status or message timestamps to determine the date/time.
   // Related: https://github.com/moltbot/moltbot/issues/1897
   //          https://github.com/moltbot/moltbot/issues/3658
-  it("does NOT include a date or time in the system prompt (cache stability)", () => {
+  it("includes a date or time in the system prompt (User Request)", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/clawd",
       userTimezone: "America/Chicago",
@@ -216,15 +216,8 @@ describe("buildAgentSystemPrompt", () => {
       userTimeFormat: "12",
     });
 
-    // The prompt should contain the timezone but NOT the formatted date/time string.
-    // This is intentional for prompt cache stability — the date/time was removed in
-    // commit 66eec295b. If you're here because you want to add it back, please see
-    // https://github.com/moltbot/moltbot/issues/3658 for the preferred approach:
-    // gateway-level timestamp injection into messages, not the system prompt.
     expect(prompt).toContain("Time zone: America/Chicago");
-    expect(prompt).not.toContain("Monday, January 5th, 2026");
-    expect(prompt).not.toContain("3:26 PM");
-    expect(prompt).not.toContain("15:26");
+    expect(prompt).toContain("Date: Monday, January 5th, 2026 — 3:26 PM");
   });
 
   it("includes model alias guidance when aliases are provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -72,11 +72,16 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  return [
+    "## Current Date & Time",
+    `Time zone: ${params.userTimezone}`,
+    params.userTime ? `Date: ${params.userTime}` : "",
+    "",
+  ];
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -500,6 +505,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the agent system prompt builder to optionally include a user-provided formatted date/time string in the “Current Date & Time” section (in addition to the timezone), and adjusts the unit test to assert that the date line is present when `userTime` is provided.

The change affects prompt stability/caching because the system prompt content can now vary across runs, whereas the existing design/documentation in this area indicates the prompt should remain stable and rely on `session_status`/message timestamps for current time information.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge until prompt stability decision is clarified/fixed
- The PR introduces dynamic date/time content into the system prompt, which contradicts existing cache-stability guidance and can materially change prompt caching behavior/costs; tests/comments are now inconsistent, suggesting the change wasn’t fully reconciled with the intended design.
- src/agents/system-prompt.ts, src/agents/system-prompt.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->