### PR TITLE
feat: inject agent/session context as environment variables in exec commands

### DIFF
--- a/src/agents/bash-tools.exec.context-injection.test.ts
+++ b/src/agents/bash-tools.exec.context-injection.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExecApprovalsResolved } from "../infra/exec-approvals.js";
+import { sanitizeBinaryOutput } from "./shell-utils.js";
+
+const isWin = process.platform === "win32";
+
+vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../infra/exec-approvals.js")>();
+  const approvals: ExecApprovalsResolved = {
+    path: "/tmp/exec-approvals.json",
+    socketPath: "/tmp/exec-approvals.sock",
+    token: "token",
+    defaults: {
+      security: "full",
+      ask: "off",
+      askFallback: "full",
+      autoAllowSkills: false,
+    },
+    agent: {
+      security: "full",
+      ask: "off",
+      askFallback: "full",
+      autoAllowSkills: false,
+    },
+    allowlist: [],
+    file: {
+      version: 1,
+      socket: { path: "/tmp/exec-approvals.sock", token: "token" },
+      defaults: {
+        security: "full",
+        ask: "off",
+        askFallback: "full",
+        autoAllowSkills: false,
+      },
+      agents: {},
+    },
+  };
+  return { ...mod, resolveExecApprovals: () => approvals };
+});
+
+const normalizeText = (value?: string) =>
+  sanitizeBinaryOutput(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .trim();
+
+describe("exec context injection (always-on)", () => {
+  it("injects agent context for main agent sessions", async () => {
+    if (isWin) {
+      // Skip on Windows as env var commands differ
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      agentId: "test-agent",
+      sessionKey: "agent:test-agent:main",
+    });
+
+    const result = await tool.execute("call1", {
+      command:
+        "echo AGENT_ID=$OPENCLAW_AGENT_ID SESSION_KEY=$OPENCLAW_SESSION_KEY SESSION_LABEL=$OPENCLAW_SESSION_LABEL SESSION_KIND=$OPENCLAW_SESSION_KIND",
+    });
+
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(output).toContain("AGENT_ID=test-agent");
+    expect(output).toContain("SESSION_KEY=agent:test-agent:main");
+    expect(output).toContain("SESSION_LABEL=main");
+    expect(output).toContain("SESSION_KIND=main");
+  });
+
+  it("injects subagent context correctly", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      agentId: "test-agent",
+      sessionKey: "agent:test-agent:subagent:abc123",
+    });
+
+    const result = await tool.execute("call1", {
+      command: "echo SESSION_LABEL=$OPENCLAW_SESSION_LABEL SESSION_KIND=$OPENCLAW_SESSION_KIND",
+    });
+
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(output).toContain("SESSION_LABEL=subagent:abc123");
+    expect(output).toContain("SESSION_KIND=subagent");
+  });
+
+  it("injects custom session context correctly", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      agentId: "test-agent",
+      sessionKey: "agent:test-agent:custom-session",
+    });
+
+    const result = await tool.execute("call1", {
+      command: "echo SESSION_LABEL=$OPENCLAW_SESSION_LABEL SESSION_KIND=$OPENCLAW_SESSION_KIND",
+    });
+
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(output).toContain("SESSION_LABEL=custom-session");
+    expect(output).toContain("SESSION_KIND=custom");
+  });
+
+  it("handles empty agentId gracefully (no crash)", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      agentId: "",
+      sessionKey: "agent:test-agent:main",
+    });
+
+    const result = await tool.execute("call1", {
+      command: "echo AGENT_ID=$OPENCLAW_AGENT_ID SESSION_KEY=$OPENCLAW_SESSION_KEY",
+    });
+
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    // Empty agentId should not be injected
+    expect(output).toContain("AGENT_ID=");
+    // Session key should still be injected
+    expect(output).toContain("SESSION_KEY=agent:test-agent:main");
+  });
+
+  it("handles empty sessionKey gracefully (no crash)", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      agentId: "test-agent",
+      sessionKey: "",
+    });
+
+    const result = await tool.execute("call1", {
+      command: "echo AGENT_ID=$OPENCLAW_AGENT_ID SESSION_KEY=$OPENCLAW_SESSION_KEY",
+    });
+
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    // Agent ID should be injected
+    expect(output).toContain("AGENT_ID=test-agent");
+    // Empty session key should not be injected
+    expect(output).toContain("SESSION_KEY=");
+  });
+
+  it("handles malformed sessionKey gracefully (missing parts)", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      agentId: "test-agent",
+      sessionKey: "agent:", // Malformed: missing agentId and rest
+    });
+
+    const result = await tool.execute("call1", {
+      command:
+        "echo AGENT_ID=$OPENCLAW_AGENT_ID SESSION_KEY=$OPENCLAW_SESSION_KEY LABEL=$OPENCLAW_SESSION_LABEL KIND=$OPENCLAW_SESSION_KIND",
+    });
+
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    // Agent ID should still be injected
+    expect(output).toContain("AGENT_ID=test-agent");
+    // Session key should be injected as-is
+    expect(output).toContain("SESSION_KEY=agent:");
+    // Label and kind should not be set due to malformed key
+    expect(output).toContain("LABEL=");
+    expect(output).toContain("KIND=");
+  });
+
+  it("handles non-agent session format gracefully", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      agentId: "test-agent",
+      sessionKey: "user:123:main", // Non-agent session format
+    });
+
+    const result = await tool.execute("call1", {
+      command:
+        "echo AGENT_ID=$OPENCLAW_AGENT_ID SESSION_KEY=$OPENCLAW_SESSION_KEY LABEL=$OPENCLAW_SESSION_LABEL KIND=$OPENCLAW_SESSION_KIND",
+    });
+
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    // Agent ID should still be injected
+    expect(output).toContain("AGENT_ID=test-agent");
+    // Session key should be injected as-is
+    expect(output).toContain("SESSION_KEY=user:123:main");
+    // Label and kind should not be set (non-agent format)
+    expect(output).toContain("LABEL=");
+    expect(output).toContain("KIND=");
+  });
+
+  it("handles missing agentId and sessionKey gracefully", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const { createExecTool } = await import("./bash-tools.exec.js");
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      // No agentId or sessionKey provided
+    });
+
+    const result = await tool.execute("call1", {
+      command: "echo AGENT_ID=$OPENCLAW_AGENT_ID SESSION_KEY=$OPENCLAW_SESSION_KEY",
+    });
+
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    // Nothing should be injected
+    expect(output).toBe("AGENT_ID= SESSION_KEY=");
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -395,6 +395,65 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
 }
 
