### PR TITLE
fix(sessions): show actual cron session model in sessions_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
+- Sessions: `sessions_list` now shows the actual model used by cron isolated sessions instead of the agent default. (#13429)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
 - CI: Implement pipeline and workflow order. Thanks @quotentiroler.

--- a/src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
@@ -417,6 +417,41 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.list returns entry.model written by cron run (#13429)", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-model-"));
+    const storePath = path.join(dir, "sessions.json");
+    testState.sessionStorePath = storePath;
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+        },
+        "cron:daily-report": {
+          sessionId: "sess-cron",
+          updatedAt: Date.now(),
+          label: "Cron: daily-report",
+          modelProvider: "google-gemini-cli",
+          model: "gemini-3-pro-preview",
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    const list = await rpcReq<{
+      sessions: Array<{ key: string; model?: string; modelProvider?: string }>;
+    }>(ws, "sessions.list", { includeGlobal: false, includeUnknown: false });
+
+    expect(list.ok).toBe(true);
+    const cronSession = list.payload?.sessions.find((s) => s.key.includes("cron:daily-report"));
+    expect(cronSession).toBeDefined();
+    expect(cronSession?.model).toBe("gemini-3-pro-preview");
+    expect(cronSession?.modelProvider).toBe("google-gemini-cli");
+
+    ws.close();
+  });
+
   test("sessions.delete rejects main and aborts active runs", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-"));
     const storePath = path.join(dir, "sessions.json");

--- a/src/gateway/session-utils.resolveSessionModelRef.test.ts
+++ b/src/gateway/session-utils.resolveSessionModelRef.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionModelRef } from "./session-utils.js";
+
+describe("resolveSessionModelRef", () => {
+  const cfg = {
+    agents: {
+      defaults: {
+        model: { primary: "anthropic/claude-opus-4-6" },
+      },
+    },
+  } as any;
+
+  it("returns agent default when session has no model info", () => {
+    const result = resolveSessionModelRef(cfg, { sessionId: "s1" } as any);
+    expect(result.model).toBe("claude-opus-4-6");
+    expect(result.provider).toBe("anthropic");
+  });
+
+  it("uses modelOverride when set by user", () => {
+    const entry = {
+      sessionId: "s1",
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    } as any;
+    const result = resolveSessionModelRef(cfg, entry);
+    expect(result.model).toBe("claude-haiku-4-5");
+    expect(result.provider).toBe("anthropic");
+  });
+
+  it("uses entry.model written by cron run when no modelOverride", () => {
+    const entry = {
+      sessionId: "s1",
+      modelProvider: "google-gemini-cli",
+      model: "gemini-3-pro-preview",
+    } as any;
+    const result = resolveSessionModelRef(cfg, entry);
+    expect(result.model).toBe("gemini-3-pro-preview");
+    expect(result.provider).toBe("google-gemini-cli");
+  });
+
+  it("prefers modelOverride over entry.model", () => {
+    const entry = {
+      sessionId: "s1",
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+      modelProvider: "google-gemini-cli",
+      model: "gemini-3-pro-preview",
+    } as any;
+    const result = resolveSessionModelRef(cfg, entry);
+    expect(result.model).toBe("claude-haiku-4-5");
+    expect(result.provider).toBe("anthropic");
+  });
+});

--- a/src/gateway/session-utils.resolveSessionModelRef.test.ts
+++ b/src/gateway/session-utils.resolveSessionModelRef.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
 import { resolveSessionModelRef } from "./session-utils.js";
 
 describe("resolveSessionModelRef", () => {
@@ -8,10 +10,10 @@ describe("resolveSessionModelRef", () => {
         model: { primary: "anthropic/claude-opus-4-6" },
       },
     },
-  } as any;
+  } as unknown as OpenClawConfig;
 
   it("returns agent default when session has no model info", () => {
-    const result = resolveSessionModelRef(cfg, { sessionId: "s1" } as any);
+    const result = resolveSessionModelRef(cfg, { sessionId: "s1" } as unknown as SessionEntry);
     expect(result.model).toBe("claude-opus-4-6");
     expect(result.provider).toBe("anthropic");
   });
@@ -21,7 +23,7 @@ describe("resolveSessionModelRef", () => {
       sessionId: "s1",
       modelOverride: "claude-haiku-4-5",
       providerOverride: "anthropic",
-    } as any;
+    } as unknown as SessionEntry;
     const result = resolveSessionModelRef(cfg, entry);
     expect(result.model).toBe("claude-haiku-4-5");
     expect(result.provider).toBe("anthropic");
