### PR TITLE
feat(session): Auto-prune consecutive NO_REPLY messages from context

### DIFF
--- a/src/agents/no-reply-pruning.test.ts
+++ b/src/agents/no-reply-pruning.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { countNoReplies, pruneConsecutiveNoReplies } from "./no-reply-pruning.js";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+function makeUserMessage(text: string): AgentMessage {
+  return { role: "user", content: text };
+}
+
+function makeAssistantMessage(text: string): AgentMessage {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+function makeNoReply(): AgentMessage {
+  return makeAssistantMessage("NO_REPLY");
+}
+
+describe("pruneConsecutiveNoReplies", () => {
+  it("returns empty array for empty input", () => {
+    expect(pruneConsecutiveNoReplies([])).toEqual([]);
+  });
+
+  it("keeps single NO_REPLY", () => {
+    const messages = [makeUserMessage("hi"), makeNoReply()];
+    const result = pruneConsecutiveNoReplies(messages);
+    expect(result).toEqual(messages);
+  });
+
+  it("prunes consecutive NO_REPLY messages, keeping 1", () => {
+    const messages = [
+      makeUserMessage("hi"),
+      makeNoReply(),
+      makeNoReply(),
+      makeNoReply(),
+      makeUserMessage("hello"),
+    ];
+    const result = pruneConsecutiveNoReplies(messages);
+    expect(result).toEqual([
+      makeUserMessage("hi"),
+      makeNoReply(),
+      makeUserMessage("hello"),
+    ]);
+  });
+
+  it("keeps multiple separate NO_REPLY runs", () => {
+    const messages = [
+      makeUserMessage("1"),
+      makeNoReply(),
+      makeUserMessage("2"),
+      makeNoReply(),
+      makeNoReply(),
+      makeUserMessage("3"),
+    ];
+    const result = pruneConsecutiveNoReplies(messages);
+    expect(result).toEqual([
+      makeUserMessage("1"),
+      makeNoReply(),
+      makeUserMessage("2"),
+      makeNoReply(),
+      makeUserMessage("3"),
+    ]);
+  });
+
+  it("respects maxConsecutive parameter", () => {
+    const messages = [
+      makeUserMessage("hi"),
+      makeNoReply(),
+      makeNoReply(),
+      makeNoReply(),
+      makeNoReply(),
+    ];
+    const result = pruneConsecutiveNoReplies(messages, 2);
+    expect(result).toEqual([
+      makeUserMessage("hi"),
+      makeNoReply(),
+      makeNoReply(),
+    ]);
+  });
+
+  it("handles maxConsecutive=0 (prune all NO_REPLYs)", () => {
+    const messages = [
+      makeUserMessage("hi"),
+      makeNoReply(),
+      makeNoReply(),
+      makeUserMessage("bye"),
+    ];
+    const result = pruneConsecutiveNoReplies(messages, 0);
+    expect(result).toEqual([
+      makeUserMessage("hi"),
+      makeUserMessage("bye"),
+    ]);
+  });
+
+  it("preserves normal assistant messages", () => {
+    const messages = [
+      makeUserMessage("hi"),
+      makeAssistantMessage("Hello!"),
+      makeNoReply(),
+      makeNoReply(),
+      makeAssistantMessage("Goodbye!"),
+    ];
+    const result = pruneConsecutiveNoReplies(messages);
+    expect(result).toEqual([
+      makeUserMessage("hi"),
+      makeAssistantMessage("Hello!"),
+      makeNoReply(),
+      makeAssistantMessage("Goodbye!"),
+    ]);
+  });
+
+  it("handles case-insensitive NO_REPLY matching", () => {
+    const messages = [
+      makeUserMessage("hi"),
+      makeAssistantMessage("no_reply"),
+      makeAssistantMessage("NO_REPLY"),
+      makeAssistantMessage("No_Reply"),
+    ];
+    const result = pruneConsecutiveNoReplies(messages);
+    expect(result).toEqual([
+      makeUserMessage("hi"),
+      makeAssistantMessage("no_reply"),
+    ]);
+  });
+
+  it("handles NO_REPLY with whitespace", () => {
+    const messages = [
+      makeUserMessage("hi"),
+      makeAssistantMessage("  NO_REPLY  "),
+      makeAssistantMessage("NO_REPLY"),
+    ];
+    const result = pruneConsecutiveNoReplies(messages);
+    expect(result).toEqual([
+      makeUserMessage("hi"),
+      makeAssistantMessage("  NO_REPLY  "),
+    ]);
+  });
+});
+
+describe("countNoReplies", () => {
+  it("returns zeros for empty array", () => {
+    expect(countNoReplies([])).toEqual({ total: 0, maxConsecutive: 0, runs: 0 });
+  });
+
+  it("counts total and consecutive NO_REPLYs", () => {
+    const messages = [
+      makeUserMessage("1"),
+      makeNoReply(),
+      makeNoReply(),
+      makeUserMessage("2"),
+      makeNoReply(),
+      makeNoReply(),
+      makeNoReply(),
+      makeUserMessage("3"),
+    ];
+    const result = countNoReplies(messages);
+    expect(result).toEqual({ total: 5, maxConsecutive: 3, runs: 2 });
+  });
+
+  it("counts single NO_REPLY correctly", () => {
+    const messages = [makeUserMessage("hi"), makeNoReply()];
+    const result = countNoReplies(messages);
+    expect(result).toEqual({ total: 1, maxConsecutive: 1, runs: 1 });
+  });
+});

--- a/src/agents/no-reply-pruning.test.ts
+++ b/src/agents/no-reply-pruning.test.ts
@@ -1,6 +1,6 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { countNoReplies, pruneConsecutiveNoReplies } from "./no-reply-pruning.js";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 function makeUserMessage(text: string): AgentMessage {
   return { role: "user", content: text };
@@ -34,11 +34,7 @@ describe("pruneConsecutiveNoReplies", () => {
       makeUserMessage("hello"),
     ];
     const result = pruneConsecutiveNoReplies(messages);
-    expect(result).toEqual([
-      makeUserMessage("hi"),
-      makeNoReply(),
-      makeUserMessage("hello"),
-    ]);
+    expect(result).toEqual([makeUserMessage("hi"), makeNoReply(), makeUserMessage("hello")]);
   });
 
   it("keeps multiple separate NO_REPLY runs", () => {
@@ -69,25 +65,13 @@ describe("pruneConsecutiveNoReplies", () => {
       makeNoReply(),
     ];
     const result = pruneConsecutiveNoReplies(messages, 2);
-    expect(result).toEqual([
-      makeUserMessage("hi"),
-      makeNoReply(),
-      makeNoReply(),
-    ]);
+    expect(result).toEqual([makeUserMessage("hi"), makeNoReply(), makeNoReply()]);
   });
 
   it("handles maxConsecutive=0 (prune all NO_REPLYs)", () => {
-    const messages = [
-      makeUserMessage("hi"),
-      makeNoReply(),
-      makeNoReply(),
-      makeUserMessage("bye"),
-    ];
+    const messages = [makeUserMessage("hi"), makeNoReply(), makeNoReply(), makeUserMessage("bye")];
     const result = pruneConsecutiveNoReplies(messages, 0);
-    expect(result).toEqual([
-      makeUserMessage("hi"),
-      makeUserMessage("bye"),
-    ]);
+    expect(result).toEqual([makeUserMessage("hi"), makeUserMessage("bye")]);
   });
 
   it("preserves normal assistant messages", () => {
@@ -115,10 +99,7 @@ describe("pruneConsecutiveNoReplies", () => {
       makeAssistantMessage("No_Reply"),
     ];
     const result = pruneConsecutiveNoReplies(messages);
-    expect(result).toEqual([
-      makeUserMessage("hi"),
-      makeAssistantMessage("no_reply"),
-    ]);
+    expect(result).toEqual([makeUserMessage("hi"), makeAssistantMessage("no_reply")]);
   });
 
   it("handles NO_REPLY with whitespace", () => {
@@ -128,10 +109,7 @@ describe("pruneConsecutiveNoReplies", () => {
       makeAssistantMessage("NO_REPLY"),
     ];
     const result = pruneConsecutiveNoReplies(messages);
-    expect(result).toEqual([
-      makeUserMessage("hi"),
-      makeAssistantMessage("  NO_REPLY  "),
-    ]);
+    expect(result).toEqual([makeUserMessage("hi"), makeAssistantMessage("  NO_REPLY  ")]);
   });
 
   it("handles multi-block assistant messages (Gemini-style merged turns)", () => {
@@ -175,10 +153,7 @@ describe("pruneConsecutiveNoReplies", () => {
       makeAssistantMessage("NO_REPLY"),
     ];
     const result = pruneConsecutiveNoReplies(messages);
-    expect(result).toEqual([
-      makeUserMessage("hi"),
-      makeAssistantMessage("Silent: NO_REPLY"),
-    ]);
+    expect(result).toEqual([makeUserMessage("hi"), makeAssistantMessage("Silent: NO_REPLY")]);
   });
 });
 

--- a/src/agents/no-reply-pruning.ts
+++ b/src/agents/no-reply-pruning.ts
@@ -1,0 +1,103 @@
+import type { AgentMessage, AssistantMessage } from "@mariozechner/pi-agent-core";
+
+/**
+ * The literal sentinel text that indicates "nothing to say".
+ * Matching is case-insensitive and ignores leading/trailing whitespace.
+ */
+const NO_REPLY_SENTINEL = "NO_REPLY";
+
+/**
+ * Check if an assistant message is a NO_REPLY sentinel.
+ */
+function isNoReplyMessage(msg: AssistantMessage): boolean {
+  const content = msg.content;
+  if (!Array.isArray(content) || content.length === 0) {
+    return false;
+  }
+  // NO_REPLY messages typically have a single text block
+  if (content.length !== 1) {
+    return false;
+  }
+  const block = content[0];
+  if (block?.type !== "text") {
+    return false;
+  }
+  const text = block.text?.trim().toUpperCase();
+  return text === NO_REPLY_SENTINEL;
+}
+
+/**
+ * Prune consecutive NO_REPLY assistant messages from the message history,
+ * keeping at most `maxConsecutive` in any run of consecutive NO_REPLYs.
+ *
+ * This prevents the model from learning that "NO_REPLY is always correct"
+ * after extended periods of heartbeat-only activity or tool failures.
+ *
+ * @param messages - The full message history
+ * @param maxConsecutive - Maximum consecutive NO_REPLY messages to keep (default: 1)
+ * @returns Pruned message array
+ *
+ * @example
+ * // Before: [user] [NO_REPLY] [user] [NO_REPLY] [NO_REPLY] [NO_REPLY] [user]
+ * // After:  [user] [NO_REPLY] [user] [NO_REPLY] [user]
+ */
+export function pruneConsecutiveNoReplies(
+  messages: AgentMessage[],
+  maxConsecutive: number = 1,
+): AgentMessage[] {
+  if (messages.length === 0 || maxConsecutive < 0) {
+    return messages;
+  }
+
+  const result: AgentMessage[] = [];
+  let consecutiveNoReplyCount = 0;
+
+  for (const msg of messages) {
+    if (msg.role === "assistant" && isNoReplyMessage(msg as AssistantMessage)) {
+      consecutiveNoReplyCount++;
+      // Only keep up to maxConsecutive NO_REPLY messages in a row
+      if (consecutiveNoReplyCount <= maxConsecutive) {
+        result.push(msg);
+      }
+      // Skip this message if we've exceeded the limit
+    } else {
+      // Not a NO_REPLY message — reset counter and keep the message
+      consecutiveNoReplyCount = 0;
+      result.push(msg);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Count total NO_REPLY messages and consecutive runs in a message history.
+ * Useful for diagnostics.
+ */
+export function countNoReplies(messages: AgentMessage[]): {
+  total: number;
+  maxConsecutive: number;
+  runs: number;
+} {
+  let total = 0;
+  let maxConsecutive = 0;
+  let runs = 0;
+  let currentRun = 0;
+
+  for (const msg of messages) {
+    if (msg.role === "assistant" && isNoReplyMessage(msg as AssistantMessage)) {
+      total++;
+      currentRun++;
+      if (currentRun === 1) {
+        runs++;
+      }
+      if (currentRun > maxConsecutive) {
+        maxConsecutive = currentRun;
+      }
+    } else {
+      currentRun = 0;
+    }
+  }
+
+  return { total, maxConsecutive, runs };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -31,6 +31,7 @@ import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
+import { pruneConsecutiveNoReplies } from "../../no-reply-pruning.js";
 import {
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
@@ -70,7 +71,6 @@ import {
   sanitizeToolsForGoogle,
 } from "../google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
-import { pruneConsecutiveNoReplies } from "../../no-reply-pruning.js";
 import { log } from "../logger.js";
 import { buildModelAliasLines } from "../model.js";
 import {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -130,6 +130,18 @@ export type AgentDefaultsConfig = {
   cliBackends?: Record<string, CliBackendConfig>;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
   contextPruning?: AgentContextPruningConfig;
+  /**
+   * Prune consecutive NO_REPLY assistant messages from context before sending to the model.
+   * Prevents the "cascade of silence" where accumulated NO_REPLYs cause the model to
+   * always respond with NO_REPLY.
+   *
+   * - true/undefined: keep at most 1 consecutive NO_REPLY (default behavior)
+   * - false: disable pruning
+   * - number: keep at most N consecutive NO_REPLYs
+   *
+   * See: https://github.com/openclaw/openclaw/issues/13387
+   */
+  pruneConsecutiveNoReply?: boolean | number;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
   /** Vector memory search configuration (per-agent overrides supported). */


### PR DESCRIPTION
Fixes #13387

## Problem

Accumulated `NO_REPLY` assistant messages in session transcripts cause the model to learn that "NO_REPLY is always correct" — a cascade of silence effect. This is particularly problematic after:
- Extended periods of heartbeat-only activity
- Tool failures or rate limits
- Discussing NO_REPLY itself (#5191)

The model sees its own history full of NO_REPLY responses and infers this is the expected behavior, leading to legitimate messages being suppressed.

## Solution

Auto-prune consecutive `NO_REPLY` assistant messages from the context before sending to the model:

### New utility function
```typescript
pruneConsecutiveNoReplies(messages, maxConsecutive = 1)
```

### Example
```
Before: [user] [NO_REPLY] [user] [NO_REPLY] [NO_REPLY] [NO_REPLY] [user]
After:  [user] [NO_REPLY] [user] [NO_REPLY] [user]
```

Only consecutive NO_REPLY messages are pruned; isolated ones are kept as they represent legitimate "nothing to say" decisions.

### Configuration

Added `agents.defaults.pruneConsecutiveNoReply`:
- `true` / `undefined`: keep at most 1 consecutive NO_REPLY (default behavior)
- `false`: disable pruning
- `number`: keep at most N consecutive NO_REPLYs

## Implementation

- New `src/agents/no-reply-pruning.ts` with `pruneConsecutiveNoReplies()` and `countNoReplies()` utilities
- Integrated into `src/agents/pi-embedded-runner/run/attempt.ts` after `limitHistoryTurns()`
- Added config type to `src/config/types.agent-defaults.ts`
- Tests in `src/agents/no-reply-pruning.test.ts`

## Related

- #5191 — NO_REPLY Cascade of Silence (describes the problem)
- #13383 — Cron announce delivery fix (addresses one manifestation)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a message-history pruning step that collapses runs of consecutive `NO_REPLY` assistant messages before the session transcript is sent to the model. This is implemented via a new `pruneConsecutiveNoReplies()` utility (plus a `countNoReplies()` diagnostic helper), wired into `runEmbeddedAttempt()` after history validation/limiting, and exposed via a new `agents.defaults.pruneConsecutiveNoReply` config option (boolean/number).

The change fits into the existing transcript sanitization pipeline (`sanitizeSessionHistory` → `validate*Turns` → `limitHistoryTurns`) by adding an additional pass to reduce repeated silent-reply artifacts that can bias the model toward continued silence.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has a couple of behavioral edge cases that can prevent pruning from applying as intended.
- Core integration point is sensible (post-validation/limiting), and tests cover basic pruning behavior. However, NO_REPLY detection is stricter than existing token detection elsewhere in the codebase, so consecutive silent replies may not be recognized/pruned in real transcripts, and negative numeric config values can silently disable pruning while producing a misleading trace stage.
- src/agents/no-reply-pruning.ts, src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->