### PR TITLE
fix: Unauthenticated Nostr profile API allows remote config tampering

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -333,6 +333,7 @@ export function createGatewayHttpServer(opts: {
     try {
       const configSnapshot = loadConfig();
       const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
+      const requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
       if (await handleHooksRequest(req, res)) {
         return;
       }
@@ -347,8 +348,23 @@ export function createGatewayHttpServer(opts: {
       if (await handleSlackHttpRequest(req, res)) {
         return;
       }
-      if (handlePluginRequest && (await handlePluginRequest(req, res))) {
-        return;
+      if (handlePluginRequest) {
+        if (requestPath.startsWith("/api/channels/")) {
+          const token = getBearerToken(req);
+          const authResult = await authorizeGatewayConnect({
+            auth: resolvedAuth,
+            connectAuth: token ? { token, password: token } : null,
+            req,
+            trustedProxies,
+          });
+          if (!authResult.ok) {
+            sendUnauthorized(res);
+            return;
+          }
+        }
+        if (await handlePluginRequest(req, res)) {
+          return;
+        }
       }
       if (openResponsesEnabled) {
         if (
@@ -372,8 +388,7 @@ export function createGatewayHttpServer(opts: {
         }
       }
       if (canvasHost) {
-        const url = new URL(req.url ?? "/", "http://localhost");
-        if (isCanvasPath(url.pathname)) {
+        if (isCanvasPath(requestPath)) {
           const ok = await authorizeCanvasRequest({
             req,
             auth: resolvedAuth,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -349,6 +349,9 @@ export function createGatewayHttpServer(opts: {
         return;
       }
       if (handlePluginRequest) {
+        // Channel HTTP endpoints are gateway-auth protected by default.
+        // Non-channel plugin routes remain plugin-owned and must enforce
+        // their own auth when exposing sensitive functionality.
         if (requestPath.startsWith("/api/channels/")) {
           const token = getBearerToken(req);
           const authResult = await authorizeGatewayConnect({

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -62,7 +62,15 @@ function createResponse(): {
   const setHeader = vi.fn();
   let body = "";
   const end = vi.fn((chunk?: unknown) => {
-    body = chunk == null ? "" : String(chunk);
+    if (typeof chunk === "string") {
+      body = chunk;
+      return;
+    }
+    if (chunk == null) {
+      body = "";
+      return;
+    }
+    body = JSON.stringify(chunk);
   });
   const res = {
     headersSent: false,

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -1,0 +1,166 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import { createGatewayHttpServer } from "./server-http.js";
+
+async function withTempConfig(params: { cfg: unknown; run: () => Promise<void> }): Promise<void> {
+  const prevConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const prevDisableCache = process.env.OPENCLAW_DISABLE_CONFIG_CACHE;
+
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-http-auth-test-"));
+  const configPath = path.join(dir, "openclaw.json");
+
+  process.env.OPENCLAW_CONFIG_PATH = configPath;
+  process.env.OPENCLAW_DISABLE_CONFIG_CACHE = "1";
+
+  try {
+    await writeFile(configPath, JSON.stringify(params.cfg, null, 2), "utf-8");
+    await params.run();
+  } finally {
+    if (prevConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = prevConfigPath;
+    }
+    if (prevDisableCache === undefined) {
+      delete process.env.OPENCLAW_DISABLE_CONFIG_CACHE;
+    } else {
+      process.env.OPENCLAW_DISABLE_CONFIG_CACHE = prevDisableCache;
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function createRequest(params: {
+  path: string;
+  authorization?: string;
+  method?: string;
+}): IncomingMessage {
+  const headers: Record<string, string> = {
+    host: "localhost:18789",
+  };
+  if (params.authorization) {
+    headers.authorization = params.authorization;
+  }
+  return {
+    method: params.method ?? "GET",
+    url: params.path,
+    headers,
+    socket: { remoteAddress: "127.0.0.1" },
+  } as IncomingMessage;
+}
+
+function createResponse(): {
+  res: ServerResponse;
+  setHeader: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+  getBody: () => string;
+} {
+  const setHeader = vi.fn();
+  let body = "";
+  const end = vi.fn((chunk?: unknown) => {
+    body = chunk == null ? "" : String(chunk);
+  });
+  const res = {
+    headersSent: false,
+    statusCode: 200,
+    setHeader,
+    end,
+  } as unknown as ServerResponse;
+  return {
+    res,
+    setHeader,
+    end,
+    getBody: () => body,
+  };
+}
+
+async function dispatchRequest(
+  server: ReturnType<typeof createGatewayHttpServer>,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  server.emit("request", req, res);
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("gateway plugin HTTP auth boundary", () => {
+  test("requires gateway auth for /api/channels/* plugin routes and allows authenticated pass-through", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "test-token",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          if (pathname === "/api/channels/nostr/default/profile") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ ok: true, route: "channel" }));
+            return true;
+          }
+          if (pathname === "/plugin/public") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ ok: true, route: "public" }));
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          resolvedAuth,
+        });
+
+        const unauthenticated = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/api/channels/nostr/default/profile" }),
+          unauthenticated.res,
+        );
+        expect(unauthenticated.res.statusCode).toBe(401);
+        expect(unauthenticated.getBody()).toContain("Unauthorized");
+        expect(handlePluginRequest).not.toHaveBeenCalled();
+
+        const authenticated = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({
+            path: "/api/channels/nostr/default/profile",
+            authorization: "Bearer test-token",
+          }),
+          authenticated.res,
+        );
+        expect(authenticated.res.statusCode).toBe(200);
+        expect(authenticated.getBody()).toContain('"route":"channel"');
+
+        const unauthenticatedPublic = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/plugin/public" }),
+          unauthenticatedPublic.res,
+        );
+        expect(unauthenticatedPublic.res.statusCode).toBe(200);
+        expect(unauthenticatedPublic.getBody()).toContain('"route":"public"');
+
+        expect(handlePluginRequest).toHaveBeenCalledTimes(2);
+      },
+    });
+  });
+});

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -66,6 +66,27 @@ function buildNostrProfileUrl(accountId: string, suffix = ""): string {
   return `/api/channels/nostr/${encodeURIComponent(accountId)}/profile${suffix}`;
 }
 
+function resolveGatewayHttpAuthHeader(host: OpenClawApp): string | null {
+  const deviceToken = host.hello?.auth?.deviceToken?.trim();
+  if (deviceToken) {
+    return `Bearer ${deviceToken}`;
+  }
+  const token = host.settings.token.trim();
+  if (token) {
+    return `Bearer ${token}`;
+  }
+  const password = host.password.trim();
+  if (password) {
+    return `Bearer ${password}`;
+  }
+  return null;
+}
+
+function buildGatewayHttpHeaders(host: OpenClawApp): Record<string, string> {
+  const authorization = resolveGatewayHttpAuthHeader(host);
+  return authorization ? { Authorization: authorization } : {};
+}
+
 export function handleNostrProfileEdit(
   host: OpenClawApp,
   accountId: string,
@@ -133,6 +154,7 @@ export async function handleNostrProfileSave(host: OpenClawApp) {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
+        ...buildGatewayHttpHeaders(host),
       },
       body: JSON.stringify(state.values),
     });
@@ -203,6 +225,7 @@ export async function handleNostrProfileImport(host: OpenClawApp) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        ...buildGatewayHttpHeaders(host),
       },
       body: JSON.stringify({ autoMerge: true }),
     });


### PR DESCRIPTION
## Fix Summary
The Nostr extension exposes profile management HTTP endpoints that do not require gateway authentication. Any network-reachable attacker can read and mutate channel profile state, trigger signed profile publishes, and persist unauthorized profile changes into the gateway config.

## Issue Linkage
Fixes #13718

## Security Snapshot
- CVSS v3.1: 8.6 (High)
- CVSS v4.0: 8.8 (High)

## Implementation Details
### Files Changed
- `src/gateway/server-http.ts` (+22/-4)
- `src/gateway/server.plugin-http-auth.test.ts` (+174/-0)
- `ui/src/ui/app-channels.ts` (+23/-0)

### Technical Analysis
Gateway request dispatch executes plugin HTTP handlers before authenticated core API handlers, and this path does not enforce `authorizeGatewayConnect`. The Nostr plugin registers an HTTP handler that accepts `GET`, `PUT`, and `POST` profile-management requests without bearer token, password, or device-auth checks. The `PUT` path writes updated profile data into persisted OpenClaw config and triggers relay publish operations.

## Validation Evidence
- Command: `pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: GPT-5.3-Codex

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR closes an auth boundary gap in the gateway HTTP dispatcher by requiring gateway authentication before dispatching *plugin-owned* handlers under `/api/channels/*`. It also updates the UI’s Nostr profile save/import calls to send an `Authorization: Bearer …` header, and adds a regression test to assert that unauthenticated requests to `/api/channels/*` plugin routes are rejected while non-channel plugin routes can remain public.

Overall, the change fits the codebase’s gateway model where channel API surfaces are intended to be gateway-auth protected, while plugins can still expose their own non-channel routes if they implement their own auth.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, but appears to change local-direct access behavior for channel plugin routes.
- Core security intent (auth before plugin dispatch for `/api/channels/*`) is sound and covered by a targeted test. The main concern is a concrete behavior change: local loopback requests without bearer credentials that previously worked for other protected surfaces may now be rejected for channel plugin routes, which could be an unintended regression depending on how local UI/proxies call these endpoints.
- src/gateway/server-http.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->