### PR TITLE
fix: pass delivery context to cron isolated agent subagents

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -407,6 +407,8 @@ export async function runCronIsolatedAgentTurn(params: {
           agentId,
           messageChannel,
           agentAccountId: resolvedDelivery.accountId,
+          messageTo: resolvedDelivery.to,
+          messageThreadId: resolvedDelivery.threadId,
           sessionFile,
           workspaceDir,
           config: cfgWithAgentDefaults,


### PR DESCRIPTION
## Problem

Subagents spawned from cron isolated sessions lose the Slack delivery context, causing `Delivering to Slack requires target` errors when the announce flow tries to deliver results.

## Root Cause

In `src/cron/isolated-agent/run.ts`, the call to `runEmbeddedPiAgent()` was missing `messageTo` and `messageThreadId` parameters. These values were correctly resolved from `resolvedDelivery` but never passed through, so all downstream tools (including `sessions_spawn`) received `undefined` as the delivery target.

The cron job's own direct announce path correctly uses `resolvedDelivery.to`. The bug is specifically in the subagent spawn path where delivery context is lost at the `runEmbeddedPiAgent` boundary.

## Fix

Pass `messageTo` and `messageThreadId` from `resolvedDelivery` to `runEmbeddedPiAgent()`, matching the pattern used in `src/auto-reply/reply/agent-runner-execution.ts`.

2 lines added.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a delivery context propagation bug in cron isolated agent sessions. The fix adds `messageTo` and `messageThreadId` parameters to the `runEmbeddedPiAgent()` call, ensuring that subagents spawned from cron jobs inherit the Slack delivery context from their parent.

- Adds `messageTo: resolvedDelivery.to` and `messageThreadId: resolvedDelivery.threadId` to the `runEmbeddedPiAgent()` call in `src/cron/isolated-agent/run.ts:410-411`
- Matches the pattern used in `src/auto-reply/reply/agent-runner-execution.ts:264-265`
- Prevents `Delivering to Slack requires target` errors when subagents attempt to announce results

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward 2-line addition that passes existing delivery context parameters to `runEmbeddedPiAgent()`. The parameters (`messageTo` and `messageThreadId`) are already defined in the function signature, already resolved from `resolvedDelivery`, and already used consistently throughout the file in other delivery paths. This pattern exactly matches the established pattern in `agent-runner-execution.ts:264-265`.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->