### PR TITLE
fix(onboard): validate workspace directory before setup steps

### DIFF
--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -370,7 +370,9 @@ describe("runOnboardingWizard", () => {
       intro: vi.fn(async () => {}),
       outro: vi.fn(async () => {}),
       note: vi.fn(async () => {}),
-      select: vi.fn(async () => "quickstart"),
+      select: vi.fn(
+        async (_params: WizardSelectParams<unknown>) => "quickstart",
+      ) as unknown as WizardPrompter["select"],
       multiselect: vi.fn(async () => []),
       text: vi.fn(async () => ""),
       confirm: vi.fn(async () => false),
@@ -418,7 +420,9 @@ describe("runOnboardingWizard", () => {
       intro: vi.fn(async () => {}),
       outro: vi.fn(async () => {}),
       note: vi.fn(async () => {}),
-      select: vi.fn(async () => "quickstart"),
+      select: vi.fn(
+        async (_params: WizardSelectParams<unknown>) => "quickstart",
+      ) as unknown as WizardPrompter["select"],
       multiselect: vi.fn(async () => []),
       text: vi.fn(async () => ""),
       confirm: vi.fn(async () => false),
@@ -466,7 +470,9 @@ describe("runOnboardingWizard", () => {
       intro: vi.fn(async () => {}),
       outro: vi.fn(async () => {}),
       note: vi.fn(async () => {}),
-      select: vi.fn(async () => "quickstart"),
+      select: vi.fn(
+        async (_params: WizardSelectParams<unknown>) => "quickstart",
+      ) as unknown as WizardPrompter["select"],
       multiselect: vi.fn(async () => []),
       text: vi.fn(async () => ""),
       confirm: vi.fn(async () => false),

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -456,6 +456,52 @@ describe("runOnboardingWizard", () => {
     expect(outroCalls[0][0]).toMatch(/workspace/i);
   });
 
+  it("re-throws non-permission workspace errors", async () => {
+    const enoentError = Object.assign(new Error("ENOENT: no such file or directory"), {
+      code: "ENOENT",
+    });
+    ensureWorkspaceAndSessions.mockRejectedValueOnce(enoentError);
+
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async () => {}),
+      select: vi.fn(async () => "quickstart"),
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    await expect(
+      runOnboardingWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          workspace: "/tmp/nonexistent/deep/path",
+          authChoice: "skip",
+          installDaemon: false,
+          skipProviders: true,
+          skipSkills: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      ),
+    ).rejects.toThrow("ENOENT");
+
+    expect(prompter.outro).not.toHaveBeenCalled();
+  });
+
   it("shows the web search hint at the end of onboarding", async () => {
     const prevBraveKey = process.env.BRAVE_API_KEY;
     delete process.env.BRAVE_API_KEY;

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -227,6 +227,8 @@ describe("runOnboardingWizard", () => {
     suiteCase = 0;
   });
 
+  beforeEach(() => vi.clearAllMocks());
+
   async function makeCaseDir(prefix: string): Promise<string> {
     const dir = path.join(suiteRoot, `${prefix}${++suiteCase}`);
     await fs.mkdir(dir, { recursive: true });
@@ -355,6 +357,103 @@ describe("runOnboardingWizard", () => {
 
   it("offers TUI hatch even without BOOTSTRAP.md", async () => {
     await runTuiHatchTest({ writeBootstrapFile: false, expectedMessage: undefined });
+  });
+
+  it("validates workspace before writing config or setting up channels", async () => {
+    const eaccesError = Object.assign(
+      new Error("EACCES: permission denied, mkdir '/root/workspace'"),
+      { code: "EACCES" },
+    );
+    ensureWorkspaceAndSessions.mockRejectedValueOnce(eaccesError);
+
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async () => {}),
+      select: vi.fn(async () => "quickstart"),
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    await expect(
+      runOnboardingWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          workspace: "/root/workspace",
+          authChoice: "skip",
+          installDaemon: false,
+          skipProviders: true,
+          skipSkills: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      ),
+    ).rejects.toThrow("exit:1");
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(setupChannels).not.toHaveBeenCalled();
+  });
+
+  it("shows workspace error message when directory is not writable", async () => {
+    const eaccesError = Object.assign(
+      new Error("EACCES: permission denied, mkdir '/root/workspace'"),
+      { code: "EACCES" },
+    );
+    ensureWorkspaceAndSessions.mockRejectedValueOnce(eaccesError);
+
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async () => {}),
+      select: vi.fn(async () => "quickstart"),
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    await expect(
+      runOnboardingWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          workspace: "/root/workspace",
+          authChoice: "skip",
+          installDaemon: false,
+          skipProviders: true,
+          skipSkills: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      ),
+    ).rejects.toThrow("exit:1");
+
+    const outroCalls = (prompter.outro as ReturnType<typeof vi.fn>).mock.calls;
+    expect(outroCalls.length).toBe(1);
+    expect(outroCalls[0][0]).toMatch(/workspace/i);
   });
 
   it("shows the web search hint at the end of onboarding", async () => {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -334,7 +334,7 @@ export async function runOnboardingWizard(
   const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
 
   try {
-    await ensureWorkspaceAndSessions(workspaceDir, runtime, {
+    await onboardHelpers.ensureWorkspaceAndSessions(workspaceDir, runtime, {
       skipBootstrap: Boolean(baseConfig.agents?.defaults?.skipBootstrap),
     });
   } catch (err) {


### PR DESCRIPTION
Fixes #13330

## Problem

The onboarding wizard collects the workspace path early (line 344-353) but doesn't actually create the workspace directory until line 454 — **after** auth setup, model selection, gateway configuration, and channel setup. If the directory is not writable (EACCES), all that interactive configuration work is wasted.

## Solution

Move `ensureWorkspaceAndSessions()` to right after workspace path resolution, wrapped in try-catch that:
- Shows a clear error message identifying the unwritable directory
- Exits gracefully with `runtime.exit(1)` before any other setup steps

This validates permissions **before** the user invests time in auth/model/gateway/channel prompts.

## Test plan

- [x] New test: "validates workspace before writing config or setting up channels" — mocks EACCES, asserts `writeConfigFile` and `setupChannels` were NOT called
- [x] New test: "shows workspace error message when directory is not writable" — asserts `prompter.outro` contains workspace-related message
- [x] Both tests fail before fix, pass after (TDD)
- [x] All 5 existing tests still pass (7 total)
- [x] `pnpm build && pnpm check` clean

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Moves workspace directory validation to happen immediately after path resolution, preventing wasted user effort on auth/model/gateway setup when the directory isn't writable. The fix wraps `ensureWorkspaceAndSessions()` in a try-catch that specifically handles permission errors (`EACCES`/`EPERM`) with a clear error message, while re-throwing other errors for normal handling.

- Validation now occurs at onboarding.ts:355-370, before any interactive prompts
- Permission errors (`EACCES`/`EPERM`) show a clear message and exit gracefully
- Non-permission errors (e.g., `ENOENT`) are re-thrown and handled normally
- Three new tests verify the fix: validates workspace before config/channels, shows error message, and re-throws non-permission errors
- All existing tests pass (7 total)
- Addresses issue #13330 effectively

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The fix is clean, focused, and well-tested with proper TDD approach (tests written first, failing before fix, passing after). The error handling specifically targets permission errors while preserving existing behavior for other error types. All three new tests comprehensively cover the validation flow, error messaging, and error re-throwing. Previous review concerns have been addressed in commit 6117d6e
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->