### PR TITLE
feat(ui): group cron jobs by name folders

### DIFF
--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -282,7 +282,7 @@ export function renderCron(props: CronProps) {
             `
           : html`
             <div class="list" style="margin-top: 12px;">
-              ${props.jobs.map((job) => renderJob(job, props))}
+              ${renderGroupedJobs(props)}
             </div>
           `
       }
@@ -543,4 +543,40 @@ function renderRun(entry: CronRunLogEntry, basePath: string) {
       </div>
     </div>
   `;
+}
+
+function renderGroupedJobs(props: CronProps) {
+  const jobsByGroup = new Map<string, CronJob[]>();
+  for (const job of props.jobs) {
+    const parts = (job.name || "").split("/");
+    const group = parts.length > 1 ? parts[0] : "";
+    if (!jobsByGroup.has(group)) {
+      jobsByGroup.set(group, []);
+    }
+    jobsByGroup.get(group)!.push(job);
+  }
+
+  const groups = Array.from(jobsByGroup.keys()).toSorted((a, b) => {
+    if (a === "") {
+      return 1;
+    }
+    if (b === "") {
+      return -1;
+    }
+    return a.localeCompare(b);
+  });
+
+  return groups.map((group) => {
+    const groupJobs = jobsByGroup.get(group)!;
+    return html`
+      <div class="cron-group" style="margin-bottom: 16px;">
+        <div class="cron-group-header" style="font-weight: 800; font-size: 14px; text-transform: uppercase; color: var(--accent); margin-bottom: 8px; border-bottom: 1px solid var(--border); padding-bottom: 4px;">
+          ${group || "Uncategorized"} (${groupJobs.length})
+        </div>
+        <div class="cron-group-list">
+          ${groupJobs.map((job) => renderJob(job, props))}
+        </div>
+      </div>
+    `;
+  });
 }


### PR DESCRIPTION
This PR adds support for grouping cron jobs in the Web UI using the forward slash ('/') as a delimiter in the job name. This helps organize multiple jobs into logical folders, improving clarity in the dashboard.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Cron Jobs view (`ui/src/ui/views/cron.ts`) to render jobs grouped by a prefix derived from the job name using `/` as a delimiter. Jobs are bucketed by the first path segment (e.g., `group/job`) and rendered under a group header with a count, with ungrouped jobs collected under an "Uncategorized" bucket and sorted last.

The grouping is implemented entirely client-side in the UI layer by introducing `renderGroupedJobs(props)` and swapping the previous flat `props.jobs.map(...)` list render to the grouped renderer.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is localized to UI rendering, is straightforward, and does not introduce clear runtime or logic errors in the reviewed diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->