### PR TITLE
feat(security): secure gateway tool pattern for sandboxed agents

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -11,6 +11,7 @@ import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
+import { createNotionTool } from "./tools/notion-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -104,6 +105,9 @@ export function createOpenClawTools(options?: {
     ...(messageTool ? [messageTool] : []),
     createTtsTool({
       agentChannel: options?.agentChannel,
+      config: options?.config,
+    }),
+    createNotionTool({
       config: options?.config,
     }),
     createGatewayTool({

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -11,13 +11,20 @@ export const DEFAULT_SANDBOX_IDLE_HOURS = 24;
 export const DEFAULT_SANDBOX_MAX_AGE_DAYS = 7;
 
 export const DEFAULT_TOOL_ALLOW = [
+  // Core coding tools
   "exec",
   "process",
   "read",
   "write",
   "edit",
   "apply_patch",
+  // Gateway tools (API keys handled server-side)
   "image",
+  "web_search",
+  "web_fetch",
+  "tts",
+  "notion",
+  // Session management
   "sessions_list",
   "sessions_history",
   "sessions_send",

--- a/src/agents/tools/notion-tool.ts
+++ b/src/agents/tools/notion-tool.ts
@@ -1,0 +1,145 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { AnyAgentTool } from "./common.js";
+import { readStringParam } from "./common.js";
+
+const NotionToolSchema = Type.Object({
+  action: Type.Union(
+    [
+      Type.Literal("search"),
+      Type.Literal("getPage"),
+      Type.Literal("createPage"),
+      Type.Literal("updatePage"),
+      Type.Literal("query"),
+    ],
+    { description: "API action to perform" },
+  ),
+  query: Type.Optional(Type.String({ description: "Search query or filter" })),
+  pageId: Type.Optional(Type.String({ description: "Page or database ID" })),
+  parentId: Type.Optional(Type.String({ description: "Parent page/database ID for creation" })),
+  title: Type.Optional(Type.String({ description: "Page title" })),
+  content: Type.Optional(Type.String({ description: "Page content (markdown)" })),
+  properties: Type.Optional(Type.String({ description: "JSON properties for database items" })),
+});
+
+const NOTION_VERSION = "2025-09-03";
+
+async function notionRequest(
+  endpoint: string,
+  apiKey: string,
+  method: "GET" | "POST" | "PATCH" = "GET",
+  body?: unknown,
+): Promise<unknown> {
+  const response = await fetch(`https://api.notion.com/v1${endpoint}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Notion-Version": NOTION_VERSION,
+      "Content-Type": "application/json",
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Notion API error (${response.status}): ${error}`);
+  }
+
+  return response.json();
+}
+
+export function createNotionTool(_opts?: { config?: OpenClawConfig }): AnyAgentTool {
+  return {
+    label: "Notion",
+    name: "notion",
+    description:
+      "Interact with Notion API. Actions: search, getPage, createPage, updatePage, query. " +
+      "API key is handled securely server-side.",
+    parameters: NotionToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const action = readStringParam(params, "action", { required: true });
+
+      // Get API key from environment (server-side only)
+      const apiKey = process.env.NOTION_API_KEY;
+      if (!apiKey) {
+        return {
+          content: [{ type: "text", text: "Notion API key not configured. Set NOTION_API_KEY." }],
+          details: { error: "missing_api_key" },
+        };
+      }
+
+      try {
+        let result: unknown;
+
+        switch (action) {
+          case "search": {
+            const query = readStringParam(params, "query") || "";
+            result = await notionRequest("/search", apiKey, "POST", { query });
+            break;
+          }
+          case "getPage": {
+            const pageId = readStringParam(params, "pageId", { required: true });
+            result = await notionRequest(`/pages/${pageId}`, apiKey);
+            break;
+          }
+          case "createPage": {
+            const parentId = readStringParam(params, "parentId", { required: true });
+            const title = readStringParam(params, "title", { required: true });
+            const content = readStringParam(params, "content");
+
+            const body: Record<string, unknown> = {
+              parent: { page_id: parentId },
+              properties: {
+                title: { title: [{ text: { content: title } }] },
+              },
+            };
+
+            if (content) {
+              body.children = [
+                {
+                  object: "block",
+                  type: "paragraph",
+                  paragraph: { rich_text: [{ text: { content } }] },
+                },
+              ];
+            }
+
+            result = await notionRequest("/pages", apiKey, "POST", body);
+            break;
+          }
+          case "updatePage": {
+            const pageId = readStringParam(params, "pageId", { required: true });
+            const properties = readStringParam(params, "properties");
+            const body = properties ? JSON.parse(properties) : {};
+            result = await notionRequest(`/pages/${pageId}`, apiKey, "PATCH", { properties: body });
+            break;
+          }
+          case "query": {
+            const pageId = readStringParam(params, "pageId", { required: true });
+            const query = readStringParam(params, "query");
+            const body = query ? JSON.parse(query) : {};
+            result = await notionRequest(`/databases/${pageId}/query`, apiKey, "POST", body);
+            break;
+          }
+          default:
+            return {
+              content: [{ type: "text", text: `Unknown action: ${action}` }],
+              details: { error: "unknown_action" },
+            };
+        }
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: { action, success: true },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `Notion error: ${message}` }],
+          details: { action, error: message },
+        };
+      }
+    },
+  };
+}

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import { redactConfigObject } from "../config/redact-snapshot.js";
 import { danger, info } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -267,7 +268,7 @@ export function registerConfigCli(program: Command) {
           throw new Error("Path is empty.");
         }
         const snapshot = await loadValidConfig();
