### PR TITLE
fix(agents): prevent sanitizeUserFacingText from rewriting conversational context overflow mentions

### DIFF
--- a/src/agents/pi-embedded-helpers.context-overflow.test.ts
+++ b/src/agents/pi-embedded-helpers.context-overflow.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeUserFacingText } from "./pi-embedded-helpers.js";
+
+describe("sanitizeUserFacingText - Context Overflow Fix", () => {
+  it("should rewrite raw context overflow errors", () => {
+    const error = "context overflow: maximum context length exceeded";
+    expect(sanitizeUserFacingText(error)).toContain("Context overflow: prompt too large");
+  });
+
+  it("should NOT rewrite conversational text mentioning context overflow", () => {
+    const conversational =
+      "I encountered a context overflow error earlier, but I have adjusted my response length to fit within the limits. Here is the answer you requested.";
+
+    expect(sanitizeUserFacingText(conversational)).toBe(conversational);
+  });
+
+  it("should NOT rewrite markdown text mentioning context overflow", () => {
+    const markdown =
+      "## Error Analysis\n\nThe previous attempt failed due to a context overflow error. Let me summarize differently.";
+
+    expect(sanitizeUserFacingText(markdown)).toBe(markdown);
+  });
+});


### PR DESCRIPTION
## Fix

The function `sanitizeUserFacingText` was incorrectly rewriting valid assistant responses that happened to mention "context overflow" (e.g., explaining why a request failed previously).

This PR adds `isLikelyAssistantContent` heuristic to detect structured responses (markdown, paragraphs, conversational markers) and skip the rewrite unless the text is explicitly a raw error payload.

Fixes #13310.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `sanitizeUserFacingText` to avoid rewriting normal assistant-facing prose that happens to mention “context overflow”, by introducing an `isLikelyAssistantContent` heuristic (length/paragraphs/markdown/conversational starts) and only applying the “raw error payload” formatting when the input still looks like an API/HTTP error.

It also adds a new Vitest file to cover the intended behavior: raw context-overflow errors should still be rewritten to the user-friendly message, while conversational/markdown explanations containing the phrase should pass through unchanged.

<h3>Confidence Score: 3/5</h3>

- This PR should not be merged until the new test import is fixed and the sanitizer’s `<final>`-stripping behavior is made consistent in the new heuristic branch.
- The core logic change is small and well-targeted, but the added test appears to import from a module path that doesn’t exist in-repo, and the new early-return path formats errors from the unstripped input, which can regress existing sanitization guarantees.
- src/agents/pi-embedded-helpers.context-overflow.test.ts, src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->