### PR TITLE
feat: conditional bootstrap file loading for heartbeat vs DM sessions

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -5,6 +5,7 @@ import { buildBootstrapContextFiles, resolveBootstrapMaxChars } from "./pi-embed
 import {
   filterBootstrapFilesForSession,
   loadWorkspaceBootstrapFiles,
+  type FilterBootstrapOptions,
   type WorkspaceBootstrapFile,
 } from "./workspace.js";
 
@@ -24,11 +25,16 @@ export async function resolveBootstrapFilesForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  isHeartbeat?: boolean;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
+  const filterOpts: FilterBootstrapOptions | undefined = params.isHeartbeat
+    ? { isHeartbeat: true }
+    : undefined;
   const bootstrapFiles = filterBootstrapFilesForSession(
     await loadWorkspaceBootstrapFiles(params.workspaceDir),
     sessionKey,
+    filterOpts,
   );
   return applyBootstrapHookOverrides({
     files: bootstrapFiles,
@@ -46,6 +52,7 @@ export async function resolveBootstrapContextForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  isHeartbeat?: boolean;
   warn?: (message: string) => void;
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -451,6 +451,7 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
+            isHeartbeat: params.isHeartbeat,
           });
 
           const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -194,6 +194,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        isHeartbeat: params.isHeartbeat,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
       });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -102,4 +102,6 @@ export type RunEmbeddedPiAgentParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  /** When true, this run is a heartbeat poll — used to filter bootstrap files. */
+  isHeartbeat?: boolean;
 };

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -90,6 +90,8 @@ export type EmbeddedRunAttemptParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  /** When true, this run is a heartbeat poll — used to filter bootstrap files. */
+  isHeartbeat?: boolean;
 };
 
 export type EmbeddedRunAttemptResult = {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -286,6 +286,7 @@ export async function runAgentTurnWithFallback(params: {
             extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
             ownerNumbers: params.followupRun.run.ownerNumbers,
             enforceFinalTag: resolveEnforceFinalTag(params.followupRun.run, provider),
+            isHeartbeat: params.isHeartbeat,
             provider,
             model,
             authProfileId,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -160,6 +160,7 @@ export function createFollowupRunner(params: {
               extraSystemPrompt: queued.run.extraSystemPrompt,
               ownerNumbers: queued.run.ownerNumbers,
               enforceFinalTag: queued.run.enforceFinalTag,
+              isHeartbeat: opts?.isHeartbeat,
               provider,
               model,
               authProfileId,


### PR DESCRIPTION
## Problem

Workspace bootstrap files (AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md, HEARTBEAT.md, MEMORY.md) are injected into **every** agent run regardless of session type. This wastes tokens:

- **DM sessions** load HEARTBEAT.md (~300-1,500 tokens) which contains heartbeat poller instructions not needed during interactive conversations
- **Heartbeat runs** load SOUL.md, TOOLS.md, USER.md, MEMORY.md which are not needed for a periodic check

For users with multiple agents and detailed HEARTBEAT.md files, this adds up to **1,400+ wasted tokens per DM message**.

## Solution

Extend `filterBootstrapFilesForSession()` to support session-type-aware filtering:

- **Subagent sessions**: AGENTS.md + TOOLS.md (unchanged, existing behavior)
- **Heartbeat sessions**: HEARTBEAT.md + AGENTS.md + IDENTITY.md (new)
- **Normal DM sessions**: All files **except** HEARTBEAT.md (new)

The `isHeartbeat` flag is threaded from the auto-reply layer through the embedded runner to the bootstrap file resolver.

## Changes

- `workspace.ts`: Added `HEARTBEAT_BOOTSTRAP_ALLOWLIST`, `DM_BOOTSTRAP_EXCLUDELIST`, and `FilterBootstrapOptions` type. Extended `filterBootstrapFilesForSession()` with optional `opts` parameter.
- `bootstrap-files.ts`: Thread `isHeartbeat` through `resolveBootstrapFilesForRun` and `resolveBootstrapContextForRun`.
- `run/types.ts` + `run/params.ts`: Added `isHeartbeat?` to embedded run params.
- `run/attempt.ts` + `run.ts`: Pass `isHeartbeat` to bootstrap context resolver.
- `followup-runner.ts` + `agent-runner-execution.ts`: Pass `isHeartbeat` to embedded runner.

## Testing

- All existing tests pass (`workspace.test.ts`: 4/4, `bootstrap-files.test.ts`: 2/2)
- Backward compatible: the `opts` parameter is optional, existing behavior unchanged when not provided

## Related Issues

- #9157 (workspace file injection wastes 93.5% of token budget)
- #1594 (heartbeat cron jobs load full main session context)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds session-type-aware bootstrap file filtering to reduce token waste: subagent runs continue to load a minimal allowlist, heartbeat runs load only HEARTBEAT.md + core identity/agent files, and normal DM sessions load everything except HEARTBEAT.md. The new `isHeartbeat` flag is threaded from the auto-reply layer through the embedded runner into the bootstrap resolver, which then calls the updated `filterBootstrapFilesForSession()`.

Main issue to address before merge: followup runs don’t register `isHeartbeat` in the agent run context, which can break downstream behavior that relies on `getAgentRunContext(runId)?.isHeartbeat` (notably webchat broadcast suppression for heartbeats).

<h3>Confidence Score: 3/5</h3>

- Not safe to merge until followup heartbeat runs are correctly classified.
- The bootstrap filtering and isHeartbeat threading are mostly consistent, but followup runs omit isHeartbeat when registering AgentRunContext, which breaks downstream heartbeat-specific behavior (e.g., suppressing heartbeat broadcasts).
- src/auto-reply/reply/followup-runner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->