### PR TITLE
fix: SSRF guard bypassed by IPv4-compatible IPv6 addresses (::127.0.0.1)

### DIFF
--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -125,6 +125,13 @@ export function isPrivateIpAddress(address: string): boolean {
       return isPrivateIpv4(ipv4);
     }
   }
+  if (normalized.startsWith("::")) {
+    const compatible = normalized.slice("::".length);
+    const ipv4 = parseIpv4FromMappedIpv6(compatible);
+    if (ipv4) {
+      return isPrivateIpv4(ipv4);
+    }
+  }
 
   if (normalized.includes(":")) {
     if (normalized === "::" || normalized === "::1") {

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -83,6 +83,79 @@ function parseIpv4FromMappedIpv6(mapped: string): number[] | null {
   return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff];
 }
 
+function parseIpv6Part(part: string): number[] | null {
+  if (!part) {
+    return [];
+  }
+  const segments = part.split(":");
+  const hextets: number[] = [];
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    if (!segment) {
+      return null;
+    }
+    if (segment.includes(".")) {
+      if (index !== segments.length - 1) {
+        return null;
+      }
+      const ipv4 = parseIpv4(segment);
+      if (!ipv4) {
+        return null;
+      }
+      hextets.push((ipv4[0] << 8) | ipv4[1], (ipv4[2] << 8) | ipv4[3]);
+      continue;
+    }
+    if (!/^[0-9a-f]{1,4}$/i.test(segment)) {
+      return null;
+    }
+    const value = Number.parseInt(segment, 16);
+    if (Number.isNaN(value) || value < 0 || value > 0xffff) {
+      return null;
+    }
+    hextets.push(value);
+  }
+  return hextets;
+}
+
+function parseIpv4FromCompatibleIpv6(address: string): number[] | null {
+  const normalized = address.split("%")[0];
+  const compressionIndex = normalized.indexOf("::");
+  if (compressionIndex !== normalized.lastIndexOf("::")) {
+    return null;
+  }
+
+  const hasCompression = compressionIndex !== -1;
+  const [headRaw, tailRaw] = hasCompression ? normalized.split("::") : [normalized, ""];
+  const head = parseIpv6Part(headRaw);
+  const tail = parseIpv6Part(tailRaw);
+  if (!head || !tail) {
+    return null;
+  }
+
+  const hextets = hasCompression
+    ? (() => {
+        const omitted = 8 - (head.length + tail.length);
+        if (omitted < 1) {
+          return null;
+        }
+        return [...head, ...Array.from({ length: omitted }, () => 0), ...tail];
+      })()
+    : head.length === 8
+      ? head
+      : null;
+
+  if (!hextets || hextets.length !== 8) {
+    return null;
+  }
+  if (!hextets.slice(0, 6).every((value) => value === 0)) {
+    return null;
+  }
+
+  const high = hextets[6];
+  const low = hextets[7];
+  return [(high >>> 8) & 0xff, high & 0xff, (low >>> 8) & 0xff, low & 0xff];
+}
+
 function isPrivateIpv4(parts: number[]): boolean {
   const [octet1, octet2] = parts;
   if (octet1 === 0) {
@@ -125,12 +198,9 @@ export function isPrivateIpAddress(address: string): boolean {
       return isPrivateIpv4(ipv4);
     }
   }
-  if (normalized.startsWith("::")) {
-    const compatible = normalized.slice("::".length);
-    const ipv4 = parseIpv4FromMappedIpv6(compatible);
-    if (ipv4) {
-      return isPrivateIpv4(ipv4);
-    }
+  const compatibleIpv4 = parseIpv4FromCompatibleIpv6(normalized);
+  if (compatibleIpv4) {
+    return isPrivateIpv4(compatibleIpv4);
   }
 
   if (normalized.includes(":")) {


### PR DESCRIPTION
## Fix Summary
The SSRF guard's `isPrivateIpAddress` function does not recognize IPv4-compatible IPv6 addresses like `::127.0.0.1` or `::7f00:1` as private/loopback. Since this function is used for both pre-resolution hostname checks and post-DNS-resolution IP validation, an attacker controlling DNS can return AAAA records with these addresses to bypass both layers and reach internal services via loopback.

## Issue Linkage
Fixes #13274

## Security Snapshot
- CVSS v3.1: 8.7 (High)
- CVSS v4.0: 9.4 (Critical)

## Implementation Details
### Files Changed
- `src/infra/net/ssrf.pinning.test.ts` (+20/-1)
- `src/infra/net/ssrf.ts` (+77/-0)

### Technical Analysis
The `isPrivateIpAddress` function (ssrf.ts:112-141) handles `::ffff:` mapped IPv6 addresses but not `::` prefixed IPv4-compatible addresses. The function checks `PRIVATE_IPV6_PREFIXES = ["fe80:", "fec0:", "fc", "fd"]` which does not match `::127.0.0.1`. The critical issue is that this same function validates resolved DNS results (line 252 in `resolvePinnedHostnameWithPolicy`), so the bypass survives both the pre-check and the post-DNS-resolution check.

Trace for `::127.0.0.1`:
1. Line 121: does not start with `::ffff:` → skip
2. Line 129: contains `:` → enter IPv6 path
3. Line 130: not `::` and not `::1` → skip
4. Line 133: no prefix in `["fe80:", "fec0:", "fc", "fd"]` matches → returns false (NOT PRIVATE)

The actual TCP connection for `::127.0.0.1` routes to `127.0.0.1` on Linux and macOS.

## Validation Evidence
- Command: `pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: GPT-5.3-Codex

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the SSRF guard’s IP classification to treat IPv4-compatible IPv6 forms (e.g. `::127.0.0.1`, `::7f00:1`) as private/loopback, and adds regression tests to ensure DNS pinning rejects these AAAA results. The change is centered in `src/infra/net/ssrf.ts` where a new parser expands `::` compression and extracts the embedded IPv4 from `::/96` addresses, feeding it through the existing IPv4 private-range logic. `fetch-guard.ts` consumes `resolvePinnedHostnameWithPolicy()`/`resolvePinnedHostname()` so this fix applies to both pre-check and post-DNS-resolution enforcement.

One critical issue to address before merge: the new “compatible IPv6” parsing also matches IPv4-mapped IPv6 (`::ffff:w.x.y.z` / `::ffff:0:0/96`) and can misclassify `::ffff:127.0.0.1` as public because it interprets the last two hextets as the IPv4 bytes (`0xffff:7f00` → `255.255.127.0`). This should be excluded/handled so mapped loopback remains blocked.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge until the IPv4-mapped IPv6 regression is fixed.
- The PR addresses an SSRF bypass, but the new IPv4-compatible IPv6 parsing also captures IPv4-mapped IPv6 and can misclassify mapped loopback (e.g. `::ffff:127.0.0.1`) as public, which is a correctness/security regression in the core guard.
- src/infra/net/ssrf.ts (parseIpv4FromCompatibleIpv6 / isPrivateIpAddress ordering and exclusions)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->