### PR TITLE
fix: BlueBubbles webhook auth bypass via loopback proxy trust

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -238,6 +238,7 @@ function createMockAccount(
     configured: true,
     config: {
       serverUrl: "http://localhost:1234",
+      password: "test-password",
       dmPolicy: "open",
       groupPolicy: "open",
       allowFrom: [],
@@ -253,9 +254,20 @@ function createMockRequest(
   body: unknown,
   headers: Record<string, string> = {},
 ): IncomingMessage {
+  const parsedUrl = new URL(url, "http://localhost");
+  const hasAuthQuery = parsedUrl.searchParams.has("guid") || parsedUrl.searchParams.has("password");
+  const hasAuthHeader =
+    headers["x-guid"] !== undefined ||
+    headers["x-password"] !== undefined ||
+    headers["x-bluebubbles-guid"] !== undefined ||
+    headers.authorization !== undefined;
+  if (!hasAuthQuery && !hasAuthHeader) {
+    parsedUrl.searchParams.set("password", "test-password");
+  }
+
   const req = new EventEmitter() as IncomingMessage;
   req.method = method;
-  req.url = url;
+  req.url = `${parsedUrl.pathname}${parsedUrl.search}`;
   req.headers = headers;
   (req as unknown as { socket: { remoteAddress: string } }).socket = { remoteAddress: "127.0.0.1" };
 

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -238,7 +238,6 @@ function createMockAccount(
     configured: true,
     config: {
       serverUrl: "http://localhost:1234",
-      password: "test-password",
       dmPolicy: "open",
       groupPolicy: "open",
       allowFrom: [],
@@ -546,7 +545,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(res.statusCode).toBe(401);
     });
 
-    it("allows localhost requests without authentication", async () => {
+    it("requires authentication for localhost requests when password is configured", async () => {
       const account = createMockAccount({ password: "secret-token" });
       const config: OpenClawConfig = {};
       const core = createMockRuntime();
@@ -579,7 +578,7 @@ describe("BlueBubbles webhook monitor", () => {
       const handled = await handleBlueBubblesWebhookRequest(req, res);
 
       expect(handled).toBe(true);
-      expect(res.statusCode).toBe(200);
+      expect(res.statusCode).toBe(401);
     });
 
     it("ignores unregistered webhook paths", async () => {

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -1533,10 +1533,6 @@ export async function handleBlueBubblesWebhookRequest(
     if (guid && guid.trim() === token) {
       return true;
     }
-    const remote = req.socket?.remoteAddress ?? "";
-    if (remote === "127.0.0.1" || remote === "::1" || remote === "::ffff:127.0.0.1") {
-      return true;
-    }
     return false;
   });
 


### PR DESCRIPTION
## Fix Summary
The BlueBubbles webhook handler bypasses its shared-secret check whenever the incoming socket address is loopback. In common same-host reverse-proxy deployments, all attacker traffic arrives as `127.0.0.1` at the gateway, so external callers can inject webhook events without knowing the BlueBubbles password.

## Issue Linkage
Fixes #13786

## Security Snapshot
- CVSS v3.1: 8.6 (High)
- CVSS v4.0: 8.8 (High)

## Implementation Details
### Files Changed
- `extensions/bluebubbles/src/monitor.test.ts` (+40/-28)
- `extensions/bluebubbles/src/monitor.ts` (+0/-4)

### Technical Analysis
BlueBubbles registers a plugin HTTP handler on the gateway plugin route path. During authentication, the handler accepts valid shared-secret tokens, but also unconditionally accepts requests from loopback remote addresses. Because reverse proxies commonly forward to `127.0.0.1:18789`, this creates an alternate unauthenticated channel that bypasses webhook secret verification.

## Validation Evidence
- Command: `pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: GPT-5.3-Codex

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes a loopback-based authentication bypass in the BlueBubbles webhook handler (`handleBlueBubblesWebhookRequest`), so requests from `127.0.0.1`/`::1`/IPv4-mapped loopback no longer skip the shared-secret check (important for same-host reverse-proxy deployments where upstream connects from loopback).

The test suite is updated to assert that loopback-origin requests still require a valid password when one is configured, and the request mock helper was modified to auto-add auth in many cases to keep unrelated tests passing.

Main concern: the new implicit-auth behavior in `createMockRequest` can unintentionally turn “unauthenticated” test requests into authenticated ones, reducing coverage for auth failures and making future regressions harder to catch.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and addresses the reported auth bypass, with one test-helper change that could weaken auth-related test coverage.
- The production change is small and directly removes the loopback trust shortcut in webhook auth. The main risk is in tests: `createMockRequest` now injects auth implicitly, which can mask missing-auth scenarios and allow regressions to slip through without failing tests.
- extensions/bluebubbles/src/monitor.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->