### PR TITLE
fix(routing): trust binding agentId to prevent multi-agent routing misdirection

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -225,6 +225,44 @@ describe("resolveAgentRoute", () => {
     expect(route.agentId).toBe("home");
     expect(route.sessionKey).toBe("agent:home:main");
   });
+
+  test("binding agentId is trusted even when not in agents.list (#13423)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "specialist", default: true, workspace: "~/specialist" }],
+      },
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram", accountId: "bot-main" },
+        },
+        {
+          agentId: "specialist",
+          match: { channel: "telegram", accountId: "specialist-bot" },
+        },
+      ],
+    };
+
+    // Message to bot-main must route to "main", not fall back to "specialist"
+    const mainRoute = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: "bot-main",
+      peer: { kind: "direct", id: "123" },
+    });
+    expect(mainRoute.agentId).toBe("main");
+    expect(mainRoute.matchedBy).toBe("binding.account");
+
+    // Message to specialist-bot routes to "specialist" as before
+    const specRoute = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: "specialist-bot",
+      peer: { kind: "direct", id: "123" },
+    });
+    expect(specRoute.agentId).toBe("specialist");
+    expect(specRoute.matchedBy).toBe("binding.account");
+  });
 });
 
 test("dmScope=per-account-channel-peer isolates DM sessions per account, channel and sender", () => {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -118,7 +118,11 @@ function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): string 
   if (match?.id?.trim()) {
     return sanitizeAgentId(match.id.trim());
   }
-  return sanitizeAgentId(resolveDefaultAgentId(cfg));
+  // Trust the requested agentId even if it is not in agents.list.
+  // Silently falling back to the default agent caused critical routing
+  // failures: messages intended for one agent were delivered to another
+  // without any indication to the user (#13423).
+  return sanitizeAgentId(trimmed);
 }
 
 function matchesChannel(


### PR DESCRIPTION
## Summary

- **Root cause:** `pickFirstExistingAgentId()` in `resolve-route.ts` silently fell back to the **default agent** when a binding's `agentId` was not found in `cfg.agents.list`. This caused messages to be delivered to the wrong agent without any indication to the user.
- **Impact:** In multi-agent Telegram deployments, messages intended for Agent A were silently routed to Agent B, causing communication interception, identity spoofing, and cross-agent information leakage.
- **Fix:** Trust the binding's explicit `agentId` even when it's not in `agents.list`. If the agent doesn't exist, that's a configuration error that should surface at the handler level, not be silently "corrected" by routing to a different agent.

## Reproduction scenario (from issue)

```json
{
  "agents": { "list": [{ "id": "specialist", "default": true }] },
  "bindings": [
    { "agentId": "main", "match": { "channel": "telegram", "accountId": "bot-main" } },
    { "agentId": "specialist", "match": { "channel": "telegram", "accountId": "specialist-bot" } }
  ]
}
```

**Before fix:** Message to `bot-main` -> silently routed to `specialist` (because `"main"` not in agents.list, falls back to default)
**After fix:** Message to `bot-main` -> correctly routed to `main`

## Changes

- `src/routing/resolve-route.ts`: Change `pickFirstExistingAgentId()` to return the requested agentId (sanitized) instead of the default agent when no match is found in agents.list
- `src/routing/resolve-route.test.ts`: Add test case reproducing the exact scenario from #13423

## Test plan

- [ ] `pnpm test src/routing/resolve-route.test.ts` — all tests pass including new #13423 regression test
- [ ] Existing binding tests still pass (they all use empty agents.list, hitting the early return)
- [ ] Manual: configure multi-agent Telegram setup with bindings, verify messages route to the correct agent

Closes #13423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes routing resolution so that when a binding specifies an explicit `agentId`, `pickFirstExistingAgentId()` no longer silently falls back to the configured default agent if that `agentId` is missing from `cfg.agents.list`. This prevents cross-agent message misdirection in multi-agent deployments by ensuring the binding’s chosen agent id is preserved (after sanitization) and any “agent doesn’t exist” problem surfaces later in the stack.

A regression test was added to cover the reported Telegram multi-agent scenario by asserting that two different bindings under the same channel route to their respective `agentId`s even when only one is present in `agents.list` (and that one is the default).

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and fixes a real routing misdirection, but the new regression test appears to use ambiguous `accountId` semantics and may not be validating the intended real-world scenario.
- Core logic change is small, localized, and consistent with stated root cause (stop default-agent fallback on missing binding agentId). However, the added test may be mis-specified (using `accountId` as a per-bot selector even though other tests treat it as an account namespace), which reduces confidence that the regression is correctly locked in.
- src/routing/resolve-route.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->