### PR TITLE
Heartbeat: inject cron-style current time into prompts

### DIFF
--- a/src/agents/current-time.ts
+++ b/src/agents/current-time.ts
@@ -1,0 +1,39 @@
+import {
+  type TimeFormatPreference,
+  formatUserTime,
+  resolveUserTimeFormat,
+  resolveUserTimezone,
+} from "./date-time.js";
+
+export type CronStyleNow = {
+  userTimezone: string;
+  formattedTime: string;
+  timeLine: string;
+};
+
+type TimeConfigLike = {
+  agents?: {
+    defaults?: {
+      userTimezone?: string;
+      timeFormat?: TimeFormatPreference;
+    };
+  };
+};
+
+export function resolveCronStyleNow(cfg: TimeConfigLike, nowMs: number): CronStyleNow {
+  const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+  const userTimeFormat = resolveUserTimeFormat(cfg.agents?.defaults?.timeFormat);
+  const formattedTime =
+    formatUserTime(new Date(nowMs), userTimezone, userTimeFormat) ?? new Date(nowMs).toISOString();
+  const timeLine = `Current time: ${formattedTime} (${userTimezone})`;
+  return { userTimezone, formattedTime, timeLine };
+}
+
+export function appendCronStyleCurrentTimeLine(text: string, cfg: TimeConfigLike, nowMs: number) {
+  const base = text.trimEnd();
+  if (!base || base.includes("Current time:")) {
+    return base;
+  }
+  const { timeLine } = resolveCronStyleNow(cfg, nowMs);
+  return `${base}\n${timeLine}`;
+}

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -12,11 +12,7 @@ import {
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
 import { lookupContextTokens } from "../../agents/context.js";
-import {
-  formatUserTime,
-  resolveUserTimeFormat,
-  resolveUserTimezone,
-} from "../../agents/date-time.js";
+import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -288,11 +284,7 @@ export async function runCronIsolatedAgentTurn(params: {
     to: deliveryPlan.to,
   });
 
-  const userTimezone = resolveUserTimezone(params.cfg.agents?.defaults?.userTimezone);
-  const userTimeFormat = resolveUserTimeFormat(params.cfg.agents?.defaults?.timeFormat);
-  const formattedTime =
-    formatUserTime(new Date(now), userTimezone, userTimeFormat) ?? new Date(now).toISOString();
-  const timeLine = `Current time: ${formattedTime} (${userTimezone})`;
+  const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);
   const base = `[cron:${params.job.id} ${params.job.name}] ${params.message}`.trim();
 
   // SECURITY: Wrap external hook content with security boundaries to prevent prompt injection

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -493,13 +493,11 @@ describe("runHeartbeatOnce", () => {
           2,
         ),
       );
-
       replySpy.mockResolvedValue([{ text: "Final alert" }]);
       const sendWhatsApp = vi.fn().mockResolvedValue({
         messageId: "m1",
         toJid: "jid",
       });
