### PR TITLE
chore(tests): remove dead _makeFile helper and unused imports from 6 test files

### DIFF
--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -1,14 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { classifyFailoverReason } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
-
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("classifyFailoverReason", () => {
   it("returns a stable reason", () => {
     expect(classifyFailoverReason("invalid api key")).toBe("auth");

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1,14 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { isBillingErrorMessage } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
-
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("isBillingErrorMessage", () => {
   it("matches credit / payment failures", () => {
     const samples = [

--- a/src/agents/pi-embedded-helpers.iscloudcodeassistformaterror.test.ts
+++ b/src/agents/pi-embedded-helpers.iscloudcodeassistformaterror.test.ts
@@ -1,14 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { isCloudCodeAssistFormatError } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
-
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("isCloudCodeAssistFormatError", () => {
   it("matches format errors", () => {
     const samples = [

--- a/src/agents/pi-embedded-helpers.normalizetextforcomparison.test.ts
+++ b/src/agents/pi-embedded-helpers.normalizetextforcomparison.test.ts
@@ -1,14 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
-
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("normalizeTextForComparison", () => {
   it("lowercases text", () => {
     expect(normalizeTextForComparison("Hello World")).toBe("hello world");

--- a/src/agents/pi-embedded-helpers.sanitizegoogleturnordering.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizegoogleturnordering.test.ts
@@ -1,15 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
-
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("sanitizeGoogleTurnOrdering", () => {
   it("prepends a synthetic user turn when history starts with assistant", () => {
     const input = [

--- a/src/agents/pi-embedded-helpers.stripthoughtsignatures.test.ts
+++ b/src/agents/pi-embedded-helpers.stripthoughtsignatures.test.ts
@@ -1,14 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { stripThoughtSignatures } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
-
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("stripThoughtSignatures", () => {
   it("returns non-array content unchanged", () => {
     expect(stripThoughtSignatures("hello")).toBe("hello");


### PR DESCRIPTION
## Summary

Removes identical dead code from 6 test files: an unused `_makeFile` helper function, unused `DEFAULT_AGENTS_FILENAME` import, and implicit `WorkspaceBootstrapFile` type reference. Likely leftover from a code generation template.

## Files cleaned (54 lines removed)
- `pi-embedded-helpers.isbillingerrormessage.test.ts`
- `pi-embedded-helpers.iscloudcodeassistformaterror.test.ts`
- `pi-embedded-helpers.sanitizegoogleturnordering.test.ts`
- `pi-embedded-helpers.classifyfailoverreason.test.ts`
- `pi-embedded-helpers.stripthoughtsignatures.test.ts`
- `pi-embedded-helpers.normalizetextforcomparison.test.ts`

Zero functional changes — only dead code removal.

## AI Disclosure
AI-assisted (Claude).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removes identical dead code from 6 test files in `src/agents/`: an unused `_makeFile` helper function and unused `DEFAULT_AGENTS_FILENAME` import. The helper also referenced `WorkspaceBootstrapFile` type without explicitly importing it, which could cause type errors.

The removed code appears to be leftover from a test template or code generation pattern, as 7 other test files in the same directory still contain the identical unused helper.

- No functional changes
- Tests don't call `_makeFile` anywhere in their bodies
- Clean removal of 54 lines of dead code across 6 files

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk - pure dead code removal
- Removed code is provably unused (never called in test bodies), identical across all 6 files, and contains no logic changes
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->