### PR TITLE
fix(docker): normalize workspace paths for container compatibility

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_MEMORY_ALT_FILENAME,
   DEFAULT_MEMORY_FILENAME,
   loadWorkspaceBootstrapFiles,
+  normalizeWorkspacePath,
   resolveDefaultAgentWorkspaceDir,
 } from "./workspace.js";
 
@@ -57,5 +58,62 @@ describe("loadWorkspaceBootstrapFiles", () => {
     );
 
     expect(memoryEntries).toHaveLength(0);
+  });
+});
+
+describe("normalizeWorkspacePath", () => {
+  it("returns the path unchanged when HOME matches", () => {
+    const result = normalizeWorkspacePath(
+      "/home/node/.openclaw/workspace",
+      { HOME: "/home/node" } as NodeJS.ProcessEnv,
+      () => "/home/node",
+    );
+    expect(result).toBe("/home/node/.openclaw/workspace");
+  });
+
+  it("remaps a foreign HOME path to the current HOME", () => {
+    const result = normalizeWorkspacePath(
+      "/Users/cy/.openclaw/workspace",
+      { HOME: "/home/node" } as NodeJS.ProcessEnv,
+      () => "/home/node",
+    );
+    expect(result).toBe("/home/node/.openclaw/workspace");
+  });
+
+  it("remaps a profiled workspace path", () => {
+    const result = normalizeWorkspacePath(
+      "/Users/cy/.openclaw/workspace-prod",
+      { HOME: "/home/node" } as NodeJS.ProcessEnv,
+      () => "/home/node",
+    );
+    expect(result).toBe("/home/node/.openclaw/workspace-prod");
+  });
+
+  it("leaves custom workspace paths untouched", () => {
+    const result = normalizeWorkspacePath(
+      "/data/my-custom-workspace",
+      { HOME: "/home/node" } as NodeJS.ProcessEnv,
+      () => "/home/node",
+    );
+    expect(result).toBe("/data/my-custom-workspace");
+  });
+
+  it("respects OPENCLAW_HOME over HOME", () => {
+    const result = normalizeWorkspacePath(
+      "/Users/cy/.openclaw/workspace",
+      { OPENCLAW_HOME: "/srv/app", HOME: "/home/node" } as NodeJS.ProcessEnv,
+      () => "/home/node",
+    );
+    expect(result).toBe("/srv/app/.openclaw/workspace");
+  });
+
+  it("handles paths with subdirectories after workspace", () => {
+    const result = normalizeWorkspacePath(
+      "/Users/cy/.openclaw/workspace/subdir",
+      { HOME: "/home/node" } as NodeJS.ProcessEnv,
+      () => "/home/node",
+    );
+    // Should NOT remap because "/subdir" doesn't start with "-"
+    expect(result).toBe("/Users/cy/.openclaw/workspace/subdir");
   });
 });

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
+import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { pathExists } from "../utils.js";
 import { getSubCliEntries, registerSubCliByName } from "./program/register.subclis.js";
 
