### PR TITLE
Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,10 @@ apps/ios/*.mobileprovision
 IDENTITY.md
 USER.md
 .tgz
+.claude/
+local/
+nul
+start-gateway.ps1
 
 # local tooling
 .serena/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   openclaw-gateway:
+    build:
+      context: .
+      args:
+        - OPENCLAW_DOCKER_APT_PACKAGES=libnspr4 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    privileged: true
     environment:
       HOME: /home/node
       TERM: xterm-256color
@@ -14,6 +19,10 @@ services:
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+      - "3005:3005"
+      - "3006:3006"
+      - "3007:3007"
+      - "3008:3008"
     init: true
     restart: unless-stopped
     command:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the repo’s tracked `docker-compose.yml` to (1) build the gateway image locally with extra APT packages (Playwright/browser deps), (2) run the gateway container in privileged mode, and (3) expose additional development ports (3005–3008).

These changes affect the default Docker workflow for anyone using the repository compose file: `build:` turns the compose setup into a local build pipeline, and `privileged: true` changes the runtime security posture. If these are meant to be purely local/dev conveniences, they should be moved to an untracked override compose instead of changing the shared default.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because it changes default Docker behavior and weakens container isolation.
- The tracked `docker-compose.yml` now forces local image builds and enables `privileged: true` by default, both of which are significant behavioral/security changes for downstream users of the repo compose file. These should be opt-in/local-only changes before merging.
- docker-compose.yml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->