### PR TITLE
test: make docker-setup Bash path portable on Windows

### DIFF
--- a/src/docker-setup.test.ts
+++ b/src/docker-setup.test.ts
@@ -121,10 +121,15 @@ describe("docker-setup.sh", () => {
     const script = await readFile(join(repoRoot, "docker-setup.sh"), "utf8");
     expect(script).not.toMatch(/^\s*declare -A\b/m);
 
-    const systemBash = "/bin/bash";
+    const systemBash = process.platform === "win32" ? "bash" : "/bin/bash";
     const assocCheck = spawnSync(systemBash, ["-c", "declare -A _t=()"], {
       encoding: "utf8",
     });
+
+    // If bash isn't available (status === null), we can't meaningfully run this check.
+    if (assocCheck.status === null) {
+      return;
+    }
     if (assocCheck.status === 0) {
       return;
     }


### PR DESCRIPTION
Fixes CI on Windows runners where /bin/bash doesn't exist (spawnSync returned status=null). Uses 'bash' on win32 and gracefully no-ops if bash isn't available.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changed the Bash 3.2 compatibility test to use `bash` instead of `/bin/bash` on Windows (where `/bin/bash` doesn't exist), and added graceful handling for environments where bash isn't available at all.

- Made bash path platform-specific: uses `bash` on win32, `/bin/bash` elsewhere
- Added null check to skip the compatibility test when bash isn't available (when `spawnSync` returns `status === null`)
- Fixes CI failures on Windows runners where the hardcoded `/bin/bash` path caused the test to fail

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and defensive. The PR only modifies test code (not production code), uses proper platform detection, and adds graceful handling for missing bash. The logic is straightforward and doesn't introduce any new dependencies or breaking changes.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->