-        const res = getAtPath(snapshot.config, parsedPath);
+        const res = getAtPath(redactConfigObject(snapshot.config), parsedPath);
         if (!res.found) {
           defaultRuntime.error(danger(`Config path not found: ${path}`));
           defaultRuntime.exit(1);


### PR DESCRIPTION
## Summary

Security improvements for sandboxed agent API access:

1. **Config redaction** - CLI `config get` now redacts resolved secrets using `__OPENCLAW_REDACTED__` sentinel, preventing agents from reading API keys through config resolution

2. **Notion gateway tool** - New tool demonstrating the secure pattern:
   - Agent calls tool with parameters (action, query, etc.)
   - Gateway injects API key server-side from `process.env`
   - Agent never sees the actual secret

3. **Default sandbox allow list** - Added gateway tools that handle secrets server-side: `web_search`, `web_fetch`, `tts`, `notion`

## Problem

Sandboxed agents could extract API secrets by:
- Calling `config get` to read resolved `${VAR_NAME}` values
- The config snapshot returned actual API keys after substitution

## Solution

This pattern allows sandboxed agents to use API-dependent tools without exposing credentials. The gateway acts as a secure proxy, injecting secrets server-side while the agent only sees tool results.

### Files Changed

- `src/cli/config-cli.ts` - Added redaction before outputting config
- `src/agents/tools/notion-tool.ts` - New gateway tool template
- `src/agents/openclaw-tools.ts` - Registered notion tool
- `src/agents/sandbox/constants.ts` - Added gateway tools to default allow list

## Test plan

- [ ] Verify `openclaw config get` redacts sensitive values
- [ ] Test notion tool from sandboxed session
- [ ] Confirm agent cannot read `NOTION_API_KEY` directly
- [ ] Verify other gateway tools (web_search, tts) work in sandbox

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens secret-handling for sandboxed agents by redacting sensitive config values in `openclaw config get`, adding a Notion “gateway” tool that injects its API key server-side, registering that tool, and expanding the default sandbox allowlist to include gateway-style API tools.

The overall direction aligns with existing gateway-side redaction (`redact-snapshot.ts`) and tool registration patterns in `createOpenClawTools`, with the main new surface area being the Notion tool implementation and the updated sandbox tool policy defaults.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one functional mismatch in the new Notion tool that will cause createPage failures for database parents.
- Core changes (config redaction and allowlist updates) are small and leverage existing redaction utilities. The main risk is the newly introduced Notion gateway tool behavior mismatch where `createPage` cannot actually create under databases despite documentation implying it can.
- src/agents/tools/notion-tool.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->