### PR TITLE
fix(gateway): handle async EPIPE on stdout/stderr during shutdown

### DIFF
--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -170,6 +170,20 @@ export function enableConsoleCapture(): void {
   }
   loggingState.consolePatched = true;
 
+  // Handle async EPIPE errors on stdout/stderr. The synchronous try/catch in
+  // the forward() wrapper below only covers errors thrown during write dispatch.
+  // When the receiving pipe closes (e.g. during shutdown), Node emits the error
+  // asynchronously on the stream. Without a listener this becomes an uncaught
+  // exception that crashes the gateway.
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on("error", (err) => {
+      if (isEpipeError(err)) {
+        return;
+      }
+      throw err;
+    });
+  }
+
   let logger: ReturnType<typeof getLogger> | null = null;
   const getLoggerLazy = () => {
     if (!logger) {

--- a/src/logging/state.ts
+++ b/src/logging/state.ts
@@ -8,6 +8,7 @@ export const loggingState = {
   consoleTimestampPrefix: false,
   consoleSubsystemFilter: null as string[] | null,
   resolvingConsoleSettings: false,
+  streamErrorHandlersInstalled: false,
   rawConsole: null as {
     log: typeof console.log;
     info: typeof console.info;


### PR DESCRIPTION
## Summary

`enableConsoleCapture()` wraps `console.*` calls with a `forward()` function that catches synchronous EPIPE via try/catch. But when the receiving pipe closes during shutdown, Node emits the error **asynchronously** on the stream's `error` event. No listener exists for this, so it becomes an uncaught exception that crashes the gateway.

On macOS this triggers launchd's launch-storm detection, which permanently unloads the LaunchAgent. The gateway stays dead until manual `openclaw gateway install`.

**Fix:** Add `process.stdout.on('error')` and `process.stderr.on('error')` listeners inside `enableConsoleCapture()` that silently swallow EPIPE/EIO (reusing the existing `isEpipeError` helper) and re-throw anything else.

## Changes

- `src/logging/console.ts`: Add stream error listeners in `enableConsoleCapture()`
- `src/logging/console-capture.test.ts`: 3 new tests (async EPIPE on stdout, async EPIPE on stderr, non-EPIPE rethrow)

## Test plan

- [x] Existing 6 tests still pass
- [x] 3 new tests verify EPIPE is swallowed and non-EPIPE is rethrown
- [x] `pnpm vitest run src/logging/console-capture.test.ts` — 9/9 passing

Closes #13367

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `enableConsoleCapture()` to handle **asynchronous** `EPIPE`/`EIO` errors emitted by `process.stdout`/`process.stderr` during shutdown by adding `error` event listeners that swallow those specific errors and rethrow others. It also adds unit tests that simulate stream `error` events on stdout/stderr to ensure `EPIPE` is ignored and non-`EPIPE` errors surface.

This fits alongside the existing console-capture behavior that already guards *synchronous* write failures (via try/catch around `stderr.write` and original console methods) by extending coverage to the async stream error path that would otherwise crash the gateway.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one correctness/robustness concern around listener accumulation on repeated initialization.
- The change is narrowly scoped and tests cover the new async EPIPE path, but the new `stream.on('error')` handlers can be registered multiple times if `enableConsoleCapture()` is called more than once in the same process (e.g., during test resets or re-init flows), leading to stacked listeners and duplicated behavior.
- src/logging/console.ts (error listener registration in enableConsoleCapture)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->