### PR TITLE
fix(docker): support macOS default Bash 3.2 by checking keys via string matching

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local seen=""
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -138,7 +138,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen="${seen} \"$k\" "
           replaced=true
           break
         fi
@@ -150,7 +150,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if [[ "$seen" != *" \"$k\" "* ]]; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
**Problem**:
`docker-setup.sh` uses `declare -A` (associative arrays) which requires Bash 4.0+. macOS ships with Bash 3.2 by default, causing the script to fail with `declare: -A: invalid option`.

**Proposed Fix**:
Replaced the associative array logic in `upsert_env` with a robust string matching approach.

**Why this approach?**
1.  **Zero Dependencies**: Users don't need to install a newer Bash via Homebrew (`brew install bash`) just to run the setup script. It works out-of-the-box on a fresh macOS installation.
2.  **Robust Matching**: Uses padded string matching (` "key" `) to ensure exact matches. This strictly prevents false positives where one key is a substring of another (e.g., ensuring `PORT` doesn't match `EXPORT`).
3.  **Minimal Changes**: The logic change is contained within `upsert_env` without altering the script's overall structure or requiring external tools like `python` or `perl`.

**Verification**:
Tested on macOS (Bash 3.2.57) and verified that `.env` is correctly updated without syntax errors.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the `upsert_env` helper in `docker-setup.sh` to avoid features not supported in older shells. It now tracks which entries were replaced using a plain string and uses pattern matching to decide whether to append missing entries when rewriting the `.env` file.

The change is localized to `upsert_env` and keeps the prior behavior: replace matching `name=value` lines for the provided names and append any missing names at the end.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is localized, removes an incompatible shell feature, and the new logic preserves the prior semantics for the fixed set of known key names used by this script.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->