### PR TITLE
fix: sessions_list shows actual model for cron sessions instead of agent default

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -211,8 +211,14 @@ async function resolveModelOverride(params: {
     cfg: params.cfg,
     agentId: params.agentId,
   });
-  const currentProvider = params.sessionEntry?.providerOverride?.trim() || configDefault.provider;
-  const currentModel = params.sessionEntry?.modelOverride?.trim() || configDefault.model;
+  const currentProvider =
+    params.sessionEntry?.providerOverride?.trim() ||
+    params.sessionEntry?.modelProvider?.trim() ||
+    configDefault.provider;
+  const currentModel =
+    params.sessionEntry?.modelOverride?.trim() ||
+    params.sessionEntry?.model?.trim() ||
+    configDefault.model;
 
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
@@ -371,7 +377,10 @@ export function createSessionStatusTool(opts?: {
       }
 
       const agentDir = resolveAgentDir(cfg, agentId);
-      const providerForCard = resolved.entry.providerOverride?.trim() || configured.provider;
+      const providerForCard =
+        resolved.entry.providerOverride?.trim() ||
+        resolved.entry.modelProvider?.trim() ||
+        configured.provider;
       const usageProvider = resolveUsageProviderId(providerForCard);
       let usageLine: string | undefined;
       if (usageProvider) {

--- a/src/gateway/session-utils.resolve-model-ref.test.ts
+++ b/src/gateway/session-utils.resolve-model-ref.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
+import { resolveSessionModelRef } from "./session-utils.js";
+
+/**
+ * Tests for resolveSessionModelRef — verifies that sessions_list reports
+ * the correct model for cron sessions that override the agent default.
+ *
+ * Regression test for: https://github.com/openclaw/openclaw/issues/13429
+ */
+describe("resolveSessionModelRef", () => {
+  const baseCfg: OpenClawConfig = {
+    llm: {
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    },
+  };
+
+  function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+    return {
+      sessionId: "test-session",
+      updatedAt: Date.now(),
+      ...overrides,
+    };
+  }
+
+  test("returns agent/config default when session has no model fields", () => {
+    const entry = makeEntry();
+    const result = resolveSessionModelRef(baseCfg, entry);
+    expect(result.model).toBe("claude-opus-4-6");
+    expect(result.provider).toBe("anthropic");
+  });
+
+  test("returns modelOverride when set (user-initiated override)", () => {
+    const entry = makeEntry({
+      modelOverride: "claude-sonnet-4-20250514",
+      providerOverride: "anthropic",
+    });
+    const result = resolveSessionModelRef(baseCfg, entry);
+    expect(result.model).toBe("claude-sonnet-4-20250514");
+    expect(result.provider).toBe("anthropic");
+  });
+
+  test("returns entry.model when set by cron run (no modelOverride)", () => {
+    const entry = makeEntry({
+      model: "gemini-3-pro-preview",
+      modelProvider: "google-gemini-cli",
+    });
+    const result = resolveSessionModelRef(baseCfg, entry);
+    expect(result.model).toBe("gemini-3-pro-preview");
+    expect(result.provider).toBe("google-gemini-cli");
+  });
+
+  test("modelOverride takes priority over entry.model", () => {
+    const entry = makeEntry({
+      modelOverride: "claude-sonnet-4-20250514",
+      providerOverride: "anthropic",
+      model: "gemini-3-pro-preview",
+      modelProvider: "google-gemini-cli",
+    });
+    const result = resolveSessionModelRef(baseCfg, entry);
+    expect(result.model).toBe("claude-sonnet-4-20250514");
+    expect(result.provider).toBe("anthropic");
+  });
+
+  test("entry.model with no modelProvider uses config default provider", () => {
+    const entry = makeEntry({
+      model: "claude-sonnet-4-20250514",
+    });
+    const result = resolveSessionModelRef(baseCfg, entry);
+    expect(result.model).toBe("claude-sonnet-4-20250514");
+    expect(result.provider).toBe("anthropic");
+  });
+
+  test("returns config default when entry is undefined", () => {
+    const result = resolveSessionModelRef(baseCfg, undefined);
+    expect(result.model).toBe("claude-opus-4-6");
+    expect(result.provider).toBe("anthropic");
+  });
+
+  test("ignores empty/whitespace model strings", () => {
+    const entry = makeEntry({
+      model: "  ",
+      modelProvider: "google-gemini-cli",
+    });
+    const result = resolveSessionModelRef(baseCfg, entry);
+    expect(result.model).toBe("claude-opus-4-6");
+    expect(result.provider).toBe("anthropic");
+  });
+});

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -537,10 +537,20 @@ export function resolveSessionModelRef(
       });
   let provider = resolved.provider;
   let model = resolved.model;
+
+  // Priority 1: User-initiated override (from /model command or sessions_patch)
   const storedModelOverride = entry?.modelOverride?.trim();
   if (storedModelOverride) {
     provider = entry?.providerOverride?.trim() || provider;
     model = storedModelOverride;
+  } else {
+    // Priority 2: Actual model used in the last run (set by cron jobs, auto-reply, etc.)
+    // This reflects the real model after fallback resolution, provider routing, etc.
+    const lastRunModel = entry?.model?.trim();
+    if (lastRunModel) {
+      provider = entry?.modelProvider?.trim() || provider;
+      model = lastRunModel;
+    }
   }
   return { provider, model };
 }


### PR DESCRIPTION
## Problem

`sessions_list` returns the agent default model (e.g., `claude-opus-4-6`) for cron isolated sessions even when the job successfully ran with a different model (e.g., `gemini-3-pro-preview`). This causes significant debugging confusion — users spend time assuming model overrides aren't working, when they actually are.

Fixes #13429

## Root Cause

`resolveSessionModelRef()` only checked `entry.modelOverride` (user-initiated overrides from `/model` command or `sessions_patch`), falling back directly to the agent default. But cron runs write the actual model to `entry.model` / `entry.modelProvider` — which was never consulted.

The same gap existed in `session-status-tool.ts`, which reads `providerOverride`/`modelOverride` directly with the same pattern.

## Fix

Updated `resolveSessionModelRef()` to use a three-tier priority:

1. **`modelOverride`/`providerOverride`** — user-initiated overrides (`/model`, `sessions_patch`)
2. **`model`/`modelProvider`** — actual model from last run (set by cron jobs, auto-reply, model fallback)
3. **Agent/config default** — fallback

Also fixed `session-status-tool.ts` which had the same resolution gap in two places.

## Testing

- Added 7 unit tests covering all priority tiers, edge cases (empty strings, undefined entry, both fields set)
- All 28 existing `session-utils` tests pass
- All 107 cron tests pass
- Sessions list gating test passes

## Impact

- `sessions_list` now correctly shows the actual model used by cron sessions
- `session_status` tool now correctly reports current model for sessions with run-time model changes  
- No behavioral change for sessions using `/model` overrides (priority 1 unchanged)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates model resolution for session display/reporting so `sessions_list` and the `session_status` tool prefer (1) explicit user overrides (`modelOverride`/`providerOverride`), then (2) the last-run model recorded on the session (`model`/`modelProvider`, e.g. from cron isolated runs), falling back to agent/config defaults. It also adds unit tests covering the resolution priority and edge cases.

The change fits into the gateway/session tooling layer by making session UI surfaces reflect the model actually used at runtime (which cron already persists to the session store).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, well-scoped (model/provider resolution priority), and match existing persisted fields used by cron runs. Call sites remain consistent, and added unit tests cover the new priority order and edge cases like whitespace/undefined.
- src/gateway/session-utils.resolve-model-ref.test.ts (minor: external link in comment)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->