### PR TITLE
fix(whatsapp): retry initial connection failures with backoff

### DIFF
--- a/src/web/auto-reply.web-auto-reply.retries-initial-connection-failure.test.ts
+++ b/src/web/auto-reply.web-auto-reply.retries-initial-connection-failure.test.ts
@@ -1,0 +1,146 @@
+import "./test-helpers.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+
+import { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
+import { resetLogger, setLoggerOverride } from "../logging.js";
+import { monitorWebChannel } from "./auto-reply.js";
+import { resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
+
+let previousHome: string | undefined;
+let tempHome: string | undefined;
+
+beforeEach(async () => {
+  resetInboundDedupe();
+  previousHome = process.env.HOME;
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-web-home-"));
+  process.env.HOME = tempHome;
+});
+
+afterEach(async () => {
+  process.env.HOME = previousHome;
+  if (tempHome) {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      try {
+        await fs.rm(tempHome, { recursive: true, force: true });
+        break;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+    tempHome = undefined;
+  }
+});
+
+describe("web auto-reply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetBaileysMocks();
+    resetLoadConfigMock();
+  });
+
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+    vi.useRealTimers();
+  });
+
+  it("retries when initial connection fails (e.g. DNS error)", async () => {
+    let callCount = 0;
+    const sleep = vi.fn(async () => {});
+    const listenerFactory = vi.fn(async () => {
+      callCount += 1;
+      if (callCount <= 2) {
+        throw new Error("getaddrinfo ENOTFOUND web.whatsapp.com");
+      }
+      // Third attempt succeeds
+      const onClose = new Promise<void>(() => {});
+      return { close: vi.fn(), onClose };
+    });
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const controller = new AbortController();
+    const run = monitorWebChannel(
+      false,
+      listenerFactory,
+      true,
+      async () => ({ text: "ok" }),
+      runtime as never,
+      controller.signal,
+      {
+        heartbeatSeconds: 1,
+        reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 5, factor: 1.1 },
+        sleep,
+      },
+    );
+
+    // Wait for retries to happen
+    const waitForThirdCall = async () => {
+      const started = Date.now();
+      while (listenerFactory.mock.calls.length < 3 && Date.now() - started < 2000) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    };
+    await waitForThirdCall();
+
+    expect(listenerFactory).toHaveBeenCalledTimes(3);
+    // sleep was called for the 2 failed attempts
+    expect(sleep).toHaveBeenCalledTimes(2);
+    // Error messages logged for failed attempts
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("initial connection failed"),
+    );
+
+    controller.abort();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await run;
+  });
+
+  it("stops after max attempts on initial connection failure", { timeout: 30_000 }, async () => {
+    const sleep = vi.fn(async () => {});
+    const listenerFactory = vi.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND web.whatsapp.com");
+    });
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    const run = monitorWebChannel(
+      false,
+      listenerFactory,
+      true,
+      async () => ({ text: "ok" }),
+      runtime as never,
+      undefined,
+      {
+        heartbeatSeconds: 1,
+        reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 2, factor: 1.1 },
+        sleep,
+      },
+    );
+
+    await run;
+
+    // Attempted 2 times then stopped
+    expect(listenerFactory).toHaveBeenCalledTimes(2);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("initial connection failed after"),
+    );
+  });
+});

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -189,24 +189,68 @@ export async function monitorWebChannel(
       return !hasControlCommand(msg.body, cfg);
     };
 
