### PR TITLE
fix(telegram): log loaded update offset on startup for debugging

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -121,6 +121,11 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,
     });
+    if (lastUpdateId !== null) {
+      (opts.runtime?.log ?? console.log)(
+        `[${account.accountId}] resuming from update offset ${lastUpdateId}`,
+      );
+    }
     const persistUpdateId = async (updateId: number) => {
       if (lastUpdateId !== null && updateId <= lastUpdateId) {
         return;


### PR DESCRIPTION
## Problem

When the Telegram polling provider starts, it loads the last update offset from disk and silently resumes from that point. If the offset is stale (e.g., from a revoked/recreated bot token), all new updates with lower IDs are silently skipped — the bot appears to consume messages but never processes them.

This is the root cause of several reports where "bot polls successfully but messages aren't processed" (#13701).

## Fix

Log the loaded offset at startup:

```
[default] resuming from update offset 123456789
```

This makes stale offsets immediately visible in logs. When users see a very high offset number after a token rotation, they know to delete the offset file.

## Changes
- `src/telegram/monitor.ts`: Add info log when `lastUpdateId` is loaded from disk

## AI Disclosure
AI-assisted (Claude). Single log line addition.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a startup info log in `src/telegram/monitor.ts` to print the persisted Telegram `lastUpdateId` (update offset) when it’s loaded from disk. This helps diagnose cases where an old offset causes new updates with lower IDs to be skipped after token rotation, making the bot appear healthy while not processing messages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single, guarded log line addition that does not affect control flow; verified it only executes when an offset is present and doesn’t change update persistence or polling behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->