### PR TITLE
fix(sandbox): add python3-pip/venv and remove PEP 668 restriction

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -10,8 +10,11 @@ RUN apt-get update \
     git \
     jq \
     python3 \
+    python3-pip \
+    python3-venv \
     ripgrep \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f /usr/lib/python*/EXTERNALLY-MANAGED
 
 RUN useradd --create-home --shell /bin/bash sandbox
 USER sandbox

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -14,7 +14,7 @@ RUN apt-get update \
     python3-venv \
     ripgrep \
   && rm -rf /var/lib/apt/lists/* \
-  && rm -f /usr/lib/python*/EXTERNALLY-MANAGED
+  && find /usr/lib /usr/local/lib -name EXTERNALLY-MANAGED -delete 2>/dev/null || true
 
 RUN useradd --create-home --shell /bin/bash sandbox
 USER sandbox

--- a/src/tts/tts-directives.ts
+++ b/src/tts/tts-directives.ts
@@ -1,0 +1,392 @@
+import type { TtsProvider } from "../config/types.tts.js";
+import type { ResolvedTtsConfig } from "./tts.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type ResolvedTtsModelOverrides = {
+  enabled: boolean;
+  allowText: boolean;
+  allowProvider: boolean;
+  allowVoice: boolean;
+  allowModelId: boolean;
+  allowVoiceSettings: boolean;
+  allowNormalization: boolean;
+  allowSeed: boolean;
+};
+
+export type TtsDirectiveOverrides = {
+  ttsText?: string;
+  provider?: TtsProvider;
+  openai?: {
+    voice?: string;
+    model?: string;
+  };
+  elevenlabs?: {
+    voiceId?: string;
+    modelId?: string;
+    seed?: number;
+    applyTextNormalization?: "auto" | "on" | "off";
+    languageCode?: string;
+    voiceSettings?: Partial<ResolvedTtsConfig["elevenlabs"]["voiceSettings"]>;
+  };
+};
+
+export type TtsDirectiveParseResult = {
+  cleanedText: string;
+  ttsText?: string;
+  hasDirective: boolean;
+  overrides: TtsDirectiveOverrides;
+  warnings: string[];
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+export function isValidVoiceId(voiceId: string): boolean {
+  return /^[a-zA-Z0-9]{10,40}$/.test(voiceId);
+}
+
+export function requireInRange(value: number, min: number, max: number, label: string): void {
+  if (!Number.isFinite(value) || value < min || value > max) {
+    throw new Error(`${label} must be between ${min} and ${max}`);
+  }
+}
+
+export function normalizeLanguageCode(code?: string): string | undefined {
+  const trimmed = code?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.toLowerCase();
+  if (!/^[a-z]{2}$/.test(normalized)) {
+    throw new Error("languageCode must be a 2-letter ISO 639-1 code (e.g. en, de, fr)");
+  }
+  return normalized;
+}
+
+export function normalizeApplyTextNormalization(mode?: string): "auto" | "on" | "off" | undefined {
+  const trimmed = mode?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.toLowerCase();
+  if (normalized === "auto" || normalized === "on" || normalized === "off") {
+    return normalized;
+  }
+  throw new Error("applyTextNormalization must be one of: auto, on, off");
+}
+
+export function normalizeSeed(seed?: number): number | undefined {
+  if (seed == null) {
+    return undefined;
+  }
+  const next = Math.floor(seed);
+  if (!Number.isFinite(next) || next < 0 || next > 4_294_967_295) {
+    throw new Error("seed must be between 0 and 4294967295");
+  }
+  return next;
+}
+
+function parseBooleanValue(value: string): boolean | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function parseNumberValue(value: string): number | undefined {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+// ── Validators (depend on OpenAI constants) ─────────────────────────────────
+
+export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as const;
+
+export const OPENAI_TTS_VOICES = [
+  "alloy",
+  "ash",
+  "coral",
+  "echo",
+  "fable",
+  "onyx",
+  "nova",
+  "sage",
+  "shimmer",
+] as const;
+
+export type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
+
+export function getOpenAITtsBaseUrl(): string {
+  return (process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1").replace(
+    /\/+$/,
+    "",
+  );
+}
+
+export function isCustomOpenAIEndpoint(): boolean {
+  return getOpenAITtsBaseUrl() !== "https://api.openai.com/v1";
+}
+
+export function isValidOpenAIModel(model: string): boolean {
+  if (isCustomOpenAIEndpoint()) {
+    return true;
+  }
+  return OPENAI_TTS_MODELS.includes(model as (typeof OPENAI_TTS_MODELS)[number]);
+}
+
+export function isValidOpenAIVoice(voice: string): voice is OpenAiTtsVoice {
+  if (isCustomOpenAIEndpoint()) {
+    return true;
+  }
+  return OPENAI_TTS_VOICES.includes(voice as OpenAiTtsVoice);
+}
+
+// ── Main parser ─────────────────────────────────────────────────────────────
+
+export function parseTtsDirectives(
+  text: string,
+  policy: ResolvedTtsModelOverrides,
+): TtsDirectiveParseResult {
+  const overrides: TtsDirectiveOverrides = {};
+  const warnings: string[] = [];
+  let cleanedText = text;
+  let hasDirective = false;
+
+  const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
+  cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
+    hasDirective = true;
+    if (policy.enabled && policy.allowText && overrides.ttsText == null) {
+      overrides.ttsText = inner.trim();
+    }
+    return "";
+  });
+
+  // Handle bare [[tts]] tag (no parameters) - just signals TTS should be used
+  const bareTtsRegex = /\[\[tts\]\]/gi;
+  cleanedText = cleanedText.replace(bareTtsRegex, (match) => {
+    hasDirective = true;
+    if (!policy.enabled) {
+      return match;
+    }
+    return "";
+  });
+
+  const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
+  cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
+    hasDirective = true;
+    if (!policy.enabled) {
+      return _match;
+    }
+    const tokens = body.split(/\s+/).filter(Boolean);
+    for (const token of tokens) {
+      const eqIndex = token.indexOf("=");
+      if (eqIndex === -1) {
+        continue;
+      }
+      const rawKey = token.slice(0, eqIndex).trim();
+      const rawValue = token.slice(eqIndex + 1).trim();
+      if (!rawKey || !rawValue) {
+        continue;
+      }
+      const key = rawKey.toLowerCase();
+      try {
+        switch (key) {
+          case "provider":
+            if (!policy.allowProvider) {
+              break;
+            }
+            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+              overrides.provider = rawValue;
+            } else {
+              warnings.push(`unsupported provider "${rawValue}"`);
+            }
+            break;
+          case "voice":
+          case "openai_voice":
+          case "openaivoice":
+            if (!policy.allowVoice) {
+              break;
+            }
+            if (isValidOpenAIVoice(rawValue)) {
+              overrides.openai = { ...overrides.openai, voice: rawValue };
+              if (!overrides.provider) {
+                overrides.provider = "openai";
+              }
+            } else {
+              warnings.push(`invalid OpenAI voice "${rawValue}"`);
+            }
+            break;
+          case "voiceid":
+          case "voice_id":
+          case "elevenlabs_voice":
+          case "elevenlabsvoice":
+            if (!policy.allowVoice) {
+              break;
+            }
+            if (isValidVoiceId(rawValue)) {
+              overrides.elevenlabs = { ...overrides.elevenlabs, voiceId: rawValue };
+              if (!overrides.provider) {
+                overrides.provider = "elevenlabs";
+              }
+            } else {
+              warnings.push(`invalid ElevenLabs voiceId "${rawValue}"`);
+            }
+            break;
+          case "model":
+          case "modelid":
+          case "model_id":
+          case "elevenlabs_model":
+          case "elevenlabsmodel":
+          case "openai_model":
+          case "openaimodel":
+            if (!policy.allowModelId) {
+              break;
+            }
+            if (isValidOpenAIModel(rawValue)) {
+              overrides.openai = { ...overrides.openai, model: rawValue };
+            } else {
+              overrides.elevenlabs = { ...overrides.elevenlabs, modelId: rawValue };
+            }
+            break;
+          case "stability":
+            if (!policy.allowVoiceSettings) {
+              break;
+            }
+            {
+              const value = parseNumberValue(rawValue);
+              if (value == null) {
+                warnings.push("invalid stability value");
+                break;
+              }
+              requireInRange(value, 0, 1, "stability");
+              overrides.elevenlabs = {
+                ...overrides.elevenlabs,
+                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, stability: value },
+              };
+            }
+            break;
+          case "similarity":
+          case "similarityboost":
+          case "similarity_boost":
+            if (!policy.allowVoiceSettings) {
+              break;
+            }
+            {
+              const value = parseNumberValue(rawValue);
+              if (value == null) {
+                warnings.push("invalid similarityBoost value");
+                break;
+              }
+              requireInRange(value, 0, 1, "similarityBoost");
+              overrides.elevenlabs = {
+                ...overrides.elevenlabs,
+                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, similarityBoost: value },
+              };
+            }
+            break;
+          case "style":
+            if (!policy.allowVoiceSettings) {
+              break;
+            }
+            {
+              const value = parseNumberValue(rawValue);
+              if (value == null) {
+                warnings.push("invalid style value");
+                break;
+              }
+              requireInRange(value, 0, 1, "style");
+              overrides.elevenlabs = {
+                ...overrides.elevenlabs,
+                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, style: value },
+              };
+            }
+            break;
+          case "speed":
+            if (!policy.allowVoiceSettings) {
+              break;
+            }
+            {
+              const value = parseNumberValue(rawValue);
+              if (value == null) {
+                warnings.push("invalid speed value");
+                break;
+              }
+              requireInRange(value, 0.5, 2, "speed");
+              overrides.elevenlabs = {
+                ...overrides.elevenlabs,
+                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, speed: value },
+              };
+            }
+            break;
+          case "speakerboost":
+          case "speaker_boost":
+          case "usespeakerboost":
+          case "use_speaker_boost":
+            if (!policy.allowVoiceSettings) {
+              break;
+            }
+            {
+              const value = parseBooleanValue(rawValue);
+              if (value == null) {
+                warnings.push("invalid useSpeakerBoost value");
+                break;
+              }
+              overrides.elevenlabs = {
+                ...overrides.elevenlabs,
+                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, useSpeakerBoost: value },
+              };
+            }
+            break;
+          case "normalize":
+          case "applytextnormalization":
+          case "apply_text_normalization":
+            if (!policy.allowNormalization) {
+              break;
+            }
+            overrides.elevenlabs = {
+              ...overrides.elevenlabs,
+              applyTextNormalization: normalizeApplyTextNormalization(rawValue),
+            };
+            break;
+          case "language":
+          case "languagecode":
+          case "language_code":
+            if (!policy.allowNormalization) {
+              break;
+            }
+            overrides.elevenlabs = {
+              ...overrides.elevenlabs,
+              languageCode: normalizeLanguageCode(rawValue),
+            };
+            break;
+          case "seed":
+            if (!policy.allowSeed) {
+              break;
+            }
+            overrides.elevenlabs = {
+              ...overrides.elevenlabs,
+              seed: normalizeSeed(Number.parseInt(rawValue, 10)),
+            };
+            break;
+          default:
+            break;
+        }
+      } catch (err) {
+        warnings.push((err as Error).message);
+      }
+    }
+    return "";
+  });
+
+  return {
+    cleanedText,
+    ttsText: overrides.ttsText,
+    hasDirective,
+    overrides,
+    warnings,
+  };
+}

