### PR TITLE
perf(cli): extract route specs from command-registry to break static import chain

### DIFF
--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -1,14 +1,8 @@
 import type { Command } from "commander";
 import type { ProgramContext } from "./context.js";
-import { agentsListCommand } from "../../commands/agents.js";
-import { healthCommand } from "../../commands/health.js";
-import { sessionsCommand } from "../../commands/sessions.js";
-import { statusCommand } from "../../commands/status.js";
-import { defaultRuntime } from "../../runtime.js";
-import { getFlagValue, getPositiveIntFlagValue, getVerboseFlag, hasFlag } from "../argv.js";
 import { registerBrowserCli } from "../browser-cli.js";
 import { registerConfigCli } from "../config-cli.js";
-import { registerMemoryCli, runMemoryStatus } from "../memory-cli.js";
+import { registerMemoryCli } from "../memory-cli.js";
 import { registerAgentCommands } from "./register.agent.js";
 import { registerConfigureCommand } from "./register.configure.js";
 import { registerMaintenanceCommands } from "./register.maintenance.js";
@@ -24,95 +18,12 @@ type CommandRegisterParams = {
   argv: string[];
 };
 
-type RouteSpec = {
-  match: (path: string[]) => boolean;
-  loadPlugins?: boolean;
-  run: (argv: string[]) => Promise<boolean>;
-};
-
-export type CommandRegistration = {
+type CommandRegistration = {
   id: string;
   register: (params: CommandRegisterParams) => void;
-  routes?: RouteSpec[];
 };
 
-const routeHealth: RouteSpec = {
-  match: (path) => path[0] === "health",
-  loadPlugins: true,
-  run: async (argv) => {
-    const json = hasFlag(argv, "--json");
-    const verbose = getVerboseFlag(argv, { includeDebug: true });
-    const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
-    if (timeoutMs === null) {
-      return false;
-    }
-    await healthCommand({ json, timeoutMs, verbose }, defaultRuntime);
-    return true;
-  },
-};
-
-const routeStatus: RouteSpec = {
-  match: (path) => path[0] === "status",
-  loadPlugins: true,
-  run: async (argv) => {
-    const json = hasFlag(argv, "--json");
-    const deep = hasFlag(argv, "--deep");
-    const all = hasFlag(argv, "--all");
-    const usage = hasFlag(argv, "--usage");
-    const verbose = getVerboseFlag(argv, { includeDebug: true });
-    const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
-    if (timeoutMs === null) {
-      return false;
-    }
-    await statusCommand({ json, deep, all, usage, timeoutMs, verbose }, defaultRuntime);
-    return true;
-  },
-};
-
-const routeSessions: RouteSpec = {
-  match: (path) => path[0] === "sessions",
-  run: async (argv) => {
-    const json = hasFlag(argv, "--json");
-    const store = getFlagValue(argv, "--store");
-    if (store === null) {
-      return false;
-    }
-    const active = getFlagValue(argv, "--active");
-    if (active === null) {
-      return false;
-    }
-    await sessionsCommand({ json, store, active }, defaultRuntime);
-    return true;
-  },
-};
-
-const routeAgentsList: RouteSpec = {
-  match: (path) => path[0] === "agents" && path[1] === "list",
-  run: async (argv) => {
-    const json = hasFlag(argv, "--json");
-    const bindings = hasFlag(argv, "--bindings");
-    await agentsListCommand({ json, bindings }, defaultRuntime);
-    return true;
-  },
-};
-
-const routeMemoryStatus: RouteSpec = {
-  match: (path) => path[0] === "memory" && path[1] === "status",
-  run: async (argv) => {
-    const agent = getFlagValue(argv, "--agent");
-    if (agent === null) {
-      return false;
-    }
-    const json = hasFlag(argv, "--json");
-    const deep = hasFlag(argv, "--deep");
-    const index = hasFlag(argv, "--index");
-    const verbose = hasFlag(argv, "--verbose");
-    await runMemoryStatus({ agent, json, deep, index, verbose });
-    return true;
-  },
-};
-
-export const commandRegistry: CommandRegistration[] = [
+const commandRegistry: CommandRegistration[] = [
   {
     id: "setup",
     register: ({ program }) => registerSetupCommand(program),
@@ -140,13 +51,11 @@ export const commandRegistry: CommandRegistration[] = [
   {
     id: "memory",
     register: ({ program }) => registerMemoryCli(program),
-    routes: [routeMemoryStatus],
   },
   {
     id: "agent",
     register: ({ program, ctx }) =>
       registerAgentCommands(program, { agentChannelOptions: ctx.agentChannelOptions }),
-    routes: [routeAgentsList],
   },
   {
     id: "subclis",
@@ -155,7 +64,6 @@ export const commandRegistry: CommandRegistration[] = [
   {
     id: "status-health-sessions",
     register: ({ program }) => registerStatusHealthSessionsCommands(program),
-    routes: [routeHealth, routeStatus, routeSessions],
   },
   {
     id: "browser",
@@ -171,18 +79,4 @@ export function registerProgramCommands(
   for (const entry of commandRegistry) {
     entry.register({ program, ctx, argv });
   }
-}
-
-export function findRoutedCommand(path: string[]): RouteSpec | null {
-  for (const entry of commandRegistry) {
-    if (!entry.routes) {
-      continue;
-    }
-    for (const route of entry.routes) {
-      if (route.match(path)) {
-        return route;
-      }
-    }
-  }
-  return null;
 }

--- a/src/cli/program/route-specs.ts
+++ b/src/cli/program/route-specs.ts
@@ -1,0 +1,109 @@
+import { getFlagValue, getPositiveIntFlagValue, getVerboseFlag, hasFlag } from "../argv.js";
+
+export type RouteSpec = {
+  match: (path: string[]) => boolean;
+  loadPlugins?: boolean;
+  run: (argv: string[]) => Promise<boolean>;
+};
+
+const routeHealth: RouteSpec = {
+  match: (path) => path[0] === "health",
+  loadPlugins: true,
+  run: async (argv) => {
+    const json = hasFlag(argv, "--json");
+    const verbose = getVerboseFlag(argv, { includeDebug: true });
+    const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
+    if (timeoutMs === null) {
+      return false;
+    }
+    const { healthCommand } = await import("../../commands/health.js");
+    const { defaultRuntime } = await import("../../runtime.js");
+    await healthCommand({ json, timeoutMs, verbose }, defaultRuntime);
+    return true;
+  },
+};
+
+const routeStatus: RouteSpec = {
+  match: (path) => path[0] === "status",
+  loadPlugins: true,
+  run: async (argv) => {
+    const json = hasFlag(argv, "--json");
+    const deep = hasFlag(argv, "--deep");
+    const all = hasFlag(argv, "--all");
+    const usage = hasFlag(argv, "--usage");
+    const verbose = getVerboseFlag(argv, { includeDebug: true });
+    const timeoutMs = getPositiveIntFlagValue(argv, "--timeout");
+    if (timeoutMs === null) {
+      return false;
+    }
+    const { statusCommand } = await import("../../commands/status.js");
+    const { defaultRuntime } = await import("../../runtime.js");
+    await statusCommand({ json, deep, all, usage, timeoutMs, verbose }, defaultRuntime);
+    return true;
+  },
+};
+
+const routeSessions: RouteSpec = {
+  match: (path) => path[0] === "sessions",
+  run: async (argv) => {
+    const json = hasFlag(argv, "--json");
+    const store = getFlagValue(argv, "--store");
+    if (store === null) {
+      return false;
+    }
+    const active = getFlagValue(argv, "--active");
+    if (active === null) {
+      return false;
+    }
+    const { sessionsCommand } = await import("../../commands/sessions.js");
+    const { defaultRuntime } = await import("../../runtime.js");
+    await sessionsCommand({ json, store, active }, defaultRuntime);
+    return true;
+  },
+};
+
+const routeAgentsList: RouteSpec = {
+  match: (path) => path[0] === "agents" && path[1] === "list",
+  run: async (argv) => {
+    const json = hasFlag(argv, "--json");
+    const bindings = hasFlag(argv, "--bindings");
+    const { agentsListCommand } = await import("../../commands/agents.js");
+    const { defaultRuntime } = await import("../../runtime.js");
+    await agentsListCommand({ json, bindings }, defaultRuntime);
+    return true;
+  },
+};
+
+const routeMemoryStatus: RouteSpec = {
+  match: (path) => path[0] === "memory" && path[1] === "status",
+  run: async (argv) => {
+    const agent = getFlagValue(argv, "--agent");
+    if (agent === null) {
+      return false;
+    }
+    const json = hasFlag(argv, "--json");
+    const deep = hasFlag(argv, "--deep");
+    const index = hasFlag(argv, "--index");
+    const verbose = hasFlag(argv, "--verbose");
+    const { runMemoryStatus } = await import("../memory-cli.js");
+    await runMemoryStatus({ agent, json, deep, index, verbose });
+    return true;
+  },
+};
+
+const routeSpecs: RouteSpec[] = [
+  routeHealth,
+  routeStatus,
+  routeSessions,
+  routeAgentsList,
+  routeMemoryStatus,
+];
+
+export function findRoutedCommand(path: string[]): RouteSpec | null {
+  for (const route of routeSpecs) {
+    if (route.match(path)) {
+      return route;
+    }
+  }
+  return null;
+}

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -4,8 +4,8 @@ import { VERSION } from "../version.js";
 import { getCommandPath, hasHelpOrVersion } from "./argv.js";
 import { emitCliBanner } from "./banner.js";
 import { ensurePluginRegistryLoaded } from "./plugin-registry.js";
-import { findRoutedCommand } from "./program/command-registry.js";
 import { ensureConfigReady } from "./program/config-guard.js";
+import { findRoutedCommand } from "./program/route-specs.js";
 
 async function prepareRoutedCommand(params: {
   argv: string[];


### PR DESCRIPTION
## Summary

- Extracts route specs (`routeHealth`, `routeStatus`, `routeSessions`, `routeAgentsList`, `routeMemoryStatus`) and `findRoutedCommand` from `command-registry.ts` into a new lightweight `route-specs.ts`
- Route spec `run()` functions now use dynamic `await import()` for their command implementations (`healthCommand`, `statusCommand`, etc.) instead of static top-level imports
- Simplifies `command-registry.ts` by removing route-related code and 6 heavy imports that were only used by the route specs
- `route.ts` now imports `findRoutedCommand` from `route-specs.ts` instead of `command-registry.ts`

## Why this matters

The bundler (tsdown/rolldown) hoists all transitive dependencies from static import chains into top-level imports. The chain `run-main.ts -> route.ts -> command-registry.ts` caused the bundled `run-main` chunk to have 111 static imports loading ~860 modules (7.56 MB) for every CLI invocation.

By breaking the `route.ts -> command-registry.ts` link, the `run-main` chunk drops from 111 to 59 static imports. This is an architectural prerequisite for per-command lazy loading (#13259) to be fully effective — together they reduce `config --help` cold-start from 6.58s to 3.92s on a 1-vCPU VPS.

## Standalone benchmarks

`openclaw config --help` cold-start, 5-run median on 1-vCPU VPS:

| Build | Time | Static imports |
|-------|------|----------------|
| Baseline (main) | 6.3s | 111 |
| This PR | 6.1s | 59 |
| This PR + #13259 | 3.9s | 60 |

The standalone improvement is small (~3%) because `run-main.ts` still calls `buildProgram()` which loads `command-registry.ts`. The full benefit is realized when combined with #13259 which replaces `buildProgram()` with lazy per-command registration.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] `pnpm test` passes (991/991 test files, 6810 tests)
- [x] Verified `config --help`, `--help`, and route commands produce correct output
- [x] Benchmarked standalone and combined with #13259 on VPS

## AI disclosure

- [x] AI-assisted (Claude)
- [x] Fully tested (build, check, full test suite, manual verification, A/B benchmarks)
- [x] I understand what this code does: it decouples the fast-route matching table from the heavy command-registry module by extracting route specs into a lightweight file with dynamic imports for command implementations

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR moves the CLI fast-path route matching (`findRoutedCommand` + route specs for `health`, `status`, `sessions`, `agents list`, `memory status`) out of `src/cli/program/command-registry.ts` into a new lightweight `src/cli/program/route-specs.ts`. The route `run()` handlers now lazily load their command implementations via dynamic `import()` (and only then import `defaultRuntime` / `runMemoryStatus`), so `src/cli/route.ts` no longer statically imports the heavier command-registry module. This reduces the static import chain for `run-main.ts -> route.ts` and improves CLI cold-start behavior without changing the routed command semantics.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge; changes are isolated and preserve routing behavior while improving import structure.
- Reviewed the three changed files and verified all call sites of `findRoutedCommand` were updated; the new `route-specs.ts` preserves the prior route matching and argument parsing while swapping static imports for dynamic imports inside `run()` handlers. No remaining references to the removed route code were found under `src/cli`.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->