### PR TITLE
tools: add description to message tool channel parameter

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -43,7 +43,12 @@ function actionNeedsExplicitTarget(action: ChannelMessageActionName): boolean {
 }
 function buildRoutingSchema() {
   return {
-    channel: Type.Optional(Type.String()),
+    channel: Type.Optional(
+      Type.String({
+        description:
+          "Messaging provider name (e.g. 'slack', 'discord'). Not the channel/conversation ID.",
+      }),
+    ),
     target: Type.Optional(channelTargetSchema({ description: "Target channel/user id or name." })),
     targets: Type.Optional(channelTargetsSchema()),
     accountId: Type.Optional(Type.String()),


### PR DESCRIPTION
## Summary

Resubmitting [#10364](https://github.com/openclaw/openclaw/pull/10364) — previous PR was auto-closed when the fork was deleted and recreated.

The `channel` parameter in `buildRoutingSchema()` is defined as a bare `Type.Optional(Type.String())` with no description. This causes AI agents to pass channel/conversation IDs instead of provider names, resulting in "Unknown channel" errors.

Adds a description: `"Messaging provider name (e.g. 'slack', 'discord'). Not the channel/conversation ID."`

One-line change. Closes #10354

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds documentation to the `channel` parameter in the message tool schema to clarify it expects a provider name (like `slack`, `discord`) rather than a channel/conversation ID. This prevents AI agents from passing incorrect values that result in "Unknown channel" errors.

- Improves the `buildRoutingSchema()` function by adding an explicit description
- The description clearly differentiates between `channel` (provider name) and `target` (channel/conversation ID)
- Documentation-only change with no logic modifications

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a documentation-only change that adds a clarifying description to a parameter. No logic is modified, no new code paths are introduced, and the change addresses a real usability issue where AI agents were confused about what value to pass. The examples provided ('slack', 'discord') are valid provider names from the codebase.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->