### PR TITLE
fix: ignore meta field changes in config file watcher

### DIFF
--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -64,6 +64,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
 ];
 
 const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
+  { prefix: "meta", kind: "none" },
   { prefix: "identity", kind: "none" },
   { prefix: "wizard", kind: "none" },
   { prefix: "logging", kind: "none" },


### PR DESCRIPTION
Fixes #13458

## What
Prevents the config file watcher from triggering a gateway restart when only `meta.*` fields change.

## Why
The gateway updates `meta.lastTouchedAt` and `meta.lastTouchedVersion` on startup. The file watcher was treating these as user-initiated config changes and triggering a restart, causing an infinite loop.

## How
Added `meta` prefix to `BASE_RELOAD_RULES_TAIL` with `kind: "none"`, matching the pattern used for other internal/bookkeeping fields like `identity`, `wizard`, and `logging`.

## Testing
- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] Verified gateway no longer restart-loops on startup

## AI-Assisted
This PR was built with AI assistance (Claude via OpenClaw). The code has been reviewed, tested, and I understand what it does.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the gateway config reload rules so that changes under the `meta.*` prefix are treated as no-ops.

In `src/gateway/config-reload.ts`, the config watcher computes changed config paths (`diffConfigPaths`) and maps them to reload behavior using ordered prefix rules. By adding `{ prefix: "meta", kind: "none" }` to the tail rules, config file writes that only update bookkeeping fields like `meta.lastTouchedAt` / `meta.lastTouchedVersion` will no longer trigger a hot reload or a gateway restart, avoiding the startup restart loop described in #13458.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, well-scoped rule addition that aligns with the config schema (meta only contains auto-written bookkeeping fields) and matches existing patterns for other no-op internal prefixes.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->