### PR TITLE
security(cli): redact sensitive values in config get output

### DIFF
--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import { redactConfigObject } from "../config/redact-snapshot.js";
 import { danger, info } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -267,7 +268,8 @@ export function registerConfigCli(program: Command) {
           throw new Error("Path is empty.");
         }
         const snapshot = await loadValidConfig();
-        const res = getAtPath(snapshot.config, parsedPath);
+        const redacted = redactConfigObject(snapshot.config);
+        const res = getAtPath(redacted, parsedPath);
         if (!res.found) {
           defaultRuntime.error(danger(`Config path not found: ${path}`));
           defaultRuntime.exit(1);


### PR DESCRIPTION
## Summary

- The CLI `openclaw config get` command returned resolved secret values (API keys, tokens, passwords) without any redaction
- The gateway RPC `config.get` endpoint already applied `redactConfigSnapshot()`, but the CLI path bypassed it
- A sandboxed agent could read credentials via `openclaw config get channels.telegram.botToken`
- Fix: apply `redactConfigObject()` to the resolved config before path extraction, aligning CLI with gateway behavior

## Changes

- `src/cli/config-cli.ts`: Import `redactConfigObject` and apply it to the config before `getAtPath()` in the `config get` action

## Test plan

- [ ] Run `openclaw config set channels.telegram.botToken "secret-123"` then `openclaw config get channels.telegram.botToken` — should return `__OPENCLAW_REDACTED__` instead of `secret-123`
- [ ] Verify `openclaw config get agents` (non-sensitive path) still returns actual values
- [ ] Existing `redact-snapshot.test.ts` tests continue to pass

Closes #13683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed a security vulnerability where `openclaw config get` exposed sensitive credentials (API keys, tokens, passwords) without redaction. The CLI bypassed the redaction logic that was already in place for the gateway RPC endpoint.

**Key changes:**
- Import `redactConfigObject` from `src/config/redact-snapshot.ts`
- Apply redaction to the config before path extraction in the `config get` action (lines 271-272)
- Aligns CLI behavior with gateway `config.get` RPC endpoint (which already used `redactConfigSnapshot()`)

**Impact:**
- Sandboxed agents and users can no longer extract plaintext credentials via `openclaw config get channels.telegram.botToken`
- Non-sensitive paths like `openclaw config get agents` continue to work normally
- The fix applies `redactConfigObject()` which replaces values matching sensitive key patterns (`/token/i`, `/password/i`, `/secret/i`, `/api.?key/i`) with `__OPENCLAW_REDACTED__`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, surgical security patch that adds a single function call to apply existing, well-tested redaction logic. The `redactConfigObject` function is already used by the gateway RPC endpoint and has comprehensive test coverage (28 test cases in `redact-snapshot.test.ts`). The change only affects the `config get` command, leaving `config set` and `config unset` unchanged (correctly, as they operate on the raw config for writes). No new logic was introduced, reducing risk of regressions.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->