### PR TITLE
android/gateway: harden manual connect identity and A2UI UX

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -31,6 +31,9 @@ pnpm openclaw gateway --port 18789 --verbose
 2) In the Android app:
 - Open **Settings**
 - Either select a discovered gateway under **Discovered Gateways**, or use **Advanced → Manual Gateway**.
+- Manual gateway defaults:
+  - Port: `443`
+  - TLS: enabled (`Require TLS`)
 - For Tailscale Serve setups:
   - Host: your tailnet DNS name (for example `my-host.tailnet.ts.net`)
   - Port: `443`
@@ -42,7 +45,15 @@ openclaw devices list
 openclaw devices approve <requestId>
 ```
 
+For Android WS pairing, use `openclaw devices ...` (not `openclaw nodes pending/...`).
+
 More details: `docs/platforms/android.md`.
+
+## Canvas landing behavior
+
+- Connected + idle canvas shows: `Ready!` / `Chat or speak.`
+- A2UI content appears after agent/CLI pushes messages (for example `canvas.a2ui.push`).
+- If gateway A2UI assets are unavailable, Android falls back to a local scaffold instead of failing hard.
 
 ## Permissions
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -30,12 +30,16 @@ pnpm openclaw gateway --port 18789 --verbose
 
 2) In the Android app:
 - Open **Settings**
-- Either select a discovered gateway under **Discovered Gateways**, or use **Advanced → Manual Gateway** (host + port).
+- Either select a discovered gateway under **Discovered Gateways**, or use **Advanced → Manual Gateway**.
+- For Tailscale Serve setups:
+  - Host: your tailnet DNS name (for example `my-host.tailnet.ts.net`)
+  - Port: `443`
+  - TLS: enabled
 
 3) Approve pairing (on the gateway machine):
 ```bash
