### PR TITLE
feat(plugins): add Kindle highlights integration plugin

### DIFF
--- a/extensions/kindle/index.ts
+++ b/extensions/kindle/index.ts
@@ -1,0 +1,9 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "../../src/plugins/types.js";
+import { createKindleTools } from "./src/kindle-tools.js";
+
+export default function register(api: OpenClawPluginApi) {
+  const tools = createKindleTools(api);
+  for (const tool of tools) {
+    api.registerTool(tool as unknown as AnyAgentTool, { optional: true });
+  }
+}

--- a/extensions/kindle/openclaw.plugin.json
+++ b/extensions/kindle/openclaw.plugin.json
@@ -1,0 +1,20 @@
+{
+  "id": "kindle",
+  "name": "Kindle Highlights",
+  "description": "Search and browse your Kindle book highlights and notes.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "clippingsPath": { "type": "string" }
+    },
+    "required": ["clippingsPath"]
+  },
+  "uiHints": {
+    "clippingsPath": {
+      "label": "Clippings File Path",
+      "placeholder": "/Volumes/Kindle/documents/My Clippings.txt",
+      "help": "Path to your Kindle 'My Clippings.txt' file"
+    }
+  }
+}

--- a/extensions/kindle/package.json
+++ b/extensions/kindle/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/kindle",
+  "version": "2026.2.9",
+  "private": true,
+  "description": "OpenClaw Kindle highlights integration plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/kindle/src/kindle-tools.test.ts
+++ b/extensions/kindle/src/kindle-tools.test.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => {
+  return {
+    default: {
+      readFile: vi.fn(),
+      stat: vi.fn(),
+    },
+  };
+});
+
+import fs from "node:fs/promises";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+import { createKindleTools, parseClippings } from "./kindle-tools.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FIXTURE_CLIPPINGS = `Thinking, Fast and Slow (Daniel Kahneman)
+- Your Highlight on page 25 | location 302-305 | Added on Monday, January 15, 2024 3:42:17 PM
+
+Nothing in life is as important as you think it is, while you are thinking about it.
+==========
+Thinking, Fast and Slow (Daniel Kahneman)
+- Your Highlight on page 35 | location 402-410 | Added on Tuesday, January 16, 2024 10:15:00 AM
+
+A reliable way to make people believe in falsehoods is frequent repetition, because familiarity is not easily distinguished from truth.
+==========
+Sapiens: A Brief History of Humankind (Yuval Noah Harari)
+- Your Highlight on page 12 | location 150-155 | Added on Wednesday, January 17, 2024 2:00:00 PM
+
+You could never convince a monkey to give you a banana by promising him limitless bananas after death in monkey heaven.
+==========
+Sapiens: A Brief History of Humankind (Yuval Noah Harari)
+- Your Note on page 13 | location 160 | Added on Wednesday, January 17, 2024 2:05:00 PM
+
+This is a great point about shared myths.
+==========
+Sapiens: A Brief History of Humankind (Yuval Noah Harari)
+- Your Bookmark on page 14 | location 170 | Added on Wednesday, January 17, 2024 2:10:00 PM
+
+==========
+The Design of Everyday Things (Don Norman)
+- Your Highlight on page 1 | location 10-12 | Added on Thursday, January 18, 2024 8:00:00 AM
+
+Good design is actually a lot harder to notice than poor design, in part because good designs fit our needs so well that the design is invisible.
+==========`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeApi(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "kindle",
+    name: "kindle",
+    source: "test",
+    config: {},
+    pluginConfig: { clippingsPath: "/fake/My Clippings.txt" },
+    runtime: { version: "test" },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    registerTool() {},
+    registerHook() {},
+    registerHttpHandler() {},
+    registerHttpRoute() {},
+    registerChannel() {},
+    registerGatewayMethod() {},
+    registerCli() {},
+    registerService() {},
+    registerProvider() {},
+    registerCommand() {},
+    on() {},
+    resolvePath: (p: string) => p,
+    ...overrides,
+  } as unknown as OpenClawPluginApi;
+}
+
+function mockFs() {
+  vi.mocked(fs.stat).mockResolvedValue({ mtimeMs: Date.now() } as Awaited<
+    ReturnType<typeof fs.stat>
+  >);
+  vi.mocked(fs.readFile).mockResolvedValue(FIXTURE_CLIPPINGS);
+}
+
+function getTools(api?: OpenClawPluginApi) {
+  const tools = createKindleTools(api ?? fakeApi());
+  const search = tools.find((t) => t.name === "kindle_search_highlights")!;
+  const listBooks = tools.find((t) => t.name === "kindle_list_books")!;
+  const getBook = tools.find((t) => t.name === "kindle_get_book_highlights")!;
+  return { search, listBooks, getBook };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("parseClippings", () => {
+  it("correctly parses highlights, notes, and bookmarks", () => {
+    const clippings = parseClippings(FIXTURE_CLIPPINGS);
+    expect(clippings).toHaveLength(6);
+
+    const highlights = clippings.filter((c) => c.type === "highlight");
+    expect(highlights).toHaveLength(4);
+
+    const notes = clippings.filter((c) => c.type === "note");
+    expect(notes).toHaveLength(1);
+
+    const bookmarks = clippings.filter((c) => c.type === "bookmark");
+    expect(bookmarks).toHaveLength(1);
+    expect(notes[0]!.content).toBe("This is a great point about shared myths.");
+  });
+
+  it("parses book title and author correctly", () => {
+    const clippings = parseClippings(FIXTURE_CLIPPINGS);
+    const first = clippings[0]!;
+    expect(first.bookTitle).toBe("Thinking, Fast and Slow");
+    expect(first.author).toBe("Daniel Kahneman");
+  });
+
+  it("parses page, location, and date", () => {
+    const clippings = parseClippings(FIXTURE_CLIPPINGS);
+    const first = clippings[0]!;
+    expect(first.page).toBe(25);
+    expect(first.location).toBe("302-305");
+    expect(first.date).toBe("Monday, January 15, 2024 3:42:17 PM");
+  });
+
+  it("handles missing author gracefully", () => {
+    const raw = `A Book Without Author
+- Your Highlight on page 1 | location 1-5 | Added on Monday, January 1, 2024 12:00:00 PM
+
+Some text here.
+==========`;
+    const clippings = parseClippings(raw);
+    expect(clippings).toHaveLength(1);
+    expect(clippings[0]!.bookTitle).toBe("A Book Without Author");
+    expect(clippings[0]!.author).toBe("");
+  });
+
+  it("handles empty/malformed entries", () => {
+    const raw = `==========
+
+==========
+Just a title line
+==========
+Some Book (Author)
+- Not a valid meta line
+
+Content here
+==========`;
+    const clippings = parseClippings(raw);
+    expect(clippings).toHaveLength(0);
+  });
+
+  it("handles multi-line content", () => {
+    const raw = `Some Book (Author)
+- Your Highlight on page 5 | location 50-55 | Added on Monday, January 1, 2024 12:00:00 PM
+
+First line of highlight.
+Second line of highlight.
+Third line.
+==========`;
+    const clippings = parseClippings(raw);
+    expect(clippings).toHaveLength(1);
+    expect(clippings[0]!.content).toBe(
+      "First line of highlight.\nSecond line of highlight.\nThird line.",
+    );
+  });
+});
+
+describe("kindle_search_highlights", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFs();
+  });
+
+  it("finds highlights matching query text", async () => {
+    const { search } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await search.execute("id", { query: "monkey" })) as any;
+    expect(res.details).toHaveLength(1);
+    expect(res.details[0].bookTitle).toBe("Sapiens: A Brief History of Humankind");
+  });
+
+  it("filters by book title when specified", async () => {
+    const { search } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await search.execute("id", { query: "a", book: "Thinking" })) as any;
+    for (const item of res.details) {
+      expect(item.bookTitle).toContain("Thinking");
+    }
+  });
+
+  it("is case-insensitive", async () => {
+    const { search } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const lower = (await search.execute("id", { query: "NOTHING IN LIFE" })) as any;
+    expect(lower.details).toHaveLength(1);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const upper = (await search.execute("id", { query: "nothing in life" })) as any;
+    expect(upper.details).toHaveLength(1);
+  });
+
+  it("respects limit", async () => {
+    const { search } = getTools();
+    // Search for common word that matches many highlights
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await search.execute("id", { query: "is", limit: 2 })) as any;
+    expect(res.details.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("kindle_list_books", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFs();
+  });
+
+  it("returns books sorted by highlight count", async () => {
+    const { listBooks } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await listBooks.execute("id", {})) as any;
+    const counts = res.details.map((b: { highlightCount: number }) => b.highlightCount);
+    for (let i = 1; i < counts.length; i++) {
+      expect(counts[i - 1]).toBeGreaterThanOrEqual(counts[i]);
+    }
+  });
+
+  it("includes correct highlight counts (excludes bookmarks)", async () => {
+    const { listBooks } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await listBooks.execute("id", {})) as any;
+
+    const thinking = res.details.find(
+      (b: { bookTitle: string }) => b.bookTitle === "Thinking, Fast and Slow",
+    );
+    expect(thinking.highlightCount).toBe(2);
+
+    // Sapiens has 1 highlight + 1 note (bookmark excluded)
+    const sapiens = res.details.find(
+      (b: { bookTitle: string }) => b.bookTitle === "Sapiens: A Brief History of Humankind",
+    );
+    expect(sapiens.highlightCount).toBe(2);
+
+    const design = res.details.find(
+      (b: { bookTitle: string }) => b.bookTitle === "The Design of Everyday Things",
+    );
+    expect(design.highlightCount).toBe(1);
+  });
+});
+
+describe("kindle_get_book_highlights", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFs();
+  });
+
+  it("returns all highlights for a matching book", async () => {
+    const { getBook } = getTools();
+    const res = (await getBook.execute("id", {
+      book: "Thinking, Fast and Slow",
+      // oxlint-disable-next-line typescript/no-explicit-any
+    })) as any;
+    expect(res.details).toHaveLength(2);
+    for (const item of res.details) {
+      expect(item.bookTitle).toBe("Thinking, Fast and Slow");
+    }
+  });
+
+  it("supports partial book title match and excludes bookmarks", async () => {
+    const { getBook } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await getBook.execute("id", { book: "Sapiens" })) as any;
+    // Sapiens has 3 clippings (highlight + note + bookmark), but bookmark is excluded
+    expect(res.details).toHaveLength(2);
+    for (const item of res.details) {
+      expect(item.bookTitle).toContain("Sapiens");
+      expect(item.type).not.toBe("bookmark");
+    }
+  });
+
+  it("returns results ordered by page/location", async () => {
+    const { getBook } = getTools();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const res = (await getBook.execute("id", { book: "Thinking" })) as any;
+    const pages = res.details.map((h: { page: number }) => h.page);
+    for (let i = 1; i < pages.length; i++) {
+      expect(pages[i - 1]).toBeLessThanOrEqual(pages[i]);
+    }
+  });
+});
+
+describe("error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("all tools throw when clippingsPath is missing", async () => {
+    const api = fakeApi({ pluginConfig: {} });
+    const { search, listBooks, getBook } = getTools(api);
+
+    await expect(search.execute("id", { query: "test" })).rejects.toThrow(/clippingsPath/);
+    await expect(listBooks.execute("id", {})).rejects.toThrow(/clippingsPath/);
+    await expect(getBook.execute("id", { book: "test" })).rejects.toThrow(/clippingsPath/);
+  });
+
+  it("tools throw readable error when file does not exist", async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error("ENOENT"));
+    const { search } = getTools();
+    await expect(search.execute("id", { query: "test" })).rejects.toThrow(
+      /clippings file not found/i,
+    );
+  });
+});

--- a/extensions/kindle/src/kindle-tools.ts
+++ b/extensions/kindle/src/kindle-tools.ts
@@ -1,0 +1,237 @@
+import { Type } from "@sinclair/typebox";
+import fs from "node:fs/promises";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+
+export type KindleClipping = {
+  bookTitle: string;
+  author: string;
+  type: "highlight" | "note" | "bookmark";
+  page?: number;
+  location?: string;
+  date?: string;
+  content: string;
+};
+
+const META_RE =
+  /^-\s*Your\s+(Highlight|Note|Bookmark)\s+(?:on\s+page\s+(\d+)\s*\|?\s*)?(?:location\s+([\d-]+)\s*\|?\s*)?(?:Added\s+on\s+(.+))?$/i;
+
+function parseBookLine(line: string): { bookTitle: string; author: string } {
+  const match = line.match(/^(.+)\s+\(([^)]+)\)\s*$/);
+  if (match) {
+    return { bookTitle: match[1]!.trim(), author: match[2]!.trim() };
+  }
+  return { bookTitle: line.trim(), author: "" };
+}
+
+function parseClippingType(raw: string): KindleClipping["type"] {
+  const lower = raw.toLowerCase();
+  if (lower === "highlight") return "highlight";
+  if (lower === "note") return "note";
+  return "bookmark";
+}
+
+export function parseClippings(raw: string): KindleClipping[] {
+  const blocks = raw.split("==========");
+  const clippings: KindleClipping[] = [];
+
+  for (const block of blocks) {
+    const lines = block.split("\n").map((l) => l.trimEnd());
+
+    while (lines.length > 0 && lines[0]!.trim() === "") {
+      lines.shift();
+    }
+
+    if (lines.length < 2) continue;
+
+    const bookLine = lines[0]!;
+    const metaLine = lines[1]!;
+
+    if (!bookLine.trim() || !metaLine.trim()) continue;
+
+    const { bookTitle, author } = parseBookLine(bookLine);
+    const metaMatch = metaLine.match(META_RE);
+    if (!metaMatch) continue;
+
+    const clipType = parseClippingType(metaMatch[1]!);
+    const page = metaMatch[2] ? Number.parseInt(metaMatch[2], 10) : undefined;
+    const location = metaMatch[3]?.trim() || undefined;
+    const date = metaMatch[4]?.trim() || undefined;
+
+    const contentLines = lines.slice(2);
+    while (contentLines.length > 0 && contentLines[0]!.trim() === "") {
+      contentLines.shift();
+    }
+    const content = contentLines.join("\n").trim();
+
+    clippings.push({
+      bookTitle,
+      author,
+      type: clipType,
+      page,
+      location,
+      date,
+      content,
+    });
+  }
+
+  return clippings;
+}
+
+let cache: { path: string; mtime: number; clippings: KindleClipping[] } | null = null;
+
+async function loadClippings(filePath: string): Promise<KindleClipping[]> {
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(filePath);
+  } catch {
+    throw new Error(`Kindle clippings file not found: ${filePath}`);
+  }
+
+  const mtime = stat.mtimeMs;
+  if (cache && cache.path === filePath && cache.mtime === mtime) {
+    return cache.clippings;
+  }
+
+  const raw = await fs.readFile(filePath, "utf-8");
+  const clippings = parseClippings(raw);
+  cache = { path: filePath, mtime, clippings };
+  return clippings;
+}
+
+function resolveClippingsPath(api: OpenClawPluginApi): string {
+  const cfg = api.pluginConfig as { clippingsPath?: string } | undefined;
+  if (!cfg?.clippingsPath) {
+    throw new Error("clippingsPath is not configured. Set it in the Kindle plugin config.");
+  }
+  return api.resolvePath(cfg.clippingsPath);
+}
+
+export function createKindleTools(api: OpenClawPluginApi) {
+  const searchHighlights = {
+    name: "kindle_search_highlights",
+    label: "Search Kindle Highlights",
+    description:
+      "Search your Kindle highlights and notes by text query, optionally filtering by book title.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Text to search for in highlight content" }),
+      book: Type.Optional(Type.String({ description: "Filter by book title (substring match)" })),
+      limit: Type.Optional(Type.Number({ description: "Max results to return (default 20)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = resolveClippingsPath(api);
+      const clippings = await loadClippings(filePath);
+
+      const query = (typeof params.query === "string" ? params.query : "").toLowerCase();
+      const bookFilter = typeof params.book === "string" ? params.book.toLowerCase() : undefined;
+      const limit = typeof params.limit === "number" ? params.limit : 20;
+
+      const matches = clippings.filter((c) => {
+        if (c.type === "bookmark") return false;
+        const contentMatch = c.content.toLowerCase().includes(query);
+        if (!contentMatch) return false;
+        if (bookFilter && !c.bookTitle.toLowerCase().includes(bookFilter)) return false;
+        return true;
+      });
+
+      const results = matches.slice(0, limit).map((c) => ({
+        bookTitle: c.bookTitle,
+        author: c.author,
+        type: c.type,
+        page: c.page,
+        location: c.location,
+        content: c.content,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        details: results,
+      };
+    },
+  };
+
+  const listBooks = {
+    name: "kindle_list_books",
+    label: "List Kindle Books",
+    description:
+      "List all books in your Kindle clippings with highlight counts, sorted by count descending.",
+    parameters: Type.Object({
+      limit: Type.Optional(Type.Number({ description: "Max books to return (default 50)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = resolveClippingsPath(api);
+      const clippings = await loadClippings(filePath);
+
+      const limit = typeof params.limit === "number" ? params.limit : 50;
+
+      const bookMap = new Map<string, { author: string; count: number }>();
+      for (const c of clippings) {
+        if (c.type === "bookmark") continue;
+        const existing = bookMap.get(c.bookTitle);
+        if (existing) {
+          existing.count++;
+        } else {
+          bookMap.set(c.bookTitle, { author: c.author, count: 1 });
+        }
+      }
+
+      const books = [...bookMap.entries()]
+        .map(([title, info]) => ({
+          bookTitle: title,
+          author: info.author,
+          highlightCount: info.count,
+        }))
+        .sort((a, b) => b.highlightCount - a.highlightCount)
+        .slice(0, limit);
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(books, null, 2) }],
+        details: books,
+      };
+    },
+  };
+
+  const getBookHighlights = {
+    name: "kindle_get_book_highlights",
+    label: "Get Book Highlights",
+    description: "Get all highlights for a specific book by exact or partial title match.",
+    parameters: Type.Object({
+      book: Type.String({ description: "Book title or partial title to match" }),
+      limit: Type.Optional(Type.Number({ description: "Max highlights to return (default 50)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const filePath = resolveClippingsPath(api);
+      const clippings = await loadClippings(filePath);
+
+      const bookQuery = (typeof params.book === "string" ? params.book : "").toLowerCase();
+      const limit = typeof params.limit === "number" ? params.limit : 50;
+
+      const matches = clippings.filter(
+        (c) => c.type !== "bookmark" && c.bookTitle.toLowerCase().includes(bookQuery),
+      );
+
+      matches.sort((a, b) => {
+        const pageDiff = (a.page ?? 0) - (b.page ?? 0);
+        if (pageDiff !== 0) return pageDiff;
+        const locA = a.location?.split("-")[0] ?? "0";
+        const locB = b.location?.split("-")[0] ?? "0";
+        return Number.parseInt(locA, 10) - Number.parseInt(locB, 10);
+      });
+
+      const results = matches.slice(0, limit).map((c) => ({
+        bookTitle: c.bookTitle,
+        author: c.author,
+        type: c.type,
+        page: c.page,
+        location: c.location,
+        content: c.content,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        details: results,
+      };
+    },
+  };
+
+  return [searchHighlights, listBooks, getBookHighlights];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/kindle:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/line:
     devDependencies:
       openclaw:
@@ -6666,7 +6672,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.58.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6682,7 +6688,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.12
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6885,7 +6891,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7720,7 +7726,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7766,7 +7772,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.2.2
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8660,14 +8666,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9242,8 +9240,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Adds `extensions/kindle/` — agent tool plugin for searching and browsing Kindle book highlights
- Parses Kindle's `My Clippings.txt` format with mtime-based caching for performance
- Tools: `kindle_search_highlights`, `kindle_list_books`, `kindle_get_book_highlights`
- All tools registered as `optional: true` (opt-in via `agents.list[].tools.allow`)
- Config: `plugins.entries.kindle.config.clippingsPath` pointing to Kindle clippings file
- Follows existing plugin patterns with TypeBox schemas and plugin manifest

## Test plan

- [x] `pnpm vitest run extensions/kindle/` — 17 tests passing
- [ ] Manual: point at a real `My Clippings.txt` and verify highlight search

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `extensions/kindle` plugin that registers three optional agent tools for reading and searching Kindle `My Clippings.txt` highlights/notes, with a simple mtime-based in-process cache and a TypeBox-typed parameter schema. Includes a plugin manifest (`openclaw.plugin.json`), package metadata, core parsing/tool implementation, and a Vitest suite covering parsing + tool behavior against fixtures.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but two user-visible correctness issues should be fixed first.
- Implementation and tests look solid overall, but two tools currently include/count notes/bookmarks while presenting results as highlights, which will produce incorrect outputs on real clippings files.
- extensions/kindle/src/kindle-tools.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->