### PR TITLE
P2P Chia blockchain wallet monitoring

### DIFF
--- a/extensions/chia-watcher/.gitignore
+++ b/extensions/chia-watcher/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+*.db
+*.db-journal
+*-certs/
+*.crt
+*.key
+*.pem

--- a/extensions/chia-watcher/.npmignore
+++ b/extensions/chia-watcher/.npmignore
@@ -1,0 +1,30 @@
+# Source files (dist/ is shipped instead)
+src/
+index.ts
+tsconfig.json
+
+# Dev/build
+node_modules/
+*.tsbuildinfo
+
+# Runtime data (NEVER ship)
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+*-certs/
+*.crt
+*.key
+*.pem
+
+# OS/editor
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/
+
+# Test
+__tests__/
+*.test.ts
+*.spec.ts
+coverage/

--- a/extensions/chia-watcher/LICENSE
+++ b/extensions/chia-watcher/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 KOBA42 Corp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/chia-watcher/README.md
+++ b/extensions/chia-watcher/README.md
@@ -1,0 +1,155 @@
+# @openclaw/chia-watcher
+
+Chia blockchain wallet monitoring plugin for [OpenClaw](https://openclaw.ai). Watches wallet addresses for incoming coins via direct peer-to-peer connection, decodes memos, and delivers real-time notifications to your messaging channel.
+
+**No API keys. No third-party services. Just you and the blockchain.**
+
+## Install
+
+```bash
+openclaw plugin install @openclaw/chia-watcher
+```
+
+Or manually:
+
+```bash
+npm install @openclaw/chia-watcher
+```
+
+Then add to your OpenClaw config (`openclaw.json`):
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "chia-watcher": {
+        "enabled": true,
+        "config": {
+          "enabled": true,
+          "network": "mainnet",
+          "wallets": ["xch1youraddress..."],
+          "notifyChannel": "telegram",
+          "notifyTo": "telegram:your_chat_id"
+        }
+      }
+    }
+  }
+}
+```
+
+Restart your gateway. The watcher auto-starts.
+
+## Features
+
+- **P2P monitoring** — connects directly to Chia full nodes via DNS introducer, no API keys or centralized services
+- **Multi-wallet** — watch unlimited addresses simultaneously
+- **Memo decoding** — automatically decodes hex memos to readable text
+- **Pattern matching** — custom handlers for structured memos (payments, NFT mints, breeding, etc.)
+- **Multi-channel notifications** — Telegram, Discord, Signal, WhatsApp, or any OpenClaw channel
+- **Transaction history** — local SQLite database, queryable via slash commands
+- **Auto-reconnect** — handles peer disconnections gracefully with exponential backoff
+- **State persistence** — remembers last sync height across restarts (no duplicate alerts)
+- **Self-signed certs** — auto-generates TLS certificates for peer connections (no openssl needed)
+- **Slash commands** — manage everything from chat
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/chia_status` | Show connection status, peer height, wallet count |
+| `/chia_watch xch1...` | Add a wallet address to monitor |
+| `/chia_unwatch xch1...` | Stop monitoring a wallet address |
+| `/chia_history [n]` | Show last n transactions (default: 10) |
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable the watcher service |
+| `network` | string | `"mainnet"` | `"mainnet"` or `"testnet11"` |
+| `wallets` | string[] | `[]` | Array of `xch1...` addresses to monitor |
+| `autoStart` | boolean | `true` | Start monitoring on gateway boot |
+| `notifyChannel` | string | — | Channel for alerts: `telegram`, `discord`, `signal`, `whatsapp` |
+| `notifyTo` | string | — | Recipient: `telegram:123456`, `discord:channelid`, etc. |
+| `minAmountXch` | number | `0` | Minimum XCH amount to trigger notification |
+| `includeCATs` | boolean | `true` | Include CAT (token) transactions |
+| `dbPath` | string | auto | Custom SQLite database path |
+| `pollIntervalMs` | integer | `30000` | Heartbeat check interval (ms) |
+| `memoHandlers` | array | `[]` | Custom memo pattern handlers (see below) |
+
+## Custom Memo Handlers
+
+Match structured memos and format custom notifications:
+
+```json
+{
+  "memoHandlers": [
+    {
+      "name": "payment",
+      "pattern": "^PAYMENT\\|(.+)\\|(.+)$",
+      "template": "Payment from {match1}: {amountXch} XCH — ref: {match2}",
+      "enabled": true
+    },
+    {
+      "name": "nft-mint",
+      "pattern": "COLLECTION_MINT\\|(.+)\\|name:(.+?)\\|",
+      "template": "NFT Minted: {match2} (type: {match1})",
+      "enabled": true
+    }
+  ]
+}
+```
+
+**Template variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `{amount}` | Amount in mojos |
+| `{amountXch}` | Amount in XCH |
+| `{address}` | Full recipient address |
+| `{addressShort}` | Truncated address |
+| `{memo}` | Decoded memo text |
+| `{height}` | Block height |
+| `{coinId}` | Coin ID |
+| `{network}` | Network name |
+| `{type}` | `XCH` or `CAT` |
+| `{assetId}` | CAT asset ID (if applicable) |
+| `{match1}`, `{match2}`, ... | Regex capture groups |
+
+## RPC Methods
+
+For programmatic control from other plugins or scripts:
+
+| Method | Description |
+|--------|-------------|
+| `chia-watcher.start` | Start the watcher |
+| `chia-watcher.stop` | Stop the watcher |
+| `chia-watcher.status` | Get current status |
+
+## Security
+
+- **No secrets stored** — TLS certs are self-signed and auto-generated locally
+- **No outbound API calls** — all monitoring is P2P via the Chia protocol
+- **Local database only** — transaction history stays on your machine
+- **Address validation** — wallet addresses are validated against `xch1` bech32m format
+- **Read-only** — the plugin only observes the blockchain, it cannot spend coins
+
+## How It Works
+
+1. Generates a self-signed TLS certificate (stored in your OpenClaw data directory)
+2. Resolves Chia full node IPs via the official DNS introducer (`dns-introducer.chia.net`)
+3. Connects to a random peer using the Chia wallet protocol
+4. Subscribes to puzzle hash updates for your wallet addresses
+5. When new coins appear, decodes the parent spend to extract memos
+6. Matches memos against your handlers and delivers formatted notifications
+7. Persists state so restarts don't replay old transactions
+
+## Requirements
+
+- OpenClaw >= 2026.2.0
+- Node.js >= 18
+- Network access to Chia mainnet peers (port 8444)
+
+## License
+
+MIT — KOBA42 Corp

