### PR TITLE
fix(cron): route text-only payloads through direct delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ USER.md
 .agent/*.json
 !.agent/workflows/
 local/
+
+# Runtime debug logs
+openclaw-*.log

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -521,9 +521,11 @@ export async function runCronIsolatedAgentTurn(params: {
       logWarn(`[cron:${params.job.id}] ${message}`);
       return withRunSession({ status: "ok", summary, outputText });
     }
-    // Shared subagent announce flow is text-based; keep direct outbound delivery
-    // for media/channel payloads so structured content is preserved.
-    if (deliveryPayloadHasStructuredContent) {
+    // Route all cron payloads (including text-only) through direct delivery.
+    // The announce flow routes through the main session which can respond with
+    // NO_REPLY, causing legitimate cron outputs to be silently dropped.
+    // See: https://github.com/openclaw/openclaw/issues/13289
+    if (deliveryPayloadHasStructuredContent || synthesizedText) {
       try {
         await deliverOutboundPayloads({
           cfg: cfgWithAgentDefaults,
@@ -540,7 +542,11 @@ export async function runCronIsolatedAgentTurn(params: {
           return withRunSession({ status: "error", summary, outputText, error: String(err) });
         }
       }
-    } else if (synthesizedText) {
+    } else if (false && synthesizedText) {
+      // NOTE: This branch is intentionally unreachable. The announce flow is
+      // preserved for potential future use but disabled because routing through
+      // the main session agent is unreliable — accumulated NO_REPLY patterns
+      // cause it to drop legitimate cron outputs.
       const announceSessionKey = resolveAgentMainSessionKey({
         cfg: params.cfg,
         agentId,


### PR DESCRIPTION
Fixes #13289

## Problem

Cron jobs with `delivery.mode: "announce"` and `sessionTarget: "isolated"` fail to deliver to messaging channels. The isolated agent produces valid text output, but `runSubagentAnnounceFlow` sends it to the main session agent, which responds with `NO_REPLY` instead of forwarding the message.

This was introduced in v2026.2.6-4 when text-only isolated agent announces were routed through the shared subagent announce flow.

## Root Cause

`runSubagentAnnounceFlow` sends a trigger message to the main session that includes: "You can respond with NO_REPLY if no announcement is needed." After accumulated heartbeat context where NO_REPLY was the correct response, the main session agent responds NO_REPLY to everything — including legitimate check-in messages that should be delivered.

## Solution

Route all cron payloads (including text-only) through direct delivery via `deliverOutboundPayloads()`, bypassing the announce flow entirely.

The announce flow branch is preserved (but made unreachable) for potential future use if the NO_REPLY reliability issue is addressed separately.

## Testing

- Verified that cron jobs with `delivery.mode: "announce"` now deliver text-only payloads directly
- No regression for media/structured content payloads (already used direct delivery)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the cron isolated-agent delivery logic so that *all* outbound cron payloads (including text-only outputs) are sent via `deliverOutboundPayloads()` instead of routing text through the shared subagent announce flow (which could elicit `NO_REPLY` from the main session and drop legitimate messages). The previous announce-flow code path is left in place but made intentionally unreachable.

The PR also includes a new `openclaw-2026-02-10.log` file containing what appears to be a local debug/runtime trace.

<h3>Confidence Score: 3/5</h3>

- This PR is not safe to merge as-is due to committed debug artifacts and intentionally dead code left in the delivery path.
- Core behavior change looks reasonable for fixing dropped text-only cron deliveries, but the PR adds a local log file to the repository and leaves a large unreachable branch (`false && ...`) that can confuse future maintenance and mask regressions.
- openclaw-2026-02-10.log, src/cron/isolated-agent/run.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->