### PR TITLE
fix(config): narrow /token/i pattern to /token$/i to avoid redacting maxTokens and contextTokens

### DIFF
--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -10,9 +10,10 @@ export const REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
 
 /**
  * Patterns that identify sensitive config field names.
- * Aligned with the UI-hint logic in schema.ts.
+ * Narrower than the UI-hint logic in schema.ts (which still uses /token/i)
+ * to avoid false-positive redaction of numeric fields like maxTokens.
  */
-const SENSITIVE_KEY_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+const SENSITIVE_KEY_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));


### PR DESCRIPTION
## Summary

Fixes #13495.

`SENSITIVE_KEY_PATTERNS` in `redact-snapshot.ts` uses `/token/i` to identify credential fields for redaction. This regex is too broad — it matches non-sensitive config keys like `maxTokens`, `contextTokens`, `inputTokens`, `outputTokens`, and `maxTokensField`, replacing their numeric/enum values with `__OPENCLAW_REDACTED__`.

When the Dashboard reads the redacted config and writes it back via `config.patch`, these fields can be permanently overwritten with the sentinel string, corrupting the config file.

## Root cause

```typescript
// Before (line 14 of redact-snapshot.ts)
const SENSITIVE_KEY_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
//                                ^^^^^^^^
//                                matches "maxTokens", "contextTokens", etc.
```

## Fix

```typescript
// After
const SENSITIVE_KEY_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
//                                ^^^^^^^^^
//                                only matches keys ending in "token"
//                                (botToken, appToken, userToken, pushToken, etc.)
```

## Verification

| Key | Old `/token/i` | New `/token$/i` |
|-----|:-:|:-:|
| `botToken` | ✅ match | ✅ match |
| `appToken` | ✅ match | ✅ match |
| `userToken` | ✅ match | ✅ match |
| `token` | ✅ match | ✅ match |
| `pushToken` | ✅ match | ✅ match |
| `maxTokens` | ✅ false positive | ❌ no match |
| `contextTokens` | ✅ false positive | ❌ no match |
| `outputTokens` | ✅ false positive | ❌ no match |
| `maxTokensField` | ✅ false positive | ❌ no match |

Non-sensitive keys like `tokenFile` (a file path) and `userTokenReadOnly` (a boolean) are also correctly excluded by the `$` anchor.

## Changes

| File | Change |
|------|--------|
| `src/config/redact-snapshot.ts` | 1-line regex fix: `/token/i` → `/token$/i` |
| `src/config/redact-snapshot.test.ts` | 3 new tests covering the false-positive scenario and round-trip integrity |

## Test plan

```bash
pnpm test src/config/redact-snapshot.test.ts
```

All existing tests pass. New tests verify that `maxTokens`, `contextTokens`, and `maxTokensField` are not redacted, while `botToken`, `apiKey`, and `token` remain correctly redacted.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR narrows the config redaction key matcher in `src/config/redact-snapshot.ts` from `/token/i` to `/token$/i` so that non-secret configuration fields like `maxTokens` and `contextTokens` are no longer replaced by the `__OPENCLAW_REDACTED__` sentinel. It also adds unit tests to cover the false-positive cases and a redact→restore round-trip.

The redaction logic is part of the config snapshot pipeline used by the gateway when serving config to the Dashboard; narrowing the regex prevents token-budget settings from being corrupted when the UI writes redacted configs back via `config.patch`/`config.set`.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a confirmed inconsistency with other sensitive-field detection logic that should be reconciled.
- The regex narrowing and added tests directly address a real config corruption issue. However, other parts of the codebase (schema/UI hint logic) still use broad token matching, creating inconsistent sensitivity marking vs. redaction behavior that should be fixed for correctness and to avoid confusing UX.
- src/config/redact-snapshot.ts, src/config/schema.ts, src/config/schema.field-metadata.ts, ui/src/ui/views/config-form.shared.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->