### PR TITLE
feat(plugins): add Linear, Google Calendar, and Kindle tool plugins

### DIFF
--- a/extensions/google-calendar/index.ts
+++ b/extensions/google-calendar/index.ts
@@ -1,0 +1,9 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "../../src/plugins/types.js";
+import { createCalendarTools } from "./src/calendar-tools.js";
+
+export default function register(api: OpenClawPluginApi) {
+  const tools = createCalendarTools(api);
+  for (const tool of tools) {
+    api.registerTool(tool as unknown as AnyAgentTool, { optional: true });
+  }
+}

--- a/extensions/google-calendar/openclaw.plugin.json
+++ b/extensions/google-calendar/openclaw.plugin.json
@@ -1,0 +1,26 @@
+{
+  "id": "google-calendar",
+  "name": "Google Calendar",
+  "description": "Query and manage Google Calendar events from your AI assistant.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "credentialsPath": { "type": "string" },
+      "calendarId": { "type": "string" },
+      "accessToken": { "type": "string" }
+    }
+  },
+  "uiHints": {
+    "credentialsPath": {
+      "label": "Service Account Credentials Path",
+      "placeholder": "~/.openclaw/google-calendar-credentials.json"
+    },
+    "calendarId": { "label": "Calendar ID", "placeholder": "primary" },
+    "accessToken": {
+      "label": "Access Token",
+      "sensitive": true,
+      "help": "Direct OAuth2 access token (alternative to service account)"
+    }
+  }
+}

