### PR TITLE
fix(gateway): MacOS clarify launchctl GUI domain bootstrap failure

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -223,6 +223,67 @@ describe("launchd install", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {
+    const originalPath = process.env.PATH;
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-launchctl-test-"));
+    try {
+      const binDir = path.join(tmpDir, "bin");
+      const homeDir = path.join(tmpDir, "home");
+      await fs.mkdir(binDir, { recursive: true });
+      await fs.mkdir(homeDir, { recursive: true });
+
+      const stubJsPath = path.join(binDir, "launchctl.js");
+      await fs.writeFile(
+        stubJsPath,
+        [
+          "const args = process.argv.slice(2);",
+          'if (args[0] === "bootstrap") {',
+          '  process.stderr.write("Bootstrap failed: 125: Domain does not support specified action\\n");',
+          "  process.exit(1);",
+          "}",
+          "process.exit(0);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      if (process.platform === "win32") {
+        await fs.writeFile(
+          path.join(binDir, "launchctl.cmd"),
+          `@echo off\r\nnode "%~dp0\\launchctl.js" %*\r\n`,
+          "utf8",
+        );
+      } else {
+        const shPath = path.join(binDir, "launchctl");
+        await fs.writeFile(shPath, `#!/bin/sh\nnode "$(dirname "$0")/launchctl.js" "$@"\n`, "utf8");
+        await fs.chmod(shPath, 0o755);
+      }
+
+      process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+
+      const env: Record<string, string | undefined> = {
+        HOME: homeDir,
+        OPENCLAW_PROFILE: "default",
+      };
+      let message = "";
+      try {
+        await installLaunchAgent({
+          env,
+          stdout: new PassThrough(),
+          programArguments: ["node", "-e", "process.exit(0)"],
+        });
+      } catch (error) {
+        message = String(error);
+      }
+      expect(message).toContain("logged-in macOS GUI session");
+      expect(message).toContain("wrong user (including sudo)");
+      expect(message).toContain("https://docs.openclaw.ai/gateway");
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("resolveLaunchAgentPlistPath", () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -363,6 +363,14 @@ function isLaunchctlNotLoaded(res: { stdout: string; stderr: string; code: numbe
   );
 }
 
+function isUnsupportedGuiDomain(detail: string): boolean {
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("domain does not support specified action") ||
+    normalized.includes("bootstrap failed: 125")
+  );
+}
+
 export async function stopLaunchAgent({
   stdout,
   env,
@@ -436,7 +444,19 @@ export async function installLaunchAgent({
   await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
-    throw new Error(`launchctl bootstrap failed: ${boot.stderr || boot.stdout}`.trim());
+    const detail = (boot.stderr || boot.stdout).trim();
+    if (isUnsupportedGuiDomain(detail)) {
+      throw new Error(
+        [
+          `launchctl bootstrap failed: ${detail}`,
+          `LaunchAgent install requires a logged-in macOS GUI session for this user (${domain}).`,
+          "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
+          "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway install --force`.",
+          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
+        ].join("\n"),
+      );
+    }
+    throw new Error(`launchctl bootstrap failed: ${detail}`);
   }
   await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
 


### PR DESCRIPTION
## Summary

Detect launchctl bootstrap domain errors ("Domain does not support specified action" / code 125) and show actionable install guidance. This clarifies that LaunchAgent install needs a logged-in GUI session and often fails under SSH/headless or wrong-user contexts.

Current baseline implementation has no clear guidance for users and is often quite confusing in `openclaw doctor` commands. This improves the mssaging and adds a targeted test for the domain-error path.

- Fixes #13794 
- Fixes #7417
lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change improves `installLaunchAgent`’s error reporting when `launchctl bootstrap` fails due to an unsupported GUI domain (e.g., headless/SSH sessions or wrong-user contexts), by detecting the specific launchctl failure text/code and throwing a more actionable message with next steps.

It also adds a focused unit test that stubs `launchctl` on `PATH` to force the domain-error output and asserts the resulting guidance text is included in the thrown error.

<h3>Confidence Score: 4/5</h3>

- This PR appears safe to merge; it adds targeted error messaging and a focused test without changing normal success paths.
- The new logic is isolated to the `launchctl bootstrap` failure branch and only triggers on well-scoped substrings. The added test uses a PATH-stubbed `launchctl` consistent with existing patterns in this test file. I couldn’t execute the test suite in this environment (no node/pnpm available), so confidence is slightly reduced.
- src/daemon/launchd.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->