### PR TITLE
feat(whatsapp): add --qr-png option to save QR code as PNG file

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -364,13 +364,15 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       }),
   },
   auth: {
-    login: async ({ cfg, accountId, runtime, verbose }) => {
+    login: async ({ cfg, accountId, runtime, verbose, qrPngPath }) => {
       const resolvedAccountId = accountId?.trim() || resolveDefaultWhatsAppAccountId(cfg);
+
       await getWhatsAppRuntime().channel.whatsapp.loginWeb(
         Boolean(verbose),
         undefined,
         runtime,
         resolvedAccountId,
+        qrPngPath ? { qrPngPath } : undefined,
       );
     },
   },

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -214,6 +214,8 @@ export type ChannelAuthAdapter = {
     runtime: RuntimeEnv;
     verbose?: boolean;
     channelInput?: string | null;
+    /** If set, save WhatsApp QR as PNG file instead of ASCII (path or directory) */
+    qrPngPath?: string;
   }) => Promise<void>;
 };
 

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -9,6 +9,7 @@ type ChannelAuthOptions = {
   channel?: string;
   account?: string;
   verbose?: boolean;
+  qrPngPath?: string;
 };
 
 export async function runChannelLogin(
@@ -34,6 +35,7 @@ export async function runChannelLogin(
     runtime,
     verbose: Boolean(opts.verbose),
     channelInput,
+    qrPngPath: opts.qrPngPath,
   });
 }
 

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -215,6 +215,7 @@ export function registerChannelsCli(program: Command) {
     .option("--channel <channel>", "Channel alias (default: whatsapp)")
     .option("--account <id>", "Account id (accountId)")
     .option("--verbose", "Verbose connection logs", false)
+    .option("--qr-png [path]", "Save QR code as PNG file (default: ./whatsapp-qr.png)", false)
     .action(async (opts) => {
       await runChannelsCommandWithDanger(async () => {
         await runChannelLogin(
@@ -222,6 +223,12 @@ export function registerChannelsCli(program: Command) {
             channel: opts.channel as string | undefined,
             account: opts.account as string | undefined,
             verbose: Boolean(opts.verbose),
+            qrPngPath:
+              opts.qrPng === true
+                ? "whatsapp-qr.png"
+                : typeof opts.qrPng === "string"
+                  ? opts.qrPng
+                  : undefined,
           },
           defaultRuntime,
         );

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -12,12 +12,14 @@ export async function loginWeb(
   waitForConnection?: typeof waitForWaConnection,
   runtime: RuntimeEnv = defaultRuntime,
   accountId?: string,
+  opts?: { qrPngPath?: string },
 ) {
   const wait = waitForConnection ?? waitForWaConnection;
   const cfg = loadConfig();
   const account = resolveWhatsAppAccount({ cfg, accountId });
   const sock = await createWaSocket(true, verbose, {
     authDir: account.authDir,
+    qrPngPath: opts?.qrPngPath,
   });
   logInfo("Waiting for WhatsApp connection...", runtime);
   try {

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -7,6 +7,7 @@ import {
 } from "@whiskeysockets/baileys";
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
+import { resolve } from "node:path";
 import qrcode from "qrcode-terminal";
 import { formatCliCommand } from "../cli/command-format.js";
 import { danger, success } from "../globals.js";
@@ -19,6 +20,7 @@ import {
   resolveWebCredsBackupPath,
   resolveWebCredsPath,
 } from "./auth-store.js";
+import { renderQrPngBase64 } from "./qr-image.js";
 
 export {
   getWebAuthAgeMs,
@@ -94,7 +96,12 @@ async function safeSaveCreds(
 export async function createWaSocket(
   printQr: boolean,
   verbose: boolean,
-  opts: { authDir?: string; onQr?: (qr: string) => void } = {},
+  opts: {
+    authDir?: string;
+    onQr?: (qr: string) => void;
+    /** If set, save QR code as PNG file (path or dir). Default filename: whatsapp-qr.png */
+    qrPngPath?: string;
+  } = {},
 ): Promise<ReturnType<typeof makeWASocket>> {
   const baseLogger = getChildLogger(
     { module: "baileys" },
@@ -125,12 +132,24 @@ export async function createWaSocket(
   sock.ev.on("creds.update", () => enqueueSaveCreds(authDir, saveCreds, sessionLogger));
   sock.ev.on(
     "connection.update",
-    (update: Partial<import("@whiskeysockets/baileys").ConnectionState>) => {
+    async (update: Partial<import("@whiskeysockets/baileys").ConnectionState>) => {
       try {
         const { connection, lastDisconnect, qr } = update;
         if (qr) {
           opts.onQr?.(qr);
-          if (printQr) {
+          if (opts.qrPngPath) {
+            const pngPath = opts.qrPngPath.endsWith(".png")
+              ? opts.qrPngPath
+              : resolve(opts.qrPngPath, "whatsapp-qr.png");
+            const dir = resolve(pngPath, "..");
+            if (!fsSync.existsSync(dir)) {
+              fsSync.mkdirSync(dir, { recursive: true });
+            }
+            const base64 = await renderQrPngBase64(qr, { scale: 8, marginModules: 4 });
+            fsSync.writeFileSync(pngPath, Buffer.from(base64, "base64"));
+            console.log(`QR code saved to: ${pngPath}`);
+            console.log("Scan this QR in WhatsApp → Linked Devices");
+          } else if (printQr) {
             console.log("Scan this QR in WhatsApp (Linked Devices):");
             qrcode.generate(qr, { small: true });
           }


### PR DESCRIPTION
Adds support for saving the WhatsApp login QR code as a PNG file instead of displaying ASCII art in the terminal.

### Usage

⁠ bash
# Save QR to specific file
openclaw channels login --qr-png ./whatsapp-qr.png

# Save QR to directory (uses default filename)
openclaw channels login --qr-png /tmp/
# → Saves to /tmp/whatsapp-qr.png
 ⁠

### Use Cases

•⁠  ⁠*Headless servers* — view QR remotely via file share/SCP
•⁠  ⁠*Remote access* — scan from another device when terminal isn't visible  
•⁠  ⁠*Docker/containers* — no TTY available for ASCII output
•⁠  ⁠*Automation* — deliver QR image via notifications

### Changes

*⁠ src/web/session.ts ⁠:*
•⁠  ⁠Extended ⁠ createWaSocket ⁠ opts with ⁠ qrPngPath?: string ⁠
•⁠  ⁠Added path resolution logic (appends ⁠ whatsapp-qr.png ⁠ if directory given)
•⁠  ⁠Creates parent directories if needed
•⁠  ⁠Renders QR via ⁠ renderQrPngBase64() ⁠ with scale 8, margin 4
•⁠  ⁠Writes PNG file and logs path
•⁠  ⁠Skips terminal ASCII output when ⁠ --qr-png ⁠ is set

### Output


QR code saved to: ./whatsapp-qr.png
Scan this QR in WhatsApp → Linked Devices


---

Want me to check if there are any missing pieces (like CLI option registration or tests)?

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `--qr-png [path]` option to `openclaw channels login` and threads the resulting `qrPngPath` through the channel auth adapter into the WhatsApp web login flow.

On the WhatsApp side, `createWaSocket` now supports `opts.qrPngPath` and, when present, renders the QR to a PNG (via `renderQrPngBase64`) and writes it to disk (creating parent directories). When `qrPngPath` is set, the terminal ASCII QR output is skipped.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but has a couple user-facing failure modes in the new QR-to-PNG path handling.
- Core wiring of the new flag through CLI → auth adapter → WhatsApp login looks consistent, and PNG generation uses existing QR rendering code. Main concerns are that write failures are swallowed while ASCII output is disabled (can leave users with no QR at all), and the file-vs-directory heuristic can mis-handle directories named '*.png'.
- src/web/session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->