### PR TITLE
fix: preserve Slack channel/user ID case in target normalization

### DIFF
--- a/src/channels/targets.test.ts
+++ b/src/channels/targets.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { buildMessagingTarget, ensureTargetId, requireTargetKind } from "./targets.js";
+import {
+  buildMessagingTarget,
+  ensureTargetId,
+  normalizeTargetId,
+  requireTargetKind,
+} from "./targets.js";
+
+describe("normalizeTargetId", () => {
+  it("preserves target id case while normalizing kind prefix", () => {
+    expect(normalizeTargetId("channel", "C0ADKTLND7U")).toBe("channel:C0ADKTLND7U");
+  });
+});
 
 describe("ensureTargetId", () => {
   it("returns the candidate when it matches", () => {

--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -16,7 +16,7 @@ export type MessagingTargetParseOptions = {
 };
 
 export function normalizeTargetId(kind: MessagingTargetKind, id: string): string {
-  return `${kind}:${id}`.toLowerCase();
+  return `${kind.toLowerCase()}:${id}`;
 }
 
 export function buildMessagingTarget(

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -281,6 +281,23 @@ describe("runMessageAction context isolation", () => {
     expect(result.channel).toBe("slack");
   });
 
+  it("treats slack channel ids passed as channel param as target in slack context", async () => {
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        channel: "C0ADKTLND7U",
+        message: "hi",
+      },
+      toolContext: { currentChannelProvider: "slack", currentChannelId: "C0ADKTLND7U" },
+      dryRun: true,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(result.channel).toBe("slack");
+    expect(result.to).toBe("C0ADKTLND7U");
+  });
+
   it("blocks cross-provider sends by default", async () => {
     await expect(
       runMessageAction({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -220,6 +220,10 @@ function readBooleanParam(params: Record<string, unknown>, key: string): boolean
   return undefined;
 }
 
+function isSlackChannelHint(raw: string): boolean {
+  return /^[CUWGD][A-Z0-9]{8,}$/i.test(raw.trim());
+}
+
 function resolveSlackAutoThreadId(params: {
   to: string;
   toolContext?: ChannelThreadingToolContext;
@@ -1044,6 +1048,18 @@ export async function runMessageAction(
     }
   }
   const explicitChannel = typeof params.channel === "string" ? params.channel.trim() : "";
+  if (explicitChannel) {
+    const inferredContextChannel = normalizeMessageChannel(
+      input.toolContext?.currentChannelProvider,
+    );
+    const looksLikeSlackId = isSlackChannelHint(explicitChannel);
+    if (inferredContextChannel === "slack" && looksLikeSlackId) {
+      if (!actionHasTarget(action, params)) {
+        params.target = explicitChannel;
+      }
+      params.channel = "slack";
+    }
+  }
   if (!explicitChannel) {
     const inferredChannel = normalizeMessageChannel(input.toolContext?.currentChannelProvider);
     if (inferredChannel && isDeliverableMessageChannel(inferredChannel)) {

--- a/src/infra/outbound/target-normalization.test.ts
+++ b/src/infra/outbound/target-normalization.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { slackPlugin } from "../../../extensions/slack/src/channel.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { normalizeTargetForProvider } from "./target-normalization.js";
+
+describe("normalizeTargetForProvider", () => {
+  beforeEach(async () => {
+    const { createPluginRuntime } = await import("../../plugins/runtime/index.js");
+    const { setSlackRuntime } = await import("../../../extensions/slack/src/runtime.js");
+    const runtime = createPluginRuntime();
+    setSlackRuntime(runtime);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: slackPlugin,
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("preserves slack id case", () => {
+    expect(normalizeTargetForProvider("slack", "C0ADKTLND7U")).toBe("channel:C0ADKTLND7U");
+  });
+
+  it("preserves case in fallback normalization", () => {
+    expect(normalizeTargetForProvider("missing-provider", "  C0ADKTLND7U  ")).toBe("C0ADKTLND7U");
+  });
+});

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -11,8 +11,7 @@ export function normalizeTargetForProvider(provider: string, raw?: string): stri
   }
   const providerId = normalizeChannelId(provider);
   const plugin = providerId ? getChannelPlugin(providerId) : undefined;
-  const normalized =
-    plugin?.messaging?.normalizeTarget?.(raw) ?? (raw.trim().toLowerCase() || undefined);
+  const normalized = plugin?.messaging?.normalizeTarget?.(raw) ?? (raw.trim() || undefined);
   return normalized || undefined;
 }
 

--- a/src/slack/targets.test.ts
+++ b/src/slack/targets.test.ts
@@ -7,17 +7,17 @@ describe("parseSlackTarget", () => {
     expect(parseSlackTarget("<@U123>")).toMatchObject({
       kind: "user",
       id: "U123",
-      normalized: "user:u123",
+      normalized: "user:U123",
     });
     expect(parseSlackTarget("user:U456")).toMatchObject({
       kind: "user",
       id: "U456",
-      normalized: "user:u456",
+      normalized: "user:U456",
     });
     expect(parseSlackTarget("slack:U789")).toMatchObject({
       kind: "user",
       id: "U789",
-      normalized: "user:u789",
+      normalized: "user:U789",
     });
   });
 
@@ -25,12 +25,12 @@ describe("parseSlackTarget", () => {
     expect(parseSlackTarget("channel:C123")).toMatchObject({
       kind: "channel",
       id: "C123",
-      normalized: "channel:c123",
+      normalized: "channel:C123",
     });
     expect(parseSlackTarget("#C999")).toMatchObject({
       kind: "channel",
       id: "C999",
-      normalized: "channel:c999",
+      normalized: "channel:C999",
     });
   });
 
@@ -53,6 +53,6 @@ describe("resolveSlackChannelId", () => {
 
 describe("normalizeSlackMessagingTarget", () => {
   it("defaults raw ids to channels", () => {
-    expect(normalizeSlackMessagingTarget("C123")).toBe("channel:c123");
+    expect(normalizeSlackMessagingTarget("C123")).toBe("channel:C123");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4751 and #10668.

Slack channel and user IDs are case-sensitive (e.g. `C0ADKTLND7U`, `U025D9U8U`). The `normalizeTargetId()` function was lowercasing the entire target string (`channel:C0ADKTLND7U` → `channel:c0adktlnd7u`), causing Slack API calls (reactions, sends, reads) to fail with `Unknown channel`.

## Changes

### 1. `src/channels/targets.ts` — `normalizeTargetId()`
Only lowercase the kind prefix, preserve the ID:
```diff
- return \`\${kind}:\${id}\`.toLowerCase();
+ return \`\${kind.toLowerCase()}:\${id}\`;
```

### 2. `src/infra/outbound/target-normalization.ts` — `normalizeTargetForProvider()`
Remove `.toLowerCase()` from the fallback path:
```diff
- plugin?.messaging?.normalizeTarget?.(raw) ?? (raw.trim().toLowerCase() || undefined);
+ plugin?.messaging?.normalizeTarget?.(raw) ?? (raw.trim() || undefined);
```

### 3. `src/infra/outbound/message-action-runner.ts` — Slack ID auto-correction
When an agent passes a Slack channel ID (like `C0ADKTLND7U`) as the `channel` parameter (which expects a provider name like `slack`), auto-detect and reinterpret:
- Adds `isSlackChannelHint()` to detect Slack-style IDs
- When in Slack context, rewrites `channel` to `"slack"` and moves the ID to `target`

## Tests

- Updated existing Slack target tests to expect preserved case
- Added new `target-normalization.test.ts` with Slack case-preservation tests  
- Added regression test for Slack IDs passed as `channel` parameter
- All 38 related tests pass ✅

## Notes

- Discord IDs are numeric and unaffected by case — no regression there
- The `preserveTargetCase()` function in `target-resolver.ts` was a partial workaround for Slack but only covered certain paths; this fix addresses the root cause

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts target normalization to preserve case for Slack channel/user IDs, fixing failures caused by lowercasing IDs during normalization. Specifically:

- `normalizeTargetId()` now lowercases only the kind prefix (`channel:`/`user:`) while keeping the ID unchanged.
- `normalizeTargetForProvider()` no longer lowercases inputs on the fallback path when no plugin normalizer is available.
- `runMessageAction()` adds a Slack-context heuristic to treat Slack-looking IDs accidentally passed via the `channel` param as the action target, and forces `channel` to `slack`.

The changes align normalization behavior with Slack’s case-sensitive identifiers and extend test coverage for Slack case preservation and the new heuristic rewrite behavior.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the Slack-channel heuristic rewrite should be tightened to avoid overriding explicit channel selection in ambiguous cases.
- Core normalization changes are small and well-covered by tests. The main risk is the new `channel`→`slack` rewrite based on a regex + Slack context, which mutates params before resolution/policy enforcement and could redirect actions unexpectedly when `channel` contains a Slack-looking string.
- src/infra/outbound/message-action-runner.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->