### PR TITLE
Fred li/interview csv processor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,16 @@
 services:
   openclaw-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: ${OPENCLAW_IMAGE:-openclaw:local}
     environment:
       HOME: /home/node
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
@@ -21,6 +27,7 @@ services:
         "node",
         "dist/index.js",
         "gateway",
+        "--allow-unconfigured",
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",
@@ -28,11 +35,17 @@ services:
       ]
 
   openclaw-cli:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: ${OPENCLAW_IMAGE:-openclaw:local}
     environment:
       HOME: /home/node
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
       BROWSER: echo
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}

--- a/examples/interview/README.md
+++ b/examples/interview/README.md
@@ -1,0 +1,66 @@
+# Interview Coding Challenge: CSV Processor
+
+## Challenge Description
+
+This is a coding challenge submission that processes advertising rotation data from CSV files and calculates Cost Per View (CPV) metrics.
+
+## Problem Statement
+
+Given two CSV files:
+- `rotations.csv` - Contains rotation schedules with start/end times
+- `spots.csv` - Contains ad spot data with creative IDs, spend, views, dates, and times
+
+Calculate:
+1. **Creative CPV**: Cost per view for each creative
+2. **Rotation CPV**: Cost per view for each rotation on each date
+
+## Input Format
+
+### rotations.csv
+```
+Name,Start,End
+Morning,6:00 AM,12:00 PM
+Afternoon,12:00 PM,6:00 PM
+Evening,6:00 PM,12:00 AM
+```
+
+### spots.csv
+```
+Creative,Spend,Views,Date,Time
+Creative_A,100,50,2024-01-01,10:00 AM
+Creative_B,200,100,2024-01-01,2:00 PM
+```
+
+## Output Format
+
+The program outputs two arrays:
+1. Creative CPV array with `{creative, CPV}` objects
+2. Rotation CPV array with `{date, rotation, CPV}` objects
+
+## Usage
+
+```bash
+node csv-processor.js
+```
+
+## Notes
+
+This submission was provided as-is from a coding interview. The code works but may have areas for improvement in terms of:
+- Error handling
+- Code style and conventions
+- Performance optimization
+- Modern JavaScript features
+- TypeScript conversion
+
+## Sample Output
+
+```
+creative CPV [
+  { creative: 'Creative_A', CPV: 2 },
+  { creative: 'Creative_B', CPV: 2 }
+]
+rotatin CPV [
+  { date: '2024-01-01', rotation: 'Morning', CPV: 2 },
+  { date: '2024-01-01', rotation: 'Afternoon', CPV: 2 }
+]
+```

