### PR TITLE
fix: .gitignore `.tgz` → `*.tgz` glob pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ apps/ios/*.mobileprovision
 docs/.local/
 IDENTITY.md
 USER.md
-.tgz
+*.tgz
 .idea
 
 # local tooling


### PR DESCRIPTION
## Summary

Resubmitting [#12391](https://github.com/openclaw/openclaw/pull/12391) — previous PR was auto-closed when the fork was deleted and recreated.

`.tgz` in `.gitignore` only matches a file literally named `.tgz`. Changed to `*.tgz` so tarballs from `npm pack` are properly ignored.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed `.gitignore` pattern from `.tgz` to `*.tgz` so that tarball files generated by `npm pack` are properly ignored. The previous pattern `.tgz` only matched a file literally named `.tgz`, not actual tarball files like `openclaw-1.0.0.tgz`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a trivial `.gitignore` fix that corrects an obvious mistake in the glob pattern. The pattern `.tgz` without the wildcard would only match a file literally named `.tgz`, not actual npm tarball files like `package-name-1.0.0.tgz`. Changing it to `*.tgz` properly ignores all tarball files as intended.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->