-
       await runHeartbeatOnce({
         cfg,
         agentId: "ops",
@@ -511,7 +509,6 @@ describe("runHeartbeatOnce", () => {
           hasActiveWebListener: () => true,
         },
       });
-
       expect(sendWhatsApp).toHaveBeenCalledTimes(1);
       expect(sendWhatsApp).toHaveBeenCalledWith("+1555", "Final alert", expect.any(Object));
       expect(replySpy).toHaveBeenCalledWith(

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -515,7 +515,10 @@ describe("runHeartbeatOnce", () => {
       expect(sendWhatsApp).toHaveBeenCalledTimes(1);
       expect(sendWhatsApp).toHaveBeenCalledWith("+1555", "Final alert", expect.any(Object));
       expect(replySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ Body: "Ops check", SessionKey: sessionKey }),
+        expect.objectContaining({
+          Body: expect.stringMatching(/Ops check[\s\S]*Current time: /),
+          SessionKey: sessionKey,
+        }),
         { isHeartbeat: true },
         cfg,
       );

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -583,18 +583,13 @@ export async function runHeartbeatOnce(opts: {
   const pendingEvents = isExecEvent || isCronEvent ? peekSystemEvents(sessionKey) : [];
   const hasExecCompletion = pendingEvents.some((evt) => evt.includes("Exec finished"));
   const hasCronEvents = isCronEvent && pendingEvents.length > 0;
-
   const prompt = hasExecCompletion
     ? EXEC_EVENT_PROMPT
     : hasCronEvents
       ? CRON_EVENT_PROMPT
       : resolveHeartbeatPrompt(cfg, heartbeat);
-
-  // Keep heartbeats consistent with cron: include an explicit "Current time: ..."
-  // line so the model has stable "now" awareness even outside channel envelopes.
-  const promptWithTime = appendCronStyleCurrentTimeLine(prompt, cfg, startedAt);
   const ctx = {
-    Body: promptWithTime,
+    Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,
     To: sender,
     Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -10,6 +10,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
+import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
 import { resolveUserTimezone } from "../agents/date-time.js";
 import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
@@ -588,8 +589,12 @@ export async function runHeartbeatOnce(opts: {
     : hasCronEvents
       ? CRON_EVENT_PROMPT
       : resolveHeartbeatPrompt(cfg, heartbeat);
+
+  // Keep heartbeats consistent with cron: include an explicit "Current time: ..."
+  // line so the model has stable "now" awareness even outside channel envelopes.
+  const promptWithTime = appendCronStyleCurrentTimeLine(prompt, cfg, startedAt);
   const ctx = {
-    Body: prompt,
+    Body: promptWithTime,
     From: sender,
     To: sender,
     Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",

--- a/src/web/auto-reply/heartbeat-runner.timestamp.test.ts
+++ b/src/web/auto-reply/heartbeat-runner.timestamp.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { runWebHeartbeatOnce } from "./heartbeat-runner.js";
+
+type LoadedConfig = ReturnType<typeof import("../../config/config.js").loadConfig>;
+
+describe("runWebHeartbeatOnce (timestamp)", () => {
+  it("injects a cron-style Current time line into the heartbeat prompt", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-web-hb-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+    try {
+      await fs.writeFile(storePath, JSON.stringify({}, null, 2));
+
+      const replyResolver = vi.fn().mockResolvedValue([{ text: "HEARTBEAT_OK" }]);
+      const cfg = {
+        agents: {
+          defaults: {
+            heartbeat: { prompt: "Ops check", every: "5m" },
+            userTimezone: "America/Chicago",
+            timeFormat: "24",
+          },
+        },
+        session: { store: storePath },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as unknown as LoadedConfig;
+
+      await runWebHeartbeatOnce({
+        cfg,
+        to: "+1555",
+        dryRun: true,
+        replyResolver,
+        sender: vi.fn(),
+      });
+
+      expect(replyResolver).toHaveBeenCalledTimes(1);
+      const ctx = replyResolver.mock.calls[0]?.[0];
+      expect(ctx?.Body).toMatch(/Ops check/);
+      expect(ctx?.Body).toMatch(/Current time: /);
+      expect(ctx?.Body).toMatch(/\(.+\)/);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/web/auto-reply/heartbeat-runner.timestamp.test.ts
+++ b/src/web/auto-reply/heartbeat-runner.timestamp.test.ts
@@ -2,9 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { runWebHeartbeatOnce } from "./heartbeat-runner.js";
-
-type LoadedConfig = ReturnType<typeof import("../../config/config.js").loadConfig>;
 
 describe("runWebHeartbeatOnce (timestamp)", () => {
   it("injects a cron-style Current time line into the heartbeat prompt", async () => {
@@ -24,7 +23,7 @@ describe("runWebHeartbeatOnce (timestamp)", () => {
         },
         session: { store: storePath },
         channels: { whatsapp: { allowFrom: ["*"] } },
-      } as unknown as LoadedConfig;
+      } as unknown as OpenClawConfig;
 
       await runWebHeartbeatOnce({
         cfg,

--- a/src/web/auto-reply/heartbeat-runner.ts
+++ b/src/web/auto-reply/heartbeat-runner.ts
@@ -1,4 +1,5 @@
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   resolveHeartbeatPrompt,
@@ -159,7 +160,11 @@ export async function runWebHeartbeatOnce(opts: {
 
     const replyResult = await replyResolver(
       {
-        Body: resolveHeartbeatPrompt(cfg.agents?.defaults?.heartbeat?.prompt),
+        Body: appendCronStyleCurrentTimeLine(
+          resolveHeartbeatPrompt(cfg.agents?.defaults?.heartbeat?.prompt),
+          cfg,
+          Date.now(),
+        ),
         From: to,
         To: to,
         MessageSid: sessionId ?? sessionSnapshot.entry?.sessionId,


### PR DESCRIPTION
#### Summary
Inject cron-style `Current time: ... (TZ)` into heartbeat prompts so the model has explicit “now” awareness on synthetic/heartbeat runs (matching cron behavior).

lobster-biscuit

#### Behavior Changes
- Heartbeat runs now include a `Current time: ... (TZ)` line in the prompt (same style as cron jobs).
- Applies to both the generic heartbeat runner and the WhatsApp Web heartbeat runner.

#### Codebase and GitHub Search
- Searched for heartbeat entrypoints by finding `getReplyFromConfig(..., { isHeartbeat: true }, ...)` callsites.
- Confirmed only the infra heartbeat runner and web heartbeat runner invoke heartbeat-mode model runs.

#### Tests
- `pnpm build`
- `pnpm check`
- `pnpm test`

#### Manual Testing (omit if N/A)
N/A

**Sign-Off**
- Models used: GPT-5 (Codex)
- Submitter effort (self-reported): medium
- Agent notes (optional, cite evidence): Full local gate run; added unit coverage for the web heartbeat runner prompt injection.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a shared `src/agents/current-time.ts` helper to format cron-style time strings (`Current time: … (TZ)`) and uses it to:

- centralize cron timestamp injection in `src/cron/isolated-agent/run.ts`
- append the same line to heartbeat prompts in both the infra heartbeat runner and the WhatsApp web heartbeat runner, so synthetic/heartbeat runs have explicit “now” context similar to cron jobs

It also updates/extends tests to assert the heartbeat prompt includes a `Current time:` line.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has at least one type-level issue in a new test file that will likely break CI.
- Core runtime changes are small and follow existing patterns (reusing cron-style timestamp formatting and appending it to heartbeat prompts). However, the newly added web heartbeat timestamp test introduces an invalid TypeScript type alias using `typeof import(...)` that likely fails `pnpm check`/typechecking, and should be corrected before merge.
- src/web/auto-reply/heartbeat-runner.timestamp.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->