### PR TITLE
fix(gateway): skip SIGUSR1 restart in config.patch for noop reload rules

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -25,6 +25,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { loadOpenClawPlugins } from "../../plugins/loader.js";
+import { buildGatewayReloadPlan, diffConfigPaths } from "../config-reload.js";
 import {
   ErrorCodes,
   errorShape,
@@ -309,6 +310,9 @@ export const configHandlers: GatewayRequestHandlers = {
         ? Math.max(0, Math.floor(restartDelayMsRaw))
         : undefined;
 
+    const changedPaths = diffConfigPaths(snapshot.config, validated.config);
+    const reloadPlan = buildGatewayReloadPlan(changedPaths);
+
     const payload: RestartSentinelPayload = {
       kind: "config-apply",
       status: "ok",
@@ -327,10 +331,20 @@ export const configHandlers: GatewayRequestHandlers = {
     } catch {
       sentinelPath = null;
     }
-    const restart = scheduleGatewaySigusr1Restart({
-      delayMs: restartDelayMs,
-      reason: "config.patch",
-    });
+
+    const restart = reloadPlan.restartGateway
+      ? scheduleGatewaySigusr1Restart({
+          delayMs: restartDelayMs,
+          reason: "config.patch",
+        })
+      : {
+          ok: true,
+          skipped: true,
+          reason: "no-restart-needed",
+          noopPaths: reloadPlan.noopPaths,
+          hotReasons: reloadPlan.hotReasons,
+        };
+
     respond(
       true,
       {
@@ -338,6 +352,13 @@ export const configHandlers: GatewayRequestHandlers = {
         path: CONFIG_PATH,
         config: redactConfigObject(validated.config),
         restart,
+        reloadPlan: {
+          changedPaths: reloadPlan.changedPaths,
+          restartGateway: reloadPlan.restartGateway,
+          restartReasons: reloadPlan.restartReasons,
+          hotReasons: reloadPlan.hotReasons,
+          noopPaths: reloadPlan.noopPaths,
+        },
         sentinel: {
           path: sentinelPath,
           payload,
@@ -420,6 +441,9 @@ export const configHandlers: GatewayRequestHandlers = {
         ? Math.max(0, Math.floor(restartDelayMsRaw))
         : undefined;
 
+    const changedPaths = diffConfigPaths(snapshot.config, restoredApply);
+    const reloadPlan = buildGatewayReloadPlan(changedPaths);
+
     const payload: RestartSentinelPayload = {
       kind: "config-apply",
       status: "ok",
@@ -438,10 +462,20 @@ export const configHandlers: GatewayRequestHandlers = {
     } catch {
       sentinelPath = null;
     }
-    const restart = scheduleGatewaySigusr1Restart({
-      delayMs: restartDelayMs,
-      reason: "config.apply",
-    });
+
+    const restart = reloadPlan.restartGateway
+      ? scheduleGatewaySigusr1Restart({
+          delayMs: restartDelayMs,
+          reason: "config.apply",
+        })
+      : {
+          ok: true,
+          skipped: true,
+          reason: "no-restart-needed",
+          noopPaths: reloadPlan.noopPaths,
+          hotReasons: reloadPlan.hotReasons,
+        };
+
     respond(
       true,
       {
@@ -449,6 +483,13 @@ export const configHandlers: GatewayRequestHandlers = {
         path: CONFIG_PATH,
         config: redactConfigObject(restoredApply),
         restart,
+        reloadPlan: {
+          changedPaths: reloadPlan.changedPaths,
+          restartGateway: reloadPlan.restartGateway,
+          restartReasons: reloadPlan.restartReasons,
+          hotReasons: reloadPlan.hotReasons,
+          noopPaths: reloadPlan.noopPaths,
+        },
         sentinel: {
           path: sentinelPath,
           payload,


### PR DESCRIPTION
## Summary

`config.patch` and `config.apply` previously unconditionally scheduled `scheduleGatewaySigusr1Restart()` after writing config, even when changed paths were noop-only (e.g. `agents.*`, `models.*`).

This bypassed the existing reload rule logic already used by the file watcher (`diffConfigPaths()` + `buildGatewayReloadPlan()`).

## What changed

- Updated `src/gateway/server-methods/config.ts`:
  - imported `diffConfigPaths` and `buildGatewayReloadPlan` from `../config-reload.js`
  - in `config.patch` and `config.apply`, compute changed paths and reload plan after writing config
  - schedule `scheduleGatewaySigusr1Restart()` only when `reloadPlan.restartGateway === true`
  - when restart is not needed, return:
    - `restart: { ok: true, skipped: true, reason: "no-restart-needed", noopPaths, hotReasons }`
  - include a `reloadPlan` summary in the response payload

- Updated `src/gateway/server.config-patch.e2e.test.ts` with new cases:
  - skips restart when only agents-scoped paths change
  - still restarts when gateway-scoped paths change
  - skips restart for mixed noop-only changes (`agents` + `models`)
  - restarts when mixed changes include restart-required paths (`agents` + `gateway`)

## Test results

Because the default Vitest config excludes `*.e2e.test.ts`, the e2e config was used to run this file:

```bash
npx vitest run --config vitest.e2e.config.ts src/gateway/server.config-patch.e2e.test.ts
```

Result: **11 passed**

## References

Fixes #5533
Refs #1997

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway `config.patch` and `config.apply` RPC handlers to compute config diffs (`diffConfigPaths`) and build a reload plan (`buildGatewayReloadPlan`) when config changes are applied. The handlers now only schedule a SIGUSR1 gateway restart when the reload plan requires it, and they return reload-plan details (including noop/hot/restart reasons) to the caller. The e2e config.patch test suite adds cases asserting restart is skipped for noop-only path changes (`agents.*`, `models.*`) and still occurs for gateway-scoped changes.

Overall, the change brings RPC-driven config updates in line with the existing file-watcher reload rules, reducing unnecessary restarts for noop-only config updates.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge once protocol/sentinel behavior is corrected
- Core restart-skipping logic is straightforward and covered by new e2e tests, but the change introduces response payload shape drift (new `reloadPlan` and a new `restart` variant) without corresponding protocol/schema updates, and it appears to still write restart sentinels even when restarts are skipped—both can break consumers or cause false restart signals.
- src/gateway/server-methods/config.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->