### PR TITLE
fix(docker-setup): improve environment variable handling in upsert_en…

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -123,13 +123,23 @@ for compose_file in "${COMPOSE_FILES[@]}"; do
 done
 
 ENV_FILE="$ROOT_DIR/.env"
+has_seen() {
+  local key="$1"
+  shift || true
+  for item in "$@"; do
+    if [[ "$item" == "$key" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 upsert_env() {
   local file="$1"
   shift
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local -a seen_keys=()
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -138,7 +148,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen_keys+=("$k")
           replaced=true
           break
         fi
@@ -150,7 +160,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if ! has_seen "$k" "${seen_keys[@]-}"; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
…v function -- making this macOS (bash 3.2) compatible.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh`’s `upsert_env` helper to avoid Bash 4+ associative arrays and instead track replaced keys via a plain array plus a small `has_seen` helper, making the script compatible with macOS’s default Bash 3.2.

The change is localized to the `.env` upsert logic and doesn’t alter the surrounding Docker Compose build/onboarding flow.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and confined to `.env` update bookkeeping; it replaces Bash 4+ associative arrays with a Bash 3.2-compatible approach while preserving behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->