### PR TITLE
fix: Web UI Form Editor number field serialization

### DIFF
--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -174,3 +174,213 @@ describe("runUpdate", () => {
     });
   });
 });
+
+describe("updateConfigFormValue with type coercion", () => {
+  it("coerces string to number when schema type is number", () => {
+    const state = createState();
+    state.configSchema = {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            maxTokens: { type: "number" },
+          },
+        },
+      },
+    };
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["models", "maxTokens"], "8192");
+
+    expect(state.configForm).toEqual({
+      models: { maxTokens: 8192 },
+    });
+  });
+
+  it("coerces string to number for integer type", () => {
+    const state = createState();
+    state.configSchema = {
+      type: "object",
+      properties: {
+        gateway: {
+          type: "object",
+          properties: {
+            port: { type: "integer" },
+          },
+        },
+      },
+    };
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["gateway", "port"], "18789");
+
+    expect(state.configForm).toEqual({
+      gateway: { port: 18789 },
+    });
+  });
+
+  it("handles nullable number types (anyOf with null)", () => {
+    const state = createState();
+    state.configSchema = {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            contextWindow: {
+              anyOf: [{ type: "number" }, { type: "null" }],
+            },
+          },
+        },
+      },
+    };
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["models", "contextWindow"], "131072");
+
+    expect(state.configForm).toEqual({
+      models: { contextWindow: 131072 },
+    });
+  });
+
+  it("preserves actual number values", () => {
+    const state = createState();
+    state.configSchema = {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            maxTokens: { type: "number" },
+          },
+        },
+      },
+    };
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["models", "maxTokens"], 4096);
+
+    expect(state.configForm).toEqual({
+      models: { maxTokens: 4096 },
+    });
+  });
+
+  it("does not coerce non-numeric strings for number fields", () => {
+    const state = createState();
+    state.configSchema = {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            maxTokens: { type: "number" },
+          },
+        },
+      },
+    };
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["models", "maxTokens"], "not-a-number");
+
+    expect(state.configForm).toEqual({
+      models: { maxTokens: "not-a-number" },
+    });
+  });
+
+  it("coerces empty string to undefined for number fields", () => {
+    const state = createState();
+    state.configSchema = {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            maxTokens: { type: "number" },
+          },
+        },
+      },
+    };
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["models", "maxTokens"], "");
+
+    expect(state.configForm).toEqual({
+      models: { maxTokens: undefined },
+    });
+  });
+
+  it("does not coerce string fields", () => {
+    const state = createState();
+    state.configSchema = {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+          },
+        },
+      },
+    };
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["models", "name"], "8192");
+
+    expect(state.configForm).toEqual({
+      models: { name: "8192" },
+    });
+  });
+
+  it("works without schema (no coercion)", () => {
+    const state = createState();
+    state.configSchema = null;
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["models", "maxTokens"], "8192");
+
+    expect(state.configForm).toEqual({
+      models: { maxTokens: "8192" },
+    });
+  });
+});

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -367,6 +367,33 @@ describe("updateConfigFormValue with type coercion", () => {
     });
   });
 
