### PR TITLE
fix(gateway): prevent infinite restart loop from meta config self-modification

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -108,6 +108,13 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("gateway.remote.url");
   });
 
+  it("treats meta fields as no-op (prevents self-modification restart loop)", () => {
+    const plan = buildGatewayReloadPlan(["meta.lastTouchedVersion", "meta.lastTouchedAt"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("meta.lastTouchedVersion");
+    expect(plan.noopPaths).toContain("meta.lastTouchedAt");
+  });
+
   it("defaults unknown paths to restart", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
     expect(plan.restartGateway).toBe(true);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -64,6 +64,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
 ];
 
 const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
+  { prefix: "meta", kind: "none" },
   { prefix: "identity", kind: "none" },
   { prefix: "wizard", kind: "none" },
   { prefix: "logging", kind: "none" },


### PR DESCRIPTION
## Summary

Fixes #13458 — The gateway enters an infinite restart loop because it modifies `meta.lastTouchedVersion` and `meta.lastTouchedAt` in `openclaw.json` on every config write. The config file watcher detects these changes but has no reload rule for the `meta` prefix, so they fall through to the default behavior: triggering a full gateway restart. Each restart writes the config again, creating the loop.

## Root Cause

In `config-reload.ts`, the `BASE_RELOAD_RULES_TAIL` array defines which config prefixes are safe to ignore (`kind: "none"`), hot-reload, or require restart. The `meta` prefix was missing from this list. When `buildGatewayReloadPlan` encounters a changed path with no matching rule, it defaults to `restartGateway = true`.

## Fix

Add `{ prefix: "meta", kind: "none" }` to `BASE_RELOAD_RULES_TAIL` so that changes to `meta.*` fields (which are auto-stamped by the application itself) are treated as no-ops by the reload system.

## Testing

- Added test case verifying `meta.lastTouchedVersion` and `meta.lastTouchedAt` are treated as no-ops
- All existing config-reload tests pass (9/9)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway config reload rules so that changes under the `meta.*` prefix are treated as no-ops, preventing a self-induced restart loop when the application stamps `meta.lastTouchedVersion` / `meta.lastTouchedAt` during config writes. It also adds a targeted unit test to ensure `buildGatewayReloadPlan` does not request a gateway restart for those meta fields.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (adds a missing reload rule for `meta.*`) and is covered by a focused test asserting these paths are treated as no-ops; no other reload behaviors are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->