### PR TITLE
test: add regression tests for sanitizeUserFacingText billing false-positive

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -27,4 +27,16 @@ describe("isBillingErrorMessage", () => {
     expect(isBillingErrorMessage("invalid api key")).toBe(false);
     expect(isBillingErrorMessage("context length exceeded")).toBe(false);
   });
+
+  it("does not match normal assistant text discussing billing topics (#13527)", () => {
+    const samples = [
+      "easier billing, can export invoices. Apple subscription handles payments and removes all billing friction",
+      "The billing department processes payment requests weekly. You should upgrade your plan to the enterprise tier.",
+      "SaaS billing best practices: accept multiple payment methods, offer monthly and annual plans, and provide credits for referrals.",
+      "Let me explain how billing works: when a payment is received, credits are added to your account and you can upgrade your plan at any time.",
+    ];
+    for (const sample of samples) {
+      expect(isBillingErrorMessage(sample)).toBe(false);
+    }
+  });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -69,4 +69,25 @@ describe("sanitizeUserFacingText", () => {
     const text = "Hello there!\n\nDifferent line.";
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
+
+  it("does not rewrite normal assistant text about billing/payment topics (#13527)", () => {
+    const text =
+      "easier billing, can export invoices. Apple subscription handles payments and removes all billing friction";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("does not rewrite SaaS pricing discussion mentioning billing and credits (#13527)", () => {
+    const text =
+      "SaaS billing best practices: accept multiple payment methods, offer monthly and annual plans, and provide credits for referrals.";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("still rewrites actual billing errors in error context (#13527)", () => {
+    expect(sanitizeUserFacingText("402 Payment Required", { errorContext: true })).toContain(
+      "billing error",
+    );
+    expect(
+      sanitizeUserFacingText("insufficient credits", { errorContext: true }),
+    ).toContain("billing error");
+  });
 });


### PR DESCRIPTION
## Summary

Adds regression tests for #13527 — `sanitizeUserFacingText()` was silently replacing normal assistant responses about billing/payment topics with a fake billing error message.

## Root cause

`isBillingErrorMessage()` had a broad keyword check: if text contained "billing" AND any of "upgrade"/"credits"/"payment"/"plan", it returned `true`. This matched normal English prose about SaaS pricing, subscriptions, etc.

The source code already has the fix:
- `isBillingErrorMessage()` now only matches specific error patterns (402, "payment required", "insufficient credits", etc.)
- `sanitizeUserFacingText()` now only applies error-pattern rewrites when `errorContext: true` is passed

## Changes

Added regression tests to prevent this from happening again:
- `isBillingErrorMessage` test: normal assistant text about billing topics must not match
- `sanitizeUserFacingText` test: normal text preserved without error context; actual billing errors still rewritten with error context

Closes #13527

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds regression tests to prevent `sanitizeUserFacingText()` from incorrectly flagging normal assistant responses about billing topics as billing errors. The fix (already merged in commits 8c73dbe and 54315ae) removed the broad keyword matching logic that was causing false positives when text contained "billing" AND any of "upgrade"/"credits"/"payment"/"plan".

The tests verify:
- `isBillingErrorMessage()` now only matches specific error patterns (402, "payment required", "insufficient credits", etc.) and does not match normal conversation about billing topics
- `sanitizeUserFacingText()` preserves normal text by default and only applies billing error rewrites when `errorContext: true` is explicitly passed

These tests provide proper regression coverage to ensure the false-positive issue from #13527 doesn't reoccur.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Pure test addition that adds regression coverage for an already-fixed bug. Tests follow existing patterns in the codebase, properly validate the fix, and have no impact on production code.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->