### PR TITLE
feat(gateway): make WebSocket maxPayload configurable

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -245,4 +245,6 @@ export type GatewayConfig = {
    * `x-real-ip`) to determine the client IP for local pairing and HTTP checks.
    */
   trustedProxies?: string[];
+  /** Maximum WebSocket message payload size in bytes. Default: 10MB. */
+  wsMaxPayload?: number;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -509,6 +509,7 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        wsMaxPayload: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,4 +1,14 @@
-export const MAX_PAYLOAD_BYTES = 512 * 1024; // cap incoming frame size
+export const DEFAULT_MAX_PAYLOAD_BYTES = 10 * 1024 * 1024; // 10 MB default
+let maxPayloadBytes = DEFAULT_MAX_PAYLOAD_BYTES;
+
+export const getMaxPayloadBytes = () => maxPayloadBytes;
+
+export const setMaxPayloadBytes = (value?: number) => {
+  if (value !== undefined && Number.isFinite(value) && value > 0) {
+    maxPayloadBytes = value;
+  }
+};
+
 export const MAX_BUFFERED_BYTES = 1.5 * 1024 * 1024; // per-connection send buffer limit
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -20,7 +20,7 @@ import {
   createChatRunState,
   createToolEventRecipientRegistry,
 } from "./server-chat.js";
-import { MAX_PAYLOAD_BYTES } from "./server-constants.js";
+import { getMaxPayloadBytes } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import { createGatewayHooksRequestHandler } from "./server/hooks.js";
 import { listenGatewayHttpServer } from "./server/http-listen.js";
@@ -165,7 +165,7 @@ export async function createGatewayRuntimeState(params: {
 
   const wss = new WebSocketServer({
     noServer: true,
-    maxPayload: MAX_PAYLOAD_BYTES,
+    maxPayload: getMaxPayloadBytes(),
   });
   for (const server of httpServers) {
     attachGatewayUpgradeHandler({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -48,6 +48,7 @@ import { NodeRegistry } from "./node-registry.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";
+import { setMaxPayloadBytes } from "./server-constants.js";
 import { buildGatewayCronService } from "./server-cron.js";
 import { startGatewayDiscovery } from "./server-discovery-runtime.js";
 import { applyGatewayLaneConcurrency } from "./server-lanes.js";
@@ -222,6 +223,7 @@ export async function startGatewayServer(
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();
   }
+  setMaxPayloadBytes(cfgAtStart.gateway?.wsMaxPayload);
   setGatewaySigusr1RestartPolicy({ allowExternal: cfgAtStart.commands?.restart === true });
   initSubagentRegistry();
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -41,7 +41,11 @@ import {
   validateConnectParams,
   validateRequestFrame,
 } from "../../protocol/index.js";
-import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
+import {
+  MAX_BUFFERED_BYTES,
+  getMaxPayloadBytes,
+  TICK_INTERVAL_MS,
+} from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import { formatError } from "../../server-utils.js";
 import { formatForLog, logWs } from "../../ws-log.js";
@@ -870,7 +874,7 @@ export function attachGatewayWsMessageHandler(params: {
               }
             : undefined,
           policy: {
-            maxPayload: MAX_PAYLOAD_BYTES,
+            maxPayload: getMaxPayloadBytes(),
             maxBufferedBytes: MAX_BUFFERED_BYTES,
             tickIntervalMs: TICK_INTERVAL_MS,
           },


### PR DESCRIPTION
## Summary

Makes the WebSocket `maxPayload` configurable via the `gateway.wsMaxPayload` config option, fixing Error 1009 when webchat users upload images.

## Changes

- **Config schema**: Added `gateway.wsMaxPayload` field (optional, integer, minimum: 1)
- **Type definition**: Added `wsMaxPayload?: number` to `GatewayConfig` type
- **Server constants**: 
  - Replaced hardcoded `MAX_PAYLOAD_BYTES = 512 * 1024` with configurable getter/setter pattern
  - New default: 10MB (was 512KB)
  - Exported `getMaxPayloadBytes()` and `setMaxPayloadBytes(value?: number)`
- **Runtime initialization**: Applied config value during gateway startup in `server.impl.ts`
- **WebSocket servers**: Updated both main and extension relay WS server creation to use `getMaxPayloadBytes()`

## Why

The hardcoded 512KB limit caused Error 1009 when webchat users uploaded images, as base64-encoded images easily exceed this size.

## Default behavior

- Default is now 10MB (20x increase from 512KB)
- Users can override via config: `gateway.wsMaxPayload: <bytes>`
- Validates positive integers only

Fixes #10243

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes the WebSocket `maxPayload` configurable to fix Error 1009 when webchat users upload images. Previously hardcoded at 512KB, the limit is now configurable via `gateway.wsMaxPayload` with a new default of 10MB.

**Key changes:**
- Added `gateway.wsMaxPayload` config field with validation (positive integer)
- Replaced hardcoded `MAX_PAYLOAD_BYTES` constant with getter/setter pattern
- Applied config value during gateway startup in `server.impl.ts:226`
- Updated both main gateway and message handler WebSocket servers to use `getMaxPayloadBytes()`
- Increased default from 512KB to 10MB (20x increase)

**Implementation is sound:**
- Config changes to `gateway.*` trigger gateway restart (verified in `config-reload.ts:83`), ensuring the new value is picked up
- Validation ensures only positive integers are accepted
- Setter safely handles undefined values by keeping the default
- All main WebSocket server instances updated to use the new getter

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows established patterns in the codebase. All WebSocket servers that handle user content are properly updated. The validation is appropriate, the default value increase is reasonable for the use case, and config hot-reload will correctly restart the gateway when this value changes. No breaking changes or security issues identified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->