### PR TITLE
fix(telegram): recognize MediaFetchError as recoverable network error (#13428)

### DIFF
--- a/src/telegram/download.ts
+++ b/src/telegram/download.ts
@@ -13,10 +13,15 @@ export async function getTelegramFile(
   fileId: string,
   timeoutMs = 30_000,
 ): Promise<TelegramFileInfo> {
-  const res = await fetch(
-    `https://api.telegram.org/bot${token}/getFile?file_id=${encodeURIComponent(fileId)}`,
-    { signal: AbortSignal.timeout(timeoutMs) },
-  );
+  let res: Response;
+  try {
+    res = await fetch(
+      `https://api.telegram.org/bot${token}/getFile?file_id=${encodeURIComponent(fileId)}`,
+      { signal: AbortSignal.timeout(timeoutMs) },
+    );
+  } catch (err) {
+    throw new Error(`getFile fetch failed for file_id ${fileId}: ${String(err)}`, { cause: err });
+  }
   if (!res.ok) {
     throw new Error(`getFile failed: ${res.status} ${res.statusText}`);
   }
@@ -37,7 +42,14 @@ export async function downloadTelegramFile(
     throw new Error("file_path missing");
   }
   const url = `https://api.telegram.org/file/bot${token}/${info.file_path}`;
-  const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  let res: Response;
+  try {
+    res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  } catch (err) {
+    throw new Error(`Failed to download telegram file from ${info.file_path}: ${String(err)}`, {
+      cause: err,
+    });
+  }
   if (!res.ok || !res.body) {
     throw new Error(`Failed to download telegram file: HTTP ${res.status}`);
   }

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -138,6 +138,14 @@ export function isRecoverableTelegramNetworkError(
       return true;
     }
 
+    // MediaFetchError with code "fetch_failed" indicates a network-level failure
+    // during media download (e.g., TypeError: fetch failed from undici).
+    // This check is unconditional — media fetch network failures are always
+    // recoverable regardless of context, since the underlying cause is transient.
+    if (name === "MediaFetchError" && code === "FETCH_FAILED") {
+      return true;
+    }
+
     if (allowMessageMatch) {
       const message = formatErrorMessage(candidate).toLowerCase();
       if (message && RECOVERABLE_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {


### PR DESCRIPTION
## Summary

Fixes #13428 — Telegram unhandled fetch rejection crashes gateway in group chats.

## Problem

`MediaFetchError` with `code: "fetch_failed"` was not recognized as a recoverable error when message matching was disabled (i.e., in **send context** where `allowMessageMatch = false`). This meant that media fetch failures originating from transient network issues (DNS hiccups, connection resets, undici `TypeError: fetch failed`) could escape as unhandled rejections and crash the gateway via `process.exit(1)`.

The existing test `network-errors.media-fetch-recoverable.test.ts` documented this expected behavior but was failing.

## Root Cause

`isRecoverableTelegramNetworkError()` relied on message-text matching to identify `MediaFetchError` as recoverable. In send context, message matching is intentionally disabled to avoid false positives, leaving `MediaFetchError` unrecognized:

1. Error code `FETCH_FAILED` was not in `RECOVERABLE_ERROR_CODES` (which contains system-level codes like `ECONNRESET`)
2. Error name `MediaFetchError` was not in `RECOVERABLE_ERROR_NAMES`
3. Message matching was disabled → no fallback detection

## Fix

**`network-errors.ts`**: Add unconditional recognition of `MediaFetchError` with `code === "FETCH_FAILED"`. Media fetch network failures are inherently transient and should be treated as recoverable regardless of context. This is a targeted check (name + code) that won't false-positive on other error types.

**`download.ts`**: Wrap bare `fetch()` calls in `getTelegramFile()` and `downloadTelegramFile()` with try/catch to preserve the cause chain. Previously, a `TypeError: fetch failed` from these functions would propagate without context, making it harder for upstream error classifiers to identify the source.

## Tests

All 419 tests in `src/telegram/` pass, including the previously-failing test:

- ✅ `network-errors.media-fetch-recoverable.test.ts` — 5/5 (was 4/5)
- ✅ `network-errors.test.ts` — 11/11
- ✅ `download.test.ts` — 2/2
- ✅ All 50 telegram test files pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change improves Telegram gateway robustness by treating grammY `MediaFetchError` failures (`code: "FETCH_FAILED"`) as recoverable even in send-context (where message matching is disabled). It also wraps the bare `fetch()` calls used for `getFile` and media download with `try/catch` to preserve an error cause chain for upstream classification.

The updated logic lives in `src/telegram/network-errors.ts` (the central retry/recoverability classifier used by `src/telegram/send.ts`/`monitor.ts`), while `src/telegram/download.ts` now throws contextual errors (with `cause`) when Telegram API/file fetch calls fail before an HTTP response exists.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to Telegram network error classification and fetch error wrapping, and the new checks are deterministic (name+code) without affecting non-network error paths. No breaking API surface changes were introduced in the modified functions.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->