### PR TITLE
fix(outbound): return error instead of silently redirecting to allowList[0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Docs: https://docs.openclaw.ai
 
+## 2026.2.13 (Unreleased)
+
+### Fixes
+
+- Security/Audit: distinguish external webhooks (`hooks.enabled`) from internal hooks (`hooks.internal.enabled`) in attack-surface summaries to avoid false exposure signals when only internal hooks are enabled. (#13474) Thanks @mcaxtr.
+- Sandbox: pass configured `sandbox.docker.env` variables to sandbox containers at `docker create` time. (#15138) Thanks @stevebot-alive.
+- Onboarding/CLI: restore terminal state without resuming paused `stdin`, so onboarding exits cleanly after choosing Web UI and the installer returns instead of appearing stuck.
+- macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.
+- Heartbeat: prevent scheduler silent-death races during runner reloads, preserve retry cooldown backoff under wake bursts, and prioritize user/action wake causes over interval/retry reasons when coalescing. (#15108) Thanks @joeykrug.
+- Outbound targets: fail closed for WhatsApp/Twitch/Google Chat fallback paths so invalid or missing targets are dropped instead of rerouted, and align resolver hints with strict target requirements. (#13578) Thanks @mcaxtr.
+- Exec/Allowlist: allow multiline heredoc bodies (`<<`, `<<-`) while keeping multiline non-heredoc shell commands blocked, so exec approval parsing permits heredoc input safely without allowing general newline command chaining. (#13811) Thanks @mcaxtr.
+- Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
+
 ## 2026.2.12
 
 ### Changes

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -386,9 +386,6 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
       if (trimmed) {
         const normalized = normalizeGoogleChatTarget(trimmed);
         if (!normalized) {
-          if ((mode === "implicit" || mode === "heartbeat") && allowList.length > 0) {
-            return { ok: true, to: allowList[0] };
-          }
           return {
             ok: false,
             error: missingTargetError(
@@ -400,9 +397,6 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         return { ok: true, to: normalized };
       }
 
-      if (allowList.length > 0) {
-        return { ok: true, to: allowList[0] };
-      }
       return {
         ok: false,
         error: missingTargetError(

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -375,13 +375,8 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
     chunker: (text, limit) => getGoogleChatRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 4000,
-    resolveTarget: ({ to, allowFrom, mode }) => {
+    resolveTarget: ({ to }) => {
       const trimmed = to?.trim() ?? "";
-      const allowListRaw = (allowFrom ?? []).map((entry) => String(entry).trim()).filter(Boolean);
-      const allowList = allowListRaw
-        .filter((entry) => entry !== "*")
-        .map((entry) => normalizeGoogleChatTarget(entry))
-        .filter((entry): entry is string => Boolean(entry));
 
       if (trimmed) {
         const normalized = normalizeGoogleChatTarget(trimmed);

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -383,10 +383,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         if (!normalized) {
           return {
             ok: false,
-            error: missingTargetError(
-              "Google Chat",
-              "<spaces/{space}|users/{user}> or channels.googlechat.dm.allowFrom[0]",
-            ),
+            error: missingTargetError("Google Chat", "<spaces/{space}|users/{user}>"),
           };
         }
         return { ok: true, to: normalized };
@@ -394,10 +391,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
 
       return {
         ok: false,
-        error: missingTargetError(
-          "Google Chat",
-          "<spaces/{space}|users/{user}> or channels.googlechat.dm.allowFrom[0]",
-        ),
+        error: missingTargetError("Google Chat", "<spaces/{space}|users/{user}>"),
       };
     },
     sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {

--- a/extensions/googlechat/src/resolve-target.test.ts
+++ b/extensions/googlechat/src/resolve-target.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  getChatChannelMeta: () => ({ id: "googlechat", label: "Google Chat" }),
+  missingTargetError: (provider: string, hint: string) =>
+    new Error(`Delivering to ${provider} requires target ${hint}`),
+  GoogleChatConfigSchema: {},
+  DEFAULT_ACCOUNT_ID: "default",
+  PAIRING_APPROVED_MESSAGE: "Approved",
+  applyAccountNameToChannelSection: vi.fn(),
+  buildChannelConfigSchema: vi.fn(),
+  deleteAccountFromConfigSection: vi.fn(),
+  formatPairingApproveHint: vi.fn(),
+  migrateBaseNameToDefaultAccount: vi.fn(),
+  normalizeAccountId: vi.fn(),
+  resolveChannelMediaMaxBytes: vi.fn(),
+  resolveGoogleChatGroupRequireMention: vi.fn(),
+  setAccountEnabledInConfigSection: vi.fn(),
+}));
+
+vi.mock("./accounts.js", () => ({
+  listGoogleChatAccountIds: vi.fn(),
+  resolveDefaultGoogleChatAccountId: vi.fn(),
+  resolveGoogleChatAccount: vi.fn(),
+}));
+
+vi.mock("./actions.js", () => ({
+  googlechatMessageActions: [],
+}));
+
+vi.mock("./api.js", () => ({
+  sendGoogleChatMessage: vi.fn(),
+  uploadGoogleChatAttachment: vi.fn(),
+  probeGoogleChat: vi.fn(),
+}));
+
+vi.mock("./monitor.js", () => ({
+  resolveGoogleChatWebhookPath: vi.fn(),
+  startGoogleChatMonitor: vi.fn(),
+}));
+
+vi.mock("./onboarding.js", () => ({
+  googlechatOnboardingAdapter: {},
+}));
+
+vi.mock("./runtime.js", () => ({
+  getGoogleChatRuntime: vi.fn(() => ({
+    channel: {
+      text: { chunkMarkdownText: vi.fn() },
+    },
+  })),
+}));
+
+vi.mock("./targets.js", () => ({
+  normalizeGoogleChatTarget: (raw?: string | null) => {
+    if (!raw?.trim()) return undefined;
+    if (raw === "invalid-target") return undefined;
+    const trimmed = raw.trim().replace(/^(googlechat|google-chat|gchat):/i, "");
+    if (trimmed.startsWith("spaces/")) return trimmed;
+    if (trimmed.includes("@")) return `users/${trimmed.toLowerCase()}`;
+    return `users/${trimmed}`;
+  },
+  isGoogleChatUserTarget: (value: string) => value.startsWith("users/"),
+  isGoogleChatSpaceTarget: (value: string) => value.startsWith("spaces/"),
+  resolveGoogleChatOutboundSpace: vi.fn(),
+}));
+
+import { googlechatPlugin } from "./channel.js";
+
+const resolveTarget = googlechatPlugin.outbound!.resolveTarget!;
+
+describe("googlechat resolveTarget", () => {
+  it("should resolve valid target", () => {
+    const result = resolveTarget({
+      to: "spaces/AAA",
+      mode: "explicit",
+      allowFrom: [],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("spaces/AAA");
+  });
+
+  it("should resolve email target", () => {
+    const result = resolveTarget({
+      to: "user@example.com",
+      mode: "explicit",
+      allowFrom: [],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("users/user@example.com");
+  });
+
+  it("should error on normalization failure with allowlist (implicit mode)", () => {
+    const result = resolveTarget({
+      to: "invalid-target",
+      mode: "implicit",
+      allowFrom: ["spaces/BBB"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("should error when no target provided with allowlist", () => {
+    const result = resolveTarget({
+      to: undefined,
+      mode: "implicit",
+      allowFrom: ["spaces/BBB"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("should error when no target and no allowlist", () => {
+    const result = resolveTarget({
+      to: undefined,
+      mode: "explicit",
+      allowFrom: [],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("should handle whitespace-only target", () => {
+    const result = resolveTarget({
+      to: "   ",
+      mode: "explicit",
+      allowFrom: [],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -163,6 +163,17 @@ describe("outbound", () => {
       expect(result.error).toContain("Missing target");
     });
 
+    it("should error when target normalizes to empty string", () => {
+      const result = twitchOutbound.resolveTarget({
+        to: "#",
+        mode: "explicit",
+        allowFrom: [],
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("Twitch");
+    });
+
     it("should filter wildcard from allowlist when checking membership", () => {
       const result = twitchOutbound.resolveTarget({
         to: "#mychannel",

--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -108,15 +108,15 @@ describe("outbound", () => {
       expect(result.to).toBe("allowed");
     });
 
-    it("should fallback to first allowlist entry when target not in list", () => {
+    it("should error when target not in allowlist (implicit mode)", () => {
       const result = twitchOutbound.resolveTarget({
         to: "#notallowed",
         mode: "implicit",
         allowFrom: ["#primary", "#secondary"],
       });
 
-      expect(result.ok).toBe(true);
-      expect(result.to).toBe("primary");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("Twitch");
     });
 
     it("should accept any target when allowlist is empty", () => {
@@ -130,15 +130,15 @@ describe("outbound", () => {
       expect(result.to).toBe("anychannel");
     });
 
-    it("should use first allowlist entry when no target provided", () => {
+    it("should error when no target provided with allowlist", () => {
       const result = twitchOutbound.resolveTarget({
         to: undefined,
         mode: "implicit",
         allowFrom: ["#fallback", "#other"],
       });
 
-      expect(result.ok).toBe(true);
-      expect(result.to).toBe("fallback");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("Twitch");
     });
 
     it("should return error when no target and no allowlist", () => {

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -63,18 +63,20 @@ export const twitchOutbound: ChannelOutboundAdapter = {
         if (allowList.includes(normalizedTo)) {
           return { ok: true, to: normalizedTo };
         }
-        // Fallback to first allowFrom entry
-        return { ok: true, to: allowList[0] };
+        return {
+          ok: false,
+          error: missingTargetError(
+            "Twitch",
+            "<channel-name> or channels.twitch.accounts.<account>.allowFrom[0]",
+          ),
+        };
       }
 
       // For explicit mode, accept any valid channel name
       return { ok: true, to: normalizedTo };
     }
 
-    // No target provided, use allowFrom fallback
-    if (allowList.length > 0) {
-      return { ok: true, to: allowList[0] };
-    }
+    // No target provided - error
 
     // No target and no allowFrom - error
     return {

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -54,6 +54,15 @@ export const twitchOutbound: ChannelOutboundAdapter = {
     // If target is provided, normalize and validate it
     if (trimmed) {
       const normalizedTo = normalizeTwitchChannel(trimmed);
+      if (!normalizedTo) {
+        return {
+          ok: false,
+          error: missingTargetError(
+            "Twitch",
+            "<channel-name> or channels.twitch.accounts.<account>.allowFrom[0]",
+          ),
+        };
+      }
 
       // For implicit/heartbeat modes with allowList, check against allowlist
       if (mode === "implicit" || mode === "heartbeat") {

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -57,10 +57,7 @@ export const twitchOutbound: ChannelOutboundAdapter = {
       if (!normalizedTo) {
         return {
           ok: false,
-          error: missingTargetError(
-            "Twitch",
-            "<channel-name> or channels.twitch.accounts.<account>.allowFrom[0]",
-          ),
+          error: missingTargetError("Twitch", "<channel-name>"),
         };
       }
 
@@ -74,10 +71,7 @@ export const twitchOutbound: ChannelOutboundAdapter = {
         }
         return {
           ok: false,
-          error: missingTargetError(
-            "Twitch",
-            "<channel-name> or channels.twitch.accounts.<account>.allowFrom[0]",
-          ),
+          error: missingTargetError("Twitch", "<channel-name>"),
         };
       }
 
@@ -90,10 +84,7 @@ export const twitchOutbound: ChannelOutboundAdapter = {
     // No target and no allowFrom - error
     return {
       ok: false,
-      error: missingTargetError(
-        "Twitch",
-        "<channel-name> or channels.twitch.accounts.<account>.allowFrom[0]",
-      ),
+      error: missingTargetError("Twitch", "<channel-name>"),
     };
   },
 

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -301,9 +301,6 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       if (trimmed) {
         const normalizedTo = normalizeWhatsAppTarget(trimmed);
         if (!normalizedTo) {
-          if ((mode === "implicit" || mode === "heartbeat") && allowList.length > 0) {
-            return { ok: true, to: allowList[0] };
-          }
           return {
             ok: false,
             error: missingTargetError(
@@ -322,13 +319,15 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
           if (allowList.includes(normalizedTo)) {
             return { ok: true, to: normalizedTo };
           }
-          return { ok: true, to: allowList[0] };
+          return {
+            ok: false,
+            error: missingTargetError(
+              "WhatsApp",
+              "<E.164|group JID> or channels.whatsapp.allowFrom[0]",
+            ),
+          };
         }
         return { ok: true, to: normalizedTo };
-      }
-
-      if (allowList.length > 0) {
-        return { ok: true, to: allowList[0] };
       }
       return {
         ok: false,

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -303,10 +303,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
         if (!normalizedTo) {
           return {
             ok: false,
-            error: missingTargetError(
-              "WhatsApp",
-              "<E.164|group JID> or channels.whatsapp.allowFrom[0]",
-            ),
+            error: missingTargetError("WhatsApp", "<E.164|group JID>"),
           };
         }
         if (isWhatsAppGroupJid(normalizedTo)) {
@@ -321,20 +318,14 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
           }
           return {
             ok: false,
-            error: missingTargetError(
-              "WhatsApp",
-              "<E.164|group JID> or channels.whatsapp.allowFrom[0]",
-            ),
+            error: missingTargetError("WhatsApp", "<E.164|group JID>"),
           };
         }
         return { ok: true, to: normalizedTo };
       }
       return {
         ok: false,
-        error: missingTargetError(
-          "WhatsApp",
-          "<E.164|group JID> or channels.whatsapp.allowFrom[0]",
-        ),
+        error: missingTargetError("WhatsApp", "<E.164|group JID>"),
       };
     },
     sendText: async ({ to, text, accountId, deps, gifPlayback }) => {

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  getChatChannelMeta: () => ({ id: "whatsapp", label: "WhatsApp" }),
+  normalizeWhatsAppTarget: (value: string) => {
+    if (value === "invalid-target") return null;
+    // Simulate E.164 normalization: strip leading + and whatsapp: prefix
+    const stripped = value.replace(/^whatsapp:/i, "").replace(/^\+/, "");
+    return stripped.includes("@g.us") ? stripped : `${stripped}@s.whatsapp.net`;
+  },
+  isWhatsAppGroupJid: (value: string) => value.endsWith("@g.us"),
+  missingTargetError: (provider: string, hint: string) =>
+    new Error(`Delivering to ${provider} requires target ${hint}`),
+  WhatsAppConfigSchema: {},
+  whatsappOnboardingAdapter: {},
+  resolveWhatsAppHeartbeatRecipients: vi.fn(),
+  buildChannelConfigSchema: vi.fn(),
+  collectWhatsAppStatusIssues: vi.fn(),
+  createActionGate: vi.fn(),
+  DEFAULT_ACCOUNT_ID: "default",
+  escapeRegExp: vi.fn(),
+  formatPairingApproveHint: vi.fn(),
+  listWhatsAppAccountIds: vi.fn(),
+  listWhatsAppDirectoryGroupsFromConfig: vi.fn(),
+  listWhatsAppDirectoryPeersFromConfig: vi.fn(),
+  looksLikeWhatsAppTargetId: vi.fn(),
+  migrateBaseNameToDefaultAccount: vi.fn(),
+  normalizeAccountId: vi.fn(),
+  normalizeE164: vi.fn(),
+  normalizeWhatsAppMessagingTarget: vi.fn(),
+  readStringParam: vi.fn(),
+  resolveDefaultWhatsAppAccountId: vi.fn(),
+  resolveWhatsAppAccount: vi.fn(),
+  resolveWhatsAppGroupRequireMention: vi.fn(),
+  resolveWhatsAppGroupToolPolicy: vi.fn(),
+  applyAccountNameToChannelSection: vi.fn(),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getWhatsAppRuntime: vi.fn(() => ({
+    channel: {
+      text: { chunkText: vi.fn() },
+      whatsapp: {
+        sendMessageWhatsApp: vi.fn(),
+        createLoginTool: vi.fn(),
+      },
+    },
+  })),
+}));
+
+import { whatsappPlugin } from "./channel.js";
+
+const resolveTarget = whatsappPlugin.outbound!.resolveTarget!;
+
+describe("whatsapp resolveTarget", () => {
+  it("should resolve valid target in explicit mode", () => {
+    const result = resolveTarget({
+      to: "5511999999999",
+      mode: "explicit",
+      allowFrom: [],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("5511999999999@s.whatsapp.net");
+  });
+
+  it("should resolve target in implicit mode with wildcard", () => {
+    const result = resolveTarget({
+      to: "5511999999999",
+      mode: "implicit",
+      allowFrom: ["*"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("5511999999999@s.whatsapp.net");
+  });
+
+  it("should resolve target in implicit mode when in allowlist", () => {
+    const result = resolveTarget({
+      to: "5511999999999",
+      mode: "implicit",
+      allowFrom: ["5511999999999"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("5511999999999@s.whatsapp.net");
+  });
+
+  it("should allow group JID regardless of allowlist", () => {
+    const result = resolveTarget({
+      to: "120363123456789@g.us",
+      mode: "implicit",
+      allowFrom: ["5511999999999"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("120363123456789@g.us");
+  });
+
+  it("should error when target not in allowlist (implicit mode)", () => {
+    const result = resolveTarget({
+      to: "5511888888888",
+      mode: "implicit",
+      allowFrom: ["5511999999999", "5511777777777"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("should error on normalization failure with allowlist (implicit mode)", () => {
+    const result = resolveTarget({
+      to: "invalid-target",
+      mode: "implicit",
+      allowFrom: ["5511999999999"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("should error when no target provided with allowlist", () => {
+    const result = resolveTarget({
+      to: undefined,
+      mode: "implicit",
+      allowFrom: ["5511999999999"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("should error when no target and no allowlist", () => {
+    const result = resolveTarget({
+      to: undefined,
+      mode: "explicit",
+      allowFrom: [],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("should handle whitespace-only target", () => {
+    const result = resolveTarget({
+      to: "   ",
+      mode: "explicit",
+      allowFrom: [],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/channels/plugins/outbound/whatsapp.test.ts
+++ b/src/channels/plugins/outbound/whatsapp.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { whatsappOutbound } from "./whatsapp.js";
+
+describe("whatsappOutbound.resolveTarget", () => {
+  it("returns error when no target is provided even with allowFrom", () => {
+    const result = whatsappOutbound.resolveTarget?.({
+      to: undefined,
+      allowFrom: ["+15551234567"],
+      mode: "implicit",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.any(Error),
+    });
+  });
+
+  it("returns error when implicit target is not in allowFrom", () => {
+    const result = whatsappOutbound.resolveTarget?.({
+      to: "+15550000000",
+      allowFrom: ["+15551234567"],
+      mode: "implicit",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.any(Error),
+    });
+  });
+
+  it("keeps group JID targets even when allowFrom does not contain them", () => {
+    const result = whatsappOutbound.resolveTarget?.({
+      to: "120363401234567890@g.us",
+      allowFrom: ["+15551234567"],
+      mode: "implicit",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      to: "120363401234567890@g.us",
+    });
+  });
+});

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -23,15 +23,9 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
     if (trimmed) {
       const normalizedTo = normalizeWhatsAppTarget(trimmed);
       if (!normalizedTo) {
-        if ((mode === "implicit" || mode === "heartbeat") && allowList.length > 0) {
-          return { ok: true, to: allowList[0] };
-        }
         return {
           ok: false,
-          error: missingTargetError(
-            "WhatsApp",
-            "<E.164|group JID> or channels.whatsapp.allowFrom[0]",
-          ),
+          error: missingTargetError("WhatsApp", "<E.164|group JID>"),
         };
       }
       if (isWhatsAppGroupJid(normalizedTo)) {
@@ -44,17 +38,17 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
         if (allowList.includes(normalizedTo)) {
           return { ok: true, to: normalizedTo };
         }
-        return { ok: true, to: allowList[0] };
+        return {
+          ok: false,
+          error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+        };
       }
       return { ok: true, to: normalizedTo };
     }
 
-    if (allowList.length > 0) {
-      return { ok: true, to: allowList[0] };
-    }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID> or channels.whatsapp.allowFrom[0]"),
+      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
     };
   },
   sendText: async ({ to, text, accountId, deps, gifPlayback }) => {

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -198,7 +198,7 @@ describe("resolveHeartbeatDeliveryTarget", () => {
     });
   });
 
-  it("applies allowFrom fallback for WhatsApp targets", () => {
+  it("rejects WhatsApp target not in allowFrom (no silent fallback)", () => {
     const cfg: OpenClawConfig = {
       agents: { defaults: { heartbeat: { target: "whatsapp", to: "+1999" } } },
       channels: { whatsapp: { allowFrom: ["+1555", "+1666"] } },
@@ -209,9 +209,8 @@ describe("resolveHeartbeatDeliveryTarget", () => {
       lastTo: "+1222",
     };
     expect(resolveHeartbeatDeliveryTarget({ cfg, entry })).toEqual({
-      channel: "whatsapp",
-      to: "+1555",
-      reason: "allowFrom-fallback",
+      channel: "none",
+      reason: "no-target",
       accountId: undefined,
       lastChannel: "whatsapp",
       lastAccountId: undefined,

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -16,7 +16,7 @@ describe("resolveOutboundTarget", () => {
     );
   });
 
-  it("falls back to whatsapp allowFrom via config", () => {
+  it("rejects whatsapp with empty target even when allowFrom configured", () => {
     const cfg: OpenClawConfig = {
       channels: { whatsapp: { allowFrom: ["+1555"] } },
     };
@@ -26,7 +26,10 @@ describe("resolveOutboundTarget", () => {
       cfg,
       mode: "explicit",
     });
-    expect(res).toEqual({ ok: true, to: "+1555" });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.message).toContain("WhatsApp");
+    }
   });
 
   it.each([
@@ -49,18 +52,18 @@ describe("resolveOutboundTarget", () => {
       expected: { ok: true as const, to: "120363401234567890@g.us" },
     },
     {
-      name: "falls back to whatsapp allowFrom",
+      name: "rejects whatsapp with empty target and allowFrom (no silent fallback)",
       input: { channel: "whatsapp" as const, to: "", allowFrom: ["+1555"] },
-      expected: { ok: true as const, to: "+1555" },
+      expectedErrorIncludes: "WhatsApp",
     },
     {
-      name: "normalizes whatsapp allowFrom fallback targets",
+      name: "rejects whatsapp with empty target and prefixed allowFrom (no silent fallback)",
       input: {
         channel: "whatsapp" as const,
         to: "",
         allowFrom: ["whatsapp:(555) 123-4567"],
       },
-      expected: { ok: true as const, to: "+5551234567" },
+      expectedErrorIncludes: "WhatsApp",
     },
     {
       name: "rejects invalid whatsapp target",


### PR DESCRIPTION
## Summary

Fixes #13345

`resolveTarget()` in WhatsApp, Twitch, and Google Chat extensions was silently redirecting outbound messages to `allowList[0]` when:

1. **Target normalization failed** (implicit/heartbeat mode) — redirected to first allowList entry
2. **Target was NOT in the allowList** (implicit/heartbeat mode) — redirected to first allowList entry  
3. **No target was provided** — redirected to first allowList entry

This is a privacy/security concern: messages intended for one conversation could be delivered to a completely different recipient without any indication.

### Fix

All 7 fallback paths across 3 channel extensions now return `{ ok: false, error: missingTargetError(...) }` instead of `{ ok: true, to: allowList[0] }`. The upstream caller in `src/infra/outbound/targets.ts` already handles `ok: false` correctly by setting `channel: "none"` with `reason: "no-target"`, so messages are safely dropped rather than misdirected.

### Changes

- **`extensions/whatsapp/src/channel.ts`** — removed 3 silent fallback paths
- **`extensions/twitch/src/outbound.ts`** — removed 2 silent fallback paths  
- **`extensions/googlechat/src/channel.ts`** — removed 2 silent fallback paths
- **`extensions/twitch/src/outbound.test.ts`** — updated 2 existing tests to expect error instead of redirect
- **`extensions/whatsapp/src/resolve-target.test.ts`** — new test file (9 tests)
- **`extensions/googlechat/src/resolve-target.test.ts`** — new test file (6 tests)

## Test plan

- [x] All 7 new/updated tests fail before the fix (TDD: proves the bug exists)
- [x] All 36 tests pass after the fix
- [x] `pnpm build` passes
- [x] `pnpm check` passes (format + typecheck + lint)
- [x] No competing PRs exist for #13345

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a critical security vulnerability where outbound messages could be silently redirected to the wrong recipient (`allowList[0]`) when target resolution failed in WhatsApp, Twitch, and Google Chat channels. The fix replaces 7 silent fallback paths with proper error returns, ensuring messages are safely dropped rather than misdirected.

- **WhatsApp** (`extensions/whatsapp/src/channel.ts`): removed 3 silent fallback paths that redirected to `allowList[0]` on normalization failure, non-allowlisted targets, and missing targets
- **Twitch** (`extensions/twitch/src/outbound.ts`): removed 2 silent fallback paths that redirected to `allowList[0]` on normalization failure and non-allowlisted targets  
- **Google Chat** (`extensions/googlechat/src/channel.ts`): removed 2 silent fallback paths and cleaned up dead allowList computation code (Google Chat never validated targets against allowList, only used it for fallback)
- **Tests**: added comprehensive test coverage (9 WhatsApp tests, 6 Google Chat tests) and updated 2 existing Twitch tests to verify error returns instead of silent redirects

The upstream handler in `src/infra/outbound/targets.ts:254-259` already correctly handles `{ ok: false }` returns by setting `channel: "none"` with `reason: "no-target"`, so the fix integrates cleanly with existing error handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The fix is well-designed and addresses a legitimate security issue. All 7 fallback paths are correctly replaced with error returns, the upstream error handling is already in place, comprehensive test coverage validates the fix, and the Google Chat refactor appropriately removes dead code. The changes are minimal, focused, and follow the existing error handling patterns.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->