### PR TITLE
[AI] Add forum thread support for Discord message actions

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -460,6 +460,7 @@ The agent can call `discord` with actions like:
 - `readMessages`, `sendMessage`, `editMessage`, `deleteMessage`
 - Read/search/pin tool payloads include normalized `timestampMs` (UTC epoch ms) and `timestampUtc` alongside raw Discord `timestamp`.
 - `threadCreate`, `threadList`, `threadReply`
+  - Forum channels require an initial post; pass `message` for the starter content and optional `appliedTags` (tag ids).
 - `pinMessage`, `unpinMessage`, `listPins`
 - `searchMessages`, `memberInfo`, `roleInfo`, `roleAdd`, `roleRemove`, `emojiList`
 - `channelInfo`, `channelList`, `voiceStatus`, `eventList`, `eventCreate`

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -282,6 +282,7 @@ export async function handleDiscordMessagingAction(
       const name = readStringParam(params, "name", { required: true });
       const messageId = readStringParam(params, "messageId");
       const content = readStringParam(params, "content");
+      const appliedTags = readStringArrayParam(params, "appliedTags");
       const autoArchiveMinutesRaw = params.autoArchiveMinutes;
       const autoArchiveMinutes =
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)
@@ -290,10 +291,16 @@ export async function handleDiscordMessagingAction(
       const thread = accountId
         ? await createThreadDiscord(
             channelId,
-            { name, messageId, autoArchiveMinutes, content },
+            { name, messageId, autoArchiveMinutes, content, appliedTags },
             { accountId },
           )
-        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes, content });
+        : await createThreadDiscord(channelId, {
+            name,
+            messageId,
+            autoArchiveMinutes,
+            content,
+            appliedTags,
+          });
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -176,6 +176,7 @@ function buildThreadSchema() {
   return {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
+    appliedTags: Type.Optional(Type.Array(Type.String())),
   };
 }
 

--- a/src/channels/plugins/actions/discord/handle-action.test.ts
+++ b/src/channels/plugins/actions/discord/handle-action.test.ts
@@ -19,6 +19,7 @@ describe("handleDiscordMessageAction", () => {
         to: "channel:123456789",
         threadName: "Forum thread",
         message: "Initial forum post body",
+        appliedTags: ["tag-1", "tag-2"],
       },
       cfg: {},
     });
@@ -28,6 +29,7 @@ describe("handleDiscordMessageAction", () => {
         channelId: "123456789",
         name: "Forum thread",
         content: "Initial forum post body",
+        appliedTags: ["tag-1", "tag-2"],
       }),
       expect.any(Object),
     );

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -185,6 +185,7 @@ export async function handleDiscordMessageAction(
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
     const content = readStringParam(params, "message");
+    const appliedTags = readStringArrayParam(params, "appliedTags");
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
@@ -196,6 +197,7 @@ export async function handleDiscordMessageAction(
         name,
         messageId,
         content,
+        appliedTags,
         autoArchiveMinutes,
       },
       cfg,

--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -87,6 +87,27 @@ describe("sendMessageDiscord", () => {
     );
   });
 
+  it("passes applied tags for forum threads", async () => {
+    const { rest, getMock, postMock } = makeRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord(
+      "chan1",
+      { name: "thread", content: "body", appliedTags: ["t1", "t2"] },
+      { rest, token: "t" },
+    );
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.threads("chan1"),
+      expect.objectContaining({
+        body: {
+          name: "thread",
+          message: { content: "body" },
+          applied_tags: ["t1", "t2"],
+        },
+      }),
+    );
+  });
+
   it("creates media threads with provided content", async () => {
     const { rest, getMock, postMock } = makeRest();
     getMock.mockResolvedValue({ type: ChannelType.GuildMedia });

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -121,6 +121,9 @@ export async function createThreadDiscord(
   if (isForumLike) {
     const starterContent = payload.content?.trim() ? payload.content : payload.name;
     body.message = { content: starterContent };
+    if (payload.appliedTags?.length) {
+      body.applied_tags = payload.appliedTags;
+    }
   }
   const route = payload.messageId
     ? Routes.threads(channelId, payload.messageId)

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -72,6 +72,7 @@ export type DiscordThreadCreate = {
   name: string;
   autoArchiveMinutes?: number;
   content?: string;
+  appliedTags?: string[];
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary
- allow the message tool to pass optional applied forum tags when creating Discord threads
- include starter post content and tags when the parent channel is a forum/media channel so posts succeed
- document the new workflow so forum automation can rely on the updated tooling

## Testing
- `pnpm build`
- `pnpm check`
- `pnpm test` (still running locally; the suite is huge but has been passing so far)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Discord thread creation to support forum/media channel requirements by (1) allowing a starter post to be included when creating threads in forum-like channels and (2) threading an optional `appliedTags` array (forum tag IDs) from the message tool/action layer down to the Discord REST call (`applied_tags`). It also adds tests for forum/media thread creation and updates the Discord channel documentation to describe the forum starter-post/tag behavior.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is one functional gap in the forum-tag feature for messageId-based thread creation.
- Changes are small and covered by new tests for forum/media thread creation and tag passing, but applied forum tags are currently ignored when creating threads from an existing message (payload.messageId set), which contradicts the new API surface and will cause unexpected behavior in that flow.
- src/discord/send.messages.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->