### PR TITLE
docs: add Terraform IaC approach to Hetzner installation guide

### DIFF
--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -329,3 +329,25 @@ All long-lived state must survive restarts, rebuilds, and reboots.
 | Node runtime        | Container filesystem              | Docker image           | Rebuilt every image build        |
 | OS packages         | Container filesystem              | Docker image           | Do not install at runtime        |
 | Docker container    | Ephemeral                         | Restartable            | Safe to destroy                  |
+
+---
+
+## Infrastructure as Code (Terraform)
+
+For teams preferring infrastructure-as-code workflows, a community-maintained Terraform setup provides:
+
+- Modular Terraform configuration with remote state management
+- Automated provisioning via cloud-init
+- Deployment scripts (bootstrap, deploy, backup/restore)
+- Security hardening (firewall, UFW, SSH-only access)
+- SSH tunnel configuration for gateway access
+
+**Repositories:**
+- Infrastructure: [openclaw-terraform-hetzner](https://github.com/andreesg/openclaw-terraform-hetzner)
+- Docker config: [openclaw-docker-config](https://github.com/andreesg/openclaw-docker-config)
+
+**Cost:** ~€6/month on Hetzner CX22 (2 vCPU, 4GB RAM)
+
+This approach complements the Docker setup above with reproducible deployments, version-controlled infrastructure, and automated disaster recovery.
+
+> **Note:** Community-maintained. For issues or contributions, see the repository links above.

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -346,8 +346,6 @@ For teams preferring infrastructure-as-code workflows, a community-maintained Te
 - Infrastructure: [openclaw-terraform-hetzner](https://github.com/andreesg/openclaw-terraform-hetzner)
 - Docker config: [openclaw-docker-config](https://github.com/andreesg/openclaw-docker-config)
 
-**Cost:** ~€6/month on Hetzner CX22 (2 vCPU, 4GB RAM)
-
 This approach complements the Docker setup above with reproducible deployments, version-controlled infrastructure, and automated disaster recovery.
 
 > **Note:** Community-maintained. For issues or contributions, see the repository links above.


### PR DESCRIPTION
## Summary

Adds a new "Infrastructure as Code (Terraform)" section to the Hetzner installation guide, documenting a community-maintained Terraform setup for users who prefer IaC workflows.

## Changes

- **`docs/install/hetzner.md`**: Added new section at end documenting Terraform-based deployment option with links to community repositories

## Context

This addresses a common request from users preferring infrastructure-as-code over manual Docker setup. The Terraform approach provides:
- Reproducible deployments
- Version-controlled infrastructure
- Automated backups and disaster recovery
- Security hardening out of the box

Built with Claude Code, tested in production. Maintaining repositories independently.

Related: [Discussion #12532](https://github.com/openclaw/openclaw/discussions/12532)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an **Infrastructure as Code (Terraform)** section to `docs/install/hetzner.md`, describing a community-maintained Terraform-based deployment option for Hetzner. It highlights what the setup provides (remote state, cloud-init provisioning, deployment/backup scripts, security hardening, SSH tunnel access), links to two community repositories.

This fits alongside the existing Hetzner/Docker installation documentation as an alternative path for teams that want reproducible, version-controlled infrastructure rather than a fully manual server setup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to documentation additions, with no code or configuration modifications affecting runtime behavior. The added section is self-contained and does not appear to introduce broken links or contradictory instructions within the doc itself.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->