### PR TITLE
feat(whatsapp): surface incoming reaction events to agent

### DIFF
--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -1,3 +1,4 @@
+import { isJidGroup } from "@whiskeysockets/baileys";
 import type { WebChannelStatus, WebInboundMsg, WebMonitorTuning } from "./types.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { resolveInboundDebounceMs } from "../../auto-reply/inbound-debounce.js";
@@ -207,11 +208,16 @@ export async function monitorWebChannel(
         await onMessage(msg);
       },
       onReaction: async (reaction) => {
-        // Surface reaction events to the agent session
+        // Surface reaction events to the conversation session (not main)
+        const isGroup = isJidGroup(reaction.chatId) === true;
         const reactionRoute = resolveAgentRoute({
           cfg,
           channel: "whatsapp",
           accountId: account.accountId,
+          peer: {
+            kind: isGroup ? "group" : "direct",
+            id: reaction.chatId,
+          },
         });
         const reactor = reaction.reactorE164 ?? reaction.reactorJid ?? "unknown";
         const targetMsgShort = reaction.targetMessageId?.slice(0, 12) ?? "?";

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -7,6 +7,26 @@ export type WebListenerCloseReason = {
   error?: unknown;
 };
 
+export type WebInboundReaction = {
+  accountId: string;
+  /** JID of the chat where reaction occurred */
+  chatId: string;
+  /** E164 of the person who reacted */
+  reactorE164: string | null;
+  /** JID of the person who reacted */
+  reactorJid: string | null;
+  /** Push name (display name) of reactor if available */
+  reactorName?: string;
+  /** The emoji reaction (empty string = removed) */
+  emoji: string;
+  /** Message ID that was reacted to */
+  targetMessageId: string;
+  /** Whether the reaction was added or removed */
+  action: "add" | "remove";
+  /** Timestamp of the reaction */
+  timestampMs?: number;
+};
+
 export type WebInboundMessage = {
   id?: string;
   from: string; // conversation id: E.164 for direct chats, group JID for groups

--- a/src/web/monitor-inbox.reactions.test.ts
+++ b/src/web/monitor-inbox.reactions.test.ts
@@ -1,0 +1,362 @@
+import { vi } from "vitest";
+
+vi.mock("../media/store.js", () => ({
+  saveMediaBuffer: vi.fn().mockResolvedValue({
+    id: "mid",
+    path: "/tmp/mid",
+    size: 1,
+    contentType: "image/jpeg",
+  }),
+}));
+
+const mockLoadConfig = vi.fn().mockReturnValue({
+  channels: {
+    whatsapp: {
+      allowFrom: ["*"],
+    },
+  },
+  messages: {
+    messagePrefix: undefined,
+    responsePrefix: undefined,
+  },
+});
+
+const readAllowFromStoreMock = vi.fn().mockResolvedValue([]);
+const upsertPairingRequestMock = vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true });
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => mockLoadConfig(),
+  };
+});
+
+vi.mock("../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+  upsertChannelPairingRequest: (...args: unknown[]) => upsertPairingRequestMock(...args),
+}));
+
+vi.mock("./session.js", () => {
+  const { EventEmitter } = require("node:events");
+  const ev = new EventEmitter();
+  const sock = {
+    ev,
+    ws: { close: vi.fn() },
+    sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    readMessages: vi.fn().mockResolvedValue(undefined),
+    updateMediaMessage: vi.fn(),
+    logger: {},
+    signalRepository: {
+      lidMapping: {
+        getPNForLID: vi.fn().mockResolvedValue(null),
+      },
+    },
+    user: { id: "123@s.whatsapp.net" },
+  };
+  return {
+    createWaSocket: vi.fn().mockResolvedValue(sock),
+    waitForWaConnection: vi.fn().mockResolvedValue(undefined),
+    getStatusCode: vi.fn(() => 500),
+  };
+});
+
+const { createWaSocket } = await import("./session.js");
+const _getSock = () => (createWaSocket as unknown as () => Promise<ReturnType<typeof mockSock>>)();
+
+function mockSock() {
+  const { EventEmitter } = require("node:events");
+  const ev = new EventEmitter();
+  return {
+    ev,
+    ws: { close: vi.fn() },
+    sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    readMessages: vi.fn().mockResolvedValue(undefined),
+    updateMediaMessage: vi.fn(),
+    logger: {},
+    signalRepository: {
+      lidMapping: {
+        getPNForLID: vi.fn().mockResolvedValue(null),
+      },
+    },
+    user: { id: "123@s.whatsapp.net" },
+  };
+}
+
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { WebInboundReaction } from "./inbound/types.js";
+import { resetLogger, setLoggerOverride } from "../logging.js";
+import { monitorWebInbox, resetWebInboundDedupe } from "./inbound.js";
+
+const ACCOUNT_ID = "default";
+let authDir: string;
+
+describe("web monitor inbox reactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readAllowFromStoreMock.mockResolvedValue([]);
+    resetWebInboundDedupe();
+    authDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+  });
+
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+    vi.useRealTimers();
+    fsSync.rmSync(authDir, { recursive: true, force: true });
+  });
+
+  it("handles incoming reaction events", async () => {
+    const onMessage = vi.fn();
+    const onReaction = vi.fn();
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: ACCOUNT_ID,
+      authDir,
+      onMessage,
+      onReaction,
+    });
+
+    const sock = await _getSock();
+
+    // Emit a reaction event
+    sock.ev.emit("messages.reaction", [
+      {
+        key: {
+          remoteJid: "15551234567@s.whatsapp.net",
+          id: "MSG123ABC",
+        },
+        reaction: {
+          key: {
+            remoteJid: "15559876543@s.whatsapp.net",
+            participant: "15559876543@s.whatsapp.net",
+          },
+          text: "👍",
+          senderTimestampMs: BigInt(Date.now()),
+        },
+      },
+    ]);
+
+    // Wait for async processing
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onReaction).toHaveBeenCalledTimes(1);
+    const reaction: WebInboundReaction = onReaction.mock.calls[0][0];
+    expect(reaction.emoji).toBe("👍");
+    expect(reaction.action).toBe("add");
+    expect(reaction.targetMessageId).toBe("MSG123ABC");
+    expect(reaction.accountId).toBe(ACCOUNT_ID);
+
+    await listener.close();
+  });
+
+  it("handles reaction removal (empty emoji)", async () => {
+    const onMessage = vi.fn();
+    const onReaction = vi.fn();
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: ACCOUNT_ID,
+      authDir,
+      onMessage,
+      onReaction,
+    });
+
+    const sock = await _getSock();
+
+    // Emit a reaction removal event (empty text = removed)
+    sock.ev.emit("messages.reaction", [
+      {
+        key: {
+          remoteJid: "15551234567@s.whatsapp.net",
+          id: "MSG456DEF",
+        },
+        reaction: {
+          key: {
+            remoteJid: "15559876543@s.whatsapp.net",
+          },
+          text: "", // Empty text means reaction removed
+          senderTimestampMs: BigInt(Date.now()),
+        },
+      },
+    ]);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onReaction).toHaveBeenCalledTimes(1);
+    const reaction: WebInboundReaction = onReaction.mock.calls[0][0];
+    expect(reaction.emoji).toBe("");
+    expect(reaction.action).toBe("remove");
+    expect(reaction.targetMessageId).toBe("MSG456DEF");
+
+    await listener.close();
+  });
+
+  it("skips reactions on status/broadcast messages", async () => {
+    const onMessage = vi.fn();
+    const onReaction = vi.fn();
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: ACCOUNT_ID,
+      authDir,
+      onMessage,
+      onReaction,
+    });
+
+    const sock = await _getSock();
+
+    // Emit reactions on status and broadcast JIDs (should be ignored)
+    sock.ev.emit("messages.reaction", [
+      {
+        key: {
+          remoteJid: "status@broadcast",
+          id: "STATUS123",
+        },
+        reaction: {
+          key: { remoteJid: "15559876543@s.whatsapp.net" },
+          text: "❤️",
+        },
+      },
+      {
+        key: {
+          remoteJid: "123456789@broadcast",
+          id: "BROADCAST123",
+        },
+        reaction: {
+          key: { remoteJid: "15559876543@s.whatsapp.net" },
+          text: "😂",
+        },
+      },
+    ]);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onReaction).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("does not call onReaction if callback not provided", async () => {
+    const onMessage = vi.fn();
+    // No onReaction callback provided
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: ACCOUNT_ID,
+      authDir,
+      onMessage,
+    });
+
+    const sock = await _getSock();
+
+    // Emit a reaction event - should not throw
+    sock.ev.emit("messages.reaction", [
+      {
+        key: {
+          remoteJid: "15551234567@s.whatsapp.net",
+          id: "MSG789",
+        },
+        reaction: {
+          key: { remoteJid: "15559876543@s.whatsapp.net" },
+          text: "🎉",
+        },
+      },
+    ]);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Should not throw, just silently skip
+    await listener.close();
+  });
+
+  it("handles multiple reactions in single event", async () => {
+    const onMessage = vi.fn();
+    const onReaction = vi.fn();
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: ACCOUNT_ID,
+      authDir,
+      onMessage,
+      onReaction,
+    });
+
+    const sock = await _getSock();
+
+    // Emit multiple reactions at once
+    sock.ev.emit("messages.reaction", [
+      {
+        key: { remoteJid: "15551111111@s.whatsapp.net", id: "MSG1" },
+        reaction: {
+          key: { remoteJid: "15552222222@s.whatsapp.net" },
+          text: "👍",
+        },
+      },
+      {
+        key: { remoteJid: "15553333333@s.whatsapp.net", id: "MSG2" },
+        reaction: {
+          key: { remoteJid: "15554444444@s.whatsapp.net" },
+          text: "❤️",
+        },
+      },
+      {
+        key: { remoteJid: "15555555555@s.whatsapp.net", id: "MSG3" },
+        reaction: {
+          key: { remoteJid: "15556666666@s.whatsapp.net" },
+          text: "😂",
+        },
+      },
+    ]);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onReaction).toHaveBeenCalledTimes(3);
+
+    const emojis = onReaction.mock.calls.map((call) => call[0].emoji);
+    expect(emojis).toEqual(["👍", "❤️", "😂"]);
+
+    await listener.close();
+  });
+
+  it("skips reactions with missing remoteJid", async () => {
+    const onMessage = vi.fn();
+    const onReaction = vi.fn();
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: ACCOUNT_ID,
+      authDir,
+      onMessage,
+      onReaction,
+    });
+
+    const sock = await _getSock();
+
+    // Emit reaction with missing remoteJid
+    sock.ev.emit("messages.reaction", [
+      {
+        key: {
+          remoteJid: null, // Missing
+          id: "MSG123",
+        },
+        reaction: {
+          key: { remoteJid: "15559876543@s.whatsapp.net" },
+          text: "👍",
+        },
+      },
+    ]);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onReaction).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for receiving WhatsApp reaction events and surfacing them as system messages to the agent session.

