### PR TITLE
fix: extend assistant text dedup across message boundaries

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -178,12 +178,25 @@ export function handleMessageUpdate(
   }
 
   if (evtType === "text_end" && ctx.state.blockReplyBreak === "text_end") {
-    if (ctx.blockChunker?.hasBuffered()) {
-      ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
-      ctx.blockChunker.reset();
-    } else if (ctx.state.blockBuffer.length > 0) {
-      ctx.emitBlockChunk(ctx.state.blockBuffer);
+    // Full-message dedup: when the full visible text matches the previous
+    // message, skip drain to suppress duplicate delivery after tool round-trips.
+    // Block chunking splits text into pieces whose individual chunks may differ
+    // across messages, so chunk-level dedup is insufficient — we compare the
+    // complete text before any chunking occurs.
+    if (next && ctx.state.lastFullMessageText && next === ctx.state.lastFullMessageText) {
       ctx.state.blockBuffer = "";
+      ctx.blockChunker?.reset();
+    } else {
+      if (next) {
+        ctx.state.lastFullMessageText = next;
+      }
+      if (ctx.blockChunker?.hasBuffered()) {
+        ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
+        ctx.blockChunker.reset();
+      } else if (ctx.state.blockBuffer.length > 0) {
+        ctx.emitBlockChunk(ctx.state.blockBuffer);
+        ctx.state.blockBuffer = "";
+      }
     }
   }
 }
@@ -281,7 +294,25 @@ export function handleMessageEnd(
     maybeEmitReasoning();
   }
 
+  // Full-message dedup: when the full visible text matches the previous
+  // message (e.g. model repeating after tool round-trips), suppress block reply.
+  // This complements the text_end check for message_end mode and catches
+  // duplicates even when block chunking is active.
+  const isFullTextDuplicate = Boolean(
+    trimmedText &&
+      ctx.state.lastFullMessageText &&
+      trimmedText === ctx.state.lastFullMessageText,
+  );
+  if (!isFullTextDuplicate && trimmedText) {
+    ctx.state.lastFullMessageText = trimmedText;
+  }
+  if (isFullTextDuplicate) {
+    ctx.blockChunker?.reset();
+    ctx.state.blockBuffer = "";
+  }
+
   if (
+    !isFullTextDuplicate &&
     (ctx.state.blockReplyBreak === "message_end" ||
       (ctx.blockChunker ? ctx.blockChunker.hasBuffered() : ctx.state.blockBuffer.length > 0)) &&
     text &&

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -45,6 +45,9 @@ export async function handleToolExecutionStart(
   if (ctx.params.onBlockReplyFlush) {
     void ctx.params.onBlockReplyFlush();
   }
+  // Mark that a tool ran since last text — dedup state will be preserved
+  // across the next message boundary to catch repeated text after tool results.
+  ctx.state.hadToolSinceLastText = true;
 
   const rawToolName = String(evt.toolName);
   const toolName = normalizeToolName(rawToolName);

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -44,7 +44,6 @@ export type EmbeddedPiSubscribeState = {
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   assistantMessageIndex: number;
-  lastAssistantTextMessageIndex: number;
   lastAssistantTextNormalized?: string;
   lastAssistantTextTrimmed?: string;
   assistantTextBaseline: number;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -45,6 +45,7 @@ export type EmbeddedPiSubscribeState = {
   lastBlockReplyText?: string;
   assistantMessageIndex: number;
   hadToolSinceLastText: boolean;
+  lastFullMessageText?: string;
   lastAssistantTextNormalized?: string;
   lastAssistantTextTrimmed?: string;
   assistantTextBaseline: number;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -44,6 +44,7 @@ export type EmbeddedPiSubscribeState = {
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   assistantMessageIndex: number;
+  hadToolSinceLastText: boolean;
   lastAssistantTextNormalized?: string;
   lastAssistantTextTrimmed?: string;
   assistantTextBaseline: number;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.deduplicates-text-across-tool-round-trip.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.deduplicates-text-across-tool-round-trip.test.ts
@@ -1,0 +1,207 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+type StubSession = {
+  subscribe: (fn: (evt: unknown) => void) => () => void;
+};
+
+type SessionEventHandler = (evt: unknown) => void;
+
+describe("subscribeEmbeddedPiSession", () => {
+  it("deduplicates assistant text repeated after tool_use round-trip (text_end mode)", () => {
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const onBlockReply = vi.fn();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-dedup-tool-roundtrip",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    // --- Assistant message 1: text + tool_use ---
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Here is my response!",
+      },
+    });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_end", content: "Here is my response!" },
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+
+    // Tool use + tool result round-trip
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "exec",
+      toolCallId: "tool-1",
+      args: { command: "set-conversation-state.sh" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "exec",
+      toolCallId: "tool-1",
+      result: "OK",
+    });
+
+    // --- Assistant message 2: model repeats same text ---
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Here is my response!",
+      },
+    });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_end", content: "Here is my response!" },
+    });
+
+    // The duplicate text should NOT produce a second block reply
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(subscription.assistantTexts).toEqual(["Here is my response!"]);
+  });
+
+  it("deduplicates assistant text repeated after tool_use round-trip (message_end mode)", () => {
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-dedup-msg-end",
+    });
+
+    // --- Assistant message 1: text + tool_use ---
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+
+    const msg1 = {
+      role: "assistant",
+      content: [{ type: "text", text: "Hello from the assistant!" }],
+    } as AssistantMessage;
+
+    handler?.({ type: "message_end", message: msg1 });
+
+    // Tool round-trip
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "exec",
+      toolCallId: "tool-2",
+      args: { command: "set-mood.sh" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "exec",
+      toolCallId: "tool-2",
+      result: "OK",
+    });
+
+    // --- Assistant message 2: model repeats same text ---
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+
+    const msg2 = {
+      role: "assistant",
+      content: [{ type: "text", text: "Hello from the assistant!" }],
+    } as AssistantMessage;
+
+    handler?.({ type: "message_end", message: msg2 });
+
+    expect(subscription.assistantTexts).toEqual(["Hello from the assistant!"]);
+  });
+
+  it("allows different text after tool_use round-trip", () => {
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const onBlockReply = vi.fn();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-dedup-different",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    // --- Assistant message 1 ---
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: "First response" },
+    });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_end", content: "First response" },
+    });
+
+    // Tool round-trip
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "exec",
+      toolCallId: "tool-3",
+      args: { command: "echo test" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "exec",
+      toolCallId: "tool-3",
+      result: "test",
+    });
+
+    // --- Assistant message 2: DIFFERENT text ---
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: "Follow-up response" },
+    });
+
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_end", content: "Follow-up response" },
+    });
+
+    // Different text should still be delivered
+    expect(onBlockReply).toHaveBeenCalledTimes(2);
+    expect(subscription.assistantTexts).toEqual(["First response", "Follow-up response"]);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -54,7 +54,6 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
     assistantMessageIndex: 0,
-    lastAssistantTextMessageIndex: -1,
     lastAssistantTextNormalized: undefined,
     lastAssistantTextTrimmed: undefined,
     assistantTextBaseline: 0,
@@ -106,28 +105,27 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastStreamedAssistant = undefined;
     state.lastStreamedAssistantCleaned = undefined;
     state.emittedAssistantUpdate = false;
-    state.lastBlockReplyText = undefined;
+    // Preserve lastBlockReplyText across messages for cross-message dedup.
     state.lastStreamedReasoning = undefined;
     state.lastReasoningSent = undefined;
     state.suppressBlockChunks = false;
     state.assistantMessageIndex += 1;
-    state.lastAssistantTextMessageIndex = -1;
-    state.lastAssistantTextNormalized = undefined;
-    state.lastAssistantTextTrimmed = undefined;
+    // Preserve lastAssistantTextNormalized and lastAssistantTextTrimmed so
+    // shouldSkipAssistantText can detect duplicates across message boundaries
+    // (e.g. model repeats text after a tool_use + tool_result round-trip).
     state.assistantTextBaseline = nextAssistantTextBaseline;
   };
 
   const rememberAssistantText = (text: string) => {
-    state.lastAssistantTextMessageIndex = state.assistantMessageIndex;
     state.lastAssistantTextTrimmed = text.trimEnd();
     const normalized = normalizeTextForComparison(text);
     state.lastAssistantTextNormalized = normalized.length > 0 ? normalized : undefined;
   };
 
   const shouldSkipAssistantText = (text: string) => {
-    if (state.lastAssistantTextMessageIndex !== state.assistantMessageIndex) {
-      return false;
-    }
+    // Check across all messages in this agent run, not just the current one.
+    // Models often repeat the same text after a tool_use + tool_result round-trip,
+    // and the previous message-scoped guard caused duplicates to be delivered.
     const trimmed = text.trimEnd();
     if (trimmed && trimmed === state.lastAssistantTextTrimmed) {
       return true;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -55,6 +55,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     lastBlockReplyText: undefined,
     assistantMessageIndex: 0,
     hadToolSinceLastText: false,
+    lastFullMessageText: undefined,
     lastAssistantTextNormalized: undefined,
     lastAssistantTextTrimmed: undefined,
     assistantTextBaseline: 0,
@@ -116,6 +117,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // legitimate identical replies across messages are still delivered.
     if (!state.hadToolSinceLastText) {
       state.lastBlockReplyText = undefined;
+      state.lastFullMessageText = undefined;
       state.lastAssistantTextNormalized = undefined;
       state.lastAssistantTextTrimmed = undefined;
     }


### PR DESCRIPTION
## Summary

- Remove the message-scope guard in `shouldSkipAssistantText` so dedup works across all messages within the same agent run
- When a model produces text + `tool_use` in one turn and repeats the identical text after the tool result, the duplicate was being delivered to the channel because dedup state was reset between messages

### Root cause

`shouldSkipAssistantText` had an early return:
```ts
if (state.lastAssistantTextMessageIndex !== state.assistantMessageIndex) {
  return false;
}
```
This meant dedup only worked within a single assistant message. Between messages (after `resetAssistantMessageState`), the guard allowed the same text through again.

### Reproduction

1. Configure an agent that calls a tool after every text response (e.g., state tracking via `exec`)
2. The model produces: `text + tool_use` → tool executes → model repeats the same text
3. Both copies are delivered to the channel (e.g., Telegram receives the message twice)

### Fix

Remove the message-index guard so the trimmed/normalized text comparison works across all messages in the agent run.

## Test plan

- [x] Verified on live Telegram bot — duplicates no longer delivered after tool_use round-trips
- [ ] Existing `normalizeTextForComparison` and `isMessagingToolDuplicate` tests unaffected

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes assistant text deduplication in `src/agents/pi-embedded-subscribe.ts` by removing the message-index guard inside `shouldSkipAssistantText`, with the goal of suppressing identical assistant text that can be repeated after tool round-trips (text + tool_use, then repeated text after tool_result).

The intent is to deduplicate repeated assistant output across assistant messages within a single agent run, particularly for messaging-channel delivery (e.g. Telegram). The dedup logic works by tracking the last emitted assistant text (trimmed and normalized) and skipping new text that compares equal.

<h3>Confidence Score: 2/5</h3>

- This PR likely does not achieve the intended cross-message dedup behavior and leaves behind inconsistent state.
- Although the guard removal is straightforward, dedup state (`lastAssistantTextTrimmed/Normalized`) is still cleared on each assistant `message_start`, which would allow identical text in the next assistant message through—the exact scenario the PR description targets. Additionally, `lastAssistantTextMessageIndex` becomes dead state and there’s no automated test covering the tool round-trip duplication case.
- src/agents/pi-embedded-subscribe.ts; src/agents/pi-embedded-subscribe.handlers.messages.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->