--- a/src/tts/tts-providers.ts
+++ b/src/tts/tts-providers.ts
@@ -1,0 +1,249 @@
+/**
+ * TTS provider implementations: ElevenLabs, OpenAI, and Edge TTS.
+ *
+ * Extracted from tts.ts to keep file sizes manageable.
+ */
+
+import { EdgeTTS } from "node-edge-tts";
+import type { ResolvedTtsConfig } from "./tts.js";
+import {
+  isValidVoiceId,
+  normalizeLanguageCode,
+  normalizeApplyTextNormalization,
+  normalizeSeed,
+  isValidOpenAIModel,
+  isValidOpenAIVoice,
+  getOpenAITtsBaseUrl,
+} from "./tts-directives.js";
+
+// ── Provider-specific constants ──────────────────────────────────────────────
+
+export const DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
+export const DEFAULT_ELEVENLABS_VOICE_ID = "pMsXgVXv3BLzUgSXRplE";
+export const DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2";
+export const DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts";
+export const DEFAULT_OPENAI_VOICE = "alloy";
+export const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
+export const DEFAULT_EDGE_LANG = "en-US";
+export const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+
+export const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
+  stability: 0.5,
+  similarityBoost: 0.75,
+  style: 0.0,
+  useSpeakerBoost: true,
+  speed: 1.0,
+};
+
+export const TELEGRAM_OUTPUT = {
+  openai: "opus" as const,
+  // ElevenLabs output formats use codec_sample_rate_bitrate naming.
+  // Opus @ 48kHz/64kbps is a good voice-note tradeoff for Telegram.
+  elevenlabs: "opus_48000_64",
+  extension: ".opus",
+  voiceCompatible: true,
+};
+
+export const DEFAULT_OUTPUT = {
+  openai: "mp3" as const,
+  elevenlabs: "mp3_44100_128",
+  extension: ".mp3",
+  voiceCompatible: false,
+};
+
+export const TELEPHONY_OUTPUT = {
+  openai: { format: "pcm" as const, sampleRate: 24000 },
+  elevenlabs: { format: "pcm_22050", sampleRate: 22050 },
+};
+
+// ── ElevenLabs helpers ───────────────────────────────────────────────────────
+
+export function normalizeElevenLabsBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim();
+  if (!trimmed) {
+    return DEFAULT_ELEVENLABS_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+function requireInRange(value: number, min: number, max: number, label: string): void {
+  if (!Number.isFinite(value) || value < min || value > max) {
+    throw new Error(`${label} must be between ${min} and ${max}`);
+  }
+}
+
+export function assertElevenLabsVoiceSettings(
+  settings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"],
+) {
+  requireInRange(settings.stability, 0, 1, "stability");
+  requireInRange(settings.similarityBoost, 0, 1, "similarityBoost");
+  requireInRange(settings.style, 0, 1, "style");
+  requireInRange(settings.speed, 0.5, 2, "speed");
+}
+
+// ── ElevenLabs TTS ───────────────────────────────────────────────────────────
+
+export async function elevenLabsTTS(params: {
+  text: string;
+  apiKey: string;
+  baseUrl: string;
+  voiceId: string;
+  modelId: string;
+  outputFormat: string;
+  seed?: number;
+  applyTextNormalization?: "auto" | "on" | "off";
+  languageCode?: string;
+  voiceSettings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"];
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const {
+    text,
+    apiKey,
+    baseUrl,
+    voiceId,
+    modelId,
+    outputFormat,
+    seed,
+    applyTextNormalization,
+    languageCode,
+    voiceSettings,
+    timeoutMs,
+  } = params;
+  if (!isValidVoiceId(voiceId)) {
+    throw new Error("Invalid voiceId format");
+  }
+  assertElevenLabsVoiceSettings(voiceSettings);
+  const normalizedLanguage = normalizeLanguageCode(languageCode);
+  const normalizedNormalization = normalizeApplyTextNormalization(applyTextNormalization);
+  const normalizedSeed = normalizeSeed(seed);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const url = new URL(`${normalizeElevenLabsBaseUrl(baseUrl)}/v1/text-to-speech/${voiceId}`);
+    if (outputFormat) {
+      url.searchParams.set("output_format", outputFormat);
+    }
+
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: {
+        "xi-api-key": apiKey,
+        "Content-Type": "application/json",
+        Accept: "audio/mpeg",
+      },
+      body: JSON.stringify({
+        text,
+        model_id: modelId,
+        seed: normalizedSeed,
+        apply_text_normalization: normalizedNormalization,
+        language_code: normalizedLanguage,
+        voice_settings: {
+          stability: voiceSettings.stability,
+          similarity_boost: voiceSettings.similarityBoost,
+          style: voiceSettings.style,
+          use_speaker_boost: voiceSettings.useSpeakerBoost,
+          speed: voiceSettings.speed,
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`ElevenLabs API error (${response.status})`);
+    }
+
+    return Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ── OpenAI TTS ───────────────────────────────────────────────────────────────
+
+export async function openaiTTS(params: {
+  text: string;
+  apiKey: string;
+  model: string;
+  voice: string;
+  responseFormat: "mp3" | "opus" | "pcm";
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
+
+  if (!isValidOpenAIModel(model)) {
+    throw new Error(`Invalid model: ${model}`);
+  }
+  if (!isValidOpenAIVoice(voice)) {
+    throw new Error(`Invalid voice: ${voice}`);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(`${getOpenAITtsBaseUrl()}/audio/speech`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        input: text,
+        voice,
+        response_format: responseFormat,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI TTS API error (${response.status})`);
+    }
+
+    return Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ── Edge TTS ─────────────────────────────────────────────────────────────────
+
+export function inferEdgeExtension(outputFormat: string): string {
+  const normalized = outputFormat.toLowerCase();
+  if (normalized.includes("webm")) {
+    return ".webm";
+  }
+  if (normalized.includes("ogg")) {
+    return ".ogg";
+  }
+  if (normalized.includes("opus")) {
+    return ".opus";
+  }
+  if (normalized.includes("wav") || normalized.includes("riff") || normalized.includes("pcm")) {
+    return ".wav";
+  }
+  return ".mp3";
+}
+
+export async function edgeTTS(params: {
+  text: string;
+  outputPath: string;
+  config: ResolvedTtsConfig["edge"];
+  timeoutMs: number;
+}): Promise<void> {
+  const { text, outputPath, config, timeoutMs } = params;
+  const tts = new EdgeTTS({
+    voice: config.voice,
+    lang: config.lang,
+    outputFormat: config.outputFormat,
+    saveSubtitles: config.saveSubtitles,
+    proxy: config.proxy,
+    rate: config.rate,
+    pitch: config.pitch,
+    volume: config.volume,
+    timeout: config.timeoutMs ?? timeoutMs,
+  });
+  await tts.ttsPromise(text, outputPath);
+}

--- a/src/tts/tts-providers.ts
+++ b/src/tts/tts-providers.ts
@@ -14,6 +14,7 @@ import {
   isValidOpenAIModel,
   isValidOpenAIVoice,
   getOpenAITtsBaseUrl,
+  requireInRange,
 } from "./tts-directives.js";
 
 // ── Provider-specific constants ──────────────────────────────────────────────
@@ -64,12 +65,6 @@ export function normalizeElevenLabsBaseUrl(baseUrl: string): string {
     return DEFAULT_ELEVENLABS_BASE_URL;
   }
   return trimmed.replace(/\/+$/, "");
-}
-
-function requireInRange(value: number, min: number, max: number, label: string): void {
-  if (!Number.isFinite(value) || value < min || value > max) {
-    throw new Error(`${label} must be between ${min} and ${max}`);
-  }
 }
 
 export function assertElevenLabsVoiceSettings(

--- a/src/tts/tts-summarize.ts
+++ b/src/tts/tts-summarize.ts
@@ -1,0 +1,141 @@
+/**
+ * TTS text summarization logic.
+ *
+ * Extracted from tts.ts to keep file sizes manageable.
+ */
+
+import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ResolvedTtsConfig } from "./tts.js";
+import { getApiKeyForModel, requireApiKey } from "../agents/model-auth.js";
+import {
+  buildModelAliasIndex,
+  resolveDefaultModelForAgent,
+  resolveModelRefFromString,
+  type ModelRef,
+} from "../agents/model-selection.js";
+import { resolveModel } from "../agents/pi-embedded-runner/model.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type SummarizeResult = {
+  summary: string;
+  latencyMs: number;
+  inputLength: number;
+  outputLength: number;
+};
+
+type SummaryModelSelection = {
+  ref: ModelRef;
+  source: "summaryModel" | "default";
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function resolveSummaryModelRef(
+  cfg: OpenClawConfig,
+  config: ResolvedTtsConfig,
+): SummaryModelSelection {
+  const defaultRef = resolveDefaultModelForAgent({ cfg });
+  const override = config.summaryModel?.trim();
+  if (!override) {
+    return { ref: defaultRef, source: "default" };
+  }
+
+  const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: defaultRef.provider });
+  const resolved = resolveModelRefFromString({
+    raw: override,
+    defaultProvider: defaultRef.provider,
+    aliasIndex,
+  });
+  if (!resolved) {
+    return { ref: defaultRef, source: "default" };
+  }
+  return { ref: resolved.ref, source: "summaryModel" };
+}
+
+function isTextContentBlock(block: { type: string }): block is TextContent {
+  return block.type === "text";
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+export async function summarizeText(params: {
+  text: string;
+  targetLength: number;
+  cfg: OpenClawConfig;
+  config: ResolvedTtsConfig;
+  timeoutMs: number;
+}): Promise<SummarizeResult> {
+  const { text, targetLength, cfg, config, timeoutMs } = params;
+  if (targetLength < 100 || targetLength > 10_000) {
+    throw new Error(`Invalid targetLength: ${targetLength}`);
+  }
+
+  const startTime = Date.now();
+  const { ref } = resolveSummaryModelRef(cfg, config);
+  const resolved = resolveModel(ref.provider, ref.model, undefined, cfg);
+  if (!resolved.model) {
+    throw new Error(resolved.error ?? `Unknown summary model: ${ref.provider}/${ref.model}`);
+  }
+  const apiKey = requireApiKey(
+    await getApiKeyForModel({ model: resolved.model, cfg }),
+    ref.provider,
+  );
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const res = await completeSimple(
+        resolved.model,
+        {
+          messages: [
+            {
+              role: "user",
+              content:
+                `You are an assistant that summarizes texts concisely while keeping the most important information. ` +
+                `Summarize the text to approximately ${targetLength} characters. Maintain the original tone and style. ` +
+                `Reply only with the summary, without additional explanations.\n\n` +
+                `<text_to_summarize>\n${text}\n</text_to_summarize>`,
+              timestamp: Date.now(),
+            },
+          ],
+        },
+        {
+          apiKey,
+          maxTokens: Math.ceil(targetLength / 2),
+          temperature: 0.3,
+          signal: controller.signal,
+        },
+      );
+
+      const summary = res.content
+        .filter(isTextContentBlock)
+        .map((block) => block.text.trim())
+        .filter(Boolean)
+        .join(" ")
+        .trim();
+
+      if (!summary) {
+        throw new Error("No summary returned");
+      }
+
+      return {
+        summary,
+        latencyMs: Date.now() - startTime,
+        inputLength: text.length,
+        outputLength: summary.length,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch (err) {
+    const error = err as Error;
+    if (error.name === "AbortError") {
+      throw new Error("Summarization timed out", { cause: err });
+    }
+    throw err;
+  }
+}

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -177,6 +177,15 @@ describe("tts", () => {
   });
 
   describe("parseTtsDirectives", () => {
+    it("recognizes bare [[tts]] tag without parameters", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello [[tts]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.cleanedText).toBe("Hello  world");
+    });
+
     it("extracts overrides and strips directives when enabled", () => {
       const policy = resolveModelOverridePolicy({ enabled: true });
       const input =

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -1,4 +1,3 @@
-import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
 import {
   existsSync,
   mkdirSync,
@@ -21,14 +20,6 @@ import type {
   TtsProvider,
   TtsModelOverrideConfig,
 } from "../config/types.tts.js";
-import { getApiKeyForModel, requireApiKey } from "../agents/model-auth.js";
-import {
-  buildModelAliasIndex,
-  resolveDefaultModelForAgent,
-  resolveModelRefFromString,
-  type ModelRef,
-} from "../agents/model-selection.js";
-import { resolveModel } from "../agents/pi-embedded-runner/model.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import { logVerbose } from "../globals.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
@@ -61,6 +52,7 @@ import {
   edgeTTS,
   inferEdgeExtension,
 } from "./tts-providers.js";
+import { summarizeText } from "./tts-summarize.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TTS_MAX_LENGTH = 1500;
@@ -476,123 +468,7 @@ export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: Tts
 // parseTtsDirectives, OPENAI_TTS_MODELS, OPENAI_TTS_VOICES, isValidOpenAIModel,
 // isValidOpenAIVoice, isCustomOpenAIEndpoint, and related types are in ./tts-directives.ts
 
-type SummarizeResult = {
-  summary: string;
-  latencyMs: number;
-  inputLength: number;
-  outputLength: number;
-};
-
-type SummaryModelSelection = {
-  ref: ModelRef;
-  source: "summaryModel" | "default";
-};
-
-function resolveSummaryModelRef(
-  cfg: OpenClawConfig,
-  config: ResolvedTtsConfig,
-): SummaryModelSelection {
-  const defaultRef = resolveDefaultModelForAgent({ cfg });
-  const override = config.summaryModel?.trim();
-  if (!override) {
-    return { ref: defaultRef, source: "default" };
-  }
-
-  const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: defaultRef.provider });
-  const resolved = resolveModelRefFromString({
-    raw: override,
-    defaultProvider: defaultRef.provider,
-    aliasIndex,
-  });
-  if (!resolved) {
-    return { ref: defaultRef, source: "default" };
-  }
-  return { ref: resolved.ref, source: "summaryModel" };
-}
-
-function isTextContentBlock(block: { type: string }): block is TextContent {
-  return block.type === "text";
-}
-
-async function summarizeText(params: {
-  text: string;
-  targetLength: number;
-  cfg: OpenClawConfig;
-  config: ResolvedTtsConfig;
-  timeoutMs: number;
-}): Promise<SummarizeResult> {
-  const { text, targetLength, cfg, config, timeoutMs } = params;
-  if (targetLength < 100 || targetLength > 10_000) {
-    throw new Error(`Invalid targetLength: ${targetLength}`);
-  }
-
-  const startTime = Date.now();
-  const { ref } = resolveSummaryModelRef(cfg, config);
-  const resolved = resolveModel(ref.provider, ref.model, undefined, cfg);
-  if (!resolved.model) {
-    throw new Error(resolved.error ?? `Unknown summary model: ${ref.provider}/${ref.model}`);
-  }
-  const apiKey = requireApiKey(
-    await getApiKeyForModel({ model: resolved.model, cfg }),
-    ref.provider,
-  );
-
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-    try {
-      const res = await completeSimple(
-        resolved.model,
-        {
-          messages: [
-            {
-              role: "user",
-              content:
-                `You are an assistant that summarizes texts concisely while keeping the most important information. ` +
-                `Summarize the text to approximately ${targetLength} characters. Maintain the original tone and style. ` +
-                `Reply only with the summary, without additional explanations.\n\n` +
-                `<text_to_summarize>\n${text}\n</text_to_summarize>`,
-              timestamp: Date.now(),
-            },
-          ],
-        },
-        {
-          apiKey,
-          maxTokens: Math.ceil(targetLength / 2),
-          temperature: 0.3,
-          signal: controller.signal,
-        },
-      );
-
-      const summary = res.content
-        .filter(isTextContentBlock)
-        .map((block) => block.text.trim())
-        .filter(Boolean)
-        .join(" ")
-        .trim();
-
-      if (!summary) {
-        throw new Error("No summary returned");
-      }
-
-      return {
-        summary,
-        latencyMs: Date.now() - startTime,
-        inputLength: text.length,
-        outputLength: summary.length,
-      };
-    } finally {
-      clearTimeout(timeout);
-    }
-  } catch (err) {
-    const error = err as Error;
-    if (error.name === "AbortError") {
-      throw new Error("Summarization timed out", { cause: err });
-    }
-    throw err;
-  }
-}
+// summarizeText, resolveSummaryModelRef, and related types are in ./tts-summarize.ts
 
 function scheduleCleanup(tempDir: string, delayMs: number = TEMP_FILE_CLEANUP_DELAY_MS): void {
   const timer = setTimeout(() => {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -612,6 +612,13 @@ function parseTtsDirectives(
     return "";
   });
 
+  // Handle bare [[tts]] tag (no parameters) - just signals TTS should be used
+  const bareTtsRegex = /\[\[tts\]\]/gi;
+  cleanedText = cleanedText.replace(bareTtsRegex, () => {
+    hasDirective = true;
+    return "";
+  });
+
   const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
   cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -594,10 +594,6 @@ function parseTtsDirectives(
   text: string,
   policy: ResolvedTtsModelOverrides,
 ): TtsDirectiveParseResult {
-  if (!policy.enabled) {
-    return { cleanedText: text, overrides: {}, warnings: [], hasDirective: false };
-  }
-
   const overrides: TtsDirectiveOverrides = {};
   const warnings: string[] = [];
   let cleanedText = text;
@@ -606,7 +602,7 @@ function parseTtsDirectives(
   const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
   cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
     hasDirective = true;
-    if (policy.allowText && overrides.ttsText == null) {
+    if (policy.enabled && policy.allowText && overrides.ttsText == null) {
       overrides.ttsText = inner.trim();
     }
     return "";
@@ -622,6 +618,9 @@ function parseTtsDirectives(
   const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
   cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;
+    if (!policy.enabled) {
+      return "";
+    }
     const tokens = body.split(/\s+/).filter(Boolean);
     for (const token of tokens) {
       const eqIndex = token.indexOf("=");

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -1,5 +1,4 @@
 import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
-import { EdgeTTS } from "node-edge-tts";
 import {
   existsSync,
   mkdirSync,
@@ -34,50 +33,40 @@ import { normalizeChannelId } from "../channels/plugins/index.js";
 import { logVerbose } from "../globals.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import {
+  parseTtsDirectives,
+  isValidVoiceId,
+  isValidOpenAIModel,
+  isValidOpenAIVoice,
+  OPENAI_TTS_MODELS,
+  OPENAI_TTS_VOICES,
+  type ResolvedTtsModelOverrides,
+  type TtsDirectiveOverrides,
+} from "./tts-directives.js";
+import {
+  DEFAULT_ELEVENLABS_BASE_URL,
+  DEFAULT_ELEVENLABS_VOICE_ID,
+  DEFAULT_ELEVENLABS_MODEL_ID,
+  DEFAULT_ELEVENLABS_VOICE_SETTINGS,
+  DEFAULT_OPENAI_MODEL,
+  DEFAULT_OPENAI_VOICE,
+  DEFAULT_EDGE_VOICE,
+  DEFAULT_EDGE_LANG,
+  DEFAULT_EDGE_OUTPUT_FORMAT,
+  TELEGRAM_OUTPUT,
+  DEFAULT_OUTPUT,
+  TELEPHONY_OUTPUT,
+  elevenLabsTTS,
+  openaiTTS,
+  edgeTTS,
+  inferEdgeExtension,
+} from "./tts-providers.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TTS_MAX_LENGTH = 1500;
 const DEFAULT_TTS_SUMMARIZE = true;
 const DEFAULT_MAX_TEXT_LENGTH = 4096;
 const TEMP_FILE_CLEANUP_DELAY_MS = 5 * 60 * 1000; // 5 minutes
-
-const DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
-const DEFAULT_ELEVENLABS_VOICE_ID = "pMsXgVXv3BLzUgSXRplE";
-const DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2";
-const DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts";
-const DEFAULT_OPENAI_VOICE = "alloy";
-const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
-const DEFAULT_EDGE_LANG = "en-US";
-const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
-
-const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
-  stability: 0.5,
-  similarityBoost: 0.75,
-  style: 0.0,
-  useSpeakerBoost: true,
-  speed: 1.0,
-};
-
-const TELEGRAM_OUTPUT = {
-  openai: "opus" as const,
-  // ElevenLabs output formats use codec_sample_rate_bitrate naming.
-  // Opus @ 48kHz/64kbps is a good voice-note tradeoff for Telegram.
-  elevenlabs: "opus_48000_64",
-  extension: ".opus",
-  voiceCompatible: true,
-};
-
-const DEFAULT_OUTPUT = {
-  openai: "mp3" as const,
-  elevenlabs: "mp3_44100_128",
-  extension: ".mp3",
-  voiceCompatible: false,
-};
-
-const TELEPHONY_OUTPUT = {
-  openai: { format: "pcm" as const, sampleRate: 24000 },
-  elevenlabs: { format: "pcm_22050", sampleRate: 22050 },
-};
 
 const TTS_AUTO_MODES = new Set<TtsAutoMode>(["off", "always", "inbound", "tagged"]);
 
@@ -137,41 +126,8 @@ type TtsUserPrefs = {
   };
 };
 
-type ResolvedTtsModelOverrides = {
-  enabled: boolean;
-  allowText: boolean;
-  allowProvider: boolean;
-  allowVoice: boolean;
-  allowModelId: boolean;
-  allowVoiceSettings: boolean;
-  allowNormalization: boolean;
-  allowSeed: boolean;
-};
-
-type TtsDirectiveOverrides = {
-  ttsText?: string;
-  provider?: TtsProvider;
-  openai?: {
-    voice?: string;
-    model?: string;
-  };
-  elevenlabs?: {
-    voiceId?: string;
-    modelId?: string;
-    seed?: number;
-    applyTextNormalization?: "auto" | "on" | "off";
-    languageCode?: string;
-    voiceSettings?: Partial<ResolvedTtsConfig["elevenlabs"]["voiceSettings"]>;
-  };
-};
-
-type TtsDirectiveParseResult = {
-  cleanedText: string;
-  ttsText?: string;
-  hasDirective: boolean;
-  overrides: TtsDirectiveOverrides;
-  warnings: string[];
-};
+// ResolvedTtsModelOverrides, TtsDirectiveOverrides, TtsDirectiveParseResult
+// are imported from ./tts-directives.js
 
 export type TtsResult = {
   success: boolean;
@@ -514,365 +470,11 @@ export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: Tts
   return Boolean(resolveTtsApiKey(config, provider));
 }
 
-function isValidVoiceId(voiceId: string): boolean {
-  return /^[a-zA-Z0-9]{10,40}$/.test(voiceId);
-}
+// normalizeElevenLabsBaseUrl, assertElevenLabsVoiceSettings, and provider
+// implementations (elevenLabsTTS, openaiTTS, edgeTTS) are in ./tts-providers.ts
 
-function normalizeElevenLabsBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.trim();
-  if (!trimmed) {
-    return DEFAULT_ELEVENLABS_BASE_URL;
-  }
-  return trimmed.replace(/\/+$/, "");
-}
-
-function requireInRange(value: number, min: number, max: number, label: string): void {
-  if (!Number.isFinite(value) || value < min || value > max) {
-    throw new Error(`${label} must be between ${min} and ${max}`);
-  }
-}
-
-function assertElevenLabsVoiceSettings(settings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"]) {
-  requireInRange(settings.stability, 0, 1, "stability");
-  requireInRange(settings.similarityBoost, 0, 1, "similarityBoost");
-  requireInRange(settings.style, 0, 1, "style");
-  requireInRange(settings.speed, 0.5, 2, "speed");
-}
-
-function normalizeLanguageCode(code?: string): string | undefined {
-  const trimmed = code?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const normalized = trimmed.toLowerCase();
-  if (!/^[a-z]{2}$/.test(normalized)) {
-    throw new Error("languageCode must be a 2-letter ISO 639-1 code (e.g. en, de, fr)");
-  }
-  return normalized;
-}
-
-function normalizeApplyTextNormalization(mode?: string): "auto" | "on" | "off" | undefined {
-  const trimmed = mode?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const normalized = trimmed.toLowerCase();
-  if (normalized === "auto" || normalized === "on" || normalized === "off") {
-    return normalized;
-  }
-  throw new Error("applyTextNormalization must be one of: auto, on, off");
-}
-
-function normalizeSeed(seed?: number): number | undefined {
-  if (seed == null) {
-    return undefined;
-  }
-  const next = Math.floor(seed);
-  if (!Number.isFinite(next) || next < 0 || next > 4_294_967_295) {
-    throw new Error("seed must be between 0 and 4294967295");
-  }
-  return next;
-}
-
-function parseBooleanValue(value: string): boolean | undefined {
-  const normalized = value.trim().toLowerCase();
-  if (["true", "1", "yes", "on"].includes(normalized)) {
-    return true;
-  }
-  if (["false", "0", "no", "off"].includes(normalized)) {
-    return false;
-  }
-  return undefined;
-}
-
-function parseNumberValue(value: string): number | undefined {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function parseTtsDirectives(
-  text: string,
-  policy: ResolvedTtsModelOverrides,
-): TtsDirectiveParseResult {
-  const overrides: TtsDirectiveOverrides = {};
-  const warnings: string[] = [];
-  let cleanedText = text;
-  let hasDirective = false;
-
-  const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
-  cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
-    hasDirective = true;
-    if (policy.enabled && policy.allowText && overrides.ttsText == null) {
-      overrides.ttsText = inner.trim();
-    }
-    return "";
-  });
-
-  // Handle bare [[tts]] tag (no parameters) - just signals TTS should be used
-  const bareTtsRegex = /\[\[tts\]\]/gi;
-  cleanedText = cleanedText.replace(bareTtsRegex, () => {
-    hasDirective = true;
-    return "";
-  });
-
-  const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
-  cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
-    hasDirective = true;
-    if (!policy.enabled) {
-      return "";
-    }
-    const tokens = body.split(/\s+/).filter(Boolean);
-    for (const token of tokens) {
-      const eqIndex = token.indexOf("=");
-      if (eqIndex === -1) {
-        continue;
-      }
-      const rawKey = token.slice(0, eqIndex).trim();
-      const rawValue = token.slice(eqIndex + 1).trim();
-      if (!rawKey || !rawValue) {
-        continue;
-      }
-      const key = rawKey.toLowerCase();
-      try {
-        switch (key) {
-          case "provider":
-            if (!policy.allowProvider) {
-              break;
-            }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
-              overrides.provider = rawValue;
-            } else {
-              warnings.push(`unsupported provider "${rawValue}"`);
-            }
-            break;
-          case "voice":
-          case "openai_voice":
-          case "openaivoice":
-            if (!policy.allowVoice) {
-              break;
-            }
-            if (isValidOpenAIVoice(rawValue)) {
-              overrides.openai = { ...overrides.openai, voice: rawValue };
-            } else {
-              warnings.push(`invalid OpenAI voice "${rawValue}"`);
-            }
-            break;
-          case "voiceid":
-          case "voice_id":
-          case "elevenlabs_voice":
-          case "elevenlabsvoice":
-            if (!policy.allowVoice) {
-              break;
-            }
-            if (isValidVoiceId(rawValue)) {
-              overrides.elevenlabs = { ...overrides.elevenlabs, voiceId: rawValue };
-            } else {
-              warnings.push(`invalid ElevenLabs voiceId "${rawValue}"`);
-            }
-            break;
-          case "model":
-          case "modelid":
-          case "model_id":
-          case "elevenlabs_model":
-          case "elevenlabsmodel":
-          case "openai_model":
-          case "openaimodel":
-            if (!policy.allowModelId) {
-              break;
-            }
-            if (isValidOpenAIModel(rawValue)) {
-              overrides.openai = { ...overrides.openai, model: rawValue };
-            } else {
-              overrides.elevenlabs = { ...overrides.elevenlabs, modelId: rawValue };
-            }
-            break;
-          case "stability":
-            if (!policy.allowVoiceSettings) {
-              break;
-            }
-            {
-              const value = parseNumberValue(rawValue);
-              if (value == null) {
-                warnings.push("invalid stability value");
-                break;
-              }
-              requireInRange(value, 0, 1, "stability");
-              overrides.elevenlabs = {
-                ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, stability: value },
-              };
-            }
-            break;
-          case "similarity":
-          case "similarityboost":
-          case "similarity_boost":
-            if (!policy.allowVoiceSettings) {
-              break;
-            }
-            {
-              const value = parseNumberValue(rawValue);
-              if (value == null) {
-                warnings.push("invalid similarityBoost value");
-                break;
-              }
-              requireInRange(value, 0, 1, "similarityBoost");
-              overrides.elevenlabs = {
-                ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, similarityBoost: value },
-              };
-            }
-            break;
-          case "style":
-            if (!policy.allowVoiceSettings) {
-              break;
-            }
-            {
-              const value = parseNumberValue(rawValue);
-              if (value == null) {
-                warnings.push("invalid style value");
-                break;
-              }
-              requireInRange(value, 0, 1, "style");
-              overrides.elevenlabs = {
-                ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, style: value },
-              };
-            }
-            break;
-          case "speed":
-            if (!policy.allowVoiceSettings) {
-              break;
-            }
-            {
-              const value = parseNumberValue(rawValue);
-              if (value == null) {
-                warnings.push("invalid speed value");
-                break;
-              }
-              requireInRange(value, 0.5, 2, "speed");
-              overrides.elevenlabs = {
-                ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, speed: value },
-              };
-            }
-            break;
-          case "speakerboost":
-          case "speaker_boost":
-          case "usespeakerboost":
-          case "use_speaker_boost":
-            if (!policy.allowVoiceSettings) {
-              break;
-            }
-            {
-              const value = parseBooleanValue(rawValue);
-              if (value == null) {
-                warnings.push("invalid useSpeakerBoost value");
-                break;
-              }
-              overrides.elevenlabs = {
-                ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, useSpeakerBoost: value },
-              };
-            }
-            break;
-          case "normalize":
-          case "applytextnormalization":
-          case "apply_text_normalization":
-            if (!policy.allowNormalization) {
-              break;
-            }
-            overrides.elevenlabs = {
-              ...overrides.elevenlabs,
-              applyTextNormalization: normalizeApplyTextNormalization(rawValue),
-            };
-            break;
-          case "language":
-          case "languagecode":
-          case "language_code":
-            if (!policy.allowNormalization) {
-              break;
-            }
-            overrides.elevenlabs = {
-              ...overrides.elevenlabs,
-              languageCode: normalizeLanguageCode(rawValue),
-            };
-            break;
-          case "seed":
-            if (!policy.allowSeed) {
-              break;
-            }
-            overrides.elevenlabs = {
-              ...overrides.elevenlabs,
-              seed: normalizeSeed(Number.parseInt(rawValue, 10)),
-            };
-            break;
-          default:
-            break;
-        }
-      } catch (err) {
-        warnings.push((err as Error).message);
-      }
-    }
-    return "";
-  });
-
-  return {
-    cleanedText,
-    ttsText: overrides.ttsText,
-    hasDirective,
-    overrides,
-    warnings,
-  };
-}
-
-export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as const;
-
-/**
- * Custom OpenAI-compatible TTS endpoint.
- * When set, model/voice validation is relaxed to allow non-OpenAI models.
- * Example: OPENAI_TTS_BASE_URL=http://localhost:8880/v1
- *
- * Note: Read at runtime (not module load) to support config.env loading.
- */
-function getOpenAITtsBaseUrl(): string {
-  return (process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1").replace(
-    /\/+$/,
-    "",
-  );
-}
-
-function isCustomOpenAIEndpoint(): boolean {
-  return getOpenAITtsBaseUrl() !== "https://api.openai.com/v1";
-}
-export const OPENAI_TTS_VOICES = [
-  "alloy",
-  "ash",
-  "coral",
-  "echo",
-  "fable",
-  "onyx",
-  "nova",
-  "sage",
-  "shimmer",
-] as const;
-
-type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
-
-function isValidOpenAIModel(model: string): boolean {
-  // Allow any model when using custom endpoint (e.g., Kokoro, LocalAI)
-  if (isCustomOpenAIEndpoint()) {
-    return true;
-  }
-  return OPENAI_TTS_MODELS.includes(model as (typeof OPENAI_TTS_MODELS)[number]);
-}
-
-function isValidOpenAIVoice(voice: string): voice is OpenAiTtsVoice {
-  // Allow any voice when using custom endpoint (e.g., Kokoro Chinese voices)
-  if (isCustomOpenAIEndpoint()) {
-    return true;
-  }
-  return OPENAI_TTS_VOICES.includes(voice as OpenAiTtsVoice);
-}
+// parseTtsDirectives, OPENAI_TTS_MODELS, OPENAI_TTS_VOICES, isValidOpenAIModel,
+// isValidOpenAIVoice, isCustomOpenAIEndpoint, and related types are in ./tts-directives.ts
 
 type SummarizeResult = {
   summary: string;
@@ -1001,167 +603,6 @@ function scheduleCleanup(tempDir: string, delayMs: number = TEMP_FILE_CLEANUP_DE
     }
   }, delayMs);
   timer.unref();
-}
-
-async function elevenLabsTTS(params: {
-  text: string;
-  apiKey: string;
-  baseUrl: string;
-  voiceId: string;
-  modelId: string;
-  outputFormat: string;
-  seed?: number;
-  applyTextNormalization?: "auto" | "on" | "off";
-  languageCode?: string;
-  voiceSettings: ResolvedTtsConfig["elevenlabs"]["voiceSettings"];
-  timeoutMs: number;
-}): Promise<Buffer> {
-  const {
-    text,
-    apiKey,
-    baseUrl,
-    voiceId,
-    modelId,
-    outputFormat,
-    seed,
-    applyTextNormalization,
-    languageCode,
-    voiceSettings,
-    timeoutMs,
-  } = params;
-  if (!isValidVoiceId(voiceId)) {
-    throw new Error("Invalid voiceId format");
-  }
-  assertElevenLabsVoiceSettings(voiceSettings);
-  const normalizedLanguage = normalizeLanguageCode(languageCode);
-  const normalizedNormalization = normalizeApplyTextNormalization(applyTextNormalization);
-  const normalizedSeed = normalizeSeed(seed);
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const url = new URL(`${normalizeElevenLabsBaseUrl(baseUrl)}/v1/text-to-speech/${voiceId}`);
-    if (outputFormat) {
-      url.searchParams.set("output_format", outputFormat);
-    }
-
-    const response = await fetch(url.toString(), {
-      method: "POST",
-      headers: {
-        "xi-api-key": apiKey,
-        "Content-Type": "application/json",
-        Accept: "audio/mpeg",
-      },
-      body: JSON.stringify({
-        text,
-        model_id: modelId,
-        seed: normalizedSeed,
-        apply_text_normalization: normalizedNormalization,
-        language_code: normalizedLanguage,
-        voice_settings: {
-          stability: voiceSettings.stability,
-          similarity_boost: voiceSettings.similarityBoost,
-          style: voiceSettings.style,
-          use_speaker_boost: voiceSettings.useSpeakerBoost,
-          speed: voiceSettings.speed,
-        },
-      }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error(`ElevenLabs API error (${response.status})`);
-    }
-
-    return Buffer.from(await response.arrayBuffer());
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-async function openaiTTS(params: {
-  text: string;
-  apiKey: string;
-  model: string;
-  voice: string;
-  responseFormat: "mp3" | "opus" | "pcm";
-  timeoutMs: number;
-}): Promise<Buffer> {
-  const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
-
-  if (!isValidOpenAIModel(model)) {
-    throw new Error(`Invalid model: ${model}`);
-  }
-  if (!isValidOpenAIVoice(voice)) {
-    throw new Error(`Invalid voice: ${voice}`);
-  }
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const response = await fetch(`${getOpenAITtsBaseUrl()}/audio/speech`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model,
-        input: text,
-        voice,
-        response_format: responseFormat,
-      }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error(`OpenAI TTS API error (${response.status})`);
-    }
-
-    return Buffer.from(await response.arrayBuffer());
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-function inferEdgeExtension(outputFormat: string): string {
-  const normalized = outputFormat.toLowerCase();
-  if (normalized.includes("webm")) {
-    return ".webm";
-  }
-  if (normalized.includes("ogg")) {
-    return ".ogg";
-  }
-  if (normalized.includes("opus")) {
-    return ".opus";
-  }
-  if (normalized.includes("wav") || normalized.includes("riff") || normalized.includes("pcm")) {
-    return ".wav";
-  }
-  return ".mp3";
-}
-
-async function edgeTTS(params: {
-  text: string;
-  outputPath: string;
-  config: ResolvedTtsConfig["edge"];
-  timeoutMs: number;
-}): Promise<void> {
-  const { text, outputPath, config, timeoutMs } = params;
-  const tts = new EdgeTTS({
-    voice: config.voice,
-    lang: config.lang,
-    outputFormat: config.outputFormat,
-    saveSubtitles: config.saveSubtitles,
-    proxy: config.proxy,
-    rate: config.rate,
-    pitch: config.pitch,
-    volume: config.volume,
-    timeout: config.timeoutMs ?? timeoutMs,
-  });
-  await tts.ttsPromise(text, outputPath);
 }
 
 export async function textToSpeech(params: {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -34,6 +34,8 @@ import {
   type ResolvedTtsModelOverrides,
   type TtsDirectiveOverrides,
 } from "./tts-directives.js";
+
+export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES };
 import {
   DEFAULT_ELEVENLABS_BASE_URL,
   DEFAULT_ELEVENLABS_VOICE_ID,


### PR DESCRIPTION
## Problem

After recent Debian bookworm-slim updates, the sandbox image enforces PEP 668 (externally-managed environment), blocking `pip install`. At the same time, `python3-venv` isn't included, so the recommended venv workaround doesn't work either.

Users see:
```
error: externally-managed-environment
```

## Fix

- Add `python3-pip` and `python3-venv` to the sandbox Dockerfile
- Remove the `EXTERNALLY-MANAGED` marker file

Since the sandbox is ephemeral and fully isolated, PEP 668's system-package protection provides no benefit here.

Closes #13492

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the sandbox image to restore Python package installation after Debian bookworm-slim started enforcing PEP 668: it installs `python3-pip`/`python3-venv` and removes the `EXTERNALLY-MANAGED` marker. It also refactors the TTS implementation by extracting directive parsing, provider implementations, and summarization into separate modules, and adds a unit test for a bare `[[tts]]` tag.

The main concerns are in the TTS refactor: the new modules (`src/tts/tts-directives.ts`, `src/tts/tts-providers.ts`) import `ResolvedTtsConfig` from `tts.ts` while `tts.ts` imports from those modules, creating ESM circular dependencies that can break at runtime. Additionally, `parseTtsDirectives` still strips `[[tts:text]]...[[/tts:text]]` blocks even when overrides are disabled, which can remove user-visible content in that mode. On the sandbox side, the `EXTERNALLY-MANAGED` removal relies on a single globbed path and may not actually remove the marker on all Debian layouts, leaving the original error in place.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to likely runtime breakage in the TTS refactor.
- Two new TTS modules introduce ESM circular dependencies with `tts.ts` that can cause runtime initialization errors, and directive parsing can unexpectedly strip `[[tts:text]]` content even when overrides are disabled. The sandbox change may also fail to remove the PEP 668 marker depending on Debian path layout.
- src/tts/tts-directives.ts, src/tts/tts-providers.ts, Dockerfile.sandbox

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->