### PR TITLE
fix: widen slugifySessionKey base from 32 to 41 chars

### DIFF
--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -11,7 +11,9 @@ export function slugifySessionKey(value: string) {
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "");
-  const base = safe.slice(0, 32) || "session";
+  // 41 keeps phone-number session keys intact with the default 13-char prefix
+  // while staying within Docker's 63-char container-name limit (63 - 13 - 9 = 41).
+  const base = safe.slice(0, 41) || "session";
   return `${base}-${hash}`;
 }
 


### PR DESCRIPTION
## Summary
Fixes #13276

`slugifySessionKey` hardcodes `safe.slice(0, 32)` for the human-readable base of container/workspace slugs. For direct-message session keys like `agent:clawfront:direct:2305705470`, the slugified form is 33 characters — the last digit of the phone number gets truncated.

Widens the base limit from 32 to 41, which fits within Docker's 63-char container-name limit with the default 13-char prefix and 9-char hash suffix (63 − 13 − 9 = 41).

## Changes
- `src/agents/sandbox/shared.ts`: increase `slugifySessionKey` base slice from 32 to 41

## Test plan
- [x] `pnpm lint` — passes
- [x] `pnpm build` — passes
- [x] `pnpm test` — all tests pass (1 pre-existing timezone test failure unrelated)
- [ ] Verify container names for phone-number session keys now preserve full number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `slugifySessionKey` in `src/agents/sandbox/shared.ts` to widen the human-readable base portion of the sandbox slug from 32 to 41 characters, preventing truncation of certain direct-message session keys (e.g., phone-number suffixes). The slug remains suffixed with an 8-hex SHA1 hash, and downstream sandbox container/workspace naming continues to enforce Docker’s 63-character limit by slicing the full container name in `src/agents/sandbox/docker.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized constant adjustment with no behavioral impact beyond allowing a longer slug base; container names are still capped to 63 characters downstream, and the function already appends a hash to preserve uniqueness.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->