### PR TITLE
feat: add Anthropic Vertex AI provider extension

### DIFF
--- a/docs/providers/vertex-anthropic.md
+++ b/docs/providers/vertex-anthropic.md
@@ -1,0 +1,93 @@
+---
+summary: "Use Anthropic Claude models via Google Cloud Vertex AI in OpenClaw"
+read_when:
+  - You want to use Claude models through Vertex AI
+  - You want to use a GCP service account for Claude
+  - You want to avoid direct Anthropic API keys
+title: "Vertex AI Anthropic"
+---
+
+# Vertex AI Anthropic
+
+Run Anthropic **Claude** models through **Google Cloud Vertex AI** instead of the direct Anthropic API. This is useful when your organization manages access through GCP projects and service accounts.
+
+## Prerequisites
+
+1. A GCP project with the **Vertex AI API** enabled
+2. Claude models enabled in your Vertex AI Model Garden
+3. One of the following authentication methods:
+   - A service account JSON key file
+   - `GOOGLE_APPLICATION_CREDENTIALS` pointing to a key file
+   - Application Default Credentials via `gcloud auth application-default login`
+
+## Environment variables
+
+| Variable                         | Required | Default        | Description                              |
+| -------------------------------- | -------- | -------------- | ---------------------------------------- |
+| `ANTHROPIC_VERTEX_PROJECT_ID`    | Yes      | -              | Your GCP project ID                      |
+| `ANTHROPIC_VERTEX_REGION`        | No       | `europe-west1` | Vertex AI region                         |
+| `SERVICE_ACCOUNT_KEY_FILE`       | No       | -              | Path to service account JSON key         |
+| `GOOGLE_APPLICATION_CREDENTIALS` | No       | -              | Standard GCP credentials path (fallback) |
+
+At least one authentication source must be available (key file or ADC).
+
+## Setup
+
+### CLI setup
+
+```bash
+# Set required environment variables
+export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+export SERVICE_ACCOUNT_KEY_FILE="/path/to/service-account-key.json"
+
+# Optional: set region (defaults to europe-west1)
+export ANTHROPIC_VERTEX_REGION="us-central1"
+
+# Run onboarding
+openclaw onboard
+# choose: GCP Service Account / ADC
+```
+
+### Config snippet
+
+```json5
+{
+  env: {
+    ANTHROPIC_VERTEX_PROJECT_ID: "my-gcp-project",
+    SERVICE_ACCOUNT_KEY_FILE: "/path/to/service-account-key.json",
+  },
+  agents: {
+    defaults: {
+      model: {
+        primary: "vertex-anthropic/claude-sonnet-4-5@20250929",
+      },
+    },
+  },
+}
+```
+
+## Available models
+
+| Model ID                     | Name              | Context | Max output |
+| ---------------------------- | ----------------- | ------- | ---------- |
+| `claude-opus-4-6`            | Claude Opus 4.6   | 200k    | 128k       |
+| `claude-sonnet-4-5@20250929` | Claude Sonnet 4.5 | 200k    | 64k        |
+
+Both models support reasoning/thinking and image input.
+
+## Authentication flow
+
+Authentication is handled internally by `google-auth-library`. The priority order is:
+
+1. `SERVICE_ACCOUNT_KEY_FILE` - explicit service account key path
+2. `GOOGLE_APPLICATION_CREDENTIALS` - standard GCP environment variable
+3. Application Default Credentials - from `gcloud auth application-default login`
+
+Tokens are automatically refreshed before expiry.
+
+## Differences from direct Anthropic API
+
+- No `ANTHROPIC_API_KEY` needed
+- Billing goes through your GCP project
+- Requests route through `{region}-aiplatform.googleapis.com`
+- Prompt caching behavior may differ from the direct API

--- a/docs/providers/vertex-anthropic.md
+++ b/docs/providers/vertex-anthropic.md
@@ -50,6 +50,8 @@ openclaw onboard
 
 ### Config snippet
 
