### PR TITLE
Hooks: support gogcli executable fallback for Gmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/CLI: when `gateway.bind=lan`, use a LAN IP for probe URLs and Control UI links. (#11448) Thanks @AnonO6.
 - CLI: make `openclaw plugins list` output scannable by hoisting source roots and shortening bundled/global/workspace plugin paths.
 - Hooks: fix bundled hooks broken since 2026.2.2 (tsdown migration). (#9295) Thanks @patrickshao.
+- Hooks/Gmail: accept both `gog` and `gogcli` executable names for setup and watcher commands. (#9420)
 - Routing: refresh bindings per message by loading config at route resolution so binding changes apply without restart. (#11372) Thanks @juanpablodlc.
 - Exec approvals: render forwarded commands in monospace for safer approval scanning. (#11937) Thanks @sebslight.
 - Config: clamp `maxTokens` to `contextWindow` to prevent invalid model configs. (#5516) Thanks @lailoo.

--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -19,6 +19,8 @@ Goal: Gmail watch -> Pub/Sub push -> `gog gmail watch serve` -> OpenClaw webhook
   Other tunnel services can work, but are DIY/unsupported and require manual wiring.
   Right now, Tailscale is what we support.
 
+OpenClaw accepts either executable name (`gog` or `gogcli`). This guide uses `gog` in examples.
+
 Example hook config (enable Gmail preset mapping):
 
 ```json5

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -293,7 +293,7 @@ All external binaries required by skills must be installed at image build time.
 
 The examples below show three common binaries only:
 
-- `gog` for Gmail access
+- `gog` or `gogcli` for Gmail access
 - `goplaces` for Google Places
 - `wacli` for WhatsApp
 

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -207,7 +207,7 @@ All external binaries required by skills must be installed at image build time.
 
 The examples below show three common binaries only:
 
-- `gog` for Gmail access
+- `gog` or `gogcli` for Gmail access
 - `goplaces` for Google Places
 - `wacli` for WhatsApp
 


### PR DESCRIPTION
Fixes #9420 linux issue by providing an alias in the code for gog to gogcli.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Gmail hook tooling to accept both `gog` and `gogcli` executable names. The hook setup/service paths now resolve the installed binary and use it consistently when starting/renewing the Gmail watch and when spawning the `gog gmail watch serve` process. `ensureDependency` was extended to support alternative binary names and improved error messaging on non-macOS platforms. Documentation and changelog were updated to reflect the new accepted executable names, and tests were added to validate binary resolution and Linux error messaging.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to Gmail hook setup/watcher logic and dependency checks; the new binary resolution is used consistently at call sites and covered by targeted unit tests. No functional regressions were identified in the changed code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->