+/**
+ * Inject agent/session context as environment variables.
+ *
+ * Security note: These environment variables are visible to all subprocesses
+ * spawned by the exec command. They should not contain sensitive credentials.
+ *
+ * Handles edge cases:
+ * - Empty/missing agentId → OPENCLAW_AGENT_ID not set
+ * - Empty/missing sessionKey → OPENCLAW_SESSION_KEY not set
+ * - Malformed sessionKey → gracefully skip parsing, no crash
+ * - Non-agent session format → gracefully skip, no vars injected
+ */
+function injectAgentContext(
+  env: Record<string, string>,
+  context: {
+    agentId?: string;
+    sessionKey?: string;
+  },
+) {
+  // Handle agentId
+  const agentId = context.agentId?.trim();
+  if (agentId) {
+    env.OPENCLAW_AGENT_ID = agentId;
+  }
+
+  // Handle sessionKey
+  const sessionKey = context.sessionKey?.trim();
+  if (!sessionKey) {
+    return;
+  }
+
+  env.OPENCLAW_SESSION_KEY = sessionKey;
+
+  // Parse session key to extract label and kind
+  // Session key format: "agent:agentId:rest" where rest is "main", "subagent:xxx", etc.
+  // If parsing fails or format is wrong, skip gracefully (no crash).
+  try {
+    const parsed = parseAgentSessionKey(sessionKey);
+    if (!parsed) {
+      // Not an agent session key format; skip label/kind injection
+      return;
+    }
+
+    const rest = parsed.rest?.trim() || "main";
+    const isSubagent = rest.toLowerCase().startsWith("subagent:");
+
+    if (isSubagent) {
+      env.OPENCLAW_SESSION_LABEL = rest; // e.g., "subagent:xxx"
+      env.OPENCLAW_SESSION_KIND = "subagent";
+    } else {
+      env.OPENCLAW_SESSION_LABEL = rest; // e.g., "main" or custom label
+      env.OPENCLAW_SESSION_KIND = rest === "main" ? "main" : "custom";
+    }
+  } catch {
+    // Parsing failed; skip label/kind injection but keep session key set
+    return;
+  }
+}
+
 function createApprovalSlug(id: string) {
   return id.slice(0, APPROVAL_SLUG_LENGTH);
 }
@@ -997,6 +1056,13 @@ export function createExecTool(
       }
       applyPathPrepend(env, defaultPathPrepend);
 