-openclaw nodes pending
-openclaw nodes approve <requestId>
+openclaw devices list
+openclaw devices approve <requestId>
 ```
 
 More details: `docs/platforms/android.md`.

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -104,6 +104,8 @@ dependencies {
   implementation("androidx.security:security-crypto:1.1.0")
   implementation("androidx.exifinterface:exifinterface:1.4.2")
   implementation("com.squareup.okhttp3:okhttp:5.3.2")
+  implementation("org.conscrypt:conscrypt-android:2.5.2")
+  implementation("net.i2p.crypto:eddsa:0.3.0")
 
   // CameraX (for node.invoke camera.* parity)
   implementation("androidx.camera:camera-core:1.5.2")

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -164,6 +164,7 @@ class NodeRuntime(context: Context) {
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
         applyMainSessionKey(mainSessionKey)
         updateStatus()
+        maybeNavigateToA2uiOnConnect()
         scope.launch { refreshBrandingFromGateway() }
         scope.launch { refreshWakeWordsFromGateway() }
       },
@@ -202,7 +203,11 @@ class NodeRuntime(context: Context) {
         nodeConnected = false
         nodeStatusText = message
         updateStatus()
-        showLocalCanvasOnDisconnect()
+        if (operatorConnected) {
+          maybeNavigateToA2uiOnConnect()
+        } else {
+          showLocalCanvasOnDisconnect()
+        }
       },
       onEvent = { _, _ -> },
       onInvoke = { req ->

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -258,12 +258,18 @@ class NodeRuntime(context: Context) {
   }
 
   private fun maybeNavigateToA2uiOnConnect() {
-    val a2uiUrl = resolveA2uiHostUrl() ?: return
     val current = canvas.currentUrl()?.trim().orEmpty()
-    if (current.isEmpty() || current == lastAutoA2uiUrl) {
-      lastAutoA2uiUrl = a2uiUrl
-      canvas.navigate(a2uiUrl)
+    if (current.isNotEmpty() && current != lastAutoA2uiUrl) return
+
+    val a2uiUrl = resolveA2uiHostUrl()
+    if (a2uiUrl.isNullOrBlank() || !canReachCanvasHost(a2uiUrl)) {
+      lastAutoA2uiUrl = null
+      canvas.navigate("")
+      return
     }
+
+    lastAutoA2uiUrl = a2uiUrl
+    canvas.navigate(a2uiUrl)
   }
 
   private fun showLocalCanvasOnDisconnect() {
@@ -358,7 +364,7 @@ class NodeRuntime(context: Context) {
           val port = manualPort.value
           if (host.isNotEmpty() && port in 1..65535) {
             didAutoConnect = true
-            connect(GatewayEndpoint.manual(host = host, port = port))
+            connect(GatewayEndpoint.manual(host = host, port = port, tlsEnabled = manualTls.value))
           }
           return@collect
         }
@@ -541,7 +547,9 @@ class NodeRuntime(context: Context) {
       caps = emptyList(),
       commands = emptyList(),
       permissions = emptyMap(),
-      client = buildClientInfo(clientId = "openclaw-control-ui", clientMode = "ui"),
+      // Use native Android client identity for operator connections.
+      // "openclaw-control-ui" is browser-only and triggers strict Origin checks.
+      client = buildClientInfo(clientId = "openclaw-android", clientMode = "ui"),
       userAgent = buildUserAgent(),
     )
   }
@@ -604,7 +612,7 @@ class NodeRuntime(context: Context) {
       _statusText.value = "Failed: invalid manual host/port"
       return
     }
-    connect(GatewayEndpoint.manual(host = host, port = port))
+    connect(GatewayEndpoint.manual(host = host, port = port, tlsEnabled = manualTls.value))
   }
 
   fun disconnect() {
@@ -1116,6 +1124,31 @@ class NodeRuntime(context: Context) {
     if (raw.isBlank()) return null
     val base = raw.trimEnd('/')
     return "${base}/__openclaw__/a2ui/?platform=android"
+  }
+
+  private fun canReachCanvasHost(a2uiUrl: String): Boolean {
+    var conn: java.net.HttpURLConnection? = null
+    return try {
+      val url = java.net.URI(a2uiUrl).toURL()
+      conn = (url.openConnection() as? java.net.HttpURLConnection) ?: return false
+      conn.connectTimeout = 1800
+      conn.readTimeout = 2200
+      conn.instanceFollowRedirects = true
+      conn.requestMethod = "GET"
+
+      val code = conn.responseCode
+      if (code !in 200..299) return false
+
+      val content =
+        conn.inputStream.bufferedReader(Charsets.UTF_8).use { reader ->
+          reader.readText()
+        }
+      !content.contains("A2UI assets not found", ignoreCase = true)
+    } catch (_: Throwable) {
+      false
+    } finally {
+      conn?.disconnect()
+    }
   }
 
   private suspend fun ensureA2uiReady(a2uiUrl: String): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -64,7 +64,7 @@ class SecurePrefs(context: Context) {
   val manualHost: StateFlow<String> = _manualHost
 
   private val _manualPort =
-    MutableStateFlow(prefs.getInt("gateway.manual.port", 18789))
+    MutableStateFlow(prefs.getInt("gateway.manual.port", 443))
   val manualPort: StateFlow<Int> = _manualPort
 
   private val _manualTls =

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
@@ -1,15 +1,25 @@
 package ai.openclaw.android.gateway
 
 import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 import android.util.Base64
 import java.io.File
 import java.security.KeyFactory
+import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.security.KeyStore
 import java.security.MessageDigest
+import java.security.PrivateKey
+import java.security.Security
 import java.security.Signature
+import java.security.spec.NamedParameterSpec
 import java.security.spec.PKCS8EncodedKeySpec
+import java.util.UUID
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import net.i2p.crypto.eddsa.EdDSASecurityProvider
+import org.conscrypt.Conscrypt
 
 @Serializable
 data class DeviceIdentity(
@@ -20,21 +30,53 @@ data class DeviceIdentity(
 )
 
 class DeviceIdentityStore(context: Context) {
+  private data class GeneratedKey(
+    val keyPair: KeyPair,
+    val privateRef: String,
+  )
+
   private val json = Json { ignoreUnknownKeys = true }
   private val identityFile = File(context.filesDir, "openclaw/identity/device.json")
 
+  init {
+    ensureCryptoProviders()
+  }
+
   @Synchronized
   fun loadOrCreate(): DeviceIdentity {
+    ensureCryptoProviders()
     val existing = load()
     if (existing != null) {
       val derived = deriveDeviceId(existing.publicKeyRawBase64)
-      if (derived != null && derived != existing.deviceId) {
-        val updated = existing.copy(deviceId = derived)
-        save(updated)
-        return updated
+      val normalized =
+        if (derived != null && derived != existing.deviceId) {
+          val updated = existing.copy(deviceId = derived)
+          save(updated)
+          updated
+        } else {
+          existing
+        }
+      val alias = keystoreAliasFromRef(normalized.privateKeyPkcs8Base64)
+      if (alias != null && !hasKeystorePrivateKey(alias)) {
+        val fresh = generate()
+        save(fresh)
+        return fresh
       }
-      return existing
+      if (signPayload("identity-check", normalized).isNullOrBlank()) {
+        val fresh = generate()
+        save(fresh)
+        return fresh
+      }
+      return normalized
     }
+    val fresh = generate()
+    save(fresh)
+    return fresh
+  }
+
+  @Synchronized
+  fun regenerate(): DeviceIdentity {
+    ensureCryptoProviders()
     val fresh = generate()
     save(fresh)
     return fresh
@@ -42,14 +84,10 @@ class DeviceIdentityStore(context: Context) {
 
   fun signPayload(payload: String, identity: DeviceIdentity): String? {
     return try {
-      val privateKeyBytes = Base64.decode(identity.privateKeyPkcs8Base64, Base64.DEFAULT)
-      val keySpec = PKCS8EncodedKeySpec(privateKeyBytes)
-      val keyFactory = KeyFactory.getInstance("Ed25519")
-      val privateKey = keyFactory.generatePrivate(keySpec)
-      val signature = Signature.getInstance("Ed25519")
-      signature.initSign(privateKey)
-      signature.update(payload.toByteArray(Charsets.UTF_8))
-      base64UrlEncode(signature.sign())
+      ensureCryptoProviders()
+      val privateKey = loadPrivateKey(identity.privateKeyPkcs8Base64) ?: return null
+      val signatureBytes = signEd25519(privateKey, payload.toByteArray(Charsets.UTF_8)) ?: return null
+      base64UrlEncode(signatureBytes)
     } catch (_: Throwable) {
       null
     }
@@ -97,17 +135,267 @@ class DeviceIdentityStore(context: Context) {
   }
 
   private fun generate(): DeviceIdentity {
-    val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
-    val spki = keyPair.public.encoded
+    val generated = generateEd25519KeyPair()
+    val spki =
+      generated.keyPair.public.encoded
+        ?: keystoreAliasFromRef(generated.privateRef)?.let(::loadKeystorePublicKeyEncoded)
+        ?: throw IllegalStateException("missing Ed25519 public key encoding")
     val rawPublic = stripSpkiPrefix(spki)
     val deviceId = sha256Hex(rawPublic)
-    val privateKey = keyPair.private.encoded
     return DeviceIdentity(
       deviceId = deviceId,
       publicKeyRawBase64 = Base64.encodeToString(rawPublic, Base64.NO_WRAP),
-      privateKeyPkcs8Base64 = Base64.encodeToString(privateKey, Base64.NO_WRAP),
+      privateKeyPkcs8Base64 = generated.privateRef,
       createdAtMs = System.currentTimeMillis(),
     )
+  }
+
+  private fun generateEd25519KeyPair(): GeneratedKey {
+    // Prefer pure-Java EdDSA first to avoid OEM/provider differences.
+    tryGenerateKeyPair(algorithm = "EdDSA", provider = "EdDSA", initializeEd25519 = false)?.let { return it }
+    tryGenerateKeyPair(algorithm = "EdDSA", provider = null, initializeEd25519 = false)?.let { return it }
+
+    // Prefer software keys from Conscrypt for deterministic decode/sign behavior.
+    tryGenerateKeyPair(algorithm = "Ed25519", provider = "Conscrypt", initializeEd25519 = false)?.let {
+      return it
+    }
+    tryGenerateKeyPair(algorithm = "Ed25519", provider = "Conscrypt", initializeEd25519 = true)?.let {
+      return it
+    }
+
+    // Fall back to keystore-backed keys if software provider is unavailable.
+    generateKeystoreEd25519KeyPair()?.let { return it }
+
+    // Avoid AndroidKeyStore providers because we need an exportable PKCS#8 private key.
+    val providers =
+      (Security.getProviders("KeyPairGenerator.Ed25519") ?: emptyArray())
+        .filterNot { it.name.contains("AndroidKeyStore", ignoreCase = true) }
+
+    for (provider in providers) {
+      tryGenerateKeyPair(algorithm = "Ed25519", provider = provider.name, initializeEd25519 = false)?.let {
+        return it
+      }
+      tryGenerateKeyPair(algorithm = "Ed25519", provider = provider.name, initializeEd25519 = true)?.let {
+        return it
+      }
+    }
+
+    // Final fallback through default provider selection.
+    tryGenerateKeyPair(algorithm = "Ed25519", provider = null, initializeEd25519 = false)?.let { return it }
+    tryGenerateKeyPair(algorithm = "Ed25519", provider = null, initializeEd25519 = true)?.let { return it }
+
+    throw IllegalStateException("unable to generate Ed25519 keypair")
+  }
+
+  private fun tryGenerateKeyPair(
+    algorithm: String,
+    provider: String?,
+    initializeEd25519: Boolean,
+  ): GeneratedKey? {
+    return try {
+      val generator =
+        if (provider.isNullOrBlank()) {
+          KeyPairGenerator.getInstance(algorithm)
+        } else {
+          KeyPairGenerator.getInstance(algorithm, provider)
+        }
+      if (initializeEd25519 && algorithm == "Ed25519") {
+        generator.initialize(NamedParameterSpec("Ed25519"))
+      }
+      val keyPair = generator.generateKeyPair()
+      if (isExportable(keyPair)) {
+        val privateRef = Base64.encodeToString(keyPair.private.encoded, Base64.NO_WRAP)
+        // Accept exportable keys only if we can reload and sign with them.
+        val roundTripPrivate = decodeExportedPrivateKey(privateRef)
+        if (roundTripPrivate == null || !canSignWithPrivateKey(roundTripPrivate)) {
+          return null
+        }
+        GeneratedKey(
+          keyPair = keyPair,
+          privateRef = privateRef,
+        )
+      } else {
+        null
+      }
+    } catch (err: Throwable) {
+      null
+    }
+  }
+
+  private fun isExportable(keyPair: KeyPair): Boolean {
+    val privateEncoded = keyPair.private.encoded
+    val publicEncoded = keyPair.public.encoded
+    return privateEncoded != null && privateEncoded.isNotEmpty() &&
+      publicEncoded != null && publicEncoded.isNotEmpty()
+  }
+
+  private fun generateKeystoreEd25519KeyPair(): GeneratedKey? {
+    val tryDigestNone = listOf(false, true)
+    for (useDigestNone in tryDigestNone) {
+      val alias = "openclaw-ed25519-${UUID.randomUUID()}"
+      try {
+        val generator = KeyPairGenerator.getInstance("Ed25519", "AndroidKeyStore")
+        val builder =
+          KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+          )
+        if (useDigestNone) {
+          builder.setDigests(KeyProperties.DIGEST_NONE)
+        }
+        generator.initialize(builder.build())
+        val keyPair = generator.generateKeyPair()
+        val publicEncoded = keyPair.public.encoded ?: loadKeystorePublicKeyEncoded(alias)
+        if (publicEncoded != null && publicEncoded.isNotEmpty() && hasKeystorePrivateKey(alias)) {
+          return GeneratedKey(
+            keyPair = keyPair,
+            privateRef = "$KEYSTORE_REF_PREFIX$alias",
+          )
+        }
+      } catch (_: Throwable) {
+        // try the next keystore spec variant
+      }
+      deleteKeystoreKey(alias)
+    }
+    return null
+  }
+
+  private fun keystoreAliasFromRef(privateRef: String): String? {
+    if (!privateRef.startsWith(KEYSTORE_REF_PREFIX)) return null
+    val alias = privateRef.removePrefix(KEYSTORE_REF_PREFIX).trim()
+    return alias.takeIf { it.isNotEmpty() }
+  }
+
+  private fun loadKeystorePrivateKey(alias: String): java.security.PrivateKey? {
+    return try {
+      val keyStore = KeyStore.getInstance("AndroidKeyStore")
+      keyStore.load(null)
+      keyStore.getKey(alias, null) as? java.security.PrivateKey
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  private fun hasKeystorePrivateKey(alias: String): Boolean {
+    return loadKeystorePrivateKey(alias) != null
+  }
+
+  private fun loadPrivateKey(privateRef: String): PrivateKey? {
+    val alias = keystoreAliasFromRef(privateRef)
+    if (alias != null) {
+      return loadKeystorePrivateKey(alias)
+    }
+    return decodeExportedPrivateKey(privateRef)
+  }
+
+  private fun decodeExportedPrivateKey(privateRef: String): PrivateKey? {
+    return try {
+      val privateKeyBytes = Base64.decode(privateRef, Base64.DEFAULT)
+      val keySpec = PKCS8EncodedKeySpec(privateKeyBytes)
+      val attempts = mutableListOf<Pair<String, String?>>()
+      attempts += "Ed25519" to null
+      attempts += "EdDSA" to null
+      for (provider in Security.getProviders("KeyFactory.Ed25519") ?: emptyArray()) {
+        attempts += "Ed25519" to provider.name
+      }
+      for (provider in Security.getProviders("KeyFactory.EdDSA") ?: emptyArray()) {
+        attempts += "EdDSA" to provider.name
+      }
+      for ((algorithm, provider) in attempts.distinct()) {
+        try {
+          val keyFactory =
+            if (provider.isNullOrBlank()) {
+              KeyFactory.getInstance(algorithm)
+            } else {
+              KeyFactory.getInstance(algorithm, provider)
+            }
+          return keyFactory.generatePrivate(keySpec)
+        } catch (_: Throwable) {
+          // try the next provider/algorithm
+        }
+      }
+      null
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  private fun signEd25519(privateKey: PrivateKey, payload: ByteArray): ByteArray? {
+    val attempts = mutableListOf<Pair<String, String?>>()
+    val algorithms = listOf("Ed25519", "NONEwithEdDSA", "EdDSA")
+    val preferredProviders =
+      listOf("EdDSA", "AndroidKeyStore", "AndroidKeyStoreBCWorkaround", "Conscrypt", "BC")
+    for (algorithm in algorithms) {
+      attempts += algorithm to null
+      for (providerName in preferredProviders) {
+        attempts += algorithm to providerName
+      }
+      for (provider in Security.getProviders("Signature.$algorithm") ?: emptyArray()) {
+        attempts += algorithm to provider.name
+      }
+    }
+    for ((algorithm, provider) in attempts.distinct()) {
+      try {
+        val signature =
+          if (provider.isNullOrBlank()) {
+            Signature.getInstance(algorithm)
+          } else {
+            Signature.getInstance(algorithm, provider)
+          }
+        signature.initSign(privateKey)
+        signature.update(payload)
+        val signed = signature.sign()
+        if (signed.isNotEmpty()) {
+          return signed
+        }
+      } catch (_: Throwable) {
+        // try next signature algorithm/provider
+      }
+    }
+    return null
+  }
+
+  private fun canSignWithPrivateKey(privateKey: PrivateKey): Boolean {
+    return signEd25519(privateKey, "identity-check".toByteArray(Charsets.UTF_8)) != null
+  }
+
+  private fun ensureCryptoProviders() {
+    if (Security.getProvider("EdDSA") == null) {
+      try {
+        Security.insertProviderAt(EdDSASecurityProvider(), 1)
+      } catch (_: Throwable) {
+        // best-effort only
+      }
+    }
+    if (Security.getProvider("Conscrypt") == null) {
+      try {
+        Security.insertProviderAt(Conscrypt.newProvider(), 1)
+      } catch (_: Throwable) {
+        // best-effort only
+      }
+    }
+  }
+
+  private fun deleteKeystoreKey(alias: String) {
+    try {
+      val keyStore = KeyStore.getInstance("AndroidKeyStore")
+      keyStore.load(null)
+      if (keyStore.containsAlias(alias)) {
+        keyStore.deleteEntry(alias)
+      }
+    } catch (_: Throwable) {
+      // best-effort only
+    }
+  }
+
+  private fun loadKeystorePublicKeyEncoded(alias: String): ByteArray? {
+    return try {
+      val keyStore = KeyStore.getInstance("AndroidKeyStore")
+      keyStore.load(null)
+      keyStore.getCertificate(alias)?.publicKey?.encoded
+    } catch (_: Throwable) {
+      null
+    }
   }
 
   private fun deriveDeviceId(publicKeyRawBase64: String): String? {
@@ -142,6 +430,7 @@ class DeviceIdentityStore(context: Context) {
   }
 
   companion object {
+    private const val KEYSTORE_REF_PREFIX = "keystore:"
     private val ED25519_SPKI_PREFIX =
       byteArrayOf(
         0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewayEndpoint.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewayEndpoint.kt
@@ -13,13 +13,13 @@ data class GatewayEndpoint(
   val tlsFingerprintSha256: String? = null,
 ) {
   companion object {
-    fun manual(host: String, port: Int): GatewayEndpoint =
+    fun manual(host: String, port: Int, tlsEnabled: Boolean = false): GatewayEndpoint =
       GatewayEndpoint(
         stableId = "manual|${host.lowercase()}|$port",
         name = "$host:$port",
         host = host,
         port = port,
-        tlsEnabled = false,
+        tlsEnabled = tlsEnabled,
         tlsFingerprintSha256 = null,
       )
   }

--- a/apps/android/app/src/test/java/ai/openclaw/android/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/NodeForegroundServiceTest.kt
@@ -9,10 +9,12 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
+import org.robolectric.annotation.ConscryptMode
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
+@ConscryptMode(ConscryptMode.Mode.OFF)
 class NodeForegroundServiceTest {
   @Test
   fun buildNotificationSetsLaunchIntent() {

--- a/apps/android/app/src/test/java/ai/openclaw/android/gateway/DeviceIdentityStoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/gateway/DeviceIdentityStoreTest.kt
@@ -1,0 +1,52 @@
+package ai.openclaw.android.gateway
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.ConscryptMode
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@ConscryptMode(ConscryptMode.Mode.OFF)
+class DeviceIdentityStoreTest {
+  @Test
+  fun loadOrCreateReturnsSignableIdentity() {
+    val app = RuntimeEnvironment.getApplication()
+    resetIdentityFiles(app.filesDir)
+    val store = DeviceIdentityStore(app)
+
+    val identity = store.loadOrCreate()
+    val publicKey = store.publicKeyBase64Url(identity)
+    val signature = store.signPayload("connect-check", identity)
+
+    assertNotNull(publicKey)
+    assertNotNull(signature)
+    assertFalse(publicKey.isNullOrBlank())
+    assertFalse(signature.isNullOrBlank())
+  }
+
+  @Test
+  fun regenerateReturnsSignableIdentity() {
+    val app = RuntimeEnvironment.getApplication()
+    resetIdentityFiles(app.filesDir)
+    val store = DeviceIdentityStore(app)
+
+    val identity = store.regenerate()
+    val publicKey = store.publicKeyBase64Url(identity)
+    val signature = store.signPayload("connect-check", identity)
+
+    assertNotNull(publicKey)
+    assertNotNull(signature)
+    assertFalse(publicKey.isNullOrBlank())
+    assertFalse(signature.isNullOrBlank())
+  }
+
+  private fun resetIdentityFiles(filesDir: File) {
+    File(filesDir, "openclaw").deleteRecursively()
+  }
+}

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -218,7 +218,15 @@ export function extractAssistantText(msg: AssistantMessage): string {
         .filter(Boolean)
     : [];
   const extracted = blocks.join("\n").trim();
-  return sanitizeUserFacingText(extracted);
+  if (extracted) {
+    return sanitizeUserFacingText(extracted);
+  }
+  // Fallback: if a provider only returns reasoning_content, surface it as text.
+  const thinking = extractAssistantThinking(msg);
+  if (!thinking) {
+    return "";
+  }
+  return sanitizeUserFacingText(thinking);
 }
 
 export function extractAssistantThinking(msg: AssistantMessage): string {


### PR DESCRIPTION
## Summary

- Harden Android gateway `connect` device identity generation/signing across provider variants.
- Retry `connect` once with regenerated identity when device auth fields cannot be produced.
- Keep manual gateway defaults aligned with Tailscale Serve (`443` + TLS enabled by default).
- Improve canvas host normalization for manual/TLS endpoints so Android uses the expected HTTPS origin.
- Keep A2UI navigation stable on reconnect paths (avoid dropping to local scaffold while operator is still connected).
- Add clearer connected-idle canvas UI (`Ready!` / `Chat or speak.`) and warning-only banners for background/node-offline states.
- Fix gateway A2UI asset resolution for bundled/npm dist runtime layouts.
- Update Android runbook docs with correct WS pairing commands (`openclaw devices ...`), manual gateway guidance, and troubleshooting.

## Testing

- `cd apps/android && ./gradlew -Pandroid.aapt2FromMavenOverride=/home/dragon/.openclaw/tools/aapt2 :app:assembleDebug :app:testDebugUnitTest` ✅
- `cd /clawdbot/openclaw && pnpm test src/canvas-host/server.test.ts` ✅

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes focus on Android gateway connectivity and A2UI UX, plus making the canvas-host A2UI asset lookup work across more runtime layouts. On Android, manual gateway defaults are moved to port 443 with TLS support, connect identity signing is made more robust with multiple crypto-provider fallbacks and a one-time regeneration retry, and the UI avoids dropping to the local scaffold during reconnect while adding “Ready!/Chat or speak.” and warning-only banners. On the server side, A2UI root discovery now considers `OPENCLAW_A2UI_ROOT` and bundled/npm dist layouts via `argv[1]`, and tests were updated to cover retrying asset lookup after an initial miss.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has at least one correctness/performance issue in A2UI root caching that should be addressed.
- Most changes are additive and covered by tests, but the updated A2UI root cache no longer caches misses, which can cause repeated filesystem scans and unstable 503/200 behavior depending on when assets appear. Fixing the miss-caching logic (or adding a TTL) would make the new lookup behavior reliable.
- src/canvas-host/a2ui.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->