### PR TITLE
fix(discord): ensure default bot loads when multiple accounts are con…

### DIFF
--- a/src/discord/accounts.ts
+++ b/src/discord/accounts.ts
@@ -22,6 +22,10 @@ function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
 
 export function listDiscordAccountIds(cfg: OpenClawConfig): string[] {
   const ids = listConfiguredAccountIds(cfg);
+  const rootToken = cfg.channels?.discord?.token;
+  if (rootToken && !ids.includes(DEFAULT_ACCOUNT_ID)) {
+    ids.push(DEFAULT_ACCOUNT_ID);
+  }
   if (ids.length === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }


### PR DESCRIPTION
…figured.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed a bug where the default Discord bot account would not load when `channels.discord.token` was configured alongside `channels.discord.accounts`. The code now correctly includes the "default" account ID in the account list when a root-level token exists, ensuring the default bot starts properly in multi-account configurations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a targeted bug fix with clear logic: it ensures the default account is included when a root token is configured. The implementation correctly handles the multi-account configuration scenario and aligns with the token resolution logic in `resolveDiscordToken`. No edge cases or potential issues identified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->