### PR TITLE
fix(discord): add proxy support for media attachment downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: add `channels.discord.proxy` for media attachment downloads in proxy-required environments. (#2503)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
 - CI: Implement pipeline and workflow order. Thanks @quotentiroler.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -251,6 +251,7 @@ Outbound Discord API calls retry on rate limits (429) using Discord `retry_after
     discord: {
       enabled: true,
       token: "abc.123",
+      proxy: "http://your-proxy:port", // optional HTTP(S) proxy for media downloads
       groupPolicy: "allowlist",
       guilds: {
         "*": {
@@ -344,6 +345,7 @@ ack reaction after the bot replies.
 - `chunkMode`: `length` (default) splits only when exceeding `textChunkLimit`; `newline` splits on blank lines (paragraph boundaries) before length chunking.
 - `maxLinesPerMessage`: soft max line count per message. Default: 17.
 - `mediaMaxMb`: clamp inbound media saved to disk.
+- `proxy`: HTTP(S) proxy URL for outbound Discord requests (media downloads). Uses undici `ProxyAgent` to bypass Node.js 22+ native fetch limitations with `global-agent`.
 - `historyLimit`: number of recent guild messages to include as context when replying to a mention (default 20; falls back to `messages.groupChat.historyLimit`; `0` disables).
 - `dmHistoryLimit`: DM history limit in user turns. Per-user overrides: `dms["<user_id>"].historyLimit`.
 - `retry`: retry policy for outbound Discord API calls (attempts, minDelayMs, maxDelayMs, jitter).

--- a/docs/zh-CN/channels/discord.md
+++ b/docs/zh-CN/channels/discord.md
@@ -255,6 +255,7 @@ Discord 到处使用数字 ID；OpenClaw 配置优先使用 ID。
     discord: {
       enabled: true,
       token: "abc.123",
+      proxy: "http://your-proxy:port", // 可选，用于媒体下载的 HTTP(S) 代理
       groupPolicy: "allowlist",
       guilds: {
         "*": {
@@ -345,6 +346,7 @@ Discord 到处使用数字 ID；OpenClaw 配置优先使用 ID。
 - `chunkMode`：`length`（默认）仅在超过 `textChunkLimit` 时分割；`newline` 在空行（段落边界）处分割，然后再进行长度分块。
 - `maxLinesPerMessage`：每条消息的软最大行数。默认：17。
 - `mediaMaxMb`：限制保存到磁盘的入站媒体大小。
+- `proxy`：用于出站 Discord 请求（媒体下载）的 HTTP(S) 代理 URL。使用 undici `ProxyAgent` 绕过 Node.js 22+ 原生 fetch 与 `global-agent` 的兼容性问题。
 - `historyLimit`：回复提及时作为上下文包含的最近服务器消息数量（默认 20；回退到 `messages.groupChat.historyLimit`；`0` 禁用）。
 - `dmHistoryLimit`：私信历史限制（用户轮次）。每用户覆盖：`dms["<user_id>"].historyLimit`。
 - `retry`：出站 Discord API 调用的重试策略（attempts、minDelayMs、maxDelayMs、jitter）。

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -118,6 +118,8 @@ export type DiscordAccountConfig = {
   /** If false, do not start this Discord account. Default: true. */
   enabled?: boolean;
   token?: string;
+  /** HTTP(S) proxy URL for outbound Discord requests (media downloads, etc.). */
+  proxy?: string;
   /** Allow bot-authored messages to trigger replies (default: false). */
   allowBots?: boolean;
   /**

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -262,6 +262,7 @@ export const DiscordAccountSchema = z
     commands: ProviderCommandsSchema,
     configWrites: z.boolean().optional(),
     token: z.string().optional(),
+    proxy: z.string().optional(),
     allowBots: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -532,6 +532,7 @@ export async function preflightDiscordMessage(
     guildHistories: params.guildHistories,
     historyLimit: params.historyLimit,
     mediaMaxBytes: params.mediaMaxBytes,
+    proxyFetch: params.proxyFetch,
     textLimit: params.textLimit,
     replyToMode: params.replyToMode,
     ackReactionScope: params.ackReactionScope,

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -26,6 +26,7 @@ export type DiscordMessagePreflightContext = {
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;
+  proxyFetch?: typeof fetch;
   textLimit: number;
   replyToMode: ReplyToMode;
   ackReactionScope: "all" | "direct" | "group-all" | "group-mentions";
@@ -90,6 +91,7 @@ export type DiscordMessagePreflightParams = {
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;
+  proxyFetch?: typeof fetch;
   textLimit: number;
   replyToMode: ReplyToMode;
   dmEnabled: boolean;

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -6,6 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const reactMessageDiscord = vi.fn(async () => {});
 const removeReactionDiscord = vi.fn(async () => {});
 
+let capturedFetchImpl: unknown;
+const fetchRemoteMediaSpy = vi.fn(async (opts: { fetchImpl?: unknown }) => {
+  capturedFetchImpl = opts.fetchImpl;
+  return { buffer: Buffer.from("img"), contentType: "image/png", fileName: "a.png" };
+});
+
 vi.mock("../send.js", () => ({
   reactMessageDiscord: (...args: unknown[]) => reactMessageDiscord(...args),
   removeReactionDiscord: (...args: unknown[]) => removeReactionDiscord(...args),
@@ -23,6 +29,18 @@ vi.mock("../../auto-reply/reply/reply-dispatcher.js", () => ({
     dispatcher: {},
     replyOptions: {},
     markDispatchIdle: vi.fn(),
+  })),
+}));
+
+vi.mock("../../media/fetch.js", () => ({
+  fetchRemoteMedia: (...args: unknown[]) =>
+    fetchRemoteMediaSpy(...(args as [{ fetchImpl?: unknown }])),
+}));
+
+vi.mock("../../media/store.js", () => ({
+  saveMediaBuffer: vi.fn(async () => ({
+    path: "/tmp/saved.png",
+    contentType: "image/png",
   })),
 }));
 
@@ -122,5 +140,71 @@ describe("processDiscordMessage ack reactions", () => {
     await processDiscordMessage(ctx as any);
 
     expect(reactMessageDiscord).toHaveBeenCalledWith("c1", "m1", "👀", { rest: {} });
+  });
+});
+
+describe("processDiscordMessage proxy fetch", () => {
+  beforeEach(() => {
+    fetchRemoteMediaSpy.mockClear();
+    capturedFetchImpl = undefined;
+  });
+
+  it("threads proxyFetch from context into fetchRemoteMedia for attachments", async () => {
+    const fakeFetch = vi.fn() as unknown as typeof fetch;
+    const ctx = await createBaseContext({
+      sender: { label: "user" },
+      proxyFetch: fakeFetch,
+      message: {
+        id: "m2",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [
+          {
+            id: "att1",
+            url: "https://cdn.discordapp.com/attachments/1/2/image.png",
+            filename: "image.png",
+            content_type: "image/png",
+            size: 1024,
+          },
+        ],
+      },
+      messageText: "check this image",
+      baseText: "check this image",
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(fetchRemoteMediaSpy).toHaveBeenCalledTimes(1);
+    expect(capturedFetchImpl).toBe(fakeFetch);
+  });
+
+  it("passes undefined fetchImpl when proxyFetch is not set", async () => {
+    capturedFetchImpl = "sentinel";
+    const ctx = await createBaseContext({
+      sender: { label: "user" },
+      message: {
+        id: "m3",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [
+          {
+            id: "att2",
+            url: "https://cdn.discordapp.com/attachments/1/2/doc.pdf",
+            filename: "doc.pdf",
+            content_type: "application/pdf",
+            size: 512,
+          },
+        ],
+      },
+      messageText: "here is a doc",
+      baseText: "here is a doc",
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(fetchRemoteMediaSpy).toHaveBeenCalledTimes(1);
+    expect(capturedFetchImpl).toBeUndefined();
   });
 });

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -49,6 +49,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     guildHistories,
     historyLimit,
     mediaMaxBytes,
+    proxyFetch,
     textLimit,
     replyToMode,
     ackReactionScope,
@@ -82,7 +83,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     commandAuthorized,
   } = ctx;
 
-  const mediaList = await resolveMediaList(message, mediaMaxBytes);
+  const mediaList = await resolveMediaList(message, mediaMaxBytes, proxyFetch);
   const text = messageText;
   if (!text) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -29,6 +29,7 @@ export function createDiscordMessageHandler(params: {
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;
+  proxyFetch?: typeof fetch;
   textLimit: number;
   replyToMode: ReplyToMode;
   dmEnabled: boolean;

--- a/src/discord/monitor/message-utils.proxy.test.ts
+++ b/src/discord/monitor/message-utils.proxy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+let capturedFetchImpl: unknown;
+
+vi.mock("../../media/fetch.js", () => ({
+  fetchRemoteMedia: vi.fn(async (opts: { fetchImpl?: unknown }) => {
+    capturedFetchImpl = opts.fetchImpl;
+    return { buffer: Buffer.from("img"), contentType: "image/png", fileName: "a.png" };
+  }),
+}));
+
+vi.mock("../../media/store.js", () => ({
+  saveMediaBuffer: vi.fn(async () => ({
+    path: "/tmp/saved.png",
+    contentType: "image/png",
+  })),
+}));
+
+const { resolveMediaList } = await import("./message-utils.js");
+
+function makeMessage(
+  attachments: Array<{ url: string; filename: string; content_type: string; id: string }>,
+) {
+  return { attachments } as Parameters<typeof resolveMediaList>[0];
+}
+
+describe("resolveMediaList proxy support", () => {
+  it("passes fetchImpl to fetchRemoteMedia when provided", async () => {
+    capturedFetchImpl = undefined;
+    const fakeFetch = vi.fn() as unknown as typeof fetch;
+    const msg = makeMessage([
+      {
+        url: "https://cdn.discordapp.com/a.png",
+        filename: "a.png",
+        content_type: "image/png",
+        id: "1",
+      },
+    ]);
+
+    await resolveMediaList(msg, 8 * 1024 * 1024, fakeFetch);
+
+    expect(capturedFetchImpl).toBe(fakeFetch);
+  });
+
+  it("passes undefined fetchImpl when no proxy is configured", async () => {
+    capturedFetchImpl = "sentinel";
+    const msg = makeMessage([
+      {
+        url: "https://cdn.discordapp.com/b.png",
+        filename: "b.png",
+        content_type: "image/png",
+        id: "2",
+      },
+    ]);
+
+    await resolveMediaList(msg, 8 * 1024 * 1024);
+
+    expect(capturedFetchImpl).toBeUndefined();
+  });
+});

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -97,6 +97,7 @@ export async function resolveDiscordChannelInfo(
 export async function resolveMediaList(
   message: Message,
   maxBytes: number,
+  fetchImpl?: typeof fetch,
 ): Promise<DiscordMediaInfo[]> {
   const attachments = message.attachments ?? [];
   if (attachments.length === 0) {
@@ -107,6 +108,7 @@ export async function resolveMediaList(
     try {
       const fetched = await fetchRemoteMedia({
         url: attachment.url,
+        fetchImpl,
         filePathHint: attachment.filename ?? attachment.url,
       });
       const saved = await saveMediaBuffer(

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -17,6 +17,7 @@ import {
 import { loadConfig } from "../../config/config.js";
 import { danger, logVerbose, shouldLogVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { makeProxyFetch } from "../../infra/net/proxy.js";
 import { createDiscordRetryRunner } from "../../infra/retry-policy.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveDiscordAccount } from "../accounts.js";
@@ -181,6 +182,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   }
   let allowFrom = dmConfig?.allowFrom;
   const mediaMaxBytes = (opts.mediaMaxMb ?? discordCfg.mediaMaxMb ?? 8) * 1024 * 1024;
+  const proxyFetch = discordCfg.proxy ? makeProxyFetch(discordCfg.proxy) : undefined;
   const textLimit = resolveTextChunkLimit(cfg, "discord", account.accountId, {
     fallbackLimit: 2000,
   });
@@ -568,6 +570,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     guildHistories,
     historyLimit,
     mediaMaxBytes,
+    proxyFetch,
     textLimit,
     replyToMode,
     dmEnabled,

--- a/src/infra/net/proxy.ts
+++ b/src/infra/net/proxy.ts
@@ -1,0 +1,14 @@
+import { ProxyAgent, fetch as undiciFetch } from "undici";
+import { wrapFetchWithAbortSignal } from "../fetch.js";
+
+export function makeProxyFetch(proxyUrl: string): typeof fetch {
+  const agent = new ProxyAgent(proxyUrl);
+  // undici's fetch is runtime-compatible with global fetch but the types diverge
+  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
+  const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
+    undiciFetch(input as string | URL, {
+      ...(init as Record<string, unknown>),
+      dispatcher: agent,
+    }) as unknown as Promise<Response>) as typeof fetch;
+  return wrapFetchWithAbortSignal(fetcher);
+}

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -1,14 +1,1 @@
-import { ProxyAgent, fetch as undiciFetch } from "undici";
-import { wrapFetchWithAbortSignal } from "../infra/fetch.js";
-
-export function makeProxyFetch(proxyUrl: string): typeof fetch {
-  const agent = new ProxyAgent(proxyUrl);
-  // undici's fetch is runtime-compatible with global fetch but the types diverge
-  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
-  const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
-    undiciFetch(input as string | URL, {
-      ...(init as Record<string, unknown>),
-      dispatcher: agent,
-    }) as unknown as Promise<Response>) as typeof fetch;
-  return wrapFetchWithAbortSignal(fetcher);
-}
+export { makeProxyFetch } from "../infra/net/proxy.js";


### PR DESCRIPTION
## Summary

Fixes #2503

Discord's `resolveMediaList` calls `fetchRemoteMedia` without a `fetchImpl`, causing it to fall back to `globalThis.fetch`. On Node.js 22+ the native fetch is backed by undici and bypasses `http.request`, so `global-agent` cannot intercept it — making media downloads from `cdn.discordapp.com` fail in proxy-required environments (e.g. China mainland).

This PR adds a `channels.discord.proxy` config field (mirroring Telegram's existing pattern) and threads a proxy-aware fetch through the message handler pipeline into `resolveMediaList` → `fetchRemoteMedia`.

## Problem

```
config.proxy → ??? → resolveMediaList() → fetchRemoteMedia({ url })
                                                    ↓
                                          fetchImpl is undefined
                                                    ↓
                                          falls back to globalThis.fetch
                                                    ↓
                                          Node 22 undici fetch (no global-agent)
                                                    ↓
                                          cdn.discordapp.com unreachable ❌
```

Telegram already handles this correctly via `makeProxyFetch` → `fetchRemoteMedia({ fetchImpl })`.

## Changes

- **Config**: add `proxy?: string` to `DiscordAccountConfig` type + zod schema
- **Infra**: move `makeProxyFetch` from `src/telegram/proxy.ts` to `src/infra/net/proxy.ts` as shared infrastructure (Telegram re-exports for backward compat)
- **Provider**: create proxy-aware fetch when `channels.discord.proxy` is set
- **Pipeline**: thread `proxyFetch` through `createDiscordMessageHandler` → `preflightDiscordMessage` → `processDiscordMessage` → `resolveMediaList` → `fetchRemoteMedia`
- **Docs**: update English + Chinese Discord docs with proxy config field
- **Changelog**: add entry under Fixes

## Data flow (after fix)

```
channels.discord.proxy: "http://host:port"
        ↓
makeProxyFetch(proxyUrl)  →  undici ProxyAgent
        ↓
createDiscordMessageHandler({ proxyFetch })
        ↓
preflightDiscordMessage(params)  →  ctx.proxyFetch
        ↓
processDiscordMessage(ctx)
        ↓
resolveMediaList(message, maxBytes, proxyFetch)
        ↓
fetchRemoteMedia({ url, fetchImpl: proxyFetch })  ✅
```

## Test plan

- [x] `tsc --noEmit` passes (zero errors)
- [x] `oxlint` passes (zero warnings/errors)
- [x] All 187 existing Discord tests pass (zero regressions)
- [x] Telegram `proxy.test.ts` passes (re-export backward compat)
- [x] Added 2 unit tests: `resolveMediaList` correctly passes/omits `fetchImpl`
- [x] Added 2 integration tests: `processDiscordMessage` threads `proxyFetch` from context into `fetchRemoteMedia` for attachment downloads

## Config example

```json5
{
  channels: {
    discord: {
      token: "YOUR_BOT_TOKEN",
      proxy: "http://your-proxy:port",
    },
  },
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

