### PR TITLE
Claude/openclaw token efficiency q ni2s

### DIFF
--- a/src/agents/anthropic-provider-check.ts
+++ b/src/agents/anthropic-provider-check.ts
@@ -1,0 +1,11 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+
+/**
+ * Check if a model targets the Anthropic Messages API.
+ */
+export function isAnthropicProvider(model: Model<Api> | undefined): boolean {
+  if (!model) {
+    return false;
+  }
+  return (model as { api?: unknown }).api === "anthropic-messages";
+}

--- a/src/agents/compaction-profiles.test.ts
+++ b/src/agents/compaction-profiles.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProfileCompactionInstructions,
+  getCompactionProfile,
+  isValidProfileId,
+  listCompactionProfiles,
+  parseCompactCommand,
+  resolveProactiveCompactionConfig,
+  shouldTriggerProactiveCompaction,
+} from "./compaction-profiles.js";
+
+describe("getCompactionProfile", () => {
+  it("returns known profiles", () => {
+    expect(getCompactionProfile("default").id).toBe("default");
+    expect(getCompactionProfile("coding").id).toBe("coding");
+    expect(getCompactionProfile("conversation").id).toBe("conversation");
+    expect(getCompactionProfile("research").id).toBe("research");
+  });
+
+  it("returns default for unknown profiles", () => {
+    expect(getCompactionProfile("unknown" as never).id).toBe("default");
+  });
+
+  it("coding profile preserves code-related items", () => {
+    const profile = getCompactionProfile("coding");
+    expect(profile.instructions).toContain("file paths");
+    expect(profile.instructions).toContain("Error messages");
+    expect(profile.instructions).toContain("Code changes");
+  });
+
+  it("conversation profile preserves decisions", () => {
+    const profile = getCompactionProfile("conversation");
+    expect(profile.instructions).toContain("decisions");
+    expect(profile.instructions).toContain("Action items");
+  });
+
+  it("research profile preserves data and sources", () => {
+    const profile = getCompactionProfile("research");
+    expect(profile.instructions).toContain("data points");
+    expect(profile.instructions).toContain("Source URLs");
+  });
+});
+
+describe("listCompactionProfiles", () => {
+  it("returns all 4 profiles", () => {
+    const profiles = listCompactionProfiles();
+    expect(profiles).toHaveLength(4);
+    const ids = profiles.map((p) => p.id);
+    expect(ids).toContain("default");
+    expect(ids).toContain("coding");
+    expect(ids).toContain("conversation");
+    expect(ids).toContain("research");
+  });
+});
+
+describe("isValidProfileId", () => {
+  it("accepts valid profiles", () => {
+    expect(isValidProfileId("default")).toBe(true);
+    expect(isValidProfileId("coding")).toBe(true);
+    expect(isValidProfileId("conversation")).toBe(true);
+    expect(isValidProfileId("research")).toBe(true);
+  });
+
+  it("rejects invalid profiles", () => {
+    expect(isValidProfileId("unknown")).toBe(false);
+    expect(isValidProfileId("")).toBe(false);
+  });
+});
+
+describe("resolveProactiveCompactionConfig", () => {
+  it("returns defaults when no config", () => {
+    const config = resolveProactiveCompactionConfig();
+    expect(config.proactiveThreshold).toBe(0.65);
+    expect(config.profile).toBe("default");
+  });
+
+  it("clamps threshold to valid range", () => {
+    const config = resolveProactiveCompactionConfig({
+      agents: { defaults: { compaction: { proactiveThreshold: 1.5 } } },
+    } as never);
+    expect(config.proactiveThreshold).toBeLessThanOrEqual(0.95);
+  });
+});
+
+describe("shouldTriggerProactiveCompaction", () => {
+  const config = resolveProactiveCompactionConfig();
+
+  it("triggers when usage exceeds threshold", () => {
+    expect(
+      shouldTriggerProactiveCompaction({
+        totalTokens: 70_000,
+        contextWindowTokens: 100_000,
+        config,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not trigger when under threshold", () => {
+    expect(
+      shouldTriggerProactiveCompaction({
+        totalTokens: 50_000,
+        contextWindowTokens: 100_000,
+        config,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger with zero tokens", () => {
+    expect(
+      shouldTriggerProactiveCompaction({
+        totalTokens: 0,
+        contextWindowTokens: 100_000,
+        config,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger with zero context window", () => {
+    expect(
+      shouldTriggerProactiveCompaction({
+        totalTokens: 70_000,
+        contextWindowTokens: 0,
+        config,
+      }),
+    ).toBe(false);
+  });
+
+  it("triggers at exact threshold", () => {
+    expect(
+      shouldTriggerProactiveCompaction({
+        totalTokens: 65_000,
+        contextWindowTokens: 100_000,
+        config,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("buildProfileCompactionInstructions", () => {
+  it("includes profile instructions", () => {
+    const instructions = buildProfileCompactionInstructions("coding");
+    expect(instructions).toContain("file paths");
+  });
+
+  it("appends custom instructions", () => {
+    const instructions = buildProfileCompactionInstructions("default", "Also preserve all URLs");
+    expect(instructions).toContain("Also preserve all URLs");
+    expect(instructions).toContain("Additional instructions");
+  });
+
+  it("ignores empty custom instructions", () => {
+    const instructions = buildProfileCompactionInstructions("default", "   ");
+    expect(instructions).not.toContain("Additional instructions");
+  });
+});
+
+describe("parseCompactCommand", () => {
+  it("parses empty input as default", () => {
+    expect(parseCompactCommand("")).toEqual({ profile: "default" });
+  });
+
+  it("parses profile name", () => {
+    expect(parseCompactCommand("coding")).toEqual({ profile: "coding" });
+    expect(parseCompactCommand("research")).toEqual({ profile: "research" });
+  });
+
+  it("parses profile with instructions", () => {
+    expect(parseCompactCommand("coding: keep all file paths")).toEqual({
+      profile: "coding",
+      instructions: "keep all file paths",
+    });
+  });
+
+  it("parses colon without profile as default with instructions", () => {
+    expect(parseCompactCommand(": keep all URLs")).toEqual({
+      profile: "default",
+      instructions: "keep all URLs",
+    });
+  });
+
+  it("treats unknown words as instructions", () => {
+    expect(parseCompactCommand("preserve everything")).toEqual({
+      profile: "default",
+      instructions: "preserve everything",
+    });
+  });
+});

--- a/src/agents/compaction-profiles.ts
+++ b/src/agents/compaction-profiles.ts
@@ -1,0 +1,195 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agent/compaction-profiles");
+
+export type CompactionProfileId = "default" | "coding" | "conversation" | "research";
+
+export type CompactionProfile = {
+  id: CompactionProfileId;
+  description: string;
+  instructions: string;
+};
+
+const PROFILES: Record<CompactionProfileId, CompactionProfile> = {
+  default: {
+    id: "default",
+    description: "General-purpose compaction preserving recent context and decisions",
+    instructions: `Summarize the conversation while preserving:
+- The most recent 3 exchanges in detail
+- Key decisions made and their rationale
+- Action items and their current status
+- Important context for ongoing tasks
+- User preferences expressed during the conversation
+Omit routine greetings, acknowledgments, and repeated information.`,
+  },
+  coding: {
+    id: "coding",
+    description: "Optimized for coding sessions preserving code context",
+    instructions: `Summarize the coding session while preserving:
+- All file paths mentioned and their purposes
+- Code changes made (what was modified, added, or removed)
+- Error messages and their resolutions
+- Build/test results and their outcomes
+- Architecture decisions and constraints
+- The current state of the task (what's done, what's pending)
+- Key technical details (library versions, API endpoints, configuration)
+Omit verbose tool output that has been processed, routine acknowledgments.`,
+  },
+  conversation: {
+    id: "conversation",
+    description: "Optimized for discussions preserving decisions and action items",
+    instructions: `Summarize the discussion while preserving:
+- All decisions made and who made them
+- Action items with assignees and deadlines
+- Key arguments and counterarguments for important decisions
+- Agreed-upon plans and timelines
+- Unresolved questions or open issues
+- Participant preferences and constraints
+Omit small talk, repeated summaries, and routine pleasantries.`,
+  },
+  research: {
+    id: "research",
+    description: "Optimized for research preserving data and sources",
+    instructions: `Summarize the research session while preserving:
+- All data points, statistics, and findings
+- Source URLs and references
+- Comparisons and analysis results
+- Hypotheses tested and their outcomes
+- Key quotes or excerpts from sources
+- Methodology and search strategies used
+- Open questions and next steps for investigation
+Omit navigation steps, failed searches, and redundant lookups.`,
+  },
+};
+
+export function getCompactionProfile(id: CompactionProfileId): CompactionProfile {
+  return PROFILES[id] ?? PROFILES.default;
+}
+
+export function listCompactionProfiles(): CompactionProfile[] {
+  return Object.values(PROFILES);
+}
+
+export function isValidProfileId(id: string): id is CompactionProfileId {
+  return id in PROFILES;
+}
+
+export type ProactiveCompactionConfig = {
+  /** Trigger proactive compaction at this fraction of context window usage. */
+  proactiveThreshold: number;
+  /** Active compaction profile. */
+  profile: CompactionProfileId;
+};
+
+const DEFAULT_PROACTIVE_CONFIG: ProactiveCompactionConfig = {
+  proactiveThreshold: 0.65,
+  profile: "default",
+};
+
+export function resolveProactiveCompactionConfig(cfg?: OpenClawConfig): ProactiveCompactionConfig {
+  const raw = cfg?.agents?.defaults?.compaction as Record<string, unknown> | undefined;
+  if (!raw) {
+    return DEFAULT_PROACTIVE_CONFIG;
+  }
+
+  const threshold =
+    typeof raw.proactiveThreshold === "number"
+      ? Math.max(0.1, Math.min(0.95, raw.proactiveThreshold))
+      : DEFAULT_PROACTIVE_CONFIG.proactiveThreshold;
+  const profileRaw = typeof raw.profile === "string" ? raw.profile : "default";
+  const profile = isValidProfileId(profileRaw) ? profileRaw : "default";
+
+  return { proactiveThreshold: threshold, profile };
+}
+
+/**
+ * Check if proactive compaction should trigger based on current context usage.
+ */
+export function shouldTriggerProactiveCompaction(params: {
+  totalTokens: number;
+  contextWindowTokens: number;
+  config: ProactiveCompactionConfig;
+}): boolean {
+  const { totalTokens, contextWindowTokens, config } = params;
+
+  if (contextWindowTokens <= 0 || totalTokens <= 0) {
+    return false;
+  }
+
+  const usage = totalTokens / contextWindowTokens;
+  const shouldTrigger = usage >= config.proactiveThreshold;
+
+  if (shouldTrigger) {
+    log.info(
+      `proactive compaction triggered: usage=${(usage * 100).toFixed(1)}% ` +
+        `threshold=${(config.proactiveThreshold * 100).toFixed(1)}% ` +
+        `profile=${config.profile}`,
+    );
+  }
+
+  return shouldTrigger;
+}
+
+/**
+ * Build compaction instructions incorporating the active profile.
+ */
+export function buildProfileCompactionInstructions(
+  profile: CompactionProfileId,
+  customInstructions?: string,
+): string {
+  const profileDef = getCompactionProfile(profile);
+  const parts = [profileDef.instructions];
+
+  if (customInstructions?.trim()) {
+    parts.push(`\nAdditional instructions:\n${customInstructions.trim()}`);
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Parse a /compact command to extract profile and custom instructions.
+ * Formats:
+ *   /compact           → default profile
+ *   /compact coding    → coding profile
+ *   /compact: custom   → default profile with custom instructions
+ *   /compact coding: custom → coding profile with custom instructions
+ */
+export function parseCompactCommand(input: string): {
+  profile: CompactionProfileId;
+  instructions?: string;
+} {
+  const trimmed = input.trim();
+
+  // Check for profile followed by colon
+  const colonIndex = trimmed.indexOf(":");
+  if (colonIndex >= 0) {
+    const beforeColon = trimmed.slice(0, colonIndex).trim();
+    const afterColon = trimmed.slice(colonIndex + 1).trim();
+
+    if (isValidProfileId(beforeColon)) {
+      return {
+        profile: beforeColon,
+        instructions: afterColon || undefined,
+      };
+    }
+
+    return {
+      profile: "default",
+      instructions: afterColon || undefined,
+    };
+  }
+
+  // Check for profile name only
+  if (isValidProfileId(trimmed)) {
+    return { profile: trimmed };
+  }
+
+  // If non-empty but not a profile, treat as custom instructions
+  if (trimmed) {
+    return { profile: "default", instructions: trimmed };
+  }
+
+  return { profile: "default" };
+}

--- a/src/agents/heartbeat-isolation.test.ts
+++ b/src/agents/heartbeat-isolation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHeartbeatAnnouncement,
+  buildIsolatedHeartbeatPrompt,
+  heartbeatNeedsAction,
+  isHeartbeatSession,
+  resolveHeartbeatIsolationConfig,
+} from "./heartbeat-isolation.js";
+
+describe("resolveHeartbeatIsolationConfig", () => {
+  it("returns defaults when no config", () => {
+    const config = resolveHeartbeatIsolationConfig();
+    expect(config.isolated).toBe(true);
+    expect(config.model).toBe("anthropic/claude-haiku");
+    expect(config.maxTokens).toBe(2000);
+  });
+
+  it("respects explicit config", () => {
+    const config = resolveHeartbeatIsolationConfig({
+      agents: {
+        defaults: {
+          heartbeat: {
+            isolated: false,
+            model: "anthropic/claude-sonnet-4-5",
+            maxTokens: 4000,
+          },
+        },
+      },
+    } as never);
+    expect(config.isolated).toBe(false);
+    expect(config.model).toBe("anthropic/claude-sonnet-4-5");
+    expect(config.maxTokens).toBe(4000);
+  });
+});
+
+describe("buildIsolatedHeartbeatPrompt", () => {
+  it("includes heartbeat check description", () => {
+    const prompt = buildIsolatedHeartbeatPrompt({});
+    expect(prompt).toContain("heartbeat check");
+    expect(prompt).toContain("isolated micro-session");
+    expect(prompt).toContain("sessions_send");
+  });
+
+  it("includes HEARTBEAT.md content when provided", () => {
+    const prompt = buildIsolatedHeartbeatPrompt({
+      heartbeatMd: "Check for new emails every 30 minutes.",
+    });
+    expect(prompt).toContain("HEARTBEAT.md");
+    expect(prompt).toContain("Check for new emails");
+  });
+
+  it("includes fallback message when no HEARTBEAT.md", () => {
+    const prompt = buildIsolatedHeartbeatPrompt({});
+    expect(prompt).toContain("HEARTBEAT_OK");
+  });
+
+  it("includes context fields", () => {
+    const prompt = buildIsolatedHeartbeatPrompt({
+      agentId: "my-agent",
+      workspaceDir: "/home/user/project",
+      userTimezone: "America/New_York",
+      currentTime: "2025-01-01 12:00",
+    });
+    expect(prompt).toContain("my-agent");
+    expect(prompt).toContain("/home/user/project");
+    expect(prompt).toContain("America/New_York");
+    expect(prompt).toContain("2025-01-01 12:00");
+  });
+
+  it("does not include main session history", () => {
+    const prompt = buildIsolatedHeartbeatPrompt({
+      heartbeatMd: "Simple check",
+    });
+    // Verify minimal prompt - no skills, no history references
+    expect(prompt).not.toContain("skills");
+    expect(prompt.length).toBeLessThan(1000);
+  });
+});
+
+describe("heartbeatNeedsAction", () => {
+  it("returns false for HEARTBEAT_OK", () => {
+    expect(heartbeatNeedsAction("HEARTBEAT_OK")).toBe(false);
+  });
+
+  it("returns false for HEARTBEAT_OK with short suffix", () => {
+    expect(heartbeatNeedsAction("HEARTBEAT_OK - all clear")).toBe(false);
+  });
+
+  it("returns true for non-OK response", () => {
+    expect(heartbeatNeedsAction("Found 3 new emails that need attention.")).toBe(true);
+  });
+
+  it("returns false for empty response", () => {
+    expect(heartbeatNeedsAction("")).toBe(false);
+    expect(heartbeatNeedsAction("   ")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(heartbeatNeedsAction("heartbeat_ok")).toBe(false);
+    expect(heartbeatNeedsAction("Heartbeat_OK")).toBe(false);
+  });
+
+  it("returns true when HEARTBEAT_OK has long suffix", () => {
+    expect(
+      heartbeatNeedsAction(
+        "HEARTBEAT_OK but actually there are important updates that need your attention",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("buildHeartbeatAnnouncement", () => {
+  it("includes session key and response", () => {
+    const announcement = buildHeartbeatAnnouncement({
+      heartbeatResponse: "Found 3 new emails",
+      sessionKey: "main",
+    });
+    expect(announcement).toContain("main");
+    expect(announcement).toContain("Found 3 new emails");
+    expect(announcement).toContain("Heartbeat action needed");
+  });
+});
+
+describe("isHeartbeatSession", () => {
+  it("identifies heartbeat sessions", () => {
+    expect(isHeartbeatSession("agent:main:heartbeat")).toBe(true);
+    expect(isHeartbeatSession("heartbeat:check")).toBe(true);
+  });
+
+  it("rejects non-heartbeat sessions", () => {
+    expect(isHeartbeatSession("agent:main")).toBe(false);
+    expect(isHeartbeatSession("cron:daily-check")).toBe(false);
+  });
+});

--- a/src/agents/heartbeat-isolation.ts
+++ b/src/agents/heartbeat-isolation.ts
@@ -1,0 +1,131 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agent/heartbeat-isolation");
+
+export type HeartbeatIsolationConfig = {
+  /** Run heartbeats in isolated micro-sessions without full session context. */
+  isolated: boolean;
+  /** Model to use for heartbeat runs. */
+  model: string;
+  /** Max tokens for heartbeat response. */
+  maxTokens: number;
+};
+
+const DEFAULT_CONFIG: HeartbeatIsolationConfig = {
+  isolated: true,
+  model: "anthropic/claude-haiku",
+  maxTokens: 2000,
+};
+
+export function resolveHeartbeatIsolationConfig(cfg?: OpenClawConfig): HeartbeatIsolationConfig {
+  const heartbeat = cfg?.agents?.defaults?.heartbeat as Record<string, unknown> | undefined;
+  if (!heartbeat) {
+    return DEFAULT_CONFIG;
+  }
+
+  return {
+    isolated:
+      typeof heartbeat.isolated === "boolean" ? heartbeat.isolated : DEFAULT_CONFIG.isolated,
+    model: typeof heartbeat.model === "string" ? heartbeat.model : DEFAULT_CONFIG.model,
+    maxTokens:
+      typeof heartbeat.maxTokens === "number" ? heartbeat.maxTokens : DEFAULT_CONFIG.maxTokens,
+  };
+}
+
+/**
+ * Build a minimal system prompt for isolated heartbeat sessions.
+ * Includes only HEARTBEAT.md content and essential context.
+ * No skills, no full conversation history.
+ */
+export function buildIsolatedHeartbeatPrompt(params: {
+  heartbeatMd?: string;
+  agentId?: string;
+  workspaceDir?: string;
+  userTimezone?: string;
+  currentTime?: string;
+}): string {
+  const sections: string[] = [];
+
+  sections.push("You are running a periodic heartbeat check.");
+  sections.push("This is an isolated micro-session with minimal context.");
+  sections.push("If an action is needed, use sessions_send to announce back to the main session.");
+
+  if (params.agentId) {
+    sections.push(`\nAgent: ${params.agentId}`);
+  }
+  if (params.workspaceDir) {
+    sections.push(`Workspace: ${params.workspaceDir}`);
+  }
+  if (params.currentTime) {
+    sections.push(`Current time: ${params.currentTime}`);
+  }
+  if (params.userTimezone) {
+    sections.push(`Timezone: ${params.userTimezone}`);
+  }
+
+  if (params.heartbeatMd?.trim()) {
+    sections.push("\n## HEARTBEAT.md\n");
+    sections.push(params.heartbeatMd.trim());
+  } else {
+    sections.push("\nNo HEARTBEAT.md found. Reply HEARTBEAT_OK if nothing needs attention.");
+  }
+
+  return sections.join("\n");
+}
+
+/**
+ * Determine if a heartbeat response indicates action is needed
+ * (i.e., should announce back to main session).
+ */
+export function heartbeatNeedsAction(response: string): boolean {
+  const trimmed = response.trim().toUpperCase();
+  // If the response is just HEARTBEAT_OK (optionally with minimal trailing text),
+  // no action is needed.
+  if (trimmed === "HEARTBEAT_OK" || trimmed.startsWith("HEARTBEAT_OK")) {
+    const afterOk = trimmed.slice("HEARTBEAT_OK".length).trim();
+    // Allow small acknowledgment text (under 30 chars)
+    if (afterOk.length <= 30) {
+      return false;
+    }
+  }
+  return trimmed.length > 0;
+}
+
+/**
+ * Build the announce-back message for a heartbeat that needs action.
+ */
+export function buildHeartbeatAnnouncement(params: {
+  heartbeatResponse: string;
+  sessionKey: string;
+}): string {
+  return (
+    `[Heartbeat action needed]\n` +
+    `Session: ${params.sessionKey}\n\n` +
+    `${params.heartbeatResponse}`
+  );
+}
+
+/**
+ * Check if a session key represents a heartbeat session.
+ */
+export function isHeartbeatSession(sessionKey: string): boolean {
+  return sessionKey.includes(":heartbeat") || sessionKey.includes("heartbeat:");
+}
+
+/**
+ * Log heartbeat isolation decision.
+ */
+export function logHeartbeatIsolation(params: {
+  sessionKey: string;
+  isolated: boolean;
+  model: string;
+}): void {
+  if (params.isolated) {
+    log.info(
+      `heartbeat running in isolated mode: session=${params.sessionKey} model=${params.model}`,
+    );
+  } else {
+    log.debug(`heartbeat running in standard mode: session=${params.sessionKey}`);
+  }
+}

--- a/src/agents/heartbeat-isolation.ts
+++ b/src/agents/heartbeat-isolation.ts
@@ -99,11 +99,7 @@ export function buildHeartbeatAnnouncement(params: {
   heartbeatResponse: string;
   sessionKey: string;
 }): string {
-  return (
-    `[Heartbeat action needed]\n` +
-    `Session: ${params.sessionKey}\n\n` +
-    `${params.heartbeatResponse}`
-  );
+  return `[Heartbeat action needed]\nSession: ${params.sessionKey}\n\n${params.heartbeatResponse}`;
 }
 
 /**

--- a/src/agents/memory-flush-default.test.ts
+++ b/src/agents/memory-flush-default.test.ts
@@ -1,0 +1,254 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  DEFAULT_FLUSH_PROMPT,
+  isNoFlushResponse,
+  listMemoryFiles,
+  loadRecentMemories,
+  readMemoryFile,
+  resolveMemoryFilePath,
+  resolveMemoryFlushDefaultConfig,
+  shouldFlushMemory,
+  writeMemoryFlush,
+} from "./memory-flush-default.js";
+
+const tmpDir = path.join(os.tmpdir(), `openclaw-memory-test-${Date.now()}`);
+
+beforeAll(async () => {
+  await fs.mkdir(tmpDir, { recursive: true });
+});
+
+afterAll(async () => {
+  try {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe("resolveMemoryFlushDefaultConfig", () => {
+  it("returns defaults", () => {
+    const config = resolveMemoryFlushDefaultConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.threshold).toBe(0.5);
+    expect(config.model).toBe("anthropic/claude-haiku");
+  });
+});
+
+describe("shouldFlushMemory", () => {
+  const config = resolveMemoryFlushDefaultConfig();
+
+  it("triggers when above threshold", () => {
+    expect(
+      shouldFlushMemory({
+        totalTokens: 60_000,
+        contextWindowTokens: 100_000,
+        config,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not trigger when below threshold", () => {
+    expect(
+      shouldFlushMemory({
+        totalTokens: 40_000,
+        contextWindowTokens: 100_000,
+        config,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger when disabled", () => {
+    expect(
+      shouldFlushMemory({
+        totalTokens: 90_000,
+        contextWindowTokens: 100_000,
+        config: { ...config, enabled: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger with zero tokens", () => {
+    expect(
+      shouldFlushMemory({
+        totalTokens: 0,
+        contextWindowTokens: 100_000,
+        config,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips if recently flushed with insufficient gain", () => {
+    expect(
+      shouldFlushMemory({
+        totalTokens: 55_000,
+        contextWindowTokens: 100_000,
+        config,
+        lastFlushTokens: 52_000, // Only 3k tokens gained, need 10k (10%)
+      }),
+    ).toBe(false);
+  });
+
+  it("flushes again after sufficient gain", () => {
+    expect(
+      shouldFlushMemory({
+        totalTokens: 70_000,
+        contextWindowTokens: 100_000,
+        config,
+        lastFlushTokens: 50_000, // 20k tokens gained, above 10k threshold
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isNoFlushResponse", () => {
+  it("detects NO_FLUSH", () => {
+    expect(isNoFlushResponse("NO_FLUSH")).toBe(true);
+    expect(isNoFlushResponse("  NO_FLUSH  ")).toBe(true);
+    expect(isNoFlushResponse("no_flush")).toBe(true);
+  });
+
+  it("rejects real content", () => {
+    expect(isNoFlushResponse("User decided to use TypeScript")).toBe(false);
+    expect(isNoFlushResponse("Key decision: migrate to PostgreSQL")).toBe(false);
+  });
+});
+
+describe("resolveMemoryFilePath", () => {
+  it("generates date-based path", () => {
+    const date = new Date(2025, 0, 15);
+    const filePath = resolveMemoryFilePath("/memory", date);
+    expect(filePath).toBe("/memory/2025-01-15.md");
+  });
+
+  it("pads month and day", () => {
+    const date = new Date(2025, 2, 5);
+    const filePath = resolveMemoryFilePath("/memory", date);
+    expect(filePath).toBe("/memory/2025-03-05.md");
+  });
+});
+
+describe("writeMemoryFlush", () => {
+  it("writes memory to file", async () => {
+    const memoryDir = path.join(tmpDir, "write-test");
+    const result = await writeMemoryFlush({
+      content: "User prefers TypeScript over JavaScript.",
+      memoryDir,
+      date: new Date(2025, 0, 1),
+    });
+    expect(result.written).toBe(true);
+    expect(result.filePath).toContain("2025-01-01.md");
+
+    const content = await fs.readFile(result.filePath, "utf8");
+    expect(content).toContain("User prefers TypeScript");
+    expect(content).toContain("Flushed at");
+  });
+
+  it("skips NO_FLUSH responses", async () => {
+    const memoryDir = path.join(tmpDir, "nofflush-test");
+    const result = await writeMemoryFlush({
+      content: "NO_FLUSH",
+      memoryDir,
+    });
+    expect(result.written).toBe(false);
+  });
+
+  it("appends to existing files", async () => {
+    const memoryDir = path.join(tmpDir, "append-test");
+    const date = new Date(2025, 5, 15);
+
+    await writeMemoryFlush({
+      content: "First entry",
+      memoryDir,
+      date,
+    });
+    await writeMemoryFlush({
+      content: "Second entry",
+      memoryDir,
+      date,
+    });
+
+    const filePath = resolveMemoryFilePath(memoryDir, date);
+    const content = await fs.readFile(filePath, "utf8");
+    expect(content).toContain("First entry");
+    expect(content).toContain("Second entry");
+  });
+});
+
+describe("listMemoryFiles", () => {
+  it("lists memory files sorted by date (newest first)", async () => {
+    const memoryDir = path.join(tmpDir, "list-test");
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(path.join(memoryDir, "2025-01-01.md"), "old");
+    await fs.writeFile(path.join(memoryDir, "2025-03-15.md"), "new");
+    await fs.writeFile(path.join(memoryDir, "not-a-memory.txt"), "ignore");
+
+    const files = await listMemoryFiles(memoryDir);
+    expect(files).toHaveLength(2);
+    expect(files[0].name).toBe("2025-03-15.md");
+    expect(files[1].name).toBe("2025-01-01.md");
+  });
+
+  it("returns empty for non-existent directory", async () => {
+    const files = await listMemoryFiles("/nonexistent/path");
+    expect(files).toEqual([]);
+  });
+});
+
+describe("loadRecentMemories", () => {
+  it("loads recent memory entries", async () => {
+    const memoryDir = path.join(tmpDir, "load-test");
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(path.join(memoryDir, "2025-01-01.md"), "Day 1 memories");
+    await fs.writeFile(path.join(memoryDir, "2025-01-02.md"), "Day 2 memories");
+
+    const result = await loadRecentMemories({ memoryDir, maxDays: 7 });
+    expect(result).toContain("Recent Memories");
+    expect(result).toContain("Day 1 memories");
+    expect(result).toContain("Day 2 memories");
+  });
+
+  it("returns empty string for no memories", async () => {
+    const result = await loadRecentMemories({
+      memoryDir: "/nonexistent/path",
+    });
+    expect(result).toBe("");
+  });
+
+  it("respects maxChars limit", async () => {
+    const memoryDir = path.join(tmpDir, "maxchars-test");
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(path.join(memoryDir, "2025-01-01.md"), "x".repeat(5000));
+
+    const result = await loadRecentMemories({
+      memoryDir,
+      maxDays: 7,
+      maxChars: 100,
+    });
+    expect(result.length).toBeLessThan(300); // header + truncated content
+  });
+});
+
+describe("readMemoryFile and deleteMemoryFile", () => {
+  it("reads existing file", async () => {
+    const filePath = path.join(tmpDir, "read-test.md");
+    await fs.writeFile(filePath, "test content");
+    const content = await readMemoryFile(filePath);
+    expect(content).toBe("test content");
+  });
+
+  it("returns null for missing file", async () => {
+    const content = await readMemoryFile("/nonexistent/file.md");
+    expect(content).toBeNull();
+  });
+});
+
+describe("DEFAULT_FLUSH_PROMPT", () => {
+  it("includes key extraction instructions", () => {
+    expect(DEFAULT_FLUSH_PROMPT).toContain("decisions");
+    expect(DEFAULT_FLUSH_PROMPT).toContain("action items");
+    expect(DEFAULT_FLUSH_PROMPT).toContain("NO_FLUSH");
+  });
+});

--- a/src/agents/memory-flush-default.test.ts
+++ b/src/agents/memory-flush-default.test.ts
@@ -120,13 +120,13 @@ describe("resolveMemoryFilePath", () => {
   it("generates date-based path", () => {
     const date = new Date(2025, 0, 15);
     const filePath = resolveMemoryFilePath("/memory", date);
-    expect(filePath).toBe("/memory/2025-01-15.md");
+    expect(filePath).toBe(path.join("/memory", "2025-01-15.md"));
   });
 
   it("pads month and day", () => {
     const date = new Date(2025, 2, 5);
     const filePath = resolveMemoryFilePath("/memory", date);
-    expect(filePath).toBe("/memory/2025-03-05.md");
+    expect(filePath).toBe(path.join("/memory", "2025-03-05.md"));
   });
 });
 

--- a/src/agents/memory-flush-default.test.ts
+++ b/src/agents/memory-flush-default.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   DEFAULT_FLUSH_PROMPT,
   isNoFlushResponse,
-  listMemoryFiles,
+  listFlushMemoryFiles,
   loadRecentMemories,
   readMemoryFile,
   resolveMemoryFilePath,
@@ -177,7 +177,7 @@ describe("writeMemoryFlush", () => {
   });
 });
 
-describe("listMemoryFiles", () => {
+describe("listFlushMemoryFiles", () => {
   it("lists memory files sorted by date (newest first)", async () => {
     const memoryDir = path.join(tmpDir, "list-test");
     await fs.mkdir(memoryDir, { recursive: true });
@@ -185,14 +185,14 @@ describe("listMemoryFiles", () => {
     await fs.writeFile(path.join(memoryDir, "2025-03-15.md"), "new");
     await fs.writeFile(path.join(memoryDir, "not-a-memory.txt"), "ignore");
 
-    const files = await listMemoryFiles(memoryDir);
+    const files = await listFlushMemoryFiles(memoryDir);
     expect(files).toHaveLength(2);
     expect(files[0].name).toBe("2025-03-15.md");
     expect(files[1].name).toBe("2025-01-01.md");
   });
 
   it("returns empty for non-existent directory", async () => {
-    const files = await listMemoryFiles("/nonexistent/path");
+    const files = await listFlushMemoryFiles("/nonexistent/path");
     expect(files).toEqual([]);
   });
 });

--- a/src/agents/memory-flush-default.ts
+++ b/src/agents/memory-flush-default.ts
@@ -1,0 +1,241 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agent/memory-flush-default");
+
+export type MemoryFlushDefaultConfig = {
+  /** Enable memory flush at context threshold (default: true). */
+  enabled: boolean;
+  /** Context usage ratio to trigger flush (0-1, default: 0.50). */
+  threshold: number;
+  /** Model to use for flush operations. */
+  model: string;
+  /** Directory for memory files. */
+  memoryDir: string;
+};
+
+const DEFAULT_CONFIG: MemoryFlushDefaultConfig = {
+  enabled: true,
+  threshold: 0.5,
+  model: "anthropic/claude-haiku",
+  memoryDir: path.join(os.homedir(), ".openclaw", "workspace", "memory"),
+};
+
+export function resolveMemoryFlushDefaultConfig(cfg?: OpenClawConfig): MemoryFlushDefaultConfig {
+  const flush = cfg?.agents?.defaults?.compaction?.memoryFlush as
+    | Record<string, unknown>
+    | undefined;
+  if (!flush) {
+    return DEFAULT_CONFIG;
+  }
+
+  return {
+    enabled: typeof flush.enabled === "boolean" ? flush.enabled : DEFAULT_CONFIG.enabled,
+    threshold:
+      typeof flush.threshold === "number"
+        ? Math.max(0.1, Math.min(0.95, flush.threshold))
+        : DEFAULT_CONFIG.threshold,
+    model: typeof flush.model === "string" ? flush.model : DEFAULT_CONFIG.model,
+    memoryDir: typeof flush.memoryDir === "string" ? flush.memoryDir : DEFAULT_CONFIG.memoryDir,
+  };
+}
+
+/**
+ * Check if memory flush should trigger based on context usage.
+ */
+export function shouldFlushMemory(params: {
+  totalTokens: number;
+  contextWindowTokens: number;
+  config: MemoryFlushDefaultConfig;
+  lastFlushTokens?: number;
+}): boolean {
+  const { totalTokens, contextWindowTokens, config, lastFlushTokens } = params;
+
+  if (!config.enabled) {
+    return false;
+  }
+  if (contextWindowTokens <= 0 || totalTokens <= 0) {
+    return false;
+  }
+
+  const usage = totalTokens / contextWindowTokens;
+  if (usage < config.threshold) {
+    return false;
+  }
+
+  // Don't flush again if we already flushed and haven't gained significant context
+  if (lastFlushTokens !== undefined && lastFlushTokens > 0) {
+    const tokensSinceFlush = totalTokens - lastFlushTokens;
+    const minGain = contextWindowTokens * 0.1; // At least 10% new context
+    if (tokensSinceFlush < minGain) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Default flush prompt for extracting memories.
+ */
+export const DEFAULT_FLUSH_PROMPT =
+  "Extract key decisions, action items, preferences, facts, state changes. " +
+  "Skip routine exchanges. Respond NO_FLUSH if nothing worth saving.";
+
+/**
+ * Build the memory file path for today's date.
+ */
+export function resolveMemoryFilePath(memoryDir: string, date?: Date): string {
+  const d = date ?? new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return path.join(memoryDir, `${yyyy}-${mm}-${dd}.md`);
+}
+
+/**
+ * Write memory content to the daily memory file.
+ * Appends to existing file if present.
+ */
+export async function writeMemoryFlush(params: {
+  content: string;
+  memoryDir: string;
+  date?: Date;
+}): Promise<{ filePath: string; written: boolean }> {
+  const { content, memoryDir } = params;
+  const trimmed = content.trim();
+
+  // Check for NO_FLUSH response
+  if (isNoFlushResponse(trimmed)) {
+    log.info("memory flush returned NO_FLUSH, skipping write");
+    return { filePath: "", written: false };
+  }
+
+  const filePath = resolveMemoryFilePath(memoryDir, params.date);
+
+  try {
+    await fs.mkdir(memoryDir, { recursive: true });
+
+    const timestamp = new Date().toISOString();
+    const entry = `\n---\n_Flushed at ${timestamp}_\n\n${trimmed}\n`;
+
+    await fs.appendFile(filePath, entry, "utf8");
+    log.info(`memory flushed to ${filePath} (${trimmed.length} chars)`);
+    return { filePath, written: true };
+  } catch (err) {
+    log.warn(`failed to write memory flush: ${err instanceof Error ? err.message : err}`);
+    return { filePath, written: false };
+  }
+}
+
+/**
+ * Check if the flush response indicates nothing to save.
+ */
+export function isNoFlushResponse(response: string): boolean {
+  const upper = response.trim().toUpperCase();
+  return upper === "NO_FLUSH" || upper.startsWith("NO_FLUSH");
+}
+
+/**
+ * List memory files in the memory directory.
+ */
+export async function listMemoryFiles(
+  memoryDir: string,
+): Promise<Array<{ name: string; path: string; size: number }>> {
+  try {
+    const entries = await fs.readdir(memoryDir, { withFileTypes: true });
+    const files: Array<{ name: string; path: string; size: number }> = [];
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) {
+        continue;
+      }
+      const filePath = path.join(memoryDir, entry.name);
+      const stat = await fs.stat(filePath);
+      files.push({
+        name: entry.name,
+        path: filePath,
+        size: stat.size,
+      });
+    }
+
+    return files.toSorted((a, b) => b.name.localeCompare(a.name)); // Most recent first
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Delete a specific memory file.
+ */
+export async function deleteMemoryFile(filePath: string): Promise<boolean> {
+  try {
+    // Security: only allow deleting from memory directory
+    const expectedDir = path.join(os.homedir(), ".openclaw");
+    const resolved = path.resolve(filePath);
+    if (!resolved.startsWith(expectedDir)) {
+      log.warn(`refused to delete file outside .openclaw: ${filePath}`);
+      return false;
+    }
+    await fs.unlink(resolved);
+    log.info(`deleted memory file: ${filePath}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a memory file's content.
+ */
+export async function readMemoryFile(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load recent memory entries for injection into future sessions.
+ * Reads the most recent N days of memory files.
+ */
+export async function loadRecentMemories(params: {
+  memoryDir: string;
+  maxDays?: number;
+  maxChars?: number;
+}): Promise<string> {
+  const { memoryDir, maxDays = 7, maxChars = 4000 } = params;
+  const files = await listMemoryFiles(memoryDir);
+
+  if (files.length === 0) {
+    return "";
+  }
+
+  const recentFiles = files.slice(0, maxDays);
+  const parts: string[] = [];
+  let totalChars = 0;
+
+  for (const file of recentFiles) {
+    if (totalChars >= maxChars) {
+      break;
+    }
+    const content = await readMemoryFile(file.path);
+    if (!content) {
+      continue;
+    }
+    const remaining = maxChars - totalChars;
+    const trimmed = content.length > remaining ? content.slice(0, remaining) + "\n..." : content;
+    parts.push(`## ${file.name}\n${trimmed}`);
+    totalChars += trimmed.length;
+  }
+
+  if (parts.length === 0) {
+    return "";
+  }
+
+  return `# Recent Memories\n\n${parts.join("\n\n")}`;
+}

--- a/src/agents/memory-flush-default.ts
+++ b/src/agents/memory-flush-default.ts
@@ -126,7 +126,7 @@ export async function writeMemoryFlush(params: {
     log.info(`memory flushed to ${filePath} (${trimmed.length} chars)`);
     return { filePath, written: true };
   } catch (err) {
-    log.warn(`failed to write memory flush: ${err instanceof Error ? err.message : err}`);
+    log.warn(`failed to write memory flush: ${err instanceof Error ? err.message : String(err)}`);
     return { filePath, written: false };
   }
 }
@@ -142,7 +142,7 @@ export function isNoFlushResponse(response: string): boolean {
 /**
  * List memory files in the memory directory.
  */
-export async function listMemoryFiles(
+export async function listFlushMemoryFiles(
   memoryDir: string,
 ): Promise<Array<{ name: string; path: string; size: number }>> {
   try {
@@ -209,7 +209,7 @@ export async function loadRecentMemories(params: {
   maxChars?: number;
 }): Promise<string> {
   const { memoryDir, maxDays = 7, maxChars = 4000 } = params;
-  const files = await listMemoryFiles(memoryDir);
+  const files = await listFlushMemoryFiles(memoryDir);
 
   if (files.length === 0) {
     return "";

--- a/src/agents/model-routing.test.ts
+++ b/src/agents/model-routing.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { classifyComplexity, resolveModelRoutingConfig, routeMessage } from "./model-routing.js";
+
+describe("resolveModelRoutingConfig", () => {
+  it("returns defaults with enabled=false", () => {
+    const config = resolveModelRoutingConfig();
+    expect(config.enabled).toBe(false);
+    expect(config.models.simple).toBe("anthropic/claude-haiku");
+    expect(config.models.medium).toBe("anthropic/claude-sonnet-4-5");
+    expect(config.models.complex).toBe("anthropic/claude-opus-4-6");
+    expect(config.opusPlanMode).toBe(false);
+  });
+
+  it("respects explicit config", () => {
+    const config = resolveModelRoutingConfig({
+      agents: {
+        defaults: {
+          modelRouting: {
+            enabled: true,
+            opusPlanMode: true,
+            models: {
+              simple: "openai/gpt-5-mini",
+            },
+          },
+        },
+      },
+    } as never);
+    expect(config.enabled).toBe(true);
+    expect(config.opusPlanMode).toBe(true);
+    expect(config.models.simple).toBe("openai/gpt-5-mini");
+    // Others should still be defaults
+    expect(config.models.medium).toBe("anthropic/claude-sonnet-4-5");
+  });
+});
+
+describe("classifyComplexity", () => {
+  describe("simple messages", () => {
+    it("classifies greetings as simple", () => {
+      expect(classifyComplexity("hi")).toBe("simple");
+      expect(classifyComplexity("hello")).toBe("simple");
+      expect(classifyComplexity("hey")).toBe("simple");
+      expect(classifyComplexity("good morning")).toBe("simple");
+      expect(classifyComplexity("What's up")).toBe("simple");
+    });
+
+    it("classifies status checks as simple", () => {
+      expect(classifyComplexity("status")).toBe("simple");
+      expect(classifyComplexity("how are you")).toBe("simple");
+      expect(classifyComplexity("are you there")).toBe("simple");
+    });
+
+    it("classifies commands as simple", () => {
+      expect(classifyComplexity("/help")).toBe("simple");
+      expect(classifyComplexity("/version")).toBe("simple");
+      expect(classifyComplexity("/model")).toBe("simple");
+    });
+
+    it("classifies very short messages as simple", () => {
+      expect(classifyComplexity("ok")).toBe("simple");
+      expect(classifyComplexity("yes")).toBe("simple");
+      expect(classifyComplexity("thanks")).toBe("simple");
+    });
+
+    it("classifies empty messages as simple", () => {
+      expect(classifyComplexity("")).toBe("simple");
+      expect(classifyComplexity("  ")).toBe("simple");
+    });
+  });
+
+  describe("complex messages", () => {
+    it("classifies multi-step requests as complex", () => {
+      expect(
+        classifyComplexity(
+          "First search for all TypeScript files, then update the imports, finally run the tests",
+        ),
+      ).toBe("complex");
+    });
+
+    it("classifies planning requests as complex", () => {
+      expect(classifyComplexity("Plan the architecture for a new microservice system")).toBe(
+        "complex",
+      );
+      expect(classifyComplexity("Refactor the entire authentication module")).toBe("complex");
+    });
+
+    it("classifies multi-tool requests as complex", () => {
+      expect(classifyComplexity("Search for all usages of deprecated API and fix them")).toBe(
+        "complex",
+      );
+    });
+
+    it("classifies long multi-sentence messages as complex", () => {
+      const longMessage =
+        "I need you to review the pull request. Check the code quality. " +
+        "Look for security vulnerabilities. Verify the test coverage. " +
+        "Make sure the documentation is updated. Run the full test suite.";
+      expect(classifyComplexity(longMessage)).toBe("complex");
+    });
+  });
+
+  describe("medium messages", () => {
+    it("classifies normal requests as medium", () => {
+      expect(classifyComplexity("What does the function calculateTotal do?")).toBe("medium");
+      expect(classifyComplexity("Show me the contents of package.json")).toBe("medium");
+    });
+  });
+});
+
+describe("routeMessage", () => {
+  const config = resolveModelRoutingConfig();
+
+  it("routes simple messages to haiku", () => {
+    const result = routeMessage({ message: "hi", config });
+    expect(result.complexity).toBe("simple");
+    expect(result.model).toBe("anthropic/claude-haiku");
+    expect(result.overridden).toBe(false);
+  });
+
+  it("routes complex messages to opus", () => {
+    const result = routeMessage({
+      message: "Plan the architecture for a new real-time notification system",
+      config,
+    });
+    expect(result.complexity).toBe("complex");
+    expect(result.model).toBe("anthropic/claude-opus-4-6");
+    expect(result.overridden).toBe(false);
+  });
+
+  it("routes medium messages to sonnet", () => {
+    const result = routeMessage({
+      message: "What does this function do?",
+      config,
+    });
+    expect(result.complexity).toBe("medium");
+    expect(result.model).toBe("anthropic/claude-sonnet-4-5");
+    expect(result.overridden).toBe(false);
+  });
+
+  it("explicit override takes precedence", () => {
+    const result = routeMessage({
+      message: "hi",
+      config,
+      explicitModelOverride: "google/gemini-3-pro-preview",
+    });
+    expect(result.model).toBe("google/gemini-3-pro-preview");
+    expect(result.overridden).toBe(true);
+  });
+
+  it("opus plan mode routes thinking to opus", () => {
+    const planConfig = { ...config, opusPlanMode: true };
+    const result = routeMessage({
+      message: "What does this do?",
+      config: planConfig,
+      isThinkingMode: true,
+    });
+    expect(result.model).toBe("anthropic/claude-opus-4-6");
+    expect(result.reason).toContain("plan mode");
+  });
+
+  it("opus plan mode does not affect non-thinking messages", () => {
+    const planConfig = { ...config, opusPlanMode: true };
+    const result = routeMessage({
+      message: "hi",
+      config: planConfig,
+      isThinkingMode: false,
+    });
+    expect(result.model).toBe("anthropic/claude-haiku");
+  });
+});

--- a/src/agents/model-routing.ts
+++ b/src/agents/model-routing.ts
@@ -1,0 +1,187 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agent/model-routing");
+
+export type ComplexityLevel = "simple" | "medium" | "complex";
+
+export type ModelRoutingConfig = {
+  /** Enable automatic model routing (default: false, opt-in). */
+  enabled: boolean;
+  /** Model tier mappings. */
+  models: {
+    simple: string;
+    medium: string;
+    complex: string;
+  };
+  /** Use Opus for plan/think mode, Sonnet for execution. */
+  opusPlanMode: boolean;
+};
+
+const DEFAULT_CONFIG: ModelRoutingConfig = {
+  enabled: false,
+  models: {
+    simple: "anthropic/claude-haiku",
+    medium: "anthropic/claude-sonnet-4-5",
+    complex: "anthropic/claude-opus-4-6",
+  },
+  opusPlanMode: false,
+};
+
+export function resolveModelRoutingConfig(cfg?: OpenClawConfig): ModelRoutingConfig {
+  const raw = cfg?.agents?.defaults as Record<string, unknown> | undefined;
+  const routing = raw?.modelRouting as Record<string, unknown> | undefined;
+
+  if (!routing) {
+    return DEFAULT_CONFIG;
+  }
+
+  const models = routing.models as Record<string, string> | undefined;
+
+  return {
+    enabled: typeof routing.enabled === "boolean" ? routing.enabled : DEFAULT_CONFIG.enabled,
+    models: {
+      simple: typeof models?.simple === "string" ? models.simple : DEFAULT_CONFIG.models.simple,
+      medium: typeof models?.medium === "string" ? models.medium : DEFAULT_CONFIG.models.medium,
+      complex: typeof models?.complex === "string" ? models.complex : DEFAULT_CONFIG.models.complex,
+    },
+    opusPlanMode:
+      typeof routing.opusPlanMode === "boolean"
+        ? routing.opusPlanMode
+        : DEFAULT_CONFIG.opusPlanMode,
+  };
+}
+
+// --- Simple message patterns ---
+
+const GREETING_PATTERNS =
+  /^(hi|hello|hey|yo|sup|good\s+(morning|afternoon|evening|night)|howdy|hola|what'?s\s+up)\b/i;
+
+const STATUS_CHECK_PATTERNS =
+  /^(status|how\s+are\s+you|what('?re|\s+are)\s+you\s+doing|are\s+you\s+(there|online|awake))\b/i;
+
+const SIMPLE_COMMAND_PATTERNS = /^\/?(help|version|model|think|compact|memory|verbose|status)\b/i;
+
+// --- Complex message patterns ---
+
+const MULTI_STEP_PATTERNS =
+  /\b(step\s+\d|first.+then.+finally|multi-?step|multiple\s+(files?|tasks?|changes?))\b/i;
+
+const PLANNING_PATTERNS =
+  /\b(plan|architect|design|refactor|restructure|implement.+feature|build.+system|create.+from\s+scratch)\b/i;
+
+const MULTI_TOOL_PATTERNS =
+  /\b(search.+and.+(edit|replace|modify|fix|update)|read.+and.+(write|create)|find.+and.+(fix|update|replace))\b/i;
+
+/**
+ * Classify message complexity using rule-based heuristics.
+ * No LLM call required.
+ */
+export function classifyComplexity(message: string): ComplexityLevel {
+  const trimmed = message.trim();
+
+  // Empty messages are simple
+  if (trimmed.length === 0) {
+    return "simple";
+  }
+
+  // Token count estimate (rough: words * 1.3)
+  const wordCount = trimmed.split(/\s+/).length;
+  const estimatedTokens = Math.ceil(wordCount * 1.3);
+
+  // Check for complex patterns FIRST (before short-circuiting on length)
+  if (MULTI_STEP_PATTERNS.test(trimmed)) {
+    return "complex";
+  }
+  if (PLANNING_PATTERNS.test(trimmed)) {
+    return "complex";
+  }
+  if (MULTI_TOOL_PATTERNS.test(trimmed)) {
+    return "complex";
+  }
+
+  // Long messages with multiple sentences tend to be complex
+  const sentenceCount = trimmed.split(/[.!?]+/).filter((s) => s.trim().length > 0).length;
+  if (sentenceCount >= 4 && estimatedTokens > 30) {
+    return "complex";
+  }
+
+  // Short messages (< 50 tokens) with simple patterns
+  if (estimatedTokens < 50) {
+    if (GREETING_PATTERNS.test(trimmed)) {
+      return "simple";
+    }
+    if (STATUS_CHECK_PATTERNS.test(trimmed)) {
+      return "simple";
+    }
+    if (SIMPLE_COMMAND_PATTERNS.test(trimmed)) {
+      return "simple";
+    }
+  }
+
+  // Very short messages (< 5 words) default to simple
+  if (wordCount < 5) {
+    return "simple";
+  }
+
+  // Default to medium
+  return "medium";
+}
+
+export type RoutingDecision = {
+  model: string;
+  complexity: ComplexityLevel;
+  reason: string;
+  overridden: boolean;
+};
+
+/**
+ * Route a message to the appropriate model based on complexity.
+ *
+ * Priority:
+ * 1. Explicit /model override (always wins)
+ * 2. Opus plan mode (if enabled and thinking/planning)
+ * 3. Automatic complexity classification
+ */
+export function routeMessage(params: {
+  message: string;
+  config: ModelRoutingConfig;
+  explicitModelOverride?: string;
+  isThinkingMode?: boolean;
+}): RoutingDecision {
+  const { message, config, explicitModelOverride, isThinkingMode } = params;
+
+  // Explicit override always takes precedence
+  if (explicitModelOverride) {
+    return {
+      model: explicitModelOverride,
+      complexity: "medium",
+      reason: "explicit model override",
+      overridden: true,
+    };
+  }
+
+  // Opus plan mode: use Opus for thinking, Sonnet for execution
+  if (config.opusPlanMode && isThinkingMode) {
+    return {
+      model: config.models.complex,
+      complexity: "complex",
+      reason: "opus plan mode (thinking/planning)",
+      overridden: false,
+    };
+  }
+
+  const complexity = classifyComplexity(message);
+  const model = config.models[complexity];
+
+  log.info(
+    `routing decision: complexity=${complexity} model=${model} message_preview="${message.slice(0, 50)}"`,
+  );
+
+  return {
+    model,
+    complexity,
+    reason: `auto-classified as ${complexity}`,
+    overridden: false,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -44,6 +44,7 @@ import {
 } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools } from "../../pi-tools.js";
+import { createPromptCachingWrapper, resolvePromptCachingConfig } from "../../prompt-caching.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
@@ -524,6 +525,15 @@ export async function runEmbeddedAttempt(
         params.modelId,
         params.streamParams,
       );
+
+      // Apply Anthropic prompt caching breakpoints
+      const promptCachingConfig = resolvePromptCachingConfig(params.config);
+      if (promptCachingConfig.enabled) {
+        activeSession.agent.streamFn = createPromptCachingWrapper(
+          activeSession.agent.streamFn,
+          promptCachingConfig,
+        );
+      }
 
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -59,6 +59,7 @@ import {
 } from "../../skills.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
+import { createTokenEfficientToolsWrapper } from "../../token-efficient-tools.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -534,6 +535,9 @@ export async function runEmbeddedAttempt(
           promptCachingConfig,
         );
       }
+
+      // Apply token-efficient tool use beta header for Anthropic
+      activeSession.agent.streamFn = createTokenEfficientToolsWrapper(activeSession.agent.streamFn);
 
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {

--- a/src/agents/prompt-caching.test.ts
+++ b/src/agents/prompt-caching.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+  addCacheBreakpoint,
+  extractCacheMetrics,
+  injectCacheBreakpoints,
+  resolvePromptCachingConfig,
+} from "./prompt-caching.js";
+
+describe("resolvePromptCachingConfig", () => {
+  it("defaults to enabled", () => {
+    expect(resolvePromptCachingConfig().enabled).toBe(true);
+    expect(resolvePromptCachingConfig({}).enabled).toBe(true);
+  });
+
+  it("respects explicit config", () => {
+    expect(
+      resolvePromptCachingConfig({
+        agents: { defaults: { promptCaching: { enabled: false } } },
+      }).enabled,
+    ).toBe(false);
+
+    expect(
+      resolvePromptCachingConfig({
+        agents: { defaults: { promptCaching: { enabled: true } } },
+      }).enabled,
+    ).toBe(true);
+  });
+});
+
+describe("addCacheBreakpoint", () => {
+  it("adds cache_control to last block", () => {
+    const blocks = [
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+    ];
+    const result = addCacheBreakpoint(blocks);
+    expect(result[0].cache_control).toBeUndefined();
+    expect(result[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("returns empty array unchanged", () => {
+    expect(addCacheBreakpoint([])).toEqual([]);
+  });
+
+  it("does not mutate original array", () => {
+    const blocks = [{ type: "text", text: "hello" }];
+    addCacheBreakpoint(blocks);
+    expect(blocks[0].cache_control).toBeUndefined();
+  });
+});
+
+describe("injectCacheBreakpoints", () => {
+  it("adds breakpoint to string system prompt", () => {
+    const context = { system: "You are a helpful assistant." };
+    const result = injectCacheBreakpoints(context);
+    expect(Array.isArray(result.system)).toBe(true);
+    const systemBlocks = result.system as Array<{
+      type: string;
+      text: string;
+      cache_control?: { type: string };
+    }>;
+    expect(systemBlocks).toHaveLength(1);
+    expect(systemBlocks[0].text).toBe("You are a helpful assistant.");
+    expect(systemBlocks[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("adds breakpoint to array system prompt", () => {
+    const context = {
+      system: [
+        { type: "text", text: "Part 1" },
+        { type: "text", text: "Part 2" },
+      ],
+    };
+    const result = injectCacheBreakpoints(context);
+    const systemBlocks = result.system as Array<{ cache_control?: { type: string } }>;
+    expect(systemBlocks[0].cache_control).toBeUndefined();
+    expect(systemBlocks[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("adds breakpoint to last tool definition", () => {
+    const context = {
+      tools: [
+        { name: "read_file", description: "Read a file" },
+        { name: "write_file", description: "Write a file" },
+      ],
+    };
+    const result = injectCacheBreakpoints(context);
+    expect((result.tools![0] as Record<string, unknown>).cache_control).toBeUndefined();
+    expect((result.tools![1] as Record<string, unknown>).cache_control).toEqual({
+      type: "ephemeral",
+    });
+  });
+
+  it("adds breakpoint to stable conversation history", () => {
+    const context = {
+      messages: [
+        { role: "user", content: "first message" },
+        { role: "assistant", content: "first response" },
+        { role: "user", content: "second message" },
+        { role: "assistant", content: "second response" },
+        { role: "user", content: "third message" },
+        { role: "assistant", content: "third response" },
+        { role: "user", content: "fourth message" },
+      ],
+    };
+    const result = injectCacheBreakpoints(context);
+    // User turns at indices 0, 2, 4, 6. Walking backwards:
+    // 1st-to-last user = index 6 ("fourth message")
+    // 2nd-to-last user = index 4 ("third message")
+    // 3rd-to-last user = index 2 ("second message")
+    // Breakpoint goes on index 1 (message before 3rd-to-last user turn)
+    const messages = result.messages!;
+    const markedMsg = messages[1];
+    const content = markedMsg.content as Array<{ cache_control?: { type: string } }>;
+    expect(content[content.length - 1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("skips conversation history breakpoint when fewer than 3 user turns", () => {
+    const context = {
+      messages: [
+        { role: "user", content: "first message" },
+        { role: "assistant", content: "first response" },
+        { role: "user", content: "second message" },
+      ],
+    };
+    const result = injectCacheBreakpoints(context);
+    // No history breakpoint should be added since we need at least 3 user turns
+    const messages = result.messages!;
+    for (const msg of messages) {
+      if (typeof msg.content === "string") {
+        // String content means no breakpoint was added
+        continue;
+      }
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          expect((block as Record<string, unknown>).cache_control).toBeUndefined();
+        }
+      }
+    }
+  });
+
+  it("does not mutate original context", () => {
+    const context = {
+      system: "test",
+      tools: [{ name: "tool1" }],
+      messages: [{ role: "user", content: "hello" }],
+    };
+    injectCacheBreakpoints(context);
+    expect(typeof context.system).toBe("string");
+    expect((context.tools[0] as Record<string, unknown>).cache_control).toBeUndefined();
+  });
+
+  it("handles empty context gracefully", () => {
+    expect(injectCacheBreakpoints({})).toEqual({});
+  });
+});
+
+describe("extractCacheMetrics", () => {
+  it("extracts metrics from usage object", () => {
+    const metrics = extractCacheMetrics({
+      inputTokens: 100,
+      cacheCreationInputTokens: 500,
+      cacheReadInputTokens: 400,
+    });
+    expect(metrics).not.toBeNull();
+    expect(metrics!.inputTokens).toBe(100);
+    expect(metrics!.cacheCreationInputTokens).toBe(500);
+    expect(metrics!.cacheReadInputTokens).toBe(400);
+    expect(metrics!.hitRate).toBe(400 / 1000);
+  });
+
+  it("returns null for empty usage", () => {
+    expect(extractCacheMetrics(null)).toBeNull();
+    expect(extractCacheMetrics(undefined)).toBeNull();
+  });
+
+  it("returns null for zero totals", () => {
+    expect(extractCacheMetrics({ inputTokens: 0 })).toBeNull();
+  });
+
+  it("handles missing cache fields as zero", () => {
+    const metrics = extractCacheMetrics({ inputTokens: 100 });
+    expect(metrics).not.toBeNull();
+    expect(metrics!.cacheCreationInputTokens).toBe(0);
+    expect(metrics!.cacheReadInputTokens).toBe(0);
+    expect(metrics!.hitRate).toBe(0);
+  });
+});

--- a/src/agents/prompt-caching.test.ts
+++ b/src/agents/prompt-caching.test.ts
@@ -85,8 +85,8 @@ describe("injectCacheBreakpoints", () => {
       ],
     };
     const result = injectCacheBreakpoints(context);
-    expect((result.tools![0] as Record<string, unknown>).cache_control).toBeUndefined();
-    expect((result.tools![1] as Record<string, unknown>).cache_control).toEqual({
+    expect(result.tools![0].cache_control).toBeUndefined();
+    expect(result.tools![1].cache_control).toEqual({
       type: "ephemeral",
     });
   });
@@ -133,7 +133,7 @@ describe("injectCacheBreakpoints", () => {
       }
       if (Array.isArray(msg.content)) {
         for (const block of msg.content) {
-          expect((block as Record<string, unknown>).cache_control).toBeUndefined();
+          expect(block.cache_control).toBeUndefined();
         }
       }
     }
@@ -147,7 +147,7 @@ describe("injectCacheBreakpoints", () => {
     };
     injectCacheBreakpoints(context);
     expect(typeof context.system).toBe("string");
-    expect((context.tools[0] as Record<string, unknown>).cache_control).toBeUndefined();
+    expect(context.tools[0].cache_control).toBeUndefined();
   });
 
   it("handles empty context gracefully", () => {

--- a/src/agents/prompt-caching.ts
+++ b/src/agents/prompt-caching.ts
@@ -1,0 +1,223 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agent/prompt-caching");
+
+export type PromptCachingConfig = {
+  enabled: boolean;
+};
+
+type ContentBlock = {
+  type: string;
+  text?: string;
+  cache_control?: { type: string };
+  [key: string]: unknown;
+};
+
+type ContextLike = {
+  system?: string | ContentBlock[];
+  messages?: Array<{
+    role?: string;
+    content?: string | ContentBlock[];
+    [key: string]: unknown;
+  }>;
+  tools?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+};
+
+export function resolvePromptCachingConfig(cfg?: OpenClawConfig): PromptCachingConfig {
+  const raw = cfg?.agents?.defaults?.promptCaching;
+  return {
+    enabled: raw?.enabled ?? true,
+  };
+}
+
+function isAnthropicProvider(model: Model<Api> | undefined): boolean {
+  if (!model) {
+    return false;
+  }
+  return (model as { api?: unknown }).api === "anthropic-messages";
+}
+
+/**
+ * Normalize system prompt into an array of content blocks for cache_control injection.
+ */
+function normalizeSystemBlocks(system: string | ContentBlock[] | undefined): ContentBlock[] | null {
+  if (!system) {
+    return null;
+  }
+  if (typeof system === "string") {
+    return [{ type: "text", text: system }];
+  }
+  if (Array.isArray(system)) {
+    return system.map((block) => ({ ...block }));
+  }
+  return null;
+}
+
+/**
+ * Add cache_control breakpoint to the last content block in an array.
+ * Returns a shallow copy with the breakpoint added.
+ */
+export function addCacheBreakpoint(blocks: ContentBlock[]): ContentBlock[] {
+  if (blocks.length === 0) {
+    return blocks;
+  }
+  const result = blocks.map((block) => ({ ...block }));
+  result[result.length - 1] = {
+    ...result[result.length - 1],
+    cache_control: { type: "ephemeral" },
+  };
+  return result;
+}
+
+/**
+ * Inject cache_control breakpoints into the Anthropic API context.
+ *
+ * Breakpoints are placed at:
+ * 1. End of system prompt (AGENTS.md + SOUL.md + TOOLS.md content)
+ * 2. End of tool/skill definitions (last tool in tools array)
+ * 3. End of stable conversation prefix (messages before the last 3 user turns)
+ *
+ * Reference: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+ */
+export function injectCacheBreakpoints(context: ContextLike): ContextLike {
+  const result = { ...context };
+
+  // Breakpoint 1: End of system prompt
+  const systemBlocks = normalizeSystemBlocks(result.system);
+  if (systemBlocks && systemBlocks.length > 0) {
+    result.system = addCacheBreakpoint(systemBlocks);
+  }
+
+  // Breakpoint 2: End of tool definitions
+  if (Array.isArray(result.tools) && result.tools.length > 0) {
+    const toolsCopy = result.tools.map((tool) => ({ ...tool }));
+    toolsCopy[toolsCopy.length - 1] = {
+      ...toolsCopy[toolsCopy.length - 1],
+      cache_control: { type: "ephemeral" },
+    };
+    result.tools = toolsCopy;
+  }
+
+  // Breakpoint 3: End of stable conversation history prefix
+  // We mark the boundary before the last 3 user turns to cache the stable history.
+  if (Array.isArray(result.messages) && result.messages.length > 0) {
+    const messages = result.messages.map((msg) => ({ ...msg }));
+    let userTurnCount = 0;
+    let breakpointIndex = -1;
+
+    // Walk backwards to find where stable history ends
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") {
+        userTurnCount++;
+        if (userTurnCount === 3) {
+          // Place breakpoint on the message just before this user turn
+          breakpointIndex = i > 0 ? i - 1 : -1;
+          break;
+        }
+      }
+    }
+
+    if (breakpointIndex >= 0) {
+      const msg = messages[breakpointIndex];
+      const content = msg.content;
+      if (typeof content === "string") {
+        messages[breakpointIndex] = {
+          ...msg,
+          content: [{ type: "text", text: content, cache_control: { type: "ephemeral" } }],
+        };
+      } else if (Array.isArray(content) && content.length > 0) {
+        const contentCopy = content.map((block: ContentBlock) => ({ ...block }));
+        contentCopy[contentCopy.length - 1] = {
+          ...contentCopy[contentCopy.length - 1],
+          cache_control: { type: "ephemeral" },
+        };
+        messages[breakpointIndex] = { ...msg, content: contentCopy };
+      }
+    }
+
+    result.messages = messages;
+  }
+
+  return result;
+}
+
+export type CacheMetrics = {
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  inputTokens: number;
+  hitRate: number;
+};
+
+/**
+ * Extract cache metrics from assistant message usage.
+ */
+export function extractCacheMetrics(
+  usage: Record<string, unknown> | undefined | null,
+): CacheMetrics | null {
+  if (!usage) {
+    return null;
+  }
+  const cacheCreation =
+    typeof usage.cacheCreationInputTokens === "number" ? usage.cacheCreationInputTokens : 0;
+  const cacheRead = typeof usage.cacheReadInputTokens === "number" ? usage.cacheReadInputTokens : 0;
+  const input = typeof usage.inputTokens === "number" ? usage.inputTokens : 0;
+
+  const totalInput = input + cacheCreation + cacheRead;
+  if (totalInput === 0) {
+    return null;
+  }
+
+  return {
+    cacheCreationInputTokens: cacheCreation,
+    cacheReadInputTokens: cacheRead,
+    inputTokens: input,
+    hitRate: totalInput > 0 ? cacheRead / totalInput : 0,
+  };
+}
+
+/**
+ * Create a streamFn wrapper that injects Anthropic prompt caching breakpoints
+ * and logs cache hit rates.
+ */
+export function createPromptCachingWrapper(
+  streamFn: StreamFn,
+  config: PromptCachingConfig,
+): StreamFn {
+  if (!config.enabled) {
+    return streamFn;
+  }
+
+  return (model, context, options) => {
+    if (!isAnthropicProvider(model)) {
+      return streamFn(model, context, options);
+    }
+
+    const modifiedContext = injectCacheBreakpoints(context as ContextLike);
+
+    const originalOnMessage = options?.onMessage;
+    const wrappedOptions = {
+      ...options,
+      onMessage: (message: Record<string, unknown>) => {
+        // Extract and log cache metrics from the response
+        const usage = message?.usage as Record<string, unknown> | undefined;
+        const metrics = extractCacheMetrics(usage);
+        if (metrics) {
+          const hitPct = (metrics.hitRate * 100).toFixed(1);
+          log.info(
+            `cache metrics: hit_rate=${hitPct}% ` +
+              `cache_read=${metrics.cacheReadInputTokens} ` +
+              `cache_creation=${metrics.cacheCreationInputTokens} ` +
+              `input=${metrics.inputTokens}`,
+          );
+        }
+        originalOnMessage?.(message);
+      },
+    };
+
+    return streamFn(model, modifiedContext, wrappedOptions);
+  };
+}

--- a/src/agents/prompt-caching.ts
+++ b/src/agents/prompt-caching.ts
@@ -1,7 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import type { Api, Model } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isAnthropicProvider } from "./anthropic-provider-check.js";
 
 const log = createSubsystemLogger("agent/prompt-caching");
 
@@ -32,13 +32,6 @@ export function resolvePromptCachingConfig(cfg?: OpenClawConfig): PromptCachingC
   return {
     enabled: raw?.enabled ?? true,
   };
-}
-
-function isAnthropicProvider(model: Model<Api> | undefined): boolean {
-  if (!model) {
-    return false;
-  }
-  return (model as { api?: unknown }).api === "anthropic-messages";
 }
 
 /**

--- a/src/agents/prompt-caching.ts
+++ b/src/agents/prompt-caching.ts
@@ -196,9 +196,12 @@ export function createPromptCachingWrapper(
       return streamFn(model, context, options);
     }
 
-    const modifiedContext = injectCacheBreakpoints(context as ContextLike);
+    const modifiedContext = injectCacheBreakpoints(context as unknown as ContextLike);
 
-    const originalOnMessage = options?.onMessage;
+    const optionsRecord = (options ?? {}) as Record<string, unknown>;
+    const originalOnMessage = optionsRecord.onMessage as
+      | ((msg: Record<string, unknown>) => void)
+      | undefined;
     const wrappedOptions = {
       ...options,
       onMessage: (message: Record<string, unknown>) => {
@@ -218,6 +221,6 @@ export function createPromptCachingWrapper(
       },
     };
 
-    return streamFn(model, modifiedContext, wrappedOptions);
+    return streamFn(model, modifiedContext as unknown as Parameters<StreamFn>[1], wrappedOptions);
   };
 }

--- a/src/agents/skills/lazy-loading.test.ts
+++ b/src/agents/skills/lazy-loading.test.ts
@@ -1,0 +1,128 @@
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { SkillEntry } from "./types.js";
+import {
+  buildCompactSkillIndex,
+  buildLazySkillSnapshot,
+  resolveLazySkillLoadingConfig,
+  resolveSkillContent,
+} from "./lazy-loading.js";
+
+function makeSkillEntry(name: string, description: string, content = ""): SkillEntry {
+  return {
+    skill: {
+      name,
+      description,
+      content,
+      filePath: `/skills/${name}/SKILL.md`,
+      baseDir: `/skills/${name}`,
+    } as Skill,
+    frontmatter: {},
+    metadata: {},
+    invocation: {},
+  };
+}
+
+describe("resolveLazySkillLoadingConfig", () => {
+  it("defaults to disabled", () => {
+    expect(resolveLazySkillLoadingConfig().enabled).toBe(false);
+    expect(resolveLazySkillLoadingConfig({}).enabled).toBe(false);
+  });
+
+  it("respects explicit config", () => {
+    expect(
+      resolveLazySkillLoadingConfig({
+        agents: { defaults: { skills: { lazyLoading: true } } },
+      } as never).enabled,
+    ).toBe(true);
+  });
+});
+
+describe("buildCompactSkillIndex", () => {
+  it("returns empty string for no skills", () => {
+    expect(buildCompactSkillIndex([])).toBe("");
+  });
+
+  it("builds compact index with name and description", () => {
+    const entries = [
+      makeSkillEntry("weather", "Get weather forecasts"),
+      makeSkillEntry("github", "Manage GitHub issues and PRs"),
+    ];
+    const result = buildCompactSkillIndex(entries);
+    expect(result).toContain("**weather**: Get weather forecasts");
+    expect(result).toContain("**github**: Manage GitHub issues and PRs");
+    expect(result).toContain("load_skill");
+  });
+
+  it("is significantly smaller than full skill content", () => {
+    const longContent = "x".repeat(5000);
+    const entries = [
+      makeSkillEntry("skill1", "Short description", longContent),
+      makeSkillEntry("skill2", "Another skill", longContent),
+      makeSkillEntry("skill3", "Third skill", longContent),
+    ];
+    const compactIndex = buildCompactSkillIndex(entries);
+    const fullContent = entries.map((e) => e.skill.content).join("\n");
+    expect(compactIndex.length).toBeLessThan(fullContent.length * 0.1);
+  });
+});
+
+describe("resolveSkillContent", () => {
+  const skills: Skill[] = [
+    {
+      name: "weather",
+      description: "Get weather",
+      content: "Full weather skill content here...",
+      filePath: "/skills/weather/SKILL.md",
+      baseDir: "/skills/weather",
+    } as Skill,
+    {
+      name: "github",
+      description: "GitHub integration",
+      content: "Full GitHub skill content here...",
+      filePath: "/skills/github/SKILL.md",
+      baseDir: "/skills/github",
+    } as Skill,
+  ];
+
+  it("returns full content for matching skill", () => {
+    const result = resolveSkillContent("weather", skills);
+    expect(result.found).toBe(true);
+    expect(result.content).toBe("Full weather skill content here...");
+  });
+
+  it("is case-insensitive", () => {
+    const result = resolveSkillContent("Weather", skills);
+    expect(result.found).toBe(true);
+  });
+
+  it("returns error for unknown skill", () => {
+    const result = resolveSkillContent("unknown", skills);
+    expect(result.found).toBe(false);
+    expect(result.content).toContain("not found");
+    expect(result.content).toContain("weather");
+    expect(result.content).toContain("github");
+  });
+
+  it("returns error for empty skills", () => {
+    const result = resolveSkillContent("test", []);
+    expect(result.found).toBe(false);
+  });
+});
+
+describe("buildLazySkillSnapshot", () => {
+  it("creates snapshot with compact prompt", () => {
+    const entries = [makeSkillEntry("weather", "Get weather")];
+    const resolvedSkills = entries.map((e) => e.skill);
+    const snapshot = buildLazySkillSnapshot({
+      entries,
+      resolvedSkills,
+      snapshotVersion: 1,
+    });
+
+    expect(snapshot.prompt).toContain("weather");
+    expect(snapshot.prompt).toContain("load_skill");
+    expect(snapshot.resolvedSkills).toHaveLength(1);
+    expect(snapshot.version).toBe(1);
+  });
+});

--- a/src/agents/skills/lazy-loading.ts
+++ b/src/agents/skills/lazy-loading.ts
@@ -1,0 +1,106 @@
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SkillEntry, SkillSnapshot } from "./types.js";
+
+export type LazySkillLoadingConfig = {
+  enabled: boolean;
+};
+
+export function resolveLazySkillLoadingConfig(cfg?: OpenClawConfig): LazySkillLoadingConfig {
+  const raw = cfg?.agents?.defaults?.skills;
+  return {
+    enabled: (raw as { lazyLoading?: boolean } | undefined)?.lazyLoading ?? false,
+  };
+}
+
+/**
+ * Build a compact skill index for the system prompt.
+ * Instead of including full SKILL.md content for every skill (~15k tokens),
+ * only include name + one-line description per skill.
+ *
+ * The agent can call `load_skill` to get full content on demand.
+ */
+export function buildCompactSkillIndex(skills: SkillEntry[]): string {
+  if (skills.length === 0) {
+    return "";
+  }
+
+  const lines = [
+    "# Available Skills",
+    "",
+    "Use `load_skill` tool with the skill name to load full instructions.",
+    "",
+  ];
+
+  for (const entry of skills) {
+    const name = entry.skill.name;
+    const description = entry.skill.description?.trim() || "No description";
+    lines.push(`- **${name}**: ${description}`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Build a compact skill prompt that replaces the full skill injection.
+ * Returns the compact index string instead of the full skill content.
+ */
+export function buildLazySkillsPrompt(params: {
+  entries: SkillEntry[];
+  config?: OpenClawConfig;
+}): string {
+  const lazyConfig = resolveLazySkillLoadingConfig(params.config);
+  if (!lazyConfig.enabled) {
+    return "";
+  }
+  return buildCompactSkillIndex(params.entries);
+}
+
+/**
+ * Resolve the full content for a specific skill by name.
+ * Used by the load_skill meta-tool.
+ */
+export function resolveSkillContent(
+  skillName: string,
+  resolvedSkills: Skill[] | undefined,
+): { content: string; found: boolean } {
+  if (!resolvedSkills || resolvedSkills.length === 0) {
+    return { content: `Skill "${skillName}" not found. No skills available.`, found: false };
+  }
+
+  const normalized = skillName.trim().toLowerCase();
+  const match = resolvedSkills.find((skill) => skill.name.toLowerCase() === normalized);
+
+  if (!match) {
+    const available = resolvedSkills.map((s) => s.name).join(", ");
+    return {
+      content: `Skill "${skillName}" not found. Available skills: ${available}`,
+      found: false,
+    };
+  }
+
+  return { content: match.content ?? `Skill "${match.name}" has no content.`, found: true };
+}
+
+/**
+ * Create a SkillSnapshot that uses the compact index instead of full content.
+ * The resolvedSkills are still stored for on-demand loading.
+ */
+export function buildLazySkillSnapshot(params: {
+  entries: SkillEntry[];
+  resolvedSkills: Skill[];
+  config?: OpenClawConfig;
+  snapshotVersion?: number;
+}): SkillSnapshot {
+  const compactPrompt = buildCompactSkillIndex(params.entries);
+
+  return {
+    prompt: compactPrompt,
+    skills: params.entries.map((entry) => ({
+      name: entry.skill.name,
+      primaryEnv: entry.metadata?.primaryEnv,
+    })),
+    resolvedSkills: params.resolvedSkills,
+    version: params.snapshotVersion,
+  };
+}

--- a/src/agents/skills/lazy-loading.ts
+++ b/src/agents/skills/lazy-loading.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "@mariozechner/pi-coding-agent";
+import fs from "node:fs";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SkillEntry, SkillSnapshot } from "./types.js";
 
@@ -79,7 +80,12 @@ export function resolveSkillContent(
     };
   }
 
-  return { content: match.content ?? `Skill "${match.name}" has no content.`, found: true };
+  try {
+    const raw = fs.readFileSync(match.filePath, "utf-8");
+    return { content: raw || `Skill "${match.name}" has no content.`, found: true };
+  } catch {
+    return { content: `Skill "${match.name}" could not be loaded.`, found: false };
+  }
 }
 
 /**

--- a/src/agents/token-efficient-tools.test.ts
+++ b/src/agents/token-efficient-tools.test.ts
@@ -1,0 +1,73 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTokenEfficientToolsWrapper,
+  TOKEN_EFFICIENT_TOOLS_BETA,
+} from "./token-efficient-tools.js";
+
+function makeAnthropicModel(): Model<Api> {
+  return { api: "anthropic-messages", id: "claude-sonnet-4-5" } as Model<Api>;
+}
+
+function makeOpenAIModel(): Model<Api> {
+  return { api: "openai-chat", id: "gpt-5" } as Model<Api>;
+}
+
+describe("createTokenEfficientToolsWrapper", () => {
+  it("adds beta header for Anthropic models with tools", () => {
+    const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
+    const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
+
+    wrapped(makeAnthropicModel(), { tools: [{ name: "read_file" }] }, {});
+
+    expect(innerFn).toHaveBeenCalledOnce();
+    const options = innerFn.mock.calls[0][2];
+    expect(options.betas).toContain(TOKEN_EFFICIENT_TOOLS_BETA);
+  });
+
+  it("preserves existing betas", () => {
+    const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
+    const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
+
+    wrapped(
+      makeAnthropicModel(),
+      { tools: [{ name: "read_file" }] },
+      { betas: ["existing-beta-1"] },
+    );
+
+    const options = innerFn.mock.calls[0][2];
+    expect(options.betas).toContain("existing-beta-1");
+    expect(options.betas).toContain(TOKEN_EFFICIENT_TOOLS_BETA);
+  });
+
+  it("skips non-Anthropic models", () => {
+    const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
+    const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
+
+    wrapped(makeOpenAIModel(), { tools: [{ name: "read_file" }] }, {});
+
+    const options = innerFn.mock.calls[0][2];
+    expect(options.betas).toBeUndefined();
+  });
+
+  it("skips when no tools present", () => {
+    const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
+    const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
+
+    wrapped(makeAnthropicModel(), { messages: [{ role: "user", content: "hello" }] }, {});
+
+    const options = innerFn.mock.calls[0][2];
+    expect(options.betas).toBeUndefined();
+  });
+
+  it("skips when tools array is empty", () => {
+    const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
+    const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
+
+    wrapped(makeAnthropicModel(), { tools: [] }, {});
+
+    const options = innerFn.mock.calls[0][2];
+    expect(options.betas).toBeUndefined();
+  });
+});

--- a/src/agents/token-efficient-tools.test.ts
+++ b/src/agents/token-efficient-tools.test.ts
@@ -19,7 +19,7 @@ describe("createTokenEfficientToolsWrapper", () => {
     const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
     const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
 
-    wrapped(makeAnthropicModel(), { tools: [{ name: "read_file" }] }, {});
+    void wrapped(makeAnthropicModel(), { tools: [{ name: "read_file" }] }, {});
 
     expect(innerFn).toHaveBeenCalledOnce();
     const options = innerFn.mock.calls[0][2];
@@ -30,7 +30,7 @@ describe("createTokenEfficientToolsWrapper", () => {
     const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
     const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
 
-    wrapped(
+    void wrapped(
       makeAnthropicModel(),
       { tools: [{ name: "read_file" }] },
       { betas: ["existing-beta-1"] },
@@ -45,7 +45,7 @@ describe("createTokenEfficientToolsWrapper", () => {
     const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
     const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
 
-    wrapped(makeOpenAIModel(), { tools: [{ name: "read_file" }] }, {});
+    void wrapped(makeOpenAIModel(), { tools: [{ name: "read_file" }] }, {});
 
     const options = innerFn.mock.calls[0][2];
     expect(options.betas).toBeUndefined();
@@ -55,7 +55,7 @@ describe("createTokenEfficientToolsWrapper", () => {
     const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
     const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
 
-    wrapped(makeAnthropicModel(), { messages: [{ role: "user", content: "hello" }] }, {});
+    void wrapped(makeAnthropicModel(), { messages: [{ role: "user", content: "hello" }] }, {});
 
     const options = innerFn.mock.calls[0][2];
     expect(options.betas).toBeUndefined();
@@ -65,7 +65,7 @@ describe("createTokenEfficientToolsWrapper", () => {
     const innerFn = vi.fn().mockReturnValue({ on: vi.fn() });
     const wrapped = createTokenEfficientToolsWrapper(innerFn as unknown as StreamFn);
 
-    wrapped(makeAnthropicModel(), { tools: [] }, {});
+    void wrapped(makeAnthropicModel(), { tools: [] }, {});
 
     const options = innerFn.mock.calls[0][2];
     expect(options.betas).toBeUndefined();

--- a/src/agents/token-efficient-tools.ts
+++ b/src/agents/token-efficient-tools.ts
@@ -1,0 +1,59 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agent/token-efficient-tools");
+
+/**
+ * The Anthropic beta header that enables token-efficient tool use encoding.
+ * Reduces tool definition token usage by 5-15%. Safe to include on all Claude
+ * versions (no-op on Claude 4+).
+ *
+ * Reference: https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+ */
+export const TOKEN_EFFICIENT_TOOLS_BETA = "token-efficient-tools-2025-02-19";
+
+function isAnthropicProvider(model: Model<Api> | undefined): boolean {
+  if (!model) {
+    return false;
+  }
+  return (model as { api?: unknown }).api === "anthropic-messages";
+}
+
+type ContextLike = {
+  tools?: unknown[];
+  [key: string]: unknown;
+};
+
+/**
+ * Create a streamFn wrapper that adds the token-efficient-tools beta header
+ * to all Anthropic API requests that include tool definitions.
+ *
+ * The header is safe to include unconditionally (no-op on Claude 4+) and
+ * reduces token usage by 5-15% for tool definitions.
+ */
+export function createTokenEfficientToolsWrapper(streamFn: StreamFn): StreamFn {
+  return (model, context, options) => {
+    if (!isAnthropicProvider(model)) {
+      return streamFn(model, context, options);
+    }
+
+    const ctx = context as ContextLike;
+    const hasTools = Array.isArray(ctx.tools) && ctx.tools.length > 0;
+
+    if (!hasTools) {
+      return streamFn(model, context, options);
+    }
+
+    // Merge beta header with any existing betas
+    const existingBetas = (options as { betas?: string[] } | undefined)?.betas ?? [];
+    const betas = [...existingBetas, TOKEN_EFFICIENT_TOOLS_BETA];
+
+    log.debug("adding token-efficient-tools beta header");
+
+    return streamFn(model, context, {
+      ...options,
+      betas,
+    });
+  };
+}

--- a/src/agents/token-efficient-tools.ts
+++ b/src/agents/token-efficient-tools.ts
@@ -38,7 +38,7 @@ export function createTokenEfficientToolsWrapper(streamFn: StreamFn): StreamFn {
       return streamFn(model, context, options);
     }
 
-    const ctx = context as ContextLike;
+    const ctx = context as unknown as ContextLike;
     const hasTools = Array.isArray(ctx.tools) && ctx.tools.length > 0;
 
     if (!hasTools) {
@@ -46,7 +46,10 @@ export function createTokenEfficientToolsWrapper(streamFn: StreamFn): StreamFn {
     }
 
     // Merge beta header with any existing betas
-    const existingBetas = (options as { betas?: string[] } | undefined)?.betas ?? [];
+    const optionsRecord = (options ?? {}) as Record<string, unknown>;
+    const existingBetas = (
+      Array.isArray(optionsRecord.betas) ? optionsRecord.betas : []
+    ) as string[];
     const betas = [...existingBetas, TOKEN_EFFICIENT_TOOLS_BETA];
 
     log.debug("adding token-efficient-tools beta header");
@@ -54,6 +57,6 @@ export function createTokenEfficientToolsWrapper(streamFn: StreamFn): StreamFn {
     return streamFn(model, context, {
       ...options,
       betas,
-    });
+    } as Parameters<StreamFn>[2]);
   };
 }

--- a/src/agents/token-efficient-tools.ts
+++ b/src/agents/token-efficient-tools.ts
@@ -1,6 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import type { Api, Model } from "@mariozechner/pi-ai";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isAnthropicProvider } from "./anthropic-provider-check.js";
 
 const log = createSubsystemLogger("agent/token-efficient-tools");
 
@@ -12,13 +12,6 @@ const log = createSubsystemLogger("agent/token-efficient-tools");
  * Reference: https://docs.anthropic.com/en/docs/build-with-claude/tool-use
  */
 export const TOKEN_EFFICIENT_TOOLS_BETA = "token-efficient-tools-2025-02-19";
-
-function isAnthropicProvider(model: Model<Api> | undefined): boolean {
-  if (!model) {
-    return false;
-  }
-  return (model as { api?: unknown }).api === "anthropic-messages";
-}
 
 type ContextLike = {
   tools?: unknown[];

--- a/src/agents/tool-output-pruning.test.ts
+++ b/src/agents/tool-output-pruning.test.ts
@@ -1,0 +1,224 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  findProtectedBoundary,
+  getToolLimit,
+  pruneToolResultText,
+  pruneToolResults,
+  readFullToolOutput,
+  resolveToolPruningConfig,
+  saveFullToolOutput,
+} from "./tool-output-pruning.js";
+
+function makeToolResult(text: string, toolName = "read"): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: `call_${Math.random().toString(36).slice(2)}`,
+    toolName,
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function makeAssistantMessage(text: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function makeUserMessage(text: string): AgentMessage {
+  return {
+    role: "user",
+    content: text,
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+// Cleanup temp files
+const tempDir = path.join(os.tmpdir(), "openclaw-tool-outputs");
+afterAll(async () => {
+  try {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe("resolveToolPruningConfig", () => {
+  it("returns defaults when no config", () => {
+    const config = resolveToolPruningConfig();
+    expect(config.maxToolResultTokens).toBe(3000);
+    expect(config.headRatio).toBe(0.4);
+    expect(config.tailRatio).toBe(0.1);
+    expect(config.protectLastAssistantTurns).toBe(3);
+    expect(config.perToolLimits.browser).toBe(2000);
+    expect(config.perToolLimits.bash).toBe(4000);
+  });
+});
+
+describe("getToolLimit", () => {
+  const config = resolveToolPruningConfig();
+
+  it("returns per-tool limit when available", () => {
+    expect(getToolLimit("browser", config)).toBe(2000);
+    expect(getToolLimit("bash", config)).toBe(4000);
+  });
+
+  it("returns default for unknown tools", () => {
+    expect(getToolLimit("custom_tool", config)).toBe(3000);
+  });
+
+  it("returns default for undefined tool name", () => {
+    expect(getToolLimit(undefined, config)).toBe(3000);
+  });
+});
+
+describe("pruneToolResultText", () => {
+  it("returns unchanged text when under limit", () => {
+    const result = pruneToolResultText({
+      text: "short text",
+      maxTokens: 1000,
+      headRatio: 0.4,
+      tailRatio: 0.1,
+    });
+    expect(result.pruned).toBe(false);
+    expect(result.text).toBe("short text");
+  });
+
+  it("prunes oversized text with head+tail preservation", () => {
+    const text = "A".repeat(4000) + "B".repeat(4000) + "C".repeat(4000);
+    const result = pruneToolResultText({
+      text,
+      maxTokens: 1000, // 4000 chars
+      headRatio: 0.4,
+      tailRatio: 0.1,
+      fullOutputPath: "/tmp/test.txt",
+    });
+
+    expect(result.pruned).toBe(true);
+    expect(result.text.length).toBeLessThan(text.length);
+    // Head should be preserved (first 40% of 4000 = 1600 chars)
+    expect(result.text.startsWith("A".repeat(1600))).toBe(true);
+    // Tail should be preserved (last 10% of 4000 = 400 chars)
+    expect(result.text.endsWith("C".repeat(400))).toBe(true);
+    // Placeholder should be present
+    expect(result.text).toContain("CONTENT PRUNED");
+    expect(result.text).toContain("/tmp/test.txt");
+  });
+});
+
+describe("saveFullToolOutput and readFullToolOutput", () => {
+  it("saves and retrieves full output", async () => {
+    const text = "Full tool output content for testing";
+    const filePath = await saveFullToolOutput(text, "test_tool");
+
+    expect(filePath).toContain("openclaw-tool-outputs");
+    expect(filePath).toContain("test_tool");
+
+    const { content, found } = await readFullToolOutput(filePath);
+    expect(found).toBe(true);
+    expect(content).toBe(text);
+  });
+
+  it("returns not found for missing files", async () => {
+    const { found } = await readFullToolOutput("/tmp/openclaw-tool-outputs/nonexistent.txt");
+    expect(found).toBe(false);
+  });
+
+  it("rejects paths outside tool output directory", async () => {
+    const { found, content } = await readFullToolOutput("/etc/passwd");
+    expect(found).toBe(false);
+    expect(content).toContain("Access denied");
+  });
+});
+
+describe("findProtectedBoundary", () => {
+  it("protects last N assistant turns", () => {
+    const messages = [
+      makeUserMessage("msg1"),
+      makeAssistantMessage("resp1"),
+      makeUserMessage("msg2"),
+      makeAssistantMessage("resp2"),
+      makeUserMessage("msg3"),
+      makeAssistantMessage("resp3"),
+    ];
+    // Protect last 2 assistant turns: resp2 (index 3) and resp3 (index 5)
+    // The boundary should be at index 3
+    expect(findProtectedBoundary(messages, 2)).toBe(3);
+  });
+
+  it("returns 0 when fewer assistant turns than protect count", () => {
+    const messages = [makeUserMessage("msg1"), makeAssistantMessage("resp1")];
+    expect(findProtectedBoundary(messages, 5)).toBe(0);
+  });
+
+  it("returns messages.length when protect count is 0", () => {
+    const messages = [makeUserMessage("msg1")];
+    expect(findProtectedBoundary(messages, 0)).toBe(1);
+  });
+});
+
+describe("pruneToolResults", () => {
+  const config = resolveToolPruningConfig();
+
+  it("does not prune small tool results", async () => {
+    const messages = [makeUserMessage("hello"), makeToolResult("small result")];
+    const { messages: result, prunedCount } = await pruneToolResults({
+      messages,
+      config,
+    });
+    expect(prunedCount).toBe(0);
+    expect(result).toEqual(messages);
+  });
+
+  it("prunes oversized tool results", async () => {
+    const bigText = "x".repeat(50_000); // Way over 3000 * 4 = 12000 chars
+    const messages = [
+      makeUserMessage("hello"),
+      makeAssistantMessage("reading file"),
+      makeToolResult(bigText),
+      makeAssistantMessage("done1"),
+      makeAssistantMessage("done2"),
+      makeAssistantMessage("done3"),
+      makeAssistantMessage("done4"),
+    ];
+    const { messages: result, prunedCount } = await pruneToolResults({
+      messages,
+      config,
+    });
+    expect(prunedCount).toBe(1);
+    const prunedMsg = result[2] as { content: Array<{ text: string }> };
+    expect(prunedMsg.content[0].text.length).toBeLessThan(bigText.length);
+    expect(prunedMsg.content[0].text).toContain("CONTENT PRUNED");
+  });
+
+  it("protects last 3 assistant turns from pruning", async () => {
+    const bigText = "x".repeat(50_000);
+    const messages = [
+      makeUserMessage("msg1"),
+      makeAssistantMessage("resp1"),
+      makeToolResult(bigText, "read"), // index 2: outside protected zone
+      makeAssistantMessage("resp2"),
+      makeUserMessage("msg2"),
+      makeAssistantMessage("resp3"), // index 5: 3rd-to-last assistant
+      makeUserMessage("msg3"),
+      makeAssistantMessage("resp4"), // index 7: 2nd-to-last assistant
+      makeToolResult(bigText, "read"), // index 8: inside protected zone (after boundary)
+      makeAssistantMessage("resp5"), // index 9: last assistant
+    ];
+    const { prunedCount } = await pruneToolResults({
+      messages,
+      config,
+    });
+    // findProtectedBoundary returns index 5 (3rd-to-last assistant)
+    // Tool result at index 2 is before the boundary so it gets pruned
+    // Tool result at index 8 is at or after the boundary so it's protected
+    expect(prunedCount).toBe(1);
+  });
+});

--- a/src/agents/tool-output-pruning.ts
+++ b/src/agents/tool-output-pruning.ts
@@ -1,0 +1,269 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agent/tool-output-pruning");
+
+/** Chars per token estimate (conservative for English text). */
+const CHARS_PER_TOKEN = 4;
+
+export type ToolPruningConfig = {
+  /** Default max tokens for tool results. */
+  maxToolResultTokens: number;
+  /** Head portion to preserve (ratio of maxTokens). */
+  headRatio: number;
+  /** Tail portion to preserve (ratio of maxTokens). */
+  tailRatio: number;
+  /** Per-tool token overrides. */
+  perToolLimits: Record<string, number>;
+  /** Number of recent assistant turns to protect from pruning. */
+  protectLastAssistantTurns: number;
+};
+
+const DEFAULT_CONFIG: ToolPruningConfig = {
+  maxToolResultTokens: 3000,
+  headRatio: 0.4,
+  tailRatio: 0.1,
+  perToolLimits: {
+    browser: 2000,
+    readMessages: 3000,
+    bash: 4000,
+  },
+  protectLastAssistantTurns: 3,
+};
+
+export function resolveToolPruningConfig(cfg?: OpenClawConfig): ToolPruningConfig {
+  const raw = cfg?.agents?.defaults?.contextPruning as Record<string, unknown> | undefined;
+  if (!raw) {
+    return DEFAULT_CONFIG;
+  }
+
+  const maxTokens =
+    typeof raw.maxToolResultTokens === "number"
+      ? raw.maxToolResultTokens
+      : DEFAULT_CONFIG.maxToolResultTokens;
+  const headRatio = typeof raw.headRatio === "number" ? raw.headRatio : DEFAULT_CONFIG.headRatio;
+  const tailRatio = typeof raw.tailRatio === "number" ? raw.tailRatio : DEFAULT_CONFIG.tailRatio;
+  const protectLast =
+    typeof raw.protectLastAssistantTurns === "number"
+      ? raw.protectLastAssistantTurns
+      : DEFAULT_CONFIG.protectLastAssistantTurns;
+
+  const perToolLimits = { ...DEFAULT_CONFIG.perToolLimits };
+  if (raw.perToolLimits && typeof raw.perToolLimits === "object") {
+    for (const [key, val] of Object.entries(raw.perToolLimits as Record<string, unknown>)) {
+      if (typeof val === "number") {
+        perToolLimits[key] = val;
+      }
+    }
+  }
+
+  return {
+    maxToolResultTokens: maxTokens,
+    headRatio,
+    tailRatio,
+    perToolLimits,
+    protectLastAssistantTurns: protectLast,
+  };
+}
+
+/**
+ * Get the max token limit for a specific tool.
+ */
+export function getToolLimit(toolName: string | undefined, config: ToolPruningConfig): number {
+  if (toolName && config.perToolLimits[toolName] !== undefined) {
+    return config.perToolLimits[toolName];
+  }
+  return config.maxToolResultTokens;
+}
+
+const PLACEHOLDER_TEMPLATE =
+  "\n\n--- CONTENT PRUNED ---\n" +
+  "[{removedTokens} tokens removed. Full output saved to: {filePath}]\n" +
+  "[Use read_tool_output tool with path above to retrieve full content.]\n" +
+  "--- END PRUNED ---\n\n";
+
+/**
+ * Prune a tool result text using head+tail preservation.
+ * Returns the pruned text and the path to the full output file (if saved).
+ */
+export function pruneToolResultText(params: {
+  text: string;
+  maxTokens: number;
+  headRatio: number;
+  tailRatio: number;
+  fullOutputPath?: string;
+}): { text: string; pruned: boolean } {
+  const { text, maxTokens, headRatio, tailRatio } = params;
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
+
+  if (text.length <= maxChars) {
+    return { text, pruned: false };
+  }
+
+  const headChars = Math.floor(maxChars * headRatio);
+  const tailChars = Math.floor(maxChars * tailRatio);
+  const removedChars = text.length - headChars - tailChars;
+  const removedTokens = Math.ceil(removedChars / CHARS_PER_TOKEN);
+
+  const head = text.slice(0, headChars);
+  const tail = text.slice(text.length - tailChars);
+
+  const placeholder = PLACEHOLDER_TEMPLATE.replace(
+    "{removedTokens}",
+    String(removedTokens),
+  ).replace("{filePath}", params.fullOutputPath ?? "N/A");
+
+  return {
+    text: head + placeholder + tail,
+    pruned: true,
+  };
+}
+
+/**
+ * Save full tool output to a temp file for later retrieval.
+ */
+export async function saveFullToolOutput(text: string, toolName: string): Promise<string> {
+  const dir = path.join(os.tmpdir(), "openclaw-tool-outputs");
+  await fs.mkdir(dir, { recursive: true });
+  const filename = `${toolName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.txt`;
+  const filePath = path.join(dir, filename);
+  await fs.writeFile(filePath, text, "utf8");
+  log.info(`saved full tool output: ${filePath} (${text.length} chars)`);
+  return filePath;
+}
+
+/**
+ * Read a previously saved full tool output.
+ */
+export async function readFullToolOutput(
+  filePath: string,
+): Promise<{ content: string; found: boolean }> {
+  try {
+    // Security: only allow reading from the expected temp directory
+    const expectedDir = path.join(os.tmpdir(), "openclaw-tool-outputs");
+    const resolved = path.resolve(filePath);
+    if (!resolved.startsWith(expectedDir)) {
+      return { content: "Access denied: path outside tool output directory.", found: false };
+    }
+    const content = await fs.readFile(resolved, "utf8");
+    return { content, found: true };
+  } catch {
+    return { content: `File not found: ${filePath}`, found: false };
+  }
+}
+
+type TextContent = { type: "text"; text: string; [key: string]: unknown };
+
+function getToolResultTextLength(msg: AgentMessage): number {
+  const content = (msg as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+  let total = 0;
+  for (const block of content) {
+    if (block && typeof block === "object" && (block as { type?: string }).type === "text") {
+      total += ((block as TextContent).text ?? "").length;
+    }
+  }
+  return total;
+}
+
+/**
+ * Find the index of the last N assistant turns in a message array.
+ * Returns the index of the first protected message, or messages.length if
+ * fewer than N assistant turns exist.
+ */
+export function findProtectedBoundary(messages: AgentMessage[], protectCount: number): number {
+  if (protectCount <= 0) {
+    return messages.length;
+  }
+
+  let assistantCount = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i] as { role?: string }).role === "assistant") {
+      assistantCount++;
+      if (assistantCount >= protectCount) {
+        return i;
+      }
+    }
+  }
+  return 0;
+}
+
+/**
+ * Prune oversized tool results in a message array.
+ * Respects per-tool limits and protects the last N assistant turns.
+ */
+export async function pruneToolResults(params: {
+  messages: AgentMessage[];
+  config: ToolPruningConfig;
+}): Promise<{ messages: AgentMessage[]; prunedCount: number }> {
+  const { messages, config } = params;
+  const protectedBoundary = findProtectedBoundary(messages, config.protectLastAssistantTurns);
+
+  let prunedCount = 0;
+  const result: AgentMessage[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    const role = (msg as { role?: string }).role;
+
+    if (role !== "toolResult" || i >= protectedBoundary) {
+      result.push(msg);
+      continue;
+    }
+
+    const toolName = (msg as { toolName?: string }).toolName;
+    const maxTokens = getToolLimit(toolName, config);
+    const textLength = getToolResultTextLength(msg);
+    const maxChars = maxTokens * CHARS_PER_TOKEN;
+
+    if (textLength <= maxChars) {
+      result.push(msg);
+      continue;
+    }
+
+    // Prune this tool result
+    const content = (msg as { content?: unknown[] }).content;
+    if (!Array.isArray(content)) {
+      result.push(msg);
+      continue;
+    }
+
+    // Save full output for retrieval
+    const fullText = content
+      .filter((b) => (b as { type?: string }).type === "text")
+      .map((b) => (b as TextContent).text)
+      .join("\n");
+    const filePath = await saveFullToolOutput(fullText, toolName ?? "unknown");
+
+    const prunedContent = content.map((block) => {
+      if ((block as { type?: string }).type !== "text") {
+        return block;
+      }
+      const textBlock = block as TextContent;
+      const { text: prunedText } = pruneToolResultText({
+        text: textBlock.text,
+        maxTokens,
+        headRatio: config.headRatio,
+        tailRatio: config.tailRatio,
+        fullOutputPath: filePath,
+      });
+      return { ...textBlock, text: prunedText };
+    });
+
+    prunedCount++;
+    log.info(
+      `pruned tool result: tool=${toolName} original=${textLength} chars ` +
+        `limit=${maxChars} chars saved=${filePath}`,
+    );
+
+    result.push({ ...msg, content: prunedContent } as AgentMessage);
+  }
+
+  return { messages: result, prunedCount };
+}

--- a/src/agents/tool-output-pruning.ts
+++ b/src/agents/tool-output-pruning.ts
@@ -158,7 +158,7 @@ export async function readFullToolOutput(
 
 type TextContent = { type: "text"; text: string; [key: string]: unknown };
 
-function getToolResultTextLength(msg: AgentMessage): number {
+function estimateToolResultTextLength(msg: AgentMessage): number {
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) {
     return 0;
@@ -219,7 +219,7 @@ export async function pruneToolResults(params: {
 
     const toolName = (msg as { toolName?: string }).toolName;
     const maxTokens = getToolLimit(toolName, config);
-    const textLength = getToolResultTextLength(msg);
+    const textLength = estimateToolResultTextLength(msg);
     const maxChars = maxTokens * CHARS_PER_TOKEN;
 
     if (textLength <= maxChars) {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -136,6 +136,8 @@ export type AgentDefaultsConfig = {
   promptCaching?: AgentPromptCachingConfig;
   /** Dynamic skill/tool loading configuration. */
   skills?: AgentSkillsConfig;
+  /** Automatic model routing configuration. */
+  modelRouting?: AgentModelRoutingConfig;
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */
@@ -268,6 +270,19 @@ export type AgentPromptCachingConfig = {
 export type AgentSkillsConfig = {
   /** Enable lazy loading of skills via compact index + load_skill tool (default: false). */
   lazyLoading?: boolean;
+};
+
+export type AgentModelRoutingConfig = {
+  /** Enable automatic model routing (default: false). */
+  enabled?: boolean;
+  /** Model tier mappings (provider/model strings). */
+  models?: {
+    simple?: string;
+    medium?: string;
+    complex?: string;
+  };
+  /** Use Opus for plan/think mode, Sonnet for execution. */
+  opusPlanMode?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -132,6 +132,8 @@ export type AgentDefaultsConfig = {
   contextPruning?: AgentContextPruningConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
+  /** Anthropic prompt caching configuration. */
+  promptCaching?: AgentPromptCachingConfig;
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */
@@ -254,6 +256,11 @@ export type AgentCompactionConfig = {
   maxHistoryShare?: number;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+};
+
+export type AgentPromptCachingConfig = {
+  /** Enable Anthropic prompt caching breakpoints (default: true). */
+  enabled?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -134,6 +134,8 @@ export type AgentDefaultsConfig = {
   compaction?: AgentCompactionConfig;
   /** Anthropic prompt caching configuration. */
   promptCaching?: AgentPromptCachingConfig;
+  /** Dynamic skill/tool loading configuration. */
+  skills?: AgentSkillsConfig;
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */
@@ -261,6 +263,11 @@ export type AgentCompactionConfig = {
 export type AgentPromptCachingConfig = {
   /** Enable Anthropic prompt caching breakpoints (default: true). */
   enabled?: boolean;
+};
+
+export type AgentSkillsConfig = {
+  /** Enable lazy loading of skills via compact index + load_skill tool (default: false). */
+  lazyLoading?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -105,6 +105,12 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    promptCaching: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     thinkingDefault: z
       .union([
         z.literal("off"),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -117,6 +117,21 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    modelRouting: z
+      .object({
+        enabled: z.boolean().optional(),
+        models: z
+          .object({
+            simple: z.string().optional(),
+            medium: z.string().optional(),
+            complex: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        opusPlanMode: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     thinkingDefault: z
       .union([
         z.literal("off"),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -111,6 +111,12 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    skills: z
+      .object({
+        lazyLoading: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     thinkingDefault: z
       .union([
         z.literal("off"),


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces several token-efficiency features for the agent runtime: compaction profiles and proactive compaction thresholds, isolated heartbeat prompts, default memory-flush behavior, rule-based model routing, Anthropic prompt caching breakpoints, a token-efficient-tools beta header wrapper, and tool-output pruning utilities.

The changes are mostly additive and covered by new unit tests, and they’re wired into the embedded runner via new streamFn wrappers. The main blockers are around integration correctness: the embedded runner currently imports prompt-caching/token-efficient-tools from paths that don’t appear to exist in the repo, and the tool-output pruning placeholder references a tool name that doesn’t exist, so the “retrieve full output” instruction can’t be followed.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge until import/path and recovery-instruction issues are fixed.
- Two issues are likely to break functionality: (1) the embedded runner imports new modules from paths that don’t exist in this repo, which should break module resolution at build/runtime; (2) tool-output pruning tells users to use a non-existent tool name to recover pruned output. The rest of the changes are additive and unit-tested.
- src/agents/pi-embedded-runner/run/attempt.ts, src/agents/tool-output-pruning.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->