### PR TITLE
fix: exclude rate limit errors from context overflow detection (#13735)

### DIFF
--- a/src/agents/pi-embedded-helpers.islikelycontextoverflowerror.test.ts
+++ b/src/agents/pi-embedded-helpers.islikelycontextoverflowerror.test.ts
@@ -22,6 +22,18 @@ describe("isLikelyContextOverflowError", () => {
     }
   });
 
+  it("excludes rate limit errors", () => {
+    const samples = [
+      "request reached organization TPD rate limit, current: 1506556, limit: 1500000",
+      "rate limit exceeded",
+      "429 Too Many Requests",
+      "exceeded your current quota",
+    ];
+    for (const sample of samples) {
+      expect(isLikelyContextOverflowError(sample)).toBe(false);
+    }
+  });
+
   it("excludes context window too small errors", () => {
     const samples = [
       "Model context window too small (minimum is 128k tokens)",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -40,6 +40,11 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (CONTEXT_WINDOW_TOO_SMALL_RE.test(errorMessage)) {
     return false;
   }
+  // Exclude rate limit errors — they can match the broad regex below
+  // (e.g. "request reached organization TPD rate limit" matches "request" + "limit")
+  if (isRateLimitErrorMessage(errorMessage)) {
+    return false;
+  }
   if (isContextOverflowError(errorMessage)) {
     return true;
   }


### PR DESCRIPTION
## Problem

`CONTEXT_OVERFLOW_HINT_RE` regex's last branch `(?:prompt|request|input).*(too (?:large|long)|exceed|over|limit|max(?:imum)?)` falsely matches Anthropic 429 rate limit messages like:

```
request reached organization TPD rate limit, current: 1506556, limit: 1500000
```

Because `request` + `limit` both match the pattern.

## Fix

Added an early return in `isLikelyContextOverflowError` that excludes rate limit errors (via the existing `isRateLimitErrorMessage` helper) before reaching the broad `CONTEXT_OVERFLOW_HINT_RE` check.

## Changes

- **`src/agents/pi-embedded-helpers/errors.ts`**: Added `isRateLimitErrorMessage()` guard before the `CONTEXT_OVERFLOW_HINT_RE` test in `isLikelyContextOverflowError()`
- **`src/agents/pi-embedded-helpers.islikelycontextoverflowerror.test.ts`**: Added test case verifying rate limit messages are not misclassified as context overflow errors

## Test plan

New test `"excludes rate limit errors"` covers:
- `request reached organization TPD rate limit, current: 1506556, limit: 1500000` (the original bug)
- `rate limit exceeded`
- `429 Too Many Requests`
- `exceeded your current quota`

Closes #13735

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts `isLikelyContextOverflowError` to early-return `false` for rate-limit messages (via the existing `isRateLimitErrorMessage` helper) before applying the broad `CONTEXT_OVERFLOW_HINT_RE`. It also adds a regression test covering several 429ate-limit wordings, including the specific Anthropic TPD limit message that previously matched `request` + `limit`.

The change fits cleanly into the existing error-classification helpers in `src/agents/pi-embedded-helpers/errors.ts` by reusing the project’s centralized rate-limit pattern list and by tightening the context-overflow heuristic ordering to reduce false positives.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, well-scoped guard that prevents a known false positive, and the added test exercises multiple representative rate-limit messages. No behavior changes occur for confirmed context overflow errors besides avoiding misclassification of 429/quota text.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->