### PR TITLE
fix(slack): remove ack reaction after tool-only replies

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -1,19 +1,17 @@
+import type { PreparedSlackMessage } from "./types.js";
 import { resolveHumanDelayConfig } from "../../../agents/identity.js";
 import { dispatchInboundMessage } from "../../../auto-reply/dispatch.js";
 import { clearHistoryEntriesIfEnabled } from "../../../auto-reply/reply/history.js";
+import { createReplyDispatcherWithTyping } from "../../../auto-reply/reply/reply-dispatcher.js";
 import { removeAckReactionAfterReply } from "../../../channels/ack-reactions.js";
 import { logAckFailure, logTypingFailure } from "../../../channels/logging.js";
-import { createReplyPrefixContext } from "../../../channels/reply-prefix.js";
+import { createReplyPrefixOptions } from "../../../channels/reply-prefix.js";
 import { createTypingCallbacks } from "../../../channels/typing.js";
-import { createReplyDispatcherWithTyping } from "../../../auto-reply/reply/reply-dispatcher.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { removeSlackReaction } from "../../actions.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
-
 import { createSlackReplyDeliveryPlan, deliverReplies } from "../replies.js";
-
-import type { PreparedSlackMessage } from "./types.js";
 
 export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessage) {
   const { ctx, account, message, route } = prepared;
@@ -67,7 +65,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       });
     },
     stop: async () => {
-      if (!didSetStatus) return;
+      if (!didSetStatus) {
+        return;
+      }
       didSetStatus = false;
       await ctx.setSlackThreadStatus({
         channelId: message.channel,
@@ -95,11 +95,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     },
   });
 
-  const prefixContext = createReplyPrefixContext({ cfg, agentId: route.agentId });
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg,
+    agentId: route.agentId,
+    channel: "slack",
+    accountId: route.accountId,
+  });
 
   const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
-    responsePrefix: prefixContext.responsePrefix,
-    responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+    ...prefixOptions,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     deliver: async (payload) => {
       const replyThreadTs = replyPlan.nextThreadTs();
@@ -134,14 +138,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         typeof account.config.blockStreaming === "boolean"
           ? !account.config.blockStreaming
           : undefined,
-      onModelSelected: (ctx) => {
-        prefixContext.onModelSelected(ctx);
-      },
+      onModelSelected,
     },
   });
   markDispatchIdle();
 
-  if (!queuedFinal) {
+  const anyReplyDelivered =
+    queuedFinal || (counts.tool ?? 0) > 0 || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+
+  if (!anyReplyDelivered) {
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,


### PR DESCRIPTION
## Summary
Fix Slack ack cleanup for tool-only replies.

`removeAckReactionAfterReply` was gated behind `anyReplyDelivered`, but that flag only counted `queuedFinal`, `counts.block`, and `counts.final`.
When a reply path emits only tool replies (`counts.tool > 0`), the function returned early and skipped ack cleanup, leaving `:eyes:` stuck.

## Change
- Include `counts.tool` in `anyReplyDelivered` calculation in `src/slack/monitor/message-handler/dispatch.ts`.

## Why this matches observed behavior
- Ack appears, but does not remove when the response path is tool-driven (`message.send`-style flows), because cleanup never runs.

## Risk
Low: only broadens the existing cleanup gate to include already-delivered tool replies.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Broadened the cleanup gate to include tool-only replies by checking `counts.tool` in addition to `queuedFinal`, `counts.block`, and `counts.final`. Previously, when replies contained only tool results (no user-facing text/blocks), the ack reaction cleanup was skipped because `queuedFinal` was false and `counts.tool` was not checked.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the reported issue by including tool-reply counts in the cleanup gate. The change is minimal, focused, and logically sound - it simply extends an existing condition to handle a previously missed case. The PR also includes minor formatting and import reordering improvements that align with the repository's code style.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->