### PR TITLE
security: add rate limiting to gateway authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ USER.md
 .agent/*.json
 !.agent/workflows/
 local/
+package-lock.json

--- a/src/gateway/auth-rate-limiter.integration.test.ts
+++ b/src/gateway/auth-rate-limiter.integration.test.ts
@@ -1,0 +1,79 @@
+import { IncomingMessage } from "node:http";
+import { Socket } from "node:net";
+import { describe, it, expect } from "vitest";
+import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
+
+/**
+ * Integration test: verify that authorizeGatewayConnect returns rate_limited
+ * after enough failed attempts from a non-local IP.
+ */
+
+function fakeReq(remoteAddress: string, host = "gateway.example.com:18789"): IncomingMessage {
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", { value: remoteAddress });
+  const req = new IncomingMessage(socket);
+  req.headers = { host };
+  return req;
+}
+
+describe("authorizeGatewayConnect rate limiting integration", () => {
+  const auth: ResolvedGatewayAuth = {
+    mode: "token",
+    token: "super-secret-token",
+    allowTailscale: false,
+  };
+
+  it("returns rate_limited after repeated failures from non-local IP", async () => {
+    // Spam 12 bad attempts from a "remote" IP
+    const results: string[] = [];
+    for (let i = 0; i < 12; i++) {
+      const result = await authorizeGatewayConnect({
+        auth,
+        connectAuth: { token: `wrong-${i}` },
+        req: fakeReq("203.0.113.1"),
+      });
+      results.push(result.reason ?? "ok");
+    }
+
+    // First 10 should be token_mismatch, then rate_limited
+    const mismatches = results.filter((r) => r === "token_mismatch").length;
+    const rateLimited = results.filter((r) => r === "rate_limited").length;
+
+    expect(mismatches).toBe(10);
+    expect(rateLimited).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not rate-limit loopback requests", async () => {
+    const results: string[] = [];
+    for (let i = 0; i < 15; i++) {
+      const result = await authorizeGatewayConnect({
+        auth,
+        connectAuth: { token: `wrong-${i}` },
+        req: fakeReq("127.0.0.1", "localhost:18789"),
+      });
+      results.push(result.reason ?? "ok");
+    }
+
+    // All should be token_mismatch — never rate_limited
+    expect(results.every((r) => r === "token_mismatch")).toBe(true);
+  });
+
+  it("valid auth still works after bad attempts from different IP", async () => {
+    // Spam from attacker IP
+    for (let i = 0; i < 12; i++) {
+      await authorizeGatewayConnect({
+        auth,
+        connectAuth: { token: `wrong-${i}` },
+        req: fakeReq("198.51.100.5"),
+      });
+    }
+
+    // Valid auth from different IP should work
+    const result = await authorizeGatewayConnect({
+      auth,
+      connectAuth: { token: "super-secret-token" },
+      req: fakeReq("192.0.2.10"),
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/gateway/auth-rate-limiter.test.ts
+++ b/src/gateway/auth-rate-limiter.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { AuthRateLimiter } from "./auth-rate-limiter.js";
+
+describe("AuthRateLimiter", () => {
+  let limiter: AuthRateLimiter;
+
+  afterEach(() => {
+    limiter?.dispose();
+  });
+
+  it("allows requests under the threshold", () => {
+    limiter = new AuthRateLimiter({ maxAttempts: 5, windowMs: 60_000, blockMs: 300_000 });
+    const ip = "192.168.1.1";
+
+    for (let i = 0; i < 4; i++) {
+      limiter.recordFailure(ip);
+    }
+
+    expect(limiter.check(ip)).toBe(true);
+    expect(limiter.isBlocked(ip)).toBe(false);
+  });
+
+  it("blocks after exceeding the threshold", () => {
+    limiter = new AuthRateLimiter({ maxAttempts: 3, windowMs: 60_000, blockMs: 300_000 });
+    const ip = "10.0.0.1";
+
+    for (let i = 0; i < 3; i++) {
+      limiter.recordFailure(ip);
+    }
+
+    expect(limiter.check(ip)).toBe(false);
+    expect(limiter.isBlocked(ip)).toBe(true);
+  });
+
+  it("does not affect other IPs", () => {
+    limiter = new AuthRateLimiter({ maxAttempts: 2, windowMs: 60_000, blockMs: 300_000 });
+
+    limiter.recordFailure("1.1.1.1");
+    limiter.recordFailure("1.1.1.1");
+
+    expect(limiter.check("1.1.1.1")).toBe(false);
+    expect(limiter.check("2.2.2.2")).toBe(true);
+  });
+
+  it("unblocks after block duration expires", () => {
+    limiter = new AuthRateLimiter({ maxAttempts: 2, windowMs: 60_000, blockMs: 100 });
+    const ip = "10.0.0.2";
+
+    limiter.recordFailure(ip);
+    limiter.recordFailure(ip);
+    expect(limiter.check(ip)).toBe(false);
+
+    // Wait for block to expire.
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(limiter.check(ip)).toBe(true);
+        expect(limiter.isBlocked(ip)).toBe(false);
+        resolve();
+      }, 150);
+    });
+  });
+
+  it("reports correct size", () => {
+    limiter = new AuthRateLimiter({ maxAttempts: 10, windowMs: 60_000, blockMs: 300_000 });
+
+    limiter.recordFailure("a");
+    limiter.recordFailure("b");
+    limiter.recordFailure("c");
+
+    expect(limiter.size).toBe(3);
+  });
+
+  it("allows unknown IPs", () => {
+    limiter = new AuthRateLimiter();
+    expect(limiter.check("never-seen")).toBe(true);
+  });
+});

--- a/src/gateway/auth-rate-limiter.ts
+++ b/src/gateway/auth-rate-limiter.ts
@@ -1,0 +1,126 @@
+/**
+ * In-memory sliding-window rate limiter for gateway authentication attempts.
+ *
+ * Tracks failed auth attempts per client IP and blocks IPs that exceed the
+ * configured threshold within the time window. Successful auths are not counted.
+ *
+ * Defaults: 10 failures per 60 seconds → blocked for 5 minutes.
+ * After the block expires the counter resets, giving the client a fresh window.
+ */
+export class AuthRateLimiter {
+  private readonly maxAttempts: number;
+  private readonly windowMs: number;
+  private readonly blockMs: number;
+
+  /** key = clientIp → { timestamps of recent failures, optional block-until } */
+  private readonly state = new Map<
+    string,
+    { failures: number[]; blockedUntil?: number }
+  >();
+
+  /** Periodic cleanup interval handle. */
+  private cleanupTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(opts?: { maxAttempts?: number; windowMs?: number; blockMs?: number }) {
+    this.maxAttempts = opts?.maxAttempts ?? 10;
+    this.windowMs = opts?.windowMs ?? 60_000;
+    this.blockMs = opts?.blockMs ?? 5 * 60_000;
+
+    // Cleanup stale entries every 60 s to avoid unbounded memory growth.
+    this.cleanupTimer = setInterval(() => this.cleanup(), 60_000);
+    if (this.cleanupTimer.unref) {
+      this.cleanupTimer.unref(); // Don't keep the process alive.
+    }
+  }
+
+  /**
+   * Check whether a request from `clientIp` is allowed.
+   * Returns `true` if the request may proceed, `false` if rate-limited.
+   */
+  check(clientIp: string): boolean {
+    const now = Date.now();
+    const entry = this.state.get(clientIp);
+    if (!entry) {
+      return true;
+    }
+
+    // Currently blocked?
+    if (entry.blockedUntil && now < entry.blockedUntil) {
+      return false;
+    }
+
+    // Block expired → reset.
+    if (entry.blockedUntil && now >= entry.blockedUntil) {
+      this.state.delete(clientIp);
+      return true;
+    }
+
+    return true;
+  }
+
+  /** Record a failed authentication attempt for `clientIp`. */
+  recordFailure(clientIp: string): void {
+    const now = Date.now();
+    let entry = this.state.get(clientIp);
+    if (!entry) {
+      entry = { failures: [] };
+      this.state.set(clientIp, entry);
+    }
+
+    // If currently blocked, nothing to do.
+    if (entry.blockedUntil && now < entry.blockedUntil) {
+      return;
+    }
+
+    // Prune failures outside the window.
+    const cutoff = now - this.windowMs;
+    entry.failures = entry.failures.filter((t) => t > cutoff);
+    entry.failures.push(now);
+
+    // Exceeded threshold → block.
+    if (entry.failures.length >= this.maxAttempts) {
+      entry.blockedUntil = now + this.blockMs;
+      entry.failures = []; // Free memory; the block timestamp is what matters now.
+    }
+  }
+
+  /** Remove entries whose block has expired and that have no recent failures. */
+  private cleanup(): void {
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+    for (const [ip, entry] of this.state) {
+      if (entry.blockedUntil && now >= entry.blockedUntil) {
+        this.state.delete(ip);
+        continue;
+      }
+      if (!entry.blockedUntil) {
+        entry.failures = entry.failures.filter((t) => t > cutoff);
+        if (entry.failures.length === 0) {
+          this.state.delete(ip);
+        }
+      }
+    }
+  }
+
+  /** Stop the background cleanup timer (for tests). */
+  dispose(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+    }
+  }
+
+  /** Current number of tracked IPs (for observability / tests). */
+  get size(): number {
+    return this.state.size;
+  }
+
+  /** Check if an IP is currently blocked (for tests / diagnostics). */
+  isBlocked(clientIp: string): boolean {
+    const entry = this.state.get(clientIp);
+    if (!entry?.blockedUntil) {
+      return false;
+    }
+    return Date.now() < entry.blockedUntil;
+  }
+}

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -24,6 +24,13 @@ export function sendUnauthorized(res: ServerResponse) {
   });
 }
 
