### PR TITLE
feat(context-pruning): add stripThinking option to strip thinking blocks from older messages

### DIFF
--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -74,6 +74,33 @@ function makeAssistant(text: string): AgentMessage {
   };
 }
 
+function makeAssistantWithBlocks(
+  blocks: Array<{ type: string; [key: string]: unknown }>,
+): AgentMessage {
+  return {
+    role: "assistant",
+    content: blocks as unknown as AgentMessage["content"],
+    api: "openai-responses",
+    provider: "openai",
+    model: "fake",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function getThinkingBlocks(msg: AgentMessage): string[] {
+  if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+    return [];
+  }
+  return (
+    msg.content.filter((b) => b.type === "thinking") as Array<{
+      type: "thinking";
+      thinking: string;
+    }>
+  ).map((b) => b.thinking);
+}
+
 function makeUser(text: string): AgentMessage {
   return { role: "user", content: text, timestamp: Date.now() };
 }
@@ -521,5 +548,112 @@ describe("context-pruning", () => {
     expect(text).toContain("abcdef");
     expect(text).toContain("efghij");
     expect(text).toContain("[Tool result trimmed:");
+  });
+
+  it("stripThinking=false leaves thinking blocks untouched", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistantWithBlocks([
+        { type: "thinking", thinking: "hidden" },
+        { type: "text", text: "answer" },
+      ]),
+    ];
+
+    const settings = {
+      ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      keepLastAssistants: 0,
+      stripThinking: false,
+    };
+
+    const ctx = {
+      model: { contextWindow: 1000 },
+    } as unknown as ExtensionContext;
+    const next = pruneContextMessages({ messages, settings, ctx });
+
+    expect(getThinkingBlocks(next[1])).toEqual(["hidden"]);
+  });
+
+  it("stripThinking=true strips thinking before cutoff", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistantWithBlocks([
+        { type: "thinking", thinking: "hidden" },
+        { type: "text", text: "answer" },
+      ]),
+    ];
+
+    const settings = {
+      ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      keepLastAssistants: 0,
+      stripThinking: true,
+    };
+
+    const ctx = {
+      model: { contextWindow: 1000 },
+    } as unknown as ExtensionContext;
+    const next = pruneContextMessages({ messages, settings, ctx });
+    const assistant = next[1];
+
+    expect(getThinkingBlocks(assistant)).toEqual([]);
+    if (assistant.role !== "assistant" || !Array.isArray(assistant.content)) {
+      throw new Error("expected assistant content array");
+    }
+    expect(assistant.content.some((b) => b.type === "text")).toBe(true);
+  });
+
+  it("stripThinking=true preserves thinking in protected tail", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistantWithBlocks([
+        { type: "thinking", thinking: "old" },
+        { type: "text", text: "a1" },
+      ]),
+      makeUser("u2"),
+      makeAssistantWithBlocks([
+        { type: "thinking", thinking: "new" },
+        { type: "text", text: "a2" },
+      ]),
+    ];
+
+    const settings = {
+      ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      keepLastAssistants: 1,
+      stripThinking: true,
+    };
+
+    const ctx = {
+      model: { contextWindow: 1000 },
+    } as unknown as ExtensionContext;
+    const next = pruneContextMessages({ messages, settings, ctx });
+
+    expect(getThinkingBlocks(next[1])).toEqual([]);
+    expect(getThinkingBlocks(next[3])).toEqual(["new"]);
+  });
+
+  it("stripThinking=true replaces empty assistant content with blank text", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistantWithBlocks([{ type: "thinking", thinking: "secret" }]),
+    ];
+
+    const settings = {
+      ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      keepLastAssistants: 0,
+      stripThinking: true,
+    };
+
+    const ctx = {
+      model: { contextWindow: 1000 },
+    } as unknown as ExtensionContext;
+    const next = pruneContextMessages({ messages, settings, ctx });
+    const assistant = next[1];
+
+    expect(getThinkingBlocks(assistant)).toEqual([]);
+    if (assistant.role !== "assistant" || !Array.isArray(assistant.content)) {
+      throw new Error("expected assistant content array");
+    }
+    expect(assistant.content).toHaveLength(1);
+    expect(assistant.content[0]?.type).toBe("text");
+    expect(assistant.content[0]?.text).toBe("");
   });
 });

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -150,8 +150,22 @@ function estimateMessageChars(message: AgentMessage): number {
   return 256;
 }
 