-    const listener = await (listenerFactory ?? monitorWebInbox)({
-      verbose,
-      accountId: account.accountId,
-      authDir: account.authDir,
-      mediaMaxMb: account.mediaMaxMb,
-      sendReadReceipts: account.sendReadReceipts,
-      debounceMs: inboundDebounceMs,
-      shouldDebounce,
-      onMessage: async (msg: WebInboundMsg) => {
-        handledMessages += 1;
-        lastMessageAt = Date.now();
-        status.lastMessageAt = lastMessageAt;
-        status.lastEventAt = lastMessageAt;
-        emitStatus();
-        _lastInboundMsg = msg;
-        await onMessage(msg);
-      },
-    });
+    let listener: Awaited<ReturnType<typeof monitorWebInbox>>;
+    try {
+      listener = await (listenerFactory ?? monitorWebInbox)({
+        verbose,
+        accountId: account.accountId,
+        authDir: account.authDir,
+        mediaMaxMb: account.mediaMaxMb,
+        sendReadReceipts: account.sendReadReceipts,
+        debounceMs: inboundDebounceMs,
+        shouldDebounce,
+        onMessage: async (msg: WebInboundMsg) => {
+          handledMessages += 1;
+          lastMessageAt = Date.now();
+          status.lastMessageAt = lastMessageAt;
+          status.lastEventAt = lastMessageAt;
+          emitStatus();
+          _lastInboundMsg = msg;
+          await onMessage(msg);
+        },
+      });
+    } catch (err) {
+      // Initial connection failed (e.g. DNS resolution error, network down).
+      // Apply the same reconnect backoff instead of letting the error escape the loop.
+      const errorStr = formatError(err);
+      reconnectLogger.warn(
+        { connectionId, error: errorStr, reconnectAttempts },
+        "web reconnect: initial connection failed",
+      );
+
+      reconnectAttempts += 1;
+      status.reconnectAttempts = reconnectAttempts;
+      status.connected = false;
+      status.lastError = errorStr;
+      status.lastEventAt = Date.now();
+      emitStatus();
+
+      if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
+        reconnectLogger.warn(
+          { connectionId, reconnectAttempts, maxAttempts: reconnectPolicy.maxAttempts },
+          "web reconnect: max attempts reached during initial connection; stopping",
+        );
+        runtime.error(
+          `WhatsApp Web initial connection failed after ${reconnectAttempts}/${reconnectPolicy.maxAttempts} attempts. Stopping web monitoring.`,
+        );
+        break;
+      }
+
+      const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
+      reconnectLogger.info(
+        { connectionId, reconnectAttempts, delayMs: delay },
+        "web reconnect: scheduling retry after initial connection failure",
+      );
+      runtime.error(
+        `WhatsApp Web initial connection failed. Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(delay)}… (${errorStr})`,
+      );
+      try {
+        await sleep(delay, abortSignal);
+      } catch {
+        break;
+      }
+      continue;
+    }
 
     status.connected = true;
     status.lastConnectedAt = Date.now();


### PR DESCRIPTION
## Problem

When the WhatsApp Web listener encounters a DNS or network error (e.g. `ENOTFOUND web.whatsapp.com`) during the **initial** connection attempt in `monitorWebChannel`, the error escapes the reconnect loop entirely. The gateway process keeps running but the WhatsApp channel remains dead until a manual restart.

This is distinct from mid-session disconnects (which are handled by the existing reconnect/backoff logic). The bug is specifically that the first `await listenerFactory()` call has no error handling — if it throws, the entire channel monitor exits.

## Root Cause

In `src/web/auto-reply/monitor.ts`, the reconnect loop calls `await listenerFactory()` without a `try/catch`. When this initial call fails (e.g., DNS resolution error), the error propagates up and exits `monitorWebChannel`. The existing backoff/retry logic only kicks in for *subsequent* disconnects (via `listener.onClose`), not for failures during initial startup.

## Fix

Wrap the `listenerFactory()` call in a `try/catch` that applies the same reconnect backoff logic:

- Logs the connection failure with context
- Increments `reconnectAttempts` and updates status
- Respects `maxAttempts` limit (stops if exceeded)
- Computes exponential backoff delay
- Uses `continue` to retry the loop iteration

This ensures initial connection failures are treated identically to mid-session disconnects.

## Tests

Added `auto-reply.web-auto-reply.retries-initial-connection-failure.test.ts` with two test cases:

1. **Retries on DNS failure** — verifies that after 2 failed `listenerFactory` calls (DNS error), the 3rd attempt succeeds and the channel connects normally
2. **Stops after max attempts** — verifies that when all connection attempts fail, the monitor exits cleanly after hitting `maxAttempts`

All existing reconnect tests continue to pass.

Fixes #13506

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a startup edge case in the WhatsApp Web auto-reply monitor where the first `listenerFactory()`/`monitorWebInbox()` call could throw (e.g., DNS/network errors) and escape the reconnect loop. The change wraps the initial listener creation in a `try/catch` and applies the same backoff/retry policy used for mid-session disconnects, including status updates and a `maxAttempts` stop condition.

It also adds a new Vitest file that exercises (1) retry-until-success for an initial DNS-style failure and (2) stopping cleanly after hitting `maxAttempts` during initial connection startup.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing test flakiness risks
- The production change is localized and uses existing reconnect/backoff primitives, but the new tests rely on wall-clock polling and a sleep stub that ignores the abort signal, which can cause intermittent failures/hangs in CI.
- src/web/auto-reply.web-auto-reply.retries-initial-connection-failure.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->