### PR TITLE
docs(pairing): add allowlist migration guide and numeric ID recommendation

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -38,6 +38,23 @@ openclaw pairing approve telegram <CODE>
 
 Supported channels: `telegram`, `whatsapp`, `signal`, `imessage`, `discord`, `slack`.
 
+### Switching to allowlist after pairing
+
+Once you've approved a sender via pairing, you can switch to `dmPolicy: "allowlist"` for a faster startup experience (no pairing step for known users). Copy the numeric user ID from `openclaw pairing list <channel>` into `allowFrom`:
+
+```json5
+{
+  channels: {
+    telegram: {
+      dmPolicy: "allowlist",
+      allowFrom: ["1580140515"], // numeric ID — more reliable than usernames
+    },
+  },
+}
+```
+
+> **Tip:** Always prefer numeric user IDs over usernames in `allowFrom`. Usernames can be changed by the user at any time, which would silently break access. Numeric IDs are permanent.
+
 ### Where the state lives
 
 Stored under `~/.openclaw/credentials/`:


### PR DESCRIPTION
## Summary

Adds a missing section to the pairing docs covering the common workflow of switching from `pairing` to `allowlist` mode after initial setup.

## Changes

- New "Switching to allowlist after pairing" section with copy-pasteable config example
- Tip recommending numeric user IDs over usernames (usernames can change, silently breaking access)

## Context

This is a common question from new users who complete pairing successfully but then want to skip the pairing step on subsequent restarts. The existing docs didn't cover this transition.

## AI Disclosure
AI-assisted (Claude). Docs-only change.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new "Switching to allowlist after pairing" section to the pairing documentation that addresses a common workflow: transitioning from `pairing` mode to `allowlist` mode after initial setup. This provides users with a clear, copy-pasteable configuration example showing how to extract numeric user IDs from `openclaw pairing list <channel>` and use them in the `allowFrom` configuration.

The documentation also includes a helpful tip recommending numeric user IDs over usernames, since usernames can be changed by users and would silently break access, while numeric IDs are permanent platform identifiers.

This change fills a documentation gap for new users who successfully complete pairing but want to skip the pairing step on subsequent gateway restarts.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a documentation-only addition.
- This is a purely additive documentation change with no code modifications. The new section is technically accurate (verified against the codebase that `openclaw pairing list` displays numeric IDs, and Telegram uses `from.id` as the user identifier), follows existing documentation patterns found in telegram.md, and addresses a real user need mentioned in the PR description.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->