### PR TITLE
chore(tests): remove dead _makeFile helpers and unused workspace imports

### DIFF
--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { classifyFailoverReason } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
 
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("classifyFailoverReason", () => {
   it("returns a stable reason", () => {
     expect(classifyFailoverReason("invalid api key")).toBe("auth");

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isBillingErrorMessage } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
 
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("isBillingErrorMessage", () => {
   it("matches credit / payment failures", () => {
     const samples = [

--- a/src/agents/pi-embedded-helpers.iscloudcodeassistformaterror.test.ts
+++ b/src/agents/pi-embedded-helpers.iscloudcodeassistformaterror.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isCloudCodeAssistFormatError } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
 
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("isCloudCodeAssistFormatError", () => {
   it("matches format errors", () => {
     const samples = [

--- a/src/agents/pi-embedded-helpers.normalizetextforcomparison.test.ts
+++ b/src/agents/pi-embedded-helpers.normalizetextforcomparison.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
 
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("normalizeTextForComparison", () => {
   it("lowercases text", () => {
     expect(normalizeTextForComparison("Hello World")).toBe("hello world");

--- a/src/agents/pi-embedded-helpers.sanitizegoogleturnordering.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizegoogleturnordering.test.ts
@@ -1,15 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
-
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("sanitizeGoogleTurnOrdering", () => {
   it("prepends a synthetic user turn when history starts with assistant", () => {
     const input = [

--- a/src/agents/pi-embedded-helpers.stripthoughtsignatures.test.ts
+++ b/src/agents/pi-embedded-helpers.stripthoughtsignatures.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { stripThoughtSignatures } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
 
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("stripThoughtSignatures", () => {
   it("returns non-array content unchanged", () => {
     expect(stripThoughtSignatures("hello")).toBe("hello");


### PR DESCRIPTION
## Summary

Six test files contained identical dead code: an unused `_makeFile` helper function referencing `WorkspaceBootstrapFile` type and `DEFAULT_AGENTS_FILENAME` import. These were never called in any test — likely leftovers from a code generation template.

## Files cleaned
- `pi-embedded-helpers.isbillingerrormessage.test.ts`
- `pi-embedded-helpers.iscloudcodeassistformaterror.test.ts`  
- `pi-embedded-helpers.classifyfailoverreason.test.ts`
- `pi-embedded-helpers.sanitizegoogleturnordering.test.ts`
- `pi-embedded-helpers.stripthoughtsignatures.test.ts`
- `pi-embedded-helpers.normalizetextforcomparison.test.ts`

## AI Disclosure
AI-assisted (Claude).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change removes an unused `_makeFile` helper and the corresponding `DEFAULT_AGENTS_FILENAME` import from six `pi-embedded-helpers.*.test.ts` files under `src/agents/`. The deleted helper was not referenced in any of the tests, so the update is purely dead-code cleanup and does not alter test behavior or production code paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- All changes are deletion-only removals of unused test-local helpers/imports; diffs show no functional logic modifications. No new references were introduced, and the remaining test code continues to compile assuming existing imports/types were already unused. Unable to run tests locally because `npm` is not available in this environment, but the change is low-risk and should be covered by CI.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->