### PR TITLE
fix(model): propagate provider model properties in fallback resolution

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -435,7 +435,6 @@ describe("resolveModel", () => {
     expect(result.model?.maxTokens).toBe(64000);
   });
 
->>>>>>> 5284bb82a (fix(model): propagate provider model properties in fallback resolution)
   it("uses codex fallback even when openai-codex provider is configured", () => {
     // This test verifies the ordering: codex fallback must fire BEFORE the generic providerCfg fallback.
     // If ordering is wrong, the generic fallback would use api: "openai-responses" (the default)

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -400,6 +400,7 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
     expect(result.model?.contextWindow).toBe(128000);
     expect(result.model?.maxTokens).toBe(64000);
+  });
 
   it("fallback uses correct model when provider has multiple models", () => {
     const cfg = {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -340,6 +340,102 @@ describe("resolveModel", () => {
     expectUnknownModelError("openai-codex", "gpt-4.1-mini");
   });
 
+  it("errors for unknown gpt-5.3-codex-* variants", () => {
+    const result = resolveModel("openai-codex", "gpt-5.3-codex-unknown", "/tmp/agent");
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: openai-codex/gpt-5.3-codex-unknown");
+  });
+
+  it("fallback does not bleed contextWindow from unrelated models[0]", () => {
+    // When a provider has models configured but the requested model is NOT in the array,
+    // the fallback should use DEFAULT_CONTEXT_TOKENS, not models[0].contextWindow.
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [
+              {
+                ...makeModel("other-model"),
+                contextWindow: 4096,
+                maxTokens: 2048,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("custom", "unknown-model", "/tmp/agent", cfg);
+
+    expect(result.model?.id).toBe("unknown-model");
+    // Should NOT be 4096 (from models[0]). Should be the default.
+    expect(result.model?.contextWindow).not.toBe(4096);
+  });
+
+  it("fallback propagates reasoning from matched provider model", () => {
+    // When a provider has a model with reasoning: true AND that model is the one requested,
+    // the fallback should propagate reasoning: true instead of hardcoding false.
+    const cfg = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434/v1",
+            api: "openai-responses",
+            models: [
+              {
+                ...makeModel("thinking-model"),
+                reasoning: true,
+                contextWindow: 128000,
+                maxTokens: 64000,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("ollama", "thinking-model", "/tmp/agent", cfg);
+
+    expect(result.model?.reasoning).toBe(true);
+    expect(result.model?.contextWindow).toBe(128000);
+    expect(result.model?.maxTokens).toBe(64000);
+
+  it("fallback uses correct model when provider has multiple models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434/v1",
+            api: "openai-responses",
+            models: [
+              {
+                ...makeModel("small-model"),
+                reasoning: false,
+                contextWindow: 4096,
+                maxTokens: 2048,
+              },
+              {
+                ...makeModel("big-model"),
+                reasoning: true,
+                contextWindow: 128000,
+                maxTokens: 64000,
+                input: ["text", "image"] as const,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("ollama", "big-model", "/tmp/agent", cfg);
+
+    expect(result.model?.reasoning).toBe(true);
+    expect(result.model?.contextWindow).toBe(128000);
+    expect(result.model?.maxTokens).toBe(64000);
+  });
+
+>>>>>>> 5284bb82a (fix(model): propagate provider model properties in fallback resolution)
   it("uses codex fallback even when openai-codex provider is configured", () => {
     // This test verifies the ordering: codex fallback must fire BEFORE the generic providerCfg fallback.
     // If ordering is wrong, the generic fallback would use api: "openai-responses" (the default)

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -81,8 +81,8 @@ export function resolveModel(
       const trimmedId = modelId.trim();
       const matchedModel = (providerCfg?.models ?? []).find((m) => m.id === trimmedId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
-        id: modelId,
-        name: matchedModel?.name ?? modelId,
+        id: trimmedId,
+        name: matchedModel?.name ?? trimmedId,
         api: matchedModel?.api ?? providerCfg?.api ?? "openai-responses",
         provider,
         baseUrl: providerCfg?.baseUrl,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -78,17 +78,18 @@ export function resolveModel(
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
+      const matchedModel = (providerCfg?.models ?? []).find((m) => m.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
-        name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
+        name: matchedModel?.name ?? modelId,
+        api: matchedModel?.api ?? providerCfg?.api ?? "openai-responses",
         provider,
         baseUrl: providerCfg?.baseUrl,
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-        maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+        reasoning: matchedModel?.reasoning ?? false,
+        input: matchedModel?.input ?? ["text"],
+        cost: matchedModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: matchedModel?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
+        maxTokens: matchedModel?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -78,7 +78,8 @@ export function resolveModel(
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
-      const matchedModel = (providerCfg?.models ?? []).find((m) => m.id === modelId);
+      const trimmedId = modelId.trim();
+      const matchedModel = (providerCfg?.models ?? []).find((m) => m.id === trimmedId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
         name: matchedModel?.name ?? modelId,


### PR DESCRIPTION
## Summary

Fixes #13575

The generic fallback in `resolveModel()` had two bugs when constructing a model from provider config:

1. **`reasoning: false` hardcoded** — ignored the matched model's `reasoning` setting, preventing `reasoning.effort` from being forwarded to the API (e.g. Ollama models with `reasoning: true`)
2. **`models[0]` for contextWindow/maxTokens** — read from the first model in the provider's array instead of the matched model, causing incorrect context limits when multiple models are configured

The fix finds the matched model by ID from the provider config and propagates all its properties (`reasoning`, `input`, `cost`, `contextWindow`, `maxTokens`, `name`, `api`) instead of using hardcoded defaults or the first model in the array.

## Test plan

- [x] Add test: fallback does not bleed contextWindow from unrelated `models[0]`
- [x] Add test: fallback propagates reasoning from matched provider model
- [x] Add test: fallback uses correct model when provider has multiple models
- [x] All 3 new tests fail before the fix, pass after
- [x] All 13 tests pass (`npx vitest run src/agents/pi-embedded-runner/model.test.ts`)
- [x] `pnpm build && pnpm check` clean

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed two bugs in the generic fallback path of `resolveModel()` when constructing models from provider config:

- **`reasoning` propagation**: Previously hardcoded to `false`, now reads from matched model config (e.g., Ollama models with `reasoning: true`)
- **`contextWindow`/`maxTokens` selection**: Previously read from `models[0]` regardless of which model was requested, now reads from the matched model

Added comprehensive test coverage for all three scenarios (unmatched model using defaults, matched model with reasoning, multiple models selecting the correct one). The fix properly finds the matched model by trimmed ID and propagates all its properties (`reasoning`, `input`, `cost`, `contextWindow`, `maxTokens`, `name`, `api`). Previous review comments about trimming inconsistencies have been addressed in follow-up commits.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no blocking issues
- The implementation correctly fixes both documented bugs with proper test coverage. All three new tests target the exact scenarios described in the PR (bleeding contextWindow, reasoning propagation, multiple model selection). Previous review concerns about trimming have been addressed. The logic is straightforward and the changes are minimal and focused.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->