### PR TITLE
fix: prevent undefined token in gateway auth config

### DIFF
--- a/src/commands/configure.gateway-auth.test.ts
+++ b/src/commands/configure.gateway-auth.test.ts
@@ -43,4 +43,43 @@ describe("buildGatewayAuthConfig", () => {
 
     expect(result).toEqual({ mode: "password", password: "secret" });
   });
+
+  it("generates random token when token param is undefined", () => {
+    const result = buildGatewayAuthConfig({
+      mode: "token",
+      token: undefined,
+    });
+
+    expect(result?.mode).toBe("token");
+    expect(result?.token).toBeDefined();
+    expect(result?.token).not.toBe("undefined");
+    expect(typeof result?.token).toBe("string");
+    expect(result?.token?.length).toBeGreaterThan(0);
+  });
+
+  it("generates random token when token param is empty string", () => {
+    const result = buildGatewayAuthConfig({
+      mode: "token",
+      token: "",
+    });
+
+    expect(result?.mode).toBe("token");
+    expect(result?.token).toBeDefined();
+    expect(result?.token).not.toBe("undefined");
+    expect(typeof result?.token).toBe("string");
+    expect(result?.token?.length).toBeGreaterThan(0);
+  });
+
+  it("generates random token when token param is whitespace only", () => {
+    const result = buildGatewayAuthConfig({
+      mode: "token",
+      token: "   ",
+    });
+
+    expect(result?.mode).toBe("token");
+    expect(result?.token).toBeDefined();
+    expect(result?.token).not.toBe("undefined");
+    expect(typeof result?.token).toBe("string");
+    expect(result?.token?.length).toBeGreaterThan(0);
+  });
 });

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -12,6 +12,7 @@ import {
   promptModelAllowlist,
 } from "./model-picker.js";
 import { promptCustomApiConfig } from "./onboard-custom.js";
+import { randomToken } from "./onboard-helpers.js";
 
 type GatewayAuthChoice = "token" | "password";
 
@@ -35,7 +36,9 @@ export function buildGatewayAuthConfig(params: {
   }
 
   if (params.mode === "token") {
-    return { ...base, mode: "token", token: params.token };
+    // Guard against undefined/empty token to prevent JSON.stringify from writing the string "undefined"
+    const safeToken = params.token?.trim() || randomToken();
+    return { ...base, mode: "token", token: safeToken };
   }
   return { ...base, mode: "password", password: params.password };
 }


### PR DESCRIPTION
## Summary

Fixes #13756

When running `openclaw configure` with token auth mode, if the token parameter is undefined, empty, or whitespace-only, the config would write the literal string `"undefined"` to `gateway.auth.token`.

This fix ensures that `buildGatewayAuthConfig` always generates a random token when the provided token is undefined, empty, or whitespace-only.

## Changes

- Import `randomToken` from `onboard-helpers.ts`
- Guard against undefined/empty token in `buildGatewayAuthConfig`
- Use `params.token?.trim() || randomToken()` to provide a fallback
- Add 3 new tests covering undefined, empty, and whitespace-only token cases

## Testing

All existing tests pass. New tests added:
- ✅ generates random token when token param is undefined
- ✅ generates random token when token param is empty string
- ✅ generates random token when token param is whitespace only

## Impact

- Prevents security issue where gateway runs with literal `"undefined"` as token
- Improves robustness of gateway configuration
- Follows defensive programming best practices

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway auth configuration builder to ensure token-mode auth never persists an undefined/blank token. `buildGatewayAuthConfig` now trims the provided token and falls back to `randomToken()` when the input is `undefined`, empty, or whitespace-only. It also adds unit tests covering those token fallback cases.

The change is localized to the configure command’s gateway-auth builder (`src/commands/configure.gateway-auth.ts`) and its colocated Vitest suite (`src/commands/configure.gateway-auth.test.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses the reported token serialization issue.
- Change is small and targeted, uses an existing `randomToken()` helper, and new unit tests cover the problematic undefined/blank inputs. I couldn’t execute the test suite in this environment (pnpm unavailable), so confidence is slightly reduced.
- src/commands/configure.gateway-auth.ts (token generation path) and src/commands/configure.gateway-auth.test.ts (test import path)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->