### PR TITLE
fix(hooks): bridge agent_end events to internal/workspace hooks

### DIFF
--- a/src/agents/agent-end-hooks.test.ts
+++ b/src/agents/agent-end-hooks.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearInternalHooks,
+  registerInternalHook,
+  type InternalHookEvent,
+} from "../hooks/internal-hooks.js";
+import { triggerAgentEndHook } from "./agent-end-hooks.js";
+
+describe("triggerAgentEndHook", () => {
+  beforeEach(() => clearInternalHooks());
+  afterEach(() => clearInternalHooks());
+
+  it("fires an agent:end internal hook with correct context", async () => {
+    let captured: InternalHookEvent | undefined;
+    registerInternalHook("agent:end", (event) => {
+      captured = event;
+    });
+
+    await triggerAgentEndHook({
+      messages: [{ role: "user", content: "hello" }],
+      success: true,
+      durationMs: 1234,
+      agentId: "test-agent",
+      sessionKey: "sess-123",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(captured).toBeDefined();
+    expect(captured!.type).toBe("agent");
+    expect(captured!.action).toBe("end");
+    expect(captured!.sessionKey).toBe("sess-123");
+    expect(captured!.context).toEqual({
+      messages: [{ role: "user", content: "hello" }],
+      success: true,
+      durationMs: 1234,
+      agentId: "test-agent",
+      workspaceDir: "/tmp/workspace",
+    });
+  });
+
+  it("includes error in context when provided", async () => {
+    let captured: InternalHookEvent | undefined;
+    registerInternalHook("agent:end", (event) => {
+      captured = event;
+    });
+
+    await triggerAgentEndHook({
+      messages: [],
+      success: false,
+      error: "prompt timed out",
+      durationMs: 60000,
+      sessionKey: "sess-456",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(captured).toBeDefined();
+    expect(captured!.context).toEqual({
+      messages: [],
+      success: false,
+      error: "prompt timed out",
+      durationMs: 60000,
+      workspaceDir: "/tmp/workspace",
+    });
+  });
+
+  it("does not throw when no handlers are registered", async () => {
+    await expect(
+      triggerAgentEndHook({
+        messages: [],
+        success: true,
+        durationMs: 0,
+        sessionKey: "sess-789",
+        workspaceDir: "/tmp",
+      }),
+    ).resolves.not.toThrow();
+  });
+});

--- a/src/agents/agent-end-hooks.ts
+++ b/src/agents/agent-end-hooks.ts
@@ -1,0 +1,29 @@
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
+
+export interface AgentEndHookParams {
+  messages: unknown[];
+  success: boolean;
+  error?: string;
+  durationMs: number;
+  agentId?: string;
+  sessionKey?: string;
+  workspaceDir: string;
+}
+
+export async function triggerAgentEndHook(params: AgentEndHookParams): Promise<void> {
+  const context: Record<string, unknown> = {
+    messages: params.messages,
+    success: params.success,
+    durationMs: params.durationMs,
+    workspaceDir: params.workspaceDir,
+  };
+  if (params.error !== undefined) {
+    context.error = params.error;
+  }
+  if (params.agentId !== undefined) {
+    context.agentId = params.agentId;
+  }
+  const sessionKey = params.sessionKey ?? "unknown";
+  const event = createInternalHookEvent("agent", "end", sessionKey, context);
+  await triggerInternalHook(event);
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -21,6 +21,7 @@ import { buildTtsSystemPromptHint } from "../../../tts/tts.js";
 import { resolveUserPath } from "../../../utils.js";
 import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
+import { triggerAgentEndHook } from "../../agent-end-hooks.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
@@ -1172,6 +1173,17 @@ export async function runEmbeddedAttempt(
               log.warn(`agent_end hook failed: ${err}`);
             });
         }
+
+        // Bridge agent_end to internal/workspace hooks (fire-and-forget)
+        void triggerAgentEndHook({
+          messages: messagesSnapshot,
+          success: !aborted && !promptError,
+          error: promptError ? describeUnknownError(promptError) : undefined,
+          durationMs: Date.now() - promptStartedAt,
+          agentId: hookAgentId,
+          sessionKey: params.sessionKey,
+          workspaceDir: params.workspaceDir,
+        });
       } finally {
         clearTimeout(abortTimer);
         if (abortWarnTimer) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1175,7 +1175,7 @@ export async function runEmbeddedAttempt(
         }
 
         // Bridge agent_end to internal/workspace hooks (fire-and-forget)
-        void triggerAgentEndHook({
+        triggerAgentEndHook({
           messages: messagesSnapshot,
           success: !aborted && !promptError,
           error: promptError ? describeUnknownError(promptError) : undefined,
@@ -1183,6 +1183,8 @@ export async function runEmbeddedAttempt(
           agentId: hookAgentId,
           sessionKey: params.sessionKey,
           workspaceDir: params.workspaceDir,
+        }).catch((err) => {
+          log.warn(`agent_end internal hook failed: ${err}`);
         });
       } finally {
         clearTimeout(abortTimer);


### PR DESCRIPTION
## Summary

Fixes #10778

When plugin hooks fire `agent_end` via `hookRunner.runAgentEnd()`, the event is not bridged to the internal/workspace hook system (`triggerInternalHook`). This means workspace hooks registered on `agent:end` never fire.

**Root cause**: `attempt.ts` only calls `hookRunner.runAgentEnd()` (plugin hooks) but never dispatches to `triggerInternalHook()` (internal hooks). The `agent:bootstrap` event already has this bridging via `bootstrap-hooks.ts`, but `agent:end` was missing the equivalent.

**Fix**: 
- New `agent-end-hooks.ts` module (following the exact pattern of `bootstrap-hooks.ts`) that creates an `InternalHookEvent` with type `"agent"`, action `"end"`, and context containing messages, success, error, durationMs, agentId, and workspaceDir
- Call `triggerAgentEndHook()` from `attempt.ts` as fire-and-forget, outside the `hookRunner?.hasHooks("agent_end")` guard so internal hooks fire regardless of plugin hooks

## Test plan

- [x] 3 new tests in `agent-end-hooks.test.ts` (TDD: all 3 fail before, pass after)
  - [x] Fires `agent:end` internal hook with correct context
  - [x] Includes error in context when provided
  - [x] Does not throw when no handlers are registered
- [x] All 18 existing `internal-hooks.test.ts` tests still pass
- [x] `pnpm build && pnpm check` passes clean

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a new internal hook bridge for the `agent:end` lifecycle event. A new `src/agents/agent-end-hooks.ts` helper builds an `InternalHookEvent` (`type: "agent"`, `action: "end"`) with a context containing the final message snapshot, success/error, duration, agentId, and workspaceDir, and then calls `triggerInternalHook`. `runEmbeddedAttempt` (`src/agents/pi-embedded-runner/run/attempt.ts`) now invokes this bridge after plugin `agent_end` hooks run, ensuring workspace/internal handlers registered on `agent:end` fire even when no plugins are present. New Vitest coverage (`src/agents/agent-end-hooks.test.ts`) validates emitted context, error inclusion, and no-op behavior when no handlers are registered.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and consistent with existing internal hook bridging patterns. The new fire-and-forget internal hook invocation properly attaches a `.catch()` to avoid unhandled promise rejections, and the new tests validate context wiring and no-handler behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->