### PR TITLE
fix(model): map developer role to system for Aliyun/Dashscope/Qianfan providers

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -41,4 +41,67 @@ describe("normalizeModelCompat", () => {
     const normalized = normalizeModelCompat(model);
     expect(normalized.compat?.supportsDeveloperRole).toBe(false);
   });
+
+  it("forces supportsDeveloperRole off for Aliyun/Dashscope models", () => {
+    const model = {
+      ...baseModel(),
+      id: "qwen3-max",
+      name: "qwen3-max",
+      provider: "aliyun",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for Qwen Portal models", () => {
+    const model = {
+      ...baseModel(),
+      id: "coder-model",
+      name: "coder-model",
+      provider: "qwen-portal",
+      baseUrl: "https://portal.qwen.ai/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for Qianfan/Baidu models", () => {
+    const model = {
+      ...baseModel(),
+      id: "deepseek-v3.2",
+      name: "deepseek-v3.2",
+      provider: "qianfan",
+      baseUrl: "https://qianfan.baidubce.com/v2",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for openai-responses API on unsupported providers", () => {
+    const model = {
+      ...baseModel(),
+      api: "openai-responses" as const,
+      provider: "aliyun",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("leaves Anthropic models untouched", () => {
+    const model = {
+      ...baseModel(),
+      api: "anthropic-messages" as const,
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat).toBeUndefined();
+  });
 });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -1,24 +1,41 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 
-function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-completions"> {
-  return model.api === "openai-completions";
+function isOpenAiCompatibleModel(model: Model<Api>): boolean {
+  return model.api === "openai-completions" || model.api === "openai-responses";
+}
+
+/**
+ * Base URL patterns for providers known to reject the OpenAI "developer" role.
+ * These providers implement OpenAI-compatible APIs but only accept the
+ * traditional "system" role.
+ */
+const DEVELOPER_ROLE_UNSUPPORTED_URL_PATTERNS = [
+  "api.z.ai",
+  "dashscope.aliyuncs.com",
+  "portal.qwen.ai",
+  "qianfan.baidubce.com",
+];
+
+function isDeveloperRoleUnsupportedProvider(model: Model<Api>): boolean {
+  const baseUrl = model.baseUrl ?? "";
+  if (model.provider === "zai" || model.provider === "qwen-portal" || model.provider === "qianfan") {
+    return true;
+  }
+  return DEVELOPER_ROLE_UNSUPPORTED_URL_PATTERNS.some((pattern) => baseUrl.includes(pattern));
 }
 
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
-  const baseUrl = model.baseUrl ?? "";
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  if (!isOpenAiCompatibleModel(model) || !isDeveloperRoleUnsupportedProvider(model)) {
     return model;
   }
 
-  const openaiModel = model;
-  const compat = openaiModel.compat ?? undefined;
+  const compat = model.compat ?? undefined;
   if (compat?.supportsDeveloperRole === false) {
     return model;
   }
 
-  openaiModel.compat = compat
+  model.compat = compat
     ? { ...compat, supportsDeveloperRole: false }
     : { supportsDeveloperRole: false };
-  return openaiModel;
+  return model;
 }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -201,17 +201,19 @@ export function resolveModel(
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
+      const matchedModel = (providerCfg?.models ?? []).find((m) => m.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
-        name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
+        name: matchedModel?.name ?? modelId,
+        api: matchedModel?.api ?? providerCfg?.api ?? "openai-responses",
         provider,
         baseUrl: providerCfg?.baseUrl,
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-        maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+        reasoning: matchedModel?.reasoning ?? false,
+        input: matchedModel?.input ?? ["text"],
+        cost: matchedModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: matchedModel?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
+        maxTokens: matchedModel?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+        compat: matchedModel?.compat,
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }


### PR DESCRIPTION
## Summary

- Aliyun/Dashscope, Qwen Portal, and Qianfan (Baidu) implement OpenAI-compatible APIs but reject the newer `developer` role with `InvalidParameter` errors
- Extend `normalizeModelCompat()` to detect these providers by provider name (`qwen-portal`, `qianfan`) or base URL pattern (`dashscope.aliyuncs.com`, `portal.qwen.ai`, `qianfan.baidubce.com`) and set `supportsDeveloperRole: false`
- Fix the fallback model construction in `resolveModel()` to propagate user-configured model properties (`reasoning`, `input`, `cost`, `compat`) from the matched `providerCfg.models` entry instead of hardcoding defaults

## Changes

- `src/agents/model-compat.ts`: Generalize provider detection from zai-only to all known unsupported providers. Handle both `openai-completions` and `openai-responses` API types.
- `src/agents/pi-embedded-runner/model.ts`: Look up the matched model from `providerCfg.models` by ID and spread its properties into the fallback model, ensuring user config is respected.
- `src/agents/model-compat.test.ts`: Add test cases for Aliyun/Dashscope, Qwen Portal, Qianfan, openai-responses API variant, and Anthropic passthrough.

## Test plan

- [ ] `pnpm test src/agents/model-compat.test.ts` — all 7 test cases pass
- [ ] Configure Aliyun provider with `qwen3-max` model, send a message — no more `InvalidParameter` error for developer role
- [ ] Configure a custom provider with `compat: { supportsDeveloperRole: false }` — flag is respected in fallback path
- [ ] Existing z.ai detection still works (backward compatible)

Closes #13633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Extends model compatibility detection to handle Aliyun/Dashscope, Qwen Portal, and Qianfan providers that reject OpenAI's `developer` role, preventing `InvalidParameter` errors

- Generalizes provider detection in `normalizeModelCompat()` from z.ai-only to all unsupported providers (by name or base URL pattern)
- Adds support for both `openai-completions` and `openai-responses` API types
- Fixes fallback model construction in `resolveModel()` to propagate user-configured properties (`reasoning`, `input`, `cost`, `compat`) from matched provider config instead of hardcoding defaults
- Comprehensive test coverage with 7 test cases covering all new providers and API variants

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and well-tested. It extends existing functionality to handle additional providers using the same proven pattern already in place for z.ai. The fallback model fix properly propagates user configuration, which is a clear improvement. All changes are backward compatible and covered by comprehensive test cases.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->