### PR TITLE
feat(whatsapp): add Newsletter/Channel JID support

### DIFF
--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -3,7 +3,7 @@ import { chunkText } from "../../../auto-reply/chunk.js";
 import { shouldLogVerbose } from "../../../globals.js";
 import { missingTargetError } from "../../../infra/outbound/target-errors.js";
 import { sendPollWhatsApp } from "../../../web/outbound.js";
-import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../../whatsapp/normalize.js";
+import { isWhatsAppGroupJid, isWhatsAppNewsletterJid, normalizeWhatsAppTarget } from "../../../whatsapp/normalize.js";
 
 export const whatsappOutbound: ChannelOutboundAdapter = {
   deliveryMode: "gateway",
@@ -25,10 +25,10 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
       if (!normalizedTo) {
         return {
           ok: false,
-          error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+          error: missingTargetError("WhatsApp", "<E.164|group JID|newsletter JID>"),
         };
       }
-      if (isWhatsAppGroupJid(normalizedTo)) {
+      if (isWhatsAppGroupJid(normalizedTo) || isWhatsAppNewsletterJid(normalizedTo)) {
         return { ok: true, to: normalizedTo };
       }
       if (mode === "implicit" || mode === "heartbeat") {
@@ -40,7 +40,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
         }
         return {
           ok: false,
-          error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+          error: missingTargetError("WhatsApp", "<E.164|group JID|newsletter JID>"),
         };
       }
       return { ok: true, to: normalizedTo };
@@ -48,7 +48,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
 
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: missingTargetError("WhatsApp", "<E.164|group JID|newsletter JID>"),
     };
   },
   sendText: async ({ to, text, accountId, deps, gifPlayback }) => {

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -21,7 +21,7 @@ import { parseSlackTarget } from "../../slack/targets.js";
 import { buildTelegramGroupPeerId } from "../../telegram/bot/helpers.js";
 import { resolveTelegramTargetChatType } from "../../telegram/inline-buttons.js";
 import { parseTelegramTarget } from "../../telegram/targets.js";
-import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
+import { isWhatsAppGroupJid, isWhatsAppNewsletterJid, normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 
 export type OutboundSessionRoute = {
   sessionKey: string;
@@ -338,8 +338,9 @@ function resolveWhatsAppSession(
     return null;
   }
   const isGroup = isWhatsAppGroupJid(normalized);
+  const isNewsletter = isWhatsAppNewsletterJid(normalized);
   const peer: RoutePeer = {
-    kind: isGroup ? "group" : "direct",
+    kind: isGroup || isNewsletter ? "group" : "direct",
     id: normalized,
   };
   const baseSessionKey = buildBaseSessionKey({
@@ -353,7 +354,7 @@ function resolveWhatsAppSession(
     sessionKey: baseSessionKey,
     baseSessionKey,
     peer,
-    chatType: isGroup ? "group" : "direct",
+    chatType: isGroup || isNewsletter ? "group" : "direct",
     from: normalized,
     to: normalized,
   };

--- a/src/whatsapp/normalize.ts
+++ b/src/whatsapp/normalize.ts
@@ -14,6 +14,14 @@ function stripWhatsAppTargetPrefixes(value: string): string {
   }
 }
 
+/**
+ * Check if value looks like a WhatsApp Newsletter/Channel JID (e.g. "120363xxx@newsletter").
+ */
+export function isWhatsAppNewsletterJid(value: string): boolean {
+  const candidate = stripWhatsAppTargetPrefixes(value);
+  return /^\d+@newsletter$/i.test(candidate);
+}
+
 export function isWhatsAppGroupJid(value: string): boolean {
   const candidate = stripWhatsAppTargetPrefixes(value);
   const lower = candidate.toLowerCase();
@@ -69,6 +77,10 @@ export function normalizeWhatsAppTarget(value: string): string | null {
     }
     const normalized = normalizeE164(phone);
     return normalized.length > 1 ? normalized : null;
+  }
+  // Pass through newsletter JIDs (e.g. "120363xxx@newsletter") for WhatsApp Channels.
+  if (isWhatsAppNewsletterJid(candidate)) {
+    return candidate;
   }
   // If the caller passed a JID-ish string that we don't understand, fail fast.
   // Otherwise normalizeE164 would happily treat "group:120@g.us" as a phone number.


### PR DESCRIPTION
## Summary

Adds support for WhatsApp Newsletter/Channel JIDs (`xxxxx@newsletter`) in the message tool's target validation. Currently, the `normalizeWhatsAppTarget()` function rejects any JID containing `@` that isn't a group JID (`@g.us`) or user JID (`@s.whatsapp.net` / `@lid`), which prevents sending messages to WhatsApp Channels.

## Changes

### `src/whatsapp/normalize.ts`
- Added `isWhatsAppNewsletterJid()` helper that matches `\d+@newsletter` format
- Newsletter JIDs are now passed through `normalizeWhatsAppTarget()` instead of being rejected

### `src/channels/plugins/outbound/whatsapp.ts`
- Newsletter JIDs are treated like group JIDs in outbound routing (bypass `allowFrom` checks, since channels are owned/administered by the sender)

## How it works

The underlying Baileys library already supports `sendMessage()` to `@newsletter` JIDs — the `toWhatsappJid()` utility in `src/utils.ts` correctly passes through any JID containing `@`. This PR only removes the validation barrier in the normalize/outbound layer that prevented newsletter targets from reaching the send path.

## Use case

WhatsApp Channels (launched 2023) are one-way broadcast channels. Bot accounts that are admins/owners of a channel should be able to post to it via the message tool using the newsletter JID as target (e.g. `120363xxx@newsletter`).

Closes #13417

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds WhatsApp Newsletter/Channel JID (`\d+@newsletter`) support by relaxing `normalizeWhatsAppTarget()` validation and allowing outbound routing to bypass `allowFrom` checks for newsletter targets (treated similarly to group JIDs).

Key behavior changes:
- `src/whatsapp/normalize.ts` introduces `isWhatsAppNewsletterJid()` and returns newsletter JIDs unchanged from `normalizeWhatsAppTarget()`.
- `src/channels/plugins/outbound/whatsapp.ts` now treats newsletter JIDs like group JIDs in `resolveTarget()`.

Main follow-up needed before merge: other parts of the outbound pipeline (session routing/metadata) still classify newsletter targets as direct chats, which likely causes inconsistent session keys and chatType compared to the adapter’s intended behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close but has a routing inconsistency that should be fixed before merge.
- Normalization and outbound adapter logic accept newsletter JIDs, but outbound session routing still treats them as direct chats, which can change session keys/metadata and lead to inconsistent behavior across the pipeline.
- src/infra/outbound/outbound-session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->