### PR TITLE
fix(agents): auto-strip images from context on empty model response

### DIFF
--- a/src/agents/pi-embedded-helpers.stripimageblocks.test.ts
+++ b/src/agents/pi-embedded-helpers.stripimageblocks.test.ts
@@ -1,0 +1,129 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { stripImageBlocksFromMessages } from "./pi-embedded-helpers/images.js";
+
+describe("stripImageBlocksFromMessages", () => {
+  it("strips image blocks from toolResult content", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "tc1",
+        content: [
+          { type: "text", text: "MEDIA:/tmp/screenshot.jpg" },
+          { type: "image", data: "base64data", mimeType: "image/jpeg" },
+        ],
+      } as unknown as AgentMessage,
+    ];
+    const { messages: result, hadImages } = stripImageBlocksFromMessages(messages);
+    expect(hadImages).toBe(true);
+    const content = (result[0] as unknown as { content: { type: string; text?: string }[] })
+      .content;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ type: "text", text: "MEDIA:/tmp/screenshot.jpg" });
+    expect(content[1]).toEqual({ type: "text", text: "[image omitted]" });
+  });
+
+  it("strips image blocks from user content", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Look at this" },
+          { type: "image", data: "abc", mimeType: "image/png" },
+        ],
+      } as unknown as AgentMessage,
+    ];
+    const { messages: result, hadImages } = stripImageBlocksFromMessages(messages);
+    expect(hadImages).toBe(true);
+    const content = (result[0] as unknown as { content: { type: string; text?: string }[] })
+      .content;
+    expect(content[1]).toEqual({ type: "text", text: "[image omitted]" });
+  });
+
+  it("strips image blocks from assistant content", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here is the result" },
+          { type: "image", data: "xyz", mimeType: "image/png" },
+        ],
+      } as unknown as AgentMessage,
+    ];
+    const { messages: result, hadImages } = stripImageBlocksFromMessages(messages);
+    expect(hadImages).toBe(true);
+    const content = (result[0] as unknown as { content: { type: string; text?: string }[] })
+      .content;
+    expect(content[1]).toEqual({ type: "text", text: "[image omitted]" });
+  });
+
+  it("returns hadImages=false when no image blocks present", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "Hello" } as AgentMessage,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hi there" }],
+      } as unknown as AgentMessage,
+    ];
+    const { messages: result, hadImages } = stripImageBlocksFromMessages(messages);
+    expect(hadImages).toBe(false);
+    expect(result).toHaveLength(2);
+  });
+
+  it("preserves non-image blocks unchanged", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "tc1",
+        content: [
+          { type: "text", text: "result text" },
+          { type: "toolCall", id: "x", name: "foo", arguments: "{}" },
+        ],
+      } as unknown as AgentMessage,
+    ];
+    const { messages: result, hadImages } = stripImageBlocksFromMessages(messages);
+    expect(hadImages).toBe(false);
+    const content = (result[0] as unknown as { content: { type: string }[] }).content;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ type: "text", text: "result text" });
+    expect(content[1]).toEqual({ type: "toolCall", id: "x", name: "foo", arguments: "{}" });
+  });
+
+  it("recursively strips nested image blocks", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "tc1",
+        content: [
+          {
+            type: "nested",
+            content: [
+              { type: "text", text: "inner text" },
+              { type: "image", data: "nested-img", mimeType: "image/png" },
+            ],
+          },
+        ],
+      } as unknown as AgentMessage,
+    ];
+    const { messages: result, hadImages } = stripImageBlocksFromMessages(messages);
+    expect(hadImages).toBe(true);
+    const outer = (result[0] as unknown as { content: { type: string; content?: unknown[] }[] })
+      .content;
+    const inner = outer[0]?.content as { type: string; text?: string }[];
+    expect(inner[0]).toEqual({ type: "text", text: "inner text" });
+    expect(inner[1]).toEqual({ type: "text", text: "[image omitted]" });
+  });
+
+  it("handles empty messages array", () => {
+    const { messages: result, hadImages } = stripImageBlocksFromMessages([]);
+    expect(hadImages).toBe(false);
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles string content without mutation", () => {
+    const messages: AgentMessage[] = [{ role: "user", content: "plain text" } as AgentMessage];
+    const { messages: result, hadImages } = stripImageBlocksFromMessages(messages);
+    expect(hadImages).toBe(false);
+    expect(result[0]?.content).toBe("plain text");
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -40,6 +40,7 @@ export {
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,
   stripImageBlocksFromMessages,
+  stripImageBlocksFromSessionFile,
 } from "./pi-embedded-helpers/images.js";
 export {
   isMessagingToolDuplicate,

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -39,6 +39,7 @@ export { downgradeOpenAIReasoningBlocks } from "./pi-embedded-helpers/openai.js"
 export {
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,
+  stripImageBlocksFromMessages,
 } from "./pi-embedded-helpers/images.js";
 export {
   isMessagingToolDuplicate,

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,6 +1,10 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddedRunAttemptParams } from "./types.js";
 import { injectHistoryImagesIntoMessages } from "./attempt.js";
 
 describe("injectHistoryImagesIntoMessages", () => {
@@ -54,5 +58,629 @@ describe("injectHistoryImagesIntoMessages", () => {
 
     expect(didMutate).toBe(false);
     expect(messages[0]?.content).toBe("noop");
+  });
+});
+
+describe("empty response image-strip retry", () => {
+  it("strips images and retries when model returns empty with images in context", async () => {
+    let promptCallCount = 0;
+    const replaceMessagesCalls: AgentMessage[][] = [];
+
+    vi.resetModules();
+
+    vi.doMock("../runs.js", () => ({
+      clearActiveEmbeddedRun: vi.fn(),
+      setActiveEmbeddedRun: vi.fn(),
+    }));
+
+    vi.doMock("../../pi-embedded-subscribe.js", () => ({
+      subscribeEmbeddedPiSession: () => ({
+        assistantTexts: [],
+        toolMetas: [],
+        unsubscribe: vi.fn(),
+        waitForCompactionRetry: () => Promise.resolve(),
+        getMessagingToolSentTexts: () => [],
+        getMessagingToolSentTargets: () => [],
+        didSendViaMessagingTool: () => false,
+        getLastToolError: () => undefined,
+        isCompacting: () => false,
+        getUsageTotals: () => ({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+        getCompactionCount: () => 0,
+      }),
+    }));
+
+    vi.doMock("./images.js", () => ({
+      detectAndLoadPromptImages: async () => ({
+        images: [],
+        historyImagesByIndex: new Map<number, ImageContent[]>(),
+      }),
+    }));
+
+    vi.doMock("../../cache-trace.js", () => ({ createCacheTrace: () => null }));
+    vi.doMock("../../anthropic-payload-log.js", () => ({
+      createAnthropicPayloadLogger: () => null,
+    }));
+    vi.doMock("../extensions.js", () => ({ buildEmbeddedExtensionPaths: () => undefined }));
+
+    vi.doMock("../../pi-settings.js", () => ({
+      ensurePiCompactionReserveTokens: () => undefined,
+      resolveCompactionReserveTokensFloor: () => 0,
+    }));
+
+    vi.doMock("../google.js", () => ({
+      sanitizeToolsForGoogle: ({ tools }: { tools: unknown }) => tools,
+      logToolSchemasForGoogle: () => undefined,
+      sanitizeSessionHistory: async ({ messages }: { messages: AgentMessage[] }) => messages,
+    }));
+
+    vi.doMock("../../session-write-lock.js", () => ({
+      acquireSessionWriteLock: async () => ({ release: async () => undefined }),
+    }));
+
+    vi.doMock("../../session-file-repair.js", () => ({
+      repairSessionFileIfNeeded: async () => undefined,
+    }));
+
+    vi.doMock("../session-manager-cache.js", () => ({
+      prewarmSessionFile: async () => undefined,
+      trackSessionManagerAccess: () => undefined,
+    }));
+
+    vi.doMock("../session-manager-init.js", () => ({
+      prepareSessionManagerForRun: async () => undefined,
+    }));
+
+    vi.doMock("../../session-tool-result-guard-wrapper.js", () => ({
+      guardSessionManager: (mgr: unknown) => mgr,
+    }));
+
+    vi.doMock("../../../plugins/hook-runner-global.js", () => ({
+      getGlobalHookRunner: () => null,
+    }));
+
+    vi.doMock("../../skills.js", () => ({
+      applySkillEnvOverrides: () => () => undefined,
+      applySkillEnvOverridesFromSnapshot: () => () => undefined,
+      loadWorkspaceSkillEntries: () => [],
+      resolveSkillsPromptForRun: () => "",
+    }));
+
+    // Session history with an image in a tool result
+    const messagesWithImage: AgentMessage[] = [
+      { role: "user", content: "take screenshot" } as AgentMessage,
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tc1", name: "browser", arguments: "{}" }],
+        stopReason: "toolUse",
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: "tc1",
+        content: [
+          { type: "text", text: "MEDIA:/tmp/screenshot.jpg" },
+          { type: "image", data: "base64data", mimeType: "image/jpeg" },
+        ],
+      } as unknown as AgentMessage,
+    ];
+
+    vi.doMock("@mariozechner/pi-coding-agent", () => {
+      const agent: {
+        streamFn?: unknown;
+        replaceMessages: (msgs: AgentMessage[]) => void;
+        setSystemPrompt: (prompt: string) => void;
+      } = {
+        streamFn: undefined,
+        replaceMessages: (msgs) => {
+          replaceMessagesCalls.push([...msgs]);
+          session.messages = msgs;
+        },
+        setSystemPrompt: () => undefined,
+      };
+      const session: {
+        sessionId: string;
+        messages: AgentMessage[];
+        isStreaming: boolean;
+        agent: typeof agent;
+        prompt: (prompt: string, _opts?: unknown) => Promise<void>;
+        steer: (text: string) => Promise<void>;
+        abort: () => Promise<void>;
+        dispose: () => void;
+      } = {
+        sessionId: "test-session-id",
+        messages: [...messagesWithImage],
+        isStreaming: false,
+        agent,
+        prompt: async () => {
+          promptCallCount++;
+          if (promptCallCount === 1) {
+            // First prompt: model returns empty (image problem)
+            session.messages.push({
+              role: "assistant",
+              content: [],
+            } as unknown as AgentMessage);
+          } else {
+            // Second prompt (after image strip): model returns text
+            session.messages.push({
+              role: "assistant",
+              content: [{ type: "text", text: "Here is my reply" }],
+            } as unknown as AgentMessage);
+          }
+        },
+        steer: async () => undefined,
+        abort: async () => undefined,
+        dispose: () => undefined,
+      };
+
+      return {
+        createAgentSession: async () => ({ session }),
+        SessionManager: {
+          open: () => ({
+            flushPendingToolResults: () => undefined,
+            getLeafEntry: () => null,
+          }),
+        },
+        SettingsManager: { create: () => ({}) },
+      };
+    });
+
+    const { runEmbeddedAttempt } = await import("./attempt.js");
+
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-strip-test-"));
+    const sessionFile = path.join(tmpRoot, "session.json");
+    await fs.writeFile(sessionFile, "{}", "utf8");
+    const agentDir = path.join(tmpRoot, "agent");
+    const workspaceDir = path.join(tmpRoot, "workspace");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    const params = {
+      sessionId: "sess-img",
+      sessionFile,
+      workspaceDir,
+      agentDir,
+      prompt: "what do you see?",
+      provider: "openai",
+      modelId: "gpt-test",
+      model: { api: "openai", provider: "openai", input: ["text", "image"] },
+      authStorage: {},
+      modelRegistry: {},
+      thinkLevel: "off",
+      timeoutMs: 60_000,
+      runId: "run-img",
+      disableTools: true,
+    } satisfies EmbeddedRunAttemptParams;
+
+    await runEmbeddedAttempt(params);
+
+    // Should have prompted twice: first empty, then retry after stripping images
+    expect(promptCallCount).toBe(2);
+
+    // replaceMessages should have been called with stripped images (text placeholder)
+    const lastReplace = replaceMessagesCalls.at(-1);
+    expect(lastReplace).toBeDefined();
+    const hasImage = lastReplace!.some((msg) => {
+      if (!Array.isArray(msg.content)) {
+        return false;
+      }
+      return (msg.content as { type: string }[]).some((b) => b.type === "image");
+    });
+    expect(hasImage).toBe(false);
+
+    // Should have "[image omitted]" placeholder
+    const hasPlaceholder = lastReplace!.some((msg) => {
+      if (!Array.isArray(msg.content)) {
+        return false;
+      }
+      return (msg.content as { type: string; text?: string }[]).some(
+        (b) => b.type === "text" && b.text === "[image omitted]",
+      );
+    });
+    expect(hasPlaceholder).toBe(true);
+  });
+});
+
+describe("empty response image-strip retry", () => {
+  it("strips images and retries when model returns empty with images in context", async () => {
+    let promptCallCount = 0;
+    const replaceMessagesCalls: AgentMessage[][] = [];
+
+    vi.resetModules();
+
+    vi.doMock("../runs.js", () => ({
+      clearActiveEmbeddedRun: vi.fn(),
+      setActiveEmbeddedRun: vi.fn(),
+    }));
+
+    vi.doMock("../../pi-embedded-subscribe.js", () => ({
+      subscribeEmbeddedPiSession: () => ({
+        assistantTexts: [],
+        toolMetas: [],
+        unsubscribe: vi.fn(),
+        waitForCompactionRetry: () => Promise.resolve(),
+        getMessagingToolSentTexts: () => [],
+        getMessagingToolSentTargets: () => [],
+        didSendViaMessagingTool: () => false,
+        getLastToolError: () => undefined,
+        isCompacting: () => false,
+        getUsageTotals: () => ({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+        getCompactionCount: () => 0,
+      }),
+    }));
+
+    vi.doMock("./images.js", () => ({
+      detectAndLoadPromptImages: async () => ({
+        images: [],
+        historyImagesByIndex: new Map<number, ImageContent[]>(),
+      }),
+    }));
+
+    vi.doMock("../../cache-trace.js", () => ({ createCacheTrace: () => null }));
+    vi.doMock("../../anthropic-payload-log.js", () => ({
+      createAnthropicPayloadLogger: () => null,
+    }));
+    vi.doMock("../extensions.js", () => ({ buildEmbeddedExtensionPaths: () => undefined }));
+
+    vi.doMock("../../pi-settings.js", () => ({
+      ensurePiCompactionReserveTokens: () => undefined,
+      resolveCompactionReserveTokensFloor: () => 0,
+    }));
+
+    vi.doMock("../google.js", () => ({
+      sanitizeToolsForGoogle: ({ tools }: { tools: unknown }) => tools,
+      logToolSchemasForGoogle: () => undefined,
+      sanitizeSessionHistory: async ({ messages }: { messages: AgentMessage[] }) => messages,
+    }));
+
+    vi.doMock("../../session-write-lock.js", () => ({
+      acquireSessionWriteLock: async () => ({ release: async () => undefined }),
+    }));
+
+    vi.doMock("../../session-file-repair.js", () => ({
+      repairSessionFileIfNeeded: async () => undefined,
+    }));
+
+    vi.doMock("../session-manager-cache.js", () => ({
+      prewarmSessionFile: async () => undefined,
+      trackSessionManagerAccess: () => undefined,
+    }));
+
+    vi.doMock("../session-manager-init.js", () => ({
+      prepareSessionManagerForRun: async () => undefined,
+    }));
+
+    vi.doMock("../../session-tool-result-guard-wrapper.js", () => ({
+      guardSessionManager: (mgr: unknown) => mgr,
+    }));
+
+    vi.doMock("../../../plugins/hook-runner-global.js", () => ({
+      getGlobalHookRunner: () => null,
+    }));
+
+    vi.doMock("../../skills.js", () => ({
+      applySkillEnvOverrides: () => () => undefined,
+      applySkillEnvOverridesFromSnapshot: () => () => undefined,
+      loadWorkspaceSkillEntries: () => [],
+      resolveSkillsPromptForRun: () => "",
+    }));
+
+    // Session history with an image in a tool result
+    const messagesWithImage: AgentMessage[] = [
+      { role: "user", content: "take screenshot" } as AgentMessage,
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tc1", name: "browser", arguments: "{}" }],
+        stopReason: "toolUse",
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: "tc1",
+        content: [
+          { type: "text", text: "MEDIA:/tmp/screenshot.jpg" },
+          { type: "image", data: "base64data", mimeType: "image/jpeg" },
+        ],
+      } as unknown as AgentMessage,
+    ];
+
+    vi.doMock("@mariozechner/pi-coding-agent", () => {
+      const agent: {
+        streamFn?: unknown;
+        replaceMessages: (msgs: AgentMessage[]) => void;
+        setSystemPrompt: (prompt: string) => void;
+      } = {
+        streamFn: undefined,
+        replaceMessages: (msgs) => {
+          replaceMessagesCalls.push([...msgs]);
+          session.messages = msgs;
+        },
+        setSystemPrompt: () => undefined,
+      };
+      const session: {
+        sessionId: string;
+        messages: AgentMessage[];
+        isStreaming: boolean;
+        agent: typeof agent;
+        prompt: (prompt: string, _opts?: unknown) => Promise<void>;
+        steer: (text: string) => Promise<void>;
+        abort: () => Promise<void>;
+        dispose: () => void;
+      } = {
+        sessionId: "test-session-id",
+        messages: [...messagesWithImage],
+        isStreaming: false,
+        agent,
+        prompt: async () => {
+          promptCallCount++;
+          if (promptCallCount === 1) {
+            // First prompt: model returns empty (image problem)
+            session.messages.push({
+              role: "assistant",
+              content: [],
+            } as unknown as AgentMessage);
+          } else {
+            // Second prompt (after image strip): model returns text
+            session.messages.push({
+              role: "assistant",
+              content: [{ type: "text", text: "Here is my reply" }],
+            } as unknown as AgentMessage);
+          }
+        },
+        steer: async () => undefined,
+        abort: async () => undefined,
+        dispose: () => undefined,
+      };
+
+      return {
+        createAgentSession: async () => ({ session }),
+        SessionManager: {
+          open: () => ({
+            flushPendingToolResults: () => undefined,
+            getLeafEntry: () => null,
+          }),
+        },
+        SettingsManager: { create: () => ({}) },
+      };
+    });
+
+    const { runEmbeddedAttempt } = await import("./attempt.js");
+
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-strip-test-"));
+    const sessionFile = path.join(tmpRoot, "session.json");
+    await fs.writeFile(sessionFile, "{}", "utf8");
+    const agentDir = path.join(tmpRoot, "agent");
+    const workspaceDir = path.join(tmpRoot, "workspace");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    const params = {
+      sessionId: "sess-img",
+      sessionFile,
+      workspaceDir,
+      agentDir,
+      prompt: "what do you see?",
+      provider: "openai",
+      modelId: "gpt-test",
+      model: { api: "openai", provider: "openai", input: ["text", "image"] },
+      authStorage: {},
+      modelRegistry: {},
+      thinkLevel: "off",
+      timeoutMs: 60_000,
+      runId: "run-img",
+      disableTools: true,
+    } satisfies EmbeddedRunAttemptParams;
+
+    await runEmbeddedAttempt(params);
+
+    // Should have prompted twice: first empty, then retry after stripping images
+    expect(promptCallCount).toBe(2);
+
+    // replaceMessages should have been called with stripped images (text placeholder)
+    const lastReplace = replaceMessagesCalls.at(-1);
+    expect(lastReplace).toBeDefined();
+    const hasImage = lastReplace!.some((msg) => {
+      if (!Array.isArray(msg.content)) {
+        return false;
+      }
+      return (msg.content as { type: string }[]).some((b) => b.type === "image");
+    });
+    expect(hasImage).toBe(false);
+
+    // Should have "[image omitted]" placeholder
+    const hasPlaceholder = lastReplace!.some((msg) => {
+      if (!Array.isArray(msg.content)) {
+        return false;
+      }
+      return (msg.content as { type: string; text?: string }[]).some(
+        (b) => b.type === "text" && b.text === "[image omitted]",
+      );
+    });
+    expect(hasPlaceholder).toBe(true);
+  });
+});
+
+describe("compaction wait abort (regression for stuck session)", () => {
+  it("clears active embedded run when aborted during waitForCompactionRetry()", async () => {
+    const abortController = new AbortController();
+
+    let handleFromSet: unknown = undefined;
+    const clearActiveEmbeddedRun = vi.fn();
+    const setActiveEmbeddedRun = vi.fn((_sessionId: string, handle: unknown) => {
+      handleFromSet = handle;
+    });
+    const unsubscribe = vi.fn();
+
+    vi.resetModules();
+
+    vi.doMock("../runs.js", () => ({
+      clearActiveEmbeddedRun,
+      setActiveEmbeddedRun,
+    }));
+
+    vi.doMock("../../pi-embedded-subscribe.js", () => ({
+      subscribeEmbeddedPiSession: () => ({
+        assistantTexts: [],
+        toolMetas: [],
+        unsubscribe,
+        waitForCompactionRetry: () => {
+          // Abort right after compaction wait begins (but keep the wait unresolved forever).
+          queueMicrotask(() => abortController.abort(new Error("test abort")));
+          return new Promise<void>(() => {});
+        },
+        getMessagingToolSentTexts: () => [],
+        getMessagingToolSentTargets: () => [],
+        didSendViaMessagingTool: () => false,
+        getLastToolError: () => undefined,
+        isCompacting: () => true,
+        getUsageTotals: () => ({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+        getCompactionCount: () => 0,
+      }),
+    }));
+
+    vi.doMock("./images.js", () => ({
+      detectAndLoadPromptImages: async () => ({
+        images: [],
+        historyImagesByIndex: new Map<number, ImageContent[]>(),
+      }),
+    }));
+
+    vi.doMock("../../cache-trace.js", () => ({
+      createCacheTrace: () => null,
+    }));
+
+    vi.doMock("../../anthropic-payload-log.js", () => ({
+      createAnthropicPayloadLogger: () => null,
+    }));
+
+    vi.doMock("../extensions.js", () => ({
+      buildEmbeddedExtensionPaths: () => undefined,
+    }));
+
+    vi.doMock("../../pi-settings.js", () => ({
+      ensurePiCompactionReserveTokens: () => undefined,
+      resolveCompactionReserveTokensFloor: () => 0,
+    }));
+
+    vi.doMock("../google.js", () => ({
+      sanitizeToolsForGoogle: ({ tools }: { tools: unknown }) => tools,
+      logToolSchemasForGoogle: () => undefined,
+      sanitizeSessionHistory: async ({ messages }: { messages: AgentMessage[] }) => messages,
+    }));
+
+    vi.doMock("../../session-write-lock.js", () => ({
+      acquireSessionWriteLock: async () => ({
+        release: async () => undefined,
+      }),
+    }));
+
+    vi.doMock("../../session-file-repair.js", () => ({
+      repairSessionFileIfNeeded: async () => undefined,
+    }));
+
+    vi.doMock("../session-manager-cache.js", () => ({
+      prewarmSessionFile: async () => undefined,
+      trackSessionManagerAccess: () => undefined,
+    }));
+
+    vi.doMock("../session-manager-init.js", () => ({
+      prepareSessionManagerForRun: async () => undefined,
+    }));
+
+    vi.doMock("../../session-tool-result-guard-wrapper.js", () => ({
+      guardSessionManager: (mgr: unknown) => mgr,
+    }));
+
+    vi.doMock("../../../plugins/hook-runner-global.js", () => ({
+      getGlobalHookRunner: () => null,
+    }));
+
+    vi.doMock("../../skills.js", () => ({
+      applySkillEnvOverrides: () => () => undefined,
+      applySkillEnvOverridesFromSnapshot: () => () => undefined,
+      loadWorkspaceSkillEntries: () => [],
+      resolveSkillsPromptForRun: () => "",
+    }));
+
+    vi.doMock("@mariozechner/pi-coding-agent", () => {
+      const agent: {
+        streamFn?: unknown;
+        replaceMessages: (msgs: AgentMessage[]) => void;
+        setSystemPrompt: (prompt: string) => void;
+      } = {
+        streamFn: undefined,
+        replaceMessages: () => undefined,
+        setSystemPrompt: () => undefined,
+      };
+      const session: {
+        sessionId: string;
+        messages: AgentMessage[];
+        isStreaming: boolean;
+        agent: typeof agent;
+        prompt: (prompt: string, _opts?: unknown) => Promise<void>;
+        steer: (text: string) => Promise<void>;
+        abort: () => Promise<void>;
+        dispose: () => void;
+      } = {
+        sessionId: "test-session-id",
+        messages: [],
+        isStreaming: false,
+        agent,
+        prompt: async () => undefined,
+        steer: async () => undefined,
+        abort: async () => undefined,
+        dispose: () => undefined,
+      };
+      agent.replaceMessages = (msgs) => {
+        session.messages = msgs;
+      };
+
+      return {
+        createAgentSession: async () => ({ session }),
+        SessionManager: {
+          open: () => ({
+            flushPendingToolResults: () => undefined,
+            getLeafEntry: () => null,
+          }),
+        },
+        SettingsManager: {
+          create: () => ({}),
+        },
+      };
+    });
+
+    const { runEmbeddedAttempt } = await import("./attempt.js");
+
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-test-"));
+    const sessionFile = path.join(tmpRoot, "session.json");
+    await fs.writeFile(sessionFile, "{}", "utf8");
+
+    const agentDir = path.join(tmpRoot, "agent");
+    const workspaceDir = path.join(tmpRoot, "workspace");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    const params = {
+      sessionId: "sess-1",
+      sessionFile,
+      workspaceDir,
+      agentDir,
+      prompt: "hello",
+      provider: "openai",
+      modelId: "gpt-test",
+      model: { api: "openai", provider: "openai", input: ["text"] },
+      authStorage: {},
+      modelRegistry: {},
+      thinkLevel: "off",
+      timeoutMs: 60_000,
+      runId: "run-1",
+      disableTools: true,
+      abortSignal: abortController.signal,
+    } satisfies EmbeddedRunAttemptParams;
+
+    const result = await runEmbeddedAttempt(params);
+
+    expect(result.aborted).toBe(true);
+    expect(setActiveEmbeddedRun).toHaveBeenCalledTimes(1);
+    expect(clearActiveEmbeddedRun).toHaveBeenCalledTimes(1);
+    expect(clearActiveEmbeddedRun).toHaveBeenCalledWith("sess-1", handleFromSet);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -36,6 +36,7 @@ import {
   isEmptyAssistantMessageContent,
   resolveBootstrapMaxChars,
   stripImageBlocksFromMessages,
+  stripImageBlocksFromSessionFile,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
@@ -840,6 +841,14 @@ export async function runEmbeddedAttempt(
                 `empty assistant response with images in context — stripping images and retrying: runId=${params.runId} sessionId=${params.sessionId}`,
               );
               activeSession.agent.replaceMessages(stripped);
+              // Also persist the image removal to the session file so subsequent
+              // messages don't reload the images from disk.
+              const fileStripped = stripImageBlocksFromSessionFile(params.sessionFile);
+              if (fileStripped > 0) {
+                log.debug(
+                  `stripped ${fileStripped} image blocks from session file: ${params.sessionFile}`,
+                );
+              }
               await abortable(activeSession.prompt(effectivePrompt));
             }
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -817,39 +817,58 @@ export async function runEmbeddedAttempt(
             });
           }
 
-          // Only pass images option if there are actually images to pass
-          // This avoids potential issues with models that don't expect the images parameter
-          if (imageResult.images.length > 0) {
-            await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
-          } else {
-            await abortable(activeSession.prompt(effectivePrompt));
+          const promptWithCurrentImages = async (): Promise<void> => {
+            // Only pass images option if there are actually images to pass.
+            // This avoids potential issues with models that don't expect the images parameter.
+            if (imageResult.images.length > 0) {
+              await abortable(
+                activeSession.prompt(effectivePrompt, { images: imageResult.images }),
+              );
+            } else {
+              await abortable(activeSession.prompt(effectivePrompt));
+            }
+          };
+          const hasTrailingEmptyAssistant = (): boolean => {
+            const last = activeSession.messages.at(-1);
+            return last?.role === "assistant" && isEmptyAssistantMessageContent(last);
+          };
+
+          await promptWithCurrentImages();
+
+          // Recovery phase 1: one in-run retry with the exact same payload.
+          // This protects vision-capable models from occasional transient empty replies
+          // without immediately mutating/persisting image history.
+          if (hasTrailingEmptyAssistant()) {
+            log.warn(
+              `empty assistant response — retrying once with original context: runId=${params.runId} sessionId=${params.sessionId}`,
+            );
+            await promptWithCurrentImages();
           }
 
-          // Recovery: if the model returned an empty response and the context contains
-          // images, strip all image blocks and retry once. Some providers (e.g. GitHub
-          // Copilot) claim vision support but silently return empty when images are present.
-          const lastAfterPrompt = activeSession.messages.at(-1);
-          if (
-            lastAfterPrompt?.role === "assistant" &&
-            isEmptyAssistantMessageContent(lastAfterPrompt)
-          ) {
+          // Recovery phase 2: only after two consecutive empty replies, strip image
+          // blocks in-memory and retry once without prompt images.
+          if (hasTrailingEmptyAssistant()) {
             const { messages: stripped, hadImages } = stripImageBlocksFromMessages(
               activeSession.messages,
             );
             if (hadImages) {
               log.warn(
-                `empty assistant response with images in context — stripping images and retrying: runId=${params.runId} sessionId=${params.sessionId}`,
+                `empty assistant response persisted after same-context retry — stripping images and retrying: runId=${params.runId} sessionId=${params.sessionId}`,
               );
               activeSession.agent.replaceMessages(stripped);
-              // Also persist the image removal to the session file so subsequent
-              // messages don't reload the images from disk.
-              const fileStripped = stripImageBlocksFromSessionFile(params.sessionFile);
-              if (fileStripped > 0) {
-                log.debug(
-                  `stripped ${fileStripped} image blocks from session file: ${params.sessionFile}`,
-                );
-              }
               await abortable(activeSession.prompt(effectivePrompt));
+
+              // Persist image stripping only after we needed strip-retry and when this
+              // turn didn't include direct prompt images. This avoids permanent deletion
+              // on one-off empty replies from otherwise healthy vision models.
+              if (!hasTrailingEmptyAssistant() && imageResult.images.length === 0) {
+                const fileStripped = stripImageBlocksFromSessionFile(params.sessionFile);
+                if (fileStripped > 0) {
+                  log.debug(
+                    `stripped ${fileStripped} image blocks from session file: ${params.sessionFile}`,
+                  );
+                }
+              }
             }
           }
         } catch (err) {
@@ -861,12 +880,38 @@ export async function runEmbeddedAttempt(
         }
 
         try {
-          await waitForCompactionRetry();
+          // Compaction-specific timeout: if compaction doesn't finish within 60 seconds,
+          // give up waiting and proceed. This prevents the session from staying stuck in
+          // active=true when compaction hangs, which would block all subsequent messages.
+          // The run's main timeout (params.timeoutMs, default 600s) is too generous for this.
+          const COMPACTION_WAIT_TIMEOUT_MS = 60_000;
+          const compactionPromise = waitForCompactionRetry();
+          const compactionTimeout = new Promise<void>((_resolve, reject) => {
+            const timer = setTimeout(() => {
+              const err = new Error(
+                `compaction wait timed out after ${COMPACTION_WAIT_TIMEOUT_MS}ms`,
+              );
+              err.name = "CompactionTimeoutError";
+              reject(err);
+            }, COMPACTION_WAIT_TIMEOUT_MS);
+            // If the compaction finishes or abort fires first, clear the timer.
+            void compactionPromise.then(
+              () => clearTimeout(timer),
+              () => clearTimeout(timer),
+            );
+          });
+          await abortable(Promise.race([compactionPromise, compactionTimeout]));
         } catch (err) {
           if (isRunnerAbortError(err)) {
             if (!promptError) {
               promptError = err;
             }
+          } else if (err instanceof Error && err.name === "CompactionTimeoutError") {
+            log.warn(
+              `embedded run compaction wait timed out: runId=${params.runId} sessionId=${params.sessionId}`,
+            );
+            // Don't treat this as a fatal error — the run completed, just compaction is slow.
+            // The session will be released in the finally block.
           } else {
             throw err;
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -880,38 +880,12 @@ export async function runEmbeddedAttempt(
         }
 
         try {
-          // Compaction-specific timeout: if compaction doesn't finish within 60 seconds,
-          // give up waiting and proceed. This prevents the session from staying stuck in
-          // active=true when compaction hangs, which would block all subsequent messages.
-          // The run's main timeout (params.timeoutMs, default 600s) is too generous for this.
-          const COMPACTION_WAIT_TIMEOUT_MS = 60_000;
-          const compactionPromise = waitForCompactionRetry();
-          const compactionTimeout = new Promise<void>((_resolve, reject) => {
-            const timer = setTimeout(() => {
-              const err = new Error(
-                `compaction wait timed out after ${COMPACTION_WAIT_TIMEOUT_MS}ms`,
-              );
-              err.name = "CompactionTimeoutError";
-              reject(err);
-            }, COMPACTION_WAIT_TIMEOUT_MS);
-            // If the compaction finishes or abort fires first, clear the timer.
-            void compactionPromise.then(
-              () => clearTimeout(timer),
-              () => clearTimeout(timer),
-            );
-          });
-          await abortable(Promise.race([compactionPromise, compactionTimeout]));
+          await abortable(waitForCompactionRetry());
         } catch (err) {
           if (isRunnerAbortError(err)) {
             if (!promptError) {
               promptError = err;
             }
-          } else if (err instanceof Error && err.name === "CompactionTimeoutError") {
-            log.warn(
-              `embedded run compaction wait timed out: runId=${params.runId} sessionId=${params.sessionId}`,
-            );
-            // Don't treat this as a fatal error — the run completed, just compaction is slow.
-            // The session will be released in the finally block.
           } else {
             throw err;
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -33,7 +33,9 @@ import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
 import {
   isCloudCodeAssistFormatError,
+  isEmptyAssistantMessageContent,
   resolveBootstrapMaxChars,
+  stripImageBlocksFromMessages,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
@@ -820,6 +822,26 @@ export async function runEmbeddedAttempt(
             await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
           } else {
             await abortable(activeSession.prompt(effectivePrompt));
+          }
+
+          // Recovery: if the model returned an empty response and the context contains
+          // images, strip all image blocks and retry once. Some providers (e.g. GitHub
+          // Copilot) claim vision support but silently return empty when images are present.
+          const lastAfterPrompt = activeSession.messages.at(-1);
+          if (
+            lastAfterPrompt?.role === "assistant" &&
+            isEmptyAssistantMessageContent(lastAfterPrompt)
+          ) {
+            const { messages: stripped, hadImages } = stripImageBlocksFromMessages(
+              activeSession.messages,
+            );
+            if (hadImages) {
+              log.warn(
+                `empty assistant response with images in context — stripping images and retrying: runId=${params.runId} sessionId=${params.sessionId}`,
+              );
+              activeSession.agent.replaceMessages(stripped);
+              await abortable(activeSession.prompt(effectivePrompt));
+            }
           }
         } catch (err) {
           promptError = err;


### PR DESCRIPTION
## Summary

When the model returns an empty assistant response and the session history contains image blocks, automatically strip all images (replacing with `[image omitted]` placeholders) and retry the prompt once.

This prevents sessions from getting permanently stuck when a provider claims vision support but silently returns empty on image input (observed with GitHub Copilot's claude-opus-4.6 proxy returning empty `content: []` when tool results contain base64 screenshots).

## Changes

- **`src/agents/pi-embedded-helpers/images.ts`**: Add `stripImageBlocksFromMessages()` helper that walks all messages and replaces `{ type: "image" }` blocks with text placeholders
- **`src/agents/pi-embedded-helpers.ts`**: Export the new helper
- **`src/agents/pi-embedded-runner/run/attempt.ts`**: After prompt completes, detect empty assistant response + images in context, strip images and retry once with a warning log

## Root Cause

1. Browser tool returns screenshot as `{ type: "image", data: "<base64>", mimeType: "image/jpeg" }` in tool result
2. Session stores it in JSONL and includes it in every subsequent prompt
3. Provider (e.g. GitHub Copilot) claims `input: ["text", "image"]` but returns empty content
4. No retry/recovery existed — empty responses were treated as valid
5. Session permanently stuck with empty replies on every message

## Test Plan

- [x] Lint passes (0 warnings, 0 errors)
- [x] Only triggers on the specific failure pattern (empty response + images present)
- [x] Single retry avoids infinite loops
- [x] Uses existing `isEmptyAssistantMessageContent()` for detection
- [ ] Manual: verify on live gateway with browser screenshot scenario

lobster-biscuit

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a recovery path for a specific failure mode in embedded agent runs: when the provider returns an “empty” assistant message while image blocks exist in the session history, the runner strips `type: "image"` blocks from stored messages (replacing them with a `[image omitted]` text placeholder) and retries the prompt once. The new stripping helper is implemented in `src/agents/pi-embedded-helpers/images.ts`, re-exported via `src/agents/pi-embedded-helpers.ts`, and invoked from the main run loop in `src/agents/pi-embedded-runner/run/attempt.ts` after a prompt completes.

Key integration concern: the retry currently changes the prompt invocation by dropping the `{ images: ... }` parameter even when prompt images were present on the first attempt, and the stripping helper only removes top-level image blocks (not nested image content inside other block types), which can cause the recovery to be ineffective depending on message structure.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of correctness gaps in the recovery behavior.
- The overall approach is reasonable and scoped (single retry, targeted trigger), but the retry currently changes request semantics by omitting the `images` parameter and the stripping helper may miss nested image blocks, either of which can make the recovery ineffective or inconsistent in real stuck-session scenarios.
- src/agents/pi-embedded-runner/run/attempt.ts; src/agents/pi-embedded-helpers/images.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->