### PR TITLE
fix: allow Slack HTTP mode without app token

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -472,7 +472,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       if (!input.useEnv && mode !== "http" && !input.appToken) {
         return (
           "Slack socket mode requires --app-token. " +
-          "For HTTP mode, set channels.slack.mode=\"http\" and channels.slack.signingSecret."
+          'For HTTP mode, set channels.slack.mode="http" and channels.slack.signingSecret.'
         );
       }
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -51,6 +51,18 @@ function getTokenForOperation(
   return botToken ?? userToken;
 }
 
+function isSlackAccountConfigured(account: ResolvedSlackAccount): boolean {
+  const botToken = account.botToken?.trim();
+  if (!botToken) {
+    return false;
+  }
+  const mode = account.config.mode ?? "socket";
+  if (mode === "http") {
+    return Boolean(account.config.signingSecret?.trim());
+  }
+  return Boolean(account.appToken?.trim());
+}
+
 export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   id: "slack",
   meta: {
@@ -116,12 +128,12 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         accountId,
         clearBaseFields: ["botToken", "appToken", "name"],
       }),
-    isConfigured: (account) => Boolean(account.botToken && account.appToken),
+    isConfigured: async (account) => isSlackAccountConfigured(account),
     describeAccount: (account) => ({
       accountId: account.accountId,
       name: account.name,
       enabled: account.enabled,
-      configured: Boolean(account.botToken && account.appToken),
+      configured: isSlackAccountConfigured(account),
       botTokenSource: account.botTokenSource,
       appTokenSource: account.appTokenSource,
     }),
@@ -565,7 +577,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       return await getSlackRuntime().channel.slack.probeSlack(token, timeoutMs);
     },
     buildAccountSnapshot: ({ account, runtime, probe }) => {
-      const configured = Boolean(account.botToken && account.appToken);
+      const configured = isSlackAccountConfigured(account);
       return {
         accountId: account.accountId,
         name: account.name,


### PR DESCRIPTION
## Why\nSlack HTTP mode (Events API) does not require an app token, but the Slack channel plugin treated accounts as unconfigured unless both botToken + appToken were present. This prevents the provider from starting in HTTP mode, so the webhook handler is never registered and POST /slack/events falls through to the Control UI (405).\n\n## What changed\n- Treat Slack accounts as configured when:\n  - mode="http": botToken + signingSecret\n  - mode="socket" (default): botToken + appToken\n- Keep configured reporting consistent across status snapshots.\n\n## Result\nHTTP mode now starts and registers the webhook handler at channels.slack.webhookPath (default /slack/events) without requiring an app token.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Slack channel configuration detection to support HTTP (Events API) mode without requiring an app-level token. It adds a shared `isSlackAccountConfigured()` helper and uses it consistently in `config.isConfigured`, `describeAccount`, and status snapshot building so configured/running reporting stays aligned.

Main issue to address before merging: the interactive/CLI setup path still rejects configurations without `appToken` (`setup.validateInput`), so users can’t actually configure HTTP mode accounts even though they’re now treated as configured at runtime.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the Slack HTTP-mode setup validation is aligned with the new configured logic.
- The change is small and localized, and the new helper reduces inconsistency across configured/status reporting. The remaining blocker is a definite behavior mismatch: `setup.validateInput` still requires `appToken` even in HTTP mode, preventing users from configuring the newly-supported mode via the intended setup flow.
- extensions/slack/src/channel.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->