### PR TITLE
docker: bake brew/gog/mcporter and fix remote bin parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,52 @@ RUN corepack enable
 WORKDIR /app
 
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
-RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES && \
-      apt-get clean && \
-      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
-    fi
+ARG GOGCLI_VERSION=0.9.0
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      file \
+      git \
+      procps \
+      $OPENCLAW_DOCKER_APT_PACKAGES; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+    mkdir -p /home/linuxbrew/.linuxbrew; \
+    chown -R node:node /home/linuxbrew; \
+    curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o /tmp/install-brew.sh; \
+    chmod +x /tmp/install-brew.sh; \
+    su node -s /bin/bash -c 'NONINTERACTIVE=1 CI=1 /tmp/install-brew.sh'; \
+    rm -f /tmp/install-brew.sh; \
+    ln -sfn /home/linuxbrew/.linuxbrew/Homebrew/Library /home/linuxbrew/.linuxbrew/Library; \
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"' \
+      'export HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew"' \
+      'export HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar"' \
+      'exec /home/linuxbrew/.linuxbrew/bin/brew "$@"' \
+      > /usr/local/bin/brew; \
+    chmod 755 /usr/local/bin/brew; \
+    chown root:root /usr/local/bin/brew
+
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64|arm64) ;; \
+      *) echo "unsupported architecture for gogcli: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/gogcli.tgz "https://github.com/steipete/gogcli/releases/download/v${GOGCLI_VERSION}/gogcli_${GOGCLI_VERSION}_linux_${arch}.tar.gz"; \
+    tar -xzf /tmp/gogcli.tgz -C /tmp; \
+    install -m 0755 /tmp/gog /usr/local/bin/gog; \
+    rm -f /tmp/gog /tmp/gogcli.tgz; \
+    /usr/local/bin/gog --version
+
+ENV HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+ENV HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
+ENV HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
+ENV PATH="${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:${PATH}"
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
@@ -31,6 +71,11 @@ RUN pnpm ui:build
 
 ENV NODE_ENV=production
 
+# Configure npm global installs for non-root runtime user.
+RUN mkdir -p /home/node/.npm-global && chown -R node:node /home/node/.npm-global
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH="/home/node/.npm-global/bin:${PATH}"
+
 # Allow non-root user to write temp files during runtime/tests.
 RUN chown -R node:node /app
 
@@ -38,6 +83,9 @@ RUN chown -R node:node /app
 # The node:22-bookworm image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
+
+# Preinstall node-backed skill CLIs for portable images.
+RUN npm i -g mcporter && mcporter --version
 
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -221,6 +221,11 @@ function parseBinProbePayload(payloadJSON: string | null | undefined, payload?: 
     if (Array.isArray(parsed.bins)) {
       return parsed.bins.map((bin) => String(bin).trim()).filter(Boolean);
     }
+    // system.which returns an object map of bin -> resolvedPath.
+    // For eligibility we only need to know which bin names are present.
+    if (parsed.bins && typeof parsed.bins === "object") {
+      return Object.keys(parsed.bins).map((bin) => bin.trim()).filter(Boolean);
+    }
     if (typeof parsed.stdout === "string") {
       return parsed.stdout
         .split(/\r?\n/)


### PR DESCRIPTION
## Summary
- bake Homebrew into the Docker image for portable in-container installs
- bake gogcli into the image (arch-aware linux release binary)
- configure non-root npm global prefix and preinstall mcporter
- fix remote skill bin parsing to handle object-map payloads from 

## Why
- resolves skill blocking due to missing in-container binaries (, )
- avoids Homebrew lock/permission failures from ad-hoc runtime installs
- correctly marks bridged skills eligible when remote node returns bin maps

## Validation
- rebuilt  and recreated 
- verified in container: Homebrew 5.0.14, v0.9.0 (99d9575 2026-01-22T04:15:12Z), 0.7.3, 10.9.2
- verified gateway smoke check succeeds
- verified skills eligibility for , , and

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Docker image build to pre-bake additional tooling (Homebrew, gogcli, and a global npm CLI) and adjusts remote skill bin parsing to accept `system.which` responses that return a map of `bin -> resolvedPath`.

On the runtime side, `src/infra/skills-remote.ts` now treats an object-shaped `bins` payload as a set of available bin names (keys) for eligibility checks, matching the implementation of `system.which` in `src/node-host/runner.ts` which returns `{ bins: Record<string,string> }`.

<h3>Confidence Score: 3/5</h3>

- This PR has clear security/reproducibility concerns in the Docker build steps that should be addressed before merging.
- The remote bin parsing change is directionally correct, but the Dockerfile now executes unpinned remote install scripts and expands installed packages in the main image, both of which materially increase supply-chain and runtime risk. There’s also a small but concrete null-object edge case in the new `bins` parsing branch.
- Dockerfile; src/infra/skills-remote.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->