### PR TITLE
docs: expand Telegram troubleshooting with common failure signatures

### DIFF
--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -44,11 +44,15 @@ Full troubleshooting: [/channels/whatsapp#troubleshooting-quick](/channels/whats
 
 ### Telegram failure signatures
 
-| Symptom                           | Fastest check                                   | Fix                                                       |
-| --------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `/start` but no usable reply flow | `openclaw pairing list telegram`                | Approve pairing or change DM policy.                      |
-| Bot online but group stays silent | Verify mention requirement and bot privacy mode | Disable privacy mode for group visibility or mention bot. |
-| Send failures with network errors | Inspect logs for Telegram API call failures     | Fix DNS/IPv6/proxy routing to `api.telegram.org`.         |
+| Symptom                                            | Fastest check                                           | Fix                                                       |
+| -------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| `/start` but no usable reply flow                  | `openclaw pairing list telegram`                        | Approve pairing or change DM policy.                      |
+| Bot online but group stays silent                  | Verify mention requirement and bot privacy mode         | Disable privacy mode for group visibility or mention bot. |
+| Send failures with network errors                  | Inspect logs for Telegram API call failures             | Fix DNS/IPv6/proxy routing to `api.telegram.org`.         |
+| Bot polls but DMs silently ignored                 | `OPENCLAW_VERBOSE=1` + check logs for "Blocked" lines   | Verify `allowFrom` includes your numeric user ID.         |
+| `dmPolicy: "open"` config validation error         | Check `allowFrom` field                                 | `open` requires `allowFrom: ["*"]`.                       |
+| `setMyCommands` fails with `BOT_COMMANDS_TOO_MUCH` | Check number of installed skills                        | Cosmetic — auto-truncated at 100 commands.                |
+| Messages consumed but never processed              | Check `~/.openclaw/state/telegram/update-offset-*.json` | Delete offset file and restart after token rotation.      |
 
 Full troubleshooting: [/channels/telegram#troubleshooting](/channels/telegram#troubleshooting)
 


### PR DESCRIPTION
## Summary

Expands the Telegram section in the channel troubleshooting quick-reference table with four additional failure signatures commonly seen in issues and support channels.

## New entries

| Symptom | Fix summary |
|---------|-------------|
| Bot polls but DMs silently ignored | Verify `allowFrom` includes numeric user ID |
| `dmPolicy: "open"` config validation error | Requires `allowFrom: ["*"]` |
| `setMyCommands BOT_COMMANDS_TOO_MUCH` | Cosmetic — auto-truncated at 100 |
| Messages consumed but never processed | Delete stale update offset file after token rotation |

## Context

These entries are based on:
- Real user reports (#13701, #13667, #13674)
- Common first-time setup pitfalls (allowFrom with usernames vs numeric IDs)
- Configuration edge cases discovered during Telegram channel setup

The existing table only had 3 entries; this brings it to 7, matching the coverage level of other channels (WhatsApp, Discord, Slack).

## AI Disclosure
This PR was AI-assisted.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change expands the Telegram troubleshooting quick-reference table in `docs/channels/troubleshooting.md` by adding four new “failure signature” rows. The new rows cover DM allowlist/user-id pitfalls, a `dmPolicy: "open"` validation case, a `setMyCommands` command-limit error, and a stale Telegram update-offset state file after token rotation. No code behavior changes are introduced; this is documentation-only and fits the existing “failure signatures” tables used for other channels on the same page.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Documentation-only change confined to a single existing troubleshooting table; no code, configuration, or build-impacting edits. The added entries are syntactically valid Markdown and consistent with adjacent sections.
- docs/channels/troubleshooting.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->