### PR TITLE
feat(context-pruning): add forcePruneRatio TTL bypass

### DIFF
--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -386,6 +386,65 @@ describe("context-pruning", () => {
     expect(second).toBeUndefined();
   });
 
+  it("forcePruneRatio bypasses cache-ttl when context is over threshold", () => {
+    const sessionManager = {};
+
+    setContextPruningRuntime(sessionManager, {
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 0,
+        forcePruneRatio: 0.7,
+        softTrimRatio: 0,
+        hardClearRatio: 0,
+        minPrunableToolChars: 0,
+        hardClear: { enabled: true, placeholder: "[cleared]" },
+        softTrim: { maxChars: 10, headChars: 3, tailChars: 3 },
+      },
+      contextWindowTokens: 1000,
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now(),
+    });
+
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeToolResult({
+        toolCallId: "t1",
+        toolName: "exec",
+        text: "x".repeat(20_000),
+      }),
+    ];
+
+    let handler:
+      | ((
+          event: { messages: AgentMessage[] },
+          ctx: ExtensionContext,
+        ) => { messages: AgentMessage[] } | undefined)
+      | undefined;
+
+    const api = {
+      on: (name: string, fn: unknown) => {
+        if (name === "context") {
+          handler = fn as typeof handler;
+        }
+      },
+      appendEntry: (_type: string, _data?: unknown) => {},
+    } as unknown as ExtensionAPI;
+
+    contextPruningExtension(api);
+    if (!handler) {
+      throw new Error("missing context handler");
+    }
+
+    const result = handler({ messages }, {
+      model: undefined,
+      sessionManager,
+    } as unknown as ExtensionContext);
+    if (!result) {
+      throw new Error("expected force prune");
+    }
+    expect(toolText(findToolResult(result.messages, "t1"))).toBe("[cleared]");
+  });
+
   it("respects tools allow/deny (deny wins; wildcards supported)", () => {
     const messages: AgentMessage[] = [
       makeUser("u1"),

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -150,8 +150,22 @@ function estimateMessageChars(message: AgentMessage): number {
   return 256;
 }
 
-function estimateContextChars(messages: AgentMessage[]): number {
+export function estimateContextChars(messages: AgentMessage[]): number {
   return messages.reduce((sum, m) => sum + estimateMessageChars(m), 0);
+}
+
+export function estimateContextUsageRatio(
+  messages: AgentMessage[],
+  contextWindowTokens?: number | null,
+): number {
+  if (!contextWindowTokens || !Number.isFinite(contextWindowTokens) || contextWindowTokens <= 0) {
+    return 0;
+  }
+  const charWindow = contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE;
+  if (charWindow <= 0) {
+    return 0;
+  }
+  return estimateContextChars(messages) / charWindow;
 }
 
 function findAssistantCutoffIndex(

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -11,6 +11,7 @@ export type ContextPruningConfig = {
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;
+  forcePruneRatio?: number;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;
@@ -30,6 +31,7 @@ export type EffectiveContextPruningSettings = {
   mode: Exclude<ContextPruningMode, "off">;
   ttlMs: number;
   keepLastAssistants: number;
+  forcePruneRatio?: number;
   softTrimRatio: number;
   hardClearRatio: number;
   minPrunableToolChars: number;
@@ -86,6 +88,9 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
 
   if (typeof cfg.keepLastAssistants === "number" && Number.isFinite(cfg.keepLastAssistants)) {
     s.keepLastAssistants = Math.max(0, Math.floor(cfg.keepLastAssistants));
+  }
+  if (typeof cfg.forcePruneRatio === "number" && Number.isFinite(cfg.forcePruneRatio)) {
+    s.forcePruneRatio = Math.min(1, Math.max(0, cfg.forcePruneRatio));
   }
   if (typeof cfg.softTrimRatio === "number" && Number.isFinite(cfg.softTrimRatio)) {
     s.softTrimRatio = Math.min(1, Math.max(0, cfg.softTrimRatio));

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -30,6 +30,7 @@ export type AgentContextPruningConfig = {
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;
+  forcePruneRatio?: number;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -60,6 +60,7 @@ export const AgentDefaultsSchema = z
         mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
         ttl: z.string().optional(),
         keepLastAssistants: z.number().int().nonnegative().optional(),
+        forcePruneRatio: z.number().min(0).max(1).optional(),
         softTrimRatio: z.number().min(0).max(1).optional(),
         hardClearRatio: z.number().min(0).max(1).optional(),
         minPrunableToolChars: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
Add optional contextPruning.forcePruneRatio to bypass the cache TTL when estimated context usage meets the threshold. The ratio uses message size versus context window size, and pruning runs immediately when the ratio is exceeded. Schema and tests cover the TTL bypass behavior.

Testing: not run (unit test added).

References #13570

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an optional `forcePruneRatio` setting to context pruning configuration (types + Zod schema) and wires it into the context-pruning extension so that, when estimated context usage exceeds the configured ratio, the normal cache TTL gate is bypassed and pruning is attempted immediately.

Implementation adds a small helper (`estimateContextUsageRatio`) in the pruner module and includes a unit test verifying that the TTL bypass triggers pruning when over the threshold.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are additive (new optional config + schema field) and localized to context-pruning gating logic. The TTL bypass computation is guarded and falls back safely when the context window is unknown. Added test covers the new behavior path.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->