+      // Always inject agent context as environment variables
+      // (see injectAgentContext for security notes)
+      injectAgentContext(env, {
+        agentId,
+        sessionKey: defaults?.sessionKey,
+      });
+
       if (host === "node") {
         const approvals = resolveExecApprovals(agentId, { security, ask });
         const hostSecurity = minSecurity(security, approvals.agent.security);
@@ -1040,11 +1106,16 @@ export function createExecTool(
         }
         const argv = buildNodeShellCommand(params.command, nodeInfo?.platform);
 
-        const nodeEnv = params.env ? { ...params.env } : undefined;
+        // Start with params.env or create empty object to ensure agent context is injected
+        const nodeEnv = params.env ? { ...params.env } : {};
 
-        if (nodeEnv) {
-          applyPathPrepend(nodeEnv, defaultPathPrepend, { requireExisting: true });
-        }
+        applyPathPrepend(nodeEnv, defaultPathPrepend, { requireExisting: true });
+
+        // Always inject agent context for node-hosted commands
+        injectAgentContext(nodeEnv, {
+          agentId,
+          sessionKey: defaults?.sessionKey,
+        });
         const baseAllowlistEval = evaluateShellAllowlist({
           command: params.command,
           allowlist: [],


### PR DESCRIPTION
# Inject Agent/Session Context as Environment Variables in Exec Commands

## Summary

This PR enables downstream CLIs and scripts to detect which agent and session invoked them by automatically injecting four environment variables into every `exec` command:

- `OPENCLAW_AGENT_ID` — The agent identifier (e.g., `lepetitpince`)
- `OPENCLAW_SESSION_KEY` — Full session key (e.g., `agent:lepetitpince:main`)
- `OPENCLAW_SESSION_LABEL` — Human-readable label (e.g., `main`, `subagent:abc123`)
- `OPENCLAW_SESSION_KIND` — Session type (`main`, `subagent`, or `custom`)

**Use case:** Multi-agent task management systems (like [clawdo](https://github.com/LePetitPince/clawdo)) need to know *which* agent invoked a command to properly track task ownership and maintain audit trails.

## Changes

- **`bash-tools.exec.ts`** (+66 lines): `injectAgentContext()` helper + unconditional call after env preparation
- **`bash-tools.exec.context-injection.test.ts`** (+266 lines): 8 tests covering happy path, edge cases, and graceful degradation

**Backward compatible:** Variables are additive. Existing scripts ignore them; new tools can depend on them.

## Design Decisions

### Always-on, no opt-in flag
Agent identity is a fact, not a preference. Making injection optional creates ecosystem fragmentation where tools cannot reliably depend on these variables being present. Like `PATH`, `HOME`, and `USER` — always there.

### Graceful degradation
If `agentId` or `sessionKey` is missing or malformed, injection is skipped silently. No crashes, no warnings. This ensures compatibility with non-agent contexts.

### Minimal variable set
Only 4 variables, all non-sensitive metadata. No credentials, no secrets — just identity and context.

## Testing

All 8 tests passing:
- ✅ Main agent session injection
- ✅ Subagent session injection
- ✅ Custom session injection
- ✅ Empty agentId (graceful skip)
- ✅ Empty sessionKey (graceful skip)
- ✅ Malformed sessionKey (graceful skip)
- ✅ Non-agent session format (graceful skip)
- ✅ Both missing (no injection, no crash)

## Usage Example

```bash
# Downstream CLIs automatically know their caller:
$ clawdo propose "Fix bug"
# clawdo reads OPENCLAW_AGENT_ID=elite-coder → task tagged automatically

# In any script:
agent_id = os.environ.get("OPENCLAW_AGENT_ID", "unknown")
```

---

Closes #11477

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds always-on injection of agent/session context into exec subprocess environments via four new `OPENCLAW_*` variables, plus a new Vitest suite that exercises main/subagent/custom session keys and several malformed/missing cases.

The injection is implemented inside `createExecTool()` after env preparation, using `parseAgentSessionKey()` to derive a human-readable label and kind from agent-formatted session keys. Tests validate expected values by running `echo` commands through the exec tool.

<h3>Confidence Score: 3/5</h3>

- This PR has a couple of correctness issues that likely need fixes before merge.
- Core implementation is small and well-contained, but the new env injection is currently inconsistent across exec hosts (node path doesn’t receive injected vars), and the JSDoc and tests don’t accurately reflect/verify the intended behavior (doc mismatch and tests can’t distinguish unset vs empty).
- src/agents/bash-tools.exec.ts, src/agents/bash-tools.exec.context-injection.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->