--- a/extensions/chia-watcher/SECURITY.md
+++ b/extensions/chia-watcher/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Considerations
+
+## Architecture
+
+This extension operates as a **read-only observer** of the Chia blockchain. It cannot sign transactions, spend coins, or access private keys.
+
+## Network
+
+- Connects to Chia full nodes via the official DNS introducer (`dns-introducer.chia.net`)
+- Uses self-signed TLS certificates for peer authentication (standard Chia protocol)
+- No outbound API calls to third-party services
+- All data stays local (SQLite database on disk)
+
+## Resource Limits
+
+| Limit | Value | Purpose |
+|-------|-------|---------|
+| Max wallets | 50 | Prevent subscription flooding |
+| Max DB rows | 100,000 | Prevent unbounded disk usage |
+| Max regex length | 200 chars | Prevent ReDoS in memo handlers |
+| Max memo handlers | 20 | Limit pattern matching overhead |
+| Event queue max | 1,000 | Backpressure on peer events |
+
+## Regex Safety
+
+User-defined memo handler patterns are validated before compilation:
+- Length limited to 200 characters
+- Known ReDoS patterns (nested quantifiers) are rejected
+- Patterns are pre-compiled at registration, not per-event
+
+## Database Path
+
+The database path is validated to ensure it resides within the OpenClaw data directory or `/tmp`. Path traversal attempts are rejected.
+
+## Dependencies
+
+- `chia-wallet-sdk` (0.29.0) — Official Chia wallet SDK for peer protocol
+- `better-sqlite3` (11.7.0) — SQLite bindings for transaction storage
+
+Both are pinned to exact versions. Verify integrity via `npm audit` before deployment.
+
+## Opt-in Only
+
+This extension is disabled by default (`config.enabled: false`). Users must explicitly configure wallet addresses and enable monitoring.
+
+## Reporting
+
+Report security issues to dev@koba42.com or open a GitHub issue.

--- a/extensions/chia-watcher/index.ts
+++ b/extensions/chia-watcher/index.ts
@@ -1,0 +1,239 @@
+import path from "path";
+import type { ChiaWatcherConfig, CoinEvent } from "./src/types";
+import { ChiaSubscriber } from "./src/subscriber";
+import { TransactionStore } from "./src/store";
+import { MemoHandlerRegistry } from "./src/memoHandlers";
+import { NotificationEngine } from "./src/notifications";
+
+export const id = "chia-watcher";
+export const name = "Chia Watcher";
+
+export function register(api: any) {
+  const logger = api.logger ?? console;
+  let subscriber: ChiaSubscriber | null = null;
+  let store: TransactionStore | null = null;
+  let handlers: MemoHandlerRegistry | null = null;
+  let notifier: NotificationEngine | null = null;
+
+  function getConfig(): ChiaWatcherConfig {
+    const cfg = api.config?.plugins?.entries?.["chia-watcher"]?.config ?? {};
+    return {
+      enabled: cfg.enabled ?? false,
+      network: cfg.network ?? "mainnet",
+      wallets: cfg.wallets ?? [],
+      autoStart: cfg.autoStart ?? true,
+      notifyChannel: cfg.notifyChannel,
+      notifyTo: cfg.notifyTo,
+      dbPath: cfg.dbPath,
+      memoHandlers: cfg.memoHandlers ?? [],
+      minAmountXch: cfg.minAmountXch ?? 0,
+      includeCATs: cfg.includeCATs ?? true,
+      pollIntervalMs: cfg.pollIntervalMs ?? 30000,
+    };
+  }
+
+  function initStore(config: ChiaWatcherConfig) {
+    const dbPath = config.dbPath ?? path.join(api.dataDir ?? ".", "chia-watcher.db");
+    store = new TransactionStore(dbPath);
+    return store;
+  }
+
+  async function startWatcher() {
+    const config = getConfig();
+    if (!config.enabled || !config.wallets.length) {
+      return { success: false, message: "Watcher not enabled or no wallets configured" };
+    }
+
+    if (subscriber?.getStatus().isRunning) {
+      return { success: false, message: "Already running" };
+    }
+
+    // Init components
+    if (!store) initStore(config);
+    handlers = new MemoHandlerRegistry(config.memoHandlers);
+    notifier = new NotificationEngine({
+      api,
+      channel: config.notifyChannel,
+      to: config.notifyTo,
+      logger,
+    });
+
+    // Load saved state
+    const savedState = store!.getState(`lastUpdate_${config.network}`);
+    const lastUpdate = savedState ? JSON.parse(savedState) : null;
+
+    const certDir = path.join(api.dataDir ?? ".", "chia-watcher-certs");
+    subscriber = new ChiaSubscriber({
+      network: config.network,
+      certDir,
+      logger,
+      lastUpdate,
+    });
+
+    // Handle coin events
+    subscriber.on("coin", async (event: CoinEvent) => {
+      // Filter by minimum amount
+      if (config.minAmountXch && event.amountXch < config.minAmountXch) return;
+      // Filter CATs if disabled
+      if (!config.includeCATs && event.isCat) return;
+
+      // Process through memo handlers
+      const result = handlers!.process(event);
+      event.matchedHandler = result.handlerName ?? undefined;
+
+      // Save to DB
+      store!.saveCoinEvent(event);
+
+      // Save state
+      const lastUp = subscriber!.getLastUpdate();
+      if (lastUp) {
+        store!.saveState(`lastUpdate_${config.network}`, JSON.stringify(lastUp));
+      }
+
+      // Send notification
+      if (result.matched && result.formattedMessage) {
+        await notifier!.sendCoinAlert(event, result.formattedMessage);
+      }
+    });
+
+    subscriber.on("error", (err: Error) => {
+      logger.error(`[chia-watcher] ${err.message}`);
+    });
+
+    subscriber.on("disconnected", () => {
+      logger.warn("[chia-watcher] Peer disconnected, will attempt reconnect...");
+    });
+
+    try {
+      // Merge config wallets + DB wallets
+      const dbWallets = store!.getActiveWallets().map((w) => w.address);
+      const allWallets = [...new Set([...config.wallets, ...dbWallets])];
+
+      await subscriber.start(allWallets);
+      return { success: true, message: `Watching ${allWallets.length} wallets on ${config.network}` };
+    } catch (err: any) {
+      return { success: false, message: err.message };
+    }
+  }
+
+  async function stopWatcher() {
+    if (!subscriber) return { success: false, message: "Not running" };
+    await subscriber.stop();
+    subscriber = null;
+    return { success: true, message: "Watcher stopped" };
+  }
+
+  // Register background service
+  api.registerService({
+    id: "chia-watcher",
+    start: async () => {
+      const config = getConfig();
+      if (config.enabled && config.autoStart) {
+        const result = await startWatcher();
+        logger.info(`[chia-watcher] Auto-start: ${result.message}`);
+      } else {
+        logger.info("[chia-watcher] Not auto-starting (disabled or autoStart=false)");
+      }
+    },
+    stop: async () => {
+      try { await stopWatcher(); } catch {}
+      try { store?.close(); } catch {}
+      store = null;
+    },
+  });
+
+  // Register slash commands
+  api.registerCommand({
+    name: "chia_watch",
+    description: "Add a wallet address to watch",
+    acceptsArgs: true,
+    requireAuth: true,
+    handler: (ctx: any) => {
+      const address = ctx.args?.trim();
+      if (!address?.startsWith("xch1")) {
+        return { text: "Usage: /chia_watch xch1..." };
+      }
+      if (!store) initStore(getConfig());
+      store!.addWallet(address);
+      return { text: `✅ Now watching ${address.slice(0, 10)}...${address.slice(-6)}` };
+    },
+  });
+
+  api.registerCommand({
+    name: "chia_unwatch",
+    description: "Stop watching a wallet address",
+    acceptsArgs: true,
+    requireAuth: true,
+    handler: (ctx: any) => {
+      const address = ctx.args?.trim();
+      if (!address) return { text: "Usage: /chia_unwatch xch1..." };
+      if (!store) initStore(getConfig());
+      store!.removeWallet(address);
+      return { text: `🛑 Stopped watching ${address.slice(0, 10)}...${address.slice(-6)}` };
+    },
+  });
+
+  api.registerCommand({
+    name: "chia_status",
+    description: "Show Chia watcher status",
+    requireAuth: true,
+    handler: () => {
+      if (!subscriber) return { text: "Chia Watcher is not running. Enable in config and restart." };
+      const status = subscriber.getStatus();
+      const stats = store?.getStats();
+      return {
+        text: [
+          `⛏️ **Chia Watcher Status**`,
+          `Network: ${status.network}`,
+          `Running: ${status.isRunning ? "✅" : "❌"}`,
+          `Peer: ${status.peerAddr ?? "none"}`,
+          `Height: ${status.peakHeight?.toLocaleString() ?? "unknown"}`,
+          `Wallets: ${status.walletCount}`,
+          `Transactions: ${stats?.totalTx ?? 0}`,
+          `Uptime: ${Math.floor(status.uptime / 60)}m`,
+        ].join("\n"),
+      };
+    },
+  });
+
+  api.registerCommand({
+    name: "chia_history",
+    description: "Show recent transactions",
+    acceptsArgs: true,
+    requireAuth: true,
+    handler: (ctx: any) => {
+      if (!store) initStore(getConfig());
+      const limit = parseInt(ctx.args?.trim() || "10", 10);
+      const txs = store!.getRecentTransactions(Math.min(limit, 50));
+      if (!txs.length) return { text: "No transactions recorded yet." };
+
+      const lines = txs.map((tx: any) => {
+        const addr = tx.address?.slice(0, 8) + "...";
+        const amt = (tx.amount_xch ?? tx.amountXch ?? 0).toFixed(4);
+        const memo = tx.memo_decoded ?? tx.memoDecoded ?? "(none)";
+        return `• ${amt} XCH → ${addr} | ${memo}`;
+      });
+
+      return { text: `📜 Recent transactions:\n${lines.join("\n")}` };
+    },
+  });
+
+  // Register RPC methods for programmatic control
+  api.registerGatewayMethod("chia-watcher.start", async ({ respond }: any) => {
+    const result = await startWatcher();
+    respond(result.success, result);
+  });
+
+  api.registerGatewayMethod("chia-watcher.stop", async ({ respond }: any) => {
+    const result = await stopWatcher();
+    respond(result.success, result);
+  });
+
+  api.registerGatewayMethod("chia-watcher.status", ({ respond }: any) => {
+    const status = subscriber?.getStatus() ?? { isRunning: false };
+    const stats = store?.getStats();
+    respond(true, { ...status, stats });
+  });
+
+  logger.info("[chia-watcher] Plugin registered");
+}

