### PR TITLE
feat(plugins): add Linear integration plugin

### DIFF
--- a/extensions/linear/index.ts
+++ b/extensions/linear/index.ts
@@ -1,0 +1,9 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "../../src/plugins/types.js";
+import { createLinearTools } from "./src/linear-tools.js";
+
+export default function register(api: OpenClawPluginApi) {
+  const tools = createLinearTools(api);
+  for (const tool of tools) {
+    api.registerTool(tool as unknown as AnyAgentTool, { optional: true });
+  }
+}

--- a/extensions/linear/openclaw.plugin.json
+++ b/extensions/linear/openclaw.plugin.json
@@ -1,0 +1,16 @@
+{
+  "id": "linear",
+  "name": "Linear",
+  "description": "Search, create, and manage Linear issues from your AI assistant.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": { "type": "string" }
+    },
+    "required": ["apiKey"]
+  },
+  "uiHints": {
+    "apiKey": { "label": "Linear API Key", "sensitive": true, "placeholder": "lin_api_..." }
+  }
+}

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/linear",
+  "version": "2026.2.9",
+  "private": true,
+  "description": "OpenClaw Linear integration plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/linear/src/linear-tools.test.ts
+++ b/extensions/linear/src/linear-tools.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+import { createLinearTools } from "./linear-tools.js";
+
+function fakeApi(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "linear",
+    name: "linear",
+    source: "test",
+    config: {},
+    pluginConfig: { apiKey: "lin_api_test123" },
+    runtime: { version: "test" },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    registerTool() {},
+    ...overrides,
+  } as unknown as OpenClawPluginApi;
+}
+
+function findTool(tools: ReturnType<typeof createLinearTools>, name: string) {
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool ${name} not found`);
+  return tool;
+}
+
+function mockFetchResponse(data: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  });
+}
+
+describe("linear tools", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates four tools", () => {
+    const tools = createLinearTools(fakeApi());
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "linear_search_issues",
+      "linear_create_issue",
+      "linear_list_teams",
+      "linear_get_issue",
+    ]);
+  });
+
+  describe("linear_search_issues", () => {
+    it("returns formatted results", async () => {
+      const mockData = {
+        data: {
+          issues: {
+            nodes: [
+              {
+                id: "id1",
+                identifier: "ENG-42",
+                title: "Fix login bug",
+                state: { name: "In Progress" },
+                assignee: { name: "Alice" },
+                priority: 2,
+                priorityLabel: "High",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+                url: "https://linear.app/team/issue/ENG-42",
+              },
+            ],
+          },
+        },
+      };
+
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      const result = await tool.execute("call1", { query: "login" });
+
+      expect(result.content[0].text).toContain("ENG-42");
+      expect(result.content[0].text).toContain("Fix login bug");
+      expect(result.content[0].text).toContain("In Progress");
+      expect(result.content[0].text).toContain("Alice");
+    });
+
+    it("passes team filter in GraphQL variables", async () => {
+      const mockData = { data: { issues: { nodes: [] } } };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await tool.execute("call2", { query: "test", teamKey: "ENG" });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.variables.filter.team).toEqual({ key: { eq: "ENG" } });
+    });
+
+    it("respects limit parameter", async () => {
+      const mockData = { data: { issues: { nodes: [] } } };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await tool.execute("call3", { query: "test", limit: 5 });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.variables.limit).toBe(5);
+    });
+
+    it("returns no-results message when empty", async () => {
+      const mockData = { data: { issues: { nodes: [] } } };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      const result = await tool.execute("call4", { query: "nonexistent" });
+
+      expect(result.content[0].text).toContain("No issues found");
+    });
+  });
+
+  describe("linear_create_issue", () => {
+    it("sends correct mutation and returns issue details", async () => {
+      // First call resolves team, second call creates issue
+      const teamResponse = {
+        data: { teams: { nodes: [{ id: "team-1", key: "ENG", name: "Engineering" }] } },
+      };
+      const createResponse = {
+        data: {
+          issueCreate: {
+            success: true,
+            issue: {
+              id: "issue-1",
+              identifier: "ENG-100",
+              title: "New feature",
+              url: "https://linear.app/team/issue/ENG-100",
+              state: { name: "Backlog" },
+            },
+          },
+        },
+      };
+
+      let callCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(async () => {
+          const data = callCount === 0 ? teamResponse : createResponse;
+          callCount++;
+          return {
+            ok: true,
+            status: 200,
+            json: async () => data,
+            text: async () => JSON.stringify(data),
+          };
+        }),
+      );
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_create_issue");
+      const result = await tool.execute("call5", {
+        title: "New feature",
+        teamKey: "ENG",
+        description: "Implement the thing",
+        priority: 2,
+      });
+
+      expect(result.content[0].text).toContain("ENG-100");
+      expect(result.content[0].text).toContain("New feature");
+      expect(result.content[0].text).toContain("Backlog");
+    });
+
+    it("throws when team not found", async () => {
+      const teamResponse = { data: { teams: { nodes: [] } } };
+      vi.stubGlobal("fetch", mockFetchResponse(teamResponse));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_create_issue");
+      await expect(tool.execute("call6", { title: "Test", teamKey: "NOPE" })).rejects.toThrow(
+        /Team with key 'NOPE' not found/,
+      );
+    });
+  });
+
+  describe("linear_list_teams", () => {
+    it("returns team list", async () => {
+      const mockData = {
+        data: {
+          teams: {
+            nodes: [
+              { id: "t1", key: "ENG", name: "Engineering", description: "Core team" },
+              { id: "t2", key: "DES", name: "Design" },
+            ],
+          },
+        },
+      };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_list_teams");
+      const result = await tool.execute("call7", {});
+
+      expect(result.content[0].text).toContain("ENG: Engineering");
+      expect(result.content[0].text).toContain("Core team");
+      expect(result.content[0].text).toContain("DES: Design");
+    });
+
+    it("returns message when no teams", async () => {
+      const mockData = { data: { teams: { nodes: [] } } };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_list_teams");
+      const result = await tool.execute("call8", {});
+
+      expect(result.content[0].text).toContain("No teams found");
+    });
+  });
+
+  describe("linear_get_issue", () => {
+    it("returns detailed issue info with comments", async () => {
+      const mockData = {
+        data: {
+          issueSearch: {
+            nodes: [
+              {
+                id: "id1",
+                identifier: "ENG-42",
+                title: "Fix login bug",
+                description: "The login form breaks on mobile.",
+                state: { name: "In Progress" },
+                assignee: { name: "Alice" },
+                priority: 2,
+                priorityLabel: "High",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+                url: "https://linear.app/team/issue/ENG-42",
+                comments: {
+                  nodes: [
+                    {
+                      body: "Working on it",
+                      user: { name: "Alice" },
+                      createdAt: "2024-01-01T12:00:00Z",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_get_issue");
+      const result = await tool.execute("call9", { identifier: "ENG-42" });
+
+      expect(result.content[0].text).toContain("ENG-42: Fix login bug");
+      expect(result.content[0].text).toContain("In Progress");
+      expect(result.content[0].text).toContain("The login form breaks on mobile");
+      expect(result.content[0].text).toContain("[Alice] Working on it");
+    });
+
+    it("returns not-found message for missing issue", async () => {
+      const mockData = { data: { issueSearch: { nodes: [] } } };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_get_issue");
+      const result = await tool.execute("call10", { identifier: "NOPE-999" });
+
+      expect(result.content[0].text).toContain("not found");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when apiKey is missing", async () => {
+      const tools = createLinearTools(fakeApi({ pluginConfig: {} }));
+      const tool = findTool(tools, "linear_search_issues");
+      await expect(tool.execute("call11", { query: "test" })).rejects.toThrow(
+        /API key not configured/,
+      );
+    });
+
+    it("throws on HTTP error response", async () => {
+      vi.stubGlobal("fetch", mockFetchResponse({}, false, 401));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await expect(tool.execute("call12", { query: "test" })).rejects.toThrow(
+        /Linear API error \(401\)/,
+      );
+    });
+
+    it("throws on GraphQL error response", async () => {
+      const mockData = { errors: [{ message: "Authentication required" }] };
+      vi.stubGlobal("fetch", mockFetchResponse(mockData));
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await expect(tool.execute("call13", { query: "test" })).rejects.toThrow(
+        /GraphQL error.*Authentication required/,
+      );
+    });
+
+    it("sends Authorization header with apiKey", async () => {
+      const mockData = { data: { issues: { nodes: [] } } };
+      const fetchMock = mockFetchResponse(mockData);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const tools = createLinearTools(fakeApi());
+      const tool = findTool(tools, "linear_search_issues");
+      await tool.execute("call14", { query: "test" });
+
+      expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe("lin_api_test123");
+    });
+  });
+});

--- a/extensions/linear/src/linear-tools.ts
+++ b/extensions/linear/src/linear-tools.ts
@@ -1,0 +1,338 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+
+type LinearPluginConfig = {
+  apiKey?: string;
+};
+
+type GraphQLResponse<T> = {
+  data?: T;
+  errors?: Array<{ message: string }>;
+};
+
+async function linearGraphQL<T>(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch("https://api.linear.app/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Linear API error (${res.status}): ${body || res.statusText}`);
+  }
+
+  const json = (await res.json()) as GraphQLResponse<T>;
+  if (json.errors?.length) {
+    throw new Error(`Linear GraphQL error: ${json.errors.map((e) => e.message).join("; ")}`);
+  }
+  if (!json.data) {
+    throw new Error("Linear API returned no data");
+  }
+  return json.data;
+}
+
+function resolveApiKey(api: OpenClawPluginApi): string {
+  const cfg = api.pluginConfig as LinearPluginConfig | undefined;
+  const apiKey = cfg?.apiKey;
+  if (!apiKey) {
+    throw new Error(
+      "Linear API key not configured. Set it in plugins.entries.linear.config.apiKey",
+    );
+  }
+  return apiKey;
+}
+
+type IssueNode = {
+  id: string;
+  identifier: string;
+  title: string;
+  state: { name: string } | null;
+  assignee: { name: string } | null;
+  priority: number;
+  priorityLabel: string;
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+  description?: string;
+};
+
+type CommentNode = {
+  body: string;
+  user: { name: string } | null;
+  createdAt: string;
+};
+
+function formatIssue(issue: IssueNode): string {
+  const parts = [
+    `${issue.identifier}: ${issue.title}`,
+    `  Status: ${issue.state?.name ?? "Unknown"}`,
+    `  Priority: ${issue.priorityLabel}`,
+    issue.assignee ? `  Assignee: ${issue.assignee.name}` : null,
+    `  URL: ${issue.url}`,
+  ];
+  return parts.filter(Boolean).join("\n");
+}
+
+export function createLinearTools(api: OpenClawPluginApi) {
+  const searchIssues = {
+    name: "linear_search_issues",
+    description: "Search Linear issues with optional filters for team, status, and assignee.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search text to find in issue titles and descriptions" }),
+      teamKey: Type.Optional(Type.String({ description: "Filter by team key (e.g. 'ENG')" })),
+      status: Type.Optional(
+        Type.String({ description: "Filter by status name (e.g. 'In Progress', 'Done')" }),
+      ),
+      assignee: Type.Optional(Type.String({ description: "Filter by assignee display name" })),
+      limit: Type.Optional(
+        Type.Number({ description: "Max results to return (default 10)", minimum: 1, maximum: 50 }),
+      ),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const apiKey = resolveApiKey(api);
+      const query = params.query as string;
+      const teamKey = params.teamKey as string | undefined;
+      const status = params.status as string | undefined;
+      const assignee = params.assignee as string | undefined;
+      const limit = (params.limit as number) || 10;
+
+      const filter: Record<string, unknown> = {};
+      if (query) filter.searchableContent = { contains: query };
+      if (teamKey) filter.team = { key: { eq: teamKey } };
+      if (status) filter.state = { name: { eqCaseInsensitive: status } };
+      if (assignee) filter.assignee = { displayName: { containsIgnoreCase: assignee } };
+
+      const gql = `
+        query SearchIssues($filter: IssueFilter, $limit: Int) {
+          issues(filter: $filter, first: $limit) {
+            nodes {
+              id identifier title
+              state { name }
+              assignee { name }
+              priority priorityLabel
+              createdAt updatedAt url
+            }
+          }
+        }
+      `;
+
+      type SearchResult = { issues: { nodes: IssueNode[] } };
+      const data = await linearGraphQL<SearchResult>(apiKey, gql, { filter, limit });
+      const issues = data.issues.nodes;
+
+      if (issues.length === 0) {
+        return {
+          content: [{ type: "text" as const, text: "No issues found matching your query." }],
+        };
+      }
+
+      const formatted = issues.map(formatIssue).join("\n\n");
+      return {
+        content: [
+          { type: "text" as const, text: `Found ${issues.length} issue(s):\n\n${formatted}` },
+        ],
+      };
+    },
+  };
+
+  const createIssue = {
+    name: "linear_create_issue",
+    description: "Create a new issue in Linear.",
+    parameters: Type.Object({
+      title: Type.String({ description: "Issue title" }),
+      teamKey: Type.String({ description: "Team key (e.g. 'ENG')" }),
+      description: Type.Optional(Type.String({ description: "Issue description (markdown)" })),
+      priority: Type.Optional(
+        Type.Number({
+          description: "Priority: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low",
+          minimum: 0,
+          maximum: 4,
+        }),
+      ),
+      assigneeId: Type.Optional(Type.String({ description: "Assignee user ID" })),
+      labelIds: Type.Optional(Type.Array(Type.String(), { description: "Label IDs to apply" })),
+      stateId: Type.Optional(Type.String({ description: "Workflow state ID" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const apiKey = resolveApiKey(api);
+      const title = params.title as string;
+      const teamKey = params.teamKey as string;
+
+      const teamGql = `
+        query GetTeam($key: String!) {
+          teams(filter: { key: { eq: $key } }) {
+            nodes { id key name }
+          }
+        }
+      `;
+      type TeamResult = { teams: { nodes: Array<{ id: string; key: string; name: string }> } };
+      const teamData = await linearGraphQL<TeamResult>(apiKey, teamGql, { key: teamKey });
+      const team = teamData.teams.nodes[0];
+      if (!team) {
+        throw new Error(`Team with key '${teamKey}' not found`);
+      }
+
+      const input: Record<string, unknown> = {
+        title,
+        teamId: team.id,
+      };
+      if (params.description) input.description = params.description;
+      if (typeof params.priority === "number") input.priority = params.priority;
+      if (params.assigneeId) input.assigneeId = params.assigneeId;
+      if (params.labelIds) input.labelIds = params.labelIds;
+      if (params.stateId) input.stateId = params.stateId;
+
+      const gql = `
+        mutation CreateIssue($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue {
+              id identifier title url
+              state { name }
+            }
+          }
+        }
+      `;
+
+      type CreateResult = {
+        issueCreate: {
+          success: boolean;
+          issue: {
+            id: string;
+            identifier: string;
+            title: string;
+            url: string;
+            state: { name: string } | null;
+          };
+        };
+      };
+      const data = await linearGraphQL<CreateResult>(apiKey, gql, { input });
+
+      if (!data.issueCreate.success) {
+        throw new Error("Failed to create issue");
+      }
+
+      const issue = data.issueCreate.issue;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Created issue ${issue.identifier}: ${issue.title}\nStatus: ${issue.state?.name ?? "Unknown"}\nURL: ${issue.url}`,
+          },
+        ],
+      };
+    },
+  };
+
+  const listTeams = {
+    name: "linear_list_teams",
+    description: "List all teams in your Linear workspace.",
+    parameters: Type.Object({}),
+    async execute(_id: string, _params: Record<string, unknown>) {
+      const apiKey = resolveApiKey(api);
+
+      const gql = `
+        query ListTeams {
+          teams {
+            nodes { id key name description }
+          }
+        }
+      `;
+
+      type TeamsResult = {
+        teams: { nodes: Array<{ id: string; key: string; name: string; description?: string }> };
+      };
+      const data = await linearGraphQL<TeamsResult>(apiKey, gql);
+      const teams = data.teams.nodes;
+
+      if (teams.length === 0) {
+        return { content: [{ type: "text" as const, text: "No teams found." }] };
+      }
+
+      const formatted = teams
+        .map((t) => `${t.key}: ${t.name}${t.description ? ` — ${t.description}` : ""}`)
+        .join("\n");
+      return {
+        content: [{ type: "text" as const, text: `Teams (${teams.length}):\n\n${formatted}` }],
+      };
+    },
+  };
+
+  const getIssue = {
+    name: "linear_get_issue",
+    description:
+      "Get detailed information about a specific Linear issue by its identifier (e.g. 'ENG-123').",
+    parameters: Type.Object({
+      identifier: Type.String({ description: "Issue identifier (e.g. 'ENG-123')" }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const apiKey = resolveApiKey(api);
+      const identifier = params.identifier as string;
+
+      const gql = `
+        query GetIssue($identifier: String!) {
+          issueSearch(query: $identifier, first: 1) {
+            nodes {
+              id identifier title description
+              state { name }
+              assignee { name }
+              priority priorityLabel
+              createdAt updatedAt url
+              comments {
+                nodes {
+                  body
+                  user { name }
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      `;
+
+      type IssueWithComments = IssueNode & {
+        comments: { nodes: CommentNode[] };
+      };
+      type GetResult = { issueSearch: { nodes: IssueWithComments[] } };
+      const data = await linearGraphQL<GetResult>(apiKey, gql, { identifier });
+
+      const issue = data.issueSearch.nodes[0];
+      if (!issue) {
+        return { content: [{ type: "text" as const, text: `Issue '${identifier}' not found.` }] };
+      }
+
+      const parts = [
+        `${issue.identifier}: ${issue.title}`,
+        `Status: ${issue.state?.name ?? "Unknown"}`,
+        `Priority: ${issue.priorityLabel}`,
+        issue.assignee ? `Assignee: ${issue.assignee.name}` : null,
+        `Created: ${issue.createdAt}`,
+        `Updated: ${issue.updatedAt}`,
+        `URL: ${issue.url}`,
+      ].filter(Boolean);
+
+      if (issue.description) {
+        parts.push("", "Description:", issue.description);
+      }
+
+      if (issue.comments.nodes.length > 0) {
+        parts.push("", `Comments (${issue.comments.nodes.length}):`);
+        for (const c of issue.comments.nodes) {
+          parts.push(`  [${c.user?.name ?? "Unknown"}] ${c.body}`);
+        }
+      }
+
+      return { content: [{ type: "text" as const, text: parts.join("\n") }] };
+    },
+  };
+
+  return [searchIssues, createIssue, listTeams, getIssue];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/linear:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/llm-task:
     devDependencies:
       openclaw:
@@ -6666,7 +6672,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.58.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6682,7 +6688,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.12
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6885,7 +6891,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7720,7 +7726,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7766,7 +7772,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.2.2
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8660,14 +8666,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9242,8 +9240,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Adds `extensions/linear/` — agent tool plugin for searching, creating, and managing Linear issues via GraphQL API
- Tools: `linear_search_issues`, `linear_create_issue`, `linear_list_teams`, `linear_get_issue`
- All tools registered as `optional: true` (opt-in via `agents.list[].tools.allow`)
- Config: `plugins.entries.linear.config.apiKey` (sensitive, masked in Control UI)
- Follows existing plugin patterns (llm-task, lobster) with TypeBox schemas and plugin manifest

## Test plan

- [x] `pnpm vitest run extensions/linear/` — 15 tests passing
- [ ] Manual: configure Linear API key and verify tool calls work end-to-end

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new optional Linear integration extension under `extensions/linear/`. It defines four agent tools (`linear_search_issues`, `linear_create_issue`, `linear_list_teams`, `linear_get_issue`) that call Linear’s GraphQL API via `fetch`, and includes a plugin manifest (`openclaw.plugin.json`) with an `apiKey` config field marked as sensitive for UI masking. Tool registration is marked `optional: true`, so these tools are opt-in via the tool allowlist policy.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low risk; functionality is isolated to a new optional extension.
- Changes are additive and scoped to a new plugin directory, with tests covering tool behavior and error handling. I did not find a confirmed runtime-breaking integration issue in the OpenClaw plugin/tool interfaces based on existing extension patterns.
- extensions/linear/src/linear-tools.ts (runtime GraphQL schema compatibility)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->