### PR TITLE
feat(auth): restore Claude Code CLI OAuth credential sync

### DIFF
--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -1,4 +1,9 @@
-import type { AuthProfileCredential, AuthProfileStore, OAuthCredential, TokenCredential } from "./types.js";
+import type {
+  AuthProfileCredential,
+  AuthProfileStore,
+  OAuthCredential,
+  TokenCredential,
+} from "./types.js";
 import {
   readClaudeCliCredentialsCached,
   readQwenCliCredentialsCached,
@@ -54,7 +59,11 @@ function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: nu
   if (cred.type !== "oauth" && cred.type !== "token") {
     return false;
   }
-  if (cred.provider !== "anthropic" && cred.provider !== "qwen-portal" && cred.provider !== "minimax-portal") {
+  if (
+    cred.provider !== "anthropic" &&
+    cred.provider !== "qwen-portal" &&
+    cred.provider !== "minimax-portal"
+  ) {
     return false;
   }
   if (typeof cred.expires !== "number") {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -9,7 +9,8 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileStore } from "./types.js";
 import { refreshQwenPortalCredentials } from "../../providers/qwen-portal-oauth.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
-import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
+import { writeClaudeCliCredentials } from "../cli-credentials.js";
+import { AUTH_STORE_LOCK_OPTIONS, CLAUDE_CLI_PROFILE_ID, log } from "./constants.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
@@ -92,6 +93,12 @@ async function refreshOAuthTokenWithLock(params: {
       type: "oauth",
     };
     saveAuthProfileStore(store, params.agentDir);
+
+    // Sync refreshed credentials back to Claude Code CLI if this is the claude-cli profile
+    // This ensures Claude Code continues to work after OpenClaw refreshes the token
+    if (params.profileId === CLAUDE_CLI_PROFILE_ID && cred.provider === "anthropic") {
+      writeClaudeCliCredentials(result.newCredentials);
+    }
 
     return result;
   } finally {

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -198,7 +198,8 @@ export function loadAuthProfileStore(): AuthProfileStore {
   const asStore = coerceAuthStore(raw);
   if (asStore) {
     // Sync from external CLI tools on every load
-    const synced = syncExternalCliCredentials(asStore);
+    // Explicitly disable Keychain prompts for non-auth read paths
+    const synced = syncExternalCliCredentials(asStore, { allowKeychainPrompt: false });
     if (synced) {
       saveJsonFile(authPath, asStore);
     }
@@ -243,12 +244,12 @@ export function loadAuthProfileStore(): AuthProfileStore {
         };
       }
     }
-    syncExternalCliCredentials(store);
+    syncExternalCliCredentials(store, { allowKeychainPrompt: false });
     return store;
   }
 
   const store: AuthProfileStore = { version: AUTH_STORE_VERSION, profiles: {} };
-  syncExternalCliCredentials(store);
+  syncExternalCliCredentials(store, { allowKeychainPrompt: false });
   return store;
 }
 

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -254,14 +254,14 @@ export function loadAuthProfileStore(): AuthProfileStore {
 
 function loadAuthProfileStoreForAgent(
   agentDir?: string,
-  _options?: { allowKeychainPrompt?: boolean },
+  options?: { allowKeychainPrompt?: boolean },
 ): AuthProfileStore {
   const authPath = resolveAuthStorePath(agentDir);
   const raw = loadJsonFile(authPath);
   const asStore = coerceAuthStore(raw);
   if (asStore) {
     // Sync from external CLI tools on every load
-    const synced = syncExternalCliCredentials(asStore);
+    const synced = syncExternalCliCredentials(asStore, options);
     if (synced) {
       saveJsonFile(authPath, asStore);
     }
@@ -322,7 +322,7 @@ function loadAuthProfileStoreForAgent(
   }
 
   const mergedOAuth = mergeOAuthFileIntoStore(store);
-  const syncedCli = syncExternalCliCredentials(store);
+  const syncedCli = syncExternalCliCredentials(store, options);
   const shouldWrite = legacy !== null || mergedOAuth || syncedCli;
   if (shouldWrite) {
     saveJsonFile(authPath, store);

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -1,7 +1,7 @@
 import type { AuthProfileStore } from "../agents/auth-profiles.js";
+import type { AuthChoice } from "./onboard-types.js";
 import { CLAUDE_CLI_PROFILE_ID } from "../agents/auth-profiles.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
-import type { AuthChoice } from "./onboard-types.js";
 
 export type AuthChoiceOption = {
   value: AuthChoice;

--- a/src/commands/auth-choice.apply.anthropic.ts
+++ b/src/commands/auth-choice.apply.anthropic.ts
@@ -1,5 +1,9 @@
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
-import { upsertAuthProfile } from "../agents/auth-profiles.js";
+import {
+  CLAUDE_CLI_PROFILE_ID,
+  ensureAuthProfileStore,
+  upsertAuthProfile,
+} from "../agents/auth-profiles.js";
 import {
   formatApiKeyPreview,
   normalizeApiKeyInput,
@@ -11,6 +15,82 @@ import { applyAuthProfileConfig, setAnthropicApiKey } from "./onboard-auth.js";
 export async function applyAuthChoiceAnthropic(
   params: ApplyAuthChoiceParams,
 ): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice === "claude-cli") {
+    let nextConfig = params.config;
+    const store = ensureAuthProfileStore(params.agentDir, {
+      allowKeychainPrompt: false,
+    });
+    const hasClaudeCli = Boolean(store.profiles[CLAUDE_CLI_PROFILE_ID]);
+    if (!hasClaudeCli && process.platform === "darwin") {
+      await params.prompter.note(
+        [
+          "macOS will show a Keychain prompt next.",
+          'Choose "Always Allow" so the launchd gateway can start without prompts.',
+          'If you choose "Allow" or "Deny", each restart will block on a Keychain alert.',
+        ].join("\n"),
+        "Claude Code CLI Keychain",
+      );
+      const proceed = await params.prompter.confirm({
+        message: "Check Keychain for Claude Code CLI credentials now?",
+        initialValue: true,
+      });
+      if (!proceed) {
+        return { config: nextConfig };
+      }
+    }
+
+    const storeWithKeychain = hasClaudeCli
+      ? store
+      : ensureAuthProfileStore(params.agentDir, {
+          allowKeychainPrompt: true,
+        });
+
+    if (!storeWithKeychain.profiles[CLAUDE_CLI_PROFILE_ID]) {
+      if (process.stdin.isTTY) {
+        const runNow = await params.prompter.confirm({
+          message: "Run `claude setup-token` now?",
+          initialValue: true,
+        });
+        if (runNow) {
+          const res = await (async () => {
+            const { spawnSync } = await import("node:child_process");
+            return spawnSync("claude", ["setup-token"], { stdio: "inherit" });
+          })();
+          if (res.error) {
+            await params.prompter.note(
+              `Failed to run claude: ${String(res.error)}`,
+              "Claude setup-token",
+            );
+          }
+        }
+      } else {
+        await params.prompter.note(
+          "`claude setup-token` requires an interactive TTY.",
+          "Claude setup-token",
+        );
+      }
+
+      const refreshed = ensureAuthProfileStore(params.agentDir, {
+        allowKeychainPrompt: true,
+      });
+      if (!refreshed.profiles[CLAUDE_CLI_PROFILE_ID]) {
+        await params.prompter.note(
+          process.platform === "darwin"
+            ? 'No Claude Code CLI credentials found in Keychain ("Claude Code-credentials") or ~/.claude/.credentials.json.'
+            : "No Claude Code CLI credentials found at ~/.claude/.credentials.json.",
+          "Claude Code CLI OAuth",
+        );
+        return { config: nextConfig };
+      }
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: CLAUDE_CLI_PROFILE_ID,
+      provider: "anthropic",
+      mode: "oauth",
+    });
+    return { config: nextConfig };
+  }
+
   if (
     params.authChoice === "setup-token" ||
     params.authChoice === "oauth" ||

--- a/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
+++ b/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
@@ -47,7 +47,7 @@ afterEach(() => {
 });
 
 describe("maybeRemoveDeprecatedCliAuthProfiles", () => {
-  it("removes deprecated CLI auth profiles from store + config", async () => {
+  it("removes deprecated codex-cli profile but preserves claude-cli", async () => {
     if (!tempAgentDir) {
       throw new Error("Missing temp agent dir");
     }
@@ -98,12 +98,14 @@ describe("maybeRemoveDeprecatedCliAuthProfiles", () => {
     const raw = JSON.parse(fs.readFileSync(authPath, "utf8")) as {
       profiles?: Record<string, unknown>;
     };
-    expect(raw.profiles?.["anthropic:claude-cli"]).toBeUndefined();
+    // claude-cli is NOT deprecated — it should be preserved
+    expect(raw.profiles?.["anthropic:claude-cli"]).toBeDefined();
+    // codex-cli IS deprecated — it should be removed
     expect(raw.profiles?.["openai-codex:codex-cli"]).toBeUndefined();
 
-    expect(next.auth?.profiles?.["anthropic:claude-cli"]).toBeUndefined();
+    expect(next.auth?.profiles?.["anthropic:claude-cli"]).toBeDefined();
     expect(next.auth?.profiles?.["openai-codex:codex-cli"]).toBeUndefined();
-    expect(next.auth?.order?.anthropic).toBeUndefined();
+    expect(next.auth?.order?.anthropic).toBeDefined();
     expect(next.auth?.order?.["openai-codex"]).toBeUndefined();
   });
 });

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -115,9 +115,6 @@ export async function maybeRemoveDeprecatedCliAuthProfiles(
 ): Promise<OpenClawConfig> {
   const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false });
   const deprecated = new Set<string>();
-  if (store.profiles[CLAUDE_CLI_PROFILE_ID] || cfg.auth?.profiles?.[CLAUDE_CLI_PROFILE_ID]) {
-    deprecated.add(CLAUDE_CLI_PROFILE_ID);
-  }
   if (store.profiles[CODEX_CLI_PROFILE_ID] || cfg.auth?.profiles?.[CODEX_CLI_PROFILE_ID]) {
     deprecated.add(CODEX_CLI_PROFILE_ID);
   }
@@ -208,9 +205,7 @@ type AuthIssue = {
 
 function formatAuthIssueHint(issue: AuthIssue): string | null {
   if (issue.provider === "anthropic" && issue.profileId === CLAUDE_CLI_PROFILE_ID) {
-    return `Deprecated profile. Use ${formatCliCommand("openclaw models auth setup-token")} or ${formatCliCommand(
-      "openclaw configure",
-    )}.`;
+    return "Run `claude setup-token` on the gateway host.";
   }
   if (issue.provider === "openai-codex" && issue.profileId === CODEX_CLI_PROFILE_ID) {
     return `Deprecated profile. Use ${formatCliCommand(

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -124,11 +124,6 @@ export async function maybeRemoveDeprecatedCliAuthProfiles(
   }
 
   const lines = ["Deprecated external CLI auth profiles detected (no longer supported):"];
-  if (deprecated.has(CLAUDE_CLI_PROFILE_ID)) {
-    lines.push(
-      `- ${CLAUDE_CLI_PROFILE_ID} (Anthropic): use setup-token → ${formatCliCommand("openclaw models auth setup-token")}`,
-    );
-  }
   if (deprecated.has(CODEX_CLI_PROFILE_ID)) {
     lines.push(
       `- ${CODEX_CLI_PROFILE_ID} (OpenAI Codex): use OAuth → ${formatCliCommand(


### PR DESCRIPTION
Re-adds Claude Code CLI integration that was removed in upstream commit 526303d9a. This restores the ability to authenticate using an existing Claude Code subscription (Claude Pro/Max) instead of manually pasting setup-tokens.

Changes:
- Re-add Claude CLI credential sync in external-cli-sync.ts
- Re-add bidirectional token refresh write-back in oauth.ts
- Re-add "Claude Code CLI" auth option in onboarding UI
- Re-add claude-cli auth handler in auth-choice.apply.anthropic.ts
- Remove claude-cli deprecation warning in doctor-auth.ts
- Pass allowKeychainPrompt options through store.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR restores Claude Code CLI credential syncing for Anthropic auth by:
- syncing Claude CLI credentials into the auth profile store on load (`external-cli-sync.ts` / `store.ts`)
- writing refreshed Anthropic OAuth credentials back into Claude CLI storage during token refresh (`oauth.ts`)
- exposing a new onboarding auth choice (`claude-cli`) and updating hints in the auth-choice UI
- removing the prior “Claude CLI is deprecated” doctor warning

Key integration points are the auth store load/sync layer and the OAuth refresh path; both now interact with `cli-credentials.ts` for reading/writing Claude CLI credentials.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a confirmed doctor-flow regression and likely macOS Keychain prompt behavior in non-auth commands.
- The doctor deprecated-profile removal logic is internally inconsistent (and contradicts its unit test), and the auth store load path can trigger Keychain prompts unexpectedly on macOS because `allowKeychainPrompt` isn’t plumbed through `loadAuthProfileStore()`. Both are concrete, user-visible issues that should be fixed before merge.
- src/commands/doctor-auth.ts, src/agents/auth-profiles/store.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->