### PR TITLE
routing: normalize account ID matching for agent bindings

### DIFF
--- a/src/docker-setup.test.ts
+++ b/src/docker-setup.test.ts
@@ -121,7 +121,7 @@ describe("docker-setup.sh", () => {
     const script = await readFile(join(repoRoot, "docker-setup.sh"), "utf8");
     expect(script).not.toMatch(/^\s*declare -A\b/m);
 
-    const systemBash = "/bin/bash";
+    const systemBash = process.platform === "win32" ? "bash" : "/bin/bash";
     const assocCheck = spawnSync(systemBash, ["-c", "declare -A _t=()"], {
       encoding: "utf8",
     });

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -191,6 +191,20 @@ describe("resolveAgentRoute", () => {
     expect(otherRoute.agentId).toBe("main");
   });
 
+  test("account binding matches normalized account IDs to avoid fallback misrouting", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [{ agentId: "main", match: { channel: "telegram", accountId: "Bot Main" } }],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: "bot-main",
+      peer: { kind: "direct", id: "1000" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+
   test("accountId=* matches any account as a channel fallback", () => {
     const cfg: OpenClawConfig = {
       bindings: [

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -8,6 +8,7 @@ import {
   buildAgentPeerSessionKey,
   DEFAULT_ACCOUNT_ID,
   DEFAULT_MAIN_KEY,
+  normalizeAccountId as normalizeSessionAccountId,
   normalizeAgentId,
   sanitizeAgentId,
 } from "./session-key.js";
@@ -60,11 +61,6 @@ function normalizeId(value: string | undefined | null): string {
   return (value ?? "").trim();
 }
 
-function normalizeAccountId(value: string | undefined | null): string {
-  const trimmed = (value ?? "").trim();
-  return trimmed ? trimmed : DEFAULT_ACCOUNT_ID;
-}
-
 function matchesAccountId(match: string | undefined, actual: string): boolean {
   const trimmed = (match ?? "").trim();
   if (!trimmed) {
@@ -73,7 +69,7 @@ function matchesAccountId(match: string | undefined, actual: string): boolean {
   if (trimmed === "*") {
     return true;
   }
-  return trimmed === actual;
+  return normalizeSessionAccountId(trimmed) === normalizeSessionAccountId(actual);
 }
 
 export function buildAgentSessionKey(params: {
@@ -170,7 +166,7 @@ function matchesTeam(match: { teamId?: string | undefined } | undefined, teamId:
 
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
   const channel = normalizeToken(input.channel);
-  const accountId = normalizeAccountId(input.accountId);
+  const accountId = normalizeSessionAccountId(input.accountId);
   const peer = input.peer ? { kind: input.peer.kind, id: normalizeId(input.peer.id) } : null;
   const guildId = normalizeId(input.guildId);
   const teamId = normalizeId(input.teamId);


### PR DESCRIPTION
## Summary
- normalize `match.accountId` and runtime `accountId` using the same canonical account normalization
- prevent fallback routing when binding and runtime account IDs differ only by case/formatting
- add regression coverage for normalized account binding matches

## Validation
- `pnpm vitest run src/routing/resolve-route.test.ts src/telegram/bot.create-telegram-bot.routes-dms-by-telegram-accountid-binding.test.ts`

Fixes #13423

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates routing account binding resolution so that accountId comparisons use the same canonical normalization as session key generation (`normalizeAccountId` from `src/routing/session-key.ts`). Concretely, `resolveAgentRoute` now normalizes the runtime accountId with the canonical normalizer, and `matchesAccountId` compares normalized forms instead of raw strings. A regression test was added to ensure bindings match when the configured accountId and runtime accountId differ only by case/formatting (e.g., `"Bot Main"` vs `"bot-main"`), preventing unintended fallback routing.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and align routing-time accountId matching with the existing canonical normalization used for session keys. The added regression test covers the reported misrouting scenario. No call sites are broken because the public API is unchanged and behavior only becomes more permissive for equivalent account IDs.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->