### PR TITLE
docs: add missing changelog entry for #4598

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 - Slack: add mention stripPatterns for /new and /reset. (#9971) Thanks @ironbyte-rgb.
 - Chrome extension: fix bundled path resolution. (#8914) Thanks @kelvinCB.
 - Compaction/errors: allow multiple compaction retries on context overflow; show clear billing errors. (#8928, #8391) Thanks @Glucksberg.
+- Agents: skip tool extraction for aborted/errored assistant messages to prevent session corruption. (#4598) Thanks @aisling404.
 
 ## 2026.2.3
 


### PR DESCRIPTION
## Summary

- PR #4598 (`fix(agents): skip tool extraction for aborted/errored assistant messages`) was merged on 2026-02-06 and shipped in `v2026.2.6`, but was omitted from the changelog and release notes.
- This adds the missing entry to the `2026.2.6 > Fixes` section.

## Context

Commit: 861725fba1b73a51305472e3d151f8c35b1b409a
PR: #4598
Release: v2026.2.6

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `CHANGELOG.md` by adding the missing v2026.2.6 Fixes entry for PR #4598 (agents: skip tool extraction for aborted/errored assistant messages) so the shipped change is reflected in the release notes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line documentation-only addition to the changelog, consistent with existing formatting and placed under the correct release section; no runtime or build-impacting code paths are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->