### PR TITLE
feat(memory): Add MMR re-ranking and temporal decay for hybrid search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Subagents: nested sub-agents (sub-sub-agents) with configurable depth. Set `agents.defaults.subagents.maxSpawnDepth: 2` to allow sub-agents to spawn their own children. Includes `maxChildrenPerAgent` limit (default 5), depth-aware tool policy, and proper announce chain routing. (#14447) Thanks @tyler6204.
-- Memory: add MMR (Maximal Marginal Relevance) re-ranking for hybrid search diversity. Configurable via `memorySearch.query.hybrid.mmr`. Thanks @rodrigouroz.
+- Memory: add MMR (Maximal Marginal Relevance) re-ranking for hybrid search diversity. Configurable via `memorySearch.query.hybrid.mmr`. Thanks @rodrigouroz. https://docs.openclaw.ai/concepts/memory
 - Memory: add opt-in temporal decay for hybrid search scoring, with configurable half-life via `memorySearch.query.hybrid.temporalDecay`. Thanks @rodrigouroz.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Subagents: nested sub-agents (sub-sub-agents) with configurable depth. Set `agents.defaults.subagents.maxSpawnDepth: 2` to allow sub-agents to spawn their own children. Includes `maxChildrenPerAgent` limit (default 5), depth-aware tool policy, and proper announce chain routing. (#14447) Thanks @tyler6204.
 - Memory: add MMR (Maximal Marginal Relevance) re-ranking for hybrid search diversity. Configurable via `memorySearch.query.hybrid.mmr`. Thanks @rodrigouroz.
+- Memory: add opt-in temporal decay for hybrid search scoring, with configurable half-life via `memorySearch.query.hybrid.temporalDecay`. Thanks @rodrigouroz.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Subagents: nested sub-agents (sub-sub-agents) with configurable depth. Set `agents.defaults.subagents.maxSpawnDepth: 2` to allow sub-agents to spawn their own children. Includes `maxChildrenPerAgent` limit (default 5), depth-aware tool policy, and proper announce chain routing. (#14447) Thanks @tyler6204.
+- Memory: add MMR (Maximal Marginal Relevance) re-ranking for hybrid search diversity. Configurable via `memorySearch.query.hybrid.mmr`. Thanks @rodrigouroz.
 
 ### Fixes
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -353,7 +353,6 @@ agents: {
 ```
 
 Tools:
-
 - `memory_search` — returns snippets with file + line ranges.
 - `memory_get` — read memory file content by path.
 
@@ -396,11 +395,11 @@ But it can be weak at exact, high-signal tokens:
 
 - IDs (`a828e60`, `b3b9895a…`)
 - code symbols (`memorySearch.query.hybrid`)
-- error strings (“sqlite-vec unavailable”)
+- error strings ("sqlite-vec unavailable")
 
 BM25 (full-text) is the opposite: strong at exact tokens, weaker at paraphrases.
 Hybrid search is the pragmatic middle ground: **use both retrieval signals** so you get
-good results for both “natural language” queries and “needle in a haystack” queries.
+good results for both "natural language" queries and "needle in a haystack" queries.
 
 #### How we merge results (the current design)
 
@@ -423,11 +422,27 @@ Notes:
 
 - `vectorWeight` + `textWeight` is normalized to 1.0 in config resolution, so weights behave as percentages.
 - If embeddings are unavailable (or the provider returns a zero-vector), we still run BM25 and return keyword matches.
-- If FTS5 can’t be created, we keep vector-only search (no hard failure).
+- If FTS5 can't be created, we keep vector-only search (no hard failure).
 
-This isn’t “IR-theory perfect”, but it’s simple, fast, and tends to improve recall/precision on real notes.
+This isn't "IR-theory perfect", but it's simple, fast, and tends to improve recall/precision on real notes.
 If we want to get fancier later, common next steps are Reciprocal Rank Fusion (RRF) or score normalization
 (min/max or z-score) before mixing.
+
+#### MMR re-ranking (diversity)
+
+When hybrid search returns results, multiple chunks may contain similar or overlapping content.
+**MMR (Maximal Marginal Relevance)** re-ranks the results to balance relevance with diversity,
+ensuring the top results aren't all saying the same thing.
+
+How it works:
+1. Results are scored by their original relevance (vector + BM25 weighted score).
+2. MMR iteratively selects results that maximize: `λ × relevance − (1−λ) × similarity_to_selected`.
+3. Already-selected results are penalized via Jaccard text similarity.
+
+The `lambda` parameter controls the trade-off:
+- `lambda = 1.0` → pure relevance (no diversity penalty)
+- `lambda = 0.0` → maximum diversity (ignores relevance)
+- Default: `0.7` (balanced, slight relevance bias)
 
 Config:
 
@@ -440,7 +455,11 @@ agents: {
           enabled: true,
           vectorWeight: 0.7,
           textWeight: 0.3,
-          candidateMultiplier: 4
+          candidateMultiplier: 4,
+          mmr: {
+            enabled: true,
+            lambda: 0.7
+          }
         }
       }
     }

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -353,6 +353,7 @@ agents: {
 ```
 
 Tools:
+
 - `memory_search` — returns snippets with file + line ranges.
 - `memory_get` — read memory file content by path.
 
@@ -428,23 +429,136 @@ This isn't "IR-theory perfect", but it's simple, fast, and tends to improve reca
 If we want to get fancier later, common next steps are Reciprocal Rank Fusion (RRF) or score normalization
 (min/max or z-score) before mixing.
 
+#### Post-processing pipeline
+
+After merging vector and keyword scores, two optional post-processing stages
+refine the result list before it reaches the agent:
+
+```
+Vector + Keyword → Weighted Merge → Temporal Decay → Sort → MMR → Top-K Results
+```
+
+Both stages are **off by default** and can be enabled independently.
+
 #### MMR re-ranking (diversity)
 
 When hybrid search returns results, multiple chunks may contain similar or overlapping content.
+For example, searching for "home network setup" might return five nearly identical snippets
+from different daily notes that all mention the same router configuration.
+
 **MMR (Maximal Marginal Relevance)** re-ranks the results to balance relevance with diversity,
-ensuring the top results aren't all saying the same thing.
+ensuring the top results cover different aspects of the query instead of repeating the same information.
 
 How it works:
+
 1. Results are scored by their original relevance (vector + BM25 weighted score).
-2. MMR iteratively selects results that maximize: `λ × relevance − (1−λ) × similarity_to_selected`.
-3. Already-selected results are penalized via Jaccard text similarity.
+2. MMR iteratively selects results that maximize: `λ × relevance − (1−λ) × max_similarity_to_selected`.
+3. Similarity between results is measured using Jaccard text similarity on tokenized content.
 
 The `lambda` parameter controls the trade-off:
+
 - `lambda = 1.0` → pure relevance (no diversity penalty)
 - `lambda = 0.0` → maximum diversity (ignores relevance)
 - Default: `0.7` (balanced, slight relevance bias)
 
-Config:
+**Example — query: "home network setup"**
+
+Given these memory files:
+
+```
+memory/2026-02-10.md  → "Configured Omada router, set VLAN 10 for IoT devices"
+memory/2026-02-08.md  → "Configured Omada router, moved IoT to VLAN 10"
+memory/2026-02-05.md  → "Set up AdGuard DNS on 192.168.10.2"
+memory/network.md     → "Router: Omada ER605, AdGuard: 192.168.10.2, VLAN 10: IoT"
+```
+
+Without MMR — top 3 results:
+
+```
+1. memory/2026-02-10.md  (score: 0.92)  ← router + VLAN
+2. memory/2026-02-08.md  (score: 0.89)  ← router + VLAN (near-duplicate!)
+3. memory/network.md     (score: 0.85)  ← reference doc
+```
+
+With MMR (λ=0.7) — top 3 results:
+
+```
+1. memory/2026-02-10.md  (score: 0.92)  ← router + VLAN
+2. memory/network.md     (score: 0.85)  ← reference doc (diverse!)
+3. memory/2026-02-05.md  (score: 0.78)  ← AdGuard DNS (diverse!)
+```
+
+The near-duplicate from Feb 8 drops out, and the agent gets three distinct pieces of information.
+
+**When to enable:** If you notice `memory_search` returning redundant or near-duplicate snippets,
+especially with daily notes that often repeat similar information across days.
+
+#### Temporal decay (recency boost)
+
+Agents with daily notes accumulate hundreds of dated files over time. Without decay,
+a well-worded note from six months ago can outrank yesterday's update on the same topic.
+
+**Temporal decay** applies an exponential multiplier to scores based on the age of each result,
+so recent memories naturally rank higher while old ones fade:
+
+```
+decayedScore = score × e^(-λ × ageInDays)
+```
+
+where `λ = ln(2) / halfLifeDays`.
+
+With the default half-life of 30 days:
+
+- Today's notes: **100%** of original score
+- 7 days ago: **~84%**
+- 30 days ago: **50%**
+- 90 days ago: **12.5%**
+- 180 days ago: **~1.6%**
+
+**Evergreen files are never decayed:**
+
+- `MEMORY.md` (root memory file)
+- Non-dated files in `memory/` (e.g., `memory/projects.md`, `memory/network.md`)
+- These contain durable reference information that should always rank normally.
+
+**Dated daily files** (`memory/YYYY-MM-DD.md`) use the date extracted from the filename.
+Other sources (e.g., session transcripts) fall back to file modification time (`mtime`).
+
+**Example — query: "what's Rod's work schedule?"**
+
+Given these memory files (today is Feb 10):
+
+```
+memory/2025-09-15.md  → "Rod works Mon-Fri, standup at 10am, pairing at 2pm"  (148 days old)
+memory/2026-02-10.md  → "Rod has standup at 14:15, 1:1 with Zeb at 14:45"    (today)
+memory/2026-02-03.md  → "Rod started new team, standup moved to 14:15"        (7 days old)
+```
+
+Without decay:
+
+```
+1. memory/2025-09-15.md  (score: 0.91)  ← best semantic match, but stale!
+2. memory/2026-02-10.md  (score: 0.82)
+3. memory/2026-02-03.md  (score: 0.80)
+```
+
+With decay (halfLife=30):
+
+```
+1. memory/2026-02-10.md  (score: 0.82 × 1.00 = 0.82)  ← today, no decay
+2. memory/2026-02-03.md  (score: 0.80 × 0.85 = 0.68)  ← 7 days, mild decay
+3. memory/2025-09-15.md  (score: 0.91 × 0.03 = 0.03)  ← 148 days, nearly gone
+```
+
+The stale September note drops to the bottom despite having the best raw semantic match.
+
+**When to enable:** If your agent has months of daily notes and you find that old,
+stale information outranks recent context. A half-life of 30 days works well for
+daily-note-heavy workflows; increase it (e.g., 90 days) if you reference older notes frequently.
+
+#### Configuration
+
+Both features are configured under `memorySearch.query.hybrid`:
 
 ```json5
 agents: {
@@ -456,9 +570,15 @@ agents: {
           vectorWeight: 0.7,
           textWeight: 0.3,
           candidateMultiplier: 4,
+          // Diversity: reduce redundant results
           mmr: {
-            enabled: true,
-            lambda: 0.7
+            enabled: true,    // default: false
+            lambda: 0.7       // 0 = max diversity, 1 = max relevance
+          },
+          // Recency: boost newer memories
+          temporalDecay: {
+            enabled: true,    // default: false
+            halfLifeDays: 30  // score halves every 30 days
           }
         }
       }
@@ -466,6 +586,12 @@ agents: {
   }
 }
 ```
+
+You can enable either feature independently:
+
+- **MMR only** — useful when you have many similar notes but age doesn't matter.
+- **Temporal decay only** — useful when recency matters but your results are already diverse.
+- **Both** — recommended for agents with large, long-running daily note histories.
 
 ### Embedding cache
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -10,6 +10,757 @@ export type ConfigSchema = ReturnType<typeof OpenClawSchema.toJSONSchema>;
 
 type JsonSchemaNode = Record<string, unknown>;
 
+const GROUP_LABELS: Record<string, string> = {
+  wizard: "Wizard",
+  update: "Update",
+  diagnostics: "Diagnostics",
+  logging: "Logging",
+  gateway: "Gateway",
+  nodeHost: "Node Host",
+  agents: "Agents",
+  tools: "Tools",
+  bindings: "Bindings",
+  audio: "Audio",
+  models: "Models",
+  messages: "Messages",
+  commands: "Commands",
+  session: "Session",
+  cron: "Cron",
+  hooks: "Hooks",
+  ui: "UI",
+  browser: "Browser",
+  talk: "Talk",
+  channels: "Messaging Channels",
+  skills: "Skills",
+  plugins: "Plugins",
+  discovery: "Discovery",
+  presence: "Presence",
+  voicewake: "Voice Wake",
+};
+
+const GROUP_ORDER: Record<string, number> = {
+  wizard: 20,
+  update: 25,
+  diagnostics: 27,
+  gateway: 30,
+  nodeHost: 35,
+  agents: 40,
+  tools: 50,
+  bindings: 55,
+  audio: 60,
+  models: 70,
+  messages: 80,
+  commands: 85,
+  session: 90,
+  cron: 100,
+  hooks: 110,
+  ui: 120,
+  browser: 130,
+  talk: 140,
+  channels: 150,
+  skills: 200,
+  plugins: 205,
+  discovery: 210,
+  presence: 220,
+  voicewake: 230,
+  logging: 900,
+};
+
+const FIELD_LABELS: Record<string, string> = {
+  "meta.lastTouchedVersion": "Config Last Touched Version",
+  "meta.lastTouchedAt": "Config Last Touched At",
+  "update.channel": "Update Channel",
+  "update.checkOnStart": "Update Check on Start",
+  "diagnostics.enabled": "Diagnostics Enabled",
+  "diagnostics.flags": "Diagnostics Flags",
+  "diagnostics.otel.enabled": "OpenTelemetry Enabled",
+  "diagnostics.otel.endpoint": "OpenTelemetry Endpoint",
+  "diagnostics.otel.protocol": "OpenTelemetry Protocol",
+  "diagnostics.otel.headers": "OpenTelemetry Headers",
+  "diagnostics.otel.serviceName": "OpenTelemetry Service Name",
+  "diagnostics.otel.traces": "OpenTelemetry Traces Enabled",
+  "diagnostics.otel.metrics": "OpenTelemetry Metrics Enabled",
+  "diagnostics.otel.logs": "OpenTelemetry Logs Enabled",
+  "diagnostics.otel.sampleRate": "OpenTelemetry Trace Sample Rate",
+  "diagnostics.otel.flushIntervalMs": "OpenTelemetry Flush Interval (ms)",
+  "diagnostics.cacheTrace.enabled": "Cache Trace Enabled",
+  "diagnostics.cacheTrace.filePath": "Cache Trace File Path",
+  "diagnostics.cacheTrace.includeMessages": "Cache Trace Include Messages",
+  "diagnostics.cacheTrace.includePrompt": "Cache Trace Include Prompt",
+  "diagnostics.cacheTrace.includeSystem": "Cache Trace Include System",
+  "agents.list.*.identity.avatar": "Identity Avatar",
+  "agents.list.*.skills": "Agent Skill Filter",
+  "gateway.remote.url": "Remote Gateway URL",
+  "gateway.remote.sshTarget": "Remote Gateway SSH Target",
+  "gateway.remote.sshIdentity": "Remote Gateway SSH Identity",
+  "gateway.remote.token": "Remote Gateway Token",
+  "gateway.remote.password": "Remote Gateway Password",
+  "gateway.remote.tlsFingerprint": "Remote Gateway TLS Fingerprint",
+  "gateway.auth.token": "Gateway Token",
+  "gateway.auth.password": "Gateway Password",
+  "tools.media.image.enabled": "Enable Image Understanding",
+  "tools.media.image.maxBytes": "Image Understanding Max Bytes",
+  "tools.media.image.maxChars": "Image Understanding Max Chars",
+  "tools.media.image.prompt": "Image Understanding Prompt",
+  "tools.media.image.timeoutSeconds": "Image Understanding Timeout (sec)",
+  "tools.media.image.attachments": "Image Understanding Attachment Policy",
+  "tools.media.image.models": "Image Understanding Models",
+  "tools.media.image.scope": "Image Understanding Scope",
+  "tools.media.models": "Media Understanding Shared Models",
+  "tools.media.concurrency": "Media Understanding Concurrency",
+  "tools.media.audio.enabled": "Enable Audio Understanding",
+  "tools.media.audio.maxBytes": "Audio Understanding Max Bytes",
+  "tools.media.audio.maxChars": "Audio Understanding Max Chars",
+  "tools.media.audio.prompt": "Audio Understanding Prompt",
+  "tools.media.audio.timeoutSeconds": "Audio Understanding Timeout (sec)",
+  "tools.media.audio.language": "Audio Understanding Language",
+  "tools.media.audio.attachments": "Audio Understanding Attachment Policy",
+  "tools.media.audio.models": "Audio Understanding Models",
+  "tools.media.audio.scope": "Audio Understanding Scope",
+  "tools.media.video.enabled": "Enable Video Understanding",
+  "tools.media.video.maxBytes": "Video Understanding Max Bytes",
+  "tools.media.video.maxChars": "Video Understanding Max Chars",
+  "tools.media.video.prompt": "Video Understanding Prompt",
+  "tools.media.video.timeoutSeconds": "Video Understanding Timeout (sec)",
+  "tools.media.video.attachments": "Video Understanding Attachment Policy",
+  "tools.media.video.models": "Video Understanding Models",
+  "tools.media.video.scope": "Video Understanding Scope",
+  "tools.links.enabled": "Enable Link Understanding",
+  "tools.links.maxLinks": "Link Understanding Max Links",
+  "tools.links.timeoutSeconds": "Link Understanding Timeout (sec)",
+  "tools.links.models": "Link Understanding Models",
+  "tools.links.scope": "Link Understanding Scope",
+  "tools.profile": "Tool Profile",
+  "tools.alsoAllow": "Tool Allowlist Additions",
+  "agents.list[].tools.profile": "Agent Tool Profile",
+  "agents.list[].tools.alsoAllow": "Agent Tool Allowlist Additions",
+  "tools.byProvider": "Tool Policy by Provider",
+  "agents.list[].tools.byProvider": "Agent Tool Policy by Provider",
+  "tools.exec.applyPatch.enabled": "Enable apply_patch",
+  "tools.exec.applyPatch.allowModels": "apply_patch Model Allowlist",
+  "tools.exec.notifyOnExit": "Exec Notify On Exit",
+  "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",
+  "tools.exec.host": "Exec Host",
+  "tools.exec.security": "Exec Security",
+  "tools.exec.ask": "Exec Ask",
+  "tools.exec.node": "Exec Node Binding",
+  "tools.exec.pathPrepend": "Exec PATH Prepend",
+  "tools.exec.safeBins": "Exec Safe Bins",
+  "tools.message.allowCrossContextSend": "Allow Cross-Context Messaging",
+  "tools.message.crossContext.allowWithinProvider": "Allow Cross-Context (Same Provider)",
+  "tools.message.crossContext.allowAcrossProviders": "Allow Cross-Context (Across Providers)",
+  "tools.message.crossContext.marker.enabled": "Cross-Context Marker",
+  "tools.message.crossContext.marker.prefix": "Cross-Context Marker Prefix",
+  "tools.message.crossContext.marker.suffix": "Cross-Context Marker Suffix",
+  "tools.message.broadcast.enabled": "Enable Message Broadcast",
+  "tools.web.search.enabled": "Enable Web Search Tool",
+  "tools.web.search.provider": "Web Search Provider",
+  "tools.web.search.apiKey": "Brave Search API Key",
+  "tools.web.search.maxResults": "Web Search Max Results",
+  "tools.web.search.timeoutSeconds": "Web Search Timeout (sec)",
+  "tools.web.search.cacheTtlMinutes": "Web Search Cache TTL (min)",
+  "tools.web.fetch.enabled": "Enable Web Fetch Tool",
+  "tools.web.fetch.maxChars": "Web Fetch Max Chars",
+  "tools.web.fetch.timeoutSeconds": "Web Fetch Timeout (sec)",
+  "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
+  "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
+  "tools.web.fetch.userAgent": "Web Fetch User-Agent",
+  "gateway.controlUi.basePath": "Control UI Base Path",
+  "gateway.controlUi.root": "Control UI Assets Root",
+  "gateway.controlUi.allowedOrigins": "Control UI Allowed Origins",
+  "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
+  "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
+  "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
+  "gateway.reload.mode": "Config Reload Mode",
+  "gateway.reload.debounceMs": "Config Reload Debounce (ms)",
+  "gateway.nodes.browser.mode": "Gateway Node Browser Mode",
+  "gateway.nodes.browser.node": "Gateway Node Browser Pin",
+  "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",
+  "gateway.nodes.denyCommands": "Gateway Node Denylist",
+  "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",
+  "nodeHost.browserProxy.allowProfiles": "Node Browser Proxy Allowed Profiles",
+  "skills.load.watch": "Watch Skills",
+  "skills.load.watchDebounceMs": "Skills Watch Debounce (ms)",
+  "agents.defaults.workspace": "Workspace",
+  "agents.defaults.repoRoot": "Repo Root",
+  "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",
+  "agents.defaults.envelopeTimezone": "Envelope Timezone",
+  "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
+  "agents.defaults.envelopeElapsed": "Envelope Elapsed",
+  "agents.defaults.memorySearch": "Memory Search",
+  "agents.defaults.memorySearch.enabled": "Enable Memory Search",
+  "agents.defaults.memorySearch.sources": "Memory Search Sources",
+  "agents.defaults.memorySearch.extraPaths": "Extra Memory Paths",
+  "agents.defaults.memorySearch.experimental.sessionMemory":
+    "Memory Search Session Index (Experimental)",
+  "agents.defaults.memorySearch.provider": "Memory Search Provider",
+  "agents.defaults.memorySearch.remote.baseUrl": "Remote Embedding Base URL",
+  "agents.defaults.memorySearch.remote.apiKey": "Remote Embedding API Key",
+  "agents.defaults.memorySearch.remote.headers": "Remote Embedding Headers",
+  "agents.defaults.memorySearch.remote.batch.concurrency": "Remote Batch Concurrency",
+  "agents.defaults.memorySearch.model": "Memory Search Model",
+  "agents.defaults.memorySearch.fallback": "Memory Search Fallback",
+  "agents.defaults.memorySearch.local.modelPath": "Local Embedding Model Path",
+  "agents.defaults.memorySearch.store.path": "Memory Search Index Path",
+  "agents.defaults.memorySearch.store.vector.enabled": "Memory Search Vector Index",
+  "agents.defaults.memorySearch.store.vector.extensionPath": "Memory Search Vector Extension Path",
+  "agents.defaults.memorySearch.chunking.tokens": "Memory Chunk Tokens",
+  "agents.defaults.memorySearch.chunking.overlap": "Memory Chunk Overlap Tokens",
+  "agents.defaults.memorySearch.sync.onSessionStart": "Index on Session Start",
+  "agents.defaults.memorySearch.sync.onSearch": "Index on Search (Lazy)",
+  "agents.defaults.memorySearch.sync.watch": "Watch Memory Files",
+  "agents.defaults.memorySearch.sync.watchDebounceMs": "Memory Watch Debounce (ms)",
+  "agents.defaults.memorySearch.sync.sessions.deltaBytes": "Session Delta Bytes",
+  "agents.defaults.memorySearch.sync.sessions.deltaMessages": "Session Delta Messages",
+  "agents.defaults.memorySearch.query.maxResults": "Memory Search Max Results",
+  "agents.defaults.memorySearch.query.minScore": "Memory Search Min Score",
+  "agents.defaults.memorySearch.query.hybrid.enabled": "Memory Search Hybrid",
+  "agents.defaults.memorySearch.query.hybrid.vectorWeight": "Memory Search Vector Weight",
+  "agents.defaults.memorySearch.query.hybrid.textWeight": "Memory Search Text Weight",
+  "agents.defaults.memorySearch.query.hybrid.candidateMultiplier":
+    "Memory Search Hybrid Candidate Multiplier",
+  "agents.defaults.memorySearch.query.hybrid.mmr.enabled": "Memory Search MMR Re-ranking",
+  "agents.defaults.memorySearch.query.hybrid.mmr.lambda": "Memory Search MMR Lambda",
+  "agents.defaults.memorySearch.query.hybrid.temporalDecay.enabled": "Memory Search Temporal Decay",
+  "agents.defaults.memorySearch.query.hybrid.temporalDecay.halfLifeDays":
+    "Memory Search Temporal Decay Half-life (Days)",
+  "agents.defaults.memorySearch.cache.enabled": "Memory Search Embedding Cache",
+  "agents.defaults.memorySearch.cache.maxEntries": "Memory Search Embedding Cache Max Entries",
+  memory: "Memory",
+  "memory.backend": "Memory Backend",
+  "memory.citations": "Memory Citations Mode",
+  "memory.qmd.command": "QMD Binary",
+  "memory.qmd.includeDefaultMemory": "QMD Include Default Memory",
+  "memory.qmd.paths": "QMD Extra Paths",
+  "memory.qmd.paths.path": "QMD Path",
+  "memory.qmd.paths.pattern": "QMD Path Pattern",
+  "memory.qmd.paths.name": "QMD Path Name",
+  "memory.qmd.sessions.enabled": "QMD Session Indexing",
+  "memory.qmd.sessions.exportDir": "QMD Session Export Directory",
+  "memory.qmd.sessions.retentionDays": "QMD Session Retention (days)",
+  "memory.qmd.update.interval": "QMD Update Interval",
+  "memory.qmd.update.debounceMs": "QMD Update Debounce (ms)",
+  "memory.qmd.update.onBoot": "QMD Update on Startup",
+  "memory.qmd.update.waitForBootSync": "QMD Wait for Boot Sync",
+  "memory.qmd.update.embedInterval": "QMD Embed Interval",
+  "memory.qmd.update.commandTimeoutMs": "QMD Command Timeout (ms)",
+  "memory.qmd.update.updateTimeoutMs": "QMD Update Timeout (ms)",
+  "memory.qmd.update.embedTimeoutMs": "QMD Embed Timeout (ms)",
+  "memory.qmd.limits.maxResults": "QMD Max Results",
+  "memory.qmd.limits.maxSnippetChars": "QMD Max Snippet Chars",
+  "memory.qmd.limits.maxInjectedChars": "QMD Max Injected Chars",
+  "memory.qmd.limits.timeoutMs": "QMD Search Timeout (ms)",
+  "memory.qmd.scope": "QMD Surface Scope",
+  "auth.profiles": "Auth Profiles",
+  "auth.order": "Auth Profile Order",
+  "auth.cooldowns.billingBackoffHours": "Billing Backoff (hours)",
+  "auth.cooldowns.billingBackoffHoursByProvider": "Billing Backoff Overrides",
+  "auth.cooldowns.billingMaxHours": "Billing Backoff Cap (hours)",
+  "auth.cooldowns.failureWindowHours": "Failover Window (hours)",
+  "agents.defaults.models": "Models",
+  "agents.defaults.model.primary": "Primary Model",
+  "agents.defaults.model.fallbacks": "Model Fallbacks",
+  "agents.defaults.imageModel.primary": "Image Model",
+  "agents.defaults.imageModel.fallbacks": "Image Model Fallbacks",
+  "agents.defaults.humanDelay.mode": "Human Delay Mode",
+  "agents.defaults.humanDelay.minMs": "Human Delay Min (ms)",
+  "agents.defaults.humanDelay.maxMs": "Human Delay Max (ms)",
+  "agents.defaults.cliBackends": "CLI Backends",
+  "commands.native": "Native Commands",
+  "commands.nativeSkills": "Native Skill Commands",
+  "commands.text": "Text Commands",
+  "commands.bash": "Allow Bash Chat Command",
+  "commands.bashForegroundMs": "Bash Foreground Window (ms)",
+  "commands.config": "Allow /config",
+  "commands.debug": "Allow /debug",
+  "commands.restart": "Allow Restart",
+  "commands.useAccessGroups": "Use Access Groups",
+  "commands.ownerAllowFrom": "Command Owners",
+  "commands.allowFrom": "Command Access Allowlist",
+  "ui.seamColor": "Accent Color",
+  "ui.assistant.name": "Assistant Name",
+  "ui.assistant.avatar": "Assistant Avatar",
+  "browser.evaluateEnabled": "Browser Evaluate Enabled",
+  "browser.snapshotDefaults": "Browser Snapshot Defaults",
+  "browser.snapshotDefaults.mode": "Browser Snapshot Mode",
+  "browser.remoteCdpTimeoutMs": "Remote CDP Timeout (ms)",
+  "browser.remoteCdpHandshakeTimeoutMs": "Remote CDP Handshake Timeout (ms)",
+  "session.dmScope": "DM Session Scope",
+  "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
+  "messages.ackReaction": "Ack Reaction Emoji",
+  "messages.ackReactionScope": "Ack Reaction Scope",
+  "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",
+  "talk.apiKey": "Talk API Key",
+  "channels.whatsapp": "WhatsApp",
+  "channels.telegram": "Telegram",
+  "channels.telegram.customCommands": "Telegram Custom Commands",
+  "channels.discord": "Discord",
+  "channels.slack": "Slack",
+  "channels.mattermost": "Mattermost",
+  "channels.signal": "Signal",
+  "channels.imessage": "iMessage",
+  "channels.bluebubbles": "BlueBubbles",
+  "channels.msteams": "MS Teams",
+  "channels.telegram.botToken": "Telegram Bot Token",
+  "channels.telegram.dmPolicy": "Telegram DM Policy",
+  "channels.telegram.streamMode": "Telegram Draft Stream Mode",
+  "channels.telegram.draftChunk.minChars": "Telegram Draft Chunk Min Chars",
+  "channels.telegram.draftChunk.maxChars": "Telegram Draft Chunk Max Chars",
+  "channels.telegram.draftChunk.breakPreference": "Telegram Draft Chunk Break Preference",
+  "channels.telegram.retry.attempts": "Telegram Retry Attempts",
+  "channels.telegram.retry.minDelayMs": "Telegram Retry Min Delay (ms)",
+  "channels.telegram.retry.maxDelayMs": "Telegram Retry Max Delay (ms)",
+  "channels.telegram.retry.jitter": "Telegram Retry Jitter",
+  "channels.telegram.network.autoSelectFamily": "Telegram autoSelectFamily",
+  "channels.telegram.timeoutSeconds": "Telegram API Timeout (seconds)",
+  "channels.telegram.capabilities.inlineButtons": "Telegram Inline Buttons",
+  "channels.whatsapp.dmPolicy": "WhatsApp DM Policy",
+  "channels.whatsapp.selfChatMode": "WhatsApp Self-Phone Mode",
+  "channels.whatsapp.debounceMs": "WhatsApp Message Debounce (ms)",
+  "channels.signal.dmPolicy": "Signal DM Policy",
+  "channels.imessage.dmPolicy": "iMessage DM Policy",
+  "channels.bluebubbles.dmPolicy": "BlueBubbles DM Policy",
+  "channels.discord.dm.policy": "Discord DM Policy",
+  "channels.discord.retry.attempts": "Discord Retry Attempts",
+  "channels.discord.retry.minDelayMs": "Discord Retry Min Delay (ms)",
+  "channels.discord.retry.maxDelayMs": "Discord Retry Max Delay (ms)",
+  "channels.discord.retry.jitter": "Discord Retry Jitter",
+  "channels.discord.maxLinesPerMessage": "Discord Max Lines Per Message",
+  "channels.discord.intents.presence": "Discord Presence Intent",
+  "channels.discord.intents.guildMembers": "Discord Guild Members Intent",
+  "channels.discord.pluralkit.enabled": "Discord PluralKit Enabled",
+  "channels.discord.pluralkit.token": "Discord PluralKit Token",
+  "channels.slack.dm.policy": "Slack DM Policy",
+  "channels.slack.allowBots": "Slack Allow Bot Messages",
+  "channels.discord.token": "Discord Bot Token",
+  "channels.slack.botToken": "Slack Bot Token",
+  "channels.slack.appToken": "Slack App Token",
+  "channels.slack.userToken": "Slack User Token",
+  "channels.slack.userTokenReadOnly": "Slack User Token Read Only",
+  "channels.slack.thread.historyScope": "Slack Thread History Scope",
+  "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
+  "channels.mattermost.botToken": "Mattermost Bot Token",
+  "channels.mattermost.baseUrl": "Mattermost Base URL",
+  "channels.mattermost.chatmode": "Mattermost Chat Mode",
+  "channels.mattermost.oncharPrefixes": "Mattermost Onchar Prefixes",
+  "channels.mattermost.requireMention": "Mattermost Require Mention",
+  "channels.signal.account": "Signal Account",
+  "channels.imessage.cliPath": "iMessage CLI Path",
+  "agents.list[].skills": "Agent Skill Filter",
+  "agents.list[].identity.avatar": "Agent Avatar",
+  "discovery.mdns.mode": "mDNS Discovery Mode",
+  "plugins.enabled": "Enable Plugins",
+  "plugins.allow": "Plugin Allowlist",
+  "plugins.deny": "Plugin Denylist",
+  "plugins.load.paths": "Plugin Load Paths",
+  "plugins.slots": "Plugin Slots",
+  "plugins.slots.memory": "Memory Plugin",
+  "plugins.entries": "Plugin Entries",
+  "plugins.entries.*.enabled": "Plugin Enabled",
+  "plugins.entries.*.config": "Plugin Config",
+  "plugins.installs": "Plugin Install Records",
+  "plugins.installs.*.source": "Plugin Install Source",
+  "plugins.installs.*.spec": "Plugin Install Spec",
+  "plugins.installs.*.sourcePath": "Plugin Install Source Path",
+  "plugins.installs.*.installPath": "Plugin Install Path",
+  "plugins.installs.*.version": "Plugin Install Version",
+  "plugins.installs.*.installedAt": "Plugin Install Time",
+};
+
+const FIELD_HELP: Record<string, string> = {
+  "meta.lastTouchedVersion": "Auto-set when OpenClaw writes the config.",
+  "meta.lastTouchedAt": "ISO timestamp of the last config write (auto-set).",
+  "update.channel": 'Update channel for git + npm installs ("stable", "beta", or "dev").',
+  "update.checkOnStart": "Check for npm updates when the gateway starts (default: true).",
+  "gateway.remote.url": "Remote Gateway WebSocket URL (ws:// or wss://).",
+  "gateway.remote.tlsFingerprint":
+    "Expected sha256 TLS fingerprint for the remote gateway (pin to avoid MITM).",
+  "gateway.remote.sshTarget":
+    "Remote gateway over SSH (tunnels the gateway port to localhost). Format: user@host or user@host:port.",
+  "gateway.remote.sshIdentity": "Optional SSH identity file path (passed to ssh -i).",
+  "agents.list.*.skills":
+    "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
+  "agents.list[].skills":
+    "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
+  "agents.list[].identity.avatar":
+    "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
+  "discovery.mdns.mode":
+    'mDNS broadcast mode ("minimal" default, "full" includes cliPath/sshPort, "off" disables mDNS).',
+  "gateway.auth.token":
+    "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
+  "gateway.auth.password": "Required for Tailscale funnel.",
+  "gateway.controlUi.basePath":
+    "Optional URL prefix where the Control UI is served (e.g. /openclaw).",
+  "gateway.controlUi.root":
+    "Optional filesystem root for Control UI assets (defaults to dist/control-ui).",
+  "gateway.controlUi.allowedOrigins":
+    "Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com).",
+  "gateway.controlUi.allowInsecureAuth":
+    "Allow Control UI auth over insecure HTTP (token-only; not recommended).",
+  "gateway.controlUi.dangerouslyDisableDeviceAuth":
+    "DANGEROUS. Disable Control UI device identity checks (token/password only).",
+  "gateway.http.endpoints.chatCompletions.enabled":
+    "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
+  "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',
+  "gateway.reload.debounceMs": "Debounce window (ms) before applying config changes.",
+  "gateway.nodes.browser.mode":
+    'Node browser routing ("auto" = pick single connected browser node, "manual" = require node param, "off" = disable).',
+  "gateway.nodes.browser.node": "Pin browser routing to a specific node id or name (optional).",
+  "gateway.nodes.allowCommands":
+    "Extra node.invoke commands to allow beyond the gateway defaults (array of command strings).",
+  "gateway.nodes.denyCommands":
+    "Commands to block even if present in node claims or default allowlist.",
+  "nodeHost.browserProxy.enabled": "Expose the local browser control server via node proxy.",
+  "nodeHost.browserProxy.allowProfiles":
+    "Optional allowlist of browser profile names exposed via the node proxy.",
+  "diagnostics.flags":
+    'Enable targeted diagnostics logs by flag (e.g. ["telegram.http"]). Supports wildcards like "telegram.*" or "*".',
+  "diagnostics.cacheTrace.enabled":
+    "Log cache trace snapshots for embedded agent runs (default: false).",
+  "diagnostics.cacheTrace.filePath":
+    "JSONL output path for cache trace logs (default: $OPENCLAW_STATE_DIR/logs/cache-trace.jsonl).",
+  "diagnostics.cacheTrace.includeMessages":
+    "Include full message payloads in trace output (default: true).",
+  "diagnostics.cacheTrace.includePrompt": "Include prompt text in trace output (default: true).",
+  "diagnostics.cacheTrace.includeSystem": "Include system prompt in trace output (default: true).",
+  "tools.exec.applyPatch.enabled":
+    "Experimental. Enables apply_patch for OpenAI models when allowed by tool policy.",
+  "tools.exec.applyPatch.allowModels":
+    'Optional allowlist of model ids (e.g. "gpt-5.2" or "openai/gpt-5.2").',
+  "tools.exec.notifyOnExit":
+    "When true (default), backgrounded exec sessions enqueue a system event and request a heartbeat on exit.",
+  "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",
+  "tools.exec.safeBins":
+    "Allow stdin-only safe binaries to run without explicit allowlist entries.",
+  "tools.message.allowCrossContextSend":
+    "Legacy override: allow cross-context sends across all providers.",
+  "tools.message.crossContext.allowWithinProvider":
+    "Allow sends to other channels within the same provider (default: true).",
+  "tools.message.crossContext.allowAcrossProviders":
+    "Allow sends across different providers (default: false).",
+  "tools.message.crossContext.marker.enabled":
+    "Add a visible origin marker when sending cross-context (default: true).",
+  "tools.message.crossContext.marker.prefix":
+    'Text prefix for cross-context markers (supports "{channel}").',
+  "tools.message.crossContext.marker.suffix":
+    'Text suffix for cross-context markers (supports "{channel}").',
+  "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
+  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
+  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
+  "tools.web.search.maxResults": "Default number of results to return (1-10).",
+  "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
+  "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",
+  "tools.web.search.perplexity.apiKey":
+    "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var).",
+  "tools.web.search.perplexity.baseUrl":
+    "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
+  "tools.web.search.perplexity.model":
+    'Perplexity model override (default: "perplexity/sonar-pro").',
+  "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
+  "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
+  "tools.web.fetch.maxCharsCap":
+    "Hard cap for web_fetch maxChars (applies to config and tool calls).",
+  "tools.web.fetch.timeoutSeconds": "Timeout in seconds for web_fetch requests.",
+  "tools.web.fetch.cacheTtlMinutes": "Cache TTL in minutes for web_fetch results.",
+  "tools.web.fetch.maxRedirects": "Maximum redirects allowed for web_fetch (default: 3).",
+  "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
+  "tools.web.fetch.readability":
+    "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
+  "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",
+  "tools.web.fetch.firecrawl.apiKey": "Firecrawl API key (fallback: FIRECRAWL_API_KEY env var).",
+  "tools.web.fetch.firecrawl.baseUrl":
+    "Firecrawl base URL (e.g. https://api.firecrawl.dev or custom endpoint).",
+  "tools.web.fetch.firecrawl.onlyMainContent":
+    "When true, Firecrawl returns only the main content (default: true).",
+  "tools.web.fetch.firecrawl.maxAgeMs":
+    "Firecrawl maxAge (ms) for cached results when supported by the API.",
+  "tools.web.fetch.firecrawl.timeoutSeconds": "Timeout in seconds for Firecrawl requests.",
+  "channels.slack.allowBots":
+    "Allow bot-authored messages to trigger Slack replies (default: false).",
+  "channels.slack.thread.historyScope":
+    'Scope for Slack thread history context ("thread" isolates per thread; "channel" reuses channel history).',
+  "channels.slack.thread.inheritParent":
+    "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
+  "channels.mattermost.botToken":
+    "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
+  "channels.mattermost.baseUrl":
+    "Base URL for your Mattermost server (e.g., https://chat.example.com).",
+  "channels.mattermost.chatmode":
+    'Reply to channel messages on mention ("oncall"), on trigger chars (">" or "!") ("onchar"), or on every message ("onmessage").',
+  "channels.mattermost.oncharPrefixes": 'Trigger prefixes for onchar mode (default: [">", "!"]).',
+  "channels.mattermost.requireMention":
+    "Require @mention in channels before responding (default: true).",
+  "auth.profiles": "Named auth profiles (provider + mode + optional email).",
+  "auth.order": "Ordered auth profile IDs per provider (used for automatic failover).",
+  "auth.cooldowns.billingBackoffHours":
+    "Base backoff (hours) when a profile fails due to billing/insufficient credits (default: 5).",
+  "auth.cooldowns.billingBackoffHoursByProvider":
+    "Optional per-provider overrides for billing backoff (hours).",
+  "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
+  "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
+  "agents.defaults.bootstrapMaxChars":
+    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
+  "agents.defaults.repoRoot":
+    "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
+  "agents.defaults.envelopeTimezone":
+    'Timezone for message envelopes ("utc", "local", "user", or an IANA timezone string).',
+  "agents.defaults.envelopeTimestamp":
+    'Include absolute timestamps in message envelopes ("on" or "off").',
+  "agents.defaults.envelopeElapsed": 'Include elapsed time in message envelopes ("on" or "off").',
+  "agents.defaults.models": "Configured model catalog (keys are full provider/model IDs).",
+  "agents.defaults.memorySearch":
+    "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",
+  "agents.defaults.memorySearch.sources":
+    'Sources to index for memory search (default: ["memory"]; add "sessions" to include session transcripts).',
+  "agents.defaults.memorySearch.extraPaths":
+    "Extra paths to include in memory search (directories or .md files; relative paths resolved from workspace).",
+  "agents.defaults.memorySearch.experimental.sessionMemory":
+    "Enable experimental session transcript indexing for memory search (default: false).",
+  "agents.defaults.memorySearch.provider":
+    'Embedding provider ("openai", "gemini", "voyage", or "local").',
+  "agents.defaults.memorySearch.remote.baseUrl":
+    "Custom base URL for remote embeddings (OpenAI-compatible proxies or Gemini overrides).",
+  "agents.defaults.memorySearch.remote.apiKey": "Custom API key for the remote embedding provider.",
+  "agents.defaults.memorySearch.remote.headers":
+    "Extra headers for remote embeddings (merged; remote overrides OpenAI headers).",
+  "agents.defaults.memorySearch.remote.batch.enabled":
+    "Enable batch API for memory embeddings (OpenAI/Gemini/Voyage; default: false).",
+  "agents.defaults.memorySearch.remote.batch.wait":
+    "Wait for batch completion when indexing (default: true).",
+  "agents.defaults.memorySearch.remote.batch.concurrency":
+    "Max concurrent embedding batch jobs for memory indexing (default: 2).",
+  "agents.defaults.memorySearch.remote.batch.pollIntervalMs":
+    "Polling interval in ms for batch status (default: 2000).",
+  "agents.defaults.memorySearch.remote.batch.timeoutMinutes":
+    "Timeout in minutes for batch indexing (default: 60).",
+  "agents.defaults.memorySearch.local.modelPath":
+    "Local GGUF model path or hf: URI (node-llama-cpp).",
+  "agents.defaults.memorySearch.fallback":
+    'Fallback provider when embeddings fail ("openai", "gemini", "local", or "none").',
+  "agents.defaults.memorySearch.store.path":
+    "SQLite index path (default: ~/.openclaw/memory/{agentId}.sqlite).",
+  "agents.defaults.memorySearch.store.vector.enabled":
+    "Enable sqlite-vec extension for vector search (default: true).",
+  "agents.defaults.memorySearch.store.vector.extensionPath":
+    "Optional override path to sqlite-vec extension library (.dylib/.so/.dll).",
+  "agents.defaults.memorySearch.query.hybrid.enabled":
+    "Enable hybrid BM25 + vector search for memory (default: true).",
+  "agents.defaults.memorySearch.query.hybrid.vectorWeight":
+    "Weight for vector similarity when merging results (0-1).",
+  "agents.defaults.memorySearch.query.hybrid.textWeight":
+    "Weight for BM25 text relevance when merging results (0-1).",
+  "agents.defaults.memorySearch.query.hybrid.candidateMultiplier":
+    "Multiplier for candidate pool size (default: 4).",
+  "agents.defaults.memorySearch.query.hybrid.mmr.enabled":
+    "Enable MMR re-ranking for result diversity (default: false).",
+  "agents.defaults.memorySearch.query.hybrid.mmr.lambda":
+    "MMR lambda: 0 = max diversity, 1 = max relevance (default: 0.7).",
+  "agents.defaults.memorySearch.query.hybrid.temporalDecay.enabled":
+    "Apply exponential time decay to hybrid scores before MMR re-ranking (default: false).",
+  "agents.defaults.memorySearch.query.hybrid.temporalDecay.halfLifeDays":
+    "Temporal decay half-life in days (default: 30).",
+  "agents.defaults.memorySearch.cache.enabled":
+    "Cache chunk embeddings in SQLite to speed up reindexing and frequent updates (default: true).",
+  memory: "Memory backend configuration (global).",
+  "memory.backend": 'Memory backend ("builtin" for OpenClaw embeddings, "qmd" for QMD sidecar).',
+  "memory.citations": 'Default citation behavior ("auto", "on", or "off").',
+  "memory.qmd.command": "Path to the qmd binary (default: resolves from PATH).",
+  "memory.qmd.includeDefaultMemory":
+    "Whether to automatically index MEMORY.md + memory/**/*.md (default: true).",
+  "memory.qmd.paths":
+    "Additional directories/files to index with QMD (path + optional glob pattern).",
+  "memory.qmd.paths.path": "Absolute or ~-relative path to index via QMD.",
+  "memory.qmd.paths.pattern": "Glob pattern relative to the path root (default: **/*.md).",
+  "memory.qmd.paths.name":
+    "Optional stable name for the QMD collection (default derived from path).",
+  "memory.qmd.sessions.enabled":
+    "Enable QMD session transcript indexing (experimental, default: false).",
+  "memory.qmd.sessions.exportDir":
+    "Override directory for sanitized session exports before indexing.",
+  "memory.qmd.sessions.retentionDays":
+    "Retention window for exported sessions before pruning (default: unlimited).",
+  "memory.qmd.update.interval":
+    "How often the QMD sidecar refreshes indexes (duration string, default: 5m).",
+  "memory.qmd.update.debounceMs":
+    "Minimum delay between successive QMD refresh runs (default: 15000).",
+  "memory.qmd.update.onBoot": "Run QMD update once on gateway startup (default: true).",
+  "memory.qmd.update.waitForBootSync":
+    "Block startup until the boot QMD refresh finishes (default: false).",
+  "memory.qmd.update.embedInterval":
+    "How often QMD embeddings are refreshed (duration string, default: 60m). Set to 0 to disable periodic embed.",
+  "memory.qmd.update.commandTimeoutMs":
+    "Timeout for QMD maintenance commands like collection list/add (default: 30000).",
+  "memory.qmd.update.updateTimeoutMs": "Timeout for `qmd update` runs (default: 120000).",
+  "memory.qmd.update.embedTimeoutMs": "Timeout for `qmd embed` runs (default: 120000).",
+  "memory.qmd.limits.maxResults": "Max QMD results returned to the agent loop (default: 6).",
+  "memory.qmd.limits.maxSnippetChars": "Max characters per snippet pulled from QMD (default: 700).",
+  "memory.qmd.limits.maxInjectedChars": "Max total characters injected from QMD hits per turn.",
+  "memory.qmd.limits.timeoutMs": "Per-query timeout for QMD searches (default: 4000).",
+  "memory.qmd.scope":
+    "Session/channel scope for QMD recall (same syntax as session.sendPolicy; default: direct-only).",
+  "agents.defaults.memorySearch.cache.maxEntries":
+    "Optional cap on cached embeddings (best-effort).",
+  "agents.defaults.memorySearch.sync.onSearch":
+    "Lazy sync: schedule a reindex on search after changes.",
+  "agents.defaults.memorySearch.sync.watch": "Watch memory files for changes (chokidar).",
+  "agents.defaults.memorySearch.sync.sessions.deltaBytes":
+    "Minimum appended bytes before session transcripts trigger reindex (default: 100000).",
+  "agents.defaults.memorySearch.sync.sessions.deltaMessages":
+    "Minimum appended JSONL lines before session transcripts trigger reindex (default: 50).",
+  "plugins.enabled": "Enable plugin/extension loading (default: true).",
+  "plugins.allow": "Optional allowlist of plugin ids; when set, only listed plugins load.",
+  "plugins.deny": "Optional denylist of plugin ids; deny wins over allowlist.",
+  "plugins.load.paths": "Additional plugin files or directories to load.",
+  "plugins.slots": "Select which plugins own exclusive slots (memory, etc.).",
+  "plugins.slots.memory":
+    'Select the active memory plugin by id, or "none" to disable memory plugins.',
+  "plugins.entries": "Per-plugin settings keyed by plugin id (enable/disable + config payloads).",
+  "plugins.entries.*.enabled": "Overrides plugin enable/disable for this entry (restart required).",
+  "plugins.entries.*.config": "Plugin-defined config payload (schema is provided by the plugin).",
+  "plugins.installs":
+    "CLI-managed install metadata (used by `openclaw plugins update` to locate install sources).",
+  "plugins.installs.*.source": 'Install source ("npm", "archive", or "path").',
+  "plugins.installs.*.spec": "Original npm spec used for install (if source is npm).",
+  "plugins.installs.*.sourcePath": "Original archive/path used for install (if any).",
+  "plugins.installs.*.installPath":
+    "Resolved install directory (usually ~/.openclaw/extensions/<id>).",
+  "plugins.installs.*.version": "Version recorded at install time (if available).",
+  "plugins.installs.*.installedAt": "ISO timestamp of last install/update.",
+  "agents.list.*.identity.avatar":
+    "Agent avatar (workspace-relative path, http(s) URL, or data URI).",
+  "agents.defaults.model.primary": "Primary model (provider/model).",
+  "agents.defaults.model.fallbacks":
+    "Ordered fallback models (provider/model). Used when the primary model fails.",
+  "agents.defaults.imageModel.primary":
+    "Optional image model (provider/model) used when the primary model lacks image input.",
+  "agents.defaults.imageModel.fallbacks": "Ordered fallback image models (provider/model).",
+  "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
+  "agents.defaults.humanDelay.mode": 'Delay style for block replies ("off", "natural", "custom").',
+  "agents.defaults.humanDelay.minMs": "Minimum delay in ms for custom humanDelay (default: 800).",
+  "agents.defaults.humanDelay.maxMs": "Maximum delay in ms for custom humanDelay (default: 2500).",
+  "commands.native":
+    "Register native commands with channels that support it (Discord/Slack/Telegram).",
+  "commands.nativeSkills":
+    "Register native skill commands (user-invocable skills) with channels that support it.",
+  "commands.text": "Allow text command parsing (slash commands only).",
+  "commands.bash":
+    "Allow bash chat command (`!`; `/bash` alias) to run host shell commands (default: false; requires tools.elevated).",
+  "commands.bashForegroundMs":
+    "How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately).",
+  "commands.config": "Allow /config chat command to read/write config on disk (default: false).",
+  "commands.debug": "Allow /debug chat command for runtime-only overrides (default: false).",
+  "commands.restart": "Allow /restart and gateway restart tool actions (default: false).",
+  "commands.useAccessGroups": "Enforce access-group allowlists/policies for commands.",
+  "commands.ownerAllowFrom":
+    "Explicit owner allowlist for owner-only tools/commands. Use channel-native IDs (optionally prefixed like \"whatsapp:+15551234567\"). '*' is ignored.",
+  "commands.allowFrom":
+    'Per-provider allowlist restricting who can use slash commands. If set, overrides the channel\'s allowFrom for command authorization. Use \'*\' key for global default; provider-specific keys (e.g. \'discord\') override the global. Example: { "*": ["user1"], "discord": ["user:123"] }.',
+  "session.dmScope":
+    'DM session scoping: "main" keeps continuity; "per-peer", "per-channel-peer", or "per-account-channel-peer" isolates DM history (recommended for shared inboxes/multi-account).',
+  "session.identityLinks":
+    "Map canonical identities to provider-prefixed peer IDs for DM session linking (example: telegram:123456).",
+  "channels.telegram.configWrites":
+    "Allow Telegram to write config in response to channel events/commands (default: true).",
+  "channels.slack.configWrites":
+    "Allow Slack to write config in response to channel events/commands (default: true).",
+  "channels.mattermost.configWrites":
+    "Allow Mattermost to write config in response to channel events/commands (default: true).",
+  "channels.discord.configWrites":
+    "Allow Discord to write config in response to channel events/commands (default: true).",
+  "channels.whatsapp.configWrites":
+    "Allow WhatsApp to write config in response to channel events/commands (default: true).",
+  "channels.signal.configWrites":
+    "Allow Signal to write config in response to channel events/commands (default: true).",
+  "channels.imessage.configWrites":
+    "Allow iMessage to write config in response to channel events/commands (default: true).",
+  "channels.msteams.configWrites":
+    "Allow Microsoft Teams to write config in response to channel events/commands (default: true).",
+  "channels.discord.commands.native": 'Override native commands for Discord (bool or "auto").',
+  "channels.discord.commands.nativeSkills":
+    'Override native skill commands for Discord (bool or "auto").',
+  "channels.telegram.commands.native": 'Override native commands for Telegram (bool or "auto").',
+  "channels.telegram.commands.nativeSkills":
+    'Override native skill commands for Telegram (bool or "auto").',
+  "channels.slack.commands.native": 'Override native commands for Slack (bool or "auto").',
+  "channels.slack.commands.nativeSkills":
+    'Override native skill commands for Slack (bool or "auto").',
+  "session.agentToAgent.maxPingPongTurns":
+    "Max reply-back turns between requester and target (0–5).",
+  "channels.telegram.customCommands":
+    "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
+  "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
+  "messages.ackReactionScope":
+    'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',
+  "messages.inbound.debounceMs":
+    "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
+  "channels.telegram.dmPolicy":
+    'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
+  "channels.telegram.streamMode":
+    "Draft streaming mode for Telegram replies (off | partial | block). Separate from block streaming; requires private topics + sendMessageDraft.",
+  "channels.telegram.draftChunk.minChars":
+    'Minimum chars before emitting a Telegram draft update when channels.telegram.streamMode="block" (default: 200).',
+  "channels.telegram.draftChunk.maxChars":
+    'Target max size for a Telegram draft update chunk when channels.telegram.streamMode="block" (default: 800; clamped to channels.telegram.textChunkLimit).',
+  "channels.telegram.draftChunk.breakPreference":
+    "Preferred breakpoints for Telegram draft chunks (paragraph | newline | sentence). Default: paragraph.",
+  "channels.telegram.retry.attempts":
+    "Max retry attempts for outbound Telegram API calls (default: 3).",
+  "channels.telegram.retry.minDelayMs": "Minimum retry delay in ms for Telegram outbound calls.",
+  "channels.telegram.retry.maxDelayMs":
+    "Maximum retry delay cap in ms for Telegram outbound calls.",
+  "channels.telegram.retry.jitter": "Jitter factor (0-1) applied to Telegram retry delays.",
+  "channels.telegram.network.autoSelectFamily":
+    "Override Node autoSelectFamily for Telegram (true=enable, false=disable).",
+  "channels.telegram.timeoutSeconds":
+    "Max seconds before Telegram API requests are aborted (default: 500 per grammY).",
+  "channels.whatsapp.dmPolicy":
+    'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
+  "channels.whatsapp.selfChatMode": "Same-phone setup (bot uses your personal WhatsApp number).",
+  "channels.whatsapp.debounceMs":
+    "Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).",
+  "channels.signal.dmPolicy":
+    'Direct message access control ("pairing" recommended). "open" requires channels.signal.allowFrom=["*"].',
+  "channels.imessage.dmPolicy":
+    'Direct message access control ("pairing" recommended). "open" requires channels.imessage.allowFrom=["*"].',
+  "channels.bluebubbles.dmPolicy":
+    'Direct message access control ("pairing" recommended). "open" requires channels.bluebubbles.allowFrom=["*"].',
+  "channels.discord.dm.policy":
+    'Direct message access control ("pairing" recommended). "open" requires channels.discord.dm.allowFrom=["*"].',
+  "channels.discord.retry.attempts":
+    "Max retry attempts for outbound Discord API calls (default: 3).",
+  "channels.discord.retry.minDelayMs": "Minimum retry delay in ms for Discord outbound calls.",
+  "channels.discord.retry.maxDelayMs": "Maximum retry delay cap in ms for Discord outbound calls.",
+  "channels.discord.retry.jitter": "Jitter factor (0-1) applied to Discord retry delays.",
+  "channels.discord.maxLinesPerMessage": "Soft max line count per Discord message (default: 17).",
+  "channels.discord.intents.presence":
+    "Enable the Guild Presences privileged intent. Must also be enabled in the Discord Developer Portal. Allows tracking user activities (e.g. Spotify). Default: false.",
+  "channels.discord.intents.guildMembers":
+    "Enable the Guild Members privileged intent. Must also be enabled in the Discord Developer Portal. Default: false.",
+  "channels.discord.pluralkit.enabled":
+    "Resolve PluralKit proxied messages and treat system members as distinct senders.",
+  "channels.discord.pluralkit.token":
+    "Optional PluralKit token for resolving private systems or members.",
+  "channels.slack.dm.policy":
+    'Direct message access control ("pairing" recommended). "open" requires channels.slack.dm.allowFrom=["*"].',
+};
+
+const FIELD_PLACEHOLDERS: Record<string, string> = {
+  "gateway.remote.url": "ws://host:18789",
+  "gateway.remote.tlsFingerprint": "sha256:ab12cd34…",
+  "gateway.remote.sshTarget": "user@host",
+  "gateway.controlUi.basePath": "/openclaw",
+  "gateway.controlUi.root": "dist/control-ui",
+  "gateway.controlUi.allowedOrigins": "https://control.example.com",
+  "channels.mattermost.baseUrl": "https://chat.example.com",
+  "agents.list[].identity.avatar": "avatars/openclaw.png",
+};
+
+const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+
+function isSensitivePath(path: string): boolean {
+  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
+}
 type JsonSchemaObject = JsonSchemaNode & {
   type?: string | string[];
   properties?: Record<string, JsonSchemaObject>;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -332,6 +332,20 @@ export type MemorySearchConfig = {
       textWeight?: number;
       /** Multiplier for candidate pool size (default: 4). */
       candidateMultiplier?: number;
+      /** Optional MMR re-ranking for result diversity. */
+      mmr?: {
+        /** Enable MMR re-ranking (default: false). */
+        enabled?: boolean;
+        /** Lambda: 0 = max diversity, 1 = max relevance (default: 0.7). */
+        lambda?: number;
+      };
+      /** Optional temporal decay to boost recency in hybrid scoring. */
+      temporalDecay?: {
+        /** Enable temporal decay (default: false). */
+        enabled?: boolean;
+        /** Half-life in days for exponential decay (default: 30). */
+        halfLifeDays?: number;
+      };
     };
   };
   /** Index cache behavior. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -434,6 +434,20 @@ export const MemorySearchSchema = z
             vectorWeight: z.number().min(0).max(1).optional(),
             textWeight: z.number().min(0).max(1).optional(),
             candidateMultiplier: z.number().int().positive().optional(),
+            mmr: z
+              .object({
+                enabled: z.boolean().optional(),
+                lambda: z.number().min(0).max(1).optional(),
+              })
+              .strict()
+              .optional(),
+            temporalDecay: z
+              .object({
+                enabled: z.boolean().optional(),
+                halfLifeDays: z.number().int().positive().optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/memory/__tests__/mmr.test.ts
+++ b/src/memory/__tests__/mmr.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect } from "vitest";
+import {
+  tokenize,
+  jaccardSimilarity,
+  textSimilarity,
+  computeMMRScore,
+  mmrRerank,
+  applyMMRToHybridResults,
+  DEFAULT_MMR_CONFIG,
+  type MMRItem,
+} from "../mmr.js";
+
+describe("tokenize", () => {
+  it("extracts alphanumeric tokens and lowercases", () => {
+    const result = tokenize("Hello World 123");
+    expect(result).toEqual(new Set(["hello", "world", "123"]));
+  });
+
+  it("handles empty string", () => {
+    expect(tokenize("")).toEqual(new Set());
+  });
+
+  it("handles special characters only", () => {
+    expect(tokenize("!@#$%^&*()")).toEqual(new Set());
+  });
+
+  it("handles underscores in tokens", () => {
+    const result = tokenize("hello_world test_case");
+    expect(result).toEqual(new Set(["hello_world", "test_case"]));
+  });
+
+  it("deduplicates repeated tokens", () => {
+    const result = tokenize("hello hello world world");
+    expect(result).toEqual(new Set(["hello", "world"]));
+  });
+});
+
+describe("jaccardSimilarity", () => {
+  it("returns 1 for identical sets", () => {
+    const set = new Set(["a", "b", "c"]);
+    expect(jaccardSimilarity(set, set)).toBe(1);
+  });
+
+  it("returns 0 for disjoint sets", () => {
+    const setA = new Set(["a", "b"]);
+    const setB = new Set(["c", "d"]);
+    expect(jaccardSimilarity(setA, setB)).toBe(0);
+  });
+
+  it("returns 1 for two empty sets", () => {
+    expect(jaccardSimilarity(new Set(), new Set())).toBe(1);
+  });
+
+  it("returns 0 when one set is empty", () => {
+    expect(jaccardSimilarity(new Set(["a"]), new Set())).toBe(0);
+    expect(jaccardSimilarity(new Set(), new Set(["a"]))).toBe(0);
+  });
+
+  it("computes correct similarity for partial overlap", () => {
+    const setA = new Set(["a", "b", "c"]);
+    const setB = new Set(["b", "c", "d"]);
+    // Intersection: {b, c} = 2, Union: {a, b, c, d} = 4
+    expect(jaccardSimilarity(setA, setB)).toBe(0.5);
+  });
+
+  it("is symmetric", () => {
+    const setA = new Set(["a", "b"]);
+    const setB = new Set(["b", "c"]);
+    expect(jaccardSimilarity(setA, setB)).toBe(jaccardSimilarity(setB, setA));
+  });
+});
+
+describe("textSimilarity", () => {
+  it("returns 1 for identical text", () => {
+    expect(textSimilarity("hello world", "hello world")).toBe(1);
+  });
+
+  it("returns 1 for same words different order", () => {
+    expect(textSimilarity("hello world", "world hello")).toBe(1);
+  });
+
+  it("returns 0 for completely different text", () => {
+    expect(textSimilarity("hello world", "foo bar")).toBe(0);
+  });
+
+  it("handles case insensitivity", () => {
+    expect(textSimilarity("Hello World", "hello world")).toBe(1);
+  });
+});
+
+describe("computeMMRScore", () => {
+  it("returns pure relevance when lambda=1", () => {
+    expect(computeMMRScore(0.8, 0.5, 1)).toBe(0.8);
+  });
+
+  it("returns negative similarity when lambda=0", () => {
+    expect(computeMMRScore(0.8, 0.5, 0)).toBe(-0.5);
+  });
+
+  it("balances relevance and diversity at lambda=0.5", () => {
+    // 0.5 * 0.8 - 0.5 * 0.6 = 0.4 - 0.3 = 0.1
+    expect(computeMMRScore(0.8, 0.6, 0.5)).toBeCloseTo(0.1);
+  });
+
+  it("computes correctly with default lambda=0.7", () => {
+    // 0.7 * 1.0 - 0.3 * 0.5 = 0.7 - 0.15 = 0.55
+    expect(computeMMRScore(1.0, 0.5, 0.7)).toBeCloseTo(0.55);
+  });
+});
+
+describe("mmrRerank", () => {
+  describe("edge cases", () => {
+    it("returns empty array for empty input", () => {
+      expect(mmrRerank([])).toEqual([]);
+    });
+
+    it("returns single item unchanged", () => {
+      const items: MMRItem[] = [{ id: "1", score: 0.9, content: "hello" }];
+      expect(mmrRerank(items)).toEqual(items);
+    });
+
+    it("returns copy, not original array", () => {
+      const items: MMRItem[] = [{ id: "1", score: 0.9, content: "hello" }];
+      const result = mmrRerank(items);
+      expect(result).not.toBe(items);
+    });
+
+    it("returns items unchanged when disabled", () => {
+      const items: MMRItem[] = [
+        { id: "1", score: 0.9, content: "hello" },
+        { id: "2", score: 0.8, content: "hello" },
+      ];
+      const result = mmrRerank(items, { enabled: false });
+      expect(result).toEqual(items);
+    });
+  });
+
+  describe("lambda edge cases", () => {
+    const diverseItems: MMRItem[] = [
+      { id: "1", score: 1.0, content: "apple banana cherry" },
+      { id: "2", score: 0.9, content: "apple banana date" },
+      { id: "3", score: 0.8, content: "elderberry fig grape" },
+    ];
+
+    it("lambda=1 returns pure relevance order", () => {
+      const result = mmrRerank(diverseItems, { lambda: 1 });
+      expect(result.map((i) => i.id)).toEqual(["1", "2", "3"]);
+    });
+
+    it("lambda=0 maximizes diversity", () => {
+      const result = mmrRerank(diverseItems, { lambda: 0 });
+      // First item is still highest score (no penalty yet)
+      expect(result[0].id).toBe("1");
+      // Second should be most different from first
+      expect(result[1].id).toBe("3"); // elderberry... is most different
+    });
+
+    it("clamps lambda > 1 to 1", () => {
+      const result = mmrRerank(diverseItems, { lambda: 1.5 });
+      expect(result.map((i) => i.id)).toEqual(["1", "2", "3"]);
+    });
+
+    it("clamps lambda < 0 to 0", () => {
+      const result = mmrRerank(diverseItems, { lambda: -0.5 });
+      expect(result[0].id).toBe("1");
+      expect(result[1].id).toBe("3");
+    });
+  });
+
+  describe("diversity behavior", () => {
+    it("promotes diverse results over similar high-scoring ones", () => {
+      const items: MMRItem[] = [
+        { id: "1", score: 1.0, content: "machine learning neural networks" },
+        { id: "2", score: 0.95, content: "machine learning deep learning" },
+        { id: "3", score: 0.9, content: "database systems sql queries" },
+        { id: "4", score: 0.85, content: "machine learning algorithms" },
+      ];
+
+      const result = mmrRerank(items, { lambda: 0.5 });
+
+      // First is always highest score
+      expect(result[0].id).toBe("1");
+      // Second should be the diverse database item, not another ML item
+      expect(result[1].id).toBe("3");
+    });
+
+    it("handles items with identical content", () => {
+      const items: MMRItem[] = [
+        { id: "1", score: 1.0, content: "identical content" },
+        { id: "2", score: 0.9, content: "identical content" },
+        { id: "3", score: 0.8, content: "different stuff" },
+      ];
+
+      const result = mmrRerank(items, { lambda: 0.5 });
+      expect(result[0].id).toBe("1");
+      // Second should be different, not identical duplicate
+      expect(result[1].id).toBe("3");
+    });
+
+    it("handles all identical content gracefully", () => {
+      const items: MMRItem[] = [
+        { id: "1", score: 1.0, content: "same" },
+        { id: "2", score: 0.9, content: "same" },
+        { id: "3", score: 0.8, content: "same" },
+      ];
+
+      const result = mmrRerank(items, { lambda: 0.7 });
+      // Should still complete without error, order by score as tiebreaker
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe("tie-breaking", () => {
+    it("uses original score as tiebreaker", () => {
+      const items: MMRItem[] = [
+        { id: "1", score: 1.0, content: "unique content one" },
+        { id: "2", score: 0.9, content: "unique content two" },
+        { id: "3", score: 0.8, content: "unique content three" },
+      ];
+
+      // With very different content and lambda=1, should be pure score order
+      const result = mmrRerank(items, { lambda: 1 });
+      expect(result.map((i) => i.id)).toEqual(["1", "2", "3"]);
+    });
+
+    it("preserves all items even with same MMR scores", () => {
+      const items: MMRItem[] = [
+        { id: "1", score: 0.5, content: "a" },
+        { id: "2", score: 0.5, content: "b" },
+        { id: "3", score: 0.5, content: "c" },
+      ];
+
+      const result = mmrRerank(items, { lambda: 0.7 });
+      expect(result).toHaveLength(3);
+      expect(new Set(result.map((i) => i.id))).toEqual(new Set(["1", "2", "3"]));
+    });
+  });
+
+  describe("score normalization", () => {
+    it("handles items with same scores", () => {
+      const items: MMRItem[] = [
+        { id: "1", score: 0.5, content: "hello world" },
+        { id: "2", score: 0.5, content: "foo bar" },
+      ];
+
+      const result = mmrRerank(items, { lambda: 0.7 });
+      expect(result).toHaveLength(2);
+    });
+
+    it("handles negative scores", () => {
+      const items: MMRItem[] = [
+        { id: "1", score: -0.5, content: "hello world" },
+        { id: "2", score: -1.0, content: "foo bar" },
+      ];
+
+      const result = mmrRerank(items, { lambda: 0.7 });
+      expect(result).toHaveLength(2);
+      // Higher score (less negative) should come first
+      expect(result[0].id).toBe("1");
+    });
+  });
+});
+
+describe("applyMMRToHybridResults", () => {
+  type HybridResult = {
+    path: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    snippet: string;
+    source: string;
+  };
+
+  it("returns empty array for empty input", () => {
+    expect(applyMMRToHybridResults([])).toEqual([]);
+  });
+
+  it("preserves all original fields", () => {
+    const results: HybridResult[] = [
+      {
+        path: "/test/file.ts",
+        startLine: 1,
+        endLine: 10,
+        score: 0.9,
+        snippet: "hello world",
+        source: "memory",
+      },
+    ];
+
+    const reranked = applyMMRToHybridResults(results);
+    expect(reranked[0]).toEqual(results[0]);
+  });
+
+  it("creates unique IDs from path and startLine", () => {
+    const results: HybridResult[] = [
+      {
+        path: "/test/a.ts",
+        startLine: 1,
+        endLine: 10,
+        score: 0.9,
+        snippet: "same content here",
+        source: "memory",
+      },
+      {
+        path: "/test/a.ts",
+        startLine: 20,
+        endLine: 30,
+        score: 0.8,
+        snippet: "same content here",
+        source: "memory",
+      },
+    ];
+
+    // Should work without ID collision
+    const reranked = applyMMRToHybridResults(results);
+    expect(reranked).toHaveLength(2);
+  });
+
+  it("re-ranks results for diversity", () => {
+    const results: HybridResult[] = [
+      {
+        path: "/a.ts",
+        startLine: 1,
+        endLine: 10,
+        score: 1.0,
+        snippet: "function add numbers together",
+        source: "memory",
+      },
+      {
+        path: "/b.ts",
+        startLine: 1,
+        endLine: 10,
+        score: 0.95,
+        snippet: "function add values together",
+        source: "memory",
+      },
+      {
+        path: "/c.ts",
+        startLine: 1,
+        endLine: 10,
+        score: 0.9,
+        snippet: "database connection pool",
+        source: "memory",
+      },
+    ];
+
+    const reranked = applyMMRToHybridResults(results, { lambda: 0.5 });
+
+    // First stays the same (highest score)
+    expect(reranked[0].path).toBe("/a.ts");
+    // Second should be the diverse one
+    expect(reranked[1].path).toBe("/c.ts");
+  });
+
+  it("respects disabled config", () => {
+    const results: HybridResult[] = [
+      { path: "/a.ts", startLine: 1, endLine: 10, score: 0.9, snippet: "test", source: "memory" },
+      { path: "/b.ts", startLine: 1, endLine: 10, score: 0.8, snippet: "test", source: "memory" },
+    ];
+
+    const reranked = applyMMRToHybridResults(results, { enabled: false });
+    expect(reranked).toEqual(results);
+  });
+});
+
+describe("DEFAULT_MMR_CONFIG", () => {
+  it("has expected default values", () => {
+    expect(DEFAULT_MMR_CONFIG.enabled).toBe(true);
+    expect(DEFAULT_MMR_CONFIG.lambda).toBe(0.7);
+  });
+});

--- a/src/memory/hybrid.test.ts
+++ b/src/memory/hybrid.test.ts
@@ -15,8 +15,8 @@ describe("memory hybrid helpers", () => {
     expect(bm25RankToScore(-100)).toBeCloseTo(1);
   });
 
-  it("mergeHybridResults unions by id and combines weighted scores", () => {
-    const merged = mergeHybridResults({
+  it("mergeHybridResults unions by id and combines weighted scores", async () => {
+    const merged = await mergeHybridResults({
       vectorWeight: 0.7,
       textWeight: 0.3,
       vector: [
@@ -50,8 +50,8 @@ describe("memory hybrid helpers", () => {
     expect(b?.score).toBeCloseTo(0.3 * 1.0);
   });
 
-  it("mergeHybridResults prefers keyword snippet when ids overlap", () => {
-    const merged = mergeHybridResults({
+  it("mergeHybridResults prefers keyword snippet when ids overlap", async () => {
+    const merged = await mergeHybridResults({
       vectorWeight: 0.5,
       textWeight: 0.5,
       vector: [

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -1,8 +1,14 @@
 import { applyMMRToHybridResults, type MMRConfig, DEFAULT_MMR_CONFIG } from "./mmr.js";
+import {
+  applyTemporalDecayToHybridResults,
+  type TemporalDecayConfig,
+  DEFAULT_TEMPORAL_DECAY_CONFIG,
+} from "./temporal-decay.js";
 
 export type HybridSource = string;
 
 export { type MMRConfig, DEFAULT_MMR_CONFIG };
+export { type TemporalDecayConfig, DEFAULT_TEMPORAL_DECAY_CONFIG };
 
 export type HybridVectorResult = {
   id: string;
@@ -42,21 +48,28 @@ export function bm25RankToScore(rank: number): number {
   return 1 / (1 + normalized);
 }
 
-export function mergeHybridResults(params: {
+export async function mergeHybridResults(params: {
   vector: HybridVectorResult[];
   keyword: HybridKeywordResult[];
   vectorWeight: number;
   textWeight: number;
+  workspaceDir?: string;
   /** MMR configuration for diversity-aware re-ranking */
   mmr?: Partial<MMRConfig>;
-}): Array<{
-  path: string;
-  startLine: number;
-  endLine: number;
-  score: number;
-  snippet: string;
-  source: HybridSource;
-}> {
+  /** Temporal decay configuration for recency-aware scoring */
+  temporalDecay?: Partial<TemporalDecayConfig>;
+  /** Test seam for deterministic time-dependent behavior */
+  nowMs?: number;
+}): Promise<
+  Array<{
+    path: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    snippet: string;
+    source: HybridSource;
+  }>
+> {
   const byId = new Map<
     string,
     {
@@ -117,7 +130,14 @@ export function mergeHybridResults(params: {
     };
   });
 
-  const sorted = merged.toSorted((a, b) => b.score - a.score);
+  const temporalDecayConfig = { ...DEFAULT_TEMPORAL_DECAY_CONFIG, ...params.temporalDecay };
+  const decayed = await applyTemporalDecayToHybridResults({
+    results: merged,
+    temporalDecay: temporalDecayConfig,
+    workspaceDir: params.workspaceDir,
+    nowMs: params.nowMs,
+  });
+  const sorted = decayed.toSorted((a, b) => b.score - a.score);
 
   // Apply MMR re-ranking if enabled
   const mmrConfig = { ...DEFAULT_MMR_CONFIG, ...params.mmr };

--- a/src/memory/mmr.test.ts
+++ b/src/memory/mmr.test.ts
@@ -148,7 +148,7 @@ describe("mmrRerank", () => {
     });
 
     it("lambda=0 maximizes diversity", () => {
-      const result = mmrRerank(diverseItems, { lambda: 0 });
+      const result = mmrRerank(diverseItems, { enabled: true, lambda: 0 });
       // First item is still highest score (no penalty yet)
       expect(result[0].id).toBe("1");
       // Second should be most different from first
@@ -161,7 +161,7 @@ describe("mmrRerank", () => {
     });
 
     it("clamps lambda < 0 to 0", () => {
-      const result = mmrRerank(diverseItems, { lambda: -0.5 });
+      const result = mmrRerank(diverseItems, { enabled: true, lambda: -0.5 });
       expect(result[0].id).toBe("1");
       expect(result[1].id).toBe("3");
     });
@@ -176,7 +176,7 @@ describe("mmrRerank", () => {
         { id: "4", score: 0.85, content: "machine learning algorithms" },
       ];
 
-      const result = mmrRerank(items, { lambda: 0.5 });
+      const result = mmrRerank(items, { enabled: true, lambda: 0.5 });
 
       // First is always highest score
       expect(result[0].id).toBe("1");
@@ -191,7 +191,7 @@ describe("mmrRerank", () => {
         { id: "3", score: 0.8, content: "different stuff" },
       ];
 
-      const result = mmrRerank(items, { lambda: 0.5 });
+      const result = mmrRerank(items, { enabled: true, lambda: 0.5 });
       expect(result[0].id).toBe("1");
       // Second should be different, not identical duplicate
       expect(result[1].id).toBe("3");
@@ -344,7 +344,7 @@ describe("applyMMRToHybridResults", () => {
       },
     ];
 
-    const reranked = applyMMRToHybridResults(results, { lambda: 0.5 });
+    const reranked = applyMMRToHybridResults(results, { enabled: true, lambda: 0.5 });
 
     // First stays the same (highest score)
     expect(reranked[0].path).toBe("/a.ts");
@@ -365,7 +365,7 @@ describe("applyMMRToHybridResults", () => {
 
 describe("DEFAULT_MMR_CONFIG", () => {
   it("has expected default values", () => {
-    expect(DEFAULT_MMR_CONFIG.enabled).toBe(true);
+    expect(DEFAULT_MMR_CONFIG.enabled).toBe(false);
     expect(DEFAULT_MMR_CONFIG.lambda).toBe(0.7);
   });
 });

--- a/src/memory/mmr.test.ts
+++ b/src/memory/mmr.test.ts
@@ -8,7 +8,7 @@ import {
   applyMMRToHybridResults,
   DEFAULT_MMR_CONFIG,
   type MMRItem,
-} from "../mmr.js";
+} from "./mmr.js";
 
 describe("tokenize", () => {
   it("extracts alphanumeric tokens and lowercases", () => {

--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -14,14 +14,14 @@ export type MMRItem = {
 };
 
 export type MMRConfig = {
-  /** Enable/disable MMR re-ranking. Default: true */
+  /** Enable/disable MMR re-ranking. Default: false (opt-in) */
   enabled: boolean;
   /** Lambda parameter: 0 = max diversity, 1 = max relevance. Default: 0.7 */
   lambda: number;
 };
 
 export const DEFAULT_MMR_CONFIG: MMRConfig = {
-  enabled: true,
+  enabled: false,
   lambda: 0.7,
 };
 
@@ -163,7 +163,7 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
       // Use original score as tiebreaker (higher is better)
       if (
         mmrScore > bestMMRScore ||
-        (mmrScore === bestMMRScore && bestItem && candidate.score > bestItem.score)
+        (mmrScore === bestMMRScore && (bestItem === null || candidate.score > bestItem.score))
       ) {
         bestMMRScore = mmrScore;
         bestItem = candidate;

--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -39,15 +39,21 @@ export function tokenize(text: string): Set<string> {
  * Returns a value in [0, 1] where 1 means identical sets.
  */
 export function jaccardSimilarity(setA: Set<string>, setB: Set<string>): number {
-  if (setA.size === 0 && setB.size === 0) return 1;
-  if (setA.size === 0 || setB.size === 0) return 0;
+  if (setA.size === 0 && setB.size === 0) {
+    return 1;
+  }
+  if (setA.size === 0 || setB.size === 0) {
+    return 0;
+  }
 
   let intersectionSize = 0;
   const smaller = setA.size <= setB.size ? setA : setB;
   const larger = setA.size <= setB.size ? setB : setA;
 
   for (const token of smaller) {
-    if (larger.has(token)) intersectionSize++;
+    if (larger.has(token)) {
+      intersectionSize++;
+    }
   }
 
   const unionSize = setA.size + setB.size - intersectionSize;
@@ -69,7 +75,9 @@ function maxSimilarityToSelected(
   selectedItems: MMRItem[],
   tokenCache: Map<string, Set<string>>,
 ): number {
-  if (selectedItems.length === 0) return 0;
+  if (selectedItems.length === 0) {
+    return 0;
+  }
 
   let maxSim = 0;
   const itemTokens = tokenCache.get(item.id) ?? tokenize(item.content);
@@ -77,7 +85,9 @@ function maxSimilarityToSelected(
   for (const selected of selectedItems) {
     const selectedTokens = tokenCache.get(selected.id) ?? tokenize(selected.content);
     const sim = jaccardSimilarity(itemTokens, selectedTokens);
-    if (sim > maxSim) maxSim = sim;
+    if (sim > maxSim) {
+      maxSim = sim;
+    }
   }
 
   return maxSim;
@@ -107,14 +117,16 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
   const { enabled = DEFAULT_MMR_CONFIG.enabled, lambda = DEFAULT_MMR_CONFIG.lambda } = config;
 
   // Early exits
-  if (!enabled || items.length <= 1) return [...items];
+  if (!enabled || items.length <= 1) {
+    return [...items];
+  }
 
   // Clamp lambda to valid range
   const clampedLambda = Math.max(0, Math.min(1, lambda));
 
   // If lambda is 1, just return sorted by relevance (no diversity penalty)
   if (clampedLambda === 1) {
-    return [...items].sort((a, b) => b.score - a.score);
+    return [...items].toSorted((a, b) => b.score - a.score);
   }
 
   // Pre-tokenize all items for efficiency
@@ -129,7 +141,9 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
   const scoreRange = maxScore - minScore;
 
   const normalizeScore = (score: number): number => {
-    if (scoreRange === 0) return 1; // All scores equal
+    if (scoreRange === 0) {
+      return 1; // All scores equal
+    }
     return (score - minScore) / scoreRange;
   };
 
@@ -175,7 +189,9 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
 export function applyMMRToHybridResults<
   T extends { score: number; snippet: string; path: string; startLine: number },
 >(results: T[], config: Partial<MMRConfig> = {}): T[] {
-  if (results.length === 0) return results;
+  if (results.length === 0) {
+    return results;
+  }
 
   // Create a map from ID to original item for type-safe retrieval
   const itemById = new Map<string, T>();

--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -1,0 +1,198 @@
+/**
+ * Maximal Marginal Relevance (MMR) re-ranking algorithm.
+ *
+ * MMR balances relevance with diversity by iteratively selecting results
+ * that maximize: λ * relevance - (1-λ) * max_similarity_to_selected
+ *
+ * @see Carbonell & Goldstein, "The Use of MMR, Diversity-Based Reranking" (1998)
+ */
+
+export type MMRItem = {
+  id: string;
+  score: number;
+  content: string;
+};
+
+export type MMRConfig = {
+  /** Enable/disable MMR re-ranking. Default: true */
+  enabled: boolean;
+  /** Lambda parameter: 0 = max diversity, 1 = max relevance. Default: 0.7 */
+  lambda: number;
+};
+
+export const DEFAULT_MMR_CONFIG: MMRConfig = {
+  enabled: true,
+  lambda: 0.7,
+};
+
+/**
+ * Tokenize text for Jaccard similarity computation.
+ * Extracts alphanumeric tokens and normalizes to lowercase.
+ */
+export function tokenize(text: string): Set<string> {
+  const tokens = text.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
+  return new Set(tokens);
+}
+
+/**
+ * Compute Jaccard similarity between two token sets.
+ * Returns a value in [0, 1] where 1 means identical sets.
+ */
+export function jaccardSimilarity(setA: Set<string>, setB: Set<string>): number {
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+
+  let intersectionSize = 0;
+  const smaller = setA.size <= setB.size ? setA : setB;
+  const larger = setA.size <= setB.size ? setB : setA;
+
+  for (const token of smaller) {
+    if (larger.has(token)) intersectionSize++;
+  }
+
+  const unionSize = setA.size + setB.size - intersectionSize;
+  return unionSize === 0 ? 0 : intersectionSize / unionSize;
+}
+
+/**
+ * Compute text similarity between two content strings using Jaccard on tokens.
+ */
+export function textSimilarity(contentA: string, contentB: string): number {
+  return jaccardSimilarity(tokenize(contentA), tokenize(contentB));
+}
+
+/**
+ * Compute the maximum similarity between an item and all selected items.
+ */
+function maxSimilarityToSelected(
+  item: MMRItem,
+  selectedItems: MMRItem[],
+  tokenCache: Map<string, Set<string>>,
+): number {
+  if (selectedItems.length === 0) return 0;
+
+  let maxSim = 0;
+  const itemTokens = tokenCache.get(item.id) ?? tokenize(item.content);
+
+  for (const selected of selectedItems) {
+    const selectedTokens = tokenCache.get(selected.id) ?? tokenize(selected.content);
+    const sim = jaccardSimilarity(itemTokens, selectedTokens);
+    if (sim > maxSim) maxSim = sim;
+  }
+
+  return maxSim;
+}
+
+/**
+ * Compute MMR score for a candidate item.
+ * MMR = λ * relevance - (1-λ) * max_similarity_to_selected
+ */
+export function computeMMRScore(relevance: number, maxSimilarity: number, lambda: number): number {
+  return lambda * relevance - (1 - lambda) * maxSimilarity;
+}
+
+/**
+ * Re-rank items using Maximal Marginal Relevance (MMR).
+ *
+ * The algorithm iteratively selects items that balance relevance with diversity:
+ * 1. Start with the highest-scoring item
+ * 2. For each remaining slot, select the item that maximizes the MMR score
+ * 3. MMR score = λ * relevance - (1-λ) * max_similarity_to_already_selected
+ *
+ * @param items - Items to re-rank, must have score and content
+ * @param config - MMR configuration (lambda, enabled)
+ * @returns Re-ranked items in MMR order
+ */
+export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConfig> = {}): T[] {
+  const { enabled = DEFAULT_MMR_CONFIG.enabled, lambda = DEFAULT_MMR_CONFIG.lambda } = config;
+
+  // Early exits
+  if (!enabled || items.length <= 1) return [...items];
+
+  // Clamp lambda to valid range
+  const clampedLambda = Math.max(0, Math.min(1, lambda));
+
+  // If lambda is 1, just return sorted by relevance (no diversity penalty)
+  if (clampedLambda === 1) {
+    return [...items].sort((a, b) => b.score - a.score);
+  }
+
+  // Pre-tokenize all items for efficiency
+  const tokenCache = new Map<string, Set<string>>();
+  for (const item of items) {
+    tokenCache.set(item.id, tokenize(item.content));
+  }
+
+  // Normalize scores to [0, 1] for fair comparison with similarity
+  const maxScore = Math.max(...items.map((i) => i.score));
+  const minScore = Math.min(...items.map((i) => i.score));
+  const scoreRange = maxScore - minScore;
+
+  const normalizeScore = (score: number): number => {
+    if (scoreRange === 0) return 1; // All scores equal
+    return (score - minScore) / scoreRange;
+  };
+
+  const selected: T[] = [];
+  const remaining = new Set(items);
+
+  // Select items iteratively
+  while (remaining.size > 0) {
+    let bestItem: T | null = null;
+    let bestMMRScore = -Infinity;
+
+    for (const candidate of remaining) {
+      const normalizedRelevance = normalizeScore(candidate.score);
+      const maxSim = maxSimilarityToSelected(candidate, selected, tokenCache);
+      const mmrScore = computeMMRScore(normalizedRelevance, maxSim, clampedLambda);
+
+      // Use original score as tiebreaker (higher is better)
+      if (
+        mmrScore > bestMMRScore ||
+        (mmrScore === bestMMRScore && bestItem && candidate.score > bestItem.score)
+      ) {
+        bestMMRScore = mmrScore;
+        bestItem = candidate;
+      }
+    }
+
+    if (bestItem) {
+      selected.push(bestItem);
+      remaining.delete(bestItem);
+    } else {
+      // Should never happen, but safety exit
+      break;
+    }
+  }
+
+  return selected;
+}
+
+/**
+ * Apply MMR re-ranking to hybrid search results.
+ * Adapts the generic MMR function to work with the hybrid search result format.
+ */
+export function applyMMRToHybridResults<
+  T extends { score: number; snippet: string; path: string; startLine: number },
+>(results: T[], config: Partial<MMRConfig> = {}): T[] {
+  if (results.length === 0) return results;
+
+  // Create a map from ID to original item for type-safe retrieval
+  const itemById = new Map<string, T>();
+
+  // Create MMR items with unique IDs
+  const mmrItems: MMRItem[] = results.map((r, index) => {
+    const id = `${r.path}:${r.startLine}:${index}`;
+    itemById.set(id, r);
+    return {
+      id,
+      score: r.score,
+      content: r.snippet,
+    };
+  });
+
+  const reranked = mmrRerank(mmrItems, config);
+
+  // Map back to original items using the ID
+  return reranked.map((item) => itemById.get(item.id)!);
+}

--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -163,7 +163,7 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
       // Use original score as tiebreaker (higher is better)
       if (
         mmrScore > bestMMRScore ||
-        (mmrScore === bestMMRScore && (bestItem === null || candidate.score > bestItem.score))
+        (mmrScore === bestMMRScore && candidate.score > (bestItem?.score ?? -Infinity))
       ) {
         bestMMRScore = mmrScore;
         bestItem = candidate;

--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { mergeHybridResults } from "./hybrid.js";
+import {
+  applyTemporalDecayToHybridResults,
+  applyTemporalDecayToScore,
+  calculateTemporalDecayMultiplier,
+} from "./temporal-decay.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW_MS = Date.UTC(2026, 1, 10, 0, 0, 0);
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-temporal-decay-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => {
+      await fs.rm(dir, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("temporal decay", () => {
+  it("matches exponential decay formula", () => {
+    const halfLifeDays = 30;
+    const ageInDays = 10;
+    const lambda = Math.LN2 / halfLifeDays;
+    const expectedMultiplier = Math.exp(-lambda * ageInDays);
+
+    expect(calculateTemporalDecayMultiplier({ ageInDays, halfLifeDays })).toBeCloseTo(
+      expectedMultiplier,
+    );
+    expect(applyTemporalDecayToScore({ score: 0.8, ageInDays, halfLifeDays })).toBeCloseTo(
+      0.8 * expectedMultiplier,
+    );
+  });
+
+  it("is 0.5 exactly at half-life", () => {
+    expect(calculateTemporalDecayMultiplier({ ageInDays: 30, halfLifeDays: 30 })).toBeCloseTo(0.5);
+  });
+
+  it("does not decay evergreen memory files", async () => {
+    const dir = await makeTempDir();
+
+    const rootMemoryPath = path.join(dir, "MEMORY.md");
+    const topicPath = path.join(dir, "memory", "projects.md");
+    await fs.mkdir(path.dirname(topicPath), { recursive: true });
+    await fs.writeFile(rootMemoryPath, "evergreen");
+    await fs.writeFile(topicPath, "topic evergreen");
+
+    const veryOld = new Date(Date.UTC(2010, 0, 1));
+    await fs.utimes(rootMemoryPath, veryOld, veryOld);
+    await fs.utimes(topicPath, veryOld, veryOld);
+
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [
+        { path: "MEMORY.md", score: 1, source: "memory" },
+        { path: "memory/projects.md", score: 0.75, source: "memory" },
+      ],
+      workspaceDir: dir,
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    expect(decayed[0]?.score).toBeCloseTo(1);
+    expect(decayed[1]?.score).toBeCloseTo(0.75);
+  });
+
+  it("applies decay in hybrid merging before ranking", async () => {
+    const merged = await mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      mmr: { enabled: false },
+      nowMs: NOW_MS,
+      vector: [
+        {
+          id: "old",
+          path: "memory/2025-01-01.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "old but high",
+          vectorScore: 0.95,
+        },
+        {
+          id: "new",
+          path: "memory/2026-02-10.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "new and relevant",
+          vectorScore: 0.8,
+        },
+      ],
+      keyword: [],
+    });
+
+    expect(merged[0]?.path).toBe("memory/2026-02-10.md");
+    expect(merged[0]?.score ?? 0).toBeGreaterThan(merged[1]?.score ?? 0);
+  });
+
+  it("handles future dates, zero age, and very old memories", async () => {
+    const merged = await mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      mmr: { enabled: false },
+      nowMs: NOW_MS,
+      vector: [
+        {
+          id: "future",
+          path: "memory/2099-01-01.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "future",
+          vectorScore: 0.9,
+        },
+        {
+          id: "today",
+          path: "memory/2026-02-10.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "today",
+          vectorScore: 0.8,
+        },
+        {
+          id: "very-old",
+          path: "memory/2000-01-01.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "ancient",
+          vectorScore: 1,
+        },
+      ],
+      keyword: [],
+    });
+
+    const byPath = new Map(merged.map((entry) => [entry.path, entry]));
+    expect(byPath.get("memory/2099-01-01.md")?.score).toBeCloseTo(0.9);
+    expect(byPath.get("memory/2026-02-10.md")?.score).toBeCloseTo(0.8);
+    expect(byPath.get("memory/2000-01-01.md")?.score ?? 1).toBeLessThan(0.001);
+  });
+
+  it("uses file mtime fallback for non-memory sources", async () => {
+    const dir = await makeTempDir();
+    const sessionPath = path.join(dir, "sessions", "thread.jsonl");
+    await fs.mkdir(path.dirname(sessionPath), { recursive: true });
+    await fs.writeFile(sessionPath, "{}\n");
+    const oldMtime = new Date(NOW_MS - 30 * DAY_MS);
+    await fs.utimes(sessionPath, oldMtime, oldMtime);
+
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [{ path: "sessions/thread.jsonl", score: 1, source: "sessions" }],
+      workspaceDir: dir,
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    expect(decayed[0]?.score).toBeCloseTo(0.5, 2);
+  });
+});

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type TemporalDecayConfig = {
+  enabled: boolean;
+  halfLifeDays: number;
+};
+
+export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
+  enabled: false,
+  halfLifeDays: 30,
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+
+export function toDecayLambda(halfLifeDays: number): number {
+  if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {
+    return 0;
+  }
+  return Math.LN2 / halfLifeDays;
+}
+
+export function calculateTemporalDecayMultiplier(params: {
+  ageInDays: number;
+  halfLifeDays: number;
+}): number {
+  const lambda = toDecayLambda(params.halfLifeDays);
+  const clampedAge = Math.max(0, params.ageInDays);
+  if (lambda <= 0 || !Number.isFinite(clampedAge)) {
+    return 1;
+  }
+  return Math.exp(-lambda * clampedAge);
+}
+
+export function applyTemporalDecayToScore(params: {
+  score: number;
+  ageInDays: number;
+  halfLifeDays: number;
+}): number {
+  return params.score * calculateTemporalDecayMultiplier(params);
+}
+
+function parseMemoryDateFromPath(filePath: string): Date | null {
+  const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "");
+  const match = DATED_MEMORY_PATH_RE.exec(normalized);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return null;
+  }
+
+  const timestamp = Date.UTC(year, month - 1, day);
+  const parsed = new Date(timestamp);
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function isEvergreenMemoryPath(filePath: string): boolean {
+  const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "");
+  if (normalized === "MEMORY.md" || normalized === "memory.md") {
+    return true;
+  }
+  if (!normalized.startsWith("memory/")) {
+    return false;
+  }
+  return !DATED_MEMORY_PATH_RE.test(normalized);
+}
+
+async function extractTimestamp(params: {
+  filePath: string;
+  source?: string;
+  workspaceDir?: string;
+}): Promise<Date | null> {
+  const fromPath = parseMemoryDateFromPath(params.filePath);
+  if (fromPath) {
+    return fromPath;
+  }
+
+  // Memory root/topic files are evergreen knowledge and should not decay.
+  if (params.source === "memory" && isEvergreenMemoryPath(params.filePath)) {
+    return null;
+  }
+
+  if (!params.workspaceDir) {
+    return null;
+  }
+
+  const absolutePath = path.isAbsolute(params.filePath)
+    ? params.filePath
+    : path.resolve(params.workspaceDir, params.filePath);
+
+  try {
+    const stat = await fs.stat(absolutePath);
+    if (!Number.isFinite(stat.mtimeMs)) {
+      return null;
+    }
+    return new Date(stat.mtimeMs);
+  } catch {
+    return null;
+  }
+}
+
+function ageInDaysFromTimestamp(timestamp: Date, nowMs: number): number {
+  const ageMs = Math.max(0, nowMs - timestamp.getTime());
+  return ageMs / DAY_MS;
+}
+
+export async function applyTemporalDecayToHybridResults<
+  T extends { path: string; score: number; source: string },
+>(params: {
+  results: T[];
+  temporalDecay?: Partial<TemporalDecayConfig>;
+  workspaceDir?: string;
+  nowMs?: number;
+}): Promise<T[]> {
+  const config = { ...DEFAULT_TEMPORAL_DECAY_CONFIG, ...params.temporalDecay };
+  if (!config.enabled) {
+    return [...params.results];
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  const timestampCache = new Map<string, Date | null>();
+
+  return Promise.all(
+    params.results.map(async (entry) => {
+      const cacheKey = `${entry.source}:${entry.path}`;
+      if (!timestampCache.has(cacheKey)) {
+        const timestamp = await extractTimestamp({
+          filePath: entry.path,
+          source: entry.source,
+          workspaceDir: params.workspaceDir,
+        });
+        timestampCache.set(cacheKey, timestamp);
+      }
+
+      const timestamp = timestampCache.get(cacheKey) ?? null;
+      if (!timestamp) {
+        return entry;
+      }
+
+      const decayedScore = applyTemporalDecayToScore({
+        score: entry.score,
+        ageInDays: ageInDaysFromTimestamp(timestamp, nowMs),
+        halfLifeDays: config.halfLifeDays,
+      });
+
+      return {
+        ...entry,
+        score: decayedScore,
+      };
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

Two complementary, opt-in post-processing features for hybrid memory search that improve result quality without changing existing behavior.

### MMR Re-ranking (Maximal Marginal Relevance)

Reduces redundancy by penalizing results too similar to already-selected ones.

- Config: `memorySearch.query.hybrid.mmr.enabled` (default: `false`)
- Lambda: `memorySearch.query.hybrid.mmr.lambda` (default: `0.7`, range 0–1)
- Uses cosine + Jaccard similarity

**Example — query: "home network setup"**

Without MMR, top 3 might be three near-identical snippets about the same router config from different daily notes. With MMR, duplicates drop out and diverse results (DNS setup, reference doc) surface instead.

### Temporal Decay (Recency Boost)

Exponential score decay based on memory age, so recent notes rank higher.

- Config: `memorySearch.query.hybrid.temporalDecay.enabled` (default: `false`)
- Half-life: `memorySearch.query.hybrid.temporalDecay.halfLifeDays` (default: `30`)
- Dated files (`memory/YYYY-MM-DD.md`) use filename date
- Evergreen files (`MEMORY.md`, topic files) are **not** decayed
- Other sources fall back to file mtime

With half-life=30: today=100%, 7d=84%, 30d=50%, 90d=12.5%

### Pipeline

```
Vector + Keyword → Weighted Merge → Temporal Decay → Sort → MMR → Top-K
```

### Design decisions

- Both **opt-in** (default disabled) — fully backwards compatible
- Both **independent** — enable one, the other, or both
- Applied at different pipeline stages (no conflict)
- Config wired through zod schema, types, field labels/help

### Tests

127 tests passing across 17 test files. New test coverage:
- `mmr.test.ts` — 40 tests (algorithm, diversity, edge cases)
- `temporal-decay.test.ts` — 5 tests (decay math, half-life, evergreen files, mtime fallback, integration)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds two opt-in post-processing stages to the hybrid memory search pipeline: **MMR re-ranking** for result diversity (reduces near-duplicate snippets) and **temporal decay** for recency-aware scoring (exponential decay based on memory age). Both are disabled by default and fully backwards compatible.

- New files: `src/memory/mmr.ts` (MMR algorithm with Jaccard similarity), `src/memory/temporal-decay.ts` (exponential decay with evergreen file exemption)
- `mergeHybridResults` in `hybrid.ts` changed from sync to async to accommodate filesystem calls in temporal decay
- Config wired through zod schema, types, and `memory-search.ts` config resolution with proper validation/clamping
- Pipeline order: `Weighted Merge → Temporal Decay → Sort → MMR → Top-K`
- Tests: comprehensive coverage for both features including edge cases
- Previous review threads identified the MMR tiebreaker bug (now fixed via `?? -Infinity` fallback) and the `timestampCache` race condition (now fixed by caching `Promise` objects instead of resolved values)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — both features are opt-in (disabled by default) with no changes to existing behavior.
- Well-structured, opt-in features with comprehensive test coverage. The code is clean with proper input validation, clamping, and edge case handling. The sync-to-async change in `mergeHybridResults` is the main surface area for regressions, and existing tests were correctly updated. No critical issues found beyond the previously flagged items which appear addressed.
- No files require special attention. The core algorithm files (`mmr.ts`, `temporal-decay.ts`) are well-tested and the integration points in `hybrid.ts` and `manager.ts` are minimal.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->