### PR TITLE
fix(configure): guard against undefined token/password in gateway auth config

### DIFF
--- a/src/commands/configure.gateway-auth.test.ts
+++ b/src/commands/configure.gateway-auth.test.ts
@@ -43,4 +43,31 @@ describe("buildGatewayAuthConfig", () => {
 
     expect(result).toEqual({ mode: "password", password: "secret" });
   });
+
+  it("throws when token is undefined", () => {
+    expect(() =>
+      buildGatewayAuthConfig({
+        mode: "token",
+        token: undefined,
+      }),
+    ).toThrow("Gateway token is required");
+  });
+
+  it("throws when token is empty string", () => {
+    expect(() =>
+      buildGatewayAuthConfig({
+        mode: "token",
+        token: "",
+      }),
+    ).toThrow("Gateway token is required");
+  });
+
+  it("throws when password is undefined", () => {
+    expect(() =>
+      buildGatewayAuthConfig({
+        mode: "password",
+        password: undefined,
+      }),
+    ).toThrow("Gateway password is required");
+  });
 });

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -35,7 +35,13 @@ export function buildGatewayAuthConfig(params: {
   }
 
   if (params.mode === "token") {
+    if (!params.token) {
+      throw new Error("Gateway token is required for token auth mode");
+    }
     return { ...base, mode: "token", token: params.token };
+  }
+  if (!params.password) {
+    throw new Error("Gateway password is required for password auth mode");
   }
   return { ...base, mode: "password", password: params.password };
 }

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -121,4 +121,10 @@ describe("normalizeGatewayTokenInput", () => {
   it("returns empty string for non-string input", () => {
     expect(normalizeGatewayTokenInput(123)).toBe("");
   });
+
+  it("rejects literal 'undefined' and 'null' strings", () => {
+    expect(normalizeGatewayTokenInput("undefined")).toBe("");
+    expect(normalizeGatewayTokenInput("null")).toBe("");
+    expect(normalizeGatewayTokenInput("  undefined  ")).toBe("");
+  });
 });

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -73,7 +73,8 @@ export function normalizeGatewayTokenInput(value: unknown): string {
   if (typeof value !== "string") {
     return "";
   }
-  return value.trim();
+  const trimmed = value.trim();
+  return trimmed === "undefined" || trimmed === "null" ? "" : trimmed;
 }
 
 export function printWizardHeader(runtime: RuntimeEnv) {


### PR DESCRIPTION
Fixes #13756

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens gateway auth configuration by rejecting missing/empty gateway credentials in `buildGatewayAuthConfig`, and tightens onboarding token normalization to treat literal `"undefined"`/`"null"` inputs as empty. It also adds unit tests for these new behaviors.

The main integration point is `src/commands/configure.gateway.ts`, which calls `buildGatewayAuthConfig` after collecting/normalizing token/password input; the new guards ensure invalid configs aren’t produced.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but tests will fail until the new error-message expectations are corrected.
- The production changes are small and targeted, but the added tests currently assert error strings that don’t match the thrown messages, which should break CI.
- src/commands/configure.gateway-auth.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->