### PR TITLE
fix(auth): skip timeout cooldown for local/self-hosted providers

### DIFF
--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { isLocalProviderUrl, isReasoningTagProvider } from "./provider-utils.js";
+
+describe("isReasoningTagProvider", () => {
+  it("returns true for ollama", () => {
+    expect(isReasoningTagProvider("ollama")).toBe(true);
+  });
+
+  it("returns false for anthropic", () => {
+    expect(isReasoningTagProvider("anthropic")).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isReasoningTagProvider(null)).toBe(false);
+    expect(isReasoningTagProvider(undefined)).toBe(false);
+  });
+});
+
+describe("isLocalProviderUrl", () => {
+  it("returns true for localhost URLs", () => {
+    expect(isLocalProviderUrl("http://localhost:11434")).toBe(true);
+    expect(isLocalProviderUrl("http://localhost:11434/v1")).toBe(true);
+  });
+
+  it("returns true for 127.0.0.1", () => {
+    expect(isLocalProviderUrl("http://127.0.0.1:11434")).toBe(true);
+  });
+
+  it("returns true for ::1 (IPv6 loopback)", () => {
+    expect(isLocalProviderUrl("http://[::1]:11434")).toBe(true);
+  });
+
+  it("returns true for 0.0.0.0", () => {
+    expect(isLocalProviderUrl("http://0.0.0.0:11434")).toBe(true);
+  });
+
+  it("returns true for private 192.168.x.x addresses", () => {
+    expect(isLocalProviderUrl("http://192.168.1.100:11434")).toBe(true);
+    expect(isLocalProviderUrl("http://192.168.50.213:8080")).toBe(true);
+  });
+
+  it("returns true for private 10.x.x.x addresses", () => {
+    expect(isLocalProviderUrl("http://10.0.0.1:11434")).toBe(true);
+  });
+
+  it("returns true for private 172.16-31.x.x addresses", () => {
+    expect(isLocalProviderUrl("http://172.16.0.1:11434")).toBe(true);
+    expect(isLocalProviderUrl("http://172.31.255.255:11434")).toBe(true);
+  });
+
+  it("returns true for .local domains", () => {
+    expect(isLocalProviderUrl("http://ollama.local:11434")).toBe(true);
+  });
+
+  it("returns false for cloud provider URLs", () => {
+    expect(isLocalProviderUrl("https://api.openai.com/v1")).toBe(false);
+    expect(isLocalProviderUrl("https://api.anthropic.com")).toBe(false);
+    expect(isLocalProviderUrl("https://generativelanguage.googleapis.com")).toBe(false);
+  });
+
+  it("returns false for null/undefined/empty", () => {
+    expect(isLocalProviderUrl(null)).toBe(false);
+    expect(isLocalProviderUrl(undefined)).toBe(false);
+    expect(isLocalProviderUrl("")).toBe(false);
+  });
+
+  it("returns false for invalid URLs", () => {
+    expect(isLocalProviderUrl("not-a-url")).toBe(false);
+  });
+
+  it("returns false for 172.15.x.x (not private range)", () => {
+    expect(isLocalProviderUrl("http://172.15.0.1:11434")).toBe(false);
+  });
+
+  it("returns false for 172.32.x.x (not private range)", () => {
+    expect(isLocalProviderUrl("http://172.32.0.1:11434")).toBe(false);
+  });
+});

--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -22,8 +22,10 @@ describe("isLocalProviderUrl", () => {
     expect(isLocalProviderUrl("http://localhost:11434/v1")).toBe(true);
   });
 
-  it("returns true for 127.0.0.1", () => {
+  it("returns true for 127.0.0.0/8 loopback range", () => {
     expect(isLocalProviderUrl("http://127.0.0.1:11434")).toBe(true);
+    expect(isLocalProviderUrl("http://127.0.0.2:11434")).toBe(true);
+    expect(isLocalProviderUrl("http://127.1.1.1:8080")).toBe(true);
   });
 
   it("returns true for ::1 (IPv6 loopback)", () => {

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -49,7 +49,7 @@ export function isLocalProviderUrl(baseUrl: string | undefined | null): boolean 
     const host = url.hostname.toLowerCase();
     return (
       host === "localhost" ||
-      host === "127.0.0.1" ||
+      host.startsWith("127.") ||
       host === "[::1]" ||
       host === "::1" ||
       host === "0.0.0.0" ||

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -34,3 +34,31 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
 
   return false;
 }
+
+/**
+ * Returns true if the given base URL points to a local/self-hosted service.
+ * Local providers (e.g. Ollama) should not be penalized with cooldown on
+ * timeouts since they have no rate limits — timeouts are just slow inference.
+ */
+export function isLocalProviderUrl(baseUrl: string | undefined | null): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+  try {
+    const url = new URL(baseUrl);
+    const host = url.hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "[::1]" ||
+      host === "::1" ||
+      host === "0.0.0.0" ||
+      host.startsWith("192.168.") ||
+      host.startsWith("10.") ||
+      host.endsWith(".local") ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
Local providers like Ollama should not enter cooldown on timeout — they have no rate limits, timeouts are just slow inference.

Closes #13336

## Changes
- **`provider-utils.ts`**: Added `isLocalProviderUrl()` helper that detects localhost, 127.0.0.1, private IPs (192.168.x, 10.x, 172.16-31.x), and .local domains
- **`run.ts`**: Skip `markAuthProfileFailure()` for timeout on local providers while still allowing profile rotation for retries

## Testing
- 16 tests (3 existing + 13 new) covering all local/cloud URL patterns, edge cases, and boundary conditions
- All pass

🤖 Generated with Claude (AI-assisted)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Prevents local/self-hosted providers (like Ollama) from entering cooldown on timeout errors by detecting local URLs and skipping the `markAuthProfileFailure()` call. Timeouts on local providers indicate slow inference rather than rate limiting, so cooldown penalties are inappropriate.

**Key changes:**
- Added `isLocalProviderUrl()` helper in `provider-utils.ts` that detects localhost, loopback IPs, private network ranges (10.x, 192.168.x, 172.16-31.x), and `.local` domains
- Modified timeout handling in `run.ts` to skip profile failure marking for local providers while still allowing profile rotation for retries
- Comprehensive test coverage with 16 tests covering local/cloud patterns, edge cases, and boundary conditions

**Minor suggestions:**
- The `[::1]` check at line 53 is redundant (URL.hostname strips brackets)
- Consider expanding `127.0.0.1` check to cover full `127.0.0.0/8` loopback range

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly solves the stated problem with a focused, well-tested solution. The logic properly skips cooldown for local timeouts while preserving profile rotation. Test coverage is excellent with 16 tests covering edge cases. Two minor style improvements suggested (redundant IPv6 bracket check and potentially incomplete loopback range detection) but neither affects correctness for typical use cases.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->