+Add the extension plugin and configure the model in `openclaw.json`:
+
 ```json5
 {
   env: {
@@ -63,6 +65,32 @@ openclaw onboard
       },
     },
   },
+  plugins: {
+    enabled: true,
+    load: {
+      paths: ["path/to/extensions/vertex-anthropic-auth"],
+    },
+    entries: {
+      "vertex-anthropic-auth": { enabled: true },
+    },
+  },
+}
+```
+
+### Auth profile
+
+After running `openclaw configure` or manually, ensure your auth profile exists in `~/.openclaw/agents/main/agent/auth-profiles.json`:
+
+```json
+{
+  "version": 1,
+  "profiles": {
+    "vertex-anthropic:<your-project-id>": {
+      "type": "token",
+      "provider": "vertex-anthropic",
+      "token": "vertex-ai-managed"
+    }
+  }
 }
 ```
 

--- a/extensions/vertex-anthropic-auth/index.ts
+++ b/extensions/vertex-anthropic-auth/index.ts
@@ -1,0 +1,117 @@
+import { registerApiProvider } from "@mariozechner/pi-ai";
+import {
+  emptyPluginConfigSchema,
+  type OpenClawPluginApi,
+  type ProviderAuthContext,
+} from "openclaw/plugin-sdk";
+import { streamAnthropicVertex, streamSimpleAnthropicVertex } from "./stream.js";
+
+const VERTEX_API_TYPE = "anthropic-vertex-messages";
+
+const DEFAULT_MODEL = "vertex-anthropic/claude-sonnet-4-5@20250929";
+
+function validateEnv(): { projectId: string; region: string; keyFile?: string } {
+  const projectId = process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+  if (!projectId) {
+    throw new Error("ANTHROPIC_VERTEX_PROJECT_ID environment variable is required");
+  }
+
+  const region = process.env.ANTHROPIC_VERTEX_REGION || "europe-west1";
+  const keyFile =
+    process.env.SERVICE_ACCOUNT_KEY_FILE || process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+  return { projectId, region, keyFile };
+}
+
+const vertexAnthropicPlugin = {
+  id: "vertex-anthropic-auth",
+  name: "Vertex AI Anthropic",
+  description: "Anthropic Claude models via Google Cloud Vertex AI",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    registerApiProvider({
+      api: VERTEX_API_TYPE,
+      stream: streamAnthropicVertex,
+      streamSimple: streamSimpleAnthropicVertex,
+    });
+
+    api.registerProvider({
+      id: "vertex-anthropic",
+      label: "Vertex AI Anthropic",
+      docsPath: "/providers/vertex-anthropic",
+      envVars: [
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "ANTHROPIC_VERTEX_REGION",
+        "SERVICE_ACCOUNT_KEY_FILE",
+      ],
+      models: {
+        baseUrl: "",
+        api: VERTEX_API_TYPE as never,
+        auth: "token",
+        models: [
+          {
+            id: "claude-opus-4-6",
+            name: "Claude Opus 4.6 (Vertex)",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+            contextWindow: 200000,
+            maxTokens: 128000,
+          },
+          {
+            id: "claude-sonnet-4-5@20250929",
+            name: "Claude Sonnet 4.5 (Vertex)",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+            contextWindow: 200000,
+            maxTokens: 64000,
+          },
+        ],
+      },
+      auth: [
+        {
+          id: "service-account",
+          label: "GCP Service Account / ADC",
+          hint: "Set ANTHROPIC_VERTEX_PROJECT_ID and optionally SERVICE_ACCOUNT_KEY_FILE",
+          kind: "custom",
+          run: async (ctx: ProviderAuthContext) => {
+            const spin = ctx.prompter.progress("Validating Vertex AI credentials...");
+            try {
+              const { projectId, region, keyFile } = validateEnv();
+
+              const authMethod = keyFile
+                ? `service account key (${keyFile})`
+                : "Application Default Credentials";
+
+              spin.stop(`Vertex AI configured (project: ${projectId}, region: ${region})`);
+
+              return {
+                profiles: [
+                  {
+                    profileId: `vertex-anthropic:${projectId}`,
+                    credential: {
+                      type: "token" as const,
+                      token: "vertex-ai-managed",
+                    },
+                  },
+                ],
+                defaultModel: DEFAULT_MODEL,
+                notes: [
+                  `Using ${authMethod} for Vertex AI authentication.`,
+                  `Project: ${projectId}, Region: ${region}`,
+                  "Token refresh is handled automatically by google-auth-library.",
+                ],
+              };
+            } catch (err) {
+              spin.stop("Vertex AI configuration failed");
+              throw err;
+            }
+          },
+        },
+      ],
+    });
+  },
+};
+
+export default vertexAnthropicPlugin;

