### PR TITLE
feat: make announce delivery summary instruction customizable (#13755)

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -380,6 +380,7 @@ export async function runSubagentAnnounceFlow(params: {
   label?: string;
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
+  summaryPrompt?: string | false;
 }): Promise<boolean> {
   let didAnnounce = false;
   let shouldDeleteChildSession = params.cleanup === "delete";
@@ -486,6 +487,18 @@ export async function runSubagentAnnounceFlow(params: {
     // Build instructional message for main agent
     const announceType = params.announceType ?? "subagent task";
     const taskLabel = params.label || params.task || "task";
+
+    const defaultSummaryPrompt = [
+      "Summarize this naturally for the user. Keep it brief (1-2 sentences). Flow it into the conversation naturally.",
+      `Do not mention technical details like tokens, stats, or that this was a ${announceType}.`,
+      "You can respond with NO_REPLY if no announcement is needed (e.g., internal task with no user-facing result).",
+    ].join("\n");
+
+    const summaryInstruction =
+      params.summaryPrompt === false || params.summaryPrompt === ""
+        ? ""
+        : (params.summaryPrompt ?? defaultSummaryPrompt);
+
     const triggerMessage = [
       `A ${announceType} "${taskLabel}" just ${statusLabel}.`,
       "",
@@ -493,10 +506,7 @@ export async function runSubagentAnnounceFlow(params: {
       reply || "(no output)",
       "",
       statsLine,
-      "",
-      "Summarize this naturally for the user. Keep it brief (1-2 sentences). Flow it into the conversation naturally.",
-      `Do not mention technical details like tokens, stats, or that this was a ${announceType}.`,
-      "You can respond with NO_REPLY if no announcement is needed (e.g., internal task with no user-facing result).",
+      ...(summaryInstruction ? ["", summaryInstruction] : []),
     ].join("\n");
 
     const queued = await maybeQueueSubagentAnnounce({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -562,6 +562,7 @@ export async function runCronIsolatedAgentTurn(params: {
           endedAt: runEndedAt,
           outcome: { status: "ok" },
           announceType: "cron job",
+          summaryPrompt: params.job.delivery?.summaryPrompt,
         });
         if (!didAnnounce) {
           const message = "cron announce delivery failed";

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -366,6 +366,7 @@ function mergeCronDelivery(
     channel: existing?.channel,
     to: existing?.to,
     bestEffort: existing?.bestEffort,
+    summaryPrompt: existing?.summaryPrompt,
   };
 
   if (typeof patch.mode === "string") {
@@ -381,6 +382,12 @@ function mergeCronDelivery(
   }
   if (typeof patch.bestEffort === "boolean") {
     next.bestEffort = patch.bestEffort;
+  }
+  if ("summaryPrompt" in patch) {
+    next.summaryPrompt =
+      patch.summaryPrompt === false || typeof patch.summaryPrompt === "string"
+        ? patch.summaryPrompt
+        : undefined;
   }
 
   return next;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -17,6 +17,7 @@ export type CronDelivery = {
   channel?: CronMessageChannel;
   to?: string;
   bestEffort?: boolean;
+  summaryPrompt?: string | false;
 };
 
 export type CronDeliveryPatch = Partial<CronDelivery>;


### PR DESCRIPTION
## feat: make announce delivery summary instruction customizable (#13755)

### Problem

When a cron job uses `delivery.mode = "announce"`, the summary instruction sent to the main session is hardcoded. Users cannot customize or disable it, which forces the agent to always summarize cron output into 1-2 sentences even when verbatim output is desired.

### Solution

Added an optional `summaryPrompt` field to `CronDelivery`:

```typescript
{
  "delivery": {
    "mode": "announce",
    "summaryPrompt": "Post the full output to the user verbatim."
  }
}
```

- `summaryPrompt: string` — custom instruction replaces the default
- `summaryPrompt: false` or `""` — no summary instruction appended
- `summaryPrompt` omitted — default behavior preserved (backward compatible)

### Changes

- `src/cron/types.ts`: Added `summaryPrompt?: string | false` to `CronDelivery`
- `src/agents/subagent-announce.ts`: Accept optional `summaryPrompt` parameter in announce flow
- `src/cron/isolated-agent/run.ts`: Pass `summaryPrompt` from job delivery config to announce flow

Closes #13755

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `summaryPrompt?: string | false` field to cron announce delivery, threads it through the isolated cron run path, and updates the shared subagent announce flow to optionally override or disable the default “summarize in 1–2 sentences” instruction.

The announce flow change is localized to how the trigger message is constructed for the main session; the isolated cron runner now passes the job’s configured `delivery.summaryPrompt` into that flow when `delivery.mode = "announce"`.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a functional issue that breaks the new setting on cron job updates.
- Core plumbing for `summaryPrompt` is correct, but `mergeCronDelivery()` does not preserve or apply `summaryPrompt`, so delivery patches will drop the configured prompt and prevent reliably updating/clearing it via `cron.update`.
- src/cron/service/jobs.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->