### PR TITLE
fix(telegram): add verbose logging for disabled dmPolicy silent drops

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -729,6 +729,20 @@ The agent sees reactions as **system notifications** in the conversation history
 - Fix by enabling IPv6 egress **or** forcing IPv4 resolution for `api.telegram.org` (for example, add an `/etc/hosts` entry using the IPv4 A record, or prefer IPv4 in your OS DNS stack), then restart the gateway.
 - Quick check: `dig +short api.telegram.org A` and `dig +short api.telegram.org AAAA` to confirm what DNS returns.
 
+**Bot is polling but DMs are silently ignored (no inbound logs):**
+
+- Most common cause: `dmPolicy` is set to `"allowlist"` but `allowFrom` doesn't include your Telegram user ID or username. Check with `openclaw status` — if the channel shows OK but messages aren't processed, verify your `allowFrom` entries.
+- Use numeric user IDs for reliability (usernames can change). Find your ID by sending a message to `@userinfobot` on Telegram.
+- If `dmPolicy` is `"pairing"` (default), you must approve the pairing code on first contact. Check `openclaw pairing list` for pending requests.
+- If `dmPolicy` is `"disabled"`, all DMs are silently dropped. Set it to `"pairing"` or `"allowlist"` to receive messages.
+- Enable verbose logging (`OPENCLAW_VERBOSE=1`) to see rejection reasons for blocked messages.
+
+**Bot polls successfully but consumes messages without processing them:**
+
+- Check the update offset file in `~/.openclaw/state/telegram/update-offset-*.json`. A stale offset from a previous bot token can cause the gateway to skip all updates with lower IDs.
+- Fix: stop the gateway, delete the offset file, then restart. The gateway will begin polling from the latest update.
+- If you recently revoked and recreated the bot token, always delete the offset file — Telegram resets update IDs for new tokens.
+
 ## Configuration reference (Telegram)
 
 Full configuration: [Configuration](/gateway/configuration)

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -223,6 +223,7 @@ export const buildTelegramMessageContext = async ({
   // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled"
   if (!isGroup) {
     if (dmPolicy === "disabled") {
+      logVerbose(`Blocked telegram DM from ${chatId} (dmPolicy: disabled)`);
       return null;
     }
 


### PR DESCRIPTION
## Summary

When `dmPolicy` is set to `"disabled"`, inbound Telegram DMs are silently dropped with no log output. Every other rejection path in `bot-message-context.ts` calls `logVerbose()` with a descriptive message — this was the only one missing.

## Changes

### Code fix (`src/telegram/bot-message-context.ts`)
- Added `logVerbose()` call when DMs are blocked due to `dmPolicy: "disabled"`, matching the existing pattern used by all other rejection paths in the same file.

### Docs improvement (`docs/channels/telegram.md`)
- Added troubleshooting entry: "Bot is polling but DMs are silently ignored" — covers misconfigured `allowFrom`, pairing approval, and disabled dmPolicy.
- Added troubleshooting entry: "Bot polls successfully but consumes messages without processing them" — covers stale update offset files after token rotation.

## Context

Relates to #13701 (Telegram inbound messages not reaching gateway). While this doesn't fix the root cause of that issue, the missing log line makes debugging significantly harder — users see no indication of why messages are being dropped.

## Testing

- [x] Verified the `logVerbose` pattern matches existing rejection paths
- [x] AI-assisted (Claude) — reviewed full code context before making changes
- [x] Lightly tested (code review + pattern matching)

## AI Disclosure
This PR was AI-assisted. The code change is a single line addition following an established pattern.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added verbose logging for `dmPolicy: "disabled"` rejection path to match existing logging pattern used by all other DM rejection paths in `bot-message-context.ts:226`. Also added two troubleshooting entries to the Telegram documentation covering silent DM drops and stale update offset issues.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single line addition following an established logging pattern, with helpful documentation improvements. The code change exactly matches the pattern used by other rejection paths in the same file (lines 194, 198-200, 299, 317-318). No logical changes to behavior, only observability improvement.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->