--- a/extensions/chia-watcher/openclaw.plugin.json
+++ b/extensions/chia-watcher/openclaw.plugin.json
@@ -1,0 +1,60 @@
+{
+  "id": "chia-watcher",
+  "description": "Chia blockchain wallet monitoring via P2P peer connection. Read-only: cannot spend coins or access keys.",
+  "securityNotice": "This extension opens P2P connections to Chia full nodes and stores transaction data locally. Review SECURITY.md before enabling.",
+  "uiHints": {
+    "network": {
+      "label": "Chia Network",
+      "help": "mainnet or testnet11"
+    },
+    "wallets": {
+      "label": "Wallet Addresses",
+      "help": "Array of xch1... addresses to monitor"
+    },
+    "autoStart": {
+      "label": "Auto-start on Gateway boot"
+    },
+    "notifyChannel": {
+      "label": "Notification Channel",
+      "help": "Channel to deliver alerts (telegram, discord, etc.)"
+    },
+    "notifyTo": {
+      "label": "Notification Recipient",
+      "help": "Target user/chat ID for notifications"
+    },
+    "dbPath": {
+      "label": "Database Path",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean" },
+      "network": { "type": "string", "enum": ["mainnet", "testnet11"], "default": "mainnet" },
+      "wallets": { "type": "array", "items": { "type": "string", "pattern": "^xch1[a-z0-9]{58}$" }, "maxItems": 50 },
+      "autoStart": { "type": "boolean", "default": true },
+      "notifyChannel": { "type": "string" },
+      "notifyTo": { "type": "string" },
+      "dbPath": { "type": "string" },
+      "memoHandlers": {
+        "type": "array",
+        "maxItems": 20,
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "pattern": { "type": "string", "maxLength": 200 },
+            "template": { "type": "string", "maxLength": 500 },
+            "enabled": { "type": "boolean", "default": true }
+          },
+          "required": ["name", "pattern", "template"]
+        }
+      },
+      "minAmountXch": { "type": "number", "default": 0 },
+      "includeCATs": { "type": "boolean", "default": true },
+      "pollIntervalMs": { "type": "integer", "default": 30000, "minimum": 5000 }
+    }
+  }
+}

