### PR TITLE
fix(whatsapp): convert Markdown formatting to WhatsApp-compatible markup

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -71,8 +71,9 @@ function markdownToWhatsApp(text: string): string {
   result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
 
   // Convert italic: remaining single *text* → _text_
-  // Only match *text* that isn't part of **text** (already converted above)
-  result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "_$1_");
+  // Bold (**text**) was already converted above, so remaining *text* is italic.
+  // Avoid lookbehind for broader runtime compatibility.
+  result = result.replace(/(?:^|([^*]))\*([^*]+)\*(?=[^*]|$)/g, "$1_$2_");
 
   // Convert headers to bold (WhatsApp has no header support)
   result = result.replace(/^#{1,6}\s+(.+)$/gm, "*$1*");


### PR DESCRIPTION
## Problem

WhatsApp uses different markup syntax than standard Markdown:

| Format | Markdown | WhatsApp |
|--------|----------|----------|
| Bold | `**text**` | `*text*` |
| Italic | `*text*` | `_text_` |
| Strikethrough | `~~text~~` | `~text~` |
| Headers | `# text` | (no equivalent) |

The LLM generates standard Markdown, but WhatsApp was receiving it as-is. This caused literal `**` and `~~` characters to appear in messages instead of formatted text.

## Fix

Adds a `markdownToWhatsApp()` converter that transforms outbound text before sending:

- `**bold**` → `*bold*`
- `*italic*` → `_italic_`
- `~~strike~~` → `~strike~`
- `# Header` → `*Header*` (bold fallback)
- Code blocks and inline code are preserved without conversion

Applied to both `sendText` and `sendMedia` (captions) in the WhatsApp outbound path.

## Design Decisions

- **Conversion order**: Bold (`**`) is converted before italic (`*`) to avoid conflicts
- **Code protection**: Code blocks and inline code are temporarily replaced before conversion to prevent mangling
- **Minimal scope**: Only affects the outbound path in the WhatsApp extension; no changes to shared infrastructure

## Testing

- [x] Verified conversion logic handles edge cases (nested formatting, code blocks)
- [x] AI-assisted (Claude) — reviewed the full outbound text path before implementing

Fixes #13715

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `markdownToWhatsApp()` helper in `extensions/whatsapp/src/channel.ts` and applies it to outbound WhatsApp messages (both plain text and media captions). The goal is to translate common Markdown markers (bold/italic/strike/headers) into WhatsApp’s markup while protecting code blocks and inline code from conversion.


<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a runtime-breaking regex compatibility issue to address first.
- Core change is small and localized to WhatsApp outbound formatting, but the italic regex uses lookbehind which can throw in unsupported JS runtimes at module load time; that needs to be rewritten for broad compatibility.
- extensions/whatsapp/src/channel.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->