### PR TITLE
fix(gateway): auto-generate token during install to prevent launchd restart loop

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -4,9 +4,16 @@ import {
   DEFAULT_GATEWAY_DAEMON_RUNTIME,
   isGatewayDaemonRuntime,
 } from "../../commands/daemon-runtime.js";
-import { loadConfig, resolveGatewayPort } from "../../config/config.js";
+import { randomToken } from "../../commands/onboard-helpers.js";
+import {
+  loadConfig,
+  readConfigFileSnapshot,
+  resolveGatewayPort,
+  writeConfigFile,
+} from "../../config/config.js";
 import { resolveIsNixMode } from "../../config/paths.js";
 import { resolveGatewayService } from "../../daemon/service.js";
+import { resolveGatewayAuth } from "../../gateway/auth.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { buildDaemonServiceSnapshot, createNullWriter, emitDaemonActionJson } from "./response.js";
@@ -93,10 +100,78 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     }
   }
 
+  // Resolve effective auth mode to determine if token auto-generation is needed.
+  // Password-mode and Tailscale-only installs do not need a token.
+  const resolvedAuth = resolveGatewayAuth({
+    authConfig: cfg.gateway?.auth,
+    tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
+  });
+  const needsToken =
+    resolvedAuth.mode === "token" && !resolvedAuth.token && !resolvedAuth.allowTailscale;
+
+  let token: string | undefined =
+    opts.token ||
+    cfg.gateway?.auth?.token ||
+    process.env.OPENCLAW_GATEWAY_TOKEN ||
+    process.env.CLAWDBOT_GATEWAY_TOKEN;
+
+  if (!token && needsToken) {
+    token = randomToken();
+    const warnMsg = "No gateway token found. Auto-generated one and saving to config.";
+    if (json) {
+      warnings.push(warnMsg);
+    } else {
+      defaultRuntime.log(warnMsg);
+    }
+
+    // Persist to config file so the gateway reads it at runtime
+    // (launchd does not inherit shell env vars, and CLI tools also
+    // read gateway.auth.token from config for gateway calls).
+    try {
+      const snapshot = await readConfigFileSnapshot();
+      if (snapshot.exists && !snapshot.valid) {
+        // Config file exists but is corrupt/unparseable — don't risk overwriting.
+        // Token is still embedded in the plist EnvironmentVariables.
+        const msg = "Warning: config file exists but is invalid; skipping token persistence.";
+        if (json) {
+          warnings.push(msg);
+        } else {
+          defaultRuntime.log(msg);
+        }
+      } else {
+        const baseConfig = snapshot.exists ? snapshot.config : {};
+        if (!baseConfig.gateway?.auth?.token) {
+          await writeConfigFile({
+            ...baseConfig,
+            gateway: {
+              ...baseConfig.gateway,
+              auth: {
+                ...baseConfig.gateway?.auth,
+                mode: baseConfig.gateway?.auth?.mode ?? "token",
+                token,
+              },
+            },
+          });
+        } else {
+          // Another process wrote a token between loadConfig() and now.
+          token = baseConfig.gateway.auth.token;
+        }
+      }
+    } catch (err) {
+      // Non-fatal: token is still embedded in the plist EnvironmentVariables.
+      const msg = `Warning: could not persist token to config: ${String(err)}`;
+      if (json) {
+        warnings.push(msg);
+      } else {
+        defaultRuntime.log(msg);
+      }
+    }
+  }
+
   const { programArguments, workingDirectory, environment } = await buildGatewayInstallPlan({
     env: process.env,
     port,
-    token: opts.token || cfg.gateway?.auth?.token || process.env.OPENCLAW_GATEWAY_TOKEN,
+    token,
     runtime: runtimeRaw,
     warn: (message) => {
       if (json) {


### PR DESCRIPTION
## Summary

- Auto-generate a gateway token during `openclaw gateway install` when auth mode is `token` and no token is configured
- Persist the token to the config file and embed it in the plist `EnvironmentVariables` (belt-and-suspenders)
- Prevents the infinite restart loop under macOS launchd, which doesn't inherit shell env vars

## Related Issues

- #5103 — Migration leaves system in broken state with restart loop + token mismatch
- #2433 — Gateway launchd job keeps retrying every 10 seconds
- #1690 — Webchat UI fails to authenticate: "gateway token missing"
- #7749 — Dashboard doesn't include token in URL

## What Changed

**`src/cli/daemon-cli/install.ts`** — the only file modified:
1. Added `resolveGatewayAuth()` check to determine if token auto-generation is needed
2. Guarded behind `needsToken` (skips password-mode and Tailscale-only installs)
3. Three-way config write strategy: no file → write minimal; valid → spread + add; invalid → skip
4. Matches existing patterns in `doctor.ts:145` and `configure.gateway.ts:185`

## Test Plan

- [x] `pnpm check` passes (format, types, lint — 0 warnings, 0 errors)
- [x] `pnpm test` passes (258 tests, 43 test files)
- [ ] Manual: remove token from config, run `openclaw gateway install --force`, verify auto-generated token in config + plist
- [ ] Manual: set existing token, reinstall, verify preserved
- [ ] Manual: password mode install — verify no spurious token generated

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends gateway install behavior and outbound messaging:

- During `openclaw gateway install`, it resolves the effective gateway auth mode and, when running in token auth with no token configured, auto-generates a token, attempts to persist it to the config file, and then passes the token into the service install plan so it’s embedded in the installed service environment.
- It threads an optional `agentId` through outbound delivery so the Slack outbound adapter can derive a per-agent “persona” (display name + icon) and uses a Slack API fallback to default identity when the bot token lacks `chat:write.customize`.
- It factors heartbeat quiet-hours logic into a dedicated helper and adjusts a docker setup test to skip a Bash 3.2 compatibility probe when `/bin/bash` is unavailable.

Overall, the changes fit into existing patterns: install uses the daemon install helpers + service-env to construct launchd/systemd/schtasks environments, and outbound delivery continues to be plugin-driven with minimal core type churn.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge, but one install-path bug can leave the service without a token in a supported env-var configuration.
- Most changes are additive and integrate with existing install/outbound abstractions. The main concern is a verified mismatch between `resolveGatewayAuth` token sources and the token actually used for service installation, which can defeat the PR’s primary fix for users relying on `CLAWDBOT_GATEWAY_TOKEN`.
- src/cli/daemon-cli/install.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->