### PR TITLE
Errors: recognize rate_limit_exceeded from Responses API response.failed

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -462,6 +462,7 @@ const ERROR_PATTERNS = {
     "quota exceeded",
     "resource_exhausted",
     "usage limit",
+    "rate_limit_exceeded",
   ],
   overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
   timeout: ["timeout", "timed out", "deadline exceeded", "context deadline exceeded"],


### PR DESCRIPTION
## Problem

When Azure OpenAI hits TPM (tokens-per-minute) rate limits during streaming via the Responses API, it sends a `response.failed` SSE event with `error.code: "rate_limit_exceeded"`. However, the upstream pi-ai library (`@mariozechner/pi-ai`) currently discards the error details and throws a bare `"Unknown error"`.

Even after pi-ai is fixed to forward the actual error (e.g. `"Response failed: rate_limit_exceeded"`), the `rate_limit_exceeded` error code (underscore-separated) doesn't match the existing rate-limit detection patterns which only check for `rate limit` (space-separated), `rate_limit` (partial match via regex), and `429`.

This means the error is not classified as a rate-limit failure, so the normal retry/failover logic in `run.ts` is not triggered.

## Root cause

The OpenAI Responses API `ResponseError.code` uses underscore_case enum values:
```typescript
code: 'server_error' | 'rate_limit_exceeded' | 'invalid_prompt' | ...
```

The existing regex `/rate[_ ]limit|too many requests|429/` does match `rate_limit`, but the full string `rate_limit_exceeded` was not explicitly covered. More importantly, when a provider returns the code as-is (e.g. `"rate_limit_exceeded"` without additional context text), the literal string pattern `"rate_limit_exceeded"` provides a reliable match.

## Fix

Add `"rate_limit_exceeded"` to `ERROR_PATTERNS.rateLimit` so it's recognized and triggers retry/failover.

## Upstream

The root cause in pi-ai (`processResponsesStream` throws `"Unknown error"` for `response.failed` events) should also be fixed in `badlogic/pi-mono`. This PR ensures that once pi-ai forwards the actual error details, openclaw correctly classifies them.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the rate-limit error detection in `src/agents/pi-embedded-helpers/errors.ts` by adding the literal string `"rate_limit_exceeded"` to `ERROR_PATTERNS.rateLimit`. This helps classify Azure OpenAI Responses API `response.failed` errors (which use underscore_case error codes) as rate-limit failures so existing retry/failover logic can trigger based on `isRateLimitErrorMessage()`/`classifyFailoverReason()`.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single additional string match in existing error classification logic, scoped to rate-limit detection, and does not alter control flow outside expanding a match set.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->