### PR TITLE
fix(slack): pass threadId through to readSlackMessages in extension plugin

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -362,6 +362,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: readStringParam(params, "threadId"),
             accountId: accountId ?? undefined,
           },
           cfg,


### PR DESCRIPTION
## Problem

`message(action=read, target=CHANNEL_ID, threadId=THREAD_TS)` returns channel-level messages instead of thread replies when using the Slack channel.

## Root Cause

The Slack extension plugin's `read` action handler in `extensions/slack/src/channel.ts` was missing the `threadId` parameter when building the `readMessages` call to `handleSlackAction`.

The core implementation in `src/channels/plugins/slack.actions.ts` correctly passes `threadId`:
```typescript
threadId: readStringParam(params, "threadId"),
```

But the extension version (which is what gets loaded at runtime) omitted it, causing `readSlackMessages` to always receive `threadId: undefined` and fall back to `conversations.history` instead of `conversations.replies`.

## Fix

One-line addition: pass `threadId: readStringParam(params, "threadId")` in the extension's read handler.

## Testing

- Existing test in `src/channels/plugins/slack.actions.test.ts` covers the core path ("forwards threadId for read")
- Existing test in `src/slack/actions.read.test.ts` confirms `readSlackMessages` uses `conversations.replies` when `threadId` is set
- The extension should have a matching integration test (not added here but recommended)

Fixes #10582, #12783, #12279, #12866

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Slack extension plugin’s `read` action handler (`extensions/slack/src/channel.ts`) to forward the `threadId` parameter into the call chain that ultimately reaches `readSlackMessages`. This aligns the extension implementation with the core Slack channel implementation in `src/channels/plugins/slack.actions.ts`, so `message(action=read, target=CHANNEL_ID, threadId=THREAD_TS)` reads thread replies (via `conversations.replies`) rather than falling back to channel history (`conversations.history`) when `threadId` was previously omitted.

The change is narrowly scoped to a single parameter pass-through, and matches existing behavior already covered in core tests (though the extension path itself isn’t directly exercised by tests in this PR).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line parameter pass-through that aligns the Slack extension plugin’s `read` action with the already-correct core implementation, and it exercises an existing code path where `threadId` is already supported. No behavior changes occur unless callers provide `threadId`, and the underlying logic and tests for thread reading already exist.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->