### PR TITLE
fix(web-search): fix Grok xAI 400 error and empty response content

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -198,6 +198,37 @@ describe("web_search grok response parsing", () => {
     expect(result.annotations).toBeUndefined();
   });
 
+  it("adjusts annotation offsets when concatenating multiple blocks", () => {
+    const result = extractGrokContent({
+      output: [
+        {
+          type: "message",
+          content: [
+            {
+              type: "output_text",
+              text: "hello", // length 5
+              annotations: [
+                { type: "url_citation", url: "https://a.com", start_index: 0, end_index: 5 },
+              ],
+            },
+            {
+              type: "output_text",
+              text: "world", // offset = 5 + 1 ("\n") = 6
+              annotations: [
+                { type: "url_citation", url: "https://b.com", start_index: 0, end_index: 5 },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.text).toBe("hello\nworld");
+    expect(result.annotations).toEqual([
+      { start_index: 0, end_index: 5, url: "https://a.com" },
+      { start_index: 6, end_index: 11, url: "https://b.com" },
+    ]);
+  });
+
   it("skips non-message output items", () => {
     const result = extractGrokContent({
       output: [


### PR DESCRIPTION
## Summary

Fixes two bugs in the Grok (xAI) `web_search` provider added in 2026.2.9 (#12419):

- **400 error**: `include: ["inline_citations"]` was sent to the xAI REST API, which rejects it with `{"code":"400","error":"Argument not supported: include"}`. Per [xAI's citation docs](https://docs.x.ai/docs/guides/web-search#inline-citations), inline citations are returned by default via the REST API — the `include` parameter is SDK-only. Removed the unsupported parameter.
- **Empty content ("No response")**: The code read `data.output_text` which does not exist in xAI's response (unlike OpenAI's Responses API). Content is nested at `output[].content[].text` where `type === "message"`. Updated `extractGrokContent` to properly traverse the response structure.
- **Missing inline citations**: Annotations are now correctly extracted from `output[].content[].annotations` instead of relying on the non-existent top-level `data.inline_citations`.

### Changes

| File | Change | Why |
|------|--------|-----|
| `web-search.ts` | Remove `body.include = ["inline_citations"]` | xAI REST API doesn't support this param; causes 400 |
| `web-search.ts` | Rewrite `extractGrokContent` to parse `output[].content[].text` | xAI doesn't have `output_text` top-level field |
| `web-search.ts` | Extract `annotations` from content blocks | Inline citations live in `annotations`, not `data.inline_citations` |
| `web-search.ts` | Respect `inlineCitations` config in response | Only include citation data when `inlineCitations: true` |
| `web-search.ts` | Add `annotations` to `GrokSearchResponse` type | Reflect xAI's actual response structure |
| `web-search.test.ts` | Update + add unit tests for `extractGrokContent` | Cover message type filtering, annotation extraction, fallback, empty response |

## Test plan

- [x] All 27 unit tests pass (`vitest run --config vitest.unit.config.ts src/agents/tools/web-search.test.ts`)
- [x] Verified with live xAI API:
  - `inlineCitations: false` → HTTP 200, full content returned, no citations in output
  - `inlineCitations: true` → HTTP 200, full content returned, inline citations correctly extracted from annotations
- [x] Backwards compatible: `output_text` fallback preserved for any future API changes

Relates to #12910, #13023, #13216, #13494

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Grok (xAI) `web_search` provider to match the xAI REST Responses API: it removes the unsupported `include` request parameter, rewrites Grok response parsing to traverse `output[].content[]` blocks to produce text, and extracts inline citation annotations from content blocks (gated behind the `inlineCitations` config). Unit tests are updated to cover the new parsing behavior and fallback to `output_text`.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but citation range handling looks incorrect for multi-block outputs.
- Core fixes (removing unsupported request param and parsing correct response fields) are straightforward and well-covered by unit tests. However, the new annotation extraction does not account for multi-block text concatenation, which can produce incorrect `start_index/end_index` offsets and break downstream citation consumers when Grok returns multiple `output_text` blocks.
- src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->