### PR TITLE
feat(whatsapp): add built-in Markdown to WhatsApp format transform

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -14,6 +14,15 @@ export type WhatsAppActionConfig = {
   polls?: boolean;
 };
 
+export type WhatsAppFormattingConfig = {
+  /**
+   * Transform standard Markdown to WhatsApp-compatible formatting.
+   * Converts **bold** → *bold*, ~~strike~~ → ~strike~, # headers → *headers*, etc.
+   * Default: true.
+   */
+  markdownTransform?: boolean;
+};
+
 export type WhatsAppConfig = {
   /** Optional per-account WhatsApp configuration (multi-account). */
   accounts?: Record<string, WhatsAppAccountConfig>;
@@ -21,6 +30,8 @@ export type WhatsAppConfig = {
   capabilities?: string[];
   /** Markdown formatting overrides (tables). */
   markdown?: MarkdownConfig;
+  /** WhatsApp-specific formatting options. */
+  formatting?: WhatsAppFormattingConfig;
   /** Allow channel-initiated config writes (default: true). */
   configWrites?: boolean;
   /** Send read receipts for incoming messages (default true). */
@@ -109,6 +120,8 @@ export type WhatsAppAccountConfig = {
   capabilities?: string[];
   /** Markdown formatting overrides (tables). */
   markdown?: MarkdownConfig;
+  /** WhatsApp-specific formatting options (per-account override). */
+  formatting?: WhatsAppFormattingConfig;
   /** Allow channel-initiated config writes (default: true). */
   configWrites?: boolean;
   /** If false, do not start this WhatsApp account provider. Default: true. */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -11,11 +11,25 @@ import {
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
+/** WhatsApp-specific formatting options. */
+export const WhatsAppFormattingSchema = z
+  .object({
+    /**
+     * Transform standard Markdown to WhatsApp-compatible formatting.
+     * Converts **bold** → *bold*, ~~strike~~ → ~strike~, # headers → *headers*, etc.
+     * Default: true.
+     */
+    markdownTransform: z.boolean().optional().default(true),
+  })
+  .strict()
+  .optional();
+
 export const WhatsAppAccountSchema = z
   .object({
     name: z.string().optional(),
     capabilities: z.array(z.string()).optional(),
     markdown: MarkdownConfigSchema,
+    formatting: WhatsAppFormattingSchema,
     configWrites: z.boolean().optional(),
     enabled: z.boolean().optional(),
     sendReadReceipts: z.boolean().optional(),
@@ -81,6 +95,7 @@ export const WhatsAppConfigSchema = z
     accounts: z.record(z.string(), WhatsAppAccountSchema.optional()).optional(),
     capabilities: z.array(z.string()).optional(),
     markdown: MarkdownConfigSchema,
+    formatting: WhatsAppFormattingSchema,
     configWrites: z.boolean().optional(),
     sendReadReceipts: z.boolean().optional(),
     dmPolicy: DmPolicySchema.optional().default("pairing"),

--- a/src/markdown/whatsapp.test.ts
+++ b/src/markdown/whatsapp.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { transformMarkdownForWhatsApp } from "./whatsapp.js";
+
+describe("transformMarkdownForWhatsApp", () => {
+  describe("bold conversion", () => {
+    it("converts **bold** to *bold*", () => {
+      expect(transformMarkdownForWhatsApp("hello **world**")).toBe("hello *world*");
+    });
+
+    it("converts __bold__ to *bold*", () => {
+      expect(transformMarkdownForWhatsApp("hello __world__")).toBe("hello *world*");
+    });
+
+    it("handles multiple bold segments", () => {
+      expect(transformMarkdownForWhatsApp("**one** and **two**")).toBe("*one* and *two*");
+    });
+
+    it("preserves already-correct WhatsApp bold", () => {
+      expect(transformMarkdownForWhatsApp("hello *world*")).toBe("hello *world*");
+    });
+  });
+
+  describe("strikethrough conversion", () => {
+    it("converts ~~strike~~ to ~strike~", () => {
+      expect(transformMarkdownForWhatsApp("hello ~~world~~")).toBe("hello ~world~");
+    });
+
+    it("handles multiple strikethrough segments", () => {
+      expect(transformMarkdownForWhatsApp("~~one~~ and ~~two~~")).toBe("~one~ and ~two~");
+    });
+  });
+
+  describe("header conversion", () => {
+    it("converts # header to *header*", () => {
+      expect(transformMarkdownForWhatsApp("# Hello")).toBe("*Hello*");
+    });
+
+    it("converts ## header to *header*", () => {
+      expect(transformMarkdownForWhatsApp("## Hello")).toBe("*Hello*");
+    });
+
+    it("converts ### header to *header*", () => {
+      expect(transformMarkdownForWhatsApp("### Hello")).toBe("*Hello*");
+    });
+
+    it("handles headers in multiline text", () => {
+      const input = "# Title\n\nSome text\n\n## Subtitle";
+      const expected = "*Title*\n\nSome text\n\n*Subtitle*";
+      expect(transformMarkdownForWhatsApp(input)).toBe(expected);
+    });
+  });
+
+  describe("link conversion", () => {
+    it("converts [text](url) to text (url)", () => {
+      expect(transformMarkdownForWhatsApp("[docs](https://example.com)")).toBe(
+        "docs (https://example.com)",
+      );
+    });
+
+    it("shows just URL when text matches URL", () => {
+      expect(transformMarkdownForWhatsApp("[https://example.com](https://example.com)")).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("handles multiple links", () => {
+      const input = "Check [docs](https://a.com) and [help](https://b.com)";
+      const expected = "Check docs (https://a.com) and help (https://b.com)";
+      expect(transformMarkdownForWhatsApp(input)).toBe(expected);
+    });
+  });
+
+  describe("image conversion", () => {
+    it("converts ![alt](url) to alt (url)", () => {
+      expect(transformMarkdownForWhatsApp("![screenshot](https://img.com/a.png)")).toBe(
+        "screenshot (https://img.com/a.png)",
+      );
+    });
+
+    it("shows just URL when alt is empty", () => {
+      expect(transformMarkdownForWhatsApp("![](https://img.com/a.png)")).toBe(
+        "https://img.com/a.png",
+      );
+    });
+  });
+
+  describe("horizontal rule removal", () => {
+    it("removes ---", () => {
+      expect(transformMarkdownForWhatsApp("before\n---\nafter")).toBe("before\n\nafter");
+    });
+
+    it("removes ***", () => {
+      expect(transformMarkdownForWhatsApp("before\n***\nafter")).toBe("before\n\nafter");
+    });
+
+    it("removes ___", () => {
+      expect(transformMarkdownForWhatsApp("before\n___\nafter")).toBe("before\n\nafter");
+    });
+  });
+
+  describe("blank line collapsing", () => {
+    it("collapses 3+ blank lines to 2", () => {
+      expect(transformMarkdownForWhatsApp("a\n\n\n\nb")).toBe("a\n\nb");
+    });
+
+    it("preserves 2 blank lines", () => {
+      expect(transformMarkdownForWhatsApp("a\n\nb")).toBe("a\n\nb");
+    });
+  });
+
+  describe("code block preservation", () => {
+    it("preserves fenced code blocks", () => {
+      const input = "```js\nconst **x** = 1;\n```";
+      expect(transformMarkdownForWhatsApp(input)).toBe(input);
+    });
+
+    it("preserves inline code", () => {
+      const input = "Use `**bold**` for emphasis";
+      expect(transformMarkdownForWhatsApp(input)).toBe("Use `**bold**` for emphasis");
+    });
+
+    it("transforms text outside code blocks", () => {
+      const input = "**bold** then ```code``` then **more**";
+      expect(transformMarkdownForWhatsApp(input)).toBe("*bold* then ```code``` then *more*");
+    });
+  });
+
+  describe("combined transformations", () => {
+    it("handles a complex message", () => {
+      const input = `# Welcome
+
+Hello **world**! Check out [our docs](https://docs.example.com).
+
+## Features
+
+- ~~Old feature~~
+- __New feature__
+
+---
+
+Thanks!`;
+
+      const expected = `*Welcome*
+
+Hello *world*! Check out our docs (https://docs.example.com).
+
+*Features*
+
+- ~Old feature~
+- *New feature*
+
+Thanks!`;
+
+      expect(transformMarkdownForWhatsApp(input)).toBe(expected);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty string", () => {
+      expect(transformMarkdownForWhatsApp("")).toBe("");
+    });
+
+    it("handles null-ish input", () => {
+      expect(transformMarkdownForWhatsApp(null as unknown as string)).toBe(null);
+      expect(transformMarkdownForWhatsApp(undefined as unknown as string)).toBe(undefined);
+    });
+
+    it("handles plain text without markdown", () => {
+      expect(transformMarkdownForWhatsApp("Hello world")).toBe("Hello world");
+    });
+  });
+});

--- a/src/markdown/whatsapp.ts
+++ b/src/markdown/whatsapp.ts
@@ -1,0 +1,156 @@
+/**
+ * Transform standard Markdown to WhatsApp-compatible formatting.
+ *
+ * WhatsApp uses its own formatting syntax:
+ * - Bold: *text* (not **text**)
+ * - Italic: _text_ (same as standard)
+ * - Strikethrough: ~text~ (not ~~text~~)
+ * - Code: ```code``` (supported) and `code` (not supported inline)
+ * - Links: not supported as [text](url), rendered as plain text
+ * - Headers: not supported, converted to bold
+ *
+ * @see https://faq.whatsapp.com/general/chats/how-to-format-your-messages
+ */
+
+type CodeBlock = {
+  placeholder: string;
+  content: string;
+};
+
+/**
+ * Protect code blocks and inline code from transformation.
+ * Uses numbered placeholders that won't collide with bold/italic patterns.
+ */
+function protectCodeBlocks(text: string): { text: string; blocks: CodeBlock[] } {
+  const blocks: CodeBlock[] = [];
+  let result = text;
+
+  // Protect fenced code blocks first (```...```)
+  result = result.replace(/```[\s\S]*?```/g, (match) => {
+    const placeholder = `%%CODEBLOCK_${blocks.length}%%`;
+    blocks.push({ placeholder, content: match });
+    return placeholder;
+  });
+
+  // Protect inline code (`...`)
+  result = result.replace(/`[^`\n]+`/g, (match) => {
+    const placeholder = `%%INLINECODE_${blocks.length}%%`;
+    blocks.push({ placeholder, content: match });
+    return placeholder;
+  });
+
+  return { text: result, blocks };
+}
+
+/**
+ * Restore protected code blocks.
+ */
+function restoreCodeBlocks(text: string, blocks: CodeBlock[]): string {
+  let result = text;
+  for (const block of blocks) {
+    result = result.replace(block.placeholder, block.content);
+  }
+  return result;
+}
+
+/**
+ * Convert standard Markdown bold (**text** or __text__) to WhatsApp bold (*text*).
+ */
+function convertBold(text: string): string {
+  // Convert **text** to *text*
+  let result = text.replace(/\*\*(.+?)\*\*/g, "*$1*");
+  // Convert __text__ to *text*
+  result = result.replace(/__(.+?)__/g, "*$1*");
+  return result;
+}
+
+/**
+ * Convert standard Markdown strikethrough (~~text~~) to WhatsApp strikethrough (~text~).
+ */
+function convertStrikethrough(text: string): string {
+  return text.replace(/~~(.+?)~~/g, "~$1~");
+}
+
+/**
+ * Convert Markdown headers (# Heading) to WhatsApp bold (*Heading*).
+ */
+function convertHeaders(text: string): string {
+  // Match lines starting with 1-6 # characters
+  return text.replace(/^(#{1,6})\s+(.+)$/gm, "*$2*");
+}
+
+/**
+ * Convert Markdown links [text](url) to WhatsApp-friendly format.
+ * WhatsApp doesn't support clickable markdown links, so we render as "text (url)" or just the URL.
+ */
+function convertLinks(text: string): string {
+  // Convert [text](url) to "text (url)" if text differs from url, else just url
+  return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, linkText, url) => {
+    const trimmedText = linkText.trim();
+    const trimmedUrl = url.trim();
+    // If link text is same as URL or empty, just show URL
+    if (!trimmedText || trimmedText === trimmedUrl) {
+      return trimmedUrl;
+    }
+    return `${trimmedText} (${trimmedUrl})`;
+  });
+}
+
+/**
+ * Convert Markdown images ![alt](url) to WhatsApp-friendly format.
+ */
+function convertImages(text: string): string {
+  // Convert ![alt](url) to "alt (url)" or just url
+  return text.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_, alt, url) => {
+    const trimmedAlt = alt.trim();
+    const trimmedUrl = url.trim();
+    if (!trimmedAlt) {
+      return trimmedUrl;
+    }
+    return `${trimmedAlt} (${trimmedUrl})`;
+  });
+}
+
+/**
+ * Remove horizontal rules (---, ***, ___) as WhatsApp doesn't support them.
+ */
+function removeHorizontalRules(text: string): string {
+  return text.replace(/^[-*_]{3,}\s*$/gm, "");
+}
+
+/**
+ * Collapse excessive blank lines (more than 2) to max 2.
+ */
+function collapseBlankLines(text: string): string {
+  return text.replace(/\n{3,}/g, "\n\n");
+}
+
+/**
+ * Transform standard Markdown to WhatsApp-compatible formatting.
+ *
+ * @param markdown - The markdown text to transform
+ * @returns WhatsApp-compatible formatted text
+ */
+export function transformMarkdownForWhatsApp(markdown: string): string {
+  if (!markdown) {
+    return markdown;
+  }
+
+  // Step 1: Protect code blocks from transformation
+  const { text: protectedText, blocks } = protectCodeBlocks(markdown);
+
+  // Step 2: Apply transformations
+  let result = protectedText;
+  result = convertHeaders(result);
+  result = convertImages(result);
+  result = convertLinks(result);
+  result = convertBold(result);
+  result = convertStrikethrough(result);
+  result = removeHorizontalRules(result);
+  result = collapseBlankLines(result);
+
+  // Step 3: Restore code blocks
+  result = restoreCodeBlocks(result, blocks);
+
+  return result;
+}

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -359,6 +359,13 @@ export async function processMessage(params: {
         }
       },
       deliver: async (payload: ReplyPayload, info) => {
+        // Resolve WhatsApp formatting options (account-level overrides channel-level)
+        const accountFormatting =
+          params.cfg.channels?.whatsapp?.accounts?.[params.route.accountId ?? ""]?.formatting;
+        const channelFormatting = params.cfg.channels?.whatsapp?.formatting;
+        const whatsappMarkdownTransform =
+          accountFormatting?.markdownTransform ?? channelFormatting?.markdownTransform ?? true;
+
         await deliverWebReply({
           replyResult: payload,
           msg: params.msg,
@@ -370,6 +377,7 @@ export async function processMessage(params: {
           // Tool + block updates are noisy; skip their log lines.
           skipLog: info.kind !== "final",
           tableMode,
+          whatsappMarkdownTransform,
         });
         didSendReply = true;
         if (info.kind === "tool") {


### PR DESCRIPTION
## Summary

Adds automatic conversion of standard Markdown to WhatsApp-compatible formatting for outbound messages. Enabled by default.

## Problem

LLMs output standard Markdown (`**bold**`, `~~strike~~`, `# headers`, etc.) but WhatsApp uses its own formatting syntax (`*bold*`, `~strike~`, no headers). Currently users need to patch source files or train agents to output WhatsApp-specific syntax.

Fixes #12129

## Solution

Built-in transform that runs automatically on outbound WhatsApp messages:

### Transforms
- `**bold**` or `__bold__` → `*bold*`
- `~~strikethrough~~` → `~strikethrough~`
- `# Headers` → `*Headers*` (bold)
- `[text](url)` → `text (url)`
- `![alt](url)` → `alt (url)`
- `---` horizontal rules → removed
- Preserves code blocks and inline code (WhatsApp supports them natively)

### Config Options

```json
{
  "channels": {
    "whatsapp": {
      "formatting": {
        "markdownTransform": true  // default
      }
    }
  }
}
```

Also supports per-account override:
```json
{
  "channels": {
    "whatsapp": {
      "accounts": {
        "myaccount": {
          "formatting": {
            "markdownTransform": false
          }
        }
      }
    }
  }
}
```

### Implementation

Applied after `convertMarkdownTables()` and before chunking in both delivery paths:
1. **Auto-reply** (`deliverWebReply`) — main path for agent responses
2. **Outbound** (`sendMessageWhatsApp`) — message tool and explicit sends

Transform ordering follows the issue recommendation: runs after table conversion to avoid `convertMarkdownTables()` re-introducing `**` markers.

## Testing

- 27 unit tests covering all transforms and edge cases
- Build passes
- Tested manually with WhatsApp channel

## Files Changed

- `src/markdown/whatsapp.ts` — new transform function
- `src/markdown/whatsapp.test.ts` — unit tests
- `src/config/types.whatsapp.ts` — config types
- `src/config/zod-schema.providers-whatsapp.ts` — Zod schema
- `src/web/auto-reply/deliver-reply.ts` — integrate transform
- `src/web/auto-reply/monitor/process-message.ts` — pass config
- `src/web/outbound.ts` — integrate transform

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a WhatsApp-specific Markdown normalization pass that converts common Markdown constructs (bold/strike/headers/links/images/hr) into WhatsApp-friendly formatting. The transform is wired into both outbound send paths: auto-reply delivery (`src/web/auto-reply/deliver-reply.ts`) and explicit outbound sends (`src/web/outbound.ts`), and it’s controlled via new `channels.whatsapp.formatting.markdownTransform` config (with per-account override) defined in the WhatsApp config types and Zod provider schema.

Main integration is: convert markdown tables → (optionally) transform markdown to WhatsApp format → chunk and send.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but there are a couple correctness issues in the new markdown transform that can corrupt output or violate type expectations.
- The new transform is integrated in the right places and is feature-scoped, but (1) placeholder restoration is not robust (non-global replace + user-collidable placeholders) and (2) the exported transform function can return null/undefined despite being typed as returning string; both can break downstream message handling.
- src/markdown/whatsapp.ts (placeholder restore + input/output type contract); src/markdown/whatsapp.test.ts (null/undefined behavior expectations)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->