### PR TITLE
fix: slug generator should use agent's primary model instead of hardcoded anthropic default

### DIFF
--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -92,6 +92,10 @@ export type OpenClawConfig = {
   channels?: ChannelsConfig;
   cron?: CronConfig;
   hooks?: HooksConfig;
+  slugGenerator?: {
+    /** Model to use for slug generation (provider/model or alias). */
+    model?: string;
+  };
   discovery?: DiscoveryConfig;
   canvasHost?: CanvasHostConfig;
   talk?: TalkConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -305,6 +305,12 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    slugGenerator: z
+      .object({
+        model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
     web: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -10,6 +10,7 @@ import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentDir,
+  resolveAgentModelPrimary,
 } from "../agents/agent-scope.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 
@@ -38,6 +39,11 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
+    // Resolve model: explicit slugGenerator config > agent primary model
+    const slugGeneratorModel = params.cfg.slugGenerator?.model;
+    const agentPrimaryModel = resolveAgentModelPrimary(params.cfg, agentId);
+    const model = slugGeneratorModel || agentPrimaryModel;
+
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
       sessionKey: "temp:slug-generator",
@@ -46,6 +52,7 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
+      model,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
Fixes #13396

## Problem

When using OpenClaw with **Bedrock-only** configuration (no Anthropic API key), the slug generator fails with:

```
FailoverError: No API key found for provider "anthropic"
```

This occurs because `runEmbeddedPiAgent` (used by slug generator) falls back to the hardcoded default `anthropic/claude-opus-4-6` instead of respecting the agent's configured primary model.

## Solution

The slug generator now resolves models in this order:
1. Explicit `slugGenerator.model` config (if provided)
2. Agent's primary model (from agent config)
3. Falls back to `runEmbeddedPiAgent`'s default resolution

## Changes

- Added `slugGenerator.model` field to `OpenClawConfig` type
- Modified `llm-slug-generator.ts` to resolve model using `resolveAgentModelPrimary`
- Pass resolved model to `runEmbeddedPiAgent`

## Testing

Tested with Bedrock-only configuration:
- Agent primary model: `amazon-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0`
- No Anthropic API key configured
- Slug generator now uses Bedrock model successfully

## Impact

This fixes startup failures for users with:
- Bedrock-only setup
- Azure OpenAI-only setup
- Any non-Anthropic provider configuration

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the LLM-based session slug generator to pick a model from configuration instead of relying on `runEmbeddedPiAgent`’s hardcoded defaults (which can force the `anthropic` provider and break “Bedrock-only”/non‑Anthropic setups). It adds an optional `slugGenerator.model` field to `OpenClawConfig`, then in `src/hooks/llm-slug-generator.ts` resolves the effective model as `cfg.slugGenerator.model` first, otherwise the default agent’s primary model via `resolveAgentModelPrimary(cfg, agentId)`, and passes that through to `runEmbeddedPiAgent`.

Overall, the change is small and consistent with existing model selection helpers (`resolveAgentModelPrimary`). I did not find any new functional issues in the changed code paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited in scope, use an existing model-resolution helper, and correctly pass an optional `model` override down to `runEmbeddedPiAgent` without altering other execution logic.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->