### PR TITLE
fix(pairing): show actual code in approval command instead of placeholder

### DIFF
--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -52,7 +52,7 @@ describe("buildPairingReply", () => {
       expect(text).toContain(`Pairing code: ${testCase.code}`);
       // CLI commands should respect OPENCLAW_PROFILE when set (most tests run with isolated profile)
       const commandRe = new RegExp(
-        `(?:openclaw|openclaw) --profile isolated pairing approve ${testCase.channel} <code>`,
+        `(?:openclaw|openclaw) --profile isolated pairing approve ${testCase.channel} ${testCase.code}`,
       );
       expect(text).toMatch(commandRe);
     });

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -15,6 +15,6 @@ export function buildPairingReply(params: {
     `Pairing code: ${code}`,
     "",
     "Ask the bot owner to approve with:",
-    formatCliCommand(`openclaw pairing approve ${channel} <code>`),
+    formatCliCommand(`openclaw pairing approve ${channel} ${code}`),
   ].join("\n");
 }

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -289,7 +289,7 @@ export const buildTelegramMessageContext = async ({
                       `Pairing code: ${code}`,
                       "",
                       "Ask the bot owner to approve with:",
-                      formatCliCommand("openclaw pairing approve telegram <code>"),
+                      formatCliCommand(`openclaw pairing approve telegram ${code}`),
                     ].join("\n"),
                   ),
               });


### PR DESCRIPTION
## Problem

When a new user DMs the bot for the first time (pairing mode), the reply shows:

```
Pairing code: abc123

Ask the bot owner to approve with:
openclaw pairing approve telegram <code>
```

The owner has to manually copy `abc123` and replace `<code>` — an unnecessary step that slows down onboarding.

## Fix

Show the actual pairing code in the command:

```
Pairing code: abc123

Ask the bot owner to approve with:
openclaw pairing approve telegram abc123
```

Ready to copy-paste.

## Changes
- `src/pairing/pairing-messages.ts` — shared builder: `<code>` → `${code}`
- `src/telegram/bot-message-context.ts` — Telegram inline reply: same fix

## AI Disclosure
AI-assisted (Claude). 2-line change.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a UX issue where pairing approval commands showed a placeholder `<code>` instead of the actual pairing code, requiring users to manually replace it. The fix interpolates the actual code directly into the command string using `${code}`, making it copy-paste ready.

**Changes:**
- Updated `buildPairingReply()` in `pairing-messages.ts` to use `${code}` instead of `<code>`
- Applied same fix to inline Telegram pairing message in `bot-message-context.ts`

**Issue found:**
- Test file expects the old placeholder behavior and will fail with these changes

<h3>Confidence Score: 3/5</h3>

- This PR improves UX but has a failing test that must be fixed
- The code changes are correct and improve the user experience. However, the test at `pairing-messages.test.ts:56` still expects the old `<code>` placeholder format and will fail. This is a critical issue that will break the test suite.
- The test file `src/pairing/pairing-messages.test.ts` needs to be updated to match the new behavior

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->