### PR TITLE
feat(commands): add /r as alias for /reset

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -395,7 +395,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       key: "reset",
       nativeName: "reset",
       description: "Reset the current session.",
-      textAlias: "/reset",
+      textAliases: ["/reset", "/r"],
       acceptsArgs: true,
       category: "session",
     }),


### PR DESCRIPTION
## Summary

Adds `/r` as a short alias for the `/reset` command.

## Motivation

For consistency with existing command aliases:
- `/t` → `/think`
- `/v` → `/verbose`
- `/elev` → `/elevated`

Having `/r` → `/reset` makes it quicker to reset sessions, especially on mobile.

## Changes

- Changed `textAlias: "/reset"` to `textAliases: ["/reset", "/r"]` in `commands-registry.data.ts`

Trivial one-liner, no breaking changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `/r` as a short alias for the `/reset` command, following the existing pattern of single-letter command aliases (`/t` → `/think`, `/v` → `/verbose`, `/elev` → `/elevated`). The implementation correctly uses `textAliases` array syntax, and the change integrates seamlessly with the existing command registry validation system.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with no risk
- Single-line change that follows established patterns in the codebase. The implementation correctly uses the `textAliases` array format, matches the coding style of other alias definitions, and integrates properly with existing validation logic. No conflicts with other commands, no breaking changes, and existing tests will automatically validate the new alias.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->