### PR TITLE
fix: pass model directly to agent for sub-agent runs

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,7 @@ excluded:
   - "*.playground"
   # Generated (protocol-gen-swift.ts)
   - apps/macos/Sources/MoltbotProtocol/GatewayModels.swift
+  - apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
 
 analyzer_rules:
   - unused_declaration

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -491,6 +491,7 @@ public struct AgentParams: Codable, Sendable {
     public let idempotencykey: String
     public let label: String?
     public let spawnedby: String?
+    public let model: String?
 
     public init(
         message: String,
@@ -515,7 +516,8 @@ public struct AgentParams: Codable, Sendable {
         extrasystemprompt: String?,
         idempotencykey: String,
         label: String?,
-        spawnedby: String?
+        spawnedby: String?,
+        model: String?
     ) {
         self.message = message
         self.agentid = agentid
@@ -540,6 +542,7 @@ public struct AgentParams: Codable, Sendable {
         self.idempotencykey = idempotencykey
         self.label = label
         self.spawnedby = spawnedby
+        self.model = model
     }
     private enum CodingKeys: String, CodingKey {
         case message
@@ -565,6 +568,7 @@ public struct AgentParams: Codable, Sendable {
         case idempotencykey = "idempotencyKey"
         case label
         case spawnedby = "spawnedBy"
+        case model
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -491,6 +491,7 @@ public struct AgentParams: Codable, Sendable {
     public let idempotencykey: String
     public let label: String?
     public let spawnedby: String?
+    public let model: String?
 
     public init(
         message: String,
@@ -515,7 +516,8 @@ public struct AgentParams: Codable, Sendable {
         extrasystemprompt: String?,
         idempotencykey: String,
         label: String?,
-        spawnedby: String?
+        spawnedby: String?,
+        model: String?
     ) {
         self.message = message
         self.agentid = agentid
@@ -540,6 +542,7 @@ public struct AgentParams: Codable, Sendable {
         self.idempotencykey = idempotencykey
         self.label = label
         self.spawnedby = spawnedby
+        self.model = model
     }
     private enum CodingKeys: String, CodingKey {
         case message
@@ -565,6 +568,7 @@ public struct AgentParams: Codable, Sendable {
         case idempotencykey = "idempotencyKey"
         case label
         case spawnedby = "spawnedBy"
+        case model
     }
 }
 

--- a/scripts/analyze_code_files.py
+++ b/scripts/analyze_code_files.py
@@ -53,6 +53,7 @@ SKIP_DIRS = {
     "Swabble",  # Separate Swift package
     "skills",  # Standalone skill scripts
     ".pi",  # Pi editor extensions
+    "OpenClawProtocol",  # Auto-generated protocol bindings
 }
 
 # Filename patterns to skip in short-file warnings (barrel exports, stubs)

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -266,6 +266,8 @@ export function createSessionsSpawnTool(opts?: {
             groupId: opts?.agentGroupId ?? undefined,
             groupChannel: opts?.agentGroupChannel ?? undefined,
             groupSpace: opts?.agentGroupSpace ?? undefined,
+            // Pass model directly to avoid session store timing issues
+            model: resolvedModel,
           },
           timeoutMs: 10_000,
         });

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -322,9 +322,11 @@ export async function agentCommand(
     // This takes precedence over session-stored overrides to avoid timing issues.
     const directModelOverride = opts.model?.trim();
     if (directModelOverride) {
-      const [modelProvider, modelName] = directModelOverride.includes("/")
-        ? directModelOverride.split("/", 2)
-        : [defaultProvider, directModelOverride];
+      // Split only on first slash to preserve hierarchical model IDs (e.g., openrouter/moonshotai/kimi-k2)
+      const slashIndex = directModelOverride.indexOf("/");
+      const [modelProvider, modelName] = slashIndex === -1
+        ? [defaultProvider, directModelOverride]
+        : [directModelOverride.slice(0, slashIndex), directModelOverride.slice(slashIndex + 1)];
       const candidateProvider = modelProvider || defaultProvider;
       const candidateModel = modelName || directModelOverride;
       const key = modelKey(candidateProvider, candidateModel);

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -317,6 +317,26 @@ export async function agentCommand(
         model = storedModelOverride;
       }
     }
+
+    // Model override passed directly to the agent command (e.g., from sessions_spawn).
+    // This takes precedence over session-stored overrides to avoid timing issues.
+    const directModelOverride = opts.model?.trim();
+    if (directModelOverride) {
+      const [modelProvider, modelName] = directModelOverride.includes("/")
+        ? directModelOverride.split("/", 2)
+        : [defaultProvider, directModelOverride];
+      const candidateProvider = modelProvider || defaultProvider;
+      const candidateModel = modelName || directModelOverride;
+      const key = modelKey(candidateProvider, candidateModel);
+      if (
+        isCliProvider(candidateProvider, cfg) ||
+        allowedModelKeys.size === 0 ||
+        allowedModelKeys.has(key)
+      ) {
+        provider = candidateProvider;
+        model = candidateModel;
+      }
+    }
     if (sessionEntry) {
       const authProfileId = sessionEntry.authProfileOverride;
       if (authProfileId) {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -324,9 +324,10 @@ export async function agentCommand(
     if (directModelOverride) {
       // Split only on first slash to preserve hierarchical model IDs (e.g., openrouter/moonshotai/kimi-k2)
       const slashIndex = directModelOverride.indexOf("/");
-      const [modelProvider, modelName] = slashIndex === -1
-        ? [defaultProvider, directModelOverride]
-        : [directModelOverride.slice(0, slashIndex), directModelOverride.slice(slashIndex + 1)];
+      const [modelProvider, modelName] =
+        slashIndex === -1
+          ? [defaultProvider, directModelOverride]
+          : [directModelOverride.slice(0, slashIndex), directModelOverride.slice(slashIndex + 1)];
       const candidateProvider = modelProvider || defaultProvider;
       const candidateModel = modelName || directModelOverride;
       const key = modelKey(candidateProvider, candidateModel);

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -74,4 +74,6 @@ export type AgentCommandOpts = {
   extraSystemPrompt?: string;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;
+  /** Model override for this run (e.g., "openrouter/pony-alpha"). Takes precedence over session override. */
+  model?: string;
 };

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -67,6 +67,8 @@ export const AgentParamsSchema = Type.Object(
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
     spawnedBy: Type.Optional(Type.String()),
+    /** Model override for sub-agent runs (e.g., "openrouter/pony-alpha"). */
+    model: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -85,6 +85,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       timeout?: number;
       label?: string;
       spawnedBy?: string;
+      model?: string;
     };
     const cfg = loadConfig();
     const idem = request.idempotencyKey;
@@ -392,6 +393,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         runId,
         lane: request.lane,
         extraSystemPrompt: request.extraSystemPrompt,
+        model: request.model,
       },
       defaultRuntime,
       context.deps,


### PR DESCRIPTION
## Problem

The `sessions_spawn` tool was setting the model via `sessions.patch` but the model override wasn't reliably persisting to the session store before the agent run started. This caused sub-agents to fall back to the default model instead of using the configured subagent model.

**Evidence from investigation:**
- `sessions_spawn` returns `modelApplied: true`
- But the session store shows `modelOverride: null`
- Sub-agents run on default model (Opus) instead of configured model

## Solution

Pass the resolved model directly through the agent call chain, bypassing the session store timing issue:

1. **sessions-spawn-tool.ts**: Add `model` param to gateway agent call
2. **schema/agent.ts**: Add `model` to `AgentParamsSchema`
3. **server-methods/agent.ts**: Accept and forward `model` to `agentCommand`
4. **commands/agent.ts**: Use `opts.model` override (takes precedence over session store)
5. **commands/agent/types.ts**: Add `model` to `AgentCommandOpts`

## Changes

- 5 files changed, 28 insertions
- No breaking changes - the model is optional and existing behavior is preserved

Fixes #13372

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads an optional `model` override through the gateway `agent` request path so sub-agent runs can use the intended model without relying on the session store write timing (`sessions.patch`). Concretely: `sessions_spawn` now passes `model` in the `agent` call, the gateway protocol schema accepts it, the gateway handler forwards it into `agentCommand`, and `agentCommand` prefers this per-call override over the session-stored override.

The main issue is in `src/commands/agent.ts`: the new parsing logic for `opts.model` uses `split("/", 2)`, which truncates hierarchical model IDs (explicitly used in this repo for OpenRouter, e.g. `openrouter/moonshotai/kimi-k2`). That will select the wrong model key and can break allowlist enforcement or cause unexpected default-model fallback.


<h3>Confidence Score: 3/5</h3>

- This PR is not safe to merge as-is due to incorrect parsing of hierarchical model IDs in the new direct model override path.
- While the overall wiring is small and coherent, the direct model override parsing in agentCommand will definitely truncate OpenRouter-style hierarchical model refs (which the repo already uses/tests for). That would cause incorrect model selection and may break allowlist behavior for sub-agent runs.
- src/commands/agent.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->