### PR TITLE
fix(security): distinguish webhooks from internal hooks in audit summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Audit: distinguish external webhooks (`hooks.enabled`) from internal hooks (`hooks.internal.enabled`) in attack-surface summaries to avoid false exposure signals when only internal hooks are enabled. (#13474) Thanks @mcaxtr.
 - Sandbox: pass configured `sandbox.docker.env` variables to sandbox containers at `docker create` time. (#15138) Thanks @stevebot-alive.
 - Onboarding/CLI: restore terminal state without resuming paused `stdin`, so onboarding exits cleanly after choosing Web UI and the installer returns instead of appearing stuck.
 - macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { collectAttackSurfaceSummaryFindings } from "./audit-extra.sync.js";
+
+describe("collectAttackSurfaceSummaryFindings", () => {
+  it("distinguishes external webhooks from internal hooks when only internal hooks are enabled", () => {
+    const cfg: OpenClawConfig = {
+      hooks: { internal: { enabled: true } },
+    };
+
+    const [finding] = collectAttackSurfaceSummaryFindings(cfg);
+    expect(finding.checkId).toBe("summary.attack_surface");
+    expect(finding.detail).toContain("hooks.webhooks: disabled");
+    expect(finding.detail).toContain("hooks.internal: enabled");
+  });
+
+  it("reports both hook systems as enabled when both are configured", () => {
+    const cfg: OpenClawConfig = {
+      hooks: { enabled: true, internal: { enabled: true } },
+    };
+
+    const [finding] = collectAttackSurfaceSummaryFindings(cfg);
+    expect(finding.detail).toContain("hooks.webhooks: enabled");
+    expect(finding.detail).toContain("hooks.internal: enabled");
+  });
+
+  it("reports both hook systems as disabled when neither is configured", () => {
+    const cfg: OpenClawConfig = {};
+
+    const [finding] = collectAttackSurfaceSummaryFindings(cfg);
+    expect(finding.detail).toContain("hooks.webhooks: disabled");
+    expect(finding.detail).toContain("hooks.internal: disabled");
+  });
+});

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -303,7 +303,8 @@ function listGroupPolicyOpen(cfg: OpenClawConfig): string[] {
 export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const group = summarizeGroupPolicy(cfg);
   const elevated = cfg.tools?.elevated?.enabled !== false;
-  const hooksEnabled = cfg.hooks?.enabled === true;
+  const webhooksEnabled = cfg.hooks?.enabled === true;
+  const internalHooksEnabled = cfg.hooks?.internal?.enabled === true;
   const browserEnabled = cfg.browser?.enabled ?? true;
 
   const detail =
@@ -311,7 +312,9 @@ export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): Securi
     `\n` +
     `tools.elevated: ${elevated ? "enabled" : "disabled"}` +
     `\n` +
-    `hooks: ${hooksEnabled ? "enabled" : "disabled"}` +
+    `hooks.webhooks: ${webhooksEnabled ? "enabled" : "disabled"}` +
+    `\n` +
+    `hooks.internal: ${internalHooksEnabled ? "enabled" : "disabled"}` +
     `\n` +
     `browser control: ${browserEnabled ? "enabled" : "disabled"}`;
 

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -47,56 +47,6 @@ describe("security audit", () => {
     );
   });
 
-  it("distinguishes external webhooks from internal hooks in the attack surface summary", async () => {
-    const cfg: OpenClawConfig = {
-      hooks: { internal: { enabled: true } },
-    };
-
-    const res = await runSecurityAudit({
-      config: cfg,
-      includeFilesystem: false,
-      includeChannelSecurity: false,
-    });
-
-    const finding = res.findings.find((f) => f.checkId === "summary.attack_surface");
-    expect(finding).toBeDefined();
-    // Should report webhooks as disabled and internal hooks as enabled
-    expect(finding?.detail).toContain("hooks.webhooks: disabled");
-    expect(finding?.detail).toContain("hooks.internal: enabled");
-  });
-
-  it("reports both hook systems as enabled when both are configured", async () => {
-    const cfg: OpenClawConfig = {
-      hooks: { enabled: true, internal: { enabled: true } },
-    };
-
-    const res = await runSecurityAudit({
-      config: cfg,
-      includeFilesystem: false,
-      includeChannelSecurity: false,
-    });
-
-    const finding = res.findings.find((f) => f.checkId === "summary.attack_surface");
-    expect(finding).toBeDefined();
-    expect(finding?.detail).toContain("hooks.webhooks: enabled");
-    expect(finding?.detail).toContain("hooks.internal: enabled");
-  });
-
-  it("reports both hook systems as disabled when neither is configured", async () => {
-    const cfg: OpenClawConfig = {};
-
-    const res = await runSecurityAudit({
-      config: cfg,
-      includeFilesystem: false,
-      includeChannelSecurity: false,
-    });
-
-    const finding = res.findings.find((f) => f.checkId === "summary.attack_surface");
-    expect(finding).toBeDefined();
-    expect(finding?.detail).toContain("hooks.webhooks: disabled");
-    expect(finding?.detail).toContain("hooks.internal: disabled");
-  });
-
   it("flags non-loopback bind without auth as critical", async () => {
     const cfg: OpenClawConfig = {
       gateway: {


### PR DESCRIPTION
## Summary

The security audit's attack surface summary reported `hooks: disabled` even when internal hooks (`hooks.internal.enabled: true`) were actively running. This confused users who had just enabled internal hooks (e.g., `session-memory`, `command-logger`) via `openclaw hooks enable`.

**Root cause:** `collectAttackSurfaceSummaryFindings()` only checked `cfg.hooks?.enabled` (the external webhook endpoint flag) and completely ignored `cfg.hooks?.internal?.enabled`.

**Fix:** Split the single `hooks:` line into two separate, unambiguous lines:
- `hooks.webhooks: disabled/enabled` — external webhook HTTP endpoint
- `hooks.internal: disabled/enabled` — internal agent event hooks

### Before
```
hooks: disabled          ← misleading when internal hooks ARE enabled
```

### After
```
hooks.webhooks: disabled
hooks.internal: enabled
```

Fixes #13466

## Test plan

- [x] Add test: internal hooks enabled + webhooks disabled → summary shows `hooks.webhooks: disabled` and `hooks.internal: enabled`
- [x] Add test: both hook systems enabled → summary shows both as enabled
- [x] Add test: neither hook system enabled → summary shows both as disabled
- [x] All 3 new tests fail before the fix, pass after (TDD)
- [x] All 47 existing tests continue to pass
- [x] `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a confusing security audit output by splitting the single `hooks:` line in the attack surface summary into two explicit lines: one for the external webhook HTTP endpoint (`hooks.webhooks`) and one for internal event hooks (`hooks.internal`).

Implementation-wise, `collectAttackSurfaceSummaryFindings()` in `src/security/audit-extra.sync.ts` now checks both `cfg.hooks?.enabled` and `cfg.hooks?.internal?.enabled` and includes both statuses in the rendered multi-line `detail` string. Tests in `src/security/audit.test.ts` were extended with three new cases to cover internal-only enabled, both enabled, and neither enabled configurations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and covered by new tests that fail before and pass after the fix; it only affects a human-readable audit summary string and keeps the finding ID unchanged. I did not find any consumers that parse the prior `hooks:` line format, so the output change should not break integrations.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->