+  it("rejects decimal values for integer fields", () => {
+    const state = createState();
+    state.configSchema = {
+      type: "object",
+      properties: {
+        gateway: {
+          type: "object",
+          properties: {
+            port: { type: "integer" },
+          },
+        },
+      },
+    };
+    state.configSnapshot = {
+      config: {},
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    updateConfigFormValue(state, ["gateway", "port"], "8080.5");
+
+    expect(state.configForm).toEqual({
+      gateway: { port: "8080.5" },
+    });
+  });
+
   it("works without schema (no coercion)", () => {
     const state = createState();
     state.configSchema = null;

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -2,6 +2,8 @@ import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot, ConfigUiHints } from "../types.ts";
 import {
   cloneConfigObject,
+  coerceValueToSchema,
+  getSchemaForPath,
   removePathValue,
   serializeConfigForm,
   setPathValue,
@@ -177,8 +179,11 @@ export function updateConfigFormValue(
   path: Array<string | number>,
   value: unknown,
 ) {
+  const schema = getSchemaForPath(state.configSchema, path);
+  const coercedValue = coerceValueToSchema(value, schema);
+
   const base = cloneConfigObject(state.configForm ?? state.configSnapshot?.config ?? {});
-  setPathValue(base, path, value);
+  setPathValue(base, path, coercedValue);
   state.configForm = base;
   state.configFormDirty = true;
   if (state.configFormMode === "form") {

--- a/ui/src/ui/controllers/config/form-utils.ts
+++ b/ui/src/ui/controllers/config/form-utils.ts
@@ -88,3 +88,108 @@ export function removePathValue(
     delete (current as Record<string, unknown>)[lastKey];
   }
 }
+
+type JsonSchema = {
+  type?: string | string[];
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema | JsonSchema[];
+  anyOf?: JsonSchema[];
+  oneOf?: JsonSchema[];
+  allOf?: JsonSchema[];
+  [key: string]: unknown;
+};
+
+export function getSchemaForPath(schema: unknown, path: Array<string | number>): JsonSchema | null {
+  if (!schema || typeof schema !== "object") {
+    return null;
+  }
+
+  let current = schema as JsonSchema;
+
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      const items = current.items;
+      if (!items) {
+        return null;
+      }
+      current = Array.isArray(items) ? (items[0] ?? null) : items;
+      if (!current) {
+        return null;
+      }
+    } else {
+      const properties = current.properties;
+      if (!properties || !properties[segment]) {
+        return null;
+      }
+      current = properties[segment];
+    }
+  }
+
+  return current;
+}
+
+export function getSchemaType(schema: JsonSchema | null): string | null {
+  if (!schema) {
+    return null;
+  }
+
+  if (typeof schema.type === "string") {
+    return schema.type;
+  }
+
+  if (Array.isArray(schema.type)) {
+    const nonNull = schema.type.filter((t) => t !== "null");
+    return nonNull.length > 0 ? nonNull[0] : null;
+  }
+
+  const variants = schema.anyOf ?? schema.oneOf;
+  if (variants && Array.isArray(variants)) {
+    const nonNull = variants.filter(
+      (v) => v.type !== "null" && (!Array.isArray(v.type) || !v.type.includes("null")),
+    );
+    if (nonNull.length > 0) {
+      return getSchemaType(nonNull[0]);
+    }
+  }
+
+  return null;
+}
+
+export function coerceValueToSchema(value: unknown, schema: JsonSchema | null): unknown {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  const schemaType = getSchemaType(schema);
+
+  if (schemaType === "number" || schemaType === "integer") {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed === "") {
+        return undefined;
+      }
+      const parsed = Number(trimmed);
+      return Number.isNaN(parsed) ? value : parsed;
+    }
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+
+  if (schemaType === "boolean") {
+    if (typeof value === "string") {
+      const lower = value.toLowerCase();
+      if (lower === "true") {
+        return true;
+      }
+      if (lower === "false") {
+        return false;
+      }
+    }
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  return value;
+}

--- a/ui/src/ui/controllers/config/form-utils.ts
+++ b/ui/src/ui/controllers/config/form-utils.ts
@@ -169,7 +169,13 @@ export function coerceValueToSchema(value: unknown, schema: JsonSchema | null): 
         return undefined;
       }
       const parsed = Number(trimmed);
-      return Number.isNaN(parsed) ? value : parsed;
+      if (Number.isNaN(parsed)) {
+        return value;
+      }
+      if (schemaType === "integer" && !Number.isInteger(parsed)) {
+        return value;
+      }
+      return parsed;
     }
     if (typeof value === "number") {
       return value;


### PR DESCRIPTION
fixes #13348

### Problem

When saving configuration through the Web UI Form Editor, numeric fields (e.g., `maxTokens`, `contextWindow`, `cost.*`) were serialized as strings instead of numbers. This caused `config.set` to reject the payload with **"invalid config"**, while the same configuration saved via Raw Config or CLI succeeded.

**Root cause:** HTML `<input>` elements return string values by default. The form serialization sent `"8192"` instead of `8192` to the server, triggering validation errors like:

```text
path:    models.providers.xai.models.0.maxTokens
message: Invalid input: expected number, received string
```

### Solution

Added schema-aware type coercion in `updateConfigFormValue()` that automatically converts string inputs to their schema-defined types before storing values in the config form.

**Key features:**
- Coerces strings to numbers for `number` and `integer` schema types
- Handles nullable types (`anyOf: [{ type: "number" }, { type: "null" }]`)
- Treats empty strings as `undefined`
- Preserves non-numeric strings (validation catches them later)
- Works without schema (backwards compatible)



### Changes

- **ui/src/ui/controllers/config.ts**: Apply type coercion before setting form values
- **ui/src/ui/controllers/config/form-utils.ts**: Add schema traversal and coercion utilities  
  (`getSchemaForPath`, `getSchemaType`, `coerceValueToSchema`)
- **ui/src/ui/controllers/config.test.ts**: Add 8 comprehensive test cases


### Testing

All tests pass (110 total, including 8 new tests):

- String `"8192"` → number `8192`
- Empty string `""` → `undefined`
- Invalid input `"not-a-number"` → preserved unchanged
- Nullable types (`number | null`) handled correctly
- String fields not affected



### Before / After

**Before:**
```json
{ "maxTokens": "8192" }
```
**After:**
```json
{ "maxTokens": 8192 }
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Web UI Form Editor serialization by introducing schema-aware coercion when writing values into `state.configForm`.

- `ui/src/ui/controllers/config.ts`: `updateConfigFormValue()` now looks up the JSON Schema at the edited path and coerces incoming values before calling `setPathValue()`.
- `ui/src/ui/controllers/config/form-utils.ts`: adds minimal JSON Schema traversal (`getSchemaForPath`, `getSchemaType`) and value coercion (`coerceValueToSchema`) for numbers/integers (and booleans).
- `ui/src/ui/controllers/config.test.ts`: adds unit tests covering numeric coercion, nullable numeric schemas, empty-string handling, and “no schema” behavior.

Overall this aligns the Form Editor’s payload types with the server’s config validation so saving via the UI behaves like Raw Config/CLI.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after addressing a couple schema/coercion correctness gaps that can leave some inputs still failing validation.
- Core change is small and covered by new tests, but the current coercion doesn’t respect `integer` semantics and the schema traversal misses common JSON Schema constructs (e.g., refs / additionalProperties / prefixItems), which can prevent coercion on real config paths and reintroduce the original save failure for those fields.
- ui/src/ui/controllers/config/form-utils.ts, ui/src/ui/controllers/config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->