### PR TITLE
Fix: propagate inline model config in resolveModel fallback path

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -135,6 +135,34 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("missing-model");
   });
 
+  it("propagates inline model config properties in fallback path", () => {
+    const cfg = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434/v1",
+            api: "openai-responses",
+            models: [
+              {
+                id: "my-reasoning-model",
+                reasoning: true,
+                contextWindow: 128000,
+                maxTokens: 32000,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("ollama", "my-reasoning-model", "/tmp/agent", cfg);
+
+    expect(result.model?.reasoning).toBe(true);
+    expect(result.model?.contextWindow).toBe(128000);
+    expect(result.model?.maxTokens).toBe(32000);
+    expect(result.model?.baseUrl).toBe("http://localhost:11434/v1");
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     const templateModel = {
       id: "gpt-5.2-codex",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -201,17 +201,22 @@ export function resolveModel(
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
+      const matchedModel = (providerCfg?.models ?? []).find((m) => m.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
         name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
+        api: matchedModel?.api ?? providerCfg?.api ?? "openai-responses",
         provider,
         baseUrl: providerCfg?.baseUrl,
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-        maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+        reasoning: matchedModel?.reasoning ?? false,
+        input: matchedModel?.input ?? ["text"],
+        cost: matchedModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow:
+          matchedModel?.contextWindow ??
+          providerCfg?.models?.[0]?.contextWindow ??
+          DEFAULT_CONTEXT_TOKENS,
+        maxTokens:
+          matchedModel?.maxTokens ?? providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }


### PR DESCRIPTION
## Problem

When a model is configured in `models.providers.<provider>.models` with properties like `reasoning: true`, `contextWindow`, or `maxTokens`, those properties are ignored if the model hits the generic fallback path in `resolveModel()`. The fallback hardcodes `reasoning: false` and picks `contextWindow`/`maxTokens` from `models[0]` instead of matching the actual model ID.

This causes `reasoning.effort` to never reach the API for Ollama and other custom providers, even when the user explicitly configures `reasoning: true` on their model.

Fixes #13575

## Root cause

In `src/agents/pi-embedded-runner/model.ts`, the fallback model construction at ~line 204 ignores per-model inline config:
- `reasoning: false` is hardcoded
- `contextWindow` and `maxTokens` use `models?.[0]` (first model) instead of the matching model

## Change

Look up the matching model entry from `providerCfg.models` by ID and propagate its properties (`reasoning`, `contextWindow`, `maxTokens`, `input`, `cost`, `api`) into the fallback model, falling back to existing defaults when no match is found.

## Test coverage

Added a test `propagates inline model config properties in fallback path` that verifies `reasoning: true`, `contextWindow`, and `maxTokens` are preserved. All 11 tests pass.

## Validation

- `pnpm test -- src/agents/pi-embedded-runner/model.test.ts` → 11/11 pass
- `pnpm check` → clean
- `pnpm lint` → 0 warnings, 0 errors

lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed the fallback path in `resolveModel()` to properly propagate per-model configuration properties (`reasoning`, `contextWindow`, `maxTokens`, `api`, `input`, `cost`) from `models.providers.<provider>.models` entries, ensuring that explicitly configured model settings are respected even when the model hits the generic fallback construction path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted, adds proper test coverage, and follows the existing code patterns. The change correctly looks up model-specific config and maintains backward compatibility through fallback chains. No logical errors or security issues detected.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->