### PR TITLE
fix(usage): deflate cumulative cache-read tokens in context display

### DIFF
--- a/src/agents/usage.e2e.test.ts
+++ b/src/agents/usage.e2e.test.ts
@@ -135,4 +135,19 @@ describe("normalizeUsage", () => {
       }),
     ).toBe(5_000); // input only, since cacheWrite is 0
   });
+
+  it("returns undefined when cumulative data has no input or cacheWrite", () => {
+    // Edge case: cache-hit-only turns where input=0 and cacheWrite=0.
+    // deflated = 0, which should yield undefined — NOT clamp to contextTokens.
+    expect(
+      deriveSessionTotalTokens({
+        usage: {
+          input: 0,
+          cacheRead: 2_000_000,
+          cacheWrite: 0,
+        },
+        contextTokens: 200_000,
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -149,8 +149,7 @@ export function deriveSessionTotalTokens(params: {
     promptTokens !== undefined &&
     promptTokens > contextTokens
   ) {
-    const deflated = input + cacheWrite;
-    total = deflated > 0 ? deflated : input || total;
+    total = input + cacheWrite;
   }
   if (!(total > 0)) {
     return undefined;


### PR DESCRIPTION
## Summary

Fixes #13782

The `/status` command always displays context as `200k/200k` (100%) in multi-turn agent sessions because cumulative `cacheRead` tokens inflate the prompt-token sum far beyond the actual context window.

**Root cause**: `deriveSessionTotalTokens()` calls `derivePromptTokens()` which sums `input + cacheRead + cacheWrite`. The usage metrics fed to this function come from `createUsageAccumulator()` in `run.ts`, which **adds** each turn's cache metrics cumulatively. After 12 turns with a 200k cached system prompt, `cacheRead` reaches ~2.4M. The sum is then clamped to `Math.min(total, contextWindow)`, always showing 100%.

**Fix**: A single API call can never have `input + cacheRead + cacheWrite > contextWindow`. When the derived prompt-token sum exceeds the context window, the data must be cumulative — so we fall back to `input + cacheWrite`, which approximates actual context consumption without cumulative cache-read inflation.

This fix is at the consumer level (`deriveSessionTotalTokens`), so it protects all three callers: session-usage persistence, cron isolated-agent runs, and the agent session-store path.

> Note: PR #13805 takes a complementary approach by fixing the accumulator (producer side). These fixes are independent and non-conflicting — both improve correctness at different layers.

## Test plan

- [x] Add test: cumulative `cacheRead` (2.4M) with 200k context → returns `input + cacheWrite`, not clamped to 200k
- [x] Add test: per-turn prompt tokens within context window → uses full sum as-is
- [x] Add test: normal usage (small cache) within context window → unchanged behavior
- [x] Add test: cumulative usage with nonzero `cacheWrite` → returns `input + cacheWrite`
- [x] Add test: cumulative usage with zero `cacheWrite` → returns `input` only
- [x] All 5 new tests fail before fix, pass after
- [x] `pnpm build` passes
- [x] `pnpm check` passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes cumulative `cacheRead` token inflation in multi-turn agent sessions that caused the `/status` command to always display context as 100% (200k/200k).

**What changed:**
- Modified `deriveSessionTotalTokens()` in `src/agents/usage.ts:140-142` to detect when cumulative metrics exceed the context window
- When `promptTokens > contextWindow`, falls back to `input + cacheWrite` to exclude inflated cumulative `cacheRead`
- Added 5 comprehensive tests covering: cumulative inflation edge case, per-turn capping, normal usage, nonzero `cacheWrite`, and zero-input scenarios

**How it works:**
The accumulator in `run.ts` sums cache metrics across turns (12 turns × 200k cached prompt = 2.4M `cacheRead`). Since a single API call can never exceed the context window, an oversized sum indicates cumulative data. The fix deflates by using only `input + cacheWrite`, which approximates actual context consumption.

The solution is consumer-side (in `deriveSessionTotalTokens`), protecting all three callers: session-usage persistence, cron isolated-agent runs, and agent session-store.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - narrow, well-tested fix addressing a specific display bug
- Clean implementation with comprehensive test coverage (5 new tests covering all edge cases), addresses the exact issue described in #13782, includes fix for previous review feedback (cache-only turns), and follows repository conventions (concise code with clear comments)
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->