### PR TITLE
fix: wrap waitForCompactionRetry() in abortable() to prevent lane deadlock on timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -830,7 +830,7 @@ export async function runEmbeddedAttempt(
         }
 
         try {
-          await waitForCompactionRetry();
+          await abortable(waitForCompactionRetry());
         } catch (err) {
           if (isRunnerAbortError(err)) {
             if (!promptError) {


### PR DESCRIPTION
## Summary

- Wrap `waitForCompactionRetry()` in the existing `abortable()` helper so the embedded run timeout's abort signal can interrupt the compaction wait
- Without this, a timeout during compaction permanently blocks the affected DM lane, leaks the session in `processing` state, and leaves a zombie run in the active count

## Problem

In `src/agents/pi-embedded-runner/run/attempt.ts`, the main prompt call is correctly wrapped:

```typescript
await abortable(activeSession.prompt(effectivePrompt));  // ✅ abort-aware
```

But the compaction wait immediately after is not:

```typescript
await waitForCompactionRetry();  // ❌ bare await, abort signal ignored
```

When the run timeout fires during compaction (e.g., OpenAI Batch API slow), `abortRun(true)` signals the `runAbortController`, but `waitForCompactionRetry()` never sees it. The `finally` block with `clearActiveEmbeddedRun()` never executes.

**Result:** session stuck in `processing`, run never cleared, lane task never completes → DM channel permanently dead until gateway restart.

## Fix

One-line change — wrap in `abortable()` (already in scope, already used for the prompt):

```diff
- await waitForCompactionRetry();
+ await abortable(waitForCompactionRetry());
```

The existing `catch` block already handles `AbortError` correctly.

## Test plan

- [ ] Existing tests pass (`pnpm test`)
- [ ] `abortable()` immediately rejects when signal already aborted (covers case where timeout fired before reaching compaction wait)
- [ ] `abortable()` rejects via abort listener when signal fires during wait (covers case where timeout fires while compaction is in-flight)
- [ ] `finally` block runs in both cases, calling `clearActiveEmbeddedRun()` and `unsubscribe()`

Fixes #13341

> [!NOTE]
> AI-assisted PR. The fix was identified through production log analysis and verified by reading the source. The one-line change connects two existing, well-tested mechanisms (`abortable()` and `waitForCompactionRetry()`) that were simply not wired together.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the embedded runner’s post-prompt compaction wait to be abort-aware by wrapping `waitForCompactionRetry()` with the existing local `abortable()` helper in `src/agents/pi-embedded-runner/run/attempt.ts`. This makes the compaction-wait phase respond to the same `runAbortController` signal used for the main `activeSession.prompt(...)` call, so run timeouts/aborts can propagate through the compaction wait and reliably reach the outer `finally` cleanup that unsubscribes and clears the active embedded run/lane handle.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line wiring fix that reuses an existing, locally-defined abort helper already used for the main prompt call. The abort error is explicitly recognized by `isRunnerAbortError`, and non-abort errors are still rethrown, so behavior outside the timeout/abort path remains unchanged.
- src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->