@@ -32,7 +34,7 @@ describe("resolveSessionModelRef", () => {
       sessionId: "s1",
       modelProvider: "google-gemini-cli",
       model: "gemini-3-pro-preview",
-    } as any;
+    } as unknown as SessionEntry;
     const result = resolveSessionModelRef(cfg, entry);
     expect(result.model).toBe("gemini-3-pro-preview");
     expect(result.provider).toBe("google-gemini-cli");
@@ -45,7 +47,7 @@ describe("resolveSessionModelRef", () => {
       providerOverride: "anthropic",
       modelProvider: "google-gemini-cli",
       model: "gemini-3-pro-preview",
-    } as any;
+    } as unknown as SessionEntry;
     const result = resolveSessionModelRef(cfg, entry);
     expect(result.model).toBe("claude-haiku-4-5");
     expect(result.provider).toBe("anthropic");

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -541,6 +541,9 @@ export function resolveSessionModelRef(
   if (storedModelOverride) {
     provider = entry?.providerOverride?.trim() || provider;
     model = storedModelOverride;
+  } else if (entry?.model?.trim()) {
+    provider = entry?.modelProvider?.trim() || provider;
+    model = entry.model.trim();
   }
   return { provider, model };
 }


### PR DESCRIPTION
## Summary
Fixes #13429

## Problem
`sessions_list` shows the agent default model (e.g., `claude-opus-4-6`) for cron isolated sessions even when the job successfully ran with a different model (e.g., `gemini-3-pro-preview`).

**Root cause:** `resolveSessionModelRef()` in `src/gateway/session-utils.ts` only checks `entry.modelOverride` (set by user via `session_status` tool) but ignores `entry.model` — the field written by `src/cron/isolated-agent/run.ts` after a successful run. When no user override exists, it falls back to the agent default model.

## Fix
Add an `else if` branch in `resolveSessionModelRef()` to check `entry.model` / `entry.modelProvider` when no `modelOverride` is set. Priority order:

1. `modelOverride` / `providerOverride` (user-set override) — highest priority
2. `model` / `modelProvider` (written by cron run) — new fallback
3. Agent default model — lowest priority

**Before:**
```typescript
if (storedModelOverride) {
    provider = entry?.providerOverride?.trim() || provider;
    model = storedModelOverride;
}
```

**After:**
```typescript
if (storedModelOverride) {
    provider = entry?.providerOverride?.trim() || provider;
    model = storedModelOverride;
} else if (entry?.model?.trim()) {
    provider = entry?.modelProvider?.trim() || provider;
    model = entry.model.trim();
}
```

## Reproduction & Verification

### Unit-level (direct function call):

**Before fix (main branch) — Bug reproduced:**
```
Cron session model: anthropic/claude-opus-4-6
  Expected: google-gemini-cli/gemini-3-pro-preview
  ❌ FAIL: shows agent default instead of actual model
```

**After fix — All verified:**
```
Cron session model: google-gemini-cli/gemini-3-pro-preview  ✅ PASS
Override session model: anthropic/claude-haiku-4-5           ✅ PASS
Empty session model: anthropic/claude-opus-4-6 (default)    ✅ PASS
```

### E2E-level (real gateway environment):

Added an e2e test in `server.sessions.gateway-server-sessions-a.e2e.test.ts` that starts a real gateway server, writes a session store entry with `model: "gemini-3-pro-preview"` and `modelProvider: "google-gemini-cli"`, then calls `sessions.list` via WebSocket RPC and verifies the returned model fields:

**Before fix (main branch) — Bug reproduced through real gateway:**
```
sessions.list RPC → cronSession.model: undefined (falls back to agent default)
  ❌ FAIL: shows agent default instead of actual model
```

**After fix — Gateway returns correct model:**
```
sessions.list RPC → cronSession.model: "gemini-3-pro-preview"
sessions.list RPC → cronSession.modelProvider: "google-gemini-cli"
  ✅ PASS
```

## Effect on User Experience

**Before fix:**
User configures a cron job with `google-gemini-cli/gemini-3-pro-preview` → job runs successfully → `sessions_list` shows `model: "claude-opus-4-6"` → user thinks the model override is broken.

**After fix:**
`sessions_list` correctly shows `model: "gemini-3-pro-preview"` for cron sessions that ran with a non-default model.

## Testing
- ✅ 4 unit tests pass (`resolveSessionModelRef` in `session-utils.resolveSessionModelRef.test.ts`)
- ✅ 1 e2e test passes (`sessions.list` RPC in `server.sessions.gateway-server-sessions-a.e2e.test.ts`)
- ✅ Existing tests unaffected
