### PR TITLE
fix(gateway): surface error details in RPC client error messages

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -327,7 +327,17 @@ export class GatewayClient {
         if (parsed.ok) {
           pending.resolve(parsed.payload);
         } else {
-          pending.reject(new Error(parsed.error?.message ?? "unknown error"));
+          const errMsg = parsed.error?.message ?? "unknown error";
+          const details = parsed.error?.details;
+          let detailsSuffix = "";
+          if (details && typeof details === "object") {
+            try {
+              detailsSuffix = `: ${JSON.stringify(details)}`;
+            } catch {
+              // Ignore circular references or BigInt values
+            }
+          }
+          pending.reject(new Error(`${errMsg}${detailsSuffix}`));
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

When the gateway RPC returns an error with a `details` object (e.g., config validation failures from `config.patch`), the gateway client only includes the top-level `message` field in the thrown Error, completely discarding the `details`.

This produces unhelpful errors like:

```
Error: invalid config
```

...when the server actually returned:

```json
{
  "code": "INVALID_REQUEST",
  "message": "invalid config",
  "details": {
    "issues": ["channels.telegram.allowFrom: Required"]
  }
}
```

This makes it extremely difficult for agents (and CLI users) to diagnose config issues without checking gateway logs.

## Fix

Append the `details` JSON to the error message when present:

```
Error: invalid config: {"issues":["channels.telegram.allowFrom: Required"]}
```

The change is minimal (5 lines) and only affects the error path — no impact on successful RPC calls.

## Context

Hit this repeatedly while configuring Telegram channel via the `config.patch` gateway tool. The agent received `invalid config` with no further context, requiring manual log inspection to identify the actual validation failure.

## Testing

- [x] Reviewed error flow: `server-methods/config.ts` → `errorShape()` → `client.ts` response handler
- [x] Verified `details` object is only appended when present and is an object
- [x] AI-assisted (Claude) — traced the full RPC error path before making the change
- [x] Lightly tested

## AI Disclosure
This PR was AI-assisted. The fix is a 5-line change in the error rejection path.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improved RPC error messages by appending `details` JSON when present, making config validation failures easier to diagnose. Also updated Telegram documentation to follow Mintlify style guidelines and added helpful DM troubleshooting logging.

**Main changes:**
- Gateway client now surfaces error details in exception messages (`"invalid config"` → `"invalid config: {\"issues\":[...]}"`)
- Documentation formatting fixes (em dashes → hyphens, curly quotes → straight quotes) per Mintlify requirements
- Added verbose logging when Telegram DMs are blocked by `dmPolicy: disabled`
- Enhanced troubleshooting documentation for Telegram DM issues

**Issues found:**
- `JSON.stringify` in error path could throw on circular references or BigInt values

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge with one minor edge case to address
- The core fix is straightforward and addresses a real usability issue. Documentation changes follow repository style guidelines. The only concern is potential JSON.stringify failure in the error path, which could cause unhelpful error messages in edge cases (though this is unlikely in practice since error details are typically simple objects)
- src/gateway/client.ts - handle potential JSON.stringify errors

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->