### PR TITLE
acceptAdd nixpacks configuration for Python and Node.js

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,17 @@
+[phases.setup]
+nixPkgs = ["python311", "nodejs_22", "pnpm"]
+
+[phases.install]
+cmds = [
+  "python3 -m pip install --upgrade pip",
+  "pip3 install -r requirements.txt",
+  "pnpm install --no-frozen-lockfile"
+]
+
+[phases.build]
+cmds = [
+  "echo 'Skipping UI build on Railway'"
+]
+
+[start]
+cmd = "python3 -m openclaw.app"


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a nixpacks configuration file for deploying OpenClaw to platforms like Railway, but the configuration is fundamentally incorrect. It treats OpenClaw as a Python project when it's actually a Node.js/TypeScript application.

**Critical issues:**
- References non-existent `requirements.txt` and `openclaw.app` Python module
- Includes Python 3.11 in dependencies despite OpenClaw being a Node.js project
- Incorrect start command (`python3 -m openclaw.app` instead of `node openclaw.mjs gateway --allow-unconfigured`)
- Missing required build steps (`pnpm build` and `pnpm ui:build`)
- Uses `--no-frozen-lockfile` instead of `--frozen-lockfile` (violates project conventions in AGENTS.md)

The configuration needs to be completely rewritten to match the existing Dockerfile pattern, which correctly builds and runs OpenClaw as a Node.js application.

<h3>Confidence Score: 0/5</h3>

- This PR cannot be merged as-is — it would break deployment completely
- The configuration is based on a fundamental misunderstanding of the project. It attempts to run OpenClaw as a Python application when it's actually a Node.js/TypeScript project. The start command references a non-existent Python module, install steps reference a non-existent `requirements.txt`, and critical build steps are missing. Deploying this would result in immediate runtime failures.
- nixpacks.toml requires complete rewrite based on the Dockerfile pattern

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->