--- a/extensions/chia-watcher/package-lock.json
+++ b/extensions/chia-watcher/package-lock.json
@@ -1,0 +1,1099 @@
+{
+  "name": "@koba42/openclaw-chia-watcher",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@koba42/openclaw-chia-watcher",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "11.7.0",
+        "chia-wallet-sdk": "0.29.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.0",
+        "@types/node": "^20.0.0",
+        "esbuild": "^0.24.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.2.0"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.7.0.tgz",
+      "integrity": "sha512-mXpa5jnIKKHeoGzBrUJrc65cXFKcILGZpU3FXR0pradUEm9MA7UZz02qfEejaMcm9iXrSOCenwwYMJ/tZ1y5Ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chia-wallet-sdk": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/chia-wallet-sdk/-/chia-wallet-sdk-0.29.0.tgz",
+      "integrity": "sha512-l4D8zaH6I1uI74NberSsxxQE64C1uFnLunT8ts30CG0TsTMrHjeGNqXKiijP+QAi7K9CwStmzuFTi6G6eUefIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      },
+      "optionalDependencies": {
+        "chia-wallet-sdk-darwin-arm64": "0.29.0",
+        "chia-wallet-sdk-darwin-universal": "0.29.0",
+        "chia-wallet-sdk-darwin-x64": "0.29.0",
+        "chia-wallet-sdk-linux-arm64-gnu": "0.29.0",
+        "chia-wallet-sdk-linux-x64-gnu": "0.29.0",
+        "chia-wallet-sdk-win32-x64-msvc": "0.29.0"
+      }
+    },
+    "node_modules/chia-wallet-sdk-darwin-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/chia-wallet-sdk-darwin-arm64/-/chia-wallet-sdk-darwin-arm64-0.29.0.tgz",
+      "integrity": "sha512-nTN/C2fPwk8EsCggiw/C/vd6aOSH+9ytRhYXxwUIzKGP7zzrFte5/BaDNEYbJBgqaq1RniPKXflW45nJR1fA9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chia-wallet-sdk-darwin-universal": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/chia-wallet-sdk-darwin-universal/-/chia-wallet-sdk-darwin-universal-0.29.0.tgz",
+      "integrity": "sha512-ULgUn+TaNFT0N1yLgrGKbGVXeMZKZyqyTixoWheVYZ1GAwFH1F1edTJ19ZWgATvYWGvW2q1BUrSPOtI+/tMatQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chia-wallet-sdk-darwin-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/chia-wallet-sdk-darwin-x64/-/chia-wallet-sdk-darwin-x64-0.29.0.tgz",
+      "integrity": "sha512-jLZIWGz8jEk1Jf6+mAu198ARmXYOpIpTGEkj3TrZMyZIpxV2XVepxYsNbM4tl6+2gNuxr98LlwBCzqmIA3HjpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chia-wallet-sdk-linux-arm64-gnu": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/chia-wallet-sdk-linux-arm64-gnu/-/chia-wallet-sdk-linux-arm64-gnu-0.29.0.tgz",
+      "integrity": "sha512-F8rpjMUE6CSUQO4YhaNM2nzVa0Z2OLDzUsb/Cgpuc8y69HSzUr4Bi5sv5UwFPXrtIUbLRPyg/AqATYfh59/gXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chia-wallet-sdk-linux-x64-gnu": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/chia-wallet-sdk-linux-x64-gnu/-/chia-wallet-sdk-linux-x64-gnu-0.29.0.tgz",
+      "integrity": "sha512-6YHfkBPlY0YFCp8qKoQMXNdyJOLsl99J6+wke/b7ZD10TbplwHpN2STxn33ruaMe4j5AW0gwr7G7iew9SMq/tQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chia-wallet-sdk-win32-x64-msvc": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/chia-wallet-sdk-win32-x64-msvc/-/chia-wallet-sdk-win32-x64-msvc-0.29.0.tgz",
+      "integrity": "sha512-syXLUItwWxE8Nb/ZOJMSOCrSAUt49TpxxNLO3q4f3Ll3EYtoC/5AJmbozVPfXY6bEIALPHgMGLNB8dyBvpZqaw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/extensions/chia-watcher/package.json
+++ b/extensions/chia-watcher/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@koba42/openclaw-chia-watcher",
+  "version": "0.1.0",
+  "description": "Chia blockchain wallet watcher plugin for OpenClaw — real-time P2P monitoring with memo decoding and multi-channel notifications",
+  "license": "MIT",
+  "author": "KOBA42 Corp <dev@koba42.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/chia-watcher"
+  },
+  "homepage": "https://github.com/openclaw/chia-watcher#readme",
+  "bugs": {
+    "url": "https://github.com/openclaw/chia-watcher/issues"
+  },
+  "keywords": [
+    "openclaw",
+    "openclaw-plugin",
+    "chia",
+    "chia-blockchain",
+    "wallet-watcher",
+    "xch",
+    "memo-decoder",
+    "notifications",
+    "telegram",
+    "discord"
+  ],
+  "type": "module",
+  "main": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "openclaw": {
+    "extensions": [
+      "./dist/index.mjs"
+    ]
+  },
+  "files": [
+    "dist/",
+    "openclaw.plugin.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "esbuild index.ts --bundle --platform=node --target=node18 --format=esm --outfile=dist/index.mjs --external:chia-wallet-sdk --external:better-sqlite3",
+    "prepublishOnly": "npm run build",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "better-sqlite3": "11.7.0",
+    "chia-wallet-sdk": "0.29.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.0"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  }
+}