--- a/examples/interview/csv-processor.js
+++ b/examples/interview/csv-processor.js
@@ -1,0 +1,132 @@
+//import file system from node.js
+var fs = require('fs');
+
+processFile('rotations.csv', 'spots.csv');
+
+//main function
+function processFile (rotations, spots) {
+  //reads the rotation file
+  fs.readFile(rotations, 'utf8', (err, result) => {
+    if (err) console.log(err);
+    let rotation = processData(result);
+    //reads the spots file
+    fs.readFile(spots, 'utf8', (error, data) => {
+      if (error) console.log(error);
+      let spot = processData(data);
+      //sets both the creativeCPV and rotationCPV into an array of objects with identification as well as CPV
+      let creativeCPV = CPVCreative(spot);
+      let rotationCPV = CPVRotation(rotation, spot);
+      console.log('creative CPV', creativeCPV);
+      console.log('rotatin CPV', rotationCPV);
+    })
+  });
+};
+
+//helper function in order to transform the data into an object
+function processData (data) {
+  let results = {}, temp, currentKey, currentEntry;
+  //splits each line according to a new line
+  let allTextLines = data.split(/\r\n|\n/);
+  //splits each entry per line according to commas
+  let entries = allTextLines.shift().split(',');
+  results.keys = entries;
+  for (let i = 0; i < allTextLines.length; i ++) {
+    temp = allTextLines[i].split(',');
+    for (let y = 0; y < temp.length; y ++) {
+      //replaces each element by taking away the ""
+      currentEntry = temp[y].replace(/['"]+/g, '');
+      currentKey = results.keys[y].replace(/['"]+/g, '');
+      // if the key exists, it should be an array, so we should push the element onto the array
+      if (results[currentKey]) results[currentKey].push(currentEntry);
+      //if it doesnt exsit, make an array with the element inside it
+      else results[currentKey] = [currentEntry];
+    }
+  }
+  return results;
+};
+
+//helper function in order to make our creative CPV object
+function CPVCreative (spot) {
+  let result = {}, creatives = spot.Creative, creative, results = [], curr;
+  for (let i = 0; i < creatives.length; i ++) {
+    creative = creatives[i];
+    //if the key/value doesn't exist, make the value a new object with spend and views being 0
+    if (!result[creative]) {
+      result[creative] = {
+        spend: 0,
+        views: 0
+      }
+    }
+    //add the current element spend to the total views of the creative it correlates with
+    result[creative].spend += parseInt(spot.Spend[i]);
+    //add the current element views to the total views of the creative it correlates with
+    result[creative].views += parseInt(spot.Views[i]);
+  }
+  //makes a new object with keys: creative and CPV then pushes it on to the results
+  for (let key in result) {
+    curr = result[key]
+    creative = {};
+    creative.creative = key;
+    creative.CPV = curr.spend / curr.views;
+    results.push(creative);
+  }
+  return results;
+}
+
+//helper function to make our rotationCPV object
+function CPVRotation (rotation, spot) {
+  //changes each date to a number in the START and END of the rotation object
+  rotation.Start = rotation.Start.map( element => timeToNumber(element));
+  rotation.End = rotation.End.map( element => timeToNumber(element));
+  let result = {}, date, time, results = [], curr, rotationObject;
+  let {Start, End} = rotation, {Spend, Views} = spot;
+  for (let i = 0; i < spot.Time.length; i ++) {
+    date = spot.Date[i];
+    time = timeToNumber(spot.Time[i]);
+    if (!result[date]) {
+      result[date] = {}
+    }
+    for (let y = 0; y < Start.length; y ++) {
+      if (Start[y] <= time && time <= End[y]) {
+        //if the certain date and rotation does not exist in the result, we make a new with spend and views = 0
+        if (!result[date][rotation.Name[y]]) {
+          result[date][rotation.Name[y]] = {
+            spend: 0,
+            views: 0
+          }
+        }
+        curr = result[date][rotation.Name[y]]
+        //add the current element views to the total views of the date/ rotation it correlates with
+        curr.spend += parseInt(Spend[i]);
+        curr.views += parseInt(Views[i]);
+      }
+    }
+  }
+  for (let dates in result) {
+    for (let rotations in result[dates]) {
+      curr = result[dates][rotations];
+      rotationObject = {};
+      rotationObject.date = dates;
+      rotationObject.rotation = rotations;
+      rotationObject.CPV = curr.spend / curr.views;
+      results.push(rotationObject);
+    }
+  }
+  return results;
+}
+
+//helper function transform times: (3:00 pm) to a number
+function timeToNumber (date) {
+  //creates an array that matches the format: (x:x AM)
+  var parts = date.match(/(\d+):(\d+) (AM|PM)/);
+  if (parts) {
+      var hours = parseInt(parts[1]),
+          minutes = parseInt(parts[2]),
+          AM = parts[3];
+      //if AM is equal to PM, and the hours is not 12, we add 12 to our total hours
+      if (AM === 'PM' && hours < 12) hours += 12;
+      //returns it in a non-integer number format
+      return hours + minutes / 100;
+  }
+  return date;
+}

--- a/scripts/patch-control-ui-auth.js
+++ b/scripts/patch-control-ui-auth.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Patches ~/.openclaw/openclaw.json to add gateway.controlUi.allowInsecureAuth: true
+ * so the dashboard can connect with just the token (no device pairing).
+ * Run from repo root: node scripts/patch-control-ui-auth.js
+ * Then restart the gateway: docker compose restart openclaw-gateway
+ */
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const configDir = process.env.OPENCLAW_CONFIG_DIR || path.join(os.homedir(), ".openclaw");
+const configPath = path.join(configDir, "openclaw.json");
+
+if (!fs.existsSync(configPath)) {
+  console.error("Config not found:", configPath);
+  process.exit(1);
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+} catch (e) {
+  console.error("Failed to read config:", e.message);
+  process.exit(1);
+}
+
+const gateway = parsed.gateway ?? {};
+const controlUi = gateway.controlUi ?? {};
+if (controlUi.allowInsecureAuth === true) {
+  console.log("Config already has gateway.controlUi.allowInsecureAuth: true");
+  process.exit(0);
+}
+
+controlUi.allowInsecureAuth = true;
+gateway.controlUi = controlUi;
+parsed.gateway = gateway;
+
+fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2), "utf8");
+console.log("Patched", configPath, "with gateway.controlUi.allowInsecureAuth: true");
+console.log("Restart the gateway: docker compose restart openclaw-gateway");

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -5,7 +5,7 @@ import { colorize, isRich, theme } from "../../terminal/theme.js";
 import { shortenHomePath } from "../../utils.js";
 import { formatCliCommand } from "../command-format.js";
 
-const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "status"]);
+const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "run", "status"]);
 const ALLOWED_INVALID_GATEWAY_SUBCOMMANDS = new Set([
   "status",
   "probe",

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -16,6 +16,10 @@ const EXAMPLES = [
     'openclaw message send --target +15555550123 --message "Hi" --json',
     "Send via your web session and print JSON result.",
   ],
+  [
+    "openclaw run",
+    "Build, start gateway in Docker, run doctor, and open the dashboard (single command).",
+  ],
   ["openclaw gateway --port 18789", "Run the WebSocket Gateway locally."],
   ["openclaw --dev gateway", "Run a dev Gateway (isolated state/config) on ws://127.0.0.1:19001."],
   ["openclaw gateway --force", "Kill anything bound to the default gateway port, then start it."],

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { dashboardCommand } from "../../commands/dashboard.js";
 import { doctorCommand } from "../../commands/doctor.js";
 import { resetCommand } from "../../commands/reset.js";
+import { runDockerCommand } from "../../commands/run-docker.js";
 import { uninstallCommand } from "../../commands/uninstall.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
@@ -9,6 +10,29 @@ import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 
 export function registerMaintenanceCommands(program: Command) {
+  program
+    .command("run")
+    .description(
+      "Build, start gateway in Docker, run doctor, and open the dashboard (single command)",
+    )
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/install/docker", "docs.openclaw.ai/install/docker")}\n`,
+    )
+    .option("--no-open", "Do not open the dashboard in the browser", false)
+    .option("--no-doctor", "Skip running doctor after starting the gateway", false)
+    .option("--no-build", "Skip building the Docker image (use existing)", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await runDockerCommand(defaultRuntime, {
+          noOpen: Boolean(opts.noOpen),
+          noDoctor: Boolean(opts.noDoctor),
+          noBuild: Boolean(opts.noBuild),
+        });
+      });
+    });
+
   program
     .command("doctor")
     .description("Health checks + quick fixes for the gateway and channels")

