### PR TITLE
Typo in Docker setup file: `declare -A` to `declare -a`

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  declare -a seen=()
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
typo/syntax adjustment: declare fails on `declare -A`; edited to `declare -a`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `docker-setup.sh`’s `upsert_env` helper to declare `seen` as an indexed array (`declare -a`) instead of an associative array (`declare -A`).

`upsert_env` still treats `seen` like a string-keyed map (keyed by env var names), so the change introduces a bash runtime error / logic break when processing keys like `OPENCLAW_GATEWAY_TOKEN` under `set -euo pipefail`. The script should either keep `seen` associative or change how it tracks seen keys.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge because it likely breaks docker-setup.sh at runtime in bash.
- The change switches `seen` from associative to indexed array, but the code still uses string subscripts. With bash `set -euo pipefail`, this can trigger arithmetic-subscript errors or incorrect behavior, preventing `.env` from being updated and potentially aborting the script.
- docker-setup.sh (upsert_env seen array usage)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->