### PR TITLE
feat(slack): add thread.implicitMentionAsParent config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Added
 
+- Slack: add `thread.implicitMentionAsParent` config option to disable implicit bot responses in threads the bot started. (#13419)
 - Commands: add `commands.allowFrom` config for separate command authorization, allowing operators to restrict slash commands to specific users while keeping chat open to others. (#12430) Thanks @thewilloftheshadow.
 - iOS: alpha node app + setup-code onboarding. (#11756) Thanks @mbelinky.
 - Channels: comprehensive BlueBubbles and channel cleanup. (#11093) Thanks @tyler6204.

--- a/src/channels/mention-gating.test.ts
+++ b/src/channels/mention-gating.test.ts
@@ -66,4 +66,52 @@ describe("resolveMentionGatingWithBypass", () => {
     expect(res.shouldBypassMention).toBe(false);
     expect(res.shouldSkip).toBe(true);
   });
+
+  it("skips when implicitMention is false even in bot-started threads (#13419)", () => {
+    const res = resolveMentionGatingWithBypass({
+      isGroup: true,
+      requireMention: true,
+      canDetectMention: true,
+      wasMentioned: false,
+      implicitMention: false,
+      hasAnyMention: false,
+      allowTextCommands: true,
+      hasControlCommand: false,
+      commandAuthorized: false,
+    });
+    expect(res.effectiveWasMentioned).toBe(false);
+    expect(res.shouldSkip).toBe(true);
+  });
+
+  it("responds when implicitMention is true in bot-started threads (#13419)", () => {
+    const res = resolveMentionGatingWithBypass({
+      isGroup: true,
+      requireMention: true,
+      canDetectMention: true,
+      wasMentioned: false,
+      implicitMention: true,
+      hasAnyMention: false,
+      allowTextCommands: true,
+      hasControlCommand: false,
+      commandAuthorized: false,
+    });
+    expect(res.effectiveWasMentioned).toBe(true);
+    expect(res.shouldSkip).toBe(false);
+  });
+
+  it("responds to explicit @mention even when implicitMention is false (#13419)", () => {
+    const res = resolveMentionGatingWithBypass({
+      isGroup: true,
+      requireMention: true,
+      canDetectMention: true,
+      wasMentioned: true,
+      implicitMention: false,
+      hasAnyMention: true,
+      allowTextCommands: true,
+      hasControlCommand: false,
+      commandAuthorized: false,
+    });
+    expect(res.effectiveWasMentioned).toBe(true);
+    expect(res.shouldSkip).toBe(false);
+  });
 });

--- a/src/config/schema.field-metadata.ts
+++ b/src/config/schema.field-metadata.ts
@@ -322,6 +322,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.slack.userTokenReadOnly": "Slack User Token Read Only",
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
+  "channels.slack.thread.implicitMentionAsParent": "Slack Thread Implicit Mention As Parent",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.chatmode": "Mattermost Chat Mode",
@@ -465,6 +466,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Scope for Slack thread history context ("thread" isolates per thread; "channel" reuses channel history).',
   "channels.slack.thread.inheritParent":
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
+  "channels.slack.thread.implicitMentionAsParent":
+    "If false, the bot will not implicitly respond in threads it started without an explicit @mention (default: true).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -369,6 +369,7 @@ const FIELD_LABELS: Record<string, string> = {
   "channels.slack.userTokenReadOnly": "Slack User Token Read Only",
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
+  "channels.slack.thread.implicitMentionAsParent": "Slack Thread Implicit Mention As Parent",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.chatmode": "Mattermost Chat Mode",
@@ -512,6 +513,8 @@ const FIELD_HELP: Record<string, string> = {
     'Scope for Slack thread history context ("thread" isolates per thread; "channel" reuses channel history).',
   "channels.slack.thread.inheritParent":
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
+  "channels.slack.thread.implicitMentionAsParent":
+    "If false, the bot will not implicitly respond in threads it started without an explicit @mention (default: true).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -73,6 +73,8 @@ export type SlackThreadConfig = {
   historyScope?: "thread" | "channel";
   /** If true, thread sessions inherit the parent channel transcript. Default: false. */
   inheritParent?: boolean;
+  /** If false, bot will not implicitly respond in threads it started without an explicit @mention. Default: true. */
+  implicitMentionAsParent?: boolean;
 };
 
 export type SlackAccountConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -445,6 +445,7 @@ export const SlackThreadSchema = z
   .object({
     historyScope: z.enum(["thread", "channel"]).optional(),
     inheritParent: z.boolean().optional(),
+    implicitMentionAsParent: z.boolean().optional(),
   })
   .strict();
 

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -89,6 +89,7 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
+  threadImplicitMentionAsParent: boolean;
   slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
   textLimit: number;
   ackReactionScope: string;
@@ -150,6 +151,7 @@ export function createSlackMonitorContext(params: {
   replyToMode: SlackMonitorContext["replyToMode"];
   threadHistoryScope: SlackMonitorContext["threadHistoryScope"];
   threadInheritParent: SlackMonitorContext["threadInheritParent"];
+  threadImplicitMentionAsParent: SlackMonitorContext["threadImplicitMentionAsParent"];
   slashCommand: SlackMonitorContext["slashCommand"];
   textLimit: number;
   ackReactionScope: string;
@@ -412,6 +414,7 @@ export function createSlackMonitorContext(params: {
     replyToMode: params.replyToMode,
     threadHistoryScope: params.threadHistoryScope,
     threadInheritParent: params.threadInheritParent,
+    threadImplicitMentionAsParent: params.threadImplicitMentionAsParent,
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,

--- a/src/slack/monitor/message-handler/prepare.inbound-contract.test.ts
+++ b/src/slack/monitor/message-handler/prepare.inbound-contract.test.ts
@@ -37,6 +37,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       replyToMode: "off",
       threadHistoryScope: "thread",
       threadInheritParent: false,
+      threadImplicitMentionAsParent: true,
       slashCommand: {
         enabled: false,
         name: "openclaw",
@@ -114,6 +115,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       replyToMode: "off",
       threadHistoryScope: "thread",
       threadInheritParent: false,
+      threadImplicitMentionAsParent: true,
       slashCommand: {
         enabled: false,
         name: "openclaw",
@@ -195,6 +197,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       replyToMode: "all",
       threadHistoryScope: "thread",
       threadInheritParent: false,
+      threadImplicitMentionAsParent: true,
       slashCommand: {
         enabled: false,
         name: "openclaw",

--- a/src/slack/monitor/message-handler/prepare.sender-prefix.test.ts
+++ b/src/slack/monitor/message-handler/prepare.sender-prefix.test.ts
@@ -39,6 +39,7 @@ describe("prepareSlackMessage sender prefix", () => {
       replyToMode: "off",
       threadHistoryScope: "channel",
       threadInheritParent: false,
+      threadImplicitMentionAsParent: true,
       slashCommand: { command: "/openclaw", enabled: true },
       textLimit: 2000,
       ackReactionScope: "off",

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -226,7 +226,8 @@ export async function prepareSlackMessage(params: {
     !isDirectMessage &&
     ctx.botUserId &&
     message.thread_ts &&
-    message.parent_user_id === ctx.botUserId,
+    message.parent_user_id === ctx.botUserId &&
+    ctx.threadImplicitMentionAsParent,
   );
 
   const sender = message.user ? await ctx.resolveUserName(message.user) : null;

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -115,6 +115,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const replyToMode = slackCfg.replyToMode ?? "off";
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
+  const threadImplicitMentionAsParent = slackCfg.thread?.implicitMentionAsParent ?? true;
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
@@ -196,6 +197,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     replyToMode,
     threadHistoryScope,
     threadInheritParent,
+    threadImplicitMentionAsParent,
     slashCommand,
     textLimit,
     ackReactionScope,


### PR DESCRIPTION
## Summary
Fixes #13419

## Problem
When the bot is the parent of a Slack thread (i.e. the bot posted the first message), `implicitMention` is always set to `true`, causing the bot to respond to every thread reply even without an explicit @mention. There is no config option to disable this behavior.

## Fix
Add `thread.implicitMentionAsParent` config option (default: `true` for backwards compatibility). When set to `false`, the bot requires an explicit @mention even in threads it started.

**Config example:**
```json
{
  "channels": {
    "slack": {
      "thread": {
        "implicitMentionAsParent": false
      }
    }
  }
}
```

**Before:**
```typescript
const implicitMention = Boolean(
  !isDirectMessage &&
  ctx.botUserId &&
  message.thread_ts &&
  message.parent_user_id === ctx.botUserId,
);
```

**After:**
```typescript
const implicitMention = Boolean(
  !isDirectMessage &&
  ctx.botUserId &&
  message.thread_ts &&
  message.parent_user_id === ctx.botUserId &&
  ctx.threadImplicitMentionAsParent,
);
```

## Reproduction & Verification

### Before fix (main branch) — Bug reproduced with real function calls:
```
Scenario: bot is thread parent, requireMention=true, no @mention
  implicitMention: true (hardcoded when bot is thread parent)
  effectiveWasMentioned: true
  shouldSkip: false

BUG CONFIRMED: bot responds to ALL thread replies even without @mention
   There is no config option to disable implicitMention for thread parents
```

### After fix — Verified with real function calls:
```
Test 1: implicitMention=true (default) — bot responds in own threads
  PASS: effectiveWasMentioned is true
  PASS: shouldSkip is false (bot responds)

Test 2: implicitMention=false (user disabled) — bot requires @mention
  PASS: effectiveWasMentioned is false
  PASS: shouldSkip is true (bot skips)

Test 3: implicitMention=false but explicit @mention — bot still responds
  PASS: effectiveWasMentioned is true
  PASS: shouldSkip is false (bot responds to @mention)

Test 4: DM — implicitMention irrelevant (DMs always respond)
  PASS: shouldSkip is false (DMs always respond)

--- Result: ALL PASSED (7/7) ---
```

## Effect on User Experience

**Before fix:**
Bot responds to every reply in threads it started, even without @mention. No way to disable this when `requireMention` is enabled.

**After fix:**
Users can set `thread.implicitMentionAsParent: false` to require explicit @mention in bot-started threads. Default remains `true` for backwards compatibility.

## Testing
- 12 tests pass (5 existing + 3 new regression tests + 4 existing fixture updates)
- Lint passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Slack configuration flag `channels.slack.thread.implicitMentionAsParent` (default `true`) to control whether the bot treats replies in threads it started as implicitly mentioned.

The change is wired end-to-end:
- Config schema/types updated (`SlackThreadSchema`, `SlackThreadConfig`, schema labels/help).
- Provider reads the new flag and passes it into `SlackMonitorContext`.
- Slack message preparation now includes the flag in the `implicitMention` calculation, so disabling it requires an explicit @mention when `requireMention` is enabled.
- Tests/fixtures updated and new regression tests added for mention gating behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, feature-scoped, and appear fully wired through config schema/types, provider context, and message handling; updated tests cover the new gating behavior and no missing call sites were found.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->