### PR TITLE
docs(telegram): add missing troubleshooting entries for common DM/polling failures

### DIFF
--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -44,11 +44,14 @@ Full troubleshooting: [/channels/whatsapp#troubleshooting-quick](/channels/whats
 
 ### Telegram failure signatures
 
-| Symptom                           | Fastest check                                   | Fix                                                       |
-| --------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `/start` but no usable reply flow | `openclaw pairing list telegram`                | Approve pairing or change DM policy.                      |
-| Bot online but group stays silent | Verify mention requirement and bot privacy mode | Disable privacy mode for group visibility or mention bot. |
-| Send failures with network errors | Inspect logs for Telegram API call failures     | Fix DNS/IPv6/proxy routing to `api.telegram.org`.         |
+| Symptom                                        | Fastest check                                             | Fix                                                                                         |
+| ---------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `/start` but no usable reply flow              | `openclaw pairing list telegram`                          | Approve pairing or change DM policy.                                                        |
+| Bot online but group stays silent              | Verify mention requirement and bot privacy mode           | Disable privacy mode for group visibility or mention bot.                                   |
+| Send failures with network errors              | Inspect logs for Telegram API call failures               | Fix DNS/IPv6/proxy routing to `api.telegram.org`.                                           |
+| DMs silently ignored (no inbound logs)         | Check `dmPolicy` and `allowFrom` config                   | Verify user ID is in `allowFrom`; use numeric IDs for reliability.                          |
+| Plugin starts but never polls ("fetch failed") | Check logs for undici/fetch errors at startup             | On Node 22+, set `channels.telegram.network.autoSelectFamily: false` or check IPv6 routing. |
+| Bot consumes messages but doesn't process them | Check update offset file in `~/.openclaw/state/telegram/` | Delete stale offset file after token rotation, then restart.                                |
 
 Full troubleshooting: [/channels/telegram#troubleshooting](/channels/telegram#troubleshooting)
 


### PR DESCRIPTION
## Summary

Adds three missing entries to the Telegram failure signatures table in the channel troubleshooting quick-reference:

| Symptom | Check | Fix |
|---------|-------|-----|
| DMs silently ignored (no inbound logs) | Check `dmPolicy` and `allowFrom` config | Verify user ID in `allowFrom`; use numeric IDs |
| Plugin starts but never polls ("fetch failed") | Check logs for undici/fetch errors | Set `network.autoSelectFamily: false` on Node 22+ |
| Bot consumes messages but doesn't process them | Check update offset file | Delete stale offset file after token rotation |

## Context

These cover the three most commonly reported Telegram issues (#13667, #13701) that weren't in the quick-reference table. Users hitting these issues currently have to dig through the full Telegram docs to find relevant troubleshooting steps.

## AI Disclosure
AI-assisted (Claude).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added three common Telegram troubleshooting entries to the quick-reference table (DMs silently ignored, polling failures on Node 22+, and stale offset issues after token rotation). Also fixed pairing approval command hints to display the actual pairing code instead of a placeholder `<code>`, improving the onboarding experience when users need to approve pairing requests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and low-risk: documentation additions to an existing table following the established format, and a simple string interpolation fix that replaces a placeholder with the actual value. No logic changes, no breaking changes, and the code fix improves user experience by making the pairing approval command immediately usable.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->