### PR TITLE
fix(discord): properly handle bot-sent @everyone mentions

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -238,7 +238,7 @@ export async function preflightDiscordMessage(
   );
   const hasAnyMention = Boolean(
     !isDirectMessage &&
-    (message.mentionedEveryone ||
+    (message.mentionedEveryone && (message.mentionedUsers?.length ?? 0) > 0 ||
       (message.mentionedUsers?.length ?? 0) > 0 ||
       (message.mentionedRoles?.length ?? 0) > 0),
   );


### PR DESCRIPTION
Fixes the issue where bot-sent @everyone mentions were not being properly routed. This ensures that mentions from the bot are handled correctly in the Discord channel.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Discord preflight mention detection by changing how `hasAnyMention` is computed when `message.mentionedEveryone` is true, intending to handle bot-sent `@everyone` mentions differently during routing/mention-gating.

The change is localized to `src/discord/monitor/message-handler.preflight.ts`, where `hasAnyMention` is passed into `matchesMentionWithExplicit(...)` and later into `resolveMentionGatingWithBypass(...)` to decide whether messages should be treated as “mentioned” (and therefore eligible for handling) in guild channels that require mentions.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is; change breaks `@everyone` mention detection in common cases.
- The only functional change modifies `hasAnyMention` so that `mentionedEveryone` no longer counts unless `mentionedUsers.length > 0`, which will make real `@everyone` pings appear as having no mentions and can cause incorrect mention-gating behavior (dropping messages when mentions are required).
- src/discord/monitor/message-handler.preflight.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->