--- a/extensions/google-calendar/package.json
+++ b/extensions/google-calendar/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/google-calendar",
+  "version": "2026.2.9",
+  "private": true,
+  "description": "OpenClaw Google Calendar integration plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/google-calendar/src/calendar-tools.test.ts
+++ b/extensions/google-calendar/src/calendar-tools.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+import { createCalendarTools } from "./calendar-tools.js";
+
+function fakeApi(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "google-calendar",
+    name: "google-calendar",
+    source: "test",
+    config: {},
+    pluginConfig: { accessToken: "test-token-123", calendarId: "primary" },
+    runtime: { version: "test" },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    registerTool() {},
+    ...overrides,
+  } as unknown as OpenClawPluginApi;
+}
+
+function findTool(tools: ReturnType<typeof createCalendarTools>, name: string) {
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool ${name} not found`);
+  return tool;
+}
+
+function mockFetchResponse(data: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  });
+}
+
+describe("calendar tools", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates four tools", () => {
+    const tools = createCalendarTools(fakeApi());
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "calendar_list_events",
+      "calendar_search_events",
+      "calendar_create_event",
+      "calendar_get_event",
+    ]);
+  });
+
+  describe("calendar_list_events", () => {
+    it("returns formatted events", async () => {
+      const mockData = {
+        items: [
+          {
+            id: "ev1",
+            summary: "Team standup",
+            start: { dateTime: "2024-03-15T09:00:00-07:00" },
+            end: { dateTime: "2024-03-15T09:30:00-07:00" },
+            location: "Room A",
+            htmlLink: "https://calendar.google.com/event/ev1",
+          },
+        ],
+      };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_list_events");
+      const result = await tool.execute("call1", {});
+
+      expect(result.content[0].text).toContain("Team standup");
+      expect(result.content[0].text).toContain("Room A");
+      expect(result.content[0].text).toContain("2024-03-15T09:00:00");
+    });
+
+    it("defaults timeMin to roughly now", async () => {
+      const mockData = { items: [] };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const before = new Date().toISOString();
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_list_events");
+      await tool.execute("call2", {});
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      const url = new URL(calledUrl);
+      const timeMin = url.searchParams.get("timeMin")!;
+      // timeMin should be close to now (within a few seconds)
+      expect(new Date(timeMin).getTime()).toBeGreaterThanOrEqual(new Date(before).getTime() - 5000);
+    });
+
+    it("respects maxResults parameter", async () => {
+      const mockData = { items: [] };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_list_events");
+      await tool.execute("call3", { maxResults: 5 });
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("maxResults")).toBe("5");
+    });
+
+    it("returns no-events message when empty", async () => {
+      const mockData = { items: [] };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_list_events");
+      const result = await tool.execute("call4", {});
+
+      expect(result.content[0].text).toContain("No upcoming events");
+    });
+  });
+
+  describe("calendar_search_events", () => {
+    it("passes query parameter to API", async () => {
+      const mockData = {
+        items: [
+          {
+            id: "ev2",
+            summary: "Dentist appointment",
+            start: { dateTime: "2024-03-20T14:00:00-07:00" },
+            end: { dateTime: "2024-03-20T15:00:00-07:00" },
+          },
+        ],
+      };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_search_events");
+      const result = await tool.execute("call5", { query: "dentist" });
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("q")).toBe("dentist");
+      expect(result.content[0].text).toContain("Dentist appointment");
+    });
+
+    it("returns no-results message", async () => {
+      const mockData = { items: [] };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_search_events");
+      const result = await tool.execute("call6", { query: "nonexistent" });
+
+      expect(result.content[0].text).toContain("No events found");
+    });
+  });
+
+  describe("calendar_create_event", () => {
+    it("sends correct POST body and returns created event", async () => {
+      const createdEvent = {
+        id: "ev3",
+        summary: "Lunch",
+        start: { dateTime: "2024-03-15T12:00:00-07:00" },
+        end: { dateTime: "2024-03-15T13:00:00-07:00" },
+        htmlLink: "https://calendar.google.com/event/ev3",
+      };
+      const fetchMock = mockFetchResponse(createdEvent);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_create_event");
+      const result = await tool.execute("call7", {
+        summary: "Lunch",
+        startTime: "2024-03-15T12:00:00-07:00",
+        endTime: "2024-03-15T13:00:00-07:00",
+        location: "Café",
+      });
+
+      // Verify POST was sent
+      const callOpts = fetchMock.mock.calls[0][1];
+      expect(callOpts.method).toBe("POST");
+      const body = JSON.parse(callOpts.body);
+      expect(body.summary).toBe("Lunch");
+      expect(body.location).toBe("Café");
+
+      expect(result.content[0].text).toContain("Created event: Lunch");
+    });
+
+    it("includes attendees when provided", async () => {
+      const createdEvent = {
+        id: "ev4",
+        summary: "Meeting",
+        start: { dateTime: "2024-03-15T10:00:00-07:00" },
+        end: { dateTime: "2024-03-15T11:00:00-07:00" },
+      };
+      const fetchMock = mockFetchResponse(createdEvent);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_create_event");
+      await tool.execute("call8", {
+        summary: "Meeting",
+        startTime: "2024-03-15T10:00:00-07:00",
+        endTime: "2024-03-15T11:00:00-07:00",
+        attendees: ["alice@example.com", "bob@example.com"],
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.attendees).toEqual([
+        { email: "alice@example.com" },
+        { email: "bob@example.com" },
+      ]);
+    });
+  });
+
+  describe("calendar_get_event", () => {
+    it("returns event details with attendees", async () => {
+      const mockEvent = {
+        id: "ev5",
+        summary: "Board meeting",
+        status: "confirmed",
+        start: { dateTime: "2024-03-15T14:00:00-07:00" },
+        end: { dateTime: "2024-03-15T16:00:00-07:00" },
+        location: "HQ",
+        description: "Quarterly review",
+        creator: { email: "boss@example.com" },
+        attendees: [
+          { email: "alice@example.com", responseStatus: "accepted" },
+          { email: "bob@example.com", responseStatus: "needsAction" },
+        ],
+        htmlLink: "https://calendar.google.com/event/ev5",
+      };
+      vi.stubGlobal("fetch", mockFetchResponse(mockEvent));
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_get_event");
+      const result = await tool.execute("call9", { eventId: "ev5" });
+
+      expect(result.content[0].text).toContain("Board meeting");
+      expect(result.content[0].text).toContain("HQ");
+      expect(result.content[0].text).toContain("Quarterly review");
+      expect(result.content[0].text).toContain("alice@example.com (accepted)");
+      expect(result.content[0].text).toContain("bob@example.com (needsAction)");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when no auth configured", async () => {
+      const tools = createCalendarTools(fakeApi({ pluginConfig: {} }));
+      const tool = findTool(tools, "calendar_list_events");
+      await expect(tool.execute("call10", {})).rejects.toThrow(/auth not configured/);
+    });
+
+    it("throws on 401 response", async () => {
+      vi.stubGlobal("fetch", mockFetchResponse({}, false, 401));
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_list_events");
+      await expect(tool.execute("call11", {})).rejects.toThrow(/Google Calendar API error \(401\)/);
+    });
+
+    it("throws on 404 response", async () => {
+      vi.stubGlobal("fetch", mockFetchResponse({}, false, 404));
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_get_event");
+      await expect(tool.execute("call12", { eventId: "nonexistent" })).rejects.toThrow(
+        /Google Calendar API error \(404\)/,
+      );
+    });
+
+    it("sends Authorization header with Bearer token", async () => {
+      const mockData = { items: [] };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createCalendarTools(fakeApi());
+      const tool = findTool(tools, "calendar_list_events");
+      await tool.execute("call13", {});
+
+      expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe("Bearer test-token-123");
+    });
+
+    it("uses calendarId from plugin config", async () => {
+      const mockData = { items: [] };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createCalendarTools(
+        fakeApi({
+          pluginConfig: { accessToken: "tok", calendarId: "work@group.calendar.google.com" },
+        }),
+      );
+      const tool = findTool(tools, "calendar_list_events");
+      await tool.execute("call14", {});
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain(encodeURIComponent("work@group.calendar.google.com"));
+    });
+  });
+});

--- a/extensions/google-calendar/src/calendar-tools.ts
+++ b/extensions/google-calendar/src/calendar-tools.ts
@@ -1,0 +1,270 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+
+type CalendarPluginConfig = {
+  accessToken?: string;
+  credentialsPath?: string;
+  calendarId?: string;
+};
+
+type CalendarEvent = {
+  id: string;
+  summary?: string;
+  description?: string;
+  location?: string;
+  start: { dateTime?: string; date?: string };
+  end: { dateTime?: string; date?: string };
+  htmlLink?: string;
+  status?: string;
+  attendees?: Array<{ email: string; responseStatus?: string }>;
+  creator?: { email: string };
+};
+
+type EventsListResponse = {
+  items?: CalendarEvent[];
+  nextPageToken?: string;
+};
+
+function resolveAuth(api: OpenClawPluginApi): string {
+  const cfg = api.pluginConfig as CalendarPluginConfig | undefined;
+  if (cfg?.accessToken) return cfg.accessToken;
+  // Service account JWT flow would go here — for now, accessToken is required
+  throw new Error(
+    "Google Calendar auth not configured. Set plugins.entries.google-calendar.config.accessToken",
+  );
+}
+
+function resolveCalendarId(api: OpenClawPluginApi, override?: string): string {
+  if (override) return override;
+  const cfg = api.pluginConfig as CalendarPluginConfig | undefined;
+  return cfg?.calendarId || "primary";
+}
+
+async function calendarFetch<T>(
+  accessToken: string,
+  url: string,
+  options?: RequestInit,
+): Promise<T> {
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Google Calendar API error (${res.status}): ${body || res.statusText}`);
+  }
+
+  return (await res.json()) as T;
+}
+
+function formatEvent(event: CalendarEvent): string {
+  const start = event.start.dateTime || event.start.date || "Unknown";
+  const end = event.end.dateTime || event.end.date || "Unknown";
+  const parts = [
+    event.summary || "(No title)",
+    `  When: ${start} → ${end}`,
+    event.location ? `  Where: ${event.location}` : null,
+    event.description ? `  Description: ${event.description.slice(0, 200)}` : null,
+    event.htmlLink ? `  Link: ${event.htmlLink}` : null,
+  ];
+  return parts.filter(Boolean).join("\n");
+}
+
+const BASE_URL = "https://www.googleapis.com/calendar/v3";
+
+export function createCalendarTools(api: OpenClawPluginApi) {
+  const listEvents = {
+    name: "calendar_list_events",
+    description: "List upcoming Google Calendar events.",
+    parameters: Type.Object({
+      maxResults: Type.Optional(
+        Type.Number({ description: "Max events to return (default 10)", minimum: 1, maximum: 100 }),
+      ),
+      timeMin: Type.Optional(
+        Type.String({ description: "Start of time range (ISO 8601 datetime, defaults to now)" }),
+      ),
+      timeMax: Type.Optional(Type.String({ description: "End of time range (ISO 8601 datetime)" })),
+      calendarId: Type.Optional(
+        Type.String({ description: "Calendar ID (defaults to config or 'primary')" }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const token = resolveAuth(api);
+      const calId = resolveCalendarId(api, params.calendarId as string | undefined);
+      const maxResults = (params.maxResults as number) || 10;
+      const timeMin = (params.timeMin as string) || new Date().toISOString();
+
+      const qs = new URLSearchParams({
+        maxResults: String(maxResults),
+        timeMin,
+        singleEvents: "true",
+        orderBy: "startTime",
+      });
+      if (params.timeMax) qs.set("timeMax", params.timeMax as string);
+
+      const url = `${BASE_URL}/calendars/${encodeURIComponent(calId)}/events?${qs}`;
+      const data = await calendarFetch<EventsListResponse>(token, url);
+      const events = data.items ?? [];
+
+      if (events.length === 0) {
+        return { content: [{ type: "text" as const, text: "No upcoming events found." }] };
+      }
+
+      const formatted = events.map(formatEvent).join("\n\n");
+      return {
+        content: [
+          { type: "text" as const, text: `Upcoming events (${events.length}):\n\n${formatted}` },
+        ],
+      };
+    },
+  };
+
+  const searchEvents = {
+    name: "calendar_search_events",
+    description: "Search Google Calendar events by text query.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search text to match in event titles and descriptions" }),
+      maxResults: Type.Optional(
+        Type.Number({ description: "Max events to return (default 10)", minimum: 1, maximum: 100 }),
+      ),
+      timeMin: Type.Optional(
+        Type.String({ description: "Start of time range (ISO 8601 datetime)" }),
+      ),
+      timeMax: Type.Optional(Type.String({ description: "End of time range (ISO 8601 datetime)" })),
+      calendarId: Type.Optional(
+        Type.String({ description: "Calendar ID (defaults to config or 'primary')" }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const token = resolveAuth(api);
+      const calId = resolveCalendarId(api, params.calendarId as string | undefined);
+      const maxResults = (params.maxResults as number) || 10;
+      const query = params.query as string;
+
+      const qs = new URLSearchParams({
+        q: query,
+        maxResults: String(maxResults),
+        singleEvents: "true",
+        orderBy: "startTime",
+      });
+      if (params.timeMin) qs.set("timeMin", params.timeMin as string);
+      if (params.timeMax) qs.set("timeMax", params.timeMax as string);
+
+      const url = `${BASE_URL}/calendars/${encodeURIComponent(calId)}/events?${qs}`;
+      const data = await calendarFetch<EventsListResponse>(token, url);
+      const events = data.items ?? [];
+
+      if (events.length === 0) {
+        return {
+          content: [{ type: "text" as const, text: `No events found matching "${query}".` }],
+        };
+      }
+
+      const formatted = events.map(formatEvent).join("\n\n");
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Found ${events.length} event(s) matching "${query}":\n\n${formatted}`,
+          },
+        ],
+      };
+    },
+  };
+
+  const createEvent = {
+    name: "calendar_create_event",
+    description: "Create a new Google Calendar event.",
+    parameters: Type.Object({
+      summary: Type.String({ description: "Event title" }),
+      startTime: Type.String({
+        description: "Start time (ISO 8601 datetime, e.g. '2024-03-15T10:00:00-07:00')",
+      }),
+      endTime: Type.String({ description: "End time (ISO 8601 datetime)" }),
+      description: Type.Optional(Type.String({ description: "Event description" })),
+      location: Type.Optional(Type.String({ description: "Event location" })),
+      attendees: Type.Optional(
+        Type.Array(Type.String(), { description: "Attendee email addresses" }),
+      ),
+      calendarId: Type.Optional(
+        Type.String({ description: "Calendar ID (defaults to config or 'primary')" }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const token = resolveAuth(api);
+      const calId = resolveCalendarId(api, params.calendarId as string | undefined);
+
+      const body: Record<string, unknown> = {
+        summary: params.summary,
+        start: { dateTime: params.startTime },
+        end: { dateTime: params.endTime },
+      };
+      if (params.description) body.description = params.description;
+      if (params.location) body.location = params.location;
+      if (Array.isArray(params.attendees)) {
+        body.attendees = (params.attendees as string[]).map((email) => ({ email }));
+      }
+
+      const url = `${BASE_URL}/calendars/${encodeURIComponent(calId)}/events`;
+      const event = await calendarFetch<CalendarEvent>(token, url, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+
+      const start = event.start.dateTime || event.start.date || "Unknown";
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Created event: ${event.summary || "(No title)"}\nWhen: ${start}\n${event.htmlLink ? `Link: ${event.htmlLink}` : ""}`,
+          },
+        ],
+      };
+    },
+  };
+
+  const getEvent = {
+    name: "calendar_get_event",
+    description: "Get details of a specific Google Calendar event by its ID.",
+    parameters: Type.Object({
+      eventId: Type.String({ description: "The event ID" }),
+      calendarId: Type.Optional(
+        Type.String({ description: "Calendar ID (defaults to config or 'primary')" }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const token = resolveAuth(api);
+      const calId = resolveCalendarId(api, params.calendarId as string | undefined);
+      const eventId = params.eventId as string;
+
+      const url = `${BASE_URL}/calendars/${encodeURIComponent(calId)}/events/${encodeURIComponent(eventId)}`;
+      const event = await calendarFetch<CalendarEvent>(token, url);
+
+      const parts = [
+        event.summary || "(No title)",
+        `Status: ${event.status || "confirmed"}`,
+        `When: ${event.start.dateTime || event.start.date || "Unknown"} → ${event.end.dateTime || event.end.date || "Unknown"}`,
+        event.location ? `Where: ${event.location}` : null,
+        event.description ? `Description: ${event.description}` : null,
+        event.htmlLink ? `Link: ${event.htmlLink}` : null,
+        event.creator ? `Created by: ${event.creator.email}` : null,
+      ].filter(Boolean);
+
+      if (event.attendees?.length) {
+        parts.push(`Attendees (${event.attendees.length}):`);
+        for (const a of event.attendees) {
+          parts.push(`  ${a.email} (${a.responseStatus || "pending"})`);
+        }
+      }
+
+      return { content: [{ type: "text" as const, text: parts.join("\n") }] };
+    },
+  };
+
+  return [listEvents, searchEvents, createEvent, getEvent];
+}

--- a/extensions/kindle/index.ts
+++ b/extensions/kindle/index.ts
@@ -1,0 +1,9 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "../../src/plugins/types.js";
+import { createKindleTools } from "./src/kindle-tools.js";
+
+export default function register(api: OpenClawPluginApi) {
+  const tools = createKindleTools(api);
+  for (const tool of tools) {
+    api.registerTool(tool as unknown as AnyAgentTool, { optional: true });
+  }
+}

--- a/extensions/kindle/openclaw.plugin.json
+++ b/extensions/kindle/openclaw.plugin.json
@@ -1,0 +1,20 @@
+{
+  "id": "kindle",
+  "name": "Kindle Highlights",
+  "description": "Search and browse your Kindle book highlights and notes.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "clippingsPath": { "type": "string" }
+    },
+    "required": ["clippingsPath"]
+  },
+  "uiHints": {
+    "clippingsPath": {
+      "label": "Clippings File Path",
+      "placeholder": "/Volumes/Kindle/documents/My Clippings.txt",
+      "help": "Path to your Kindle 'My Clippings.txt' file"
+    }
+  }
+}

