### PR TITLE
fix(browser): forward profile in browser.request handler

### DIFF
--- a/src/discord/monitor.slash.test.ts
+++ b/src/discord/monitor.slash.test.ts
@@ -18,6 +18,7 @@ vi.mock("@buape/carbon", () => ({
   MessageReactionRemoveListener: class {},
   PresenceUpdateListener: class {},
   Row: class {},
+  StringSelectMenu: class {},
 }));
 
 vi.mock("../auto-reply/dispatch.js", async (importOriginal) => {

--- a/src/gateway/server-methods/browser.test.ts
+++ b/src/gateway/server-methods/browser.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ...(() => {
+    const dispatch = vi.fn();
+    return {
+      dispatch,
+      createBrowserControlContext: vi.fn(() => ({})),
+      startBrowserControlServiceFromConfig: vi.fn(async () => ({ ok: true })),
+      createBrowserRouteDispatcher: vi.fn(() => ({ dispatch })),
+    };
+  })(),
+}));
+
+vi.mock("../../browser/control-service.js", () => ({
+  createBrowserControlContext: mocks.createBrowserControlContext,
+  startBrowserControlServiceFromConfig: mocks.startBrowserControlServiceFromConfig,
+}));
+
+vi.mock("../../browser/routes/dispatcher.js", () => ({
+  createBrowserRouteDispatcher: mocks.createBrowserRouteDispatcher,
+}));
+
+import { browserHandlers } from "./browser.js";
+
+describe("browser.request profile forwarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.dispatch.mockResolvedValue({ status: 200, body: { ok: true } });
+  });
+
+  it("forwards top-level profile to local browser dispatcher query", async () => {
+    const respond = vi.fn();
+    await browserHandlers["browser.request"]({
+      params: {
+        method: "POST",
+        path: "/tabs/open",
+        profile: "openclaw",
+        body: { url: "https://example.com" },
+      },
+      respond,
+      context: {
+        nodeRegistry: {
+          listConnected: () => [],
+        },
+      },
+    } as never);
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/tabs/open",
+        query: expect.objectContaining({ profile: "openclaw" }),
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
+
+  it("prefers top-level profile over query.profile when both are set", async () => {
+    const respond = vi.fn();
+    await browserHandlers["browser.request"]({
+      params: {
+        method: "GET",
+        path: "/",
+        profile: "openclaw",
+        query: { profile: "chrome" },
+      },
+      respond,
+      context: {
+        nodeRegistry: {
+          listConnected: () => [],
+        },
+      },
+    } as never);
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/",
+        query: expect.objectContaining({ profile: "openclaw" }),
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
+});

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -16,6 +16,7 @@ type BrowserRequestParams = {
   method?: string;
   path?: string;
   query?: Record<string, unknown>;
+  profile?: string;
   body?: unknown;
   timeoutMs?: number;
 };
@@ -150,7 +151,14 @@ export const browserHandlers: GatewayRequestHandlers = {
     const typed = params as BrowserRequestParams;
     const methodRaw = typeof typed.method === "string" ? typed.method.trim().toUpperCase() : "";
     const path = typeof typed.path === "string" ? typed.path.trim() : "";
-    const query = typed.query && typeof typed.query === "object" ? typed.query : undefined;
+    const rawQuery = typed.query && typeof typed.query === "object" ? typed.query : undefined;
+    const explicitProfile = typeof typed.profile === "string" ? typed.profile.trim() : "";
+    const queryProfile = typeof rawQuery?.profile === "string" ? rawQuery.profile.trim() : "";
+    const profile = explicitProfile || queryProfile || undefined;
+    const query = {
+      ...rawQuery,
+      ...(profile ? { profile } : {}),
+    };
     const body = typed.body;
     const timeoutMs =
       typeof typed.timeoutMs === "number" && Number.isFinite(typed.timeoutMs)
@@ -210,7 +218,7 @@ export const browserHandlers: GatewayRequestHandlers = {
         query,
         body,
         timeoutMs,
-        profile: typeof query?.profile === "string" ? query.profile : undefined,
+        profile,
       };
       const res = await context.nodeRegistry.invoke({
         nodeId: nodeTarget.nodeId,


### PR DESCRIPTION
## Summary
- fix gateway `browser.request` to honor top-level `profile` in params (not only `query.profile`)
- normalize effective profile once and forward it to both local dispatcher query and node proxy params
- add regression tests covering top-level profile forwarding and precedence over query.profile

## Why
Some callers (including tool flows) send `profile` at the top level. The gateway handler previously ignored that field for local browser dispatch, which could silently fall back to default profile (`chrome`) and trigger extension-coupled errors like "No tab connected" even when `profile="openclaw"` was requested.

## AI assistance
- AI-assisted: implemented with Codex

## Testing
- Degree: lightly tested
- `pnpm vitest src/gateway/server-methods/browser.test.ts --run`

Fixes #13166

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway `browser.request` handler to normalize an effective `profile` value (preferring top-level `params.profile` over `params.query.profile`) and forward it consistently to both the local browser route dispatcher and the remote `browser.proxy` node invocation.

It also adds regression tests to ensure top-level `profile` is honored and that it takes precedence when both locations specify a profile.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, but the added uses an unrealistic mock that can hide regressions in the handler readiness check.
- The runtime change is small and well-scoped (profile normalization/forwarding). The main concern is test validity: mocking `startBrowserControlServiceFromConfig` to return `{ ok: true }` does not match the actual return type (`BrowserServerState | null`), which can reduce the regression value of the new tests.
- src/gateway/server-methods/browser.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->