### PR TITLE
fix: security audit distinguishes internal hooks from external webhooks

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -294,15 +294,28 @@ function listGroupPolicyOpen(cfg: OpenClawConfig): string[] {
 export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const group = summarizeGroupPolicy(cfg);
   const elevated = cfg.tools?.elevated?.enabled !== false;
-  const hooksEnabled = cfg.hooks?.enabled === true;
+  const webhooksEnabled = cfg.hooks?.enabled === true;
+  const internalHooksEnabled = cfg.hooks?.internal?.enabled === true;
+  const internalHooksActive = internalHooksEnabled
+    ? Object.values(cfg.hooks?.internal?.entries ?? {}).filter((e: any) => e.enabled !== false).length
+    : 0;
   const browserEnabled = cfg.browser?.enabled ?? true;
+
+  let hooksStatus: string;
+  if (webhooksEnabled) {
+    hooksStatus = "webhooks: enabled";
+  } else if (internalHooksEnabled && internalHooksActive > 0) {
+    hooksStatus = `webhooks: disabled, internal: enabled (${internalHooksActive} active)`;
+  } else {
+    hooksStatus = "disabled";
+  }
 
   const detail =
     `groups: open=${group.open}, allowlist=${group.allowlist}` +
     `\n` +
     `tools.elevated: ${elevated ? "enabled" : "disabled"}` +
     `\n` +
-    `hooks: ${hooksEnabled ? "enabled" : "disabled"}` +
+    `hooks: ${hooksStatus}` +
     `\n` +
     `browser control: ${browserEnabled ? "enabled" : "disabled"}`;
 


### PR DESCRIPTION
## Problem

`openclaw security audit` reports `hooks: disabled` even when internal (bundled) hooks are enabled and active. This is because the check only looks at `hooks.enabled` (the external webhook endpoint flag) and ignores `hooks.internal.enabled`.

Fixes #13466

## Changes

In `src/security/audit-extra.sync.ts`, the hooks status now distinguishes between:

- **`webhooks: enabled`** — external webhook endpoint is on
- **`webhooks: disabled, internal: enabled (N active)`** — external webhooks off but internal hooks are running
- **`disabled`** — both systems off

## Before / After

**Before:**
```
hooks: disabled
```

**After** (with 2 internal hooks active):
```
hooks: webhooks: disabled, internal: enabled (2 active)
```

## Testing

Tested against a live gateway running v2026.2.9 with `hooks.internal.enabled: true` and two active internal hooks (`session-memory`, `command-logger`). Before the fix, audit showed `hooks: disabled`; after, it correctly reflects the internal hooks state.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the security audit “attack surface summary” to report hooks in a more granular way:

- Distinguishes external webhook endpoint state (`hooks.enabled`) from internal/bundled hooks (`hooks.internal.enabled`).
- Includes an “N active” count for internal hook entries when internal hooks are enabled.

The change is localized to `collectAttackSurfaceSummaryFindings` (used by `runSecurityAudit` in `src/security/audit.ts`).

One correctness issue remains: the new internal hook activity count is computed only from `hooks.internal.entries`, but the runtime hook loader also supports legacy `hooks.internal.handlers`. In configs using only legacy handlers, audit will still show `hooks: disabled` even though internal hooks will load and run.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but hook status may be incorrect for legacy internal hook configs.
- The change is small and isolated, but the internal hook “active” detection only considers `hooks.internal.entries` while the runtime loader also supports `hooks.internal.handlers`, which can lead to incorrect audit output in real configurations.
- src/security/audit-extra.sync.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->