--- a/extensions/vertex-anthropic-auth/index.ts
+++ b/extensions/vertex-anthropic-auth/index.ts
@@ -1,4 +1,3 @@
-import { registerApiProvider } from "@mariozechner/pi-ai";
 import {
   emptyPluginConfigSchema,
   type OpenClawPluginApi,
@@ -29,13 +28,12 @@ const vertexAnthropicPlugin = {
   description: "Anthropic Claude models via Google Cloud Vertex AI",
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
-    registerApiProvider({
-      api: VERTEX_API_TYPE,
-      stream: streamAnthropicVertex,
-      streamSimple: streamSimpleAnthropicVertex,
-    });
-
     api.registerProvider({
+      apiProvider: {
+        api: VERTEX_API_TYPE,
+        stream: streamAnthropicVertex,
+        streamSimple: streamSimpleAnthropicVertex,
+      },
       id: "vertex-anthropic",
       label: "Vertex AI Anthropic",
       docsPath: "/providers/vertex-anthropic",
@@ -45,7 +43,8 @@ const vertexAnthropicPlugin = {
         "SERVICE_ACCOUNT_KEY_FILE",
       ],
       models: {
-        baseUrl: "",
+        baseUrl: "https://vertex.googleapis.com",
+        apiKey: "vertex-ai-managed",
         api: VERTEX_API_TYPE as never,
         auth: "token",
         models: [

--- a/extensions/vertex-anthropic-auth/openclaw.plugin.json
+++ b/extensions/vertex-anthropic-auth/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "vertex-anthropic-auth",
+  "providers": ["vertex-anthropic"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/vertex-anthropic-auth/package.json
+++ b/extensions/vertex-anthropic-auth/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openclaw/vertex-anthropic-auth",
+  "version": "2026.2.10",
+  "private": true,
+  "description": "OpenClaw Anthropic Vertex AI provider plugin",
+  "type": "module",
+  "dependencies": {
+    "@anthropic-ai/vertex-sdk": "^0.14.3",
+    "google-auth-library": "^9.0.0"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/vertex-anthropic-auth/stream.ts
+++ b/extensions/vertex-anthropic-auth/stream.ts
@@ -1,0 +1,465 @@
+import type {
+  Api,
+  AssistantMessageEventStream,
+  Context,
+  Model,
+  SimpleStreamOptions,
+  StreamOptions,
+} from "@mariozechner/pi-ai";
+import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
+import { calculateCost } from "@mariozechner/pi-ai/dist/models.js";
+import {
+  buildBaseOptions,
+  adjustMaxTokensForThinking,
+} from "@mariozechner/pi-ai/dist/providers/simple-options.js";
+import { transformMessages } from "@mariozechner/pi-ai/dist/providers/transform-messages.js";
+import { AssistantMessageEventStream as EventStream } from "@mariozechner/pi-ai/dist/utils/event-stream.js";
+import { parseStreamingJson } from "@mariozechner/pi-ai/dist/utils/json-parse.js";
+import { sanitizeSurrogates } from "@mariozechner/pi-ai/dist/utils/sanitize-unicode.js";
+import { GoogleAuth } from "google-auth-library";
+
+type VertexStreamOptions = StreamOptions & {
+  thinkingEnabled?: boolean;
+  thinkingBudgetTokens?: number;
+  effort?: string;
+  interleavedThinking?: boolean;
+  toolChoice?: string | { type: string; name?: string };
+};
+
+let cachedClient: AnthropicVertex | null = null;
+
+function getClient(): AnthropicVertex {
+  if (cachedClient) return cachedClient;
+
+  const region = process.env.ANTHROPIC_VERTEX_REGION || "europe-west1";
+  const projectId = process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+
+  if (!projectId) {
+    throw new Error("ANTHROPIC_VERTEX_PROJECT_ID is required. Set it to your GCP project ID.");
+  }
+
+  const keyFile =
+    process.env.SERVICE_ACCOUNT_KEY_FILE || process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+  const googleAuth = keyFile
+    ? new GoogleAuth({
+        keyFile,
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      })
+    : new GoogleAuth({
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      });
+
+  cachedClient = new AnthropicVertex({ region, projectId, googleAuth });
+  return cachedClient;
+}
+
+function mapStopReason(reason: string): "stop" | "length" | "toolUse" | "error" {
+  switch (reason) {
+    case "end_turn":
+    case "pause_turn":
+    case "stop_sequence":
+      return "stop";
+    case "max_tokens":
+      return "length";
+    case "tool_use":
+      return "toolUse";
+    case "refusal":
+    case "sensitive":
+      return "error";
+    default:
+      throw new Error(`Unhandled stop reason: ${reason}`);
+  }
+}
+
+function normalizeToolCallId(id: string) {
+  return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+}
+
+function convertContentBlocks(content: any[]) {
+  const hasImages = content.some((c: any) => c.type === "image");
+  if (!hasImages) {
+    return sanitizeSurrogates(content.map((c: any) => c.text ?? "").join("\n"));
+  }
+  const blocks = content.map((block: any) => {
+    if (block.type === "text") {
+      return { type: "text", text: sanitizeSurrogates(block.text ?? "") };
+    }
+    return {
+      type: "image",
+      source: { type: "base64", media_type: block.mimeType, data: block.data },
+    };
+  });
+  if (!blocks.some((b: any) => b.type === "text")) {
+    blocks.unshift({ type: "text", text: "(see attached image)" });
+  }
+  return blocks;
+}
+
+function buildVertexMessages(contextMessages: any[], model: any) {
+  const params: any[] = [];
+  const transformed = transformMessages(contextMessages, model, normalizeToolCallId);
+
+  for (let i = 0; i < transformed.length; i++) {
+    const msg: any = transformed[i];
+    if (msg.role === "user") {
+      if (typeof msg.content === "string") {
+        if (msg.content.trim().length > 0) {
+          params.push({ role: "user", content: sanitizeSurrogates(msg.content) });
+        }
+      } else {
+        const blocks = msg.content.map((item: any) => {
+          if (item.type === "text") {
+            return { type: "text", text: sanitizeSurrogates(item.text) };
+          }
+          return {
+            type: "image",
+            source: { type: "base64", media_type: item.mimeType, data: item.data },
+          };
+        });
+        let filtered = !model?.input.includes("image")
+          ? blocks.filter((b: any) => b.type !== "image")
+          : blocks;
+        filtered = filtered.filter((b: any) => b.type !== "text" || b.text.trim().length > 0);
+        if (filtered.length === 0) continue;
+        params.push({ role: "user", content: filtered });
+      }
+    } else if (msg.role === "assistant") {
+      const blocks: any[] = [];
+      for (const block of msg.content) {
+        if (block.type === "text") {
+          if (block.text.trim().length === 0) continue;
+          blocks.push({ type: "text", text: sanitizeSurrogates(block.text) });
+        } else if (block.type === "thinking") {
+          if (block.thinking.trim().length === 0) continue;
+          if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
+            blocks.push({ type: "text", text: sanitizeSurrogates(block.thinking) });
+          } else {
+            blocks.push({
+              type: "thinking",
+              thinking: sanitizeSurrogates(block.thinking),
+              signature: block.thinkingSignature,
+            });
+          }
+        } else if (block.type === "toolCall") {
+          blocks.push({
+            type: "tool_use",
+            id: block.id,
+            name: block.name,
+            input: block.arguments ?? {},
+          });
+        }
+      }
+      if (blocks.length === 0) continue;
+      params.push({ role: "assistant", content: blocks });
+    } else if (msg.role === "toolResult") {
+      const toolResults: any[] = [];
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: msg.toolCallId,
+        content: convertContentBlocks(msg.content),
+        is_error: msg.isError,
+      });
+      let j = i + 1;
+      while (j < transformed.length && (transformed[j] as any).role === "toolResult") {
+        const next: any = transformed[j];
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: next.toolCallId,
+          content: convertContentBlocks(next.content),
+          is_error: next.isError,
+        });
+        j++;
+      }
+      i = j - 1;
+      params.push({ role: "user", content: toolResults });
+    }
+  }
+  return params;
+}
+
+function convertTools(tools: any) {
+  if (!tools) return [];
+  return tools.map((tool: any) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: {
+      type: "object",
+      properties: tool.parameters?.properties || {},
+      required: tool.parameters?.required || [],
+    },
+  }));
+}
+
+function supportsAdaptiveThinking(modelId: string) {
+  return modelId.includes("opus-4-6") || modelId.includes("opus-4.6");
+}
+
+function mapThinkingLevelToEffort(level: string): "low" | "medium" | "high" | "max" {
+  switch (level) {
+    case "minimal":
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    case "xhigh":
+      return "max";
+    default:
+      return "high";
+  }
+}
+
+function buildParams(model: any, context: any, options?: VertexStreamOptions) {
+  const params: any = {
+    model: model.id,
+    messages: buildVertexMessages(context.messages, model),
+    max_tokens: options?.maxTokens || (model.maxTokens / 3) | 0,
+    stream: true,
+  };
+
+  if (context.systemPrompt) {
+    params.system = [{ type: "text", text: sanitizeSurrogates(context.systemPrompt) }];
+  }
+
+  if (options?.temperature !== undefined) {
+    params.temperature = options.temperature;
+  }
+
+  if (context.tools) {
+    params.tools = convertTools(context.tools);
+  }
+
+  if (options?.thinkingEnabled && model.reasoning) {
+    if (supportsAdaptiveThinking(model.id)) {
+      params.thinking = { type: "adaptive" };
+      if (options.effort) {
+        params.output_config = { effort: options.effort };
+      }
+    } else {
+      params.thinking = { type: "enabled", budget_tokens: options.thinkingBudgetTokens || 1024 };
+    }
+  }
+
+  if (options?.toolChoice) {
+    params.tool_choice =
+      typeof options.toolChoice === "string" ? { type: options.toolChoice } : options.toolChoice;
+  }
+
+  return params;
+}
+
+export const streamAnthropicVertex = (
+  model: Model<Api>,
+  context: Context,
+  options?: VertexStreamOptions,
+): AssistantMessageEventStream => {
+  const stream: any = new (EventStream as any)();
+
+  (async () => {
+    const output: any = {
+      role: "assistant",
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    try {
+      const client = getClient();
+      const params = buildParams(model, context, options);
+      options?.onPayload?.(params);
+
+      const anthropicStream = client.messages.stream(params, { signal: options?.signal });
+
+      stream.push({ type: "start", partial: output });
+      const blocks: any[] = output.content;
+
+      for await (const event of anthropicStream) {
+        if (event.type === "message_start") {
+          const mu = (event as any).message.usage;
+          output.usage.input = mu.input_tokens || 0;
+          output.usage.output = mu.output_tokens || 0;
+          output.usage.cacheRead = mu.cache_read_input_tokens || 0;
+          output.usage.cacheWrite = mu.cache_creation_input_tokens || 0;
+          output.usage.totalTokens =
+            output.usage.input +
+            output.usage.output +
+            output.usage.cacheRead +
+            output.usage.cacheWrite;
+          calculateCost(model as any, output.usage);
+        } else if (event.type === "content_block_start") {
+          const cb = (event as any).content_block;
+          const idx = (event as any).index;
+
+          if (cb.type === "text") {
+            blocks.push({ type: "text", text: "", index: idx });
+            stream.push({ type: "text_start", contentIndex: blocks.length - 1, partial: output });
+          } else if (cb.type === "thinking") {
+            blocks.push({ type: "thinking", thinking: "", thinkingSignature: "", index: idx });
+            stream.push({
+              type: "thinking_start",
+              contentIndex: blocks.length - 1,
+              partial: output,
+            });
+          } else if (cb.type === "tool_use") {
+            blocks.push({
+              type: "toolCall",
+              id: cb.id,
+              name: cb.name,
+              arguments: cb.input ?? {},
+              partialJson: "",
+              index: idx,
+            });
+            stream.push({
+              type: "toolcall_start",
+              contentIndex: blocks.length - 1,
+              partial: output,
+            });
+          }
+        } else if (event.type === "content_block_delta") {
+          const delta = (event as any).delta;
+          const idx = (event as any).index;
+          const index = blocks.findIndex((b: any) => b.index === idx);
+          const block = blocks[index];
+
+          if (delta.type === "text_delta" && block?.type === "text") {
+            block.text += delta.text;
+            stream.push({
+              type: "text_delta",
+              contentIndex: index,
+              delta: delta.text,
+              partial: output,
+            });
+          } else if (delta.type === "thinking_delta" && block?.type === "thinking") {
+            block.thinking += delta.thinking;
+            stream.push({
+              type: "thinking_delta",
+              contentIndex: index,
+              delta: delta.thinking,
+              partial: output,
+            });
+          } else if (delta.type === "input_json_delta" && block?.type === "toolCall") {
+            block.partialJson += delta.partial_json;
+            block.arguments = parseStreamingJson(block.partialJson);
+            stream.push({
+              type: "toolcall_delta",
+              contentIndex: index,
+              delta: delta.partial_json,
+              partial: output,
+            });
+          } else if (delta.type === "signature_delta" && block?.type === "thinking") {
+            block.thinkingSignature = (block.thinkingSignature || "") + delta.signature;
+          }
+        } else if (event.type === "content_block_stop") {
+          const idx = (event as any).index;
+          const index = blocks.findIndex((b: any) => b.index === idx);
+          const block = blocks[index];
+          if (block) {
+            delete block.index;
+            if (block.type === "text") {
+              stream.push({
+                type: "text_end",
+                contentIndex: index,
+                content: block.text,
+                partial: output,
+              });
+            } else if (block.type === "thinking") {
+              stream.push({
+                type: "thinking_end",
+                contentIndex: index,
+                content: block.thinking,
+                partial: output,
+              });
+            } else if (block.type === "toolCall") {
+              block.arguments = parseStreamingJson(block.partialJson);
+              delete block.partialJson;
+              stream.push({
+                type: "toolcall_end",
+                contentIndex: index,
+                toolCall: block,
+                partial: output,
+              });
+            }
+          }
+        } else if (event.type === "message_delta") {
+          const delta = (event as any).delta;
+          const eu = (event as any).usage;
+
+          if (delta.stop_reason) {
+            output.stopReason = mapStopReason(delta.stop_reason);
+          }
+          if (eu.input_tokens != null) output.usage.input = eu.input_tokens;
+          if (eu.output_tokens != null) output.usage.output = eu.output_tokens;
+          if (eu.cache_read_input_tokens != null)
+            output.usage.cacheRead = eu.cache_read_input_tokens;
+          if (eu.cache_creation_input_tokens != null)
+            output.usage.cacheWrite = eu.cache_creation_input_tokens;
+          output.usage.totalTokens =
+            output.usage.input +
+            output.usage.output +
+            output.usage.cacheRead +
+            output.usage.cacheWrite;
+          calculateCost(model as any, output.usage);
+        }
+      }
+
+      if (options?.signal?.aborted) throw new Error("Request was aborted");
+      if (output.stopReason === "aborted" || output.stopReason === "error") {
+        throw new Error("An unknown error occurred");
+      }
+
+      stream.push({ type: "done", reason: output.stopReason, message: output });
+      stream.end();
+    } catch (error) {
+      for (const block of output.content) delete block.index;
+      output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      stream.push({ type: "error", reason: output.stopReason, error: output });
+      stream.end();
+    }
+  })();
+
+  return stream;
+};
+
+export const streamSimpleAnthropicVertex = (
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions,
+): AssistantMessageEventStream => {
+  const base = buildBaseOptions(model, options, (options as any)?.apiKey ?? "");
+
+  if (!(options as any)?.reasoning) {
+    return streamAnthropicVertex(model, context, { ...base, thinkingEnabled: false });
+  }
+
+  if (supportsAdaptiveThinking(model.id)) {
+    const effort = mapThinkingLevelToEffort((options as any).reasoning);
+    return streamAnthropicVertex(model, context, { ...base, thinkingEnabled: true, effort });
+  }
+
+  const adjusted = adjustMaxTokensForThinking(
+    base.maxTokens || 0,
+    model.maxTokens,
+    (options as any).reasoning,
+    (options as any).thinkingBudgets,
+  );
+  return streamAnthropicVertex(model, context, {
+    ...base,
+    maxTokens: adjusted.maxTokens,
+    thinkingEnabled: true,
+    thinkingBudgetTokens: adjusted.thinkingBudget,
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,19 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/vertex-anthropic-auth:
+    dependencies:
+      '@anthropic-ai/vertex-sdk':
+        specifier: ^0.14.3
+        version: 0.14.3(zod@4.3.6)
+      google-auth-library:
+        specifier: ^9.0.0
+        version: 9.15.1
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/voice-call:
     dependencies:
       '@sinclair/typebox':
@@ -610,6 +623,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@anthropic-ai/vertex-sdk@0.14.3':
+    resolution: {integrity: sha512-GJZTkkvN66gM3Epqm9laKEjC3orQqzmQt8JAgTN9+zlb+I+1/oEd3Z7rj2tkEKCTeOUVScdhcXPudN8GdpuGqA==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -3718,9 +3734,17 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
   gaxios@7.1.3:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
     engines: {node: '>=18'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
 
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
@@ -3768,6 +3792,14 @@ packages:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
     engines: {node: '>=18'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -3782,6 +3814,10 @@ packages:
   grammy@1.40.0:
     resolution: {integrity: sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==}
     engines: {node: ^12.20.0 || >=14.13.1}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   gtoken@8.0.0:
     resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
@@ -5411,6 +5447,10 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
   validate-npm-package-name@6.0.2:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -5619,6 +5659,15 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.3.6
+
+  '@anthropic-ai/vertex-sdk@0.14.3(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      google-auth-library: 9.15.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - zod
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -6666,7 +6715,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.58.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6682,7 +6731,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.12
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6885,7 +6934,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7720,7 +7769,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7766,7 +7815,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.2.2
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8660,14 +8709,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9243,8 +9284,6 @@ snapshots:
 
   flatbuffers@24.12.23: {}
 
-  follow-redirects@1.15.11: {}
-
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
@@ -9300,6 +9339,17 @@ snapshots:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
 
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gaxios@7.1.3:
     dependencies:
       extend: 3.0.2
@@ -9307,6 +9357,15 @@ snapshots:
       node-fetch: 3.3.2
       rimraf: 5.0.10
     transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
       - supports-color
 
   gcp-metadata@8.1.2:
@@ -9384,6 +9443,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -9396,6 +9469,14 @@ snapshots:
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11182,6 +11263,8 @@ snapshots:
   uuid@3.4.0: {}
 
   uuid@8.3.2: {}
+
+  uuid@9.0.1: {}
 
   validate-npm-package-name@6.0.2: {}
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -122,6 +122,11 @@ export type ProviderPlugin = {
   auth: ProviderAuthMethod[];
   formatApiKey?: (cred: AuthProfileCredential) => string;
   refreshOAuth?: (cred: OAuthCredential) => Promise<OAuthCredential>;
+  apiProvider?: {
+    api: string;
+    stream: (...args: unknown[]) => unknown;
+    streamSimple: (...args: unknown[]) => unknown;
+  };
 };
 
 export type OpenClawPluginGatewayMethod = {


### PR DESCRIPTION
## Summary

Adds support for Anthropic Claude models (Opus 4.6, Sonnet 4.5) via Google Cloud Vertex AI as an OpenClaw extension plugin.

**Problem**: OpenClaw supports Claude via direct Anthropic API and Gemini via Vertex AI, but not Claude via Vertex AI. Using Claude through a GCP project with service account authentication avoids requiring direct Anthropic API keys.

**Solution**: A new extension plugin (`vertex-anthropic-auth`) that:
- Registers a custom `anthropic-vertex-messages` API type with streaming functions adapted from pi-ai's Anthropic provider
- Uses `@anthropic-ai/vertex-sdk` (`AnthropicVertex`) for Vertex AI endpoint routing and Google Cloud OAuth
- Authenticates via `google-auth-library` supporting service account keys, `GOOGLE_APPLICATION_CREDENTIALS`, and gcloud ADC
- Bridges plugin-registered providers into the model resolution pipeline (`models-config.ts`) and the pi-ai API registry

**Core changes to OpenClaw** (beyond the extension):
- `src/agents/models-config.ts`: Plugin providers are now integrated into `ensureOpenClawModelsJson`, including registering custom API streaming providers from the ESM context (solving the jiti/ESM module instance mismatch)
- `src/plugins/types.ts`: Added optional `apiProvider` field to `ProviderPlugin` for carrying stream functions

## Test plan

- [x] Direct streaming test: `streamAnthropicVertex` with Sonnet text response
- [x] Direct streaming test: `streamSimpleAnthropicVertex` with Opus thinking/reasoning
- [x] `openclaw agent --local` with `vertex-anthropic/claude-sonnet-4-5@20250929` - text response
- [x] `openclaw agent --local` with `--thinking medium` - reasoning mode
- [x] Auth profile resolution via auth-profiles.json (token type with `vertex-ai-managed` placeholder)
- [ ] Service account key file authentication (`SERVICE_ACCOUNT_KEY_FILE`)
- [ ] Token auto-refresh (google-auth-library handles internally)