-function estimateContextChars(messages: AgentMessage[]): number {
+export function estimateContextChars(messages: AgentMessage[]): number {
   return messages.reduce((sum, m) => sum + estimateMessageChars(m), 0);
+}
+
+export function estimateContextUsageRatio(
+  messages: AgentMessage[],
+  contextWindowTokens?: number | null,
+): number {
+  if (!contextWindowTokens || !Number.isFinite(contextWindowTokens) || contextWindowTokens <= 0) {
+    return 0;
+  }
+  const charWindow = contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE;
+  if (charWindow <= 0) {
+    return 0;
+  }
+  return estimateContextChars(messages) / charWindow;
 }
 
 function findAssistantCutoffIndex(

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -260,16 +260,48 @@ export function pruneContextMessages(params: {
 
   const totalCharsBefore = estimateContextChars(messages);
   let totalChars = totalCharsBefore;
+  let next: AgentMessage[] | null = null;
+
+  if (settings.stripThinking) {
+    for (let i = pruneStartIndex; i < cutoffIndex; i++) {
+      const msg = messages[i];
+      if (!msg || msg.role !== "assistant") {
+        continue;
+      }
+      const content = msg.content;
+      if (!Array.isArray(content)) {
+        continue;
+      }
+      let removedChars = 0;
+      const filtered = content.filter((block) => {
+        if (block.type === "thinking") {
+          removedChars += block.thinking.length;
+          return false;
+        }
+        return true;
+      });
+      if (removedChars === 0) {
+        continue;
+      }
+      const nextContent = filtered.length > 0 ? filtered : [asText("")];
+      if (!next) {
+        next = messages.slice();
+      }
+      next[i] = { ...msg, content: nextContent } as AgentMessage;
+      totalChars = Math.max(0, totalChars - removedChars);
+    }
+  }
+
   let ratio = totalChars / charWindow;
   if (ratio < settings.softTrimRatio) {
-    return messages;
+    return next ?? messages;
   }
 
   const prunableToolIndexes: number[] = [];
-  let next: AgentMessage[] | null = null;
+  const sourceMessages = next ?? messages;
 
   for (let i = pruneStartIndex; i < cutoffIndex; i++) {
-    const msg = messages[i];
+    const msg = sourceMessages[i];
     if (!msg || msg.role !== "toolResult") {
       continue;
     }

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -12,6 +12,7 @@ export type ContextPruningConfig = {
   ttl?: string;
   keepLastAssistants?: number;
   stripThinking?: boolean;
+  forcePruneRatio?: number;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;
@@ -32,6 +33,7 @@ export type EffectiveContextPruningSettings = {
   ttlMs: number;
   keepLastAssistants: number;
   stripThinking: boolean;
+  forcePruneRatio?: number;
   softTrimRatio: number;
   hardClearRatio: number;
   minPrunableToolChars: number;
@@ -92,6 +94,9 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
   }
   if (typeof cfg.stripThinking === "boolean") {
     s.stripThinking = cfg.stripThinking;
+  }
+  if (typeof cfg.forcePruneRatio === "number" && Number.isFinite(cfg.forcePruneRatio)) {
+    s.forcePruneRatio = Math.min(1, Math.max(0, cfg.forcePruneRatio));
   }
   if (typeof cfg.softTrimRatio === "number" && Number.isFinite(cfg.softTrimRatio)) {
     s.softTrimRatio = Math.min(1, Math.max(0, cfg.softTrimRatio));

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -11,6 +11,7 @@ export type ContextPruningConfig = {
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;
+  stripThinking?: boolean;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;
@@ -30,6 +31,7 @@ export type EffectiveContextPruningSettings = {
   mode: Exclude<ContextPruningMode, "off">;
   ttlMs: number;
   keepLastAssistants: number;
+  stripThinking: boolean;
   softTrimRatio: number;
   hardClearRatio: number;
   minPrunableToolChars: number;
@@ -49,6 +51,7 @@ export const DEFAULT_CONTEXT_PRUNING_SETTINGS: EffectiveContextPruningSettings =
   mode: "cache-ttl",
   ttlMs: 5 * 60 * 1000,
   keepLastAssistants: 3,
+  stripThinking: false,
   softTrimRatio: 0.3,
   hardClearRatio: 0.5,
   minPrunableToolChars: 50_000,
@@ -86,6 +89,9 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
 
   if (typeof cfg.keepLastAssistants === "number" && Number.isFinite(cfg.keepLastAssistants)) {
     s.keepLastAssistants = Math.max(0, Math.floor(cfg.keepLastAssistants));
+  }
+  if (typeof cfg.stripThinking === "boolean") {
+    s.stripThinking = cfg.stripThinking;
   }
   if (typeof cfg.softTrimRatio === "number" && Number.isFinite(cfg.softTrimRatio)) {
     s.softTrimRatio = Math.min(1, Math.max(0, cfg.softTrimRatio));

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -31,6 +31,7 @@ export type AgentContextPruningConfig = {
   ttl?: string;
   keepLastAssistants?: number;
   stripThinking?: boolean;
+  forcePruneRatio?: number;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -30,6 +30,7 @@ export type AgentContextPruningConfig = {
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;
+  stripThinking?: boolean;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -61,6 +61,7 @@ export const AgentDefaultsSchema = z
         ttl: z.string().optional(),
         keepLastAssistants: z.number().int().nonnegative().optional(),
         stripThinking: z.boolean().optional(),
+        forcePruneRatio: z.number().min(0).max(1).optional(),
         softTrimRatio: z.number().min(0).max(1).optional(),
         hardClearRatio: z.number().min(0).max(1).optional(),
         minPrunableToolChars: z.number().int().nonnegative().optional(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -60,6 +60,7 @@ export const AgentDefaultsSchema = z
         mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
         ttl: z.string().optional(),
         keepLastAssistants: z.number().int().nonnegative().optional(),
+        stripThinking: z.boolean().optional(),
         softTrimRatio: z.number().min(0).max(1).optional(),
         hardClearRatio: z.number().min(0).max(1).optional(),
         minPrunableToolChars: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
Problem: reasoning models with extended thinking keep large thinking blocks in history, and cache-ttl pruning never removes them, so old thinking consumes context.

Add contextPruning.stripThinking to remove thinking blocks outside keepLastAssistants during pruning. It leaves a blank text block if stripping empties the assistant content and preserves the recent tail. Default is false and tests cover stripThinking on and off plus tail preservation.

Testing: existing + new tests pass; verified with Claude Opus 4.6 and thinkingDefault: high.

References #13519