### PR TITLE
feat(web-search): add ZAI Search (zsearch) provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ USER.md
 # local tooling
 .serena/
 
+# IDE
+.idea/
+
 # Agent credentials and memory (NEVER COMMIT)
 /memory/
 .agent/*.json

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -11,6 +11,7 @@ const {
   resolveGrokModel,
   resolveGrokInlineCitations,
   extractGrokContent,
+  mapBraveFreshnessToZai,
 } = __testing;
 
 describe("web_search perplexity baseUrl defaults", () => {
@@ -161,5 +162,31 @@ describe("web_search grok response parsing", () => {
     expect(extractGrokContent({ output_text: "hello from output_text" })).toBe(
       "hello from output_text",
     );
+  });
+});
+
+describe("web_search ZAI Search freshness mapping", () => {
+  it("maps pd to oneDay", () => {
+    expect(mapBraveFreshnessToZai("pd")).toBe("oneDay");
+  });
+
+  it("maps pw to oneWeek", () => {
+    expect(mapBraveFreshnessToZai("pw")).toBe("oneWeek");
+  });
+
+  it("maps pm to oneMonth", () => {
+    expect(mapBraveFreshnessToZai("pm")).toBe("oneMonth");
+  });
+
+  it("maps py to oneYear", () => {
+    expect(mapBraveFreshnessToZai("py")).toBe("oneYear");
+  });
+
+  it("returns noLimit for undefined", () => {
+    expect(mapBraveFreshnessToZai(undefined)).toBe("noLimit");
+  });
+
+  it("returns noLimit for unknown values", () => {
+    expect(mapBraveFreshnessToZai("2024-01-01to2024-01-31")).toBe("noLimit");
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -66,7 +66,7 @@ const WebSearchSchema = Type.Object({
   freshness: Type.Optional(
     Type.String({
       description:
-        "Filter results by discovery time (Brave only). Values: 'pd' (past 24h), 'pw' (past week), 'pm' (past month), 'py' (past year), or date range 'YYYY-MM-DDtoYYYY-MM-DD'.",
+        "Filter results by discovery time (Brave and ZAI Search). Values: 'pd' (past 24h), 'pw' (past week), 'pm' (past month), 'py' (past year), or date range 'YYYY-MM-DDtoYYYY-MM-DD'.",
     }),
   ),
 });
@@ -444,9 +444,9 @@ async function initZsearchSession(
     id: 0,
     method: "initialize",
     params: {
-      protocolVersion: "2024-11-05",
+      protocolVersion: "2025-03-26",
       capabilities: {},
-      clientInfo: { name: "openclaw", version: "1.0.0" },
+      clientInfo: { name: "ExampleClient", version: "1.0.0" },
     },
   };
 
@@ -473,6 +473,19 @@ async function initZsearchSession(
 
   // Consume the response body to avoid leaking resources.
   await res.text();
+
+  // Send initialized notification as required by MCP spec.
+  await fetch(baseUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${apiKey}`,
+      "Mcp-Session-Id": sessionId,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    signal: withTimeout(undefined, timeoutMs),
+  });
 
   return sessionId;
 }

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -21,4 +21,55 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts zsearch provider and config", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "zsearch",
+            zsearch: {
+              apiKey: "test-zai-key",
+              contentSize: "medium",
+              location: "us",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts zsearch provider without config block", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            provider: "zsearch",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid zsearch contentSize", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            provider: "zsearch",
+            zsearch: {
+              contentSize: "invalid",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -336,8 +336,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", or "grok"). */
-      provider?: "brave" | "perplexity" | "grok";
+      /** Search provider ("brave", "perplexity", "grok", or "zsearch"). */
+      provider?: "brave" | "perplexity" | "grok" | "zsearch";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -363,6 +363,17 @@ export type ToolsConfig = {
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
         inlineCitations?: boolean;
+      };
+      /** ZAI Search-specific configuration (used when provider="zsearch"). */
+      zsearch?: {
+        /** API key for ZAI Search (defaults to ZAI_API_KEY env var). */
+        apiKey?: string;
+        /** Base URL for ZAI Search MCP endpoint (defaults to ZAI_SEARCH_BASE_URL env var or "https://api.z.ai/api/mcp/web_search_prime/mcp"). */
+        baseUrl?: string;
+        /** Content size: "medium" (400-600 words) or "high" (2500 words). */
+        contentSize?: "medium" | "high";
+        /** Location filter: "cn" or "us". */
+        location?: "cn" | "us";
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -171,7 +171,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("grok"), z.literal("zsearch")])
+      .optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -189,6 +191,15 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional(),
         model: z.string().optional(),
         inlineCitations: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    zsearch: z
+      .object({
+        apiKey: z.string().optional(),
+        baseUrl: z.string().url().optional(),
+        contentSize: z.union([z.literal("medium"), z.literal("high")]).optional(),
+        location: z.union([z.literal("cn"), z.literal("us")]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
- Add ZAI Search (`zsearch`) as a new `web_search` provider alongside Brave, Perplexity, and Grok
- Implements the two-step MCP Streamable HTTP protocol: `initialize` to obtain `Mcp-Session-Id`, then `tools/call` with that session header
- Supports freshness filters (mapped from Brave format), content size (`medium`/`high`), location (`cn`/`us`), and `baseUrl` override via config or `ZAI_SEARCH_BASE_URL` env var
- API key resolved from config `tools.web.search.zsearch.apiKey` or `ZAI_API_KEY` / `Z_AI_API_KEY` env vars

## Changed files
- `src/agents/tools/web-search.ts` — provider implementation, MCP session init, search execution
- `src/config/types.tools.ts` — `zsearch` config type definition
- `src/config/zod-schema.agent-runtime.ts` — Zod validation schema for `zsearch` config
- `src/agents/tools/web-search.test.ts` — tests for freshness mapping
- `src/config/config.web-search-provider.test.ts` — config validation tests
- `.gitignore` — add `.idea/`

## Test plan
- [x] Unit tests pass (34 tests across 2 files)
- [x] Manual verification: MCP init + search call returns valid results
- [ ] Integration test with live ZAI API key

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added ZAI Search (`zsearch`) as a new web search provider alongside Brave, Perplexity, and Grok. The implementation follows the two-step MCP Streamable HTTP protocol with session initialization and subsequent search calls.

**Key changes:**
- Implemented MCP session management with `initialize` handshake to obtain session ID
- Added freshness filter mapping from Brave format to ZAI format (`pd` → `oneDay`, etc.)
- Supports content size (`medium`/`high`), location (`cn`/`us`), and custom `baseUrl` configuration
- API key resolution from config or `ZAI_API_KEY`/`Z_AI_API_KEY` environment variables
- Comprehensive test coverage for freshness mapping and config validation
- Cache key includes provider-specific parameters (contentSize, location, freshness)
- Proper error handling for JSON-RPC responses and tool errors

The implementation is well-structured and follows existing patterns in the codebase for other search providers.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns for other search providers, includes comprehensive tests, and handles errors properly. The only minor issue is a schema description that should be updated to reflect ZAI Search support for freshness filtering. The code is well-structured with proper session management, timeout handling, and cache invalidation.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->