@@ -152,7 +153,7 @@ function updateCompletionProfile(
 }
 
 function getShellProfilePath(shell: CompletionShell): string {
-  const home = process.env.HOME || os.homedir();
+  const home = resolveRequiredHomeDir();
   if (shell === "zsh") {
     return path.join(home, ".zshrc");
   }
@@ -274,7 +275,7 @@ export function registerCompletionCli(program: Command) {
 }
 
 export async function installCompletion(shell: string, yes: boolean, binName = "openclaw") {
-  const home = process.env.HOME || os.homedir();
+  const home = resolveRequiredHomeDir();
   let profilePath = "";
   let sourceLine = "";
 

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -5,6 +5,7 @@ import type {
   ConfigureWizardParams,
   WizardSection,
 } from "./configure.shared.js";
+import { normalizeWorkspacePath } from "../agents/workspace.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { readConfigFileSnapshot, resolveGatewayPort, writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
@@ -266,10 +267,11 @@ export async function runConfigureWizard(
       };
       didSetGatewayMode = true;
     }
-    let workspaceDir =
+    let workspaceDir = normalizeWorkspacePath(
       nextConfig.agents?.defaults?.workspace ??
-      baseConfig.agents?.defaults?.workspace ??
-      DEFAULT_WORKSPACE;
+        baseConfig.agents?.defaults?.workspace ??
+        DEFAULT_WORKSPACE,
+    );
     let gatewayPort = resolveGatewayPort(baseConfig);
     let gatewayToken: string | undefined =
       nextConfig.gateway?.auth?.token ??

--- a/src/commands/onboard-non-interactive/local/workspace.ts
+++ b/src/commands/onboard-non-interactive/local/workspace.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { OnboardOptions } from "../../onboard-types.js";
+import { normalizeWorkspacePath } from "../../../agents/workspace.js";
 import { resolveUserPath } from "../../../utils.js";
 
 export function resolveNonInteractiveWorkspaceDir(params: {
@@ -7,9 +8,10 @@ export function resolveNonInteractiveWorkspaceDir(params: {
   baseConfig: OpenClawConfig;
   defaultWorkspaceDir: string;
 }) {
+  const fromConfig = params.baseConfig.agents?.defaults?.workspace;
   const raw = (
     params.opts.workspace ??
-    params.baseConfig.agents?.defaults?.workspace ??
+    (fromConfig ? normalizeWorkspacePath(fromConfig) : undefined) ??
     params.defaultWorkspaceDir
   ).trim();
   return resolveUserPath(raw);

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -1,5 +1,6 @@
 import type { RuntimeEnv } from "../runtime.js";
 import type { OnboardOptions } from "./onboard-types.js";
+import { normalizeWorkspacePath } from "../agents/workspace.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
@@ -55,8 +56,11 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
   if (normalizedOpts.reset) {
     const snapshot = await readConfigFileSnapshot();
     const baseConfig = snapshot.valid ? snapshot.config : {};
+    const storedWorkspace = baseConfig.agents?.defaults?.workspace;
     const workspaceDefault =
-      normalizedOpts.workspace ?? baseConfig.agents?.defaults?.workspace ?? DEFAULT_WORKSPACE;
+      normalizedOpts.workspace ??
+      (storedWorkspace ? normalizeWorkspacePath(storedWorkspace) : undefined) ??
+      DEFAULT_WORKSPACE;
     await handleReset("full", resolveUserPath(workspaceDefault), runtime);
   }
 


### PR DESCRIPTION
## Summary

Fixes `EACCES: permission denied, mkdir '/Users'` error when running `docker compose run --rm openclaw-cli onboard` in Docker containers.

## Problem

The existing `openclaw.json` (created on macOS host, mounted into container) stores absolute host paths like `workspace: /Users/cy/.openclaw/workspace`. Inside the container (`HOME=/home/node`, user `node` uid 1000), the onboarding tries to `mkdir` this macOS path, which fails because the `node` user cannot create `/Users` in the container root.

## Solution

Add `normalizeWorkspacePath()` utility that detects when a stored workspace path follows the `<HOME>/.openclaw/workspace` pattern but with a different HOME than the current environment, and remaps it to the current HOME.

## Changes

- Add `normalizeWorkspacePath()` in `workspace.ts`
- Apply normalization at all workspace config read sites:
  - `onboarding.ts` (interactive wizard)
  - `onboard.ts` (reset path)
  - `workspace.ts` (non-interactive onboarding)
  - `configure.wizard.ts` (configure command)
- Fix `completion-cli.ts` to use `resolveRequiredHomeDir()` instead of direct `process.env.HOME || os.homedir()` access
- Add comprehensive unit tests for path normalization edge cases

## Impact

- ✅ No config format change - zero migration needed
- ✅ No impact on non-Docker users (same HOME = path unchanged)
- ✅ Custom workspace paths preserved (only default-pattern paths remapped)
- ✅ Respects `OPENCLAW_HOME`, `HOME`, and `USERPROFILE` env vars

## Testing

- All existing tests pass
- New unit tests cover normalization edge cases (foreign HOME, profiles, custom paths, env var precedence)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a Docker onboarding failure where a host-generated `openclaw.json` can contain an absolute workspace path (e.g. macOS `/Users/...`) that isn’t writable inside the container. It introduces `normalizeWorkspacePath()` (in `src/agents/workspace.ts`) and applies it when reading stored workspace paths in the onboarding/configure flows (`src/wizard/onboarding.ts`, `src/commands/onboard.ts`, `src/commands/onboard-non-interactive/local/workspace.ts`, `src/commands/configure.wizard.ts`). It also updates completion install logic to use the centralized home-directory resolver (`src/cli/completion-cli.ts`) and adds unit tests covering normalization behavior.

Key integration point: the normalization is applied at config read sites before `resolveUserPath()` and before workspace/session initialization, aiming to keep config portable across environments while preserving truly custom workspace paths.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a couple of merge-blocking issues that can break user configs or leak local tooling config into the repo.
- The overall approach is reasonable and tests were added, but (1) a local Claude settings file was committed and should not ship, and (2) `normalizeWorkspacePath()` currently matches the normalization suffix anywhere in the path, which can incorrectly rewrite custom workspace paths that contain `/.openclaw/workspace` as a subpath. Fixing those should make the PR safe to merge.
- src/agents/workspace.ts, .claude/settings.local.json

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->