--- a/extensions/chia-watcher/src/memoHandlers.ts
+++ b/extensions/chia-watcher/src/memoHandlers.ts
@@ -1,0 +1,133 @@
+import type { CoinEvent, MemoHandler } from "./types";
+import { LIMITS } from "./types";
+
+export interface HandlerResult {
+  matched: boolean;
+  handlerName: string | null;
+  formattedMessage: string | null;
+}
+
+const BUILT_IN_HANDLERS: MemoHandler[] = [
+  {
+    name: "any-coin",
+    pattern: ".*",
+    template: "💰 Received {amountXch} XCH to {addressShort}\n📝 Memo: {memo}\n📏 Height: {height}",
+    enabled: true,
+  },
+];
+
+/**
+ * Validate a regex pattern for safety.
+ * Rejects patterns that are too long or catastrophically backtracking.
+ */
+function validateRegex(pattern: string): RegExp | null {
+  if (pattern.length > LIMITS.MAX_REGEX_LENGTH) return null;
+
+  // Reject known ReDoS patterns: nested quantifiers like (a+)+, (a*)*
+  if (/(\+|\*|\{)\s*\)(\+|\*|\{|\?)/.test(pattern)) return null;
+
+  try {
+    // Test compilation with a timeout-safe approach
+    const regex = new RegExp(pattern);
+    // Test against a short string to catch obvious issues
+    "test".match(regex);
+    return regex;
+  } catch {
+    return null;
+  }
+}
+
+export class MemoHandlerRegistry {
+  private handlers: MemoHandler[] = [];
+  private compiledRegex: Map<string, RegExp> = new Map();
+
+  constructor(customHandlers?: MemoHandler[]) {
+    const custom = (customHandlers ?? [])
+      .filter((h) => h.enabled !== false)
+      .slice(0, LIMITS.MAX_MEMO_HANDLERS);
+
+    // Pre-compile and validate all regex patterns
+    for (const handler of custom) {
+      if (handler.template.length > LIMITS.MAX_TEMPLATE_LENGTH) continue;
+      const regex = validateRegex(handler.pattern);
+      if (regex) {
+        this.handlers.push(handler);
+        this.compiledRegex.set(handler.name, regex);
+      }
+    }
+
+    // Add built-in handlers
+    for (const handler of BUILT_IN_HANDLERS) {
+      this.handlers.push(handler);
+      this.compiledRegex.set(handler.name, new RegExp(handler.pattern));
+    }
+  }
+
+  process(event: CoinEvent): HandlerResult {
+    const memo = event.memoDecoded ?? "";
+
+    for (const handler of this.handlers) {
+      const regex = this.compiledRegex.get(handler.name);
+      if (!regex) continue;
+
+      try {
+        const match = memo.match(regex);
+        if (match) {
+          const formatted = this.formatTemplate(handler.template, event, match);
+          return { matched: true, handlerName: handler.name, formattedMessage: formatted };
+        }
+      } catch {
+        // Regex execution error, skip
+      }
+    }
+
+    return { matched: false, handlerName: null, formattedMessage: null };
+  }
+
+  private formatTemplate(template: string, event: CoinEvent, match: RegExpMatchArray): string {
+    const addressShort = event.address.slice(0, 10) + "..." + event.address.slice(-6);
+
+    let result = template
+      .replace(/\{amount\}/g, String(event.amount))
+      .replace(/\{amountXch\}/g, event.amountXch.toFixed(6))
+      .replace(/\{address\}/g, event.address)
+      .replace(/\{addressShort\}/g, addressShort)
+      .replace(/\{memo\}/g, event.memoDecoded ?? "(none)")
+      .replace(/\{memoHex\}/g, event.memoHex ?? "")
+      .replace(/\{height\}/g, String(event.createdHeight))
+      .replace(/\{coinId\}/g, event.coinId)
+      .replace(/\{network\}/g, event.network)
+      .replace(/\{type\}/g, event.isCat ? "CAT" : "XCH")
+      .replace(/\{assetId\}/g, event.assetId ?? "");
+
+    // Replace match groups: {match1}, {match2}, etc. (max 9)
+    for (let i = 1; i < Math.min(match.length, 10); i++) {
+      result = result.replace(new RegExp(`\\{match${i}\\}`, "g"), match[i] ?? "");
+    }
+
+    return result;
+  }
+
+  updateHandlers(handlers: MemoHandler[]) {
+    this.compiledRegex.clear();
+    this.handlers = [];
+
+    const custom = handlers
+      .filter((h) => h.enabled !== false)
+      .slice(0, LIMITS.MAX_MEMO_HANDLERS);
+
+    for (const handler of custom) {
+      if (handler.template.length > LIMITS.MAX_TEMPLATE_LENGTH) continue;
+      const regex = validateRegex(handler.pattern);
+      if (regex) {
+        this.handlers.push(handler);
+        this.compiledRegex.set(handler.name, regex);
+      }
+    }
+
+    for (const handler of BUILT_IN_HANDLERS) {
+      this.handlers.push(handler);
+      this.compiledRegex.set(handler.name, new RegExp(handler.pattern));
+    }
+  }
+}

--- a/extensions/chia-watcher/src/notifications.ts
+++ b/extensions/chia-watcher/src/notifications.ts
@@ -1,0 +1,77 @@
+import type { CoinEvent } from "./types";
+
+export class NotificationEngine {
+  private api: any;
+  private channel: string | undefined;
+  private to: string | undefined;
+  private logger: any;
+
+  constructor(opts: { api: any; channel?: string; to?: string; logger?: any }) {
+    this.api = opts.api;
+    this.channel = opts.channel;
+    this.to = opts.to;
+    this.logger = opts.logger ?? console;
+  }
+
+  async send(message: string): Promise<boolean> {
+    try {
+      const to = this.to;
+      const channel = this.channel;
+      
+      if (!to) {
+        this.logger.warn(`[chia-watcher] No notification target configured`);
+        this.logger.info(`[chia-watcher] NOTIFICATION: ${message}`);
+        return false;
+      }
+
+      // Extract the raw chat ID from "telegram:123456" format
+      const chatId = to.includes(":") ? to.split(":").slice(1).join(":") : to;
+
+      // Use OpenClaw runtime channel APIs for direct delivery
+      if (channel === "telegram" && this.api.runtime?.channel?.telegram?.sendMessageTelegram) {
+        await this.api.runtime.channel.telegram.sendMessageTelegram(chatId, message);
+        return true;
+      }
+
+      if (channel === "signal" && this.api.runtime?.channel?.signal?.sendMessageSignal) {
+        await this.api.runtime.channel.signal.sendMessageSignal(chatId, message);
+        return true;
+      }
+
+      if (channel === "discord" && this.api.runtime?.channel?.discord?.sendMessageDiscord) {
+        await this.api.runtime.channel.discord.sendMessageDiscord(chatId, message);
+        return true;
+      }
+
+      if (channel === "whatsapp" && this.api.runtime?.channel?.whatsapp?.sendMessageWhatsApp) {
+        await this.api.runtime.channel.whatsapp.sendMessageWhatsApp(chatId, message);
+        return true;
+      }
+
+      // Fallback: inject as system event into main session
+      if (this.api.runtime?.system?.enqueueSystemEvent) {
+        this.api.runtime.system.enqueueSystemEvent(message, { sessionKey: "agent:main:main" });
+        this.logger.info(`[chia-watcher] Notification injected as system event`);
+        return true;
+      }
+
+      this.logger.warn(`[chia-watcher] No delivery method available, logging only`);
+      this.logger.info(`[chia-watcher] NOTIFICATION: ${message}`);
+      return false;
+    } catch (err: any) {
+      this.logger.error(`[chia-watcher] Failed to send notification: ${err.message}`);
+      return false;
+    }
+  }
+
+  async sendCoinAlert(event: CoinEvent, formattedMessage: string): Promise<boolean> {
+    const prefix = event.isCat ? "🪙" : "💰";
+    const fullMessage = `${prefix} **Chia Watcher Alert**\n\n${formattedMessage}`;
+    return this.send(fullMessage);
+  }
+
+  updateConfig(channel?: string, to?: string) {
+    this.channel = channel;
+    this.to = to;
+  }
+}

--- a/extensions/chia-watcher/src/store.ts
+++ b/extensions/chia-watcher/src/store.ts
@@ -1,0 +1,169 @@
+import Database from "better-sqlite3";
+import path from "path";
+import fs from "fs";
+import type { CoinEvent } from "./types";
+import { LIMITS } from "./types";
+
+/**
+ * Validate and resolve the database path.
+ * Must be within the OpenClaw data directory or /tmp.
+ */
+function validateDbPath(dbPath: string, baseDir: string): string {
+  const resolved = path.resolve(baseDir, dbPath);
+  const normalizedBase = path.resolve(baseDir);
+  const normalizedTmp = path.resolve("/tmp");
+
+  if (!resolved.startsWith(normalizedBase) && !resolved.startsWith(normalizedTmp)) {
+    throw new Error(
+      `Database path must be within the OpenClaw data directory or /tmp. Got: ${resolved}`
+    );
+  }
+
+  if (!resolved.endsWith(".db") && !resolved.endsWith(".sqlite")) {
+    throw new Error(`Database path must end with .db or .sqlite. Got: ${resolved}`);
+  }
+
+  // Ensure parent directory exists
+  const dir = path.dirname(resolved);
+  fs.mkdirSync(dir, { recursive: true });
+
+  return resolved;
+}
+
+export class TransactionStore {
+  private db: Database.Database;
+
+  constructor(dbPath: string, baseDir?: string) {
+    const resolvedPath = baseDir ? validateDbPath(dbPath, baseDir) : dbPath;
+    this.db = new Database(resolvedPath);
+    this.db.pragma("journal_mode = WAL");
+    this.migrate();
+  }
+
+  private migrate() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS transactions (
+        coin_id TEXT PRIMARY KEY,
+        address TEXT NOT NULL,
+        amount INTEGER NOT NULL,
+        amount_xch REAL NOT NULL,
+        memo_hex TEXT,
+        memo_decoded TEXT,
+        is_cat INTEGER NOT NULL DEFAULT 0,
+        asset_id TEXT,
+        created_height INTEGER NOT NULL,
+        spent_height INTEGER,
+        network TEXT NOT NULL,
+        matched_handler TEXT,
+        timestamp TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_tx_address ON transactions(address);
+      CREATE INDEX IF NOT EXISTS idx_tx_network ON transactions(network);
+      CREATE INDEX IF NOT EXISTS idx_tx_created_height ON transactions(created_height);
+      CREATE INDEX IF NOT EXISTS idx_tx_timestamp ON transactions(timestamp);
+
+      CREATE TABLE IF NOT EXISTS watched_wallets (
+        address TEXT PRIMARY KEY,
+        label TEXT,
+        added_at TEXT NOT NULL DEFAULT (datetime('now')),
+        active INTEGER NOT NULL DEFAULT 1
+      );
+
+      CREATE TABLE IF NOT EXISTS state (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+  }
+
+  saveCoinEvent(event: CoinEvent): void {
+    // Enforce row limit — prune oldest if at capacity
+    this.pruneIfNeeded();
+
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO transactions
+        (coin_id, address, amount, amount_xch, memo_hex, memo_decoded, is_cat, asset_id, created_height, spent_height, network, matched_handler, timestamp)
+      VALUES
+        (@coinId, @address, @amount, @amountXch, @memoHex, @memoDecoded, @isCat, @assetId, @createdHeight, @spentHeight, @network, @matchedHandler, @timestamp)
+    `);
+    stmt.run({
+      coinId: event.coinId,
+      address: event.address,
+      amount: event.amount,
+      amountXch: event.amountXch,
+      memoHex: event.memoHex,
+      memoDecoded: event.memoDecoded,
+      isCat: event.isCat ? 1 : 0,
+      assetId: event.assetId ?? null,
+      createdHeight: event.createdHeight,
+      spentHeight: event.spentHeight,
+      network: event.network,
+      matchedHandler: event.matchedHandler ?? null,
+      timestamp: event.timestamp,
+    });
+  }
+
+  private pruneIfNeeded(): void {
+    const count = (this.db.prepare("SELECT COUNT(*) as c FROM transactions").get() as any).c;
+    if (count >= LIMITS.MAX_DB_ROWS) {
+      this.db.prepare(
+        `DELETE FROM transactions WHERE coin_id IN (
+          SELECT coin_id FROM transactions ORDER BY created_height ASC LIMIT ?
+        )`
+      ).run(LIMITS.DB_PRUNE_BATCH);
+    }
+  }
+
+  getRecentTransactions(limit = 50): CoinEvent[] {
+    const safeLimit = Math.min(Math.max(1, limit), 200);
+    return this.db
+      .prepare("SELECT * FROM transactions ORDER BY created_height DESC LIMIT ?")
+      .all(safeLimit) as CoinEvent[];
+  }
+
+  getTransactionsByAddress(address: string, limit = 50): CoinEvent[] {
+    const safeLimit = Math.min(Math.max(1, limit), 200);
+    return this.db
+      .prepare("SELECT * FROM transactions WHERE address = ? ORDER BY created_height DESC LIMIT ?")
+      .all(address, safeLimit) as CoinEvent[];
+  }
+
+  saveState(key: string, value: string): void {
+    this.db.prepare("INSERT OR REPLACE INTO state (key, value) VALUES (?, ?)").run(key, value);
+  }
+
+  getState(key: string): string | null {
+    const row = this.db.prepare("SELECT value FROM state WHERE key = ?").get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  }
+
+  addWallet(address: string, label?: string): void {
+    // Enforce wallet limit
+    const count = (this.db.prepare("SELECT COUNT(*) as c FROM watched_wallets WHERE active = 1").get() as any).c;
+    if (count >= LIMITS.MAX_WALLETS) {
+      throw new Error(`Maximum wallet limit (${LIMITS.MAX_WALLETS}) reached`);
+    }
+    this.db.prepare("INSERT OR REPLACE INTO watched_wallets (address, label, active) VALUES (?, ?, 1)").run(address, label ?? null);
+  }
+
+  removeWallet(address: string): void {
+    this.db.prepare("UPDATE watched_wallets SET active = 0 WHERE address = ?").run(address);
+  }
+
+  getActiveWallets(): { address: string; label: string | null }[] {
+    return this.db.prepare("SELECT address, label FROM watched_wallets WHERE active = 1").all() as any[];
+  }
+
+  getStats(): { totalTx: number; uniqueAddresses: number; latestHeight: number | null } {
+    const totalTx = (this.db.prepare("SELECT COUNT(*) as c FROM transactions").get() as any).c;
+    const uniqueAddresses = (this.db.prepare("SELECT COUNT(DISTINCT address) as c FROM transactions").get() as any).c;
+    const latestHeight = (this.db.prepare("SELECT MAX(created_height) as h FROM transactions").get() as any).h;
+    return { totalTx, uniqueAddresses, latestHeight };
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/extensions/chia-watcher/src/subscriber.ts
+++ b/extensions/chia-watcher/src/subscriber.ts
@@ -1,0 +1,385 @@
+import {
+  Address,
+  Certificate,
+  Clvm,
+  Coin,
+  CoinStateFilters,
+  Connector,
+  Peer,
+  PeerOptions,
+  toHex,
+  fromHex,
+} from "chia-wallet-sdk";
+import dns from "dns/promises";
+import fs from "fs";
+import path from "path";
+import { EventEmitter } from "events";
+import type { CoinEvent, WatcherStatus } from "./types";
+import { MAINNET_CONFIG, TESTNET_CONFIG, LIMITS } from "./types";
+
+export interface SubscriberEvents {
+  coin: (event: CoinEvent) => void;
+  connected: (peerAddr: string, height: number) => void;
+  disconnected: () => void;
+  error: (err: Error) => void;
+  heightUpdate: (height: number) => void;
+}
+
+export class ChiaSubscriber extends EventEmitter {
+  private peer: any = null;
+  private peerAddr: string | null = null;
+  private peakHeight: number = 0;
+  private peakHash: Uint8Array | null = null;
+  private isRunning = false;
+  private startTime: Date | null = null;
+  private transactionCount = 0;
+  private errorCount = 0;
+  private lastUpdate: { previousHeight: number; headerHash: string } | null = null;
+  private puzzleHashes = new Set<string>();
+  private closed = false;
+  private network: "mainnet" | "testnet11";
+  private certDir: string;
+  private logger: any;
+  private monitorInterval: ReturnType<typeof setInterval> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private walletAddresses: string[] = [];
+  private networkConfig: any;
+  private cert: any;
+  private pendingEvents = 0;
+
+  constructor(opts: {
+    network: "mainnet" | "testnet11";
+    certDir: string;
+    logger?: any;
+    lastUpdate?: { previousHeight: number; headerHash: string } | null;
+  }) {
+    super();
+    this.network = opts.network;
+    this.certDir = opts.certDir;
+    this.logger = opts.logger ?? console;
+    this.lastUpdate = opts.lastUpdate ?? null;
+  }
+
+  async start(wallets: string[]): Promise<void> {
+    if (this.isRunning) return;
+
+    if (wallets.length > LIMITS.MAX_WALLETS) {
+      throw new Error(`Maximum ${LIMITS.MAX_WALLETS} wallets allowed, got ${wallets.length}`);
+    }
+    this.walletAddresses = wallets;
+    this.networkConfig = this.network === "testnet11" ? TESTNET_CONFIG : MAINNET_CONFIG;
+    this.cert = this.loadOrGenerateCert();
+
+    await this.connectAndSubscribe();
+  }
+
+  private async connectAndSubscribe(): Promise<void> {
+    // Try connecting to a random peer (up to 10 attempts)
+    for (let attempt = 0; attempt < 10; attempt++) {
+      try {
+        const ips = await this.lookupIntroducer(this.networkConfig.introducer);
+        if (!ips.length) throw new Error("No peers from DNS introducer");
+
+        const ip = ips[Math.floor(Math.random() * ips.length)];
+        const socketAddr = ip.includes(":") ? `[${ip}]:${this.networkConfig.port}` : `${ip}:${this.networkConfig.port}`;
+
+        const connector = new Connector(this.cert);
+        const options = new PeerOptions();
+        this.peer = await Peer.connect(this.networkConfig.networkId, socketAddr, connector, options);
+
+        const event = await this.peer.next();
+        if (!event?.newPeakWallet) throw new Error("No initial peak");
+
+        this.peakHeight = event.newPeakWallet.height;
+        this.peakHash = event.newPeakWallet.peakHash ?? null;
+        this.peerAddr = socketAddr;
+        this.isRunning = true;
+        this.closed = false;
+        this.startTime = this.startTime ?? new Date();
+
+        this.logger.info(`[chia-watcher] Connected to ${socketAddr} at height ${this.peakHeight}`);
+        this.emit("connected", socketAddr, this.peakHeight);
+
+        // Subscribe to wallets BEFORE starting event loop
+        // This ensures we don't miss events
+        await this.subscribeWallets(this.walletAddresses, this.networkConfig);
+
+        // Now start consuming events
+        this.startEventLoop();
+
+        // Start heartbeat monitor
+        if (this.monitorInterval) clearInterval(this.monitorInterval);
+        this.monitorInterval = setInterval(() => {
+          if (this.closed && this.isRunning) {
+            this.handleDisconnect();
+          }
+        }, 30000);
+
+        return;
+      } catch (err: any) {
+        this.logger.warn(`[chia-watcher] Connection attempt ${attempt + 1}/10 failed: ${err.message}`);
+      }
+    }
+
+    throw new Error("Failed to connect after 10 attempts");
+  }
+
+  async stop(): Promise<void> {
+    this.isRunning = false;
+    if (this.monitorInterval) clearInterval(this.monitorInterval);
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    if (this.peer && !this.closed) {
+      try {
+        await this.peer.removePuzzleSubscriptions(null);
+      } catch {}
+    }
+    this.closed = true;
+    this.peer = null;
+    this.puzzleHashes.clear();
+    this.logger.info("[chia-watcher] Subscriber stopped");
+  }
+
+  getStatus(): WatcherStatus {
+    const uptime = this.startTime ? Date.now() - this.startTime.getTime() : 0;
+    return {
+      isRunning: this.isRunning,
+      startedAt: this.startTime?.toISOString() ?? null,
+      network: this.network,
+      walletCount: this.puzzleHashes.size,
+      wallets: [],
+      transactionCount: this.transactionCount,
+      errorCount: this.errorCount,
+      peakHeight: this.peakHeight || null,
+      peerAddr: this.peerAddr,
+      uptime: Math.floor(uptime / 1000),
+    };
+  }
+
+  getLastUpdate() {
+    return this.lastUpdate;
+  }
+
+  private startEventLoop() {
+    const handleEvent = (event: any) => {
+      if (!event) {
+        this.closed = true;
+        this.handleDisconnect();
+        return;
+      }
+
+      if (event.newPeakWallet) {
+        this.peakHeight = event.newPeakWallet.height;
+        this.peakHash = event.newPeakWallet.peakHash ?? null;
+        this.emit("heightUpdate", this.peakHeight);
+      }
+
+      if (event.coinStateUpdate) {
+        this.lastUpdate = {
+          previousHeight: event.coinStateUpdate.height,
+          headerHash: toHex(event.coinStateUpdate.peakHash),
+        };
+        if (event.coinStateUpdate.items.length) {
+          // Backpressure: drop events if queue is overwhelmed
+          if (this.pendingEvents >= LIMITS.EVENT_QUEUE_MAX) {
+            this.logger.warn(`[chia-watcher] Event queue full (${this.pendingEvents}), dropping batch`);
+            this.errorCount++;
+          } else {
+            this.pendingEvents++;
+            this.processCoinStates(event.coinStateUpdate.items)
+              .catch((err) => {
+                this.errorCount++;
+                this.emit("error", err);
+              })
+              .finally(() => { this.pendingEvents--; });
+          }
+        }
+      }
+
+      // Continue consuming events
+      if (this.peer && !this.closed) {
+        this.peer.next().then(handleEvent).catch(() => {
+          this.closed = true;
+          this.handleDisconnect();
+        });
+      }
+    };
+
+    if (this.peer && !this.closed) {
+      this.peer.next().then(handleEvent).catch(() => {
+        this.closed = true;
+        this.handleDisconnect();
+      });
+    }
+  }
+
+  private async subscribeWallets(addresses: string[], networkConfig: any) {
+    const newHashes = addresses
+      .map((addr) => toHex(Address.decode(addr).puzzleHash))
+      .filter((h) => !this.puzzleHashes.has(h));
+
+    if (!newHashes.length) return;
+
+    // If no saved state, start from current peak (don't replay entire history)
+    let previousHeight = this.lastUpdate?.previousHeight;
+    let headerHash: Uint8Array;
+
+    if (this.lastUpdate?.headerHash) {
+      headerHash = fromHex(this.lastUpdate.headerHash.replace(/^0x/, ""));
+    } else if (this.peakHash) {
+      // Start from current tip - only get future coins
+      previousHeight = this.peakHeight;
+      headerHash = this.peakHash;
+      this.logger.info(`[chia-watcher] No saved state, subscribing from current height ${this.peakHeight}`);
+    } else {
+      // Absolute fallback - use genesis (will be slow)
+      headerHash = fromHex(networkConfig.genesisChallenge.replace(/^0x/, ""));
+    }
+
+    try {
+      while (true) {
+        const result = await this.peer.requestPuzzleState(
+          newHashes.map((h) => fromHex(h)),
+          previousHeight,
+          headerHash,
+          new CoinStateFilters(true, true, false, 0n),
+          true
+        );
+
+        if (result.coinStates.length) {
+          this.lastUpdate = {
+            previousHeight: result.height,
+            headerHash: toHex(result.headerHash),
+          };
+          await this.processCoinStates(result.coinStates);
+        }
+
+        if (result.isFinished) break;
+        previousHeight = result.height;
+        headerHash = result.headerHash;
+      }
+    } catch (err: any) {
+      this.logger.warn(`[chia-watcher] Error during wallet subscription: ${err.message}`);
+      // Don't throw - we're still connected, just failed to get historical state
+    }
+
+    for (const h of newHashes) this.puzzleHashes.add(h);
+    this.logger.info(`[chia-watcher] Subscribed to ${newHashes.length} wallet puzzle hashes`);
+  }
+
+  private async processCoinStates(coinStates: any[]) {
+    const clvm = new Clvm();
+
+    for (const cs of coinStates) {
+      try {
+        // Skip spent coins (we only care about created/received)
+        if (cs.spentHeight) continue;
+
+        let parentPuzzle: any;
+        let parentSolution: any;
+
+        try {
+          const result = await this.peer.requestPuzzleAndSolution(cs.coin.parentCoinInfo, cs.createdHeight ?? 0);
+          parentPuzzle = clvm.deserialize(result.puzzle).puzzle();
+          parentSolution = clvm.deserialize(result.solution);
+        } catch {
+          continue;
+        }
+
+        const isCat = !!parentPuzzle.parseCatInfo();
+        const catInfo = parentPuzzle.parseCatInfo();
+        const conditions = parentPuzzle.program.run(parentSolution, 11_000_000_000n, false).value.toList() ?? [];
+        const createCoins = conditions.map((c: any) => c.parseCreateCoin()).filter(Boolean);
+        const createCoin = createCoins.find((cc: any) =>
+          new Coin(cs.coin.parentCoinInfo, cc.puzzleHash, cc.amount).coinId().equals(cs.coin.coinId())
+        );
+
+        if (!createCoin) continue;
+
+        const memos = createCoin.memos?.toList() ?? [];
+        const memo = isCat ? memos[1] : memos[0];
+        const memoHex = memo ? memo.toAtom()?.toString("hex") : null;
+        const memoDecoded = memoHex ? this.decodeHexMemo(memoHex) : null;
+
+        const coinEvent: CoinEvent = {
+          coinId: cs.coin.coinId().toString("hex"),
+          address: new Address(cs.coin.puzzleHash, "xch").encode(),
+          amount: Number(cs.coin.amount),
+          amountXch: Number(cs.coin.amount) / 1_000_000_000_000,
+          memoHex,
+          memoDecoded,
+          isCat,
+          assetId: catInfo ? toHex(catInfo.assetId) : undefined,
+          createdHeight: cs.createdHeight,
+          spentHeight: cs.spentHeight,
+          network: this.network,
+          timestamp: new Date().toISOString(),
+        };
+
+        this.transactionCount++;
+        this.emit("coin", coinEvent);
+      } catch (err: any) {
+        this.errorCount++;
+        this.logger.warn(`[chia-watcher] Error processing coin state: ${err.message}`);
+      }
+    }
+  }
+
+  private handleDisconnect() {
+    if (!this.isRunning) return;
+    this.logger.warn("[chia-watcher] Peer disconnected, reconnecting in 30s...");
+    this.emit("disconnected");
+    if (this.monitorInterval) clearInterval(this.monitorInterval);
+    this.monitorInterval = null;
+    this.puzzleHashes.clear();
+    this.peer = null;
+
+    // Auto-reconnect after delay
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = setTimeout(async () => {
+      if (!this.isRunning) return;
+      try {
+        await this.connectAndSubscribe();
+        this.logger.info("[chia-watcher] Reconnected successfully");
+      } catch (err: any) {
+        this.logger.error(`[chia-watcher] Reconnect failed: ${err.message}`);
+        // Try again in 60s
+        this.reconnectTimer = setTimeout(() => this.handleDisconnect(), 60000);
+      }
+    }, 30000);
+  }
+
+  private loadOrGenerateCert(): any {
+    const certPath = path.join(this.certDir, "watcher.crt");
+    const keyPath = path.join(this.certDir, "watcher.key");
+
+    if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
+      return Certificate.load(certPath, keyPath);
+    }
+
+    fs.mkdirSync(this.certDir, { recursive: true });
+    const cert = Certificate.generate();
+    fs.writeFileSync(certPath, cert.certPem);
+    fs.writeFileSync(keyPath, cert.keyPem);
+    return cert;
+  }
+
+  private decodeHexMemo(hex: string): string | null {
+    try {
+      const clean = hex.replace(/\s/g, "");
+      if (clean.length % 2 !== 0) return null;
+      return Buffer.from(clean, "hex").toString("utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  private async lookupIntroducer(introducer: string): Promise<string[]> {
+    try {
+      const ipv4 = await dns.resolve4(introducer);
+      const ipv6 = await dns.resolve6(introducer).catch(() => []);
+      return [...ipv4, ...ipv6].sort(() => Math.random() - 0.5);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/extensions/chia-watcher/src/types.ts
+++ b/extensions/chia-watcher/src/types.ts
@@ -1,0 +1,74 @@
+/** Resource limits to prevent abuse */
+export const LIMITS = {
+  MAX_WALLETS: 50,
+  MAX_MEMO_HANDLERS: 20,
+  MAX_DB_ROWS: 100_000,
+  MAX_REGEX_LENGTH: 200,
+  MAX_TEMPLATE_LENGTH: 500,
+  DB_PRUNE_BATCH: 10_000,
+  EVENT_QUEUE_MAX: 1000,
+} as const;
+
+export interface ChiaWatcherConfig {
+  enabled: boolean;
+  network: "mainnet" | "testnet11";
+  wallets: string[];
+  autoStart: boolean;
+  notifyChannel?: string;
+  notifyTo?: string;
+  dbPath?: string;
+  memoHandlers?: MemoHandler[];
+  minAmountXch?: number;
+  includeCATs?: boolean;
+  pollIntervalMs?: number;
+}
+
+export interface MemoHandler {
+  name: string;
+  pattern: string; // regex string
+  template: string; // notification template with {amount}, {memo}, {address}, {match1}, etc.
+  enabled: boolean;
+}
+
+export interface CoinEvent {
+  coinId: string;
+  address: string;
+  amount: number; // mojos
+  amountXch: number;
+  memoHex: string | null;
+  memoDecoded: string | null;
+  isCat: boolean;
+  assetId?: string;
+  createdHeight: number;
+  spentHeight: number | null;
+  network: string;
+  timestamp: string;
+  matchedHandler?: string;
+}
+
+export interface WatcherStatus {
+  isRunning: boolean;
+  startedAt: string | null;
+  network: string;
+  walletCount: number;
+  wallets: string[];
+  transactionCount: number;
+  errorCount: number;
+  peakHeight: number | null;
+  peerAddr: string | null;
+  uptime: number;
+}
+
+export const MAINNET_CONFIG = {
+  introducer: "dns-introducer.chia.net",
+  networkId: "mainnet",
+  port: 8444,
+  genesisChallenge: "ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb",
+};
+
+export const TESTNET_CONFIG = {
+  introducer: "testnet11-introducer.chia.net",
+  networkId: "testnet11",
+  port: 58444,
+  genesisChallenge: "37a90eb5185a9c4439a91ddc98bbadce7b4feba060d50116a067de66bf236615",
+};

--- a/extensions/chia-watcher/tsconfig.json
+++ b/extensions/chia-watcher/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "dist",
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
Adds a new extension that monitors Chia wallet addresses for incoming coins via direct peer-to-peer connection (no API keys needed).

Features:
- Real-time P2P monitoring via Chia wallet protocol
- Multi-wallet support with bech32m address validation
- Automatic memo decoding (hex → UTF-8)
- Custom memo pattern handlers with regex matching
- Multi-channel notifications (Telegram, Discord, Signal, etc.)
- Local SQLite transaction history
- Slash commands: /chia_watch, /chia_unwatch, /chia_status, /chia_history
- Auto-reconnect with backoff on peer disconnect
- State persistence across gateway restarts
- Self-signed TLS certificate generation (no openssl dependency)

Published on npm as @koba42/openclaw-chia-watcher

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `extensions/chia-watcher` plugin that connects directly to Chia full nodes via `chia-wallet-sdk`, subscribes to puzzle-hash updates for configured wallet addresses, decodes on-chain memos, stores events in a local SQLite DB (`better-sqlite3`), and exposes management via slash commands and gateway RPC methods.

The extension is self-contained under `extensions/chia-watcher/` with its own `package.json`, JSON schema (`openclaw.plugin.json`) for config UI/validation, and an `index.ts` that registers a background service plus `/chia_*` commands. Runtime integration primarily flows through `api.registerService`, `api.registerCommand`, and `api.registerGatewayMethod`, and relies on OpenClaw’s plugin runtime for message delivery and state persistence.

Key issue to resolve before merge: the notification delivery implementation appears wired to an API shape that doesn’t match OpenClaw’s runtime channel surface, so configured Telegram/Discord/Signal/WhatsApp notifications will not be delivered as intended and will fall back to injecting a system event/logging.

<h3>Confidence Score: 2/5</h3>

- This PR has a clear functional wiring bug that prevents notifications from being delivered via the configured channels.
- The core Chia subscription/store pieces are plausibly correct, but notification delivery is a primary feature and is currently implemented against an API shape that does not match the plugin runtime, so users will not get Telegram/Discord/Signal/WhatsApp messages as configured. Until that’s fixed/verified end-to-end, merge risk is high for feature correctness.
- extensions/chia-watcher/src/notifications.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->