--- a/extensions/kindle/package.json
+++ b/extensions/kindle/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/kindle",
+  "version": "2026.2.9",
+  "private": true,
+  "description": "OpenClaw Kindle highlights integration plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/kindle/src/kindle-tools.test.ts
+++ b/extensions/kindle/src/kindle-tools.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => {
+  return {
+    default: {
+      readFile: vi.fn(),
+      stat: vi.fn(),
+    },
+  };
+});
+
+import fs from "node:fs/promises";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+import { createKindleTools, parseClippings } from "./kindle-tools.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FIXTURE_CLIPPINGS = `Thinking, Fast and Slow (Daniel Kahneman)
+- Your Highlight on page 25 | location 302-305 | Added on Monday, January 15, 2024 3:42:17 PM
+
+Nothing in life is as important as you think it is, while you are thinking about it.
+==========
+Thinking, Fast and Slow (Daniel Kahneman)
+- Your Highlight on page 35 | location 402-410 | Added on Tuesday, January 16, 2024 10:15:00 AM
+
+A reliable way to make people believe in falsehoods is frequent repetition, because familiarity is not easily distinguished from truth.
+==========
+Sapiens: A Brief History of Humankind (Yuval Noah Harari)
+- Your Highlight on page 12 | location 150-155 | Added on Wednesday, January 17, 2024 2:00:00 PM
+
+You could never convince a monkey to give you a banana by promising him limitless bananas after death in monkey heaven.
+==========
+Sapiens: A Brief History of Humankind (Yuval Noah Harari)
+- Your Note on page 13 | location 160 | Added on Wednesday, January 17, 2024 2:05:00 PM
+
+This is a great point about shared myths.
+==========
+The Design of Everyday Things (Don Norman)
+- Your Highlight on page 1 | location 10-12 | Added on Thursday, January 18, 2024 8:00:00 AM
+
+Good design is actually a lot harder to notice than poor design, in part because good designs fit our needs so well that the design is invisible.
+==========`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeApi(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "kindle",
+    name: "kindle",
+    source: "test",
+    config: {},
+    pluginConfig: { clippingsPath: "/fake/My Clippings.txt" },
+    runtime: { version: "test" },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    registerTool() {},
+    registerHook() {},
+    registerHttpHandler() {},
+    registerHttpRoute() {},
+    registerChannel() {},
+    registerGatewayMethod() {},
+    registerCli() {},
+    registerService() {},
+    registerProvider() {},
+    registerCommand() {},
+    on() {},
+    resolvePath: (p: string) => p,
+    ...overrides,
+  } as unknown as OpenClawPluginApi;
+}
+
+function mockFs() {
+  vi.mocked(fs.stat).mockResolvedValue({ mtimeMs: Date.now() } as Awaited<
+    ReturnType<typeof fs.stat>
+  >);
+  vi.mocked(fs.readFile).mockResolvedValue(FIXTURE_CLIPPINGS);
+}
+
+function getTools(api?: OpenClawPluginApi) {
+  const tools = createKindleTools(api ?? fakeApi());
+  const search = tools.find((t) => t.name === "kindle_search_highlights")!;
+  const listBooks = tools.find((t) => t.name === "kindle_list_books")!;
+  const getBook = tools.find((t) => t.name === "kindle_get_book_highlights")!;
+  return { search, listBooks, getBook };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("parseClippings", () => {
+  it("correctly parses highlights, notes, and bookmarks", () => {
+    const clippings = parseClippings(FIXTURE_CLIPPINGS);
+    expect(clippings).toHaveLength(5);
+
+    const highlights = clippings.filter((c) => c.type === "highlight");
+    expect(highlights).toHaveLength(4);
+
+    const notes = clippings.filter((c) => c.type === "note");
+    expect(notes).toHaveLength(1);
+    expect(notes[0]!.content).toBe("This is a great point about shared myths.");
+  });
+
+  it("parses book title and author correctly", () => {
+    const clippings = parseClippings(FIXTURE_CLIPPINGS);
+    const first = clippings[0]!;
+    expect(first.bookTitle).toBe("Thinking, Fast and Slow");
+    expect(first.author).toBe("Daniel Kahneman");
+  });
+
+  it("parses page, location, and date", () => {
+    const clippings = parseClippings(FIXTURE_CLIPPINGS);
+    const first = clippings[0]!;
+    expect(first.page).toBe(25);
+    expect(first.location).toBe("302-305");
+    expect(first.date).toBe("Monday, January 15, 2024 3:42:17 PM");
+  });
+
+  it("handles missing author gracefully", () => {
+    const raw = `A Book Without Author
+- Your Highlight on page 1 | location 1-5 | Added on Monday, January 1, 2024 12:00:00 PM
+
+Some text here.
+==========`;
+    const clippings = parseClippings(raw);
+    expect(clippings).toHaveLength(1);
+    expect(clippings[0]!.bookTitle).toBe("A Book Without Author");
+    expect(clippings[0]!.author).toBe("");
+  });
+
+  it("handles empty/malformed entries", () => {
+    const raw = `==========
+
+==========
+Just a title line
+==========
+Some Book (Author)
+- Not a valid meta line
+
+Content here
+==========`;
+    const clippings = parseClippings(raw);
+    expect(clippings).toHaveLength(0);
+  });
+
+  it("handles multi-line content", () => {
+    const raw = `Some Book (Author)
+- Your Highlight on page 5 | location 50-55 | Added on Monday, January 1, 2024 12:00:00 PM
+
+First line of highlight.
+Second line of highlight.
+Third line.
+==========`;
+    const clippings = parseClippings(raw);
+    expect(clippings).toHaveLength(1);
+    expect(clippings[0]!.content).toBe(
+      "First line of highlight.\nSecond line of highlight.\nThird line.",
+    );
+  });
+});
+
+describe("kindle_search_highlights", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFs();
+  });
+
+  it("finds highlights matching query text", async () => {
+    const { search } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await search.execute("id", { query: "monkey" })) as any;
+    expect(res.details).toHaveLength(1);
+    expect(res.details[0].bookTitle).toBe("Sapiens: A Brief History of Humankind");
+  });
+
+  it("filters by book title when specified", async () => {
+    const { search } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await search.execute("id", { query: "a", book: "Thinking" })) as any;
+    for (const item of res.details) {
+      expect(item.bookTitle).toContain("Thinking");
+    }
+  });
+
+  it("is case-insensitive", async () => {
+    const { search } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const lower = (await search.execute("id", { query: "NOTHING IN LIFE" })) as any;
+    expect(lower.details).toHaveLength(1);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const upper = (await search.execute("id", { query: "nothing in life" })) as any;
+    expect(upper.details).toHaveLength(1);
+  });
+
+  it("respects limit", async () => {
+    const { search } = getTools();
+    // Search for common word that matches many highlights
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await search.execute("id", { query: "is", limit: 2 })) as any;
+    expect(res.details.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("kindle_list_books", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFs();
+  });
+
+  it("returns books sorted by highlight count", async () => {
+    const { listBooks } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await listBooks.execute("id", {})) as any;
+    const counts = res.details.map((b: { highlightCount: number }) => b.highlightCount);
+    for (let i = 1; i < counts.length; i++) {
+      expect(counts[i - 1]).toBeGreaterThanOrEqual(counts[i]);
+    }
+  });
+
+  it("includes correct highlight counts", async () => {
+    const { listBooks } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await listBooks.execute("id", {})) as any;
+
+    const thinking = res.details.find(
+      (b: { bookTitle: string }) => b.bookTitle === "Thinking, Fast and Slow",
+    );
+    expect(thinking.highlightCount).toBe(2);
+
+    const sapiens = res.details.find(
+      (b: { bookTitle: string }) => b.bookTitle === "Sapiens: A Brief History of Humankind",
+    );
+    expect(sapiens.highlightCount).toBe(2);
+
+    const design = res.details.find(
+      (b: { bookTitle: string }) => b.bookTitle === "The Design of Everyday Things",
+    );
+    expect(design.highlightCount).toBe(1);
+  });
+});
+
+describe("kindle_get_book_highlights", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFs();
+  });
+
+  it("returns all highlights for a matching book", async () => {
+    const { getBook } = getTools();
+    const res = (await getBook.execute("id", {
+      book: "Thinking, Fast and Slow",
+      // oxlint-disable-next-line typescript/no-explicit-any
+    })) as any;
+    expect(res.details).toHaveLength(2);
+    for (const item of res.details) {
+      expect(item.bookTitle).toBe("Thinking, Fast and Slow");
+    }
+  });
+
+  it("supports partial book title match", async () => {
+    const { getBook } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await getBook.execute("id", { book: "Sapiens" })) as any;
+    expect(res.details).toHaveLength(2);
+    for (const item of res.details) {
+      expect(item.bookTitle).toContain("Sapiens");
+    }
+  });
+
+  it("returns results ordered by page/location", async () => {
+    const { getBook } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await getBook.execute("id", { book: "Thinking" })) as any;
+    const pages = res.details.map((h: { page: number }) => h.page);
+    for (let i = 1; i < pages.length; i++) {
+      expect(pages[i - 1]).toBeLessThanOrEqual(pages[i]);
+    }
+  });
+});
+
+describe("error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("all tools throw when clippingsPath is missing", async () => {
+    const api = fakeApi({ pluginConfig: {} });
+    const { search, listBooks, getBook } = getTools(api);
+
+    await expect(search.execute("id", { query: "test" })).rejects.toThrow(/clippingsPath/);
+    await expect(listBooks.execute("id", {})).rejects.toThrow(/clippingsPath/);
+    await expect(getBook.execute("id", { book: "test" })).rejects.toThrow(/clippingsPath/);
+  });
+
+  it("tools throw readable error when file does not exist", async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error("ENOENT"));
+    const { search } = getTools();
+    await expect(search.execute("id", { query: "test" })).rejects.toThrow(
+      /clippings file not found/i,
+    );
+  });
+});

--- a/extensions/kindle/src/kindle-tools.ts
+++ b/extensions/kindle/src/kindle-tools.ts
@@ -1,0 +1,259 @@
+import { Type } from "@sinclair/typebox";
+import fs from "node:fs/promises";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type KindleClipping = {
+  bookTitle: string;
+  author: string;
+  type: "highlight" | "note" | "bookmark";
+  page?: number;
+  location?: string;
+  date?: string;
+  content: string;
+};
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+const META_RE =
+  /^-\s*Your\s+(Highlight|Note|Bookmark)\s+(?:on\s+page\s+(\d+)\s*\|?\s*)?(?:location\s+([\d-]+)\s*\|?\s*)?(?:Added\s+on\s+(.+))?$/i;
+
+function parseBookLine(line: string): { bookTitle: string; author: string } {
+  // Author is in the last set of parentheses
+  const match = line.match(/^(.+)\s+\(([^)]+)\)\s*$/);
+  if (match) {
+    return { bookTitle: match[1]!.trim(), author: match[2]!.trim() };
+  }
+  return { bookTitle: line.trim(), author: "" };
+}
+
+function parseClippingType(raw: string): KindleClipping["type"] {
+  const lower = raw.toLowerCase();
+  if (lower === "highlight") return "highlight";
+  if (lower === "note") return "note";
+  return "bookmark";
+}
+
+export function parseClippings(raw: string): KindleClipping[] {
+  const blocks = raw.split("==========");
+  const clippings: KindleClipping[] = [];
+
+  for (const block of blocks) {
+    const lines = block.split("\n").map((l) => l.trimEnd());
+
+    // Strip leading empty lines
+    while (lines.length > 0 && lines[0]!.trim() === "") {
+      lines.shift();
+    }
+
+    if (lines.length < 2) continue;
+
+    const bookLine = lines[0]!;
+    const metaLine = lines[1]!;
+
+    if (!bookLine.trim() || !metaLine.trim()) continue;
+
+    const { bookTitle, author } = parseBookLine(bookLine);
+    const metaMatch = metaLine.match(META_RE);
+    if (!metaMatch) continue;
+
+    const clipType = parseClippingType(metaMatch[1]!);
+    const page = metaMatch[2] ? Number.parseInt(metaMatch[2], 10) : undefined;
+    const location = metaMatch[3]?.trim() || undefined;
+    const date = metaMatch[4]?.trim() || undefined;
+
+    // Content starts after the empty line (line index 2 is typically empty)
+    const contentLines = lines.slice(2);
+    // Skip leading empty line(s) in content
+    while (contentLines.length > 0 && contentLines[0]!.trim() === "") {
+      contentLines.shift();
+    }
+    const content = contentLines.join("\n").trim();
+
+    clippings.push({
+      bookTitle,
+      author,
+      type: clipType,
+      page,
+      location,
+      date,
+      content,
+    });
+  }
+
+  return clippings;
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+let cache: { path: string; mtime: number; clippings: KindleClipping[] } | null = null;
+
+async function loadClippings(filePath: string): Promise<KindleClipping[]> {
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(filePath);
+  } catch {
+    throw new Error(`Kindle clippings file not found: ${filePath}`);
+  }
+
+  const mtime = stat.mtimeMs;
+  if (cache && cache.path === filePath && cache.mtime === mtime) {
+    return cache.clippings;
+  }
+
+  const raw = await fs.readFile(filePath, "utf-8");
+  const clippings = parseClippings(raw);
+  cache = { path: filePath, mtime, clippings };
+  return clippings;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resolveClippingsPath(api: OpenClawPluginApi): string {
+  const cfg = api.pluginConfig as { clippingsPath?: string } | undefined;
+  if (!cfg?.clippingsPath) {
+    throw new Error("clippingsPath is not configured. Set it in the Kindle plugin config.");
+  }
+  return api.resolvePath(cfg.clippingsPath);
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+export function createKindleTools(api: OpenClawPluginApi) {
+  const searchHighlights = {
+    name: "kindle_search_highlights",
+    label: "Search Kindle Highlights",
+    description:
+      "Search your Kindle highlights and notes by text query, optionally filtering by book title.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Text to search for in highlight content" }),
+      book: Type.Optional(Type.String({ description: "Filter by book title (substring match)" })),
+      limit: Type.Optional(Type.Number({ description: "Max results to return (default 20)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = resolveClippingsPath(api);
+      const clippings = await loadClippings(filePath);
+
+      const query = (typeof params.query === "string" ? params.query : "").toLowerCase();
+      const bookFilter = typeof params.book === "string" ? params.book.toLowerCase() : undefined;
+      const limit = typeof params.limit === "number" ? params.limit : 20;
+
+      const matches = clippings.filter((c) => {
+        if (c.type === "bookmark") return false;
+        const contentMatch = c.content.toLowerCase().includes(query);
+        if (!contentMatch) return false;
+        if (bookFilter && !c.bookTitle.toLowerCase().includes(bookFilter)) return false;
+        return true;
+      });
+
+      const results = matches.slice(0, limit).map((c) => ({
+        bookTitle: c.bookTitle,
+        author: c.author,
+        type: c.type,
+        page: c.page,
+        location: c.location,
+        content: c.content,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        details: results,
+      };
+    },
+  };
+
+  const listBooks = {
+    name: "kindle_list_books",
+    label: "List Kindle Books",
+    description:
+      "List all books in your Kindle clippings with highlight counts, sorted by count descending.",
+    parameters: Type.Object({
+      limit: Type.Optional(Type.Number({ description: "Max books to return (default 50)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = resolveClippingsPath(api);
+      const clippings = await loadClippings(filePath);
+
+      const limit = typeof params.limit === "number" ? params.limit : 50;
+
+      const bookMap = new Map<string, { author: string; count: number }>();
+      for (const c of clippings) {
+        const existing = bookMap.get(c.bookTitle);
+        if (existing) {
+          existing.count++;
+        } else {
+          bookMap.set(c.bookTitle, { author: c.author, count: 1 });
+        }
+      }
+
+      const books = [...bookMap.entries()]
+        .map(([title, info]) => ({
+          bookTitle: title,
+          author: info.author,
+          highlightCount: info.count,
+        }))
+        .sort((a, b) => b.highlightCount - a.highlightCount)
+        .slice(0, limit);
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(books, null, 2) }],
+        details: books,
+      };
+    },
+  };
+
+  const getBookHighlights = {
+    name: "kindle_get_book_highlights",
+    label: "Get Book Highlights",
+    description: "Get all highlights for a specific book by exact or partial title match.",
+    parameters: Type.Object({
+      book: Type.String({ description: "Book title or partial title to match" }),
+      limit: Type.Optional(Type.Number({ description: "Max highlights to return (default 50)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = resolveClippingsPath(api);
+      const clippings = await loadClippings(filePath);
+
+      const bookQuery = (typeof params.book === "string" ? params.book : "").toLowerCase();
+      const limit = typeof params.limit === "number" ? params.limit : 50;
+
+      const matches = clippings.filter((c) => c.bookTitle.toLowerCase().includes(bookQuery));
+
+      // Sort by page then location for natural reading order
+      matches.sort((a, b) => {
+        const pageDiff = (a.page ?? 0) - (b.page ?? 0);
+        if (pageDiff !== 0) return pageDiff;
+        const locA = a.location?.split("-")[0] ?? "0";
+        const locB = b.location?.split("-")[0] ?? "0";
+        return Number.parseInt(locA, 10) - Number.parseInt(locB, 10);
+      });
+
+      const results = matches.slice(0, limit).map((c) => ({
+        bookTitle: c.bookTitle,
+        author: c.author,
+        type: c.type,
+        page: c.page,
+        location: c.location,
+        content: c.content,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        details: results,
+      };
+    },
+  };
+
+  return [searchHighlights, listBooks, getBookHighlights];
+}

--- a/extensions/linear/index.ts
+++ b/extensions/linear/index.ts
@@ -1,0 +1,9 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "../../src/plugins/types.js";
+import { createLinearTools } from "./src/linear-tools.js";
+
+export default function register(api: OpenClawPluginApi) {
+  const tools = createLinearTools(api);
+  for (const tool of tools) {
+    api.registerTool(tool as unknown as AnyAgentTool, { optional: true });
+  }
+}

--- a/extensions/linear/openclaw.plugin.json
+++ b/extensions/linear/openclaw.plugin.json
@@ -1,0 +1,16 @@
+{
+  "id": "linear",
+  "name": "Linear",
+  "description": "Search, create, and manage Linear issues from your AI assistant.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": { "type": "string" }
+    },
+    "required": ["apiKey"]
+  },
+  "uiHints": {
+    "apiKey": { "label": "Linear API Key", "sensitive": true, "placeholder": "lin_api_..." }
+  }
+}

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/linear",
+  "version": "2026.2.9",
+  "private": true,
+  "description": "OpenClaw Linear integration plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/linear/src/linear-tools.test.ts
+++ b/extensions/linear/src/linear-tools.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+import { createLinearTools } from "./linear-tools.js";
+
+function fakeApi(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "linear",
+    name: "linear",
+    source: "test",
+    config: {},
+    pluginConfig: { apiKey: "lin_api_test123" },
+    runtime: { version: "test" },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    registerTool() {},
+    ...overrides,
+  } as unknown as OpenClawPluginApi;
+}
+
+function findTool(tools: ReturnType<typeof createLinearTools>, name: string) {
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool ${name} not found`);
+  return tool;
+}
+
+function mockFetchResponse(data: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  });
+}
+
+describe("linear tools", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates four tools", () => {
+    const tools = createLinearTools(fakeApi());
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "linear_search_issues",
+      "linear_create_issue",
+      "linear_list_teams",
+      "linear_get_issue",
+    ]);
+  });
+
+  describe("linear_search_issues", () => {
+    it("returns formatted results", async () => {
+      const mockData = {
+        data: {
+          issues: {
+            nodes: [
+              {
+                id: "id1",
+                identifier: "ENG-42",
+                title: "Fix login bug",
+                state: { name: "In Progress" },
+                assignee: { name: "Alice" },
+                priority: 2,
+                priorityLabel: "High",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+                url: "https://linear.app/team/issue/ENG-42",
+              },
+            ],
+          },
+        },
+      };
+
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      const result = await tool.execute("call1", { query: "login" });
+
+      expect(result.content[0].text).toContain("ENG-42");
+      expect(result.content[0].text).toContain("Fix login bug");
+      expect(result.content[0].text).toContain("In Progress");
+      expect(result.content[0].text).toContain("Alice");
+    });
+
+    it("passes team filter in GraphQL variables", async () => {
+      const mockData = { data: { issues: { nodes: [] } } };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await tool.execute("call2", { query: "test", teamKey: "ENG" });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.variables.filter.team).toEqual({ key: { eq: "ENG" } });
+    });
+
+    it("respects limit parameter", async () => {
+      const mockData = { data: { issues: { nodes: [] } } };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await tool.execute("call3", { query: "test", limit: 5 });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.variables.limit).toBe(5);
+    });
+
+    it("returns no-results message when empty", async () => {
+      const mockData = { data: { issues: { nodes: [] } } };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      const result = await tool.execute("call4", { query: "nonexistent" });
+
+      expect(result.content[0].text).toContain("No issues found");
+    });
+  });
+
+  describe("linear_create_issue", () => {
+    it("sends correct mutation and returns issue details", async () => {
+      // First call resolves team, second call creates issue
+      const teamResponse = {
+        data: { teams: { nodes: [{ id: "team-1", key: "ENG", name: "Engineering" }] } },
+      };
+      const createResponse = {
+        data: {
+          issueCreate: {
+            success: true,
+            issue: {
+              id: "issue-1",
+              identifier: "ENG-100",
+              title: "New feature",
+              url: "https://linear.app/team/issue/ENG-100",
+              state: { name: "Backlog" },
+            },
+          },
+        },
+      };
+
+      let callCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(async () => {
+          const data = callCount === 0 ? teamResponse : createResponse;
+          callCount++;
+          return {
+            ok: true,
+            status: 200,
+            json: async () => data,
+            text: async () => JSON.stringify(data),
+          };
+        }),
+      );
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_create_issue");
+      const result = await tool.execute("call5", {
+        title: "New feature",
+        teamKey: "ENG",
+        description: "Implement the thing",
+        priority: 2,
+      });
+
+      expect(result.content[0].text).toContain("ENG-100");
+      expect(result.content[0].text).toContain("New feature");
+      expect(result.content[0].text).toContain("Backlog");
+    });
+
+    it("throws when team not found", async () => {
+      const teamResponse = { data: { teams: { nodes: [] } } };
+      vi.stubGlobal("fetch", mockFetchResponse(teamResponse));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_create_issue");
+      await expect(tool.execute("call6", { title: "Test", teamKey: "NOPE" })).rejects.toThrow(
+        /Team with key 'NOPE' not found/,
+      );
+    });
+  });
+
+  describe("linear_list_teams", () => {
+    it("returns team list", async () => {
+      const mockData = {
+        data: {
+          teams: {
+            nodes: [
+              { id: "t1", key: "ENG", name: "Engineering", description: "Core team" },
+              { id: "t2", key: "DES", name: "Design" },
+            ],
+          },
+        },
+      };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_list_teams");
+      const result = await tool.execute("call7", {});
+
+      expect(result.content[0].text).toContain("ENG: Engineering");
+      expect(result.content[0].text).toContain("Core team");
+      expect(result.content[0].text).toContain("DES: Design");
+    });
+
+    it("returns message when no teams", async () => {
+      const mockData = { data: { teams: { nodes: [] } } };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_list_teams");
+      const result = await tool.execute("call8", {});
+
+      expect(result.content[0].text).toContain("No teams found");
+    });
+  });
+
+  describe("linear_get_issue", () => {
+    it("returns detailed issue info with comments", async () => {
+      const mockData = {
+        data: {
+          issueSearch: {
+            nodes: [
+              {
+                id: "id1",
+                identifier: "ENG-42",
+                title: "Fix login bug",
+                description: "The login form breaks on mobile.",
+                state: { name: "In Progress" },
+                assignee: { name: "Alice" },
+                priority: 2,
+                priorityLabel: "High",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+                url: "https://linear.app/team/issue/ENG-42",
+                comments: {
+                  nodes: [
+                    {
+                      body: "Working on it",
+                      user: { name: "Alice" },
+                      createdAt: "2024-01-01T12:00:00Z",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_get_issue");
+      const result = await tool.execute("call9", { identifier: "ENG-42" });
+
+      expect(result.content[0].text).toContain("ENG-42: Fix login bug");
+      expect(result.content[0].text).toContain("In Progress");
+      expect(result.content[0].text).toContain("The login form breaks on mobile");
+      expect(result.content[0].text).toContain("[Alice] Working on it");
+    });
+
+    it("returns not-found message for missing issue", async () => {
+      const mockData = { data: { issueSearch: { nodes: [] } } };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_get_issue");
+      const result = await tool.execute("call10", { identifier: "NOPE-999" });
+
+      expect(result.content[0].text).toContain("not found");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when apiKey is missing", async () => {
+      const tools = createLinearTools(fakeApi({ pluginConfig: {} }));
+      const tool = findTool(tools, "linear_search_issues");
+      await expect(tool.execute("call11", { query: "test" })).rejects.toThrow(
+        /API key not configured/,
+      );
+    });
+
+    it("throws on HTTP error response", async () => {
+      vi.stubGlobal("fetch", mockFetchResponse({}, false, 401));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await expect(tool.execute("call12", { query: "test" })).rejects.toThrow(
+        /Linear API error \(401\)/,
+      );
+    });
+
+    it("throws on GraphQL error response", async () => {
+      const mockData = { errors: [{ message: "Authentication required" }] };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await expect(tool.execute("call13", { query: "test" })).rejects.toThrow(
+        /GraphQL error.*Authentication required/,
+      );
+    });
+
+    it("sends Authorization header with apiKey", async () => {
+      const mockData = { data: { issues: { nodes: [] } } };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await tool.execute("call14", { query: "test" });
+
+      expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe("lin_api_test123");
+    });
+  });
+});

--- a/extensions/linear/src/linear-tools.ts
+++ b/extensions/linear/src/linear-tools.ts
@@ -1,0 +1,340 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+
+type LinearPluginConfig = {
+  apiKey?: string;
+};
+
+type GraphQLResponse<T> = {
+  data?: T;
+  errors?: Array<{ message: string }>;
+};
+
+async function linearGraphQL<T>(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch("https://api.linear.app/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Linear API error (${res.status}): ${body || res.statusText}`);
+  }
+
+  const json = (await res.json()) as GraphQLResponse<T>;
+  if (json.errors?.length) {
+    throw new Error(`Linear GraphQL error: ${json.errors.map((e) => e.message).join("; ")}`);
+  }
+  if (!json.data) {
+    throw new Error("Linear API returned no data");
+  }
+  return json.data;
+}
+
+function resolveApiKey(api: OpenClawPluginApi): string {
+  const cfg = api.pluginConfig as LinearPluginConfig | undefined;
+  const apiKey = cfg?.apiKey;
+  if (!apiKey) {
+    throw new Error(
+      "Linear API key not configured. Set it in plugins.entries.linear.config.apiKey",
+    );
+  }
+  return apiKey;
+}
+
+type IssueNode = {
+  id: string;
+  identifier: string;
+  title: string;
+  state: { name: string } | null;
+  assignee: { name: string } | null;
+  priority: number;
+  priorityLabel: string;
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+  description?: string;
+};
+
+type CommentNode = {
+  body: string;
+  user: { name: string } | null;
+  createdAt: string;
+};
+
+function formatIssue(issue: IssueNode): string {
+  const parts = [
+    `${issue.identifier}: ${issue.title}`,
+    `  Status: ${issue.state?.name ?? "Unknown"}`,
+    `  Priority: ${issue.priorityLabel}`,
+    issue.assignee ? `  Assignee: ${issue.assignee.name}` : null,
+    `  URL: ${issue.url}`,
+  ];
+  return parts.filter(Boolean).join("\n");
+}
+
+export function createLinearTools(api: OpenClawPluginApi) {
+  const searchIssues = {
+    name: "linear_search_issues",
+    description: "Search Linear issues with optional filters for team, status, and assignee.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search text to find in issue titles and descriptions" }),
+      teamKey: Type.Optional(Type.String({ description: "Filter by team key (e.g. 'ENG')" })),
+      status: Type.Optional(
+        Type.String({ description: "Filter by status name (e.g. 'In Progress', 'Done')" }),
+      ),
+      assignee: Type.Optional(Type.String({ description: "Filter by assignee display name" })),
+      limit: Type.Optional(
+        Type.Number({ description: "Max results to return (default 10)", minimum: 1, maximum: 50 }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const apiKey = resolveApiKey(api);
+      const query = params.query as string;
+      const teamKey = params.teamKey as string | undefined;
+      const status = params.status as string | undefined;
+      const assignee = params.assignee as string | undefined;
+      const limit = (params.limit as number) || 10;
+
+      // Build filter object
+      const filter: Record<string, unknown> = {};
+      if (query) filter.searchableContent = { contains: query };
+      if (teamKey) filter.team = { key: { eq: teamKey } };
+      if (status) filter.state = { name: { eqCaseInsensitive: status } };
+      if (assignee) filter.assignee = { displayName: { containsIgnoreCase: assignee } };
+
+      const gql = `
+        query SearchIssues($filter: IssueFilter, $limit: Int) {
+          issues(filter: $filter, first: $limit) {
+            nodes {
+              id identifier title
+              state { name }
+              assignee { name }
+              priority priorityLabel
+              createdAt updatedAt url
+            }
+          }
+        }
+      `;
+
+      type SearchResult = { issues: { nodes: IssueNode[] } };
+      const data = await linearGraphQL<SearchResult>(apiKey, gql, { filter, limit });
+      const issues = data.issues.nodes;
+
+      if (issues.length === 0) {
+        return {
+          content: [{ type: "text" as const, text: "No issues found matching your query." }],
+        };
+      }
+
+      const formatted = issues.map(formatIssue).join("\n\n");
+      return {
+        content: [
+          { type: "text" as const, text: `Found ${issues.length} issue(s):\n\n${formatted}` },
+        ],
+      };
+    },
+  };
+
+  const createIssue = {
+    name: "linear_create_issue",
+    description: "Create a new issue in Linear.",
+    parameters: Type.Object({
+      title: Type.String({ description: "Issue title" }),
+      teamKey: Type.String({ description: "Team key (e.g. 'ENG')" }),
+      description: Type.Optional(Type.String({ description: "Issue description (markdown)" })),
+      priority: Type.Optional(
+        Type.Number({
+          description: "Priority: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low",
+          minimum: 0,
+          maximum: 4,
+        }),
+      ),
+      assigneeId: Type.Optional(Type.String({ description: "Assignee user ID" })),
+      labelIds: Type.Optional(Type.Array(Type.String(), { description: "Label IDs to apply" })),
+      stateId: Type.Optional(Type.String({ description: "Workflow state ID" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const apiKey = resolveApiKey(api);
+      const title = params.title as string;
+      const teamKey = params.teamKey as string;
+
+      // Resolve team ID from key
+      const teamGql = `
+        query GetTeam($key: String!) {
+          teams(filter: { key: { eq: $key } }) {
+            nodes { id key name }
+          }
+        }
+      `;
+      type TeamResult = { teams: { nodes: Array<{ id: string; key: string; name: string }> } };
+      const teamData = await linearGraphQL<TeamResult>(apiKey, teamGql, { key: teamKey });
+      const team = teamData.teams.nodes[0];
+      if (!team) {
+        throw new Error(`Team with key '${teamKey}' not found`);
+      }
+
+      const input: Record<string, unknown> = {
+        title,
+        teamId: team.id,
+      };
+      if (params.description) input.description = params.description;
+      if (typeof params.priority === "number") input.priority = params.priority;
+      if (params.assigneeId) input.assigneeId = params.assigneeId;
+      if (params.labelIds) input.labelIds = params.labelIds;
+      if (params.stateId) input.stateId = params.stateId;
+
+      const gql = `
+        mutation CreateIssue($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue {
+              id identifier title url
+              state { name }
+            }
+          }
+        }
+      `;
+
+      type CreateResult = {
+        issueCreate: {
+          success: boolean;
+          issue: {
+            id: string;
+            identifier: string;
+            title: string;
+            url: string;
+            state: { name: string } | null;
+          };
+        };
+      };
+      const data = await linearGraphQL<CreateResult>(apiKey, gql, { input });
+
+      if (!data.issueCreate.success) {
+        throw new Error("Failed to create issue");
+      }
+
+      const issue = data.issueCreate.issue;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Created issue ${issue.identifier}: ${issue.title}\nStatus: ${issue.state?.name ?? "Unknown"}\nURL: ${issue.url}`,
+          },
+        ],
+      };
+    },
+  };
+
+  const listTeams = {
+    name: "linear_list_teams",
+    description: "List all teams in your Linear workspace.",
+    parameters: Type.Object({}),
+    async execute(_id: string, _params: Record<string, unknown>) {
+      const apiKey = resolveApiKey(api);
+
+      const gql = `
+        query ListTeams {
+          teams {
+            nodes { id key name description }
+          }
+        }
+      `;
+
+      type TeamsResult = {
+        teams: { nodes: Array<{ id: string; key: string; name: string; description?: string }> };
+      };
+      const data = await linearGraphQL<TeamsResult>(apiKey, gql);
+      const teams = data.teams.nodes;
+
+      if (teams.length === 0) {
+        return { content: [{ type: "text" as const, text: "No teams found." }] };
+      }
+
+      const formatted = teams
+        .map((t) => `${t.key}: ${t.name}${t.description ? ` — ${t.description}` : ""}`)
+        .join("\n");
+      return {
+        content: [{ type: "text" as const, text: `Teams (${teams.length}):\n\n${formatted}` }],
+      };
+    },
+  };
+
+  const getIssue = {
+    name: "linear_get_issue",
+    description:
+      "Get detailed information about a specific Linear issue by its identifier (e.g. 'ENG-123').",
+    parameters: Type.Object({
+      identifier: Type.String({ description: "Issue identifier (e.g. 'ENG-123')" }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const apiKey = resolveApiKey(api);
+      const identifier = params.identifier as string;
+
+      const gql = `
+        query GetIssue($identifier: String!) {
+          issueSearch(query: $identifier, first: 1) {
+            nodes {
+              id identifier title description
+              state { name }
+              assignee { name }
+              priority priorityLabel
+              createdAt updatedAt url
+              comments {
+                nodes {
+                  body
+                  user { name }
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      `;
+
+      type IssueWithComments = IssueNode & {
+        comments: { nodes: CommentNode[] };
+      };
+      type GetResult = { issueSearch: { nodes: IssueWithComments[] } };
+      const data = await linearGraphQL<GetResult>(apiKey, gql, { identifier });
+
+      const issue = data.issueSearch.nodes[0];
+      if (!issue) {
+        return { content: [{ type: "text" as const, text: `Issue '${identifier}' not found.` }] };
+      }
+
+      const parts = [
+        `${issue.identifier}: ${issue.title}`,
+        `Status: ${issue.state?.name ?? "Unknown"}`,
+        `Priority: ${issue.priorityLabel}`,
+        issue.assignee ? `Assignee: ${issue.assignee.name}` : null,
+        `Created: ${issue.createdAt}`,
+        `Updated: ${issue.updatedAt}`,
+        `URL: ${issue.url}`,
+      ].filter(Boolean);
+
+      if (issue.description) {
+        parts.push("", "Description:", issue.description);
+      }
+
+      if (issue.comments.nodes.length > 0) {
+        parts.push("", `Comments (${issue.comments.nodes.length}):`);
+        for (const c of issue.comments.nodes) {
+          parts.push(`  [${c.user?.name ?? "Unknown"}] ${c.body}`);
+        }
+      }
+
+      return { content: [{ type: "text" as const, text: parts.join("\n") }] };
+    },
+  };
+
+  return [searchIssues, createIssue, listTeams, getIssue];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/google-calendar:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/google-gemini-cli-auth:
     devDependencies:
       openclaw:
@@ -342,7 +348,19 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/kindle:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/line:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
+  extensions/linear:
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -6666,7 +6684,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.58.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6682,7 +6700,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.12
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6885,7 +6903,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7720,7 +7738,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7766,7 +7784,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.2.2
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8660,14 +8678,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9242,8 +9252,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- **Linear plugin** (`extensions/linear/`): Agent tools for searching, creating, and managing Linear issues via GraphQL API. Tools: `linear_search_issues`, `linear_create_issue`, `linear_list_teams`, `linear_get_issue`.
- **Google Calendar plugin** (`extensions/google-calendar/`): Agent tools for querying and managing Google Calendar events via REST API. Tools: `calendar_list_events`, `calendar_search_events`, `calendar_create_event`, `calendar_get_event`.
- **Kindle Highlights plugin** (`extensions/kindle/`): Agent tools for searching and browsing Kindle book highlights by parsing `My Clippings.txt`. Tools: `kindle_search_highlights`, `kindle_list_books`, `kindle_get_book_highlights`.

All tools are registered as `optional: true` (opt-in via agent allowlist). Each plugin follows existing patterns (llm-task, lobster) with TypeBox schemas, plugin manifests, and comprehensive Vitest tests (47 tests total, all passing).

## Test plan

- [x] `pnpm vitest run extensions/linear/` — 15 tests passing
- [x] `pnpm vitest run extensions/google-calendar/` — 15 tests passing
- [x] `pnpm vitest run extensions/kindle/` — 17 tests passing
- [ ] Manual: configure Linear API key and verify tool calls work end-to-end
- [ ] Manual: configure Google Calendar access token and verify event listing
- [ ] Manual: point Kindle plugin at a real `My Clippings.txt` and verify highlight search

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds three opt-in tool plugins under `extensions/`: Linear (GraphQL issue search/create/list/get), Google Calendar (REST event list/search/create/get), and Kindle Highlights (parse `My Clippings.txt` for search/list/get). Each extension registers agent tools with TypeBox schemas and includes Vitest coverage.

Main integration risk is config/behavior mismatches: the Google Calendar manifest advertises a service-account `credentialsPath`, but the implementation only supports `accessToken`; and the Kindle tools’ “highlights” semantics don’t match what they actually return/count when notes/bookmarks are present.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge until config/contract mismatches are fixed
- The changes are well-scoped and tested, but there are confirmed user-facing correctness issues: Google Calendar’s advertised auth config will fail at runtime, and Kindle tools miscount/return non-highlight clippings contrary to their descriptions.
- extensions/google-calendar/openclaw.plugin.json, extensions/google-calendar/src/calendar-tools.ts, extensions/kindle/src/kindle-tools.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->