--- a/src/commands/run-docker.ts
+++ b/src/commands/run-docker.ts
@@ -1,0 +1,262 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { RuntimeEnv } from "../runtime.js";
+import { DEFAULT_GATEWAY_PORT } from "../config/paths.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { ensureDir } from "../utils.js";
+import { detectBrowserOpenSupport, openUrl } from "./onboard-helpers.js";
+
+const COMPOSE_FILENAME = "docker-compose.yml";
+const EXTRA_COMPOSE_FILENAME = "docker-compose.extra.yml";
+const ENV_FILENAME = ".env";
+
+export type RunDockerOptions = {
+  /** Skip opening the dashboard in the browser. */
+  noOpen?: boolean;
+  /** Skip running doctor after starting the gateway. */
+  noDoctor?: boolean;
+  /** Skip building the image (use existing). */
+  noBuild?: boolean;
+};
+
+function findRepoRoot(startDir: string): string | null {
+  let dir = path.resolve(startDir);
+  const root = path.parse(dir).root;
+  while (dir !== root) {
+    const composePath = path.join(dir, COMPOSE_FILENAME);
+    if (fs.existsSync(composePath)) {
+      const content = fs.readFileSync(composePath, "utf8");
+      if (content.includes("openclaw-gateway")) {
+        return dir;
+      }
+    }
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+function parseEnvFile(filePath: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!fs.existsSync(filePath)) {
+    return out;
+  }
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) {
+      continue;
+    }
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    const unquoted = value.replace(/^["']|["']$/g, "");
+    out[key] = unquoted;
+  }
+  return out;
+}
+
+function writeEnvFile(filePath: string, vars: Record<string, string>) {
+  const lines = Object.entries(vars).map(([k, v]) => `${k}=${v}`);
+  fs.writeFileSync(filePath, lines.join("\n") + "\n", "utf8");
+}
+
+function upsertEnvFile(filePath: string, vars: Record<string, string>) {
+  const existing = parseEnvFile(filePath);
+  const merged = { ...existing, ...vars };
+  writeEnvFile(filePath, merged);
+}
+
+function ensureMinimalConfig(
+  configDir: string,
+  config: { port: number; bind: string; token: string },
+) {
+  const configPath = path.join(configDir, "openclaw.json");
+  const minimal = {
+    gateway: {
+      mode: "local" as const,
+      port: config.port,
+      bind: config.bind,
+      auth: { mode: "token" as const, token: config.token },
+      controlUi: { allowInsecureAuth: true },
+    },
+  };
+  if (!fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, JSON.stringify(minimal, null, 2), "utf8");
+    return;
+  }
+  // Patch existing config so Control UI can connect with token only (no device pairing).
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const gateway = (parsed.gateway ?? {}) as Record<string, unknown>;
+    const controlUi = (gateway.controlUi ?? {}) as Record<string, unknown>;
+    if (controlUi.allowInsecureAuth !== true) {
+      controlUi.allowInsecureAuth = true;
+      gateway.controlUi = controlUi;
+      parsed.gateway = gateway;
+      fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2), "utf8");
+    }
+  } catch {
+    // If parse/merge fails, leave config as-is.
+  }
+}
+
+export async function runDockerCommand(
+  runtime: RuntimeEnv,
+  options: RunDockerOptions = {},
+): Promise<void> {
+  const repoRoot =
+    process.env.OPENCLAW_REPO_ROOT?.trim() ||
+    findRepoRoot(process.cwd()) ||
+    findRepoRoot(path.resolve(__dirname, "../.."));
+  if (!repoRoot) {
+    runtime.error(
+      "OpenClaw repo root not found. Run from the openclaw repo directory (where docker-compose.yml is) or set OPENCLAW_REPO_ROOT.",
+    );
+    runtime.exit(1);
+  }
+
+  const envPath = path.join(repoRoot, ENV_FILENAME);
+  const existingEnv = parseEnvFile(envPath);
+
+  const configDir = existingEnv.OPENCLAW_CONFIG_DIR?.trim() || path.join(os.homedir(), ".openclaw");
+  const workspaceDir =
+    existingEnv.OPENCLAW_WORKSPACE_DIR?.trim() || path.join(configDir, "workspace");
+  const port = Number(existingEnv.OPENCLAW_GATEWAY_PORT?.trim()) || DEFAULT_GATEWAY_PORT;
+  const bind = existingEnv.OPENCLAW_GATEWAY_BIND?.trim() || "lan";
+  let token = existingEnv.OPENCLAW_GATEWAY_TOKEN?.trim();
+  if (!token) {
+    token = crypto.randomBytes(32).toString("hex");
+  }
+
+  const envVars: Record<string, string> = {
+    OPENCLAW_CONFIG_DIR: configDir,
+    OPENCLAW_WORKSPACE_DIR: workspaceDir,
+    OPENCLAW_GATEWAY_PORT: String(port),
+    OPENCLAW_GATEWAY_BIND: bind,
+    OPENCLAW_GATEWAY_TOKEN: token,
+    OPENCLAW_IMAGE: existingEnv.OPENCLAW_IMAGE?.trim() || "openclaw:local",
+  };
+  upsertEnvFile(envPath, envVars);
+
+  await ensureDir(configDir);
+  await ensureDir(workspaceDir);
+  ensureMinimalConfig(configDir, { port: 18789, bind, token });
+
+  const composeFiles = [path.join(repoRoot, COMPOSE_FILENAME)];
+  if (fs.existsSync(path.join(repoRoot, EXTRA_COMPOSE_FILENAME))) {
+    composeFiles.push(path.join(repoRoot, EXTRA_COMPOSE_FILENAME));
+  }
+  const composeArgs = composeFiles.flatMap((f) => ["-f", f]);
+
+  const runDocker = (args: string[], timeoutMs: number) =>
+    runCommandWithTimeout(["docker", "compose", ...composeArgs, ...args], {
+      cwd: repoRoot,
+      env: { ...process.env, ...envVars },
+      timeoutMs,
+    });
+
+  const imageName = envVars.OPENCLAW_IMAGE ?? "openclaw:local";
+
+  runtime.log("==> Building Docker image (this may take a few minutes on first run)");
+  if (!options.noBuild) {
+    try {
+      await runDocker(["build"], 600_000);
+    } catch (err) {
+      runtime.error(
+        "Docker build failed. Ensure Docker is running and you have docker compose v2.",
+      );
+      throw err;
+    }
+  } else {
+    try {
+      await runCommandWithTimeout(["docker", "image", "inspect", imageName], {
+        cwd: repoRoot,
+        env: { ...process.env, ...envVars },
+        timeoutMs: 5000,
+      });
+    } catch {
+      runtime.error(
+        `Image ${imageName} not found. Build it first: from the openclaw repo run "docker compose build", or run "openclaw run" without --no-build.`,
+      );
+      runtime.exit(1);
+    }
+  }
+
+  runtime.log("==> Starting gateway");
+  try {
+    await runDocker(["up", "-d", "openclaw-gateway"], 60_000);
+  } catch (err) {
+    runtime.error(
+      "Failed to start gateway. If you see 'pull access denied', the image was not built locally. From the openclaw repo run: docker compose build && docker compose up -d openclaw-gateway",
+    );
+    throw err;
+  }
+
+  runtime.log("==> Waiting for gateway to be ready");
+  const healthEnv = { ...envVars, OPENCLAW_GATEWAY_TOKEN: token };
+  const runDockerWithToken = (args: string[], timeoutMs: number) =>
+    runCommandWithTimeout(["docker", "compose", ...composeArgs, ...args], {
+      cwd: repoRoot,
+      env: { ...process.env, ...healthEnv },
+      timeoutMs,
+    });
+  const maxAttempts = 12;
+  const delayMs = 2500;
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise((r) => setTimeout(r, delayMs));
+    try {
+      await runDockerWithToken(
+        ["run", "--rm", "openclaw-cli", "health", "--timeout", "5000"],
+        15_000,
+      );
+      break;
+    } catch {
+      if (i === maxAttempts - 1) {
+        runtime.error(
+          "Gateway did not become healthy in time. Check: docker compose logs openclaw-gateway",
+        );
+        runtime.exit(1);
+      }
+    }
+  }
+
+  if (!options.noDoctor) {
+    runtime.log("==> Running doctor (health check + fixes)");
+    try {
+      await runDocker(
+        ["run", "--rm", "openclaw-cli", "doctor", "--fix", "--non-interactive"],
+        120_000,
+      );
+    } catch {
+      runtime.log("Doctor reported issues (non-fatal). Check output above.");
+    }
+  }
+
+  const dashboardUrl = `http://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`;
+  runtime.log("");
+  runtime.log("Dashboard: " + dashboardUrl);
+  runtime.log("Config: " + configDir);
+  runtime.log("");
+  runtime.log(
+    "To get chat working: add an API key to the gateway (e.g. Anthropic or OpenAI). From the openclaw repo, add ANTHROPIC_API_KEY=sk-... or OPENAI_API_KEY=sk-... to .env, then run: docker compose up -d openclaw-gateway",
+  );
+  runtime.log("");
+
+  if (!options.noOpen) {
+    const browserSupport = await detectBrowserOpenSupport();
+    if (browserSupport.ok) {
+      const opened = await openUrl(dashboardUrl);
+      if (opened) {
+        runtime.log("Opened dashboard in your browser.");
+      }
+    } else {
+      runtime.log("Open the URL above in your browser to use the Control UI.");
+    }
+  }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `openclaw run` maintenance command that builds and starts the gateway via Docker Compose, waits for it to become healthy, optionally runs `doctor`, and opens the Control UI dashboard. It also updates `docker-compose.yml` to build images locally and to pass through common LLM API key env vars, plus adds a helper script to patch `gateway.controlUi.allowInsecureAuth` in the local config.

The core logic lives in `src/commands/run-docker.ts`, and the CLI wiring is done via `src/cli/program/register.maintenance.ts` with help text updates in `src/cli/program/help.ts` and config-guard allowances in `src/cli/program/config-guard.ts`.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to incorrect port handling and risky `.env` rewriting behavior in the new `openclaw run` flow.
- `run-docker` hard-codes the gateway port in generated config and docker-compose, so `OPENCLAW_GATEWAY_PORT` won’t behave as expected, and it unconditionally rewrites `.env` in a way that can break existing user configurations by removing comments/quoting/formatting. These are user-facing correctness and reliability issues in a command intended to simplify setup.
- src/commands/run-docker.ts, docker-compose.yml

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->