+export function sendRateLimited(res: ServerResponse) {
+  res.setHeader("Retry-After", "300");
+  sendJson(res, 429, {
+    error: { message: "Too many failed authentication attempts. Try again later.", type: "rate_limited" },
+  });
+}
+
 export function sendInvalidRequest(res: ServerResponse, message: string) {
   sendJson(res, 400, {
     error: { message, type: "invalid_request_error" },

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -10,6 +10,7 @@ import {
   readJsonBodyOrError,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
   setSseHeaders,
   writeDone,
@@ -191,7 +192,11 @@ export async function handleOpenAiHttpRequest(
     trustedProxies: opts.trustedProxies,
   });
   if (!authResult.ok) {
-    sendUnauthorized(res);
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res);
+    } else {
+      sendUnauthorized(res);
+    }
     return true;
   }
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -39,6 +39,7 @@ import {
   readJsonBodyOrError,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
   setSseHeaders,
   writeDone,
@@ -350,7 +351,11 @@ export async function handleOpenResponsesHttpRequest(
     trustedProxies: opts.trustedProxies,
   });
   if (!authResult.ok) {
-    sendUnauthorized(res);
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res);
+    } else {
+      sendUnauthorized(res);
+    }
     return true;
   }
 

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -27,6 +27,7 @@ import {
   sendInvalidRequest,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
 } from "./http-common.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