## Changes

- Add `WebInboundReaction` type in `src/web/inbound/types.ts`
- Add `messages.reaction` event handler in `src/web/inbound/monitor.ts`
- Wire up reaction events to system messages in `src/web/auto-reply/monitor.ts`

## How it works

When a user reacts to a message, the agent sees a system event like:
```
System: [Reaction] 👍 from +1234567890 on message ABC123...
```

Or for removed reactions:
```
System: [Reaction removed] from +1234567890 on message ABC123...
```

## Use cases

- Agents can acknowledge user reactions ("Thanks for the thumbs up!")
- Reactions can serve as lightweight feedback signals
- Enables more natural conversational flows

## Testing

- Build passes ✅
- Manually tested with WhatsApp sandbox

Closes #11460

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds WhatsApp reaction event handling, surfacing reactions as system messages to the agent. The implementation follows a similar pattern to Telegram's reaction handling but has a routing issue that needs correction.

**Key changes:**
- New `WebInboundReaction` type with reactor info, emoji, target message ID, and action (add/remove)
- Event listener for `messages.reaction` with proper cleanup in close handler
- System event formatting: `[Reaction] 👍 from +1234567890 on message ABC123...`

**Issue found:**
- Reaction events currently route to the main session instead of the specific conversation session where the reaction occurred. The Telegram implementation shows the correct pattern (including peer info in route resolution).

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one routing fix needed
- The implementation is well-structured and follows existing patterns. One critical routing bug prevents reactions from appearing in the correct conversation context. Error handling and cleanup are properly implemented. The fix is straightforward.
- Pay attention to `src/web/auto-reply/monitor.ts` - the routing logic needs correction to include peer context

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->