### PR TITLE
fix: prevent steer during tool execution to avoid tool_use/tool_result mismatch (#13704)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -660,6 +660,7 @@ export async function runEmbeddedAttempt(
         },
         isStreaming: () => activeSession.isStreaming,
         isCompacting: () => subscription.isCompacting(),
+        isToolRunning: () => subscription.isToolRunning(),
         abort: abortRun,
       };
       setActiveEmbeddedRun(params.sessionId, queueHandle);

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -606,6 +606,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     toolMetas,
     unsubscribe,
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,
+    isToolRunning: () => state.toolMetaById.size > 0,
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
     // Returns true if any messaging tool successfully sent a message.


### PR DESCRIPTION
## Problem

When a long-running exec command is in progress and a queued subagent announcement is delivered, `queueEmbeddedPiMessage` injects the message via `steer` into the active session. This inserts a user message between `tool_use` and `tool_result`, breaking Anthropic's strict pairing requirement and causing API rejection:

```
invalid_request_error: messages.59: `tool_use` ids were found without `tool_result` blocks immediately after: call_52523385.
```

## Root Cause

`queueEmbeddedPiMessage` only checks `isStreaming()` and `isCompacting()` before injecting messages, but doesn't check whether tools are currently executing. When a tool (e.g., exec) is running, the session has an outstanding `tool_use` waiting for its `tool_result`. Injecting a user message at this point breaks the pairing.

## Fix

Added `isToolRunning` check to `EmbeddedPiQueueHandle` and `queueEmbeddedPiMessage`. When tools are executing, `queueEmbeddedPiMessage` returns `false`, causing the caller to fall through to the queue path (`enqueueAnnounce`), which delivers the message after the current tool loop completes.

The implementation leverages the existing `toolMetaById` map in the subscription state, which already tracks in-flight tools (entries added on `tool_execution_start`, removed on `tool_execution_end`). No new state is needed — just a new accessor `isToolRunning()` that checks `toolMetaById.size > 0`.

### Changes

- **`src/agents/pi-embedded-runner/runs.ts`**: Added optional `isToolRunning` to `EmbeddedPiQueueHandle` type; added guard in `queueEmbeddedPiMessage` that returns `false` when tools are running
- **`src/agents/pi-embedded-runner/run/attempt.ts`**: Wired `subscription.isToolRunning()` into the `queueHandle`
- **`src/agents/pi-embedded-subscribe.ts`**: Exposed `isToolRunning()` from subscription return, backed by `state.toolMetaById.size > 0`

Closes #13704