@@ -123,7 +124,11 @@ export async function handleToolsInvokeHttpRequest(
     trustedProxies: opts.trustedProxies ?? cfg.gateway?.trustedProxies,
   });
   if (!authResult.ok) {
-    sendUnauthorized(res);
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res);
+    } else {
+      sendUnauthorized(res);
+    }
     return true;
   }
 


### PR DESCRIPTION
## Summary

Add per-IP rate limiting for failed gateway authentication attempts to prevent brute-force attacks.

## Problem

The gateway accepts unlimited authentication attempts with no rate limiting. An attacker can brute-force gateway tokens at 600+ attempts/second against any exposed instance. With common/weak tokens, this leads to full gateway compromise in seconds.

**Proof of concept:** A simple Python script using `aiohttp` with 50 concurrent connections achieved ~645 attempts/sec against a local gateway, cracking a weak token in under 2 seconds.

## Solution

- **New `AuthRateLimiter` class** — sliding-window rate limiter tracking failed attempts per client IP
- **Default thresholds:** 10 failures within 60 seconds → IP blocked for 5 minutes
- **Integrated into `authorizeGatewayConnect()`** — covers all auth paths (token, password)
- **HTTP endpoints** return `429 Too Many Requests` with `Retry-After: 300` header
- **WebSocket connections** are rejected through the existing error flow
- **Local/loopback requests are exempt** — no rate limiting for localhost connections
- **Memory-safe:** automatic cleanup of stale entries every 60 seconds, `unref()`ed timer

## Files Changed

| File | Change |
|------|--------|
| `src/gateway/auth-rate-limiter.ts` | New rate limiter class |
| `src/gateway/auth-rate-limiter.test.ts` | 6 tests (threshold, blocking, expiry, isolation) |
| `src/gateway/auth.ts` | Integrate rate limiter into `authorizeGatewayConnect()` |
| `src/gateway/http-common.ts` | Add `sendRateLimited()` helper (429 + Retry-After) |
| `src/gateway/openai-http.ts` | Return 429 on rate-limited auth |
| `src/gateway/openresponses-http.ts` | Return 429 on rate-limited auth |
| `src/gateway/tools-invoke-http.ts` | Return 429 on rate-limited auth |

## Testing

All existing auth tests pass. New test suite covers:
- Requests under threshold are allowed
- Requests exceeding threshold are blocked
- Different IPs are isolated
- Block expires after configured duration
- Unknown IPs are always allowed

## Related

- CWE-307: Improper Restriction of Excessive Authentication Attempts
- This does **not** address weak token generation (separate concern) — only limits brute-force velocity

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an in-memory, per-client-IP rate limiter for failed gateway authentication attempts and integrates it into `authorizeGatewayConnect()`. HTTP handlers (`openai-http`, `openresponses-http`, `tools-invoke-http`) now map the new `rate_limited` auth failure reason to a `429` response with a `Retry-After` header via `sendRateLimited()`.

Key integration point is `src/gateway/auth.ts`, where requests (except local direct/loopback) are checked before auth evaluation, and failed token/password comparisons record failures for the resolved client IP. The limiter includes periodic cleanup with an `unref()`’d timer to avoid keeping the process alive.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness issue in how missing/unknown client IPs are bucketed for rate limiting.
- Core rate-limiting logic and HTTP 429 handling are straightforward, but the constant fallback key `"unknown"` means multiple distinct clients can unintentionally share one limiter bucket whenever the client IP cannot be resolved, leading to collateral lockouts.
- src/gateway/auth.ts (client IP fallback / bucketing)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->