### PR TITLE
fix: honor systemPrompt from before_agent_start hook result

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -737,8 +737,14 @@ export async function runEmbeddedAttempt(
                 messageProvider: params.messageProvider ?? undefined,
               },
             );
+            if (hookResult?.systemPrompt) {
+              effectivePrompt = hookResult.systemPrompt;
+              log.debug(
+                `hooks: replaced system prompt via before_agent_start (${hookResult.systemPrompt.length} chars)`,
+              );
+            }
             if (hookResult?.prependContext) {
-              effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
+              effectivePrompt = `${hookResult.prependContext}\n\n${effectivePrompt}`;
               log.debug(
                 `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
               );


### PR DESCRIPTION
## Bug

The `before_agent_start` hook type defines a `systemPrompt` field in its result type (`PluginHookBeforeAgentStartResult`), and the hook merger in `hooks.ts` correctly accumulates it:

```ts
// src/plugins/hooks.ts:187-188
(acc, next) => ({
  systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
  prependContext: ...
})
```

However, the only consumer in `attempt.ts` only checks `prependContext` and completely ignores `systemPrompt`:

```ts
// src/agents/pi-embedded-runner/run/attempt.ts
if (hookResult?.prependContext) {
  effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
}
// hookResult.systemPrompt is never read
```

This means plugins returning `{ systemPrompt: "..." }` from `before_agent_start` have no effect.

## Fix

Added handling for `hookResult.systemPrompt` before the existing `prependContext` check. When a plugin returns `systemPrompt`, it replaces the full system prompt. `prependContext` is applied after, so both can be combined.

## Use Case

Plugins that need to modify (e.g. strip framework sections from) the system prompt for agents using small local models. The full ~14KB prompt overwhelms small models' ability to make tool calls, but the hook's `systemPrompt` return — designed for exactly this — was silently discarded.

## Changes

- `src/agents/pi-embedded-runner/run/attempt.ts`: Read `hookResult.systemPrompt` and apply it before `prependContext` (+7 lines, -1 line)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the embedded agent runner’s `before_agent_start` hook handling so plugins can replace the full system prompt via `hookResult.systemPrompt`, and then optionally prepend additional context via `hookResult.prependContext`. This aligns the runner with the hook result type and the existing hook merge behavior in `src/plugins/hooks.ts`, which already accumulates `systemPrompt` but previously had no effect in the embedded attempt execution path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff is a straightforward fix: it wires an already-supported hook result field (`systemPrompt`) into the only consumer (`runEmbeddedAttempt`) without changing behavior when plugins don’t return that field. The updated ordering (replace, then prepend) is consistent and the string used for prepending now references the effective prompt.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->