### PR TITLE
fix: harden archive extraction and plugin update rollback

### DIFF
--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -12,6 +12,40 @@ export type ArchiveLogger = {
 
 const TAR_SUFFIXES = [".tgz", ".tar.gz", ".tar"];
 
+function isPathInside(basePath: string, candidatePath: string): boolean {
+  const base = path.resolve(basePath);
+  const candidate = path.resolve(base, candidatePath);
+  const rel = path.relative(base, candidate);
+  return rel === "" || (!rel.startsWith(`..${path.sep}`) && rel !== ".." && !path.isAbsolute(rel));
+}
+
+function resolveSafeEntryPath(params: {
+  baseDir: string;
+  entryPath: string;
+  origin: "zip" | "tar";
+}): string {
+  const trimmed = params.entryPath.trim();
+  if (!trimmed) {
+    throw new Error(`${params.origin} entry has empty path`);
+  }
+  if (!isPathInside(params.baseDir, trimmed)) {
+    throw new Error(`${params.origin} entry escapes destination: ${params.entryPath}`);
+  }
+  return path.resolve(params.baseDir, trimmed);
+}
+
+function assertSafeEntry(params: { baseDir: string; entryPath: string; origin: "zip" | "tar" }) {
+  resolveSafeEntryPath(params);
+}
+
+function isArchiveLinkEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const entryType = String((entry as { type?: unknown }).type ?? "").toLowerCase();
+  return entryType.includes("link");
+}
+
 export function resolveArchiveKind(filePath: string): ArchiveKind | null {
   const lower = filePath.toLowerCase();
   if (lower.endsWith(".zip")) {
@@ -73,22 +107,17 @@ async function extractZip(params: { archivePath: string; destDir: string }): Pro
   const buffer = await fs.readFile(params.archivePath);
   const zip = await JSZip.loadAsync(buffer);
   const entries = Object.values(zip.files);
+  const baseDir = path.resolve(params.destDir);
 
   for (const entry of entries) {
     const entryPath = entry.name.replaceAll("\\", "/");
     if (!entryPath || entryPath.endsWith("/")) {
-      const dirPath = path.resolve(params.destDir, entryPath);
-      if (!dirPath.startsWith(params.destDir)) {
-        throw new Error(`zip entry escapes destination: ${entry.name}`);
-      }
+      const dirPath = resolveSafeEntryPath({ baseDir, entryPath, origin: "zip" });
       await fs.mkdir(dirPath, { recursive: true });
       continue;
     }
 
-    const outPath = path.resolve(params.destDir, entryPath);
-    if (!outPath.startsWith(params.destDir)) {
-      throw new Error(`zip entry escapes destination: ${entry.name}`);
-    }
+    const outPath = resolveSafeEntryPath({ baseDir, entryPath, origin: "zip" });
     await fs.mkdir(path.dirname(outPath), { recursive: true });
     const data = await entry.async("nodebuffer");
     await fs.writeFile(outPath, data);
@@ -108,8 +137,19 @@ export async function extractArchive(params: {
 
   const label = kind === "zip" ? "extract zip" : "extract tar";
   if (kind === "tar") {
+    const baseDir = path.resolve(params.destDir);
     await withTimeout(
-      tar.x({ file: params.archivePath, cwd: params.destDir }),
+      tar.x({
+        file: params.archivePath,
+        cwd: params.destDir,
+        filter: (entryPath, entry) => {
+          assertSafeEntry({ baseDir, entryPath, origin: "tar" });
+          if (isArchiveLinkEntry(entry)) {
+            throw new Error(`tar entry is a link: ${entryPath}`);
+          }
+          return true;
+        },
+      }),
       params.timeoutMs,
       label,
     );


### PR DESCRIPTION
## Summary
- harden archive extraction path handling for tar/zip plugin packages
- avoid throwing inside tar filters while still rejecting unsafe archive entries
- fix plugin update rollback so failed dependency installs (including thrown npm errors) restore the previous plugin state
- add regression coverage for update rollback after npm install throws

## Testing
- pnpm test src/infra/archive.test.ts
- pnpm test src/plugins/install.test.ts
