### PR TITLE
feat(hooks): add agentId support to webhook mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Agents: auto-select `zai/glm-4.6v` for image understanding when ZAI is primary provider. (#10267) Thanks @liuy.
 - Paths: add `OPENCLAW_HOME` for overriding the home directory used by internal path resolution. (#12091) Thanks @sebslight.
 - Onboarding: add Custom Provider flow for OpenAI and Anthropic-compatible endpoints. (#11106) Thanks @MackDing.
+- Hooks: route webhook agent runs to specific `agentId`s, add `hooks.allowedAgentIds` controls, and fall back to default agent when unknown IDs are provided. (#13672) Thanks @BillChirico.
 
 ### Fixes
 

--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -61,6 +61,7 @@ Payload:
 {
   "message": "Run this",
   "name": "Email",
+  "agentId": "hooks",
   "sessionKey": "hook:email:msg-123",
   "wakeMode": "now",
   "deliver": true,
@@ -74,6 +75,7 @@ Payload:
 
 - `message` **required** (string): The prompt or message for the agent to process.
 - `name` optional (string): Human-readable name for the hook (e.g., "GitHub"), used as a prefix in session summaries.
+- `agentId` optional (string): Route this hook to a specific agent (must exist in `agents.list`). When set, the hook runs using that agent's workspace and configuration. Defaults to the default agent.
 - `sessionKey` optional (string): The key used to identify the agent's session. Defaults to a random `hook:<uuid>`. Using a consistent key allows for a multi-turn conversation within the hook context.
 - `wakeMode` optional (`now` | `next-heartbeat`): Whether to trigger an immediate heartbeat (default `now`) or wait for the next periodic check.
 - `deliver` optional (boolean): If `true`, the agent's response will be sent to the messaging channel. Defaults to `true`. Responses that are only heartbeat acknowledgments are automatically skipped.
@@ -104,6 +106,7 @@ Mapping options (summary):
 - TS transforms require a TS loader (e.g. `bun` or `tsx`) or precompiled `.js` at runtime.
 - Set `deliver: true` + `channel`/`to` on mappings to route replies to a chat surface
   (`channel` defaults to `last` and falls back to WhatsApp).
+- `agentId` routes the hook to a specific agent (must exist in `agents.list`); uses that agent's workspace and config.
 - `allowUnsafeExternalContent: true` disables the external content safety wrapper for that hook
   (dangerous; only for trusted internal sources).
 - `openclaw webhooks gmail setup` writes `hooks.gmail` config for `openclaw webhooks gmail run`.

--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -20,6 +20,7 @@ Gateway can expose a small HTTP webhook endpoint for external triggers.
     path: "/hooks",
     // Optional: restrict explicit `agentId` routing to this allowlist.
     // Omit or include "*" to allow any agent.
+    // Set [] to deny all explicit `agentId` routing.
     allowedAgentIds: ["hooks", "main"],
   },
 }
@@ -110,7 +111,7 @@ Mapping options (summary):
 - Set `deliver: true` + `channel`/`to` on mappings to route replies to a chat surface
   (`channel` defaults to `last` and falls back to WhatsApp).
 - `agentId` routes the hook to a specific agent; unknown IDs fall back to the default agent.
-- `hooks.allowedAgentIds` restricts explicit `agentId` routing. Omit it (or include `*`) to allow any agent.
+- `hooks.allowedAgentIds` restricts explicit `agentId` routing. Omit it (or include `*`) to allow any agent. Set `[]` to deny explicit `agentId` routing.
 - `allowUnsafeExternalContent: true` disables the external content safety wrapper for that hook
   (dangerous; only for trusted internal sources).
 - `openclaw webhooks gmail setup` writes `hooks.gmail` config for `openclaw webhooks gmail run`.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -3176,12 +3176,16 @@ Defaults:
     enabled: true,
     token: "shared-secret",
     path: "/hooks",
+    // Optional: restrict explicit `agentId` routing.
+    // Omit or include "*" to allow any agent.
+    allowedAgentIds: ["hooks", "main"],
     presets: ["gmail"],
     transformsDir: "~/.openclaw/hooks",
     mappings: [
       {
         match: { path: "gmail" },
         action: "agent",
+        agentId: "hooks",
         wakeMode: "now",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
@@ -3203,7 +3207,7 @@ Requests must include the hook token:
 Endpoints:
 
 - `POST /hooks/wake` → `{ text, mode?: "now"|"next-heartbeat" }`
-- `POST /hooks/agent` → `{ message, name?, sessionKey?, wakeMode?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
+- `POST /hooks/agent` → `{ message, name?, agentId?, sessionKey?, wakeMode?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
 - `POST /hooks/<name>` → resolved via `hooks.mappings`
 
 `/hooks/agent` always posts a summary into the main session (and can optionally trigger an immediate heartbeat via `wakeMode: "now"`).
@@ -3214,6 +3218,8 @@ Mapping notes:
 - `match.source` matches a payload field (e.g. `{ source: "gmail" }`) so you can use a generic `/hooks/ingest` path.
 - Templates like `{{messages[0].subject}}` read from the payload.
 - `transform` can point to a JS/TS module that returns a hook action.
+- `agentId` can route to a specific agent; unknown IDs fall back to the default agent.
+- `hooks.allowedAgentIds` restricts explicit `agentId` routing (`*` or omitted means allow all).
 - `deliver: true` sends the final reply to a channel; `channel` defaults to `last` (falls back to WhatsApp).
 - If there is no prior delivery route, set `channel` + `to` explicitly (required for Telegram/Discord/Google Chat/Slack/Signal/iMessage/MS Teams).
 - `model` overrides the LLM for this hook run (`provider/model` or alias; must be allowed if `agents.defaults.models` is set).

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -3178,6 +3178,7 @@ Defaults:
     path: "/hooks",
     // Optional: restrict explicit `agentId` routing.
     // Omit or include "*" to allow any agent.
+    // Set [] to deny all explicit `agentId` routing.
     allowedAgentIds: ["hooks", "main"],
     presets: ["gmail"],
     transformsDir: "~/.openclaw/hooks",
@@ -3219,7 +3220,7 @@ Mapping notes:
 - Templates like `{{messages[0].subject}}` read from the payload.
 - `transform` can point to a JS/TS module that returns a hook action.
 - `agentId` can route to a specific agent; unknown IDs fall back to the default agent.
-- `hooks.allowedAgentIds` restricts explicit `agentId` routing (`*` or omitted means allow all).
+- `hooks.allowedAgentIds` restricts explicit `agentId` routing (`*` or omitted means allow all, `[]` denies all explicit routing).
 - `deliver: true` sends the final reply to a channel; `channel` defaults to `last` (falls back to WhatsApp).
 - If there is no prior delivery route, set `channel` + `to` explicitly (required for Telegram/Discord/Google Chat/Slack/Signal/iMessage/MS Teams).
 - `model` overrides the LLM for this hook run (`provider/model` or alias; must be allowed if `agents.defaults.models` is set).

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -14,7 +14,7 @@ export type HookMappingConfig = {
   action?: "wake" | "agent";
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
-  /** Route this hook to a specific agent (must exist in agents.list). */
+  /** Route this hook to a specific agent (unknown ids fall back to the default agent). */
   agentId?: string;
   sessionKey?: string;
   messageTemplate?: string;
@@ -117,6 +117,11 @@ export type HooksConfig = {
   enabled?: boolean;
   path?: string;
   token?: string;
+  /**
+   * Restrict explicit hook `agentId` routing to these agent ids.
+   * Omit or include `*` to allow any agent.
+   */
+  allowedAgentIds?: string[];
   maxBodyBytes?: number;
   presets?: string[];
   transformsDir?: string;

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -14,6 +14,8 @@ export type HookMappingConfig = {
   action?: "wake" | "agent";
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
+  /** Route this hook to a specific agent (must exist in agents.list). */
+  agentId?: string;
   sessionKey?: string;
   messageTemplate?: string;
   textTemplate?: string;

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -119,7 +119,7 @@ export type HooksConfig = {
   token?: string;
   /**
    * Restrict explicit hook `agentId` routing to these agent ids.
-   * Omit or include `*` to allow any agent.
+   * Omit or include `*` to allow any agent. Set `[]` to deny all explicit `agentId` routing.
    */
   allowedAgentIds?: string[];
   maxBodyBytes?: number;

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -12,6 +12,7 @@ export const HookMappingSchema = z
     action: z.union([z.literal("wake"), z.literal("agent")]).optional(),
     wakeMode: z.union([z.literal("now"), z.literal("next-heartbeat")]).optional(),
     name: z.string().optional(),
+    agentId: z.string().optional(),
     sessionKey: z.string().optional(),
     messageTemplate: z.string().optional(),
     textTemplate: z.string().optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -301,6 +301,7 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         path: z.string().optional(),
         token: z.string().optional(),
+        allowedAgentIds: z.array(z.string()).optional(),
         maxBodyBytes: z.number().int().positive().optional(),
         presets: z.array(z.string()).optional(),
         transformsDir: z.string().optional(),

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -152,6 +152,53 @@ describe("hooks mapping", () => {
     }
   });
 
+  it("passes agentId from mapping", async () => {
+    const mappings = resolveHookMappings({
+      mappings: [
+        {
+          id: "hooks-agent",
+          match: { path: "gmail" },
+          action: "agent",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+          agentId: "hooks",
+        },
+      ],
+    });
+    const result = await applyHookMappings(mappings, {
+      payload: { messages: [{ subject: "Hello" }] },
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.agentId).toBe("hooks");
+    }
+  });
+
+  it("agentId is undefined when not set", async () => {
+    const mappings = resolveHookMappings({
+      mappings: [
+        {
+          id: "no-agent",
+          match: { path: "gmail" },
+          action: "agent",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+        },
+      ],
+    });
+    const result = await applyHookMappings(mappings, {
+      payload: { messages: [{ subject: "Hello" }] },
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.agentId).toBeUndefined();
+    }
+  });
+
   it("rejects missing message", async () => {
     const mappings = resolveHookMappings({
       mappings: [{ match: { path: "noop" }, action: "agent" }],

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -10,6 +10,7 @@ export type HookMappingResolved = {
   action: "wake" | "agent";
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
+  agentId?: string;
   sessionKey?: string;
   messageTemplate?: string;
   textTemplate?: string;
@@ -45,6 +46,7 @@ export type HookAction =
       kind: "agent";
       message: string;
       name?: string;
+      agentId?: string;
       wakeMode: "now" | "next-heartbeat";
       sessionKey?: string;
       deliver?: boolean;
@@ -83,6 +85,7 @@ type HookTransformResult = Partial<{
   text: string;
   mode: "now" | "next-heartbeat";
   message: string;
+  agentId: string;
   wakeMode: "now" | "next-heartbeat";
   name: string;
   sessionKey: string;
@@ -196,6 +199,7 @@ function normalizeHookMapping(
     action,
     wakeMode,
     name: mapping.name,
+    agentId: mapping.agentId?.trim() || undefined,
     sessionKey: mapping.sessionKey,
     messageTemplate: mapping.messageTemplate,
     textTemplate: mapping.textTemplate,
@@ -247,6 +251,7 @@ function buildActionFromMapping(
       kind: "agent",
       message,
       name: renderOptional(mapping.name, ctx),
+      agentId: mapping.agentId,
       wakeMode: mapping.wakeMode ?? "now",
       sessionKey: renderOptional(mapping.sessionKey, ctx),
       deliver: mapping.deliver,
@@ -285,6 +290,7 @@ function mergeAction(
     message,
     wakeMode,
     name: override.name ?? baseAgent?.name,
+    agentId: override.agentId ?? baseAgent?.agentId,
     sessionKey: override.sessionKey ?? baseAgent?.sessionKey,
     deliver: typeof override.deliver === "boolean" ? override.deliver : baseAgent?.deliver,
     allowUnsafeExternalContent:

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -126,6 +126,23 @@ describe("gateway hooks helpers", () => {
     const bad = normalizeAgentPayload({ message: "yo", channel: "sms" });
     expect(bad.ok).toBe(false);
   });
+
+  test("normalizeAgentPayload passes agentId", () => {
+    const ok = normalizeAgentPayload(
+      { message: "hello", agentId: "hooks" },
+      { idFactory: () => "fixed" },
+    );
+    expect(ok.ok).toBe(true);
+    if (ok.ok) {
+      expect(ok.value.agentId).toBe("hooks");
+    }
+
+    const noAgent = normalizeAgentPayload({ message: "hello" }, { idFactory: () => "fixed" });
+    expect(noAgent.ok).toBe(true);
+    if (noAgent.ok) {
+      expect(noAgent.value.agentId).toBeUndefined();
+    }
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -183,6 +183,48 @@ describe("gateway hooks helpers", () => {
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(true);
     expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(false);
   });
+
+  test("isHookAgentAllowed treats empty allowlist as deny-all for explicit agentId", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowedAgentIds: [],
+      },
+      agents: {
+        list: [{ id: "main", default: true }, { id: "hooks" }],
+      },
+    } as OpenClawConfig;
+    const resolved = resolveHooksConfig(cfg);
+    expect(resolved).not.toBeNull();
+    if (!resolved) {
+      return;
+    }
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
+    expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);
+    expect(isHookAgentAllowed(resolved, "main")).toBe(false);
+  });
+
+  test("isHookAgentAllowed treats wildcard allowlist as allow-all", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowedAgentIds: ["*"],
+      },
+      agents: {
+        list: [{ id: "main", default: true }, { id: "hooks" }],
+      },
+    } as OpenClawConfig;
+    const resolved = resolveHooksConfig(cfg);
+    expect(resolved).not.toBeNull();
+    if (!resolved) {
+      return;
+    }
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
+    expect(isHookAgentAllowed(resolved, "hooks")).toBe(true);
+    expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(true);
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -2,7 +2,9 @@ import type { IncomingMessage } from "node:http";
 import { randomUUID } from "node:crypto";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { type HookMappingResolved, resolveHookMappings } from "./hooks-mapping.js";
 
@@ -14,6 +16,13 @@ export type HooksConfigResolved = {
   token: string;
   maxBodyBytes: number;
   mappings: HookMappingResolved[];
+  agentPolicy: HookAgentPolicyResolved;
+};
+
+export type HookAgentPolicyResolved = {
+  defaultAgentId: string;
+  knownAgentIds: Set<string>;
+  allowedAgentIds?: Set<string>;
 };
 
 export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | null {
@@ -35,12 +44,44 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
       ? cfg.hooks.maxBodyBytes
       : DEFAULT_HOOKS_MAX_BODY_BYTES;
   const mappings = resolveHookMappings(cfg.hooks);
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const knownAgentIds = resolveKnownAgentIds(cfg, defaultAgentId);
+  const allowedAgentIds = resolveAllowedAgentIds(cfg.hooks?.allowedAgentIds);
   return {
     basePath: trimmed,
     token,
     maxBodyBytes,
     mappings,
+    agentPolicy: {
+      defaultAgentId,
+      knownAgentIds,
+      allowedAgentIds,
+    },
   };
+}
+
+function resolveKnownAgentIds(cfg: OpenClawConfig, defaultAgentId: string): Set<string> {
+  const known = new Set(listAgentIds(cfg));
+  known.add(defaultAgentId);
+  return known;
+}
+
+function resolveAllowedAgentIds(raw: string[] | undefined): Set<string> | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const allowed = new Set<string>();
+  for (const entry of raw) {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed === "*") {
+      return undefined;
+    }
+    allowed.add(normalizeAgentId(trimmed));
+  }
+  return allowed.size > 0 ? allowed : undefined;
 }
 
 export function extractHookToken(req: IncomingMessage): string | undefined {
@@ -173,6 +214,40 @@ export function resolveHookChannel(raw: unknown): HookMessageChannel | null {
 export function resolveHookDeliver(raw: unknown): boolean {
   return raw !== false;
 }
+
+export function resolveHookTargetAgentId(
+  hooksConfig: HooksConfigResolved,
+  agentId: string | undefined,
+): string | undefined {
+  const raw = agentId?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = normalizeAgentId(raw);
+  if (hooksConfig.agentPolicy.knownAgentIds.has(normalized)) {
+    return normalized;
+  }
+  return hooksConfig.agentPolicy.defaultAgentId;
+}
+
+export function isHookAgentAllowed(
+  hooksConfig: HooksConfigResolved,
+  agentId: string | undefined,
+): boolean {
+  // Keep backwards compatibility for callers that omit agentId.
+  const raw = agentId?.trim();
+  if (!raw) {
+    return true;
+  }
+  const allowed = hooksConfig.agentPolicy.allowedAgentIds;
+  if (!allowed) {
+    return true;
+  }
+  const resolved = resolveHookTargetAgentId(hooksConfig, raw);
+  return resolved ? allowed.has(resolved) : false;
+}
+
+export const getHookAgentPolicyError = () => "agentId is not allowed by hooks.allowedAgentIds";
 
 export function normalizeAgentPayload(
   payload: Record<string, unknown>,

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -138,6 +138,7 @@ export function normalizeWakePayload(
 export type HookAgentPayload = {
   message: string;
   name: string;
+  agentId?: string;
   wakeMode: "now" | "next-heartbeat";
   sessionKey: string;
   deliver: boolean;
@@ -188,6 +189,9 @@ export function normalizeAgentPayload(
   }
   const nameRaw = payload.name;
   const name = typeof nameRaw === "string" && nameRaw.trim() ? nameRaw.trim() : "Hook";
+  const agentIdRaw = payload.agentId;
+  const agentId =
+    typeof agentIdRaw === "string" && agentIdRaw.trim() ? agentIdRaw.trim() : undefined;
   const wakeMode = payload.wakeMode === "next-heartbeat" ? "next-heartbeat" : "now";
   const sessionKeyRaw = payload.sessionKey;
   const idFactory = opts?.idFactory ?? randomUUID;
@@ -220,6 +224,7 @@ export function normalizeAgentPayload(
     value: {
       message,
       name,
+      agentId,
       wakeMode,
       sessionKey,
       deliver,

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -71,17 +71,22 @@ function resolveAllowedAgentIds(raw: string[] | undefined): Set<string> | undefi
     return undefined;
   }
   const allowed = new Set<string>();
+  let hasWildcard = false;
   for (const entry of raw) {
     const trimmed = entry.trim();
     if (!trimmed) {
       continue;
     }
     if (trimmed === "*") {
-      return undefined;
+      hasWildcard = true;
+      break;
     }
     allowed.add(normalizeAgentId(trimmed));
   }
-  return allowed.size > 0 ? allowed : undefined;
+  if (hasWildcard) {
+    return undefined;
+  }
+  return allowed;
 }
 
 export function extractHookToken(req: IncomingMessage): string | undefined {
@@ -240,7 +245,7 @@ export function isHookAgentAllowed(
     return true;
   }
   const allowed = hooksConfig.agentPolicy.allowedAgentIds;
-  if (!allowed) {
+  if (allowed === undefined) {
     return true;
   }
   const resolved = resolveHookTargetAgentId(hooksConfig, raw);

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -28,13 +28,16 @@ import {
 import { applyHookMappings } from "./hooks-mapping.js";
 import {
   extractHookToken,
+  getHookAgentPolicyError,
   getHookChannelError,
   type HookMessageChannel,
   type HooksConfigResolved,
+  isHookAgentAllowed,
   normalizeAgentPayload,
   normalizeHookHeaders,
   normalizeWakePayload,
   readJsonBody,
+  resolveHookTargetAgentId,
   resolveHookChannel,
   resolveHookDeliver,
 } from "./hooks.js";
@@ -208,7 +211,14 @@ export function createHooksRequestHandler(
         sendJson(res, 400, { ok: false, error: normalized.error });
         return true;
       }
-      const runId = dispatchAgentHook(normalized.value);
+      if (!isHookAgentAllowed(hooksConfig, normalized.value.agentId)) {
+        sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+        return true;
+      }
+      const runId = dispatchAgentHook({
+        ...normalized.value,
+        agentId: resolveHookTargetAgentId(hooksConfig, normalized.value.agentId),
+      });
       sendJson(res, 202, { ok: true, runId });
       return true;
     }
@@ -244,10 +254,14 @@ export function createHooksRequestHandler(
             sendJson(res, 400, { ok: false, error: getHookChannelError() });
             return true;
           }
+          if (!isHookAgentAllowed(hooksConfig, mapped.action.agentId)) {
+            sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+            return true;
+          }
           const runId = dispatchAgentHook({
             message: mapped.action.message,
             name: mapped.action.name ?? "Hook",
-            agentId: mapped.action.agentId,
+            agentId: resolveHookTargetAgentId(hooksConfig, mapped.action.agentId),
             wakeMode: mapped.action.wakeMode,
             sessionKey: mapped.action.sessionKey ?? "",
             deliver: resolveHookDeliver(mapped.action.deliver),

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -52,6 +52,7 @@ type HookDispatchers = {
   dispatchAgentHook: (value: {
     message: string;
     name: string;
+    agentId?: string;
     wakeMode: "now" | "next-heartbeat";
     sessionKey: string;
     deliver: boolean;
@@ -246,6 +247,7 @@ export function createHooksRequestHandler(
           const runId = dispatchAgentHook({
             message: mapped.action.message,
             name: mapped.action.name ?? "Hook",
+            agentId: mapped.action.agentId,
             wakeMode: mapped.action.wakeMode,
             sessionKey: mapped.action.sessionKey ?? "",
             deliver: resolveHookDeliver(mapped.action.deliver),

--- a/src/gateway/server.hooks.e2e.test.ts
+++ b/src/gateway/server.hooks.e2e.test.ts
@@ -17,6 +17,9 @@ const resolveMainKey = () => resolveMainSessionKeyFromConfig();
 describe("gateway server hooks", () => {
   test("handles auth, wake, and agent flows", async () => {
     testState.hooksConfig = { enabled: true, token: "hook-secret" };
+    testState.agentsConfig = {
+      list: [{ id: "main", default: true }, { id: "hooks" }],
+    };
     const port = await getFreePort();
     const server = await startGatewayServer(port);
     try {
@@ -81,6 +84,48 @@ describe("gateway server hooks", () => {
         job?: { payload?: { model?: string } };
       };
       expect(call?.job?.payload?.model).toBe("openai/gpt-4.1-mini");
+      drainSystemEvents(resolveMainKey());
+
+      cronIsolatedRun.mockReset();
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "ok",
+        summary: "done",
+      });
+      const resAgentWithId = await fetch(`http://127.0.0.1:${port}/hooks/agent`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer hook-secret",
+        },
+        body: JSON.stringify({ message: "Do it", name: "Email", agentId: "hooks" }),
+      });
+      expect(resAgentWithId.status).toBe(202);
+      await waitForSystemEvent();
+      const routedCall = cronIsolatedRun.mock.calls[0]?.[0] as {
+        job?: { agentId?: string };
+      };
+      expect(routedCall?.job?.agentId).toBe("hooks");
+      drainSystemEvents(resolveMainKey());
+
+      cronIsolatedRun.mockReset();
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "ok",
+        summary: "done",
+      });
+      const resAgentUnknown = await fetch(`http://127.0.0.1:${port}/hooks/agent`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer hook-secret",
+        },
+        body: JSON.stringify({ message: "Do it", name: "Email", agentId: "missing-agent" }),
+      });
+      expect(resAgentUnknown.status).toBe(202);
+      await waitForSystemEvent();
+      const fallbackCall = cronIsolatedRun.mock.calls[0]?.[0] as {
+        job?: { agentId?: string };
+      };
+      expect(fallbackCall?.job?.agentId).toBe("main");
       drainSystemEvents(resolveMainKey());
 
       const resQuery = await fetch(`http://127.0.0.1:${port}/hooks/wake?token=hook-secret`, {
@@ -149,6 +194,97 @@ describe("gateway server hooks", () => {
         body: "{",
       });
       expect(resBadJson.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("enforces hooks.allowedAgentIds for explicit agent routing", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: "hook-secret",
+      allowedAgentIds: ["hooks"],
+      mappings: [
+        {
+          match: { path: "mapped" },
+          action: "agent",
+          agentId: "main",
+          messageTemplate: "Mapped: {{payload.subject}}",
+        },
+      ],
+    };
+    testState.agentsConfig = {
+      list: [{ id: "main", default: true }, { id: "hooks" }],
+    };
+    const port = await getFreePort();
+    const server = await startGatewayServer(port);
+    try {
+      cronIsolatedRun.mockReset();
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "ok",
+        summary: "done",
+      });
+      const resNoAgent = await fetch(`http://127.0.0.1:${port}/hooks/agent`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer hook-secret",
+        },
+        body: JSON.stringify({ message: "No explicit agent" }),
+      });
+      expect(resNoAgent.status).toBe(202);
+      await waitForSystemEvent();
+      const noAgentCall = cronIsolatedRun.mock.calls[0]?.[0] as {
+        job?: { agentId?: string };
+      };
+      expect(noAgentCall?.job?.agentId).toBeUndefined();
+      drainSystemEvents(resolveMainKey());
+
+      cronIsolatedRun.mockReset();
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "ok",
+        summary: "done",
+      });
+      const resAllowed = await fetch(`http://127.0.0.1:${port}/hooks/agent`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer hook-secret",
+        },
+        body: JSON.stringify({ message: "Allowed", agentId: "hooks" }),
+      });
+      expect(resAllowed.status).toBe(202);
+      await waitForSystemEvent();
+      const allowedCall = cronIsolatedRun.mock.calls[0]?.[0] as {
+        job?: { agentId?: string };
+      };
+      expect(allowedCall?.job?.agentId).toBe("hooks");
+      drainSystemEvents(resolveMainKey());
+
+      const resDenied = await fetch(`http://127.0.0.1:${port}/hooks/agent`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer hook-secret",
+        },
+        body: JSON.stringify({ message: "Denied", agentId: "main" }),
+      });
+      expect(resDenied.status).toBe(400);
+      const deniedBody = (await resDenied.json()) as { error?: string };
+      expect(deniedBody.error).toContain("hooks.allowedAgentIds");
+
+      const resMappedDenied = await fetch(`http://127.0.0.1:${port}/hooks/mapped`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer hook-secret",
+        },
+        body: JSON.stringify({ subject: "hello" }),
+      });
+      expect(resMappedDenied.status).toBe(400);
+      const mappedDeniedBody = (await resMappedDenied.json()) as { error?: string };
+      expect(mappedDeniedBody.error).toContain("hooks.allowedAgentIds");
+      expect(peekSystemEvents(resolveMainKey()).length).toBe(0);
     } finally {
       await server.close();
     }

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -32,6 +32,7 @@ export function createGatewayHooksRequestHandler(params: {
   const dispatchAgentHook = (value: {
     message: string;
     name: string;
+    agentId?: string;
     wakeMode: "now" | "next-heartbeat";
     sessionKey: string;
     deliver: boolean;
@@ -48,6 +49,7 @@ export function createGatewayHooksRequestHandler(params: {
     const now = Date.now();
     const job: CronJob = {
       id: jobId,
+      agentId: value.agentId,
       name: value.name,
       enabled: true,
       createdAtMs: now,


### PR DESCRIPTION
## Summary

Add `agentId` support to webhook hook mappings, allowing hooks to route to a specific agent instead of always using the default.

## Motivation

When using webhook hooks (e.g., Gmail), each hook run loads the full bootstrap files (~45KB) from the default agent's workspace. For simple processing tasks (triage an email, send a notification), this burns unnecessary tokens.

With `agentId` support, users can create a lightweight agent with minimal bootstrap files and route webhook hooks to it, significantly reducing per-hook token cost — without losing capability in the main agent.

Cron jobs already support `agentId` via `CronJob.agentId`, and `runCronIsolatedAgentTurn` already handles agent resolution. This PR simply wires the field through from webhook mappings.

## Changes

**Config type + validation** (3 files):
- `src/config/types.hooks.ts` — Add `agentId?: string` to `HookMappingConfig`
- `src/config/zod-schema.hooks.ts` — Add `agentId` to Zod schema

**Mapping logic** (1 file):
- `src/gateway/hooks-mapping.ts` — Thread `agentId` through `HookMappingResolved`, `HookAction`, `HookTransformResult`, `normalizeHookMapping`, `buildActionFromMapping`, and `mergeAction`

**Hook dispatch** (3 files):
- `src/gateway/hooks.ts` — Add `agentId` to `HookAgentPayload` + `normalizeAgentPayload`
- `src/gateway/server-http.ts` — Pass `agentId` through `HookDispatchers` type and mapped hook dispatch
- `src/gateway/server/hooks.ts` — Set `agentId` on the `CronJob` passed to `runCronIsolatedAgentTurn`

**Tests** (2 files):
- `src/gateway/hooks-mapping.test.ts` — Tests for agentId passthrough + undefined when not set
- `src/gateway/hooks.test.ts` — Tests for `normalizeAgentPayload` with/without agentId

**Docs** (1 file):
- `docs/automation/webhook.md` — Document `agentId` for `/hooks/agent` endpoint and mapping options

## Usage

### Config mapping
```json5
{
  hooks: {
    mappings: [{
      match: { path: "gmail" },
      agentId: "hooks",  // Route to lightweight agent
      // ...
    }]
  }
}
```

### Direct endpoint
```bash
curl -X POST http://127.0.0.1:18789/hooks/agent \
  -H 'Authorization: Bearer SECRET' \
  -d '{"message": "Process this", "agentId": "hooks"}'
```

## Backward compatible

- `agentId` is optional everywhere — omitting it preserves existing behavior (default agent)
- No changes to existing config schemas or API contracts
- Transform modules can override `agentId` via the existing merge mechanism

## Test results

All 15 tests pass (existing + new):
```
✓ hooks-mapping.test.ts > passes agentId from mapping
✓ hooks-mapping.test.ts > agentId is undefined when not set
✓ hooks.test.ts > normalizeAgentPayload passes agentId
```

`tsc --noEmit` passes with zero errors.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `agentId` support to webhook hook mappings, enabling hooks to route to specific agents instead of always using the default agent. This reduces token costs for simple processing tasks by allowing lightweight agents with minimal bootstrap files.

The implementation threads `agentId` through the entire webhook pipeline:
- Config layer adds the optional field to types and Zod schema
- Mapping layer passes it through `HookMappingResolved`, `HookAction`, and transform results
- Dispatch layer includes it in `HookAgentPayload` and `HookDispatchers` type
- Server layer sets it on the `CronJob` passed to `runCronIsolatedAgentTurn`, which already had agent resolution logic for cron jobs

The change is fully backward compatible - `agentId` is optional everywhere and omitting it preserves existing behavior (default agent). Test coverage includes both cases: when `agentId` is set and when it's undefined.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, follows existing patterns, and leverages infrastructure already in place for cron jobs. All changes are additive and backward compatible - the `agentId` field is optional throughout the stack. Type definitions are properly updated across TypeScript types and Zod schemas. The change threads a single optional field through multiple layers without modifying existing logic. Test coverage includes both positive (agentId set) and negative (agentId undefined) cases.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->