### PR TITLE
Fix openai-codex/gpt-5.3-codex API format resolution

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -239,4 +239,82 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("gpt-5.3-codex");
     expect(result.model?.provider).toBe("openai-codex");
   });
+
+  it("overrides api format for openai-codex gpt-5.3-codex even when in registry", () => {
+    // This test verifies the fix for issue #13189
+    // When gpt-5.3-codex exists in the registry with wrong api format,
+    // it should be overridden to use "openai-codex-responses"
+    const registryModel = {
+      id: "gpt-5.3-codex",
+      name: "GPT-5.3 Codex",
+      provider: "openai-codex",
+      api: "openai-completions", // Wrong API format in registry
+      baseUrl: undefined, // No baseUrl or wrong baseUrl
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 2, output: 16, cacheRead: 0.2, cacheWrite: 0 },
+      contextWindow: 300000,
+      maxTokens: 150000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.3-codex") {
+          return registryModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+      api: "openai-codex-responses", // Should be corrected
+      baseUrl: "https://chatgpt.com/backend-api", // Should be set correctly
+      reasoning: true,
+      contextWindow: 300000,
+      maxTokens: 150000,
+    });
+  });
+
+  it("overrides api format for openai-codex gpt-5.2-codex when in registry", () => {
+    // Test that gpt-5.2-codex also gets the correct overrides
+    const registryModel = {
+      id: "gpt-5.2-codex",
+      name: "GPT-5.2 Codex",
+      provider: "openai-codex",
+      api: "openai-completions", // Wrong API format in registry
+      baseUrl: "https://wrong.example.com", // Wrong baseUrl
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 272000,
+      maxTokens: 128000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.2-codex") {
+          return registryModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.2-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.2-codex",
+      api: "openai-codex-responses", // Should be corrected
+      baseUrl: "https://chatgpt.com/backend-api", // Should be corrected
+      reasoning: true,
+      contextWindow: 272000,
+      maxTokens: 128000,
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -165,6 +165,28 @@ export function resolveModel(
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
+
+  // Check if this is an openai-codex model that needs special handling
+  const normalizedProvider = normalizeProviderId(provider);
+  const trimmedModelId = modelId.trim().toLowerCase();
+  const isCodexModel =
+    normalizedProvider === "openai-codex" &&
+    (trimmedModelId === OPENAI_CODEX_GPT_53_MODEL_ID ||
+      OPENAI_CODEX_TEMPLATE_MODEL_IDS.some((id) => id === trimmedModelId));
+
+  if (model && isCodexModel) {
+    // Apply Codex-specific overrides even when model exists in registry
+    return {
+      model: normalizeModelCompat({
+        ...model,
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+      } as Model<Api>),
+      authStorage,
+      modelRegistry,
+    };
+  }
+
   if (!model) {
     const providers = cfg?.models?.providers ?? {};
     const inlineModels = buildInlineProviderModels(providers);


### PR DESCRIPTION
## Description
Fixes #13189

This PR fixes an issue where `openai-codex/gpt-5.3-codex` and `gpt-5.2-codex` models were incorrectly resolved with `api: "openai-completions"` when they existed in the built-in model catalog, causing HTTP 500 errors.

## Problem
When these models exist in the registry with the wrong API format, the model resolver would return them immediately without applying the necessary Codex-specific overrides. This caused requests to fail because they were sent to the wrong endpoint.

## Solution
Added a check in `resolveModel()` that detects when an openai-codex model (gpt-5.3-codex or gpt-5.2-codex) is found in the registry and applies the correct overrides:
- `api: "openai-codex-responses"`
- `baseUrl: "https://chatgpt.com/backend-api"`

## Testing
- Added comprehensive test cases to verify the fix works correctly
- All existing tests continue to pass
- New tests specifically cover the scenario where models exist in the registry with wrong configuration

## Files Changed
- `src/agents/pi-embedded-runner/model.ts` - Added override logic for Codex models
- `src/agents/pi-embedded-runner/model.test.ts` - Added test coverage for the fix

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `resolveModel()` to apply Codex-specific overrides (`api: "openai-codex-responses"`, `baseUrl: "https://chatgpt.com/backend-api"`) even when a matching `openai-codex` model is found in the discovered model registry, preventing Codex requests from being routed to the `openai-completions` endpoint.

Test coverage was extended in `src/agents/pi-embedded-runner/model.test.ts` to cover the regression scenario where `gpt-5.3-codex` and `gpt-5.2-codex` exist in the registry with an incorrect `api` and/or `baseUrl`, ensuring the resolver returns the corrected configuration.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing the Codex ID matching gap noted below.
- The override logic is narrowly scoped and covered by new tests for the reported regression. The main remaining concern is that the Codex override currently only matches exact IDs, which can allow variant IDs (if used) to bypass the fix and continue resolving to the wrong API/baseUrl.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->