### PR TITLE
fix(skills): correct apple-notes SKILL.md memo -a syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
+- Skills: fix incorrect `memo notes -a "Title"` syntax in apple-notes SKILL.md; clarify that `-a` is a boolean flag. (#13532)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
 - CI: Implement pipeline and workflow order. Thanks @quotentiroler.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -43,7 +43,7 @@ Create Notes
 
 - Add a new note: `memo notes -a`
   - Opens an interactive editor to compose the note.
-- Quick add with title: `memo notes -a "Note Title"`
+  - Note: `-a` is a boolean flag and does not accept a title argument. The note title in Apple Notes is set by memo internally and cannot be controlled via the CLI.
 
 Edit Notes
 


### PR DESCRIPTION
## Summary
Fixes #13532

## Problem
The `apple-notes` skill's `SKILL.md` documents a nonexistent feature: `memo notes -a "Note Title"`. The `-a` flag in the `memo` CLI is a boolean switch that opens an interactive editor — it does not accept a title argument. The agent follows the skill's instructions, the command silently ignores the extra argument, and the note gets the default title instead of the user-requested one.

Additionally, the upstream `memo` CLI hardcodes the note name to "New Note" in its AppleScript template (`addmemo.py:33-34`), so note titles cannot be controlled via the CLI at all. An upstream issue has been filed: https://github.com/antoniorodr/memo/issues/14

## Fix
Remove the incorrect `memo notes -a "Note Title"` syntax and clarify that `-a` is a boolean flag whose title behavior is controlled internally by memo.

**Before:**
```markdown
- Add a new note: `memo notes -a`
  - Opens an interactive editor to compose the note.
- Quick add with title: `memo notes -a "Note Title"`
```

**After:**
```markdown
- Add a new note: `memo notes -a`
  - Opens an interactive editor to compose the note.
  - Note: `-a` is a boolean flag and does not accept a title argument. The note title in Apple Notes is set by memo internally and cannot be controlled via the CLI.
```

## Effect on User Experience

**Before fix:**
The agent calls `memo notes -a "Meeting Notes"` as instructed by SKILL.md. The extra argument is silently ignored, and the note appears in Apple Notes with title "New Note" instead of "Meeting Notes".

**After fix:**
The skill no longer instructs the agent to use a nonexistent title syntax. The agent will use `memo notes -a` correctly and can inform the user about the title limitation.

## Testing
- Pure documentation fix, no code logic changes
- Lint passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the `apple-notes` skill documentation to remove the incorrect `memo notes -a "Title"` usage and clarify that `-a` is a boolean flag whose note title behavior is controlled internally by `memo`.

Also adds a changelog entry describing the doc fix.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge once the changelog PR reference is corrected.
- The functional change is a documentation correction in `skills/apple-notes/SKILL.md`. The only concrete issue found is a misreferenced number in `CHANGELOG.md` that should point to this PR for traceability.
- CHANGELOG.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->