### PR TITLE
fix(otel): sanitize OTLP endpoint URL resolution

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -278,4 +278,28 @@ describe("diagnostics-otel service", () => {
     expect(options?.url).toBe("https://collector.example.com/v1/traces");
     await service.stop?.();
   });
+
+  test("keeps signal-qualified endpoint unchanged when it has query params", async () => {
+    const service = createDiagnosticsOtelService();
+    await service.start({
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "https://collector.example.com/v1/traces?timeout=30s",
+            protocol: "http/protobuf",
+            traces: true,
+            metrics: false,
+            logs: false,
+          },
+        },
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+
+    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
+    expect(options?.url).toBe("https://collector.example.com/v1/traces?timeout=30s");
+    await service.stop?.();
+  });
 });

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -30,6 +30,7 @@ const sdkStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const sdkShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const logEmit = vi.hoisted(() => vi.fn());
 const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const traceExporterCtor = vi.hoisted(() => vi.fn());
 
 vi.mock("@opentelemetry/api", () => ({
   metrics: {
@@ -55,7 +56,11 @@ vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
 }));
 
 vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
-  OTLPTraceExporter: class {},
+  OTLPTraceExporter: class {
+    constructor(options?: unknown) {
+      traceExporterCtor(options);
+    }
+  },
 }));
 
 vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
@@ -118,6 +123,7 @@ describe("diagnostics-otel service", () => {
     sdkShutdown.mockClear();
     logEmit.mockClear();
     logShutdown.mockClear();
+    traceExporterCtor.mockClear();
     registerLogTransportMock.mockReset();
   });
 
@@ -222,6 +228,54 @@ describe("diagnostics-otel service", () => {
     });
     expect(logEmit).toHaveBeenCalled();
 
+    await service.stop?.();
+  });
+
+  test("appends signal path when endpoint contains non-signal /v1 segment", async () => {
+    const service = createDiagnosticsOtelService();
+    await service.start({
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "https://www.comet.com/opik/api/v1/private/otel",
+            protocol: "http/protobuf",
+            traces: true,
+            metrics: false,
+            logs: false,
+          },
+        },
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+
+    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
+    expect(options?.url).toBe("https://www.comet.com/opik/api/v1/private/otel/v1/traces");
+    await service.stop?.();
+  });
+
+  test("keeps already signal-qualified endpoint unchanged", async () => {
+    const service = createDiagnosticsOtelService();
+    await service.start({
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "https://collector.example.com/v1/traces",
+            protocol: "http/protobuf",
+            traces: true,
+            metrics: false,
+            logs: false,
+          },
+        },
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+
+    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
+    expect(options?.url).toBe("https://collector.example.com/v1/traces");
     await service.stop?.();
   });
 });

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -302,4 +302,28 @@ describe("diagnostics-otel service", () => {
     expect(options?.url).toBe("https://collector.example.com/v1/traces?timeout=30s");
     await service.stop?.();
   });
+
+  test("keeps signal-qualified endpoint unchanged when signal path casing differs", async () => {
+    const service = createDiagnosticsOtelService();
+    await service.start({
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "https://collector.example.com/v1/Traces",
+            protocol: "http/protobuf",
+            traces: true,
+            metrics: false,
+            logs: false,
+          },
+        },
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+
+    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
+    expect(options?.url).toBe("https://collector.example.com/v1/Traces");
+    await service.stop?.();
+  });
 });

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -23,7 +23,8 @@ function resolveOtelUrl(endpoint: string | undefined, path: string): string | un
   if (!endpoint) {
     return undefined;
   }
-  if (/\/v1\/(?:traces|metrics|logs)$/.test(endpoint)) {
+  const endpointWithoutQueryOrFragment = endpoint.split(/[?#]/, 1)[0] ?? endpoint;
+  if (/\/v1\/(?:traces|metrics|logs)$/.test(endpointWithoutQueryOrFragment)) {
     return endpoint;
   }
   return `${endpoint}/${path}`;

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -23,7 +23,7 @@ function resolveOtelUrl(endpoint: string | undefined, path: string): string | un
   if (!endpoint) {
     return undefined;
   }
-  if (endpoint.includes("/v1/")) {
+  if (/\/v1\/(?:traces|metrics|logs)$/.test(endpoint)) {
     return endpoint;
   }
   return `${endpoint}/${path}`;

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -24,7 +24,7 @@ function resolveOtelUrl(endpoint: string | undefined, path: string): string | un
     return undefined;
   }
   const endpointWithoutQueryOrFragment = endpoint.split(/[?#]/, 1)[0] ?? endpoint;
-  if (/\/v1\/(?:traces|metrics|logs)$/.test(endpointWithoutQueryOrFragment)) {
+  if (/\/v1\/(?:traces|metrics|logs)$/i.test(endpointWithoutQueryOrFragment)) {
     return endpoint;
   }
   return `${endpoint}/${path}`;


### PR DESCRIPTION
## Summary
Sanitizes OTLP endpoint resolution so non-signal endpoints that contain internal `/v1/` segments still append the correct signal path. Keeps already signal-qualified endpoints unchanged. lobster-biscuit

## Motivation
This prevents silent cloud export misrouting for valid backends like Opik that use `/api/v1/...` in their base URL. Closes https://github.com/openclaw/openclaw/issues/13783

### Changes
- Inspired by #4255 and follow-up debugging from #12897, replaced broad `/v1/` detection with strict signal-path matching (`/v1/traces|/v1/metrics|/v1/logs`) before appending.
- Added resolver-focused tests that verify both internal-`/v1/` base endpoints and already signal-qualified endpoints.

### Related
- https://github.com/openclaw/openclaw/issues/13783
- https://github.com/openclaw/openclaw/issues/3201
- https://github.com/openclaw/openclaw/pull/2574
- https://github.com/openclaw/openclaw/pull/4255
- https://github.com/openclaw/openclaw/pull/12897

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes OTLP endpoint URL resolution to prevent misrouting for backends that contain internal `/v1/` segments (like Opik's `/api/v1/...`). The change replaces simple substring matching with strict signal-path pattern matching (`/v1/traces`, `/v1/metrics`, `/v1/logs`) that strips query parameters and fragments before testing, ensuring already signal-qualified endpoints remain unchanged while non-signal endpoints get the correct signal path appended.

**Key improvements:**
- Strips query params and fragments before regex matching to avoid false negatives
- Uses strict end-of-pathname matching for signal paths instead of broad `/v1/` substring detection
- Preserves original endpoint (including query params) when already signal-qualified
- Adds comprehensive test coverage for both internal-`/v1/` base endpoints and signal-qualified endpoints with query parameters

The implementation correctly addresses the regression mentioned in the previous thread by extracting the pathname portion for testing while preserving the full URL for the return value.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is focused, well-tested, and correctly addresses the reported issue. The previous thread's concern about query parameters has been properly resolved through the `endpoint.split(/[?#]/, 1)[0]` approach. The test suite includes three relevant test cases covering the key scenarios (non-signal `/v1/` segments, already signal-qualified endpoints, and signal-qualified endpoints with query params). The logic is straightforward and the regex pattern is precise.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->