### PR TITLE
fix(session): keep daily resets from metadata updates

### DIFF
--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -6,7 +6,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import {
   clearSessionStoreCacheForTest,
   loadSessionStore,
-  mergeSessionEntry,
   resolveAndPersistSessionFile,
   updateSessionStore,
 } from "../sessions.js";
@@ -16,9 +15,9 @@ import {
   resolveSessionTranscriptPathInDir,
   validateSessionId,
 } from "./paths.js";
-import { resolveSessionResetPolicy } from "./reset.js";
+import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js";
 import { appendAssistantMessageToSessionTranscript } from "./transcript.js";
-import type { SessionEntry } from "./types.js";
+import { mergeSessionEntry, type SessionEntry } from "./types.js";
 
 function useTempSessionsFixture(prefix: string) {
   let tempDir = "";
@@ -353,5 +352,73 @@ describe("resolveAndPersistSessionFile", () => {
     expect(result.sessionEntry.sessionId).toBe(sessionId);
     const saved = loadSessionStore(fixture.storePath(), { skipCache: true });
     expect(saved[sessionKey]?.sessionFile).toBe(fallbackSessionFile);
+  });
+});
+
+describe("mergeSessionEntry — updatedAt behavior (#21161)", () => {
+  it("does not auto-bump updatedAt when merging metadata-only patch into existing entry", () => {
+    const sixHoursAgo = Date.now() - 6 * 60 * 60 * 1000;
+    const existing: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: sixHoursAgo,
+    };
+
+    const merged = mergeSessionEntry(existing, { chatType: "group" });
+
+    // updatedAt must stay at the original value — not jump to Date.now().
+    expect(merged.updatedAt).toBe(sixHoursAgo);
+    expect(merged.chatType).toBe("group");
+  });
+
+  it("advances updatedAt when patch explicitly provides a newer value", () => {
+    const existing: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: 1000,
+    };
+    const now = Date.now();
+
+    const merged = mergeSessionEntry(existing, { updatedAt: now });
+
+    expect(merged.updatedAt).toBe(now);
+  });
+
+  it("defaults updatedAt to Date.now() for brand-new entries", () => {
+    const before = Date.now();
+    const merged = mergeSessionEntry(undefined, { sessionId: "new-session" });
+    const after = Date.now();
+
+    expect(merged.updatedAt).toBeGreaterThanOrEqual(before);
+    expect(merged.updatedAt).toBeLessThanOrEqual(after);
+  });
+});
+
+describe("daily reset freshness after metadata merge (#21161)", () => {
+  it("session updated before 4am resets after the daily boundary", () => {
+    // Simulate a session last active at 3am — before the 4am daily reset.
+    const today4am = new Date();
+    today4am.setHours(4, 0, 0, 0);
+
+    const lastActive = today4am.getTime() - 60 * 60 * 1000; // 3am today
+    const now = today4am.getTime() + 60 * 60 * 1000; // 5am today
+
+    const existing: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: lastActive,
+    };
+
+    // Simulate a metadata-only merge (like recordSessionMetaFromInbound).
+    const merged = mergeSessionEntry(existing, { chatType: "group" });
+
+    // The merge must NOT bump updatedAt.
+    expect(merged.updatedAt).toBe(lastActive);
+
+    // Freshness check should detect the session as stale (past daily boundary).
+    const freshness = evaluateSessionFreshness({
+      updatedAt: merged.updatedAt,
+      now,
+      policy: { mode: "daily", atHour: 4 },
+    });
+
+    expect(freshness.fresh).toBe(false);
   });
 });

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -230,7 +230,7 @@ export function mergeSessionEntry(
   patch: Partial<SessionEntry>,
 ): SessionEntry {
   const sessionId = patch.sessionId ?? existing?.sessionId ?? crypto.randomUUID();
-  const updatedAt = Math.max(existing?.updatedAt ?? 0, patch.updatedAt ?? 0, Date.now());
+  const updatedAt = patch.updatedAt ?? existing?.updatedAt ?? Date.now();
   if (!existing) {
     return normalizeSessionRuntimeModelFields({ ...patch, sessionId, updatedAt });
   }


### PR DESCRIPTION
Noticed that my main telegram thread got reset daily, but the Discord channels my bot were in, kept their context. Difference was that only my main channel has heartbeats. Tasked Opus with finding the bug, creating a failing test, fixing the bug. Tested by setting expiration time to 17:00, and seeing a discord session expire.

Potentially related:
- #11224
- #11520

---
## Summary
- prevent metadata-only inbound updates from bumping session updatedAt, so daily resets can trigger for group/channel sessions
- add regression coverage for daily resets blocked by inbound metadata and for heartbeat runs after the boundary

## Investigation
- traced inbound flow (recordInboundSession -> recordSessionMetaFromInbound -> mergeSessionEntry) and found updatedAt was always bumped to Date.now()
- daily reset in initSessionState uses updatedAt, so the metadata write made sessions look fresh and blocked resets

## Testing (lightly tested)
- bunx vitest src/auto-reply/reply/session.test.ts src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
- Manual (user): set expiration to 17:00, message at 17:00 created new session

## AI-assisted
- Yes, AI-assisted
- I understand what this change does and why it fixes the issue
- Prompts/session logs available on request

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Modified `mergeSessionEntry` in `src/config/sessions/types.ts:120` to preserve existing `updatedAt` when no explicit timestamp is provided in the patch. This prevents metadata-only inbound updates (like `recordSessionMetaFromInbound`) from bumping session timestamps, which was blocking daily session resets for group/channel sessions that received heartbeats or other metadata updates.

The change works with the existing call sites:
- `recordSessionMetaFromInbound` (line 850 in store.ts) passes metadata patches without `updatedAt`, so sessions correctly retain their original timestamp
- `updateLastRoute` (line 919 in store.ts) explicitly provides `updatedAt: Math.max(existing?.updatedAt ?? 0, now)`, so routing updates correctly advance the timestamp

The test coverage validates all three paths: metadata-only merges preserve timestamps, explicit updates advance timestamps, and new entries default to `Date.now()`. The integration test confirms daily reset freshness evaluation works correctly after metadata merges.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgically targeted (single-line change) with comprehensive test coverage. The logic correctly preserves timestamps for metadata-only updates while maintaining explicit timestamp updates. All three behavioral paths are tested, and the integration test validates the actual daily reset scenario.
- No files require special attention

<sub>Last reviewed commit: 9c061d9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->