### PR TITLE
fix(models): suggest correct provider prefix when model is not allowed

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -394,6 +394,20 @@ export function resolveAllowedModelRef(params: {
     defaultModel: params.defaultModel,
   });
   if (!status.allowed) {
+    // Try to find a matching model under a different provider to suggest the correct prefix
+    const modelName = resolved.ref.model;
+    const allowed = buildAllowedModelSet({
+      cfg: params.cfg,
+      catalog: params.catalog,
+      defaultProvider: params.defaultProvider,
+      defaultModel: params.defaultModel,
+    });
+    const suggestion = [...allowed.allowedKeys].find((key) => key.endsWith(`/${modelName}`));
+    if (suggestion) {
+      return {
+        error: `model not allowed: ${status.key}. Did you mean "${suggestion}"?`,
+      };
+    }
     return { error: `model not allowed: ${status.key}` };
   }
 


### PR DESCRIPTION
Fixes #13425 - When model is rejected due to wrong provider prefix, suggest the correct one if a matching model name exists in the allowlist.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `resolveAllowedModelRef` to, on a disallowed model key, look for an allowlisted model with the same model name under a different provider and include a "Did you mean \"provider/model\"?" hint in the error message. This sits in the model-selection path used by both the gateway session patching flow and the isolated-agent runner, so it affects user-facing validation errors when setting a model override.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the new suggestion logic misses an important allow-any scenario.
- The PR is small and localized, but the provider-prefix suggestion currently searches `allowed.allowedKeys`, which is empty when the allowlist is not configured (`allowAny`), so the main user-visible improvement can be skipped in a common configuration. Fixing the suggestion source would align behavior with the intended UX without changing enforcement logic.
- src/agents/model-selection.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->