### PR TITLE
fix: compare base64 string length instead of decoded bytes for image size limit

### DIFF
--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -63,11 +63,15 @@ async function resizeImageBase64IfNeeded(params: {
   width?: number;
   height?: number;
 }> {
+  // Compare base64 string length (not decoded buffer size) because the Anthropic
+  // Messages API enforces the size limit on the encoded base64 payload.
+  // Base64 inflates data by ~33%, so a 3.75 MB buffer produces ~5 MB of base64.
+  const base64Length = params.base64.length;
   const buf = Buffer.from(params.base64, "base64");
   const meta = await getImageMetadata(buf);
   const width = meta?.width;
   const height = meta?.height;
-  const overBytes = buf.byteLength > params.maxBytes;
+  const overBytes = base64Length > params.maxBytes;
   const hasDimensions = typeof width === "number" && typeof height === "number";
   if (
     hasDimensions &&
@@ -104,7 +108,7 @@ async function resizeImageBase64IfNeeded(params: {
     .filter((v, i, arr) => v > 0 && arr.indexOf(v) === i)
     .toSorted((a, b) => b - a);
 
-  let smallest: { buffer: Buffer; size: number } | null = null;
+  let smallest: { buffer: Buffer; base64: string; size: number } | null = null;
   for (const side of sideGrid) {
     for (const quality of qualities) {
       const out = await resizeToJpeg({
@@ -113,23 +117,24 @@ async function resizeImageBase64IfNeeded(params: {
         quality,
         withoutEnlargement: true,
       });
-      if (!smallest || out.byteLength < smallest.size) {
-        smallest = { buffer: out, size: out.byteLength };
+      const outBase64 = out.toString("base64");
+      if (!smallest || outBase64.length < smallest.size) {
+        smallest = { buffer: out, base64: outBase64, size: outBase64.length };
       }
-      if (out.byteLength <= params.maxBytes) {
+      if (outBase64.length <= params.maxBytes) {
         log.info("Image resized", {
           label: params.label,
           width,
           height,
           maxDimensionPx: params.maxDimensionPx,
           maxBytes: params.maxBytes,
-          originalBytes: buf.byteLength,
-          resizedBytes: out.byteLength,
+          originalBase64Len: base64Length,
+          resizedBase64Len: outBase64.length,
           quality,
           side,
         });
         return {
-          base64: out.toString("base64"),
+          base64: outBase64,
           mimeType: "image/jpeg",
           resized: true,
           width,
@@ -139,10 +144,10 @@ async function resizeImageBase64IfNeeded(params: {
     }
   }
 
-  const best = smallest?.buffer ?? buf;
+  const bestSize = smallest?.size ?? base64Length;
   const maxMb = (params.maxBytes / (1024 * 1024)).toFixed(0);
-  const gotMb = (best.byteLength / (1024 * 1024)).toFixed(2);
-  throw new Error(`Image could not be reduced below ${maxMb}MB (got ${gotMb}MB)`);
+  const gotMb = (bestSize / (1024 * 1024)).toFixed(2);
+  throw new Error(`Image could not be reduced below ${maxMb}MB base64 (got ${gotMb}MB)`);
 }
 
 export async function sanitizeContentBlocksImages(


### PR DESCRIPTION
## Problem

`resizeImageBase64IfNeeded` in `tool-images.ts` compares the **decoded buffer size** (`buf.byteLength`) against `MAX_IMAGE_BYTES` (5MB), but the Anthropic Messages API checks the **base64 string length** against the 5MB limit.

Base64 encoding inflates data by ~33%, so an image with decoded size ~3.75–5 MB produces a base64 string that exceeds 5 MB. This passes the current check but gets rejected by the API.

Once such an image enters session history, **all subsequent messages fail** (including plain text), because the oversized image is included in every API request.

### Error
```
LLM request rejected: messages.10.content.1.image.source.base64: invalid base64 data
```

## Fix

- Compare `params.base64.length` (base64 string length) instead of `buf.byteLength` (decoded size) for the initial size check
- Compare `outBase64.length` in the resize loop instead of `out.byteLength`
- Update log fields and error messages to reflect base64 sizes

## Testing

Reproduced by sending a ~4MB JPEG via Telegram. Before fix: API rejection on every subsequent message. After fix: image gets properly resized below the 5MB base64 limit.

Fixes #5344

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed image size validation to compare base64 string length instead of decoded buffer size, matching Anthropic Messages API's 5MB limit enforcement on encoded payloads. This prevents images with ~3.75-5MB decoded size from passing validation but getting rejected by the API, which previously broke all subsequent messages in the session.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The fix correctly addresses a real bug where images were incorrectly validated against decoded buffer size rather than base64 string length. All comparisons are consistently updated (initial check, resize loop, logging, error messages), and the logic is sound. The existing test continues to validate correct behavior, though with a slightly weaker assertion.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->