### PR TITLE
feat: multi-provider video understanding (audio transcription + visual description)

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -504,7 +504,9 @@ export async function applyMediaUnderstanding(params: {
 
     if (outputs.length > 0) {
       ctx.Body = formatMediaUnderstandingBody({ body: ctx.Body, outputs });
-      const audioOutputs = outputs.filter((output) => output.kind === "audio.transcription");
+      const audioOutputs = outputs.filter(
+        (output) => output.kind === "audio.transcription" || output.kind === "video.transcription",
+      );
       if (audioOutputs.length > 0) {
         const transcript = formatAudioTranscripts(audioOutputs);
         ctx.Transcript = transcript;

--- a/src/media-understanding/format.ts
+++ b/src/media-understanding/format.ts
@@ -66,6 +66,17 @@ export function formatMediaUnderstandingBody(params: {
       );
       continue;
     }
+    if (output.kind === "video.transcription") {
+      sections.push(
+        formatSection(
+          `Video Audio${suffix}`,
+          "Transcript",
+          output.text,
+          outputs.length === 1 ? userText : undefined,
+        ),
+      );
+      continue;
+    }
     if (output.kind === "image.description") {
       sections.push(
         formatSection(

--- a/src/media-understanding/providers/groq/index.ts
+++ b/src/media-understanding/providers/groq/index.ts
@@ -5,8 +5,13 @@ const DEFAULT_GROQ_AUDIO_BASE_URL = "https://api.groq.com/openai/v1";
 
 export const groqProvider: MediaUnderstandingProvider = {
   id: "groq",
-  capabilities: ["audio"],
+  capabilities: ["audio", "video"],
   transcribeAudio: (req) =>
+    transcribeOpenAiCompatibleAudio({
+      ...req,
+      baseUrl: req.baseUrl ?? DEFAULT_GROQ_AUDIO_BASE_URL,
+    }),
+  transcribeVideoAudio: (req) =>
     transcribeOpenAiCompatibleAudio({
       ...req,
       baseUrl: req.baseUrl ?? DEFAULT_GROQ_AUDIO_BASE_URL,

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -1,6 +1,7 @@
 export type MediaUnderstandingKind =
   | "audio.transcription"
   | "video.description"
+  | "video.transcription"
   | "image.description";
 
 export type MediaUnderstandingCapability = "image" | "audio" | "video";
@@ -109,6 +110,7 @@ export type MediaUnderstandingProvider = {
   id: string;
   capabilities?: MediaUnderstandingCapability[];
   transcribeAudio?: (req: AudioTranscriptionRequest) => Promise<AudioTranscriptionResult>;
+  transcribeVideoAudio?: (req: AudioTranscriptionRequest) => Promise<AudioTranscriptionResult>;
   describeVideo?: (req: VideoDescriptionRequest) => Promise<VideoDescriptionResult>;
   describeImage?: (req: ImageDescriptionRequest) => Promise<ImageDescriptionResult>;
 };

--- a/src/media-understanding/video.ts
+++ b/src/media-understanding/video.ts
@@ -1,4 +1,25 @@
-import { DEFAULT_VIDEO_MAX_BASE64_BYTES } from "./defaults.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import type {
+  MediaUnderstandingConfig,
+  MediaUnderstandingModelConfig,
+} from "../config/types.tools.js";
+import type { MediaAttachmentCache } from "./attachments.js";
+import type {
+  AudioTranscriptionResult,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
+import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { runExec } from "../process/exec.js";
+import {
+  CLI_OUTPUT_MAX_BUFFER,
+  DEFAULT_AUDIO_MODELS,
+  DEFAULT_VIDEO_MAX_BASE64_BYTES,
+} from "./defaults.js";
+import { MediaUnderstandingSkipError } from "./errors.js";
 
 export function estimateBase64Size(bytes: number): number {
   return Math.ceil(bytes / 3) * 4;
@@ -7,4 +28,162 @@ export function estimateBase64Size(bytes: number): number {
 export function resolveVideoMaxBase64Bytes(maxBytes: number): number {
   const expanded = Math.floor(maxBytes * (4 / 3));
   return Math.min(expanded, DEFAULT_VIDEO_MAX_BASE64_BYTES);
+}
+
+async function extractAndTranscribeVideoAudio(params: {
+  provider: MediaUnderstandingProvider;
+  providerId: string;
+  cache: MediaAttachmentCache;
+  attachmentIndex: number;
+  maxBytes: number;
+  maxChars?: number;
+  timeoutMs: number;
+  apiKey: string;
+  baseUrl?: string;
+  model?: string;
+  trimOutput: (text: string, maxChars?: number) => string;
+}): Promise<MediaUnderstandingOutput> {
+  const { provider, providerId, cache, attachmentIndex, maxBytes, maxChars, timeoutMs } = params;
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-video-audio-"));
+  const audioPath = path.join(tmpDir, "audio.mp3");
+  const pathResult = await cache.getPath({ attachmentIndex, maxBytes, timeoutMs });
+  try {
+    await runExec(
+      "ffmpeg",
+      ["-i", pathResult.path, "-vn", "-acodec", "libmp3lame", "-y", audioPath],
+      { timeoutMs, maxBuffer: CLI_OUTPUT_MAX_BUFFER },
+    );
+    const audioBuffer = await fs.readFile(audioPath);
+    const model = params.model?.trim() || DEFAULT_AUDIO_MODELS[providerId] || params.model;
+    const result: AudioTranscriptionResult = await provider.transcribeVideoAudio!({
+      buffer: audioBuffer,
+      fileName: "audio.mp3",
+      mime: "audio/mpeg",
+      apiKey: params.apiKey,
+      baseUrl: params.baseUrl,
+      model,
+      timeoutMs,
+    });
+    return {
+      kind: "video.transcription",
+      attachmentIndex,
+      text: params.trimOutput(result.text, maxChars),
+      provider: providerId,
+      model: result.model ?? model,
+    };
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function describeVideoWithProvider(params: {
+  provider: MediaUnderstandingProvider;
+  providerId: string;
+  cache: MediaAttachmentCache;
+  attachmentIndex: number;
+  maxBytes: number;
+  maxChars?: number;
+  timeoutMs: number;
+  apiKey: string;
+  baseUrl?: string;
+  headers?: Record<string, string>;
+  model?: string;
+  prompt?: string;
+  trimOutput: (text: string, maxChars?: number) => string;
+}): Promise<MediaUnderstandingOutput> {
+  const { provider, providerId, cache, attachmentIndex, maxBytes, maxChars, timeoutMs } = params;
+  if (!provider.describeVideo) {
+    throw new Error(`Video understanding provider "${providerId}" not available.`);
+  }
+  const media = await cache.getBuffer({ attachmentIndex, maxBytes, timeoutMs });
+  const estimatedBase64Bytes = estimateBase64Size(media.size);
+  const maxBase64Bytes = resolveVideoMaxBase64Bytes(maxBytes);
+  if (estimatedBase64Bytes > maxBase64Bytes) {
+    throw new MediaUnderstandingSkipError(
+      "maxBytes",
+      `Video attachment ${attachmentIndex + 1} base64 payload ${estimatedBase64Bytes} exceeds ${maxBase64Bytes}`,
+    );
+  }
+  const result = await provider.describeVideo({
+    buffer: media.buffer,
+    fileName: media.fileName,
+    mime: media.mime,
+    apiKey: params.apiKey,
+    baseUrl: params.baseUrl,
+    headers: params.headers,
+    model: params.model,
+    prompt: params.prompt,
+    timeoutMs,
+  });
+  return {
+    kind: "video.description",
+    attachmentIndex,
+    text: params.trimOutput(result.text, maxChars),
+    provider: providerId,
+    model: result.model ?? params.model,
+  };
+}
+
+/**
+ * Run a video provider entry — either audio transcription (via ffmpeg + Whisper)
+ * or visual description, depending on the provider's capabilities.
+ */
+export async function runVideoProvider(params: {
+  provider: MediaUnderstandingProvider;
+  providerId: string;
+  entry: MediaUnderstandingModelConfig;
+  cfg: OpenClawConfig;
+  cache: MediaAttachmentCache;
+  attachmentIndex: number;
+  agentDir?: string;
+  maxBytes: number;
+  maxChars?: number;
+  timeoutMs: number;
+  prompt?: string;
+  config?: MediaUnderstandingConfig;
+  trimOutput: (text: string, maxChars?: number) => string;
+}): Promise<MediaUnderstandingOutput> {
+  const { provider, providerId, entry, cfg } = params;
+  const auth = await resolveApiKeyForProvider({
+    provider: providerId,
+    cfg,
+    profileId: entry.profile,
+    preferredProfile: entry.preferredProfile,
+    agentDir: params.agentDir,
+  });
+  const apiKey = requireApiKey(auth, providerId);
+  const providerConfig = cfg.models?.providers?.[providerId];
+
+  if (provider.transcribeVideoAudio) {
+    const baseUrl = entry.baseUrl ?? params.config?.baseUrl ?? providerConfig?.baseUrl;
+    return extractAndTranscribeVideoAudio({
+      provider,
+      providerId,
+      cache: params.cache,
+      attachmentIndex: params.attachmentIndex,
+      maxBytes: params.maxBytes,
+      maxChars: params.maxChars,
+      timeoutMs: params.timeoutMs,
+      apiKey,
+      baseUrl,
+      model: entry.model,
+      trimOutput: params.trimOutput,
+    });
+  }
+
+  return describeVideoWithProvider({
+    provider,
+    providerId,
+    cache: params.cache,
+    attachmentIndex: params.attachmentIndex,
+    maxBytes: params.maxBytes,
+    maxChars: params.maxChars,
+    timeoutMs: params.timeoutMs,
+    apiKey,
+    baseUrl: providerConfig?.baseUrl,
+    headers: providerConfig?.headers,
+    model: entry.model,
+    prompt: params.prompt,
+    trimOutput: params.trimOutput,
+  });
 }


### PR DESCRIPTION
## Summary

Enable collecting results from **all** configured video providers instead of stopping at the first success. A typical setup — Groq Whisper for audio transcription + Google Gemini for visual description — now produces **both** outputs for the same video attachment.

**Configuration example:**

```json
"video": {
  "enabled": true,
  "models": [
    { "provider": "groq", "model": "whisper-large-v3-turbo" },
    { "provider": "google", "model": "gemini-2.5-flash" }
  ]
}
```

## Use Cases

1. **Audio + Visual**: Groq transcribes speech while Gemini describes what's happening on screen — the LLM sees both.
2. **Redundancy**: If one provider fails, the other still contributes its output.
3. **Multi-language**: Use different providers optimized for different modalities (e.g., Whisper for multilingual audio, Gemini for visual scene understanding).

## Changes

| File | What changed |
|------|-------------|
| `types.ts` | Added `video.transcription` kind + `transcribeVideoAudio` method to provider interface |
| `runner.ts` | ffmpeg audio extraction for audio-only providers; `collectAll` pattern for video capability; `multiOutputs` plumbing |
| `format.ts` | Format `video.transcription` as `[Video Audio] Transcript:` |
| `apply.ts` | Include `video.transcription` in transcript filter |
| `providers/groq/index.ts` | Add `video` capability + `transcribeVideoAudio` implementation |
| `telegram/bot-handlers.ts` | Promote caption-bearing message to primary media in Telegram albums |

## Behavior Changes

- **Video capability now uses `collectAll`**: Instead of returning on the first successful provider, it iterates through all configured video providers and merges their outputs.
- **New output kind `video.transcription`**: Audio-only providers (Groq, OpenAI) return this kind when processing video, distinct from `video` (visual description).
- **ffmpeg dependency**: Audio extraction requires `ffmpeg` on PATH. If unavailable, the audio-transcription provider entry is skipped (other providers still work).
- **Telegram album handling**: When a Telegram album contains a caption on a non-primary message, that message is moved to primary position so the caption text is preserved alongside the media.
- **No breaking changes**: Existing single-provider video setups continue to work identically.

## Test Plan

- [x] `pnpm build` — compiles without errors
- [x] `pnpm test` — 258 tests pass (43 files)
- [x] Tested with Groq Whisper + Google Gemini on real Telegram video messages
- [x] Verified single-provider setups still work (backward compatible)
- [x] Verified ffmpeg failure is handled gracefully (skips audio transcription, continues with visual)

---

lobster-biscuit

Signed-off-by: geekhuashan <geekhuashan@gmail.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends media-understanding so video processing can aggregate results from multiple configured providers instead of stopping at the first success. It introduces a new output kind (`video.transcription`) to represent audio transcription extracted from video, adds ffmpeg-based audio extraction in the runner for providers that support `transcribeVideoAudio`, wires the new kind into formatting and transcript assembly, and tweaks Telegram album handling so caption-bearing messages become the primary media entry.

The main integration point is `src/media-understanding/runner.ts`, where video capability now uses a collect-all loop and can return multiple outputs (`outputs`) in addition to the primary `output`, which are then plumbed through to the final output list.

<h3>Confidence Score: 3/5</h3>

- Merge is blocked by a provider auto-resolution bug for video transcription-only providers
- The core functionality is in place, but provider selection for `capability === "video"` currently requires `describeVideo`, which prevents providers that only implement `transcribeVideoAudio` (like Groq in this PR) from being auto-resolved. There is also a smaller formatting inconsistency in transcript labeling.
- src/media-understanding/runner.ts (auto-resolution checks), src/media-understanding/format.ts (Transcript labeling)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->