### PR TITLE
UI: redesign config panel and raw mode UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
+    ],
+    "ignoredBuiltDependencies": [
+      "core-js"
     ]
   }
 }

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -7,9 +7,10 @@
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr);
   gap: 0;
-  height: calc(100vh - 160px);
-  margin: -16px;
-  border-radius: var(--radius-xl);
+  height: 100%;
+  min-height: 0;
+  margin: 0;
+  border-radius: 0;
   border: 1px solid var(--border);
   background: var(--panel);
 }
@@ -66,7 +67,17 @@
   width: 16px;
   height: 16px;
   color: var(--muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   pointer-events: none;
+}
+
+.config-search__icon svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
 }
 
 .config-search__input {
@@ -103,16 +114,18 @@
 
 .config-search__clear {
   position: absolute;
-  right: 22px;
+  right: 18px;
   top: 50%;
   transform: translateY(-50%);
-  width: 22px;
-  height: 22px;
+  min-width: 52px;
+  height: 24px;
+  padding: 0 8px;
   border: none;
-  border-radius: var(--radius-full);
+  border-radius: var(--radius-sm);
   background: var(--bg-hover);
   color: var(--muted);
-  font-size: 14px;
+  font-size: 11px;
+  font-weight: 600;
   line-height: 1;
   cursor: pointer;
   display: flex;
@@ -197,6 +210,27 @@
   text-overflow: ellipsis;
 }
 
+.config-nav__meta {
+  flex-shrink: 0;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: var(--radius-full);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.config-nav__item.active .config-nav__meta {
+  color: var(--accent);
+  border-color: rgba(255, 77, 77, 0.3);
+}
+
 /* Mode Toggle */
 .config-mode-toggle {
   display: flex;
@@ -258,6 +292,10 @@
   padding: 14px 22px;
   background: var(--bg-accent);
   border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  backdrop-filter: blur(8px);
 }
 
 :root[data-theme="light"] .config-actions {
@@ -269,6 +307,11 @@
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.config-actions__left {
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .config-changes-badge {
@@ -286,50 +329,64 @@
   color: var(--muted);
 }
 
-/* Diff Panel */
-.config-diff {
-  margin: 18px 22px 0;
-  border: 1px solid rgba(255, 77, 77, 0.25);
-  border-radius: var(--radius-lg);
-  background: var(--accent-subtle);
-  overflow: hidden;
+/* Diff Dropdown (inside actions) */
+.config-actions-diff {
+  position: relative;
 }
 
-.config-diff__summary {
+.config-actions-diff__trigger {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 14px 18px;
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: 600;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(255, 77, 77, 0.35);
+  background: var(--accent-subtle);
   color: var(--accent);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
   list-style: none;
 }
 
-.config-diff__summary::-webkit-details-marker {
+.config-actions-diff__trigger::-webkit-details-marker {
   display: none;
 }
 
-.config-diff__chevron {
-  width: 16px;
-  height: 16px;
+.config-actions-diff__chevron {
+  width: 14px;
+  height: 14px;
   transition: transform var(--duration-normal) var(--ease-out);
 }
 
-.config-diff__chevron svg {
+.config-actions-diff__chevron svg {
   width: 100%;
   height: 100%;
 }
 
-.config-diff[open] .config-diff__chevron {
+.config-actions-diff[open] .config-actions-diff__chevron {
   transform: rotate(180deg);
 }
 
+.config-actions-diff__panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: min(960px, calc(100vw - 56px));
+  max-width: calc(100vw - 32px);
+  border: 1px solid rgba(255, 77, 77, 0.25);
+  border-radius: var(--radius-lg);
+  background: var(--accent-subtle);
+  box-shadow: var(--shadow-lg);
+  z-index: 40;
+}
+
 .config-diff__content {
-  padding: 0 18px 18px;
+  padding: 12px;
   display: grid;
   gap: 10px;
+  max-height: min(56vh, 520px);
+  overflow: auto;
 }
 
 .config-diff__item {
@@ -378,7 +435,8 @@
 .config-section-hero {
   display: flex;
   align-items: center;
-  gap: 16px;
+  justify-content: space-between;
+  gap: 12px;
   padding: 16px 22px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-accent);
@@ -386,6 +444,13 @@
 
 :root[data-theme="light"] .config-section-hero {
   background: var(--bg-hover);
+}
+
+.config-section-hero__lead {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
 }
 
 .config-section-hero__icon {
@@ -424,6 +489,13 @@
   color: var(--muted);
 }
 
+.config-section-hero__meta {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
 /* Subsection Nav */
 .config-subnav {
   display: flex;
@@ -432,6 +504,7 @@
   border-bottom: 1px solid var(--border);
   background: var(--bg-accent);
   overflow-x: auto;
+  overflow-y: visible;
 }
 
 :root[data-theme="light"] .config-subnav {
@@ -469,18 +542,300 @@
   background: var(--accent-subtle);
 }
 
+.config-help {
+  position: relative;
+  display: inline-flex;
+}
+
+.config-help__trigger {
+  list-style: none;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.config-help__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.config-help[open] .config-help__trigger {
+  color: var(--accent);
+  border-color: rgba(255, 77, 77, 0.35);
+}
+
+.config-help__panel {
+  position: fixed;
+  left: var(--config-help-left, 12px);
+  top: var(--config-help-top, 12px);
+  width: max-content;
+  min-width: 220px;
+  max-width: min(420px, calc(100vw - 24px));
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.45;
+  word-break: break-word;
+  box-shadow: var(--shadow-lg);
+  max-height: min(320px, calc(100vh - 24px));
+  overflow: auto;
+  z-index: 160;
+}
+
 /* Content Area */
 .config-content {
   flex: 1;
   overflow-y: auto;
-  padding: 22px;
+  padding: 18px 22px 22px;
+}
+
+.config-raw-layout {
+  display: grid;
+  grid-template-columns: minmax(360px, 1.25fr) minmax(320px, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.config-raw-editor,
+.config-raw-panel {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  min-width: 0;
+}
+
+:root[data-theme="light"] .config-raw-editor,
+:root[data-theme="light"] .config-raw-panel {
+  background: white;
+}
+
+.config-raw-field {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
 }
 
 .config-raw-field textarea {
-  min-height: 500px;
+  min-height: 520px;
+  width: 100%;
   font-family: var(--mono);
   font-size: 13px;
   line-height: 1.55;
+  resize: vertical;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.config-raw-error {
+  margin: 0 12px 12px;
+}
+
+.config-raw-error__meta {
+  margin-top: 6px;
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.config-raw-error__context {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: var(--radius-md);
+  background: rgba(127, 29, 29, 0.12);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow-x: hidden;
+}
+
+:root[data-theme="light"] .config-raw-error__context {
+  background: rgba(254, 226, 226, 0.7);
+}
+
+.config-raw-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.config-raw-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .config-raw-panel__header {
+  background: var(--bg-hover);
+}
+
+.config-raw-panel__title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.config-raw-panel__actions {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.config-raw-panel__action {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.config-raw-panel__action:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.config-raw-panel__action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.config-raw-panel__empty {
+  padding: 14px 12px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.config-raw-tree {
+  padding: 8px 10px 12px;
+  max-height: 660px;
+  overflow: auto;
+  overflow-x: hidden;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.config-raw-node,
+.config-raw-leaf {
+  margin: 2px 0;
+  min-width: 0;
+}
+
+.config-raw-node__summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  cursor: pointer;
+  padding: 3px 6px;
+  border-radius: var(--radius-sm);
+  transition: background var(--duration-fast) ease;
+  overflow-wrap: anywhere;
+}
+
+.config-raw-node__summary:hover {
+  background: var(--bg-hover);
+}
+
+.config-raw-node__summary::-webkit-details-marker {
+  display: none;
+}
+
+.config-raw-node__children {
+  margin-left: 14px;
+  padding-left: 10px;
+  border-left: 1px dashed var(--border);
+  min-width: 0;
+}
+
+.config-raw-node__meta {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.config-raw-node__empty {
+  color: var(--muted);
+  padding: 4px 6px;
+}
+
+.config-raw-leaf {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 3px 6px;
+}
+
+.config-raw-key {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.config-raw-token {
+  font-family: inherit;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.config-raw-token--key {
+  color: var(--accent);
+}
+
+.config-raw-token--index {
+  color: var(--muted);
+}
+
+.config-raw-token--string {
+  color: var(--ok);
+}
+
+.config-raw-token--number {
+  color: #f59e0b;
+}
+
+.config-raw-token--boolean {
+  color: #38bdf8;
+}
+
+.config-raw-token--null,
+.config-raw-token--unknown,
+.config-raw-token--punct {
+  color: var(--muted);
+}
+
+:root[data-theme="light"] .config-raw-token--boolean {
+  color: #0ea5e9;
 }
 
 /* Loading State */
@@ -530,12 +885,25 @@
   font-size: 15px;
 }
 
+.config-progressive-hint {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  font-size: 12px;
+  background: var(--bg-accent);
+}
+
 /* ===========================================
    Section Cards
    =========================================== */
 
 .config-form--modern {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  grid-auto-flow: row dense;
+  align-items: start;
   gap: 26px;
 }
 
@@ -543,8 +911,9 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-elevated);
-  overflow: hidden;
+  overflow: visible;
   transition: border-color var(--duration-fast) ease;
+  min-width: 0;
 }
 
 .config-section-card:hover {
@@ -604,6 +973,7 @@
 
 .config-section-card__content {
   padding: 22px;
+  min-width: 0;
 }
 
 /* ===========================================
@@ -612,12 +982,107 @@
 
 .cfg-fields {
   display: grid;
-  gap: 22px;
+  gap: 12px;
+}
+
+.cfg-fields--embedded {
+  display: block;
+  column-width: 280px;
+  column-gap: 12px;
+}
+
+.cfg-fields__meta {
+  display: flex;
+  justify-content: flex-end;
+  break-inside: avoid;
+  margin: 0 0 10px;
+}
+
+.cfg-fields--top {
+  display: block;
+  column-width: 280px;
+  column-gap: 12px;
+  break-inside: avoid;
+}
+
+.cfg-fields--top > * {
+  display: block;
+  width: 100%;
+  margin: 0 0 10px;
+  min-width: 0;
+  break-inside: avoid;
+}
+
+.cfg-fields--embedded > * {
+  display: block;
+  width: 100%;
+  margin: 0 0 10px;
+  break-inside: avoid;
+}
+
+.cfg-fields--top > .cfg-item--full {
+  column-span: all;
+}
+
+.cfg-fields--embedded > .cfg-item--full {
+  column-span: all;
 }
 
 .cfg-field {
   display: grid;
   gap: 8px;
+  min-width: 0;
+}
+
+.cfg-field--compact {
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .cfg-field--compact {
+  background: white;
+}
+
+.cfg-field--number {
+  grid-template-columns: 1fr;
+  align-items: stretch;
+  gap: 6px;
+}
+
+.cfg-field--number .cfg-field__header {
+  align-items: flex-start;
+}
+
+.cfg-field--number .cfg-number {
+  justify-self: stretch;
+  max-width: none;
+}
+
+.cfg-field--number-no-label {
+  grid-template-columns: 1fr;
+}
+
+.cfg-field--number-no-label .cfg-number {
+  justify-self: stretch;
+  max-width: none;
+}
+
+.cfg-item {
+  min-width: 0;
+}
+
+.cfg-field__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.cfg-field__header--icon-only {
+  justify-content: flex-end;
 }
 
 .cfg-field--error {
@@ -625,6 +1090,18 @@
   border-radius: var(--radius-md);
   background: var(--danger-subtle);
   border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.cfg-field--fallback {
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+}
+
+.cfg-field__warning {
+  color: var(--muted);
+  font-size: 12px;
 }
 
 .cfg-field__label {
@@ -644,10 +1121,69 @@
   color: var(--danger);
 }
 
+.cfg-help {
+  position: relative;
+  display: inline-flex;
+}
+
+.cfg-help__trigger {
+  list-style: none;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.cfg-help__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.cfg-help[open] .cfg-help__trigger {
+  color: var(--accent);
+  border-color: rgba(255, 77, 77, 0.35);
+}
+
+.cfg-help__panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  left: auto;
+  width: max-content;
+  min-width: 180px;
+  max-width: min(var(--cfg-help-max-width, 340px), calc(100vw - 24px));
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.45;
+  word-break: break-word;
+  max-height: min(280px, calc(100vh - 80px));
+  overflow: auto;
+  box-shadow: var(--shadow-lg);
+  z-index: 120;
+}
+
+.cfg-help[data-align="left"] .cfg-help__panel {
+  left: 0;
+  right: auto;
+}
+
 /* Text Input */
 .cfg-input-wrap {
   display: flex;
   gap: 10px;
+  min-width: 0;
 }
 
 .cfg-input {
@@ -689,7 +1225,8 @@
 }
 
 .cfg-input__reset {
-  padding: 10px 14px;
+  min-width: 62px;
+  padding: 8px 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
@@ -744,7 +1281,11 @@
 
 /* Number Input */
 .cfg-number {
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: minmax(38px, 44px) minmax(0, 1fr) minmax(38px, 44px);
+  align-items: stretch;
+  width: 100%;
+  max-width: none;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-md);
   overflow: hidden;
@@ -756,12 +1297,13 @@
 }
 
 .cfg-number__btn {
-  width: 44px;
+  width: 100%;
+  min-height: 34px;
   border: none;
   background: var(--bg-elevated);
   color: var(--text);
-  font-size: 18px;
-  font-weight: 300;
+  font-size: 15px;
+  font-weight: 600;
   cursor: pointer;
   transition: background var(--duration-fast) ease;
 }
@@ -784,16 +1326,22 @@
 }
 
 .cfg-number__input {
-  width: 85px;
-  padding: 11px;
+  width: 100%;
+  min-width: 0;
+  padding: 6px 8px;
   border: none;
   border-left: 1px solid var(--border);
   border-right: 1px solid var(--border);
   background: transparent;
   font-size: 14px;
   text-align: center;
+  font-variant-numeric: tabular-nums;
   outline: none;
   -moz-appearance: textfield;
+}
+
+.cfg-number__input:focus {
+  background: var(--bg-hover);
 }
 
 .cfg-number__input::-webkit-outer-spin-button,
@@ -831,7 +1379,11 @@
 
 /* Segmented Control */
 .cfg-segmented {
-  display: inline-flex;
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
   padding: 4px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
@@ -843,6 +1395,8 @@
 }
 
 .cfg-segmented__btn {
+  flex: 1 1 120px;
+  min-width: 0;
   padding: 9px 18px;
   border: none;
   border-radius: var(--radius-sm);
@@ -850,6 +1404,9 @@
   color: var(--muted);
   font-size: 13px;
   font-weight: 500;
+  white-space: normal;
+  word-break: break-word;
+  line-height: 1.25;
   cursor: pointer;
   transition:
     background var(--duration-fast) ease,
@@ -877,8 +1434,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 18px;
-  padding: 16px 18px;
+  gap: 10px;
+  min-height: 36px;
+  padding: 6px 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-accent);
@@ -911,16 +1469,27 @@
   min-width: 0;
 }
 
+.cfg-toggle-row__label-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cfg-toggle-row__help-icon {
+  display: inline-flex;
+  justify-content: flex-end;
+}
+
 .cfg-toggle-row__label {
   display: block;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--text);
 }
 
 .cfg-toggle-row__help {
   display: block;
-  margin-top: 3px;
+  margin-top: 2px;
   font-size: 12px;
   color: var(--muted);
   line-height: 1.45;
@@ -941,8 +1510,8 @@
 
 .cfg-toggle__track {
   display: block;
-  width: 50px;
-  height: 28px;
+  width: 42px;
+  height: 24px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-full);
@@ -959,10 +1528,10 @@
 .cfg-toggle__track::after {
   content: "";
   position: absolute;
-  top: 3px;
-  left: 3px;
-  width: 20px;
-  height: 20px;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
   background: var(--text);
   border-radius: var(--radius-full);
   box-shadow: var(--shadow-sm);
@@ -977,7 +1546,7 @@
 }
 
 .cfg-toggle input:checked + .cfg-toggle__track::after {
-  transform: translateX(22px);
+  transform: translateX(18px);
   background: var(--ok);
 }
 
@@ -990,7 +1559,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-accent);
-  overflow: hidden;
+  overflow: visible;
 }
 
 :root[data-theme="light"] .cfg-object {
@@ -1021,6 +1590,12 @@
   color: var(--text);
 }
 
+.cfg-object__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .cfg-object__chevron {
   width: 18px;
   height: 18px;
@@ -1037,31 +1612,38 @@
   transform: rotate(180deg);
 }
 
-.cfg-object__help {
-  padding: 0 18px 14px;
-  font-size: 12px;
-  color: var(--muted);
-  border-bottom: 1px solid var(--border);
+.cfg-object__content {
+  padding: 12px;
+  display: block;
+  column-width: 280px;
+  column-gap: 12px;
+  min-width: 0;
 }
 
-.cfg-object__content {
-  padding: 18px;
-  display: grid;
-  gap: 18px;
+.cfg-object__content > * {
+  display: block;
+  width: 100%;
+  margin: 0 0 10px;
+  break-inside: avoid;
+}
+
+.cfg-object__content > .cfg-item--full {
+  column-span: all;
 }
 
 /* Array */
 .cfg-array {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .cfg-array__header {
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 14px 18px;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 10px;
   background: var(--bg-accent);
   border-bottom: 1px solid var(--border);
 }
@@ -1077,10 +1659,17 @@
   color: var(--text);
 }
 
+.cfg-array__label-wrap {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .cfg-array__count {
   font-size: 12px;
   color: var(--muted);
-  padding: 4px 10px;
+  padding: 2px 8px;
   background: var(--bg-elevated);
   border-radius: var(--radius-full);
 }
@@ -1093,7 +1682,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 14px;
+  padding: 5px 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
@@ -1131,7 +1720,7 @@
 }
 
 .cfg-array__empty {
-  padding: 36px 18px;
+  padding: 14px 10px;
   text-align: center;
   color: var(--muted);
   font-size: 13px;
@@ -1151,7 +1740,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 18px;
+  padding: 8px 10px;
   background: var(--bg-accent);
   border-bottom: 1px solid var(--border);
 }
@@ -1200,22 +1789,24 @@
 }
 
 .cfg-array__item-content {
-  padding: 18px;
+  padding: 10px;
+  min-width: 0;
 }
 
 /* Map (custom entries) */
 .cfg-map {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .cfg-map__header {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   justify-content: space-between;
-  gap: 14px;
-  padding: 14px 18px;
+  gap: 8px;
+  padding: 8px 10px;
   background: var(--bg-accent);
   border-bottom: 1px solid var(--border);
 }
@@ -1230,11 +1821,17 @@
   color: var(--muted);
 }
 
+.cfg-map__label-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .cfg-map__add {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 14px;
+  padding: 5px 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
@@ -1260,23 +1857,37 @@
 }
 
 .cfg-map__empty {
-  padding: 28px 18px;
+  padding: 12px 10px;
   text-align: center;
   color: var(--muted);
   font-size: 13px;
 }
 
 .cfg-map__items {
-  display: grid;
-  gap: 10px;
-  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 8px;
+  padding: 10px;
 }
 
 .cfg-map__item {
   display: grid;
-  grid-template-columns: 150px 1fr auto;
-  gap: 10px;
+  grid-template-columns: minmax(120px, 180px) minmax(0, 1fr) auto;
+  gap: 8px;
   align-items: start;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .cfg-map__item {
+  background: white;
+}
+
+.cfg-map__item > * {
+  min-width: 0;
 }
 
 .cfg-map__item-key {
@@ -1285,6 +1896,16 @@
 
 .cfg-map__item-value {
   min-width: 0;
+}
+
+.cfg-map__item-value .cfg-field--compact {
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.cfg-map__item-value .cfg-field__header {
+  margin-bottom: 2px;
 }
 
 .cfg-map__item-remove {
@@ -1329,13 +1950,78 @@
   color: var(--danger);
 }
 
+.config-issues {
+  margin: 12px 22px 22px;
+}
+
+.config-issues__title {
+  font-size: 13px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.config-issues__list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+}
+
+.config-issues__item {
+  display: grid;
+  gap: 2px;
+  font-size: 12px;
+}
+
+.config-issues__item code {
+  font-family: var(--mono);
+  color: var(--danger);
+}
+
 /* ===========================================
    Mobile Responsiveness
    =========================================== */
 
+@media (max-width: 1100px) {
+  .config-raw-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .config-raw-field textarea {
+    min-height: 400px;
+  }
+
+  .config-raw-tree {
+    max-height: 360px;
+  }
+
+  .cfg-map__item {
+    grid-template-columns: minmax(120px, 1fr) auto;
+    grid-template-areas:
+      "key remove"
+      "value value";
+    gap: 8px;
+  }
+
+  .cfg-map__item-key {
+    grid-area: key;
+  }
+
+  .cfg-map__item-value {
+    grid-area: value;
+  }
+
+  .cfg-map__item-remove {
+    grid-area: remove;
+    justify-self: end;
+    align-self: center;
+  }
+}
+
 @media (max-width: 768px) {
   .config-layout {
     grid-template-columns: 1fr;
+    height: 100%;
   }
 
   .config-sidebar {
@@ -1381,8 +2067,33 @@
     justify-content: center;
   }
 
+  .config-actions-diff {
+    width: 100%;
+  }
+
+  .config-actions-diff__trigger {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .config-actions-diff__panel {
+    left: 0;
+    width: min(96vw, calc(100vw - 32px));
+    max-width: calc(100vw - 24px);
+  }
+
   .config-section-hero {
     padding: 14px 16px;
+    align-items: flex-start;
+  }
+
+  .config-section-hero__lead {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .config-section-hero__meta {
+    margin-left: 0;
   }
 
   .config-subnav {
@@ -1391,6 +2102,48 @@
 
   .config-content {
     padding: 18px;
+  }
+
+  .config-raw-field {
+    padding: 10px;
+  }
+
+  .config-raw-field textarea {
+    min-height: 300px;
+  }
+
+  .config-raw-panel__header {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .config-raw-panel__actions {
+    width: 100%;
+  }
+
+  .config-raw-panel__action {
+    flex: 1;
+    text-align: center;
+  }
+
+  .cfg-fields--top {
+    column-width: auto;
+    column-count: 1;
+  }
+
+  .cfg-fields--embedded {
+    column-width: auto;
+    column-count: 1;
+  }
+
+  .config-form--modern {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .cfg-object__content {
+    column-width: auto;
+    column-count: 1;
   }
 
   .config-section-card__header {
@@ -1407,11 +2160,20 @@
 
   .cfg-map__item {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      "key"
+      "value"
+      "remove";
     gap: 10px;
   }
 
   .cfg-map__item-remove {
     justify-self: end;
+    align-self: start;
+  }
+
+  .config-issues {
+    margin: 12px 18px 18px;
   }
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -158,6 +158,19 @@
   gap: 8px;
 }
 
+.topbar-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.topbar-meta--config .pill {
+  height: 30px;
+  padding: 4px 10px;
+  font-size: 11px;
+}
+
 .topbar-status .pill {
   padding: 6px 10px;
   gap: 6px;
@@ -441,6 +454,15 @@
   gap: 24px;
   overflow: hidden;
   padding-bottom: 0;
+}
+
+.content--config {
+  padding: 0;
+  overflow: hidden;
+}
+
+.content--config > * + * {
+  margin-top: 0;
 }
 
 .content--chat > * + * {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -42,6 +42,17 @@
     white-space: nowrap;
     flex-shrink: 0;
   }
+
+  .topbar-meta--config {
+    max-width: 100%;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+  }
+
+  .topbar-meta--config::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 /* Mobile-specific styles */
@@ -78,6 +89,11 @@
     gap: 6px;
     width: auto;
     flex-wrap: nowrap;
+  }
+
+  .topbar-meta--config .pill {
+    font-size: 10px;
+    padding: 3px 8px;
   }
 
   .topbar-status .pill {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -105,6 +105,7 @@ export type AppViewState = {
   configForm: Record<string, unknown> | null;
   configFormOriginal: Record<string, unknown> | null;
   configFormMode: "form" | "raw";
+  configRenderLimit: number;
   configSearchQuery: string;
   configActiveSection: string | null;
   configActiveSubsection: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -179,6 +179,7 @@ export class OpenClawApp extends LitElement {
   @state() configFormOriginal: Record<string, unknown> | null = null;
   @state() configFormDirty = false;
   @state() configFormMode: "form" | "raw" = "form";
+  @state() configRenderLimit = 6;
   @state() configSearchQuery = "";
   @state() configActiveSection: string | null = null;
   @state() configActiveSubsection: string | null = null;

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -12,6 +12,84 @@ function isAnySchema(schema: JsonSchema): boolean {
   return keys.length === 0;
 }
 
+function inferType(schema: JsonSchema): string | undefined {
+  return (
+    schemaType(schema) ??
+    (schema.properties || schema.additionalProperties ? "object" : undefined) ??
+    (schema.items ? "array" : undefined)
+  );
+}
+
+function mergeAllOfNodes(base: JsonSchema, patch: JsonSchema): JsonSchema | null {
+  const baseType = inferType(base);
+  const patchType = inferType(patch);
+  if (!baseType && !patchType) {
+    return { ...base, ...patch };
+  }
+  if ((baseType && baseType !== "object") || (patchType && patchType !== "object")) {
+    return null;
+  }
+  const baseRequired = Array.isArray(base.required) ? base.required : [];
+  const patchRequired = Array.isArray(patch.required) ? patch.required : [];
+  const required = Array.from(new Set([...baseRequired, ...patchRequired]));
+  const merged: JsonSchema = {
+    ...base,
+    ...patch,
+    type: "object",
+    properties: {
+      ...base.properties,
+      ...patch.properties,
+    },
+    additionalProperties: patch.additionalProperties ?? base.additionalProperties,
+    allOf: undefined,
+    anyOf: undefined,
+    oneOf: undefined,
+  };
+  if (required.length > 0) {
+    merged.required = required;
+  } else {
+    delete merged.required;
+  }
+  return merged;
+}
+
+function normalizeAllOf(schema: JsonSchema, path: Array<string | number>): ConfigSchemaAnalysis | null {
+  const allOf = schema.allOf;
+  if (!allOf || allOf.length === 0) {
+    return null;
+  }
+  let merged: JsonSchema = {
+    ...schema,
+    allOf: undefined,
+  };
+  const unsupported = new Set<string>();
+  for (const entry of allOf) {
+    if (!entry || typeof entry !== "object") {
+      return null;
+    }
+    const normalized = normalizeSchemaNode(entry, path);
+    if (!normalized.schema) {
+      return null;
+    }
+    const nextMerged = mergeAllOfNodes(merged, normalized.schema);
+    if (!nextMerged) {
+      return null;
+    }
+    merged = nextMerged;
+    for (const unsupportedPath of normalized.unsupportedPaths) {
+      unsupported.add(unsupportedPath);
+    }
+  }
+  const normalizedMerged = normalizeSchemaNode(merged, path);
+  for (const unsupportedPath of normalizedMerged.unsupportedPaths) {
+    unsupported.add(unsupportedPath);
+  }
+  return {
+    schema: normalizedMerged.schema,
+    unsupportedPaths: Array.from(unsupported),
+  };
+}
+
 function normalizeEnum(values: unknown[]): { enumValues: unknown[]; nullable: boolean } {
   const filtered = values.filter((value) => value != null);
   const nullable = filtered.length !== values.length;
@@ -39,7 +117,15 @@ function normalizeSchemaNode(
   const normalized: JsonSchema = { ...schema };
   const pathLabel = pathKey(path) || "<root>";
 
-  if (schema.anyOf || schema.oneOf || schema.allOf) {
+  if (schema.allOf) {
+    const merged = normalizeAllOf(schema, path);
+    if (merged) {
+      return merged;
+    }
+    return { schema, unsupportedPaths: [pathLabel] };
+  }
+
+  if (schema.anyOf || schema.oneOf) {
     const union = normalizeUnion(schema, path);
     if (union) {
       return union;
@@ -48,8 +134,7 @@ function normalizeSchemaNode(
   }
 
   const nullable = Array.isArray(schema.type) && schema.type.includes("null");
-  const type =
-    schemaType(schema) ?? (schema.properties || schema.additionalProperties ? "object" : undefined);
+  const type = inferType(schema);
   normalized.type = type ?? schema.type;
   normalized.nullable = nullable || schema.nullable;
 
@@ -79,15 +164,17 @@ function normalizeSchemaNode(
     normalized.properties = normalizedProps;
 
     if (schema.additionalProperties === true) {
-      unsupported.add(pathLabel);
+      normalized.additionalProperties = {};
     } else if (schema.additionalProperties === false) {
       normalized.additionalProperties = false;
     } else if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
-      if (!isAnySchema(schema.additionalProperties)) {
+      if (isAnySchema(schema.additionalProperties)) {
+        normalized.additionalProperties = {};
+      } else {
         const res = normalizeSchemaNode(schema.additionalProperties, [...path, "*"]);
         normalized.additionalProperties = res.schema ?? schema.additionalProperties;
-        if (res.unsupportedPaths.length > 0) {
-          unsupported.add(pathLabel);
+        for (const unsupportedPath of res.unsupportedPaths) {
+          unsupported.add(unsupportedPath);
         }
       }
     }
@@ -98,8 +185,8 @@ function normalizeSchemaNode(
     } else {
       const res = normalizeSchemaNode(itemsSchema, [...path, "*"]);
       normalized.items = res.schema ?? itemsSchema;
-      if (res.unsupportedPaths.length > 0) {
-        unsupported.add(pathLabel);
+      for (const unsupportedPath of res.unsupportedPaths) {
+        unsupported.add(unsupportedPath);
       }
     }
   } else if (

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import JSON5 from "json5";
 import type { ConfigUiHints } from "../types.ts";
 import {
   defaultValue,
@@ -28,7 +29,194 @@ function jsonValue(value: unknown): string {
   }
 }
 
-// SVG Icons as template literals
+function shortValue(value: unknown, max = 80): string {
+  const raw = jsonValue(value).replace(/\s+/g, " ").trim();
+  if (!raw) {
+    return "";
+  }
+  if (raw.length <= max) {
+    return raw;
+  }
+  return `${raw.slice(0, max - 3)}...`;
+}
+
+function fallbackHelpForType(type: string | undefined): string {
+  switch (type) {
+    case "string":
+      return "Enter a text value.";
+    case "number":
+    case "integer":
+      return "Enter a numeric value.";
+    case "boolean":
+      return "Toggle this setting on or off.";
+    case "array":
+      return "Manage one or more values.";
+    case "object":
+      return "Configure grouped settings.";
+    default:
+      return "Configure this setting.";
+  }
+}
+
+function buildHelpText(schema: JsonSchema, explicitHelp?: string): string {
+  const help = explicitHelp?.trim() || schema.description?.trim() || "";
+  const parts: string[] = [];
+  if (help) {
+    parts.push(help);
+  } else {
+    parts.push(fallbackHelpForType(schemaType(schema)));
+  }
+  if (schema.enum && schema.enum.length > 0) {
+    parts.push(
+      `Allowed values: ${schema.enum
+        .map((entry) => shortValue(entry, 24))
+        .filter(Boolean)
+        .join(", ")}.`,
+    );
+  }
+  if (schema.default !== undefined) {
+    const def = shortValue(schema.default, 60);
+    if (def) {
+      parts.push(`Default: ${def}.`);
+    }
+  }
+  return parts.join(" ");
+}
+
+function positionHelpPopover(details: HTMLDetailsElement): void {
+  const doc = details.ownerDocument;
+  const view = doc.defaultView;
+  const panel = details.querySelector<HTMLElement>(".cfg-help__panel");
+  if (!view || !panel) {
+    return;
+  }
+
+  const viewportPadding = 12;
+  const maxWidth = Math.max(180, Math.min(360, view.innerWidth - viewportPadding * 2));
+  details.style.setProperty("--cfg-help-max-width", `${maxWidth}px`);
+
+  const triggerRect = details.getBoundingClientRect();
+  const panelWidth = Math.min(maxWidth, panel.scrollWidth || maxWidth);
+  const leftIfRightAligned = triggerRect.right - panelWidth;
+  const rightIfLeftAligned = triggerRect.left + panelWidth;
+
+  let align: "right" | "left" = "right";
+  if (leftIfRightAligned < viewportPadding && rightIfLeftAligned <= view.innerWidth - viewportPadding) {
+    align = "left";
+  } else if (leftIfRightAligned < viewportPadding && rightIfLeftAligned > view.innerWidth - viewportPadding) {
+    const spaceOnLeft = triggerRect.right;
+    const spaceOnRight = view.innerWidth - triggerRect.left;
+    align = spaceOnRight >= spaceOnLeft ? "left" : "right";
+  }
+
+  details.dataset.align = align;
+}
+
+function renderHelpPopover(label: string, helpText: string): TemplateResult {
+  return html`
+    <details
+      class="cfg-help"
+      @toggle=${(event: Event) => {
+        const details = event.currentTarget as HTMLDetailsElement;
+        if (!details.open) {
+          delete details.dataset.align;
+          return;
+        }
+        const doc = details.ownerDocument;
+        doc.querySelectorAll<HTMLDetailsElement>(".cfg-help[open]").forEach((entry) => {
+          if (entry !== details) {
+            entry.open = false;
+          }
+        });
+        const alignPopover = () => positionHelpPopover(details);
+        alignPopover();
+        doc.defaultView?.requestAnimationFrame(alignPopover);
+      }}
+    >
+      <summary
+        class="cfg-help__trigger"
+        aria-label=${`Help for ${label}`}
+        @click=${(event: Event) => event.stopPropagation()}
+      >
+        ?
+      </summary>
+      <div class="cfg-help__panel">${helpText}</div>
+    </details>
+  `;
+}
+
+function renderFieldHeader(
+  label: string,
+  helpText: string,
+  showLabel: boolean,
+  showHelp = true,
+): TemplateResult | typeof nothing {
+  if (!showLabel) {
+    return nothing;
+  }
+  if (!showHelp) {
+    return html`
+      <div class="cfg-field__header">
+        <label class="cfg-field__label">${label}</label>
+      </div>
+    `;
+  }
+  return html`
+    <div class="cfg-field__header">
+      <label class="cfg-field__label">${label}</label>
+      ${renderHelpPopover(label, helpText)}
+    </div>
+  `;
+}
+
+function renderRawFallback(params: {
+  schema: JsonSchema;
+  value: unknown;
+  path: Array<string | number>;
+  hints: ConfigUiHints;
+  disabled: boolean;
+  reason: string;
+  showLabel?: boolean;
+  onPatch: (path: Array<string | number>, value: unknown) => void;
+}): TemplateResult {
+  const { schema, value, path, hints, disabled, reason, onPatch } = params;
+  const showLabel = params.showLabel ?? true;
+  const hint = hintForPath(path, hints);
+  const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
+  const helpText = buildHelpText(schema, hint?.help);
+  const fallback = jsonValue(value);
+  return html`
+    <div class="cfg-field cfg-field--fallback cfg-item cfg-item--full">
+      ${renderFieldHeader(label, helpText, showLabel)}
+      <div class="cfg-field__warning">${reason}</div>
+      <textarea
+        class="cfg-textarea cfg-textarea--sm"
+        placeholder="JSON5 value"
+        rows="4"
+        .value=${fallback}
+        ?disabled=${disabled}
+        @change=${(event: Event) => {
+          const target = event.target as HTMLTextAreaElement;
+          const raw = target.value.trim();
+          if (!raw) {
+            onPatch(path, undefined);
+            target.setCustomValidity("");
+            return;
+          }
+          try {
+            onPatch(path, JSON5.parse(raw));
+            target.setCustomValidity("");
+          } catch {
+            target.setCustomValidity("Invalid JSON5 value");
+            target.reportValidity();
+            target.value = fallback;
+          }
+        }}
+      ></textarea>
+    </div>
+  `;
+}
+
 const icons = {
   chevronDown: html`
     <svg
@@ -55,18 +243,6 @@ const icons = {
       <line x1="5" y1="12" x2="19" y2="12"></line>
     </svg>
   `,
-  minus: html`
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <line x1="5" y1="12" x2="19" y2="12"></line>
-    </svg>
-  `,
   trash: html`
     <svg
       viewBox="0 0 24 24"
@@ -78,19 +254,6 @@ const icons = {
     >
       <polyline points="3 6 5 6 21 6"></polyline>
       <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-    </svg>
-  `,
-  edit: html`
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
     </svg>
   `,
 };
@@ -110,65 +273,65 @@ export function renderNode(params: {
   const type = schemaType(schema);
   const hint = hintForPath(path, hints);
   const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
-  const help = hint?.help ?? schema.description;
+  const helpText = buildHelpText(schema, hint?.help);
   const key = pathKey(path);
 
   if (unsupported.has(key)) {
-    return html`<div class="cfg-field cfg-field--error">
-      <div class="cfg-field__label">${label}</div>
-      <div class="cfg-field__error">Unsupported schema node. Use Raw mode.</div>
-    </div>`;
+    return renderRawFallback({
+      schema,
+      value,
+      path,
+      hints,
+      disabled,
+      showLabel,
+      reason: "This field uses a complex schema. Edit as JSON5.",
+      onPatch,
+    });
   }
 
-  // Handle anyOf/oneOf unions
   if (schema.anyOf || schema.oneOf) {
     const variants = schema.anyOf ?? schema.oneOf ?? [];
     const nonNull = variants.filter(
-      (v) => !(v.type === "null" || (Array.isArray(v.type) && v.type.includes("null"))),
+      (entry) => !(entry.type === "null" || (Array.isArray(entry.type) && entry.type.includes("null"))),
     );
 
     if (nonNull.length === 1) {
       return renderNode({ ...params, schema: nonNull[0] });
     }
 
-    // Check if it's a set of literal values (enum-like)
-    const extractLiteral = (v: JsonSchema): unknown => {
-      if (v.const !== undefined) {
-        return v.const;
+    const extractLiteral = (entry: JsonSchema): unknown => {
+      if (entry.const !== undefined) {
+        return entry.const;
       }
-      if (v.enum && v.enum.length === 1) {
-        return v.enum[0];
+      if (entry.enum && entry.enum.length === 1) {
+        return entry.enum[0];
       }
       return undefined;
     };
     const literals = nonNull.map(extractLiteral);
-    const allLiterals = literals.every((v) => v !== undefined);
+    const allLiterals = literals.every((entry) => entry !== undefined);
 
     if (allLiterals && literals.length > 0 && literals.length <= 5) {
-      // Use segmented control for small sets
       const resolvedValue = value ?? schema.default;
       return html`
-        <div class="cfg-field">
-          ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-          ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing}
+        <div class="cfg-field cfg-field--compact cfg-item cfg-item--compact">
+          ${renderFieldHeader(label, helpText, showLabel)}
           <div class="cfg-segmented">
             ${literals.map(
-              (lit) => html`
-              <button
-                type="button"
-                class="cfg-segmented__btn ${
-                  // oxlint-disable typescript/no-base-to-string
-                  lit === resolvedValue || String(lit) === String(resolvedValue) ? "active" : ""
-                }"
-                ?disabled=${disabled}
-                @click=${() => onPatch(path, lit)}
-              >
-                ${
-                  // oxlint-disable typescript/no-base-to-string
-                  String(lit)
-                }
-              </button>
-            `,
+              (literal) => html`
+                <button
+                  type="button"
+                  class="cfg-segmented__btn ${
+                    literal === resolvedValue || String(literal) === String(resolvedValue)
+                      ? "active"
+                      : ""
+                  }"
+                  ?disabled=${disabled}
+                  @click=${() => onPatch(path, literal)}
+                >
+                  ${String(literal)}
+                </button>
+              `,
             )}
           </div>
         </div>
@@ -176,17 +339,12 @@ export function renderNode(params: {
     }
 
     if (allLiterals && literals.length > 5) {
-      // Use dropdown for larger sets
       return renderSelect({ ...params, options: literals, value: value ?? schema.default });
     }
 
-    // Handle mixed primitive types
-    const primitiveTypes = new Set(nonNull.map((variant) => schemaType(variant)).filter(Boolean));
-    const normalizedTypes = new Set(
-      [...primitiveTypes].map((v) => (v === "integer" ? "number" : v)),
-    );
-
-    if ([...normalizedTypes].every((v) => ["string", "number", "boolean"].includes(v as string))) {
+    const primitiveTypes = new Set(nonNull.map((entry) => schemaType(entry)).filter(Boolean));
+    const normalizedTypes = new Set([...primitiveTypes].map((entry) => (entry === "integer" ? "number" : entry)));
+    if ([...normalizedTypes].every((entry) => ["string", "number", "boolean"].includes(entry as string))) {
       const hasString = normalizedTypes.has("string");
       const hasNumber = normalizedTypes.has("number");
       const hasBoolean = normalizedTypes.has("boolean");
@@ -205,29 +363,40 @@ export function renderNode(params: {
         });
       }
     }
+
+    return renderRawFallback({
+      schema,
+      value,
+      path,
+      hints,
+      disabled,
+      showLabel,
+      reason: "This union is not safely editable with basic controls.",
+      onPatch,
+    });
   }
 
-  // Enum - use segmented for small, dropdown for large
   if (schema.enum) {
     const options = schema.enum;
     if (options.length <= 5) {
       const resolvedValue = value ?? schema.default;
       return html`
-        <div class="cfg-field">
-          ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-          ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing}
+        <div class="cfg-field cfg-field--compact cfg-item cfg-item--compact">
+          ${renderFieldHeader(label, helpText, showLabel)}
           <div class="cfg-segmented">
             ${options.map(
-              (opt) => html`
-              <button
-                type="button"
-                class="cfg-segmented__btn ${opt === resolvedValue || String(opt) === String(resolvedValue) ? "active" : ""}"
-                ?disabled=${disabled}
-                @click=${() => onPatch(path, opt)}
-              >
-                ${String(opt)}
-              </button>
-            `,
+              (option) => html`
+                <button
+                  type="button"
+                  class="cfg-segmented__btn ${
+                    option === resolvedValue || String(option) === String(resolvedValue) ? "active" : ""
+                  }"
+                  ?disabled=${disabled}
+                  @click=${() => onPatch(path, option)}
+                >
+                  ${String(option)}
+                </button>
+              `,
             )}
           </div>
         </div>
@@ -236,17 +405,14 @@ export function renderNode(params: {
     return renderSelect({ ...params, options, value: value ?? schema.default });
   }
 
-  // Object type - collapsible section
   if (type === "object") {
     return renderObject(params);
   }
 
-  // Array type
   if (type === "array") {
     return renderArray(params);
   }
 
-  // Boolean - toggle row
   if (type === "boolean") {
     const displayValue =
       typeof value === "boolean"
@@ -255,41 +421,43 @@ export function renderNode(params: {
           ? schema.default
           : false;
     return html`
-      <label class="cfg-toggle-row ${disabled ? "disabled" : ""}">
+      <div class="cfg-item cfg-item--compact">
+        <label class="cfg-toggle-row ${disabled ? "disabled" : ""}">
         <div class="cfg-toggle-row__content">
-          <span class="cfg-toggle-row__label">${label}</span>
-          ${help ? html`<span class="cfg-toggle-row__help">${help}</span>` : nothing}
+          ${showLabel ? html`<span class="cfg-toggle-row__label">${label}</span>` : nothing}
         </div>
         <div class="cfg-toggle">
           <input
             type="checkbox"
             .checked=${displayValue}
             ?disabled=${disabled}
-            @change=${(e: Event) => onPatch(path, (e.target as HTMLInputElement).checked)}
+            @change=${(event: Event) => onPatch(path, (event.target as HTMLInputElement).checked)}
           />
           <span class="cfg-toggle__track"></span>
         </div>
-      </label>
+        </label>
+      </div>
     `;
   }
 
-  // Number/Integer
   if (type === "number" || type === "integer") {
     return renderNumberInput(params);
   }
 
-  // String
   if (type === "string") {
     return renderTextInput({ ...params, inputType: "text" });
   }
 
-  // Fallback
-  return html`
-    <div class="cfg-field cfg-field--error">
-      <div class="cfg-field__label">${label}</div>
-      <div class="cfg-field__error">Unsupported type: ${type}. Use Raw mode.</div>
-    </div>
-  `;
+  return renderRawFallback({
+    schema,
+    value,
+    path,
+    hints,
+    disabled,
+    showLabel,
+    reason: `Unsupported field type${type ? `: ${type}` : ""}. Edit as JSON5.`,
+    onPatch,
+  });
 }
 
 function renderTextInput(params: {
@@ -306,22 +474,16 @@ function renderTextInput(params: {
   const showLabel = params.showLabel ?? true;
   const hint = hintForPath(path, hints);
   const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
-  const help = hint?.help ?? schema.description;
+  const helpText = buildHelpText(schema, hint?.help);
   const isSensitive = hint?.sensitive ?? isSensitivePath(path);
   const placeholder =
     hint?.placeholder ??
-    // oxlint-disable typescript/no-base-to-string
-    (isSensitive
-      ? "••••"
-      : schema.default !== undefined
-        ? `Default: ${String(schema.default)}`
-        : "");
+    (isSensitive ? "******" : schema.default !== undefined ? `Default: ${String(schema.default)}` : "");
   const displayValue = value ?? "";
 
   return html`
-    <div class="cfg-field">
-      ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-      ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing}
+    <div class="cfg-field cfg-field--compact cfg-item cfg-item--compact">
+      ${renderFieldHeader(label, helpText, showLabel)}
       <div class="cfg-input-wrap">
         <input
           type=${isSensitive ? "password" : inputType}
@@ -329,8 +491,8 @@ function renderTextInput(params: {
           placeholder=${placeholder}
           .value=${displayValue == null ? "" : String(displayValue)}
           ?disabled=${disabled}
-          @input=${(e: Event) => {
-            const raw = (e.target as HTMLInputElement).value;
+          @input=${(event: Event) => {
+            const raw = (event.target as HTMLInputElement).value;
             if (inputType === "number") {
               if (raw.trim() === "") {
                 onPatch(path, undefined);
@@ -342,25 +504,27 @@ function renderTextInput(params: {
             }
             onPatch(path, raw);
           }}
-          @change=${(e: Event) => {
+          @change=${(event: Event) => {
             if (inputType === "number") {
               return;
             }
-            const raw = (e.target as HTMLInputElement).value;
+            const raw = (event.target as HTMLInputElement).value;
             onPatch(path, raw.trim());
           }}
         />
         ${
           schema.default !== undefined
             ? html`
-          <button
-            type="button"
-            class="cfg-input__reset"
-            title="Reset to default"
-            ?disabled=${disabled}
-            @click=${() => onPatch(path, schema.default)}
-          >↺</button>
-        `
+                <button
+                  type="button"
+                  class="cfg-input__reset"
+                  title="Reset to default"
+                  ?disabled=${disabled}
+                  @click=${() => onPatch(path, schema.default)}
+                >
+                  Reset
+                </button>
+              `
             : nothing
         }
       </div>
@@ -381,28 +545,30 @@ function renderNumberInput(params: {
   const showLabel = params.showLabel ?? true;
   const hint = hintForPath(path, hints);
   const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
-  const help = hint?.help ?? schema.description;
+  const helpText = buildHelpText(schema, hint?.help);
   const displayValue = value ?? schema.default ?? "";
   const numValue = typeof displayValue === "number" ? displayValue : 0;
+  const numberFieldClass = showLabel ? "cfg-field--number" : "cfg-field--number cfg-field--number-no-label";
 
   return html`
-    <div class="cfg-field">
-      ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-      ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing}
+    <div class="cfg-field cfg-field--compact ${numberFieldClass} cfg-item cfg-item--compact">
+      ${renderFieldHeader(label, helpText, showLabel, false)}
       <div class="cfg-number">
         <button
           type="button"
           class="cfg-number__btn"
           ?disabled=${disabled}
           @click=${() => onPatch(path, numValue - 1)}
-        >−</button>
+        >
+          -
+        </button>
         <input
           type="number"
           class="cfg-number__input"
           .value=${displayValue == null ? "" : String(displayValue)}
           ?disabled=${disabled}
-          @input=${(e: Event) => {
-            const raw = (e.target as HTMLInputElement).value;
+          @input=${(event: Event) => {
+            const raw = (event.target as HTMLInputElement).value;
             const parsed = raw === "" ? undefined : Number(raw);
             onPatch(path, parsed);
           }}
@@ -412,7 +578,9 @@ function renderNumberInput(params: {
           class="cfg-number__btn"
           ?disabled=${disabled}
           @click=${() => onPatch(path, numValue + 1)}
-        >+</button>
+        >
+          +
+        </button>
       </div>
     </div>
   `;
@@ -432,31 +600,30 @@ function renderSelect(params: {
   const showLabel = params.showLabel ?? true;
   const hint = hintForPath(path, hints);
   const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
-  const help = hint?.help ?? schema.description;
+  const helpText = buildHelpText(schema, hint?.help);
   const resolvedValue = value ?? schema.default;
   const currentIndex = options.findIndex(
-    (opt) => opt === resolvedValue || String(opt) === String(resolvedValue),
+    (option) => option === resolvedValue || String(option) === String(resolvedValue),
   );
   const unset = "__unset__";
 
   return html`
-    <div class="cfg-field">
-      ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-      ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing}
+    <div class="cfg-field cfg-field--compact cfg-item cfg-item--compact">
+      ${renderFieldHeader(label, helpText, showLabel)}
       <select
         class="cfg-select"
         ?disabled=${disabled}
         .value=${currentIndex >= 0 ? String(currentIndex) : unset}
-        @change=${(e: Event) => {
-          const val = (e.target as HTMLSelectElement).value;
-          onPatch(path, val === unset ? undefined : options[Number(val)]);
+        @change=${(event: Event) => {
+          const raw = (event.target as HTMLSelectElement).value;
+          onPatch(path, raw === unset ? undefined : options[Number(raw)]);
         }}
       >
         <option value=${unset}>Select...</option>
         ${options.map(
-          (opt, idx) => html`
-          <option value=${String(idx)}>${String(opt)}</option>
-        `,
+          (option, index) => html`
+            <option value=${String(index)}>${String(option)}</option>
+          `,
         )}
       </select>
     </div>
@@ -474,9 +641,10 @@ function renderObject(params: {
   onPatch: (path: Array<string | number>, value: unknown) => void;
 }): TemplateResult {
   const { schema, value, path, hints, unsupported, disabled, onPatch } = params;
+  const showLabel = params.showLabel ?? true;
   const hint = hintForPath(path, hints);
   const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
-  const help = hint?.help ?? schema.description;
+  const helpText = buildHelpText(schema, hint?.help);
 
   const fallback = value ?? schema.default;
   const obj =
@@ -486,7 +654,6 @@ function renderObject(params: {
   const props = schema.properties ?? {};
   const entries = Object.entries(props);
 
-  // Sort by hint order
   const sorted = entries.toSorted((a, b) => {
     const orderA = hintForPath([...path, a[0]], hints)?.order ?? 0;
     const orderB = hintForPath([...path, b[0]], hints)?.order ?? 0;
@@ -498,12 +665,22 @@ function renderObject(params: {
 
   const reserved = new Set(Object.keys(props));
   const additional = schema.additionalProperties;
-  const allowExtra = Boolean(additional) && typeof additional === "object";
+  const mapSchema =
+    additional === true
+      ? ({ type: "object" } as JsonSchema)
+      : additional && typeof additional === "object"
+        ? additional
+        : null;
+  const primitiveChildCount = sorted.filter(([, node]) => {
+    const nodeType = schemaType(node);
+    return nodeType === "string" || nodeType === "number" || nodeType === "integer" || nodeType === "boolean";
+  }).length;
+  const complexChildCount = sorted.length - primitiveChildCount + (mapSchema ? 1 : 0);
+  const fullWidth = complexChildCount > 4 || sorted.length >= 12;
 
-  // For top-level, don't wrap in collapsible
   if (path.length === 1) {
     return html`
-      <div class="cfg-fields">
+      <div class="cfg-fields cfg-fields--top">
         ${sorted.map(([propKey, node]) =>
           renderNode({
             schema: node,
@@ -516,9 +693,9 @@ function renderObject(params: {
           }),
         )}
         ${
-          allowExtra
+          mapSchema
             ? renderMapField({
-                schema: additional,
+                schema: mapSchema,
                 value: obj,
                 path,
                 hints,
@@ -533,14 +710,48 @@ function renderObject(params: {
     `;
   }
 
-  // Nested objects get collapsible treatment
+  if (!showLabel) {
+    return html`
+      <div class="cfg-fields cfg-fields--embedded">
+        <div class="cfg-fields__meta">${renderHelpPopover(label, helpText)}</div>
+        ${sorted.map(([propKey, node]) =>
+          renderNode({
+            schema: node,
+            value: obj[propKey],
+            path: [...path, propKey],
+            hints,
+            unsupported,
+            disabled,
+            onPatch,
+          }),
+        )}
+        ${
+          mapSchema
+            ? renderMapField({
+                schema: mapSchema,
+                value: obj,
+                path,
+                hints,
+                unsupported,
+                disabled,
+                reservedKeys: reserved,
+                onPatch,
+              })
+            : nothing
+        }
+      </div>
+    `;
+  }
+
   return html`
-    <details class="cfg-object" open>
+    <details class="cfg-object cfg-item ${fullWidth ? "cfg-item--full" : "cfg-item--compact"}" open>
       <summary class="cfg-object__header">
         <span class="cfg-object__title">${label}</span>
-        <span class="cfg-object__chevron">${icons.chevronDown}</span>
+        <span class="cfg-object__meta">
+          ${renderHelpPopover(label, helpText)}
+          <span class="cfg-object__chevron">${icons.chevronDown}</span>
+        </span>
       </summary>
-      ${help ? html`<div class="cfg-object__help">${help}</div>` : nothing}
       <div class="cfg-object__content">
         ${sorted.map(([propKey, node]) =>
           renderNode({
@@ -554,9 +765,9 @@ function renderObject(params: {
           }),
         )}
         ${
-          allowExtra
+          mapSchema
             ? renderMapField({
-                schema: additional,
+                schema: mapSchema,
                 value: obj,
                 path,
                 hints,
@@ -586,24 +797,40 @@ function renderArray(params: {
   const showLabel = params.showLabel ?? true;
   const hint = hintForPath(path, hints);
   const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
-  const help = hint?.help ?? schema.description;
+  const helpText = buildHelpText(schema, hint?.help);
 
   const itemsSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
   if (!itemsSchema) {
-    return html`
-      <div class="cfg-field cfg-field--error">
-        <div class="cfg-field__label">${label}</div>
-        <div class="cfg-field__error">Unsupported array schema. Use Raw mode.</div>
-      </div>
-    `;
+    return renderRawFallback({
+      schema,
+      value,
+      path,
+      hints,
+      disabled,
+      showLabel,
+      reason: "Array item schema is missing. Edit as JSON5.",
+      onPatch,
+    });
   }
 
   const arr = Array.isArray(value) ? value : Array.isArray(schema.default) ? schema.default : [];
+  const itemType = schemaType(itemsSchema);
+  const hasComplexItems = arr.some((entry) => typeof entry === "object" && entry !== null);
+  const fullWidth = itemType === "object" || itemType === "array" || hasComplexItems || arr.length >= 4;
 
   return html`
-    <div class="cfg-array">
+    <div class="cfg-array cfg-item ${fullWidth ? "cfg-item--full" : "cfg-item--compact"}">
       <div class="cfg-array__header">
-        ${showLabel ? html`<span class="cfg-array__label">${label}</span>` : nothing}
+        ${
+          showLabel
+            ? html`
+                <span class="cfg-array__label-wrap">
+                  <span class="cfg-array__label">${label}</span>
+                  ${renderHelpPopover(label, helpText)}
+                </span>
+              `
+            : html`<span class="cfg-array__label-wrap">${renderHelpPopover(label, helpText)}</span>`
+        }
         <span class="cfg-array__count">${arr.length} item${arr.length !== 1 ? "s" : ""}</span>
         <button
           type="button"
@@ -618,7 +845,6 @@ function renderArray(params: {
           Add
         </button>
       </div>
-      ${help ? html`<div class="cfg-array__help">${help}</div>` : nothing}
 
       ${
         arr.length === 0
@@ -626,43 +852,43 @@ function renderArray(params: {
               <div class="cfg-array__empty">No items yet. Click "Add" to create one.</div>
             `
           : html`
-        <div class="cfg-array__items">
-          ${arr.map(
-            (item, idx) => html`
-            <div class="cfg-array__item">
-              <div class="cfg-array__item-header">
-                <span class="cfg-array__item-index">#${idx + 1}</span>
-                <button
-                  type="button"
-                  class="cfg-array__item-remove"
-                  title="Remove item"
-                  ?disabled=${disabled}
-                  @click=${() => {
-                    const next = [...arr];
-                    next.splice(idx, 1);
-                    onPatch(path, next);
-                  }}
-                >
-                  ${icons.trash}
-                </button>
+              <div class="cfg-array__items">
+                ${arr.map(
+                  (item, idx) => html`
+                    <div class="cfg-array__item">
+                      <div class="cfg-array__item-header">
+                        <span class="cfg-array__item-index">#${idx + 1}</span>
+                        <button
+                          type="button"
+                          class="cfg-array__item-remove"
+                          title="Remove item"
+                          ?disabled=${disabled}
+                          @click=${() => {
+                            const next = [...arr];
+                            next.splice(idx, 1);
+                            onPatch(path, next);
+                          }}
+                        >
+                          ${icons.trash}
+                        </button>
+                      </div>
+                      <div class="cfg-array__item-content">
+                        ${renderNode({
+                          schema: itemsSchema,
+                          value: item,
+                          path: [...path, idx],
+                          hints,
+                          unsupported,
+                          disabled,
+                          showLabel: false,
+                          onPatch,
+                        })}
+                      </div>
+                    </div>
+                  `,
+                )}
               </div>
-              <div class="cfg-array__item-content">
-                ${renderNode({
-                  schema: itemsSchema,
-                  value: item,
-                  path: [...path, idx],
-                  hints,
-                  unsupported,
-                  disabled,
-                  showLabel: false,
-                  onPatch,
-                })}
-              </div>
-            </div>
-          `,
-          )}
-        </div>
-      `
+            `
       }
     </div>
   `;
@@ -681,11 +907,19 @@ function renderMapField(params: {
   const { schema, value, path, hints, unsupported, disabled, reservedKeys, onPatch } = params;
   const anySchema = isAnySchema(schema);
   const entries = Object.entries(value ?? {}).filter(([key]) => !reservedKeys.has(key));
+  const helpText = "Extra key/value entries not explicitly listed in the schema.";
+  const valueType = schemaType(schema);
+  const hasComplexEntries = entries.some(([, entryValue]) => typeof entryValue === "object" && entryValue !== null);
+  const schemaIsComplex = !anySchema && (valueType === "object" || valueType === "array");
+  const fullWidth = schemaIsComplex || hasComplexEntries || entries.length >= 4;
 
   return html`
-    <div class="cfg-map">
+    <div class="cfg-map cfg-item ${fullWidth ? "cfg-item--full" : "cfg-item--compact"}">
       <div class="cfg-map__header">
-        <span class="cfg-map__label">Custom entries</span>
+        <span class="cfg-map__label-wrap">
+          <span class="cfg-map__label">Custom entries</span>
+          ${renderHelpPopover("Custom entries", helpText)}
+        </span>
         <button
           type="button"
           class="cfg-map__add"
@@ -713,89 +947,93 @@ function renderMapField(params: {
               <div class="cfg-map__empty">No custom entries.</div>
             `
           : html`
-        <div class="cfg-map__items">
-          ${entries.map(([key, entryValue]) => {
-            const valuePath = [...path, key];
-            const fallback = jsonValue(entryValue);
-            return html`
-              <div class="cfg-map__item">
-                <div class="cfg-map__item-key">
-                  <input
-                    type="text"
-                    class="cfg-input cfg-input--sm"
-                    placeholder="Key"
-                    .value=${key}
-                    ?disabled=${disabled}
-                    @change=${(e: Event) => {
-                      const nextKey = (e.target as HTMLInputElement).value.trim();
-                      if (!nextKey || nextKey === key) {
-                        return;
-                      }
-                      const next = { ...value };
-                      if (nextKey in next) {
-                        return;
-                      }
-                      next[nextKey] = next[key];
-                      delete next[key];
-                      onPatch(path, next);
-                    }}
-                  />
-                </div>
-                <div class="cfg-map__item-value">
-                  ${
-                    anySchema
-                      ? html`
-                        <textarea
-                          class="cfg-textarea cfg-textarea--sm"
-                          placeholder="JSON value"
-                          rows="2"
-                          .value=${fallback}
+              <div class="cfg-map__items">
+                ${entries.map(([key, entryValue]) => {
+                  const valuePath = [...path, key];
+                  const fallback = jsonValue(entryValue);
+                  return html`
+                    <div class="cfg-map__item">
+                      <div class="cfg-map__item-key">
+                        <input
+                          type="text"
+                          class="cfg-input cfg-input--sm"
+                          placeholder="Key"
+                          .value=${key}
                           ?disabled=${disabled}
-                          @change=${(e: Event) => {
-                            const target = e.target as HTMLTextAreaElement;
-                            const raw = target.value.trim();
-                            if (!raw) {
-                              onPatch(valuePath, undefined);
+                          @change=${(event: Event) => {
+                            const nextKey = (event.target as HTMLInputElement).value.trim();
+                            if (!nextKey || nextKey === key) {
                               return;
                             }
-                            try {
-                              onPatch(valuePath, JSON.parse(raw));
-                            } catch {
-                              target.value = fallback;
+                            const next = { ...value };
+                            if (nextKey in next) {
+                              return;
                             }
+                            next[nextKey] = next[key];
+                            delete next[key];
+                            onPatch(path, next);
                           }}
-                        ></textarea>
-                      `
-                      : renderNode({
-                          schema,
-                          value: entryValue,
-                          path: valuePath,
-                          hints,
-                          unsupported,
-                          disabled,
-                          showLabel: false,
-                          onPatch,
-                        })
-                  }
-                </div>
-                <button
-                  type="button"
-                  class="cfg-map__item-remove"
-                  title="Remove entry"
-                  ?disabled=${disabled}
-                  @click=${() => {
-                    const next = { ...value };
-                    delete next[key];
-                    onPatch(path, next);
-                  }}
-                >
-                  ${icons.trash}
-                </button>
+                        />
+                      </div>
+                      <div class="cfg-map__item-value">
+                        ${
+                          anySchema
+                            ? html`
+                                <textarea
+                                  class="cfg-textarea cfg-textarea--sm"
+                                  placeholder="JSON5 value"
+                                  rows="2"
+                                  .value=${fallback}
+                                  ?disabled=${disabled}
+                                  @change=${(event: Event) => {
+                                    const target = event.target as HTMLTextAreaElement;
+                                    const raw = target.value.trim();
+                                    if (!raw) {
+                                      onPatch(valuePath, undefined);
+                                      target.setCustomValidity("");
+                                      return;
+                                    }
+                                    try {
+                                      onPatch(valuePath, JSON5.parse(raw));
+                                      target.setCustomValidity("");
+                                    } catch {
+                                      target.setCustomValidity("Invalid JSON5 value");
+                                      target.reportValidity();
+                                      target.value = fallback;
+                                    }
+                                  }}
+                                ></textarea>
+                              `
+                            : renderNode({
+                                schema,
+                                value: entryValue,
+                                path: valuePath,
+                                hints,
+                                unsupported,
+                                disabled,
+                                showLabel: false,
+                                onPatch,
+                              })
+                        }
+                      </div>
+                      <button
+                        type="button"
+                        class="cfg-map__item-remove"
+                        title="Remove entry"
+                        ?disabled=${disabled}
+                        @click=${() => {
+                          const next = { ...value };
+                          delete next[key];
+                          onPatch(path, next);
+                        }}
+                      >
+                        ${icons.trash}
+                      </button>
+                    </div>
+                  `;
+                })}
               </div>
-            `;
-          })}
-        </div>
-      `
+            `
       }
     </div>
   `;

--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -10,11 +10,43 @@ export type ConfigFormProps = {
   value: Record<string, unknown> | null;
   disabled?: boolean;
   unsupportedPaths?: string[];
+  renderLimit?: number;
   searchQuery?: string;
   activeSection?: string | null;
   activeSubsection?: string | null;
   onPatch: (path: Array<string | number>, value: unknown) => void;
 };
+
+let sortedRootEntriesCache:
+  | {
+      properties: Record<string, JsonSchema>;
+      uiHints: ConfigUiHints;
+      entries: Array<[string, JsonSchema]>;
+    }
+  | null = null;
+
+function getSortedRootEntries(
+  properties: Record<string, JsonSchema>,
+  uiHints: ConfigUiHints,
+): Array<[string, JsonSchema]> {
+  if (
+    sortedRootEntriesCache &&
+    sortedRootEntriesCache.properties === properties &&
+    sortedRootEntriesCache.uiHints === uiHints
+  ) {
+    return sortedRootEntriesCache.entries;
+  }
+  const entries = Object.entries(properties).toSorted((a, b) => {
+    const orderA = hintForPath([a[0]], uiHints)?.order ?? 50;
+    const orderB = hintForPath([b[0]], uiHints)?.order ?? 50;
+    if (orderA !== orderB) {
+      return orderA - orderB;
+    }
+    return a[0].localeCompare(b[0]);
+  });
+  sortedRootEntriesCache = { properties, uiHints, entries };
+  return entries;
+}
 
 // SVG Icons for section cards (Lucide-style)
 const sectionIcons = {
@@ -275,10 +307,52 @@ export const SECTION_META: Record<string, { label: string; description: string }
 };
 
 function getSectionIcon(key: string) {
-  return sectionIcons[key as keyof typeof sectionIcons] ?? sectionIcons.default;
+  const normalized = key
+    .trim()
+    .toLowerCase()
+    .replace(/[\s._-]+/g, "");
+
+  const canonical = (() => {
+    switch (normalized) {
+      case "canvashost":
+        return "canvasHost";
+      case "authentication":
+      case "credentials":
+        return "auth";
+      case "message":
+        return "messages";
+      case "command":
+        return "commands";
+      case "skill":
+        return "skills";
+      case "tool":
+        return "tools";
+      case "channel":
+        return "channels";
+      case "model":
+        return "models";
+      case "plugin":
+        return "plugins";
+      case "discover":
+        return "discovery";
+      case "voice":
+        return "talk";
+      case "onboarding":
+        return "wizard";
+      default:
+        return normalized;
+    }
+  })();
+
+  return sectionIcons[canonical as keyof typeof sectionIcons] ?? sectionIcons.default;
 }
 
-function matchesSearch(key: string, schema: JsonSchema, query: string): boolean {
+function matchesSearch(
+  key: string,
+  schema: JsonSchema,
+  query: string,
+  uiHints: ConfigUiHints,
+): boolean {
   if (!query) {
     return true;
   }
@@ -296,6 +370,22 @@ function matchesSearch(key: string, schema: JsonSchema, query: string): boolean 
       return true;
     }
     if (meta.description.toLowerCase().includes(q)) {
+      return true;
+    }
+  }
+
+  const hintPrefix = `${key}.`;
+  for (const [path, hint] of Object.entries(uiHints)) {
+    if (!path.startsWith(hintPrefix)) {
+      continue;
+    }
+    if (path.toLowerCase().includes(q)) {
+      return true;
+    }
+    if (hint.label?.toLowerCase().includes(q)) {
+      return true;
+    }
+    if (hint.help?.toLowerCase().includes(q)) {
       return true;
     }
   }
@@ -352,6 +442,49 @@ function schemaMatches(schema: JsonSchema, query: string): boolean {
   return false;
 }
 
+function scoreMatch(text: string, query: string): number {
+  const value = text.toLowerCase();
+  if (!value || !query) {
+    return 0;
+  }
+  if (value === query) {
+    return 120;
+  }
+  if (value.startsWith(query)) {
+    return 80;
+  }
+  if (value.includes(query)) {
+    return 40;
+  }
+  return 0;
+}
+
+function scoreSectionSearch(
+  key: string,
+  schema: JsonSchema,
+  query: string,
+  uiHints: ConfigUiHints,
+): number {
+  const q = query.toLowerCase();
+  let score = 0;
+  const meta = SECTION_META[key];
+  score += scoreMatch(key, q) * 2;
+  score += scoreMatch(meta?.label ?? "", q) * 2;
+  score += scoreMatch(meta?.description ?? "", q);
+  score += scoreMatch(schema.title ?? "", q) * 2;
+  score += scoreMatch(schema.description ?? "", q);
+  const hintPrefix = `${key}.`;
+  for (const [path, hint] of Object.entries(uiHints)) {
+    if (!path.startsWith(hintPrefix)) {
+      continue;
+    }
+    score += scoreMatch(path.slice(hintPrefix.length), q);
+    score += scoreMatch(hint.label ?? "", q);
+    score += scoreMatch(hint.help ?? "", q);
+  }
+  return score;
+}
+
 export function renderConfigForm(props: ConfigFormProps) {
   if (!props.schema) {
     return html`
@@ -371,24 +504,27 @@ export function renderConfigForm(props: ConfigFormProps) {
   const activeSection = props.activeSection;
   const activeSubsection = props.activeSubsection ?? null;
 
-  const entries = Object.entries(properties).toSorted((a, b) => {
-    const orderA = hintForPath([a[0]], props.uiHints)?.order ?? 50;
-    const orderB = hintForPath([b[0]], props.uiHints)?.order ?? 50;
-    if (orderA !== orderB) {
-      return orderA - orderB;
-    }
-    return a[0].localeCompare(b[0]);
-  });
+  const entries = getSortedRootEntries(properties, props.uiHints);
 
-  const filteredEntries = entries.filter(([key, node]) => {
+  let filteredEntries = entries.filter(([key, node]) => {
     if (activeSection && key !== activeSection) {
       return false;
     }
-    if (searchQuery && !matchesSearch(key, node, searchQuery)) {
+    if (searchQuery && !matchesSearch(key, node, searchQuery, props.uiHints)) {
       return false;
     }
     return true;
   });
+  if (searchQuery) {
+    filteredEntries = filteredEntries.toSorted((a, b) => {
+      const scoreA = scoreSectionSearch(a[0], a[1], searchQuery, props.uiHints);
+      const scoreB = scoreSectionSearch(b[0], b[1], searchQuery, props.uiHints);
+      if (scoreA !== scoreB) {
+        return scoreB - scoreA;
+      }
+      return a[0].localeCompare(b[0]);
+    });
+  }
 
   let subsectionContext: { sectionKey: string; subsectionKey: string; schema: JsonSchema } | null =
     null;
@@ -418,6 +554,15 @@ export function renderConfigForm(props: ConfigFormProps) {
       </div>
     `;
   }
+
+  const progressiveEnabled =
+    activeSection == null &&
+    !activeSubsection &&
+    searchQuery.trim().length === 0 &&
+    typeof props.renderLimit === "number";
+  const renderLimit = progressiveEnabled ? Math.max(1, Math.floor(props.renderLimit ?? 0)) : filteredEntries.length;
+  const visibleEntries = progressiveEnabled ? filteredEntries.slice(0, renderLimit) : filteredEntries;
+  const remainingEntries = filteredEntries.length - visibleEntries.length;
 
   return html`
     <div class="config-form config-form--modern">
@@ -462,7 +607,7 @@ export function renderConfigForm(props: ConfigFormProps) {
               </section>
             `;
             })()
-          : filteredEntries.map(([key, node]) => {
+          : visibleEntries.map(([key, node]) => {
               const meta = SECTION_META[key] ?? {
                 label: key.charAt(0).toUpperCase() + key.slice(1),
                 description: node.description ?? "",
@@ -498,5 +643,14 @@ export function renderConfigForm(props: ConfigFormProps) {
             })
       }
     </div>
+    ${
+      remainingEntries > 0
+        ? html`
+            <div class="config-progressive-hint">
+              Loading ${remainingEntries} more section${remainingEntries === 1 ? "" : "s"}...
+            </div>
+          `
+        : nothing
+    }
   `;
 }

--- a/ui/src/ui/views/config-form.shared.ts
+++ b/ui/src/ui/views/config-form.shared.ts
@@ -4,6 +4,7 @@ export type JsonSchema = {
   type?: string | string[];
   title?: string;
   description?: string;
+  required?: string[];
   properties?: Record<string, JsonSchema>;
   items?: JsonSchema | JsonSchema[];
   additionalProperties?: JsonSchema | boolean;

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -198,4 +198,51 @@ describe("config view", () => {
     input.dispatchEvent(new Event("input", { bubbles: true }));
     expect(onSearchChange).toHaveBeenCalledWith("gateway");
   });
+
+  it("sorts sections by search relevance in nav", () => {
+    const container = document.createElement("div");
+    render(
+      renderConfig({
+        ...baseProps(),
+        searchQuery: "channel",
+        schema: {
+          type: "object",
+          properties: {
+            gateway: { type: "object", description: "Gateway settings", properties: {} },
+            channels: { type: "object", description: "Messaging channels", properties: {} },
+          },
+        },
+      }),
+      container,
+    );
+
+    const labels = Array.from(container.querySelectorAll(".config-nav__label")).map((node) =>
+      node.textContent?.trim(),
+    );
+    expect(labels[0]).toBe("All Settings");
+    expect(labels[1]).toBe("Channels");
+  });
+
+  it("blocks save/apply when raw JSON5 is invalid", () => {
+    const container = document.createElement("div");
+    render(
+      renderConfig({
+        ...baseProps(),
+        formMode: "raw",
+        raw: "{ invalid: [ }",
+        originalRaw: "{\n}\n",
+      }),
+      container,
+    );
+
+    const saveButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.trim() === "Save",
+    );
+    const applyButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.trim() === "Apply",
+    );
+    expect(saveButton?.disabled).toBe(true);
+    expect(applyButton?.disabled).toBe(true);
+    expect(container.textContent).toContain("JSON5 validation failed");
+  });
 });

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1,5 +1,8 @@
 import { html, nothing } from "lit";
+import { keyed } from "lit/directives/keyed.js";
+import JSON5 from "json5";
 import type { ConfigUiHints } from "../types.ts";
+import { icons } from "../icons.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 import { analyzeConfigSchema, renderConfigForm, SECTION_META } from "./config-form.ts";
 
@@ -19,6 +22,8 @@ export type ConfigProps = {
   formMode: "form" | "raw";
   formValue: Record<string, unknown> | null;
   originalValue: Record<string, unknown> | null;
+  formDirty?: boolean;
+  renderLimit?: number;
   searchQuery: string;
   activeSection: string | null;
   activeSubsection: string | null;
@@ -34,327 +39,743 @@ export type ConfigProps = {
   onUpdate: () => void;
 };
 
-// SVG Icons for sidebar (Lucide-style)
-const sidebarIcons = {
-  all: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <rect x="3" y="3" width="7" height="7"></rect>
-      <rect x="14" y="3" width="7" height="7"></rect>
-      <rect x="14" y="14" width="7" height="7"></rect>
-      <rect x="3" y="14" width="7" height="7"></rect>
-    </svg>
-  `,
-  env: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="3"></circle>
-      <path
-        d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"
-      ></path>
-    </svg>
-  `,
-  update: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-      <polyline points="7 10 12 15 17 10"></polyline>
-      <line x1="12" y1="15" x2="12" y2="3"></line>
-    </svg>
-  `,
-  agents: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path
-        d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2z"
-      ></path>
-      <circle cx="8" cy="14" r="1"></circle>
-      <circle cx="16" cy="14" r="1"></circle>
-    </svg>
-  `,
-  auth: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
-      <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-    </svg>
-  `,
-  channels: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-    </svg>
-  `,
-  messages: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-      <polyline points="22,6 12,13 2,6"></polyline>
-    </svg>
-  `,
-  commands: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <polyline points="4 17 10 11 4 5"></polyline>
-      <line x1="12" y1="19" x2="20" y2="19"></line>
-    </svg>
-  `,
-  hooks: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
-      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
-    </svg>
-  `,
-  skills: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <polygon
-        points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
-      ></polygon>
-    </svg>
-  `,
-  tools: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path
-        d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
-      ></path>
-    </svg>
-  `,
-  gateway: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="10"></circle>
-      <line x1="2" y1="12" x2="22" y2="12"></line>
-      <path
-        d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
-      ></path>
-    </svg>
-  `,
-  wizard: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M15 4V2"></path>
-      <path d="M15 16v-2"></path>
-      <path d="M8 9h2"></path>
-      <path d="M20 9h2"></path>
-      <path d="M17.8 11.8 19 13"></path>
-      <path d="M15 9h0"></path>
-      <path d="M17.8 6.2 19 5"></path>
-      <path d="m3 21 9-9"></path>
-      <path d="M12.2 6.2 11 5"></path>
-    </svg>
-  `,
-  // Additional sections
-  meta: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M12 20h9"></path>
-      <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path>
-    </svg>
-  `,
-  logging: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-      <polyline points="14 2 14 8 20 8"></polyline>
-      <line x1="16" y1="13" x2="8" y2="13"></line>
-      <line x1="16" y1="17" x2="8" y2="17"></line>
-      <polyline points="10 9 9 9 8 9"></polyline>
-    </svg>
-  `,
-  browser: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="10"></circle>
-      <circle cx="12" cy="12" r="4"></circle>
-      <line x1="21.17" y1="8" x2="12" y2="8"></line>
-      <line x1="3.95" y1="6.06" x2="8.54" y2="14"></line>
-      <line x1="10.88" y1="21.94" x2="15.46" y2="14"></line>
-    </svg>
-  `,
-  ui: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-      <line x1="3" y1="9" x2="21" y2="9"></line>
-      <line x1="9" y1="21" x2="9" y2="9"></line>
-    </svg>
-  `,
-  models: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path
-        d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"
-      ></path>
-      <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
-      <line x1="12" y1="22.08" x2="12" y2="12"></line>
-    </svg>
-  `,
-  bindings: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
-      <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
-      <line x1="6" y1="6" x2="6.01" y2="6"></line>
-      <line x1="6" y1="18" x2="6.01" y2="18"></line>
-    </svg>
-  `,
-  broadcast: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"></path>
-      <path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"></path>
-      <circle cx="12" cy="12" r="2"></circle>
-      <path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"></path>
-      <path d="M19.1 4.9C23 8.8 23 15.1 19.1 19"></path>
-    </svg>
-  `,
-  audio: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M9 18V5l12-2v13"></path>
-      <circle cx="6" cy="18" r="3"></circle>
-      <circle cx="18" cy="16" r="3"></circle>
-    </svg>
-  `,
-  session: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
-      <circle cx="9" cy="7" r="4"></circle>
-      <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
-      <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
-    </svg>
-  `,
-  cron: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="10"></circle>
-      <polyline points="12 6 12 12 16 14"></polyline>
-    </svg>
-  `,
-  web: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="10"></circle>
-      <line x1="2" y1="12" x2="22" y2="12"></line>
-      <path
-        d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
-      ></path>
-    </svg>
-  `,
-  discovery: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="11" cy="11" r="8"></circle>
-      <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-    </svg>
-  `,
-  canvasHost: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-      <circle cx="8.5" cy="8.5" r="1.5"></circle>
-      <polyline points="21 15 16 10 5 21"></polyline>
-    </svg>
-  `,
-  talk: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path>
-      <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
-      <line x1="12" y1="19" x2="12" y2="23"></line>
-      <line x1="8" y1="23" x2="16" y2="23"></line>
-    </svg>
-  `,
-  plugins: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M12 2v6"></path>
-      <path d="m4.93 10.93 4.24 4.24"></path>
-      <path d="M2 12h6"></path>
-      <path d="m4.93 13.07 4.24-4.24"></path>
-      <path d="M12 22v-6"></path>
-      <path d="m19.07 13.07-4.24-4.24"></path>
-      <path d="M22 12h-6"></path>
-      <path d="m19.07 10.93-4.24 4.24"></path>
-    </svg>
-  `,
-  default: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-      <polyline points="14 2 14 8 20 8"></polyline>
-    </svg>
-  `,
-};
+type SearchScore = { score: number; hits: number };
 
-// Section definitions
-const SECTIONS: Array<{ key: string; label: string }> = [
-  { key: "env", label: "Environment" },
-  { key: "update", label: "Updates" },
-  { key: "agents", label: "Agents" },
-  { key: "auth", label: "Authentication" },
-  { key: "channels", label: "Channels" },
-  { key: "messages", label: "Messages" },
-  { key: "commands", label: "Commands" },
-  { key: "hooks", label: "Hooks" },
-  { key: "skills", label: "Skills" },
-  { key: "tools", label: "Tools" },
-  { key: "gateway", label: "Gateway" },
-  { key: "wizard", label: "Setup Wizard" },
-];
+type SectionEntry = {
+  key: string;
+  label: string;
+  description: string;
+  schema: JsonSchema;
+  order: number;
+  search: SearchScore;
+};
 
 type SubsectionEntry = {
   key: string;
   label: string;
-  description?: string;
+  description: string;
+  schema: JsonSchema;
   order: number;
+  search: SearchScore;
 };
 
-const ALL_SUBSECTION = "__all__";
+type ConfigIssueRow = {
+  path: string;
+  message: string;
+};
 
-function getSectionIcon(key: string) {
-  return sidebarIcons[key as keyof typeof sidebarIcons] ?? sidebarIcons.default;
+type DiffEntry = { path: string; from: unknown; to: unknown };
+
+type RawParseState = {
+  raw: string;
+  value: Record<string, unknown> | null;
+  error: string | null;
+  errorLine: number | null;
+  errorColumn: number | null;
+  errorContext: string | null;
+};
+
+const KNOWN_SECTION_ORDER = [
+  "env",
+  "update",
+  "diagnostics",
+  "logging",
+  "gateway",
+  "nodeHost",
+  "agents",
+  "tools",
+  "bindings",
+  "audio",
+  "models",
+  "messages",
+  "commands",
+  "session",
+  "cron",
+  "hooks",
+  "ui",
+  "browser",
+  "talk",
+  "channels",
+  "skills",
+  "plugins",
+  "discovery",
+  "presence",
+  "voicewake",
+  "wizard",
+] as const;
+
+const KNOWN_ORDER_MAP = new Map<string, number>(
+  KNOWN_SECTION_ORDER.map((key, index) => [key, index * 10 + 10]),
+);
+
+const ALL_SUBSECTION = "__all__";
+const DIFF_LIMIT = 120;
+const RAW_TREE_MAX_CHARS = 120_000;
+
+const schemaAnalysisCache = new WeakMap<object, ReturnType<typeof analyzeConfigSchema>>();
+let sectionsCache:
+  | {
+      schema: JsonSchema | null;
+      uiHints: ConfigUiHints;
+      query: string;
+      value: SectionEntry[];
+    }
+  | null = null;
+let subsectionsCache:
+  | {
+      sectionKey: string;
+      schema: JsonSchema | undefined;
+      uiHints: ConfigUiHints;
+      query: string;
+      value: SubsectionEntry[];
+    }
+  | null = null;
+const diffCache = new WeakMap<object, WeakMap<object, Map<string, DiffEntry[]>>>();
+let rawParseCache: RawParseState | null = null;
+
+function normalizeConfigKey(key: string): string {
+  return key
+    .trim()
+    .toLowerCase()
+    .replace(/[\s._-]+/g, "");
 }
 
-function resolveSectionMeta(
-  key: string,
-  schema?: JsonSchema,
-): {
-  label: string;
-  description?: string;
-} {
-  const meta = SECTION_META[key];
-  if (meta) {
-    return meta;
+function canonicalDocKey(raw: string): string {
+  switch (raw) {
+    case "channel":
+      return "channels";
+    case "agent":
+      return "agents";
+    case "tool":
+      return "tools";
+    case "model":
+      return "models";
+    case "command":
+      return "commands";
+    case "skill":
+      return "skills";
+    case "plugin":
+      return "plugins";
+    case "discover":
+      return "discovery";
+    case "voice":
+      return "talk";
+    case "onboarding":
+      return "wizard";
+    case "authentication":
+    case "credentials":
+      return "auth";
+    case "node":
+    case "nodes":
+      return "nodehost";
+    case "canvas":
+      return "canvashost";
+    default:
+      return raw;
   }
+}
+
+// Summaries distilled from docs/gateway/configuration.md and related docs/channels/*.
+const SECTION_DOC_HELP: Record<string, string> = {
+  env: "From docs: environment variable sources, shellEnv import, and ${VAR} substitution in config.",
+  update: "From docs: update channel and auto-update policy for runtime components.",
+  diagnostics: "From docs: diagnostics and health-check surfaces used for troubleshooting.",
+  logging: "From docs: log levels, log file path, console format, and sensitive data redaction.",
+  gateway: "From docs: Gateway mode/bind/auth/port settings and config reload behavior.",
+  nodehost: "From docs: node host connection and runtime settings for attached nodes.",
+  agents: "From docs: agent list/defaults, workspace/repoRoot, and multi-agent behavior.",
+  tools: "From docs: tool settings and controls for tool invocation behavior.",
+  bindings: "From docs: routing bindings that map channels/sources to agents.",
+  audio: "From docs: audio input/output parameters and voice data handling.",
+  models: "From docs: model providers, base URLs, credentials, and routing options.",
+  messages: "From docs: inbound/queue/group-message behavior and delivery controls.",
+  commands: "From docs: chat command handling rules and command routing behavior.",
+  session: "From docs: session persistence, context windows, and conversation state handling.",
+  cron: "From docs: Gateway scheduler configuration for periodic tasks.",
+  hooks: "From docs: Gateway webhook integrations and outbound hook behavior.",
+  ui: "From docs: control UI and appearance-related behavior.",
+  browser: "From docs: openclaw-managed browser automation runtime settings.",
+  talk: "From docs: talk mode, speech pipeline, and voice behavior settings.",
+  channels: "From docs: channel transports, accounts, DM/group policies, and channel behavior.",
+  skills: "From docs: skills configuration and skill runtime controls.",
+  plugins: "From docs: extension/plugin loading and runtime plugin behavior.",
+  discovery: "From docs: mDNS and wide-area discovery settings for gateway discovery.",
+  presence: "From docs: presence and broadcast visibility behavior.",
+  voicewake: "From docs: wake-word and voice wake forwarding settings.",
+  wizard: "From docs: onboarding wizard metadata written by CLI flows.",
+  web: "From docs: runtime settings for web-based channels including WhatsApp web.",
+  auth: "From docs: auth profile metadata, provider order, and auth mode selection.",
+  canvashost: "From docs: Canvas Host LAN/tailnet file serving and live reload.",
+};
+
+function sectionDocHelp(sectionKey: string | null, sectionLabel = "Section"): string {
+  if (!sectionKey) {
+    return "Shows all configuration sections and their key controls.";
+  }
+  const normalized = canonicalDocKey(normalizeConfigKey(sectionKey));
+  return (
+    SECTION_DOC_HELP[normalized] ??
+    `From docs: "${sectionLabel}" controls runtime behavior for this OpenClaw module.`
+  );
+}
+
+function summarizeSchema(label: string, schema: JsonSchema): string {
+  const type = schemaType(schema);
+  if (schema.enum && schema.enum.length > 0) {
+    const values = schema.enum
+      .slice(0, 4)
+      .map((value) => String(value))
+      .join(", ");
+    return `Allowed values include: ${values}${schema.enum.length > 4 ? ", ..." : ""}.`;
+  }
+  if (type === "object") {
+    const keys = Object.keys(schema.properties ?? {});
+    if (keys.length > 0) {
+      const preview = keys
+        .slice(0, 4)
+        .map((key) => humanize(key))
+        .join(", ");
+      return `${label} contains: ${preview}${keys.length > 4 ? ", ..." : ""}.`;
+    }
+    if (schema.additionalProperties) {
+      return `${label} supports custom key/value entries.`;
+    }
+    return `${label} contains nested options.`;
+  }
+  if (type === "array") {
+    const items = Array.isArray(schema.items) ? schema.items[0] : schema.items;
+    const itemType = items ? schemaType(items) : undefined;
+    return `${label} manages a list${itemType ? ` of ${itemType} entries` : ""}.`;
+  }
+  if (type === "boolean") {
+    return `${label} is an on/off toggle.`;
+  }
+  if (type === "number" || type === "integer") {
+    return `${label} expects a numeric value.`;
+  }
+  if (type === "string") {
+    return `${label} expects a text value.`;
+  }
+  return `${label} controls this part of configuration.`;
+}
+
+function sectionHeroHelpText(section: SectionEntry, subsection: SubsectionEntry | null): string {
+  const sectionHelp = sectionDocHelp(section.key, section.label);
+  if (subsection) {
+    const detail = subsection.description.trim();
+    const summary = summarizeSchema(subsection.label, subsection.schema);
+    if (detail.length > 0) {
+      return `${sectionHelp} Current block "${subsection.label}": ${detail} ${summary}`;
+    }
+    return `${sectionHelp} Current block "${subsection.label}". ${summary}`;
+  }
+  const detail = section.description.trim();
+  const summary = summarizeSchema(section.label, section.schema);
+  if (detail.length > 0) {
+    return `${sectionHelp} ${detail} ${summary}`;
+  }
+  return `${sectionHelp} ${summary}`;
+}
+
+function positionInfoPopover(details: HTMLDetailsElement): void {
+  const doc = details.ownerDocument;
+  const view = doc.defaultView;
+  const panel = details.querySelector<HTMLElement>(".config-help__panel");
+  if (!view || !panel) {
+    return;
+  }
+
+  const viewportPadding = 12;
+  const maxWidth = Math.max(220, Math.min(420, view.innerWidth - viewportPadding * 2));
+  panel.style.maxWidth = `${maxWidth}px`;
+
+  const triggerRect = details.getBoundingClientRect();
+  const panelWidth = Math.min(maxWidth, panel.scrollWidth || maxWidth);
+  const panelHeight = panel.scrollHeight;
+  const left = Math.max(
+    viewportPadding,
+    Math.min(view.innerWidth - panelWidth - viewportPadding, triggerRect.right - panelWidth),
+  );
+  const top = Math.min(
+    view.innerHeight - Math.min(panelHeight, 320) - viewportPadding,
+    triggerRect.bottom + 8,
+  );
+
+  details.style.setProperty("--config-help-left", `${Math.max(left, viewportPadding)}px`);
+  details.style.setProperty("--config-help-top", `${Math.max(top, viewportPadding)}px`);
+}
+
+function renderInfoPopover(label: string, helpText: string) {
+  return html`
+    <details
+      class="config-help"
+      @toggle=${(event: Event) => {
+        const details = event.currentTarget as HTMLDetailsElement;
+        if (!details.open) {
+          return;
+        }
+        const doc = details.ownerDocument;
+        doc.querySelectorAll<HTMLDetailsElement>(".config-help[open]").forEach((entry) => {
+          if (entry !== details) {
+            entry.open = false;
+          }
+        });
+        const alignPopover = () => positionInfoPopover(details);
+        alignPopover();
+        doc.defaultView?.requestAnimationFrame(alignPopover);
+      }}
+    >
+      <summary
+        class="config-help__trigger"
+        aria-label=${`Help for ${label}`}
+        @click=${(event: Event) => event.stopPropagation()}
+      >
+        ?
+      </summary>
+      <div class="config-help__panel">${helpText}</div>
+    </details>
+  `;
+}
+
+function renderSectionIcon(key: string) {
+  const normalized = normalizeConfigKey(key);
+  switch (normalized) {
+    case "env":
+      return icons.settings;
+    case "diagnostics":
+    case "debug":
+      return icons.bug;
+    case "logging":
+      return icons.scrollText;
+    case "meta":
+      return icons.edit;
+    case "node":
+    case "nodehost":
+    case "nodes":
+      return icons.monitor;
+    case "channel":
+    case "channels":
+      return icons.messageSquare;
+    case "agent":
+    case "agents":
+      return icons.folder;
+    case "authentication":
+    case "credentials":
+    case "auth":
+      return icons.plug;
+    case "memory":
+    case "history":
+      return icons.fileText;
+    case "message":
+    case "messages":
+      return icons.messageSquare;
+    case "command":
+    case "commands":
+      return icons.fileCode;
+    case "webhooks":
+    case "hooks":
+      return icons.link;
+    case "skill":
+    case "skills":
+      return icons.zap;
+    case "tool":
+    case "tools":
+      return icons.wrench;
+    case "sessions":
+    case "session":
+      return icons.fileText;
+    case "scheduler":
+    case "schedule":
+    case "cron":
+      return icons.loader;
+    case "broadcast":
+    case "presence":
+      return icons.radio;
+    case "audio":
+    case "voice":
+    case "talk":
+      return icons.smartphone;
+    case "ux":
+    case "ui":
+    case "bindings":
+      return icons.settings;
+    case "model":
+    case "models":
+      return icons.barChart;
+    case "browser":
+      return icons.monitor;
+    case "onboarding":
+    case "wizard":
+      return icons.loader;
+    case "canvas":
+    case "canvashost":
+      return icons.image;
+    case "plugin":
+    case "plugins":
+      return icons.puzzle;
+    case "update":
+      return icons.arrowDown;
+    case "gateway":
+    case "web":
+    case "discover":
+    case "discovery":
+      return icons.globe;
+    case "wakeword":
+    case "voicewake":
+      return icons.smartphone;
+    default:
+      return icons.settings;
+  }
+}
+
+function normalizeSectionMeta(
+  key: string,
+  schema: JsonSchema,
+  uiHints: ConfigUiHints,
+): { label: string; description: string } {
+  const hint = hintForPath([key], uiHints);
+  const fromMeta = SECTION_META[key];
   return {
-    label: schema?.title ?? humanize(key),
-    description: schema?.description ?? "",
+    label: hint?.label ?? fromMeta?.label ?? schema.title ?? humanize(key),
+    description: hint?.help ?? fromMeta?.description ?? schema.description ?? "",
   };
 }
 
-function resolveSubsections(params: {
+function tokenizeSearch(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function scoreText(text: string, tokens: string[]): SearchScore {
+  if (!text || tokens.length === 0) {
+    return { score: 0, hits: 0 };
+  }
+  const value = text.toLowerCase();
+  let score = 0;
+  let hits = 0;
+  for (const token of tokens) {
+    if (!token) {
+      continue;
+    }
+    if (value === token) {
+      score += 120;
+      hits += 1;
+      continue;
+    }
+    if (value.startsWith(token)) {
+      score += 80;
+      hits += 1;
+      continue;
+    }
+    if (value.includes(token)) {
+      score += 40;
+      hits += 1;
+    }
+  }
+  return { score, hits };
+}
+
+function mergeScores(a: SearchScore, b: SearchScore): SearchScore {
+  return {
+    score: a.score + b.score,
+    hits: a.hits + b.hits,
+  };
+}
+
+function scoreSchema(schema: JsonSchema, tokens: string[], depth = 0): SearchScore {
+  if (!schema || tokens.length === 0 || depth > 6) {
+    return { score: 0, hits: 0 };
+  }
+  let result = { score: 0, hits: 0 };
+  result = mergeScores(result, scoreText(schema.title ?? "", tokens));
+  result = mergeScores(result, scoreText(schema.description ?? "", tokens));
+  if (schema.enum) {
+    for (const entry of schema.enum) {
+      result = mergeScores(result, scoreText(String(entry), tokens));
+    }
+  }
+  if (schema.properties) {
+    for (const [key, node] of Object.entries(schema.properties)) {
+      result = mergeScores(result, scoreText(key, tokens));
+      result = mergeScores(result, scoreSchema(node, tokens, depth + 1));
+    }
+  }
+  if (schema.items) {
+    const items = Array.isArray(schema.items) ? schema.items : [schema.items];
+    for (const item of items) {
+      result = mergeScores(result, scoreSchema(item, tokens, depth + 1));
+    }
+  }
+  if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+    result = mergeScores(result, scoreSchema(schema.additionalProperties, tokens, depth + 1));
+  }
+  for (const union of [schema.anyOf, schema.oneOf, schema.allOf]) {
+    if (!union) {
+      continue;
+    }
+    for (const entry of union) {
+      result = mergeScores(result, scoreSchema(entry, tokens, depth + 1));
+    }
+  }
+  return result;
+}
+
+function scoreHintEntries(sectionKey: string, uiHints: ConfigUiHints, tokens: string[]): SearchScore {
+  if (tokens.length === 0) {
+    return { score: 0, hits: 0 };
+  }
+  let result = { score: 0, hits: 0 };
+  const prefix = `${sectionKey}.`;
+  for (const [path, hint] of Object.entries(uiHints)) {
+    if (!path.startsWith(prefix)) {
+      continue;
+    }
+    result = mergeScores(result, scoreText(path.slice(prefix.length), tokens));
+    if (hint.label) {
+      result = mergeScores(result, scoreText(hint.label, tokens));
+    }
+    if (hint.help) {
+      result = mergeScores(result, scoreText(hint.help, tokens));
+    }
+  }
+  return result;
+}
+
+function scoreSection(params: {
   key: string;
-  schema: JsonSchema | undefined;
+  schema: JsonSchema;
   uiHints: ConfigUiHints;
-}): SubsectionEntry[] {
-  const { key, schema, uiHints } = params;
+  label: string;
+  description: string;
+  tokens: string[];
+}): SearchScore {
+  const { key, schema, uiHints, label, description, tokens } = params;
+  if (tokens.length === 0) {
+    return { score: 0, hits: 0 };
+  }
+  let result = { score: 0, hits: 0 };
+  result = mergeScores(result, scoreText(key, tokens));
+  result = mergeScores(result, scoreText(label, tokens));
+  result = mergeScores(result, scoreText(description, tokens));
+  result = mergeScores(result, scoreHintEntries(key, uiHints, tokens));
+  result = mergeScores(result, scoreSchema(schema, tokens));
+  return result;
+}
+
+function analyzeConfigSchemaCached(raw: unknown) {
+  if (!raw || typeof raw !== "object") {
+    return analyzeConfigSchema(raw);
+  }
+  const key = raw as object;
+  const cached = schemaAnalysisCache.get(key);
+  if (cached) {
+    return cached;
+  }
+  const analysis = analyzeConfigSchema(raw);
+  schemaAnalysisCache.set(key, analysis);
+  return analysis;
+}
+
+function resolveSections(params: {
+  schema: JsonSchema | null;
+  uiHints: ConfigUiHints;
+  searchQuery: string;
+}): SectionEntry[] {
+  const { schema, uiHints, searchQuery } = params;
   if (!schema || schemaType(schema) !== "object" || !schema.properties) {
     return [];
   }
-  const entries = Object.entries(schema.properties).map(([subKey, node]) => {
-    const hint = hintForPath([key, subKey], uiHints);
-    const label = hint?.label ?? node.title ?? humanize(subKey);
+  const tokens = tokenizeSearch(searchQuery);
+  const items: SectionEntry[] = [];
+  for (const [key, node] of Object.entries(schema.properties)) {
+    const meta = normalizeSectionMeta(key, node, uiHints);
+    const order = hintForPath([key], uiHints)?.order ?? KNOWN_ORDER_MAP.get(key) ?? 9999;
+    const search = scoreSection({
+      key,
+      schema: node,
+      uiHints,
+      label: meta.label,
+      description: meta.description,
+      tokens,
+    });
+    if (tokens.length > 0 && search.score <= 0) {
+      continue;
+    }
+    items.push({
+      key,
+      label: meta.label,
+      description: meta.description,
+      schema: node,
+      order,
+      search,
+    });
+  }
+  items.sort((a, b) => {
+    if (tokens.length > 0) {
+      if (a.search.score !== b.search.score) {
+        return b.search.score - a.search.score;
+      }
+      if (a.search.hits !== b.search.hits) {
+        return b.search.hits - a.search.hits;
+      }
+    }
+    if (a.order !== b.order) {
+      return a.order - b.order;
+    }
+    return a.label.localeCompare(b.label);
+  });
+  return items;
+}
+
+function resolveSectionsCached(params: {
+  schema: JsonSchema | null;
+  uiHints: ConfigUiHints;
+  searchQuery: string;
+}): SectionEntry[] {
+  if (
+    sectionsCache &&
+    sectionsCache.schema === params.schema &&
+    sectionsCache.uiHints === params.uiHints &&
+    sectionsCache.query === params.searchQuery
+  ) {
+    return sectionsCache.value;
+  }
+  const value = resolveSections(params);
+  sectionsCache = {
+    schema: params.schema,
+    uiHints: params.uiHints,
+    query: params.searchQuery,
+    value,
+  };
+  return value;
+}
+
+function resolveSubsections(params: {
+  sectionKey: string;
+  schema: JsonSchema | undefined;
+  uiHints: ConfigUiHints;
+  searchQuery: string;
+}): SubsectionEntry[] {
+  const { sectionKey, schema, uiHints, searchQuery } = params;
+  if (!schema || schemaType(schema) !== "object" || !schema.properties) {
+    return [];
+  }
+  const tokens = tokenizeSearch(searchQuery);
+  const entries: SubsectionEntry[] = [];
+  for (const [key, node] of Object.entries(schema.properties)) {
+    const hint = hintForPath([sectionKey, key], uiHints);
+    const label = hint?.label ?? node.title ?? humanize(key);
     const description = hint?.help ?? node.description ?? "";
     const order = hint?.order ?? 50;
-    return { key: subKey, label, description, order };
+    const search = mergeScores(
+      mergeScores(scoreText(key, tokens), scoreText(label, tokens)),
+      mergeScores(scoreText(description, tokens), scoreSchema(node, tokens)),
+    );
+    if (tokens.length > 0 && search.score <= 0) {
+      continue;
+    }
+    entries.push({ key, label, description, schema: node, order, search });
+  }
+  entries.sort((a, b) => {
+    if (tokens.length > 0) {
+      if (a.search.score !== b.search.score) {
+        return b.search.score - a.search.score;
+      }
+      if (a.search.hits !== b.search.hits) {
+        return b.search.hits - a.search.hits;
+      }
+    }
+    if (a.order !== b.order) {
+      return a.order - b.order;
+    }
+    return a.label.localeCompare(b.label);
   });
-  entries.sort((a, b) => (a.order !== b.order ? a.order - b.order : a.key.localeCompare(b.key)));
   return entries;
 }
 
-function computeDiff(
-  original: Record<string, unknown> | null,
-  current: Record<string, unknown> | null,
-): Array<{ path: string; from: unknown; to: unknown }> {
-  if (!original || !current) {
-    return [];
+function resolveSubsectionsCached(params: {
+  sectionKey: string;
+  schema: JsonSchema | undefined;
+  uiHints: ConfigUiHints;
+  searchQuery: string;
+}): SubsectionEntry[] {
+  if (
+    subsectionsCache &&
+    subsectionsCache.sectionKey === params.sectionKey &&
+    subsectionsCache.schema === params.schema &&
+    subsectionsCache.uiHints === params.uiHints &&
+    subsectionsCache.query === params.searchQuery
+  ) {
+    return subsectionsCache.value;
   }
-  const changes: Array<{ path: string; from: unknown; to: unknown }> = [];
+  const value = resolveSubsections(params);
+  subsectionsCache = {
+    sectionKey: params.sectionKey,
+    schema: params.schema,
+    uiHints: params.uiHints,
+    query: params.searchQuery,
+    value,
+  };
+  return value;
+}
+
+function readPathValue(root: unknown, path: Array<string | number>): unknown {
+  let cursor = root;
+  for (const segment of path) {
+    if (!cursor || typeof cursor !== "object") {
+      return undefined;
+    }
+    cursor = (cursor as Record<string | number, unknown>)[segment];
+  }
+  return cursor;
+}
+
+function diffScopeKey(path: Array<string | number>): string {
+  return path.length > 0 ? path.join(".") : "<root>";
+}
+
+function computeDiffScoped(
+  original: Record<string, unknown>,
+  current: Record<string, unknown>,
+  scopePath: Array<string | number>,
+  limit = DIFF_LIMIT,
+): DiffEntry[] {
+  const scopedOriginal = readPathValue(original, scopePath);
+  const scopedCurrent = readPathValue(current, scopePath);
+  const changes: DiffEntry[] = [];
+  const basePath = scopePath.join(".");
 
   function compare(orig: unknown, curr: unknown, path: string) {
-    if (orig === curr) {
+    if (changes.length >= limit || orig === curr) {
       return;
     }
+
     if (typeof orig !== typeof curr) {
-      changes.push({ path, from: orig, to: curr });
+      changes.push({ path: path || "<root>", from: orig, to: curr });
       return;
     }
     if (typeof orig !== "object" || orig === null || curr === null) {
-      if (orig !== curr) {
-        changes.push({ path, from: orig, to: curr });
-      }
+      changes.push({ path: path || "<root>", from: orig, to: curr });
       return;
     }
     if (Array.isArray(orig) && Array.isArray(curr)) {
-      if (JSON.stringify(orig) !== JSON.stringify(curr)) {
-        changes.push({ path, from: orig, to: curr });
+      if (orig.length !== curr.length) {
+        changes.push({ path: path || "<root>", from: orig, to: curr });
+        return;
       }
+      for (let index = 0; index < orig.length; index += 1) {
+        compare(orig[index], curr[index], path ? `${path}.${index}` : String(index));
+        if (changes.length >= limit) {
+          return;
+        }
+      }
+      return;
+    }
+    if (Array.isArray(orig) !== Array.isArray(curr)) {
+      changes.push({ path: path || "<root>", from: orig, to: curr });
       return;
     }
     const origObj = orig as Record<string, unknown>;
@@ -362,14 +783,45 @@ function computeDiff(
     const allKeys = new Set([...Object.keys(origObj), ...Object.keys(currObj)]);
     for (const key of allKeys) {
       compare(origObj[key], currObj[key], path ? `${path}.${key}` : key);
+      if (changes.length >= limit) {
+        return;
+      }
     }
   }
 
-  compare(original, current, "");
+  compare(scopedOriginal, scopedCurrent, basePath);
   return changes;
 }
 
-function truncateValue(value: unknown, maxLen = 40): string {
+function computeDiffScopedCached(
+  original: Record<string, unknown> | null,
+  current: Record<string, unknown> | null,
+  scopePath: Array<string | number>,
+): DiffEntry[] {
+  if (!original || !current) {
+    return [];
+  }
+  const key = diffScopeKey(scopePath);
+  let currentMap = diffCache.get(original);
+  if (!currentMap) {
+    currentMap = new WeakMap<object, Map<string, DiffEntry[]>>();
+    diffCache.set(original, currentMap);
+  }
+  let scopeMap = currentMap.get(current);
+  if (!scopeMap) {
+    scopeMap = new Map<string, DiffEntry[]>();
+    currentMap.set(current, scopeMap);
+  }
+  const cached = scopeMap.get(key);
+  if (cached) {
+    return cached;
+  }
+  const value = computeDiffScoped(original, current, scopePath, DIFF_LIMIT);
+  scopeMap.set(key, value);
+  return value;
+}
+
+function truncateValue(value: unknown, maxLen = 52): string {
   let str: string;
   try {
     const json = JSON.stringify(value);
@@ -380,76 +832,304 @@ function truncateValue(value: unknown, maxLen = 40): string {
   if (str.length <= maxLen) {
     return str;
   }
-  return str.slice(0, maxLen - 3) + "...";
+  return `${str.slice(0, maxLen - 3)}...`;
+}
+
+function parseJson5ErrorLocation(message: string): { line: number | null; column: number | null } {
+  const patterns = [
+    /at\s+(\d+):(\d+)/i,
+    /\((\d+):(\d+)\)/,
+    /line\s+(\d+)\s*(?:,|and)?\s*column\s+(\d+)/i,
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(message);
+    if (!match) {
+      continue;
+    }
+    return {
+      line: Number.parseInt(match[1] ?? "", 10) || null,
+      column: Number.parseInt(match[2] ?? "", 10) || null,
+    };
+  }
+  return { line: null, column: null };
+}
+
+function buildRawErrorContext(raw: string, line: number | null, column: number | null): string | null {
+  if (!line || !column) {
+    return null;
+  }
+  const lines = raw.split(/\r?\n/);
+  if (line < 1 || line > lines.length) {
+    return null;
+  }
+  const start = Math.max(1, line - 1);
+  const end = Math.min(lines.length, line + 1);
+  const width = String(end).length;
+  const context: string[] = [];
+  for (let current = start; current <= end; current += 1) {
+    context.push(`${String(current).padStart(width, " ")} | ${lines[current - 1] ?? ""}`);
+    if (current === line) {
+      context.push(`${" ".repeat(width)} | ${" ".repeat(Math.max(0, column - 1))}^`);
+    }
+  }
+  return context.join("\n");
+}
+
+function parseRawJson5(raw: string): RawParseState {
+  if (rawParseCache && rawParseCache.raw === raw) {
+    return rawParseCache;
+  }
+
+  let value: Record<string, unknown> | null = null;
+  let error: string | null = null;
+  let errorLine: number | null = null;
+  let errorColumn: number | null = null;
+
+  try {
+    const parsed = JSON5.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      error = "Root config must be an object.";
+    } else {
+      value = parsed as Record<string, unknown>;
+    }
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+    const location = parseJson5ErrorLocation(error);
+    errorLine = location.line;
+    errorColumn = location.column;
+  }
+
+  const errorContext = error ? buildRawErrorContext(raw, errorLine, errorColumn) : null;
+  rawParseCache = {
+    raw,
+    value,
+    error,
+    errorLine,
+    errorColumn,
+    errorContext,
+  };
+  return rawParseCache;
+}
+
+function setRawTreeExpanded(target: EventTarget | null, expand: boolean): void {
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const panel = target.closest(".config-raw-panel");
+  if (!panel) {
+    return;
+  }
+  const nodes = panel.querySelectorAll<HTMLDetailsElement>(".config-raw-node");
+  nodes.forEach((node, index) => {
+    node.open = expand ? true : index === 0;
+  });
+}
+
+function renderRawToken(value: unknown) {
+  if (typeof value === "string") {
+    return html`<span class="config-raw-token config-raw-token--string">${JSON.stringify(value)}</span>`;
+  }
+  if (typeof value === "number") {
+    const text = Number.isFinite(value)
+      ? String(value)
+      : Number.isNaN(value)
+        ? "NaN"
+        : value > 0
+          ? "Infinity"
+          : "-Infinity";
+    return html`<span class="config-raw-token config-raw-token--number">${text}</span>`;
+  }
+  if (typeof value === "boolean") {
+    return html`<span class="config-raw-token config-raw-token--boolean">${String(value)}</span>`;
+  }
+  if (value === null) {
+    return html`<span class="config-raw-token config-raw-token--null">null</span>`;
+  }
+  return html`<span class="config-raw-token config-raw-token--unknown">${String(value)}</span>`;
+}
+
+function renderRawKey(label: string, indexed = false) {
+  const keyText = indexed ? `[${label}]` : JSON.stringify(label);
+  const keyClass = indexed ? "config-raw-token--index" : "config-raw-token--key";
+  return html`
+    <span class="config-raw-token ${keyClass}">${keyText}</span>
+    <span class="config-raw-token config-raw-token--punct">:</span>
+  `;
+}
+
+function renderRawTreeNode(params: {
+  value: unknown;
+  depth: number;
+  label?: string;
+  indexed?: boolean;
+}) {
+  const { value, depth, label, indexed = false } = params;
+  const keyTemplate =
+    label !== undefined ? html`<span class="config-raw-key">${renderRawKey(label, indexed)}</span>` : nothing;
+
+  if (Array.isArray(value)) {
+    const countLabel = `${value.length} item${value.length === 1 ? "" : "s"}`;
+    return html`
+      <details class="config-raw-node config-raw-node--array" ?open=${depth === 0}>
+        <summary class="config-raw-node__summary">
+          ${keyTemplate}
+          <span class="config-raw-token config-raw-token--punct">[</span>
+          <span class="config-raw-node__meta">${countLabel}</span>
+          <span class="config-raw-token config-raw-token--punct">]</span>
+        </summary>
+        <div class="config-raw-node__children">
+          ${
+            value.length > 0
+              ? value.map((entry, index) =>
+                  renderRawTreeNode({ value: entry, depth: depth + 1, label: String(index), indexed: true }),
+                )
+              : html`<div class="config-raw-node__empty">empty array</div>`
+          }
+        </div>
+      </details>
+    `;
+  }
+
+  if (value && typeof value === "object") {
+    const objectValue = value as Record<string, unknown>;
+    const entries = Object.entries(objectValue);
+    const countLabel = `${entries.length} field${entries.length === 1 ? "" : "s"}`;
+    return html`
+      <details class="config-raw-node config-raw-node--object" ?open=${depth === 0}>
+        <summary class="config-raw-node__summary">
+          ${keyTemplate}
+          <span class="config-raw-token config-raw-token--punct">{</span>
+          <span class="config-raw-node__meta">${countLabel}</span>
+          <span class="config-raw-token config-raw-token--punct">}</span>
+        </summary>
+        <div class="config-raw-node__children">
+          ${
+            entries.length > 0
+              ? entries.map(([entryKey, entryValue]) =>
+                  renderRawTreeNode({ value: entryValue, depth: depth + 1, label: entryKey }),
+                )
+              : html`<div class="config-raw-node__empty">empty object</div>`
+          }
+        </div>
+      </details>
+    `;
+  }
+
+  return html`<div class="config-raw-leaf">${keyTemplate}${renderRawToken(value)}</div>`;
+}
+
+function normalizeIssues(issues: unknown[]): ConfigIssueRow[] {
+  const rows: ConfigIssueRow[] = [];
+  for (const issue of issues) {
+    if (issue && typeof issue === "object") {
+      const path =
+        typeof (issue as { path?: unknown }).path === "string"
+          ? (issue as { path: string }).path || "<root>"
+          : "<root>";
+      const message =
+        typeof (issue as { message?: unknown }).message === "string"
+          ? (issue as { message: string }).message
+          : JSON.stringify(issue);
+      rows.push({ path, message });
+      continue;
+    }
+    rows.push({ path: "<root>", message: String(issue) });
+  }
+  return rows;
 }
 
 export function renderConfig(props: ConfigProps) {
-  const validity = props.valid == null ? "unknown" : props.valid ? "valid" : "invalid";
-  const analysis = analyzeConfigSchema(props.schema);
-  const formUnsafe = analysis.schema ? analysis.unsupportedPaths.length > 0 : false;
-
-  // Get available sections from schema
-  const schemaProps = analysis.schema?.properties ?? {};
-  const availableSections = SECTIONS.filter((s) => s.key in schemaProps);
-
-  // Add any sections in schema but not in our list
-  const knownKeys = new Set(SECTIONS.map((s) => s.key));
-  const extraSections = Object.keys(schemaProps)
-    .filter((k) => !knownKeys.has(k))
-    .map((k) => ({ key: k, label: k.charAt(0).toUpperCase() + k.slice(1) }));
-
-  const allSections = [...availableSections, ...extraSections];
-
-  const activeSectionSchema =
-    props.activeSection && analysis.schema && schemaType(analysis.schema) === "object"
-      ? analysis.schema.properties?.[props.activeSection]
-      : undefined;
-  const activeSectionMeta = props.activeSection
-    ? resolveSectionMeta(props.activeSection, activeSectionSchema)
+  const analysis = analyzeConfigSchemaCached(props.schema);
+  const sections = resolveSectionsCached({
+    schema: analysis.schema,
+    uiHints: props.uiHints,
+    searchQuery: props.searchQuery,
+  });
+  const sectionKeys = new Set(sections.map((section) => section.key));
+  const activeSection =
+    props.activeSection && sectionKeys.has(props.activeSection) ? props.activeSection : null;
+  const activeSectionSchema = activeSection
+    ? sections.find((section) => section.key === activeSection)?.schema
+    : undefined;
+  const activeSectionMeta = activeSection
+    ? sections.find((section) => section.key === activeSection)
     : null;
-  const subsections = props.activeSection
-    ? resolveSubsections({
-        key: props.activeSection,
+
+  const subsections = activeSection
+    ? resolveSubsectionsCached({
+        sectionKey: activeSection,
         schema: activeSectionSchema,
         uiHints: props.uiHints,
+        searchQuery: props.searchQuery,
       })
     : [];
-  const allowSubnav =
-    props.formMode === "form" && Boolean(props.activeSection) && subsections.length > 0;
+
+  const showSubnav =
+    props.formMode === "form" &&
+    Boolean(activeSection) &&
+    subsections.length > 0 &&
+    props.searchQuery.trim().length === 0;
+
   const isAllSubsection = props.activeSubsection === ALL_SUBSECTION;
-  const effectiveSubsection = props.searchQuery
-    ? null
-    : isAllSubsection
-      ? null
-      : (props.activeSubsection ?? subsections[0]?.key ?? null);
-
-  // Compute diff for showing changes (works for both form and raw modes)
-  const diff = props.formMode === "form" ? computeDiff(props.originalValue, props.formValue) : [];
+  const effectiveSubsection = isAllSubsection ? null : (props.activeSubsection ?? null);
+  const activeSubsectionMeta =
+    effectiveSubsection && activeSection
+      ? subsections.find((entry) => entry.key === effectiveSubsection) ?? null
+      : null;
+  const diffScopePath =
+    activeSection && activeSubsectionMeta
+      ? ([activeSection, activeSubsectionMeta.key] as Array<string | number>)
+      : activeSection
+        ? ([activeSection] as Array<string | number>)
+        : [];
+  const formDirty =
+    props.formDirty ?? (computeDiffScopedCached(props.originalValue, props.formValue, []).length > 0);
+  const hasScopedDiffContext = diffScopePath.length > 0;
+  const diff =
+    props.formMode === "form" && formDirty && hasScopedDiffContext
+      ? computeDiffScopedCached(props.originalValue, props.formValue, diffScopePath)
+      : [];
   const hasRawChanges = props.formMode === "raw" && props.raw !== props.originalRaw;
-  const hasChanges = props.formMode === "form" ? diff.length > 0 : hasRawChanges;
+  const hasChanges = props.formMode === "form" ? formDirty : hasRawChanges;
+  const showDiffDropdown = props.formMode === "form" && formDirty;
+  const formUnsafe = analysis.schema ? analysis.unsupportedPaths.length > 0 : false;
+  const rawParse = props.formMode === "raw" ? parseRawJson5(props.raw) : null;
+  const rawValidationError = rawParse?.error ?? null;
+  const rawTreeUnavailableReason =
+    props.formMode === "raw" && props.raw.length > RAW_TREE_MAX_CHARS
+      ? `Structured view is disabled for payloads above ${RAW_TREE_MAX_CHARS.toLocaleString()} chars.`
+      : rawValidationError
+        ? "Fix JSON5 errors to unlock structured view."
+        : null;
+  const issues = normalizeIssues(props.issues);
 
-  // Save/apply buttons require actual changes to be enabled.
-  // Note: formUnsafe warns about unsupported schema paths but shouldn't block saving.
   const canSaveForm = Boolean(props.formValue) && !props.loading && Boolean(analysis.schema);
   const canSave =
     props.connected &&
     !props.saving &&
     hasChanges &&
-    (props.formMode === "raw" ? true : canSaveForm);
+    (props.formMode === "raw" ? !rawValidationError : canSaveForm);
   const canApply =
     props.connected &&
     !props.applying &&
     !props.updating &&
     hasChanges &&
-    (props.formMode === "raw" ? true : canSaveForm);
+    (props.formMode === "raw" ? !rawValidationError : canSaveForm);
   const canUpdate = props.connected && !props.applying && !props.updating;
+
+  const validity = rawValidationError
+    ? "invalid"
+    : props.valid == null
+      ? "unknown"
+      : props.valid
+        ? "valid"
+        : "invalid";
 
   return html`
     <div class="config-layout">
-      <!-- Sidebar -->
       <aside class="config-sidebar">
         <div class="config-sidebar__header">
-          <div class="config-sidebar__title">Settings</div>
+          <div class="config-sidebar__title">Configuration</div>
           <span
             class="pill pill--sm ${
               validity === "valid" ? "pill--ok" : validity === "invalid" ? "pill--danger" : ""
@@ -458,69 +1138,64 @@ export function renderConfig(props: ConfigProps) {
           >
         </div>
 
-        <!-- Search -->
         <div class="config-search">
-          <svg
-            class="config-search__icon"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <circle cx="11" cy="11" r="8"></circle>
-            <path d="M21 21l-4.35-4.35"></path>
-          </svg>
+          <span class="config-search__icon">${icons.search}</span>
           <input
             type="text"
             class="config-search__input"
-            placeholder="Search settings..."
+            placeholder="Search settings, fields, descriptions..."
             .value=${props.searchQuery}
-            @input=${(e: Event) => props.onSearchChange((e.target as HTMLInputElement).value)}
+            @input=${(event: Event) => props.onSearchChange((event.target as HTMLInputElement).value)}
           />
           ${
             props.searchQuery
               ? html`
-                <button
-                  class="config-search__clear"
-                  @click=${() => props.onSearchChange("")}
-                >
-                  ×
-                </button>
-              `
+                  <button class="config-search__clear" @click=${() => props.onSearchChange("")}>
+                    Clear
+                  </button>
+                `
               : nothing
           }
         </div>
 
-        <!-- Section nav -->
         <nav class="config-nav">
           <button
-            class="config-nav__item ${props.activeSection === null ? "active" : ""}"
+            class="config-nav__item ${activeSection === null ? "active" : ""}"
             @click=${() => props.onSectionChange(null)}
           >
-            <span class="config-nav__icon">${sidebarIcons.all}</span>
+            <span class="config-nav__icon">${icons.settings}</span>
             <span class="config-nav__label">All Settings</span>
+            ${
+              props.searchQuery
+                ? html`<span class="config-nav__meta">${sections.length}</span>`
+                : nothing
+            }
           </button>
-          ${allSections.map(
+
+          ${sections.map(
             (section) => html`
               <button
-                class="config-nav__item ${props.activeSection === section.key ? "active" : ""}"
+                class="config-nav__item ${activeSection === section.key ? "active" : ""}"
+                title=${section.description || section.label}
                 @click=${() => props.onSectionChange(section.key)}
               >
-                <span class="config-nav__icon"
-                  >${getSectionIcon(section.key)}</span
-                >
+                <span class="config-nav__icon">${renderSectionIcon(section.key)}</span>
                 <span class="config-nav__label">${section.label}</span>
+                ${
+                  props.searchQuery
+                    ? html`<span class="config-nav__meta">${Math.max(1, section.search.hits)}</span>`
+                    : nothing
+                }
               </button>
             `,
           )}
         </nav>
 
-        <!-- Mode toggle at bottom -->
         <div class="config-sidebar__footer">
           <div class="config-mode-toggle">
             <button
               class="config-mode-toggle__btn ${props.formMode === "form" ? "active" : ""}"
-              ?disabled=${props.schemaLoading || !props.schema}
+              ?disabled=${props.schemaLoading || !analysis.schema}
               @click=${() => props.onFormModeChange("form")}
             >
               Form
@@ -535,207 +1210,292 @@ export function renderConfig(props: ConfigProps) {
         </div>
       </aside>
 
-      <!-- Main content -->
       <main class="config-main">
-        <!-- Action bar -->
         <div class="config-actions">
           <div class="config-actions__left">
             ${
               hasChanges
                 ? html`
-                  <span class="config-changes-badge"
-                    >${
-                      props.formMode === "raw"
-                        ? "Unsaved changes"
-                        : `${diff.length} unsaved change${diff.length !== 1 ? "s" : ""}`
-                    }</span
-                  >
-                `
-                : html`
-                    <span class="config-status muted">No changes</span>
+                    <span class="config-changes-badge"
+                      >${
+                        props.formMode === "raw"
+                          ? "Unsaved changes"
+                          : "Unsaved changes"
+                      }</span
+                    >
                   `
+                : html`<span class="config-status muted">No changes</span>`
+            }
+            ${
+              rawValidationError
+                ? html`<span class="pill pill--sm pill--danger">Invalid JSON5</span>`
+                : nothing
+            }
+            ${
+              showDiffDropdown
+                ? html`
+                    <details class="config-actions-diff">
+                      <summary class="config-actions-diff__trigger">
+                        <span>Changes</span>
+                        <span class="config-actions-diff__chevron">${icons.arrowDown}</span>
+                      </summary>
+                      <div class="config-actions-diff__panel">
+                        ${
+                          hasScopedDiffContext
+                            ? html`
+                                <div class="config-diff__content">
+                                  ${
+                                    diff.length > 0
+                                      ? diff.map(
+                                          (change) => html`
+                                            <div class="config-diff__item">
+                                              <div class="config-diff__path">${change.path || "<root>"}</div>
+                                              <div class="config-diff__values">
+                                                <span class="config-diff__from">${truncateValue(change.from)}</span>
+                                                <span class="config-diff__arrow">-></span>
+                                                <span class="config-diff__to">${truncateValue(change.to)}</span>
+                                              </div>
+                                            </div>
+                                          `,
+                                        )
+                                      : html`
+                                          <div class="config-diff__item">
+                                            <div class="config-diff__values">
+                                              <span class="config-diff__path"
+                                                >No changes in current section. Changes may be in another section.</span
+                                              >
+                                            </div>
+                                          </div>
+                                        `
+                                  }
+                                  ${
+                                    diff.length >= DIFF_LIMIT
+                                      ? html`
+                                          <div class="config-diff__item">
+                                            <div class="config-diff__values">
+                                              <span class="config-diff__path"
+                                                >Showing first ${DIFF_LIMIT} changes for performance.</span
+                                              >
+                                            </div>
+                                          </div>
+                                        `
+                                      : nothing
+                                  }
+                                </div>
+                              `
+                            : html`
+                                <div class="config-diff__content">
+                                  <div class="config-diff__item">
+                                    <div class="config-diff__values">
+                                      <span class="config-diff__path">Select a section to view detailed changes.</span>
+                                    </div>
+                                  </div>
+                                </div>
+                              `
+                        }
+                      </div>
+                    </details>
+                  `
+                : nothing
             }
           </div>
           <div class="config-actions__right">
-            <button
-              class="btn btn--sm"
-              ?disabled=${props.loading}
-              @click=${props.onReload}
-            >
-              ${props.loading ? "Loading…" : "Reload"}
+            <button class="btn btn--sm" ?disabled=${props.loading} @click=${props.onReload}>
+              ${props.loading ? "Loading..." : "Reload"}
             </button>
-            <button
-              class="btn btn--sm primary"
-              ?disabled=${!canSave}
-              @click=${props.onSave}
-            >
-              ${props.saving ? "Saving…" : "Save"}
+            <button class="btn btn--sm primary" ?disabled=${!canSave} @click=${props.onSave}>
+              ${props.saving ? "Saving..." : "Save"}
             </button>
-            <button
-              class="btn btn--sm"
-              ?disabled=${!canApply}
-              @click=${props.onApply}
-            >
-              ${props.applying ? "Applying…" : "Apply"}
+            <button class="btn btn--sm" ?disabled=${!canApply} @click=${props.onApply}>
+              ${props.applying ? "Applying..." : "Apply"}
             </button>
-            <button
-              class="btn btn--sm"
-              ?disabled=${!canUpdate}
-              @click=${props.onUpdate}
-            >
-              ${props.updating ? "Updating…" : "Update"}
+            <button class="btn btn--sm" ?disabled=${!canUpdate} @click=${props.onUpdate}>
+              ${props.updating ? "Updating..." : "Update"}
             </button>
           </div>
         </div>
 
-        <!-- Diff panel (form mode only - raw mode doesn't have granular diff) -->
-        ${
-          hasChanges && props.formMode === "form"
-            ? html`
-              <details class="config-diff">
-                <summary class="config-diff__summary">
-                  <span
-                    >View ${diff.length} pending
-                    change${diff.length !== 1 ? "s" : ""}</span
-                  >
-                  <svg
-                    class="config-diff__chevron"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <polyline points="6 9 12 15 18 9"></polyline>
-                  </svg>
-                </summary>
-                <div class="config-diff__content">
-                  ${diff.map(
-                    (change) => html`
-                      <div class="config-diff__item">
-                        <div class="config-diff__path">${change.path}</div>
-                        <div class="config-diff__values">
-                          <span class="config-diff__from"
-                            >${truncateValue(change.from)}</span
-                          >
-                          <span class="config-diff__arrow">→</span>
-                          <span class="config-diff__to"
-                            >${truncateValue(change.to)}</span
-                          >
-                        </div>
-                      </div>
-                    `,
-                  )}
-                </div>
-              </details>
-            `
-            : nothing
-        }
         ${
           activeSectionMeta && props.formMode === "form"
             ? html`
-              <div class="config-section-hero">
-                <div class="config-section-hero__icon">
-                  ${getSectionIcon(props.activeSection ?? "")}
-                </div>
-                <div class="config-section-hero__text">
-                  <div class="config-section-hero__title">
-                    ${activeSectionMeta.label}
+                <div class="config-section-hero">
+                  <div class="config-section-hero__lead">
+                    <div class="config-section-hero__icon">${renderSectionIcon(activeSectionMeta.key)}</div>
+                    <div class="config-section-hero__text">
+                      <div class="config-section-hero__title">${activeSectionMeta.label}</div>
+                      ${
+                        activeSectionMeta.description
+                          ? html`<div class="config-section-hero__desc">${activeSectionMeta.description}</div>`
+                          : nothing
+                      }
+                    </div>
                   </div>
-                  ${
-                    activeSectionMeta.description
-                      ? html`<div class="config-section-hero__desc">
-                        ${activeSectionMeta.description}
-                      </div>`
-                      : nothing
-                  }
+                  <div class="config-section-hero__meta">
+                    ${keyed(
+                      `${activeSectionMeta.key}:${activeSubsectionMeta?.key ?? ALL_SUBSECTION}`,
+                      renderInfoPopover(
+                        `${activeSectionMeta.label} help`,
+                        sectionHeroHelpText(activeSectionMeta, activeSubsectionMeta),
+                      ),
+                    )}
+                  </div>
                 </div>
-              </div>
-            `
-            : nothing
-        }
-        ${
-          allowSubnav
-            ? html`
-              <div class="config-subnav">
-                <button
-                  class="config-subnav__item ${effectiveSubsection === null ? "active" : ""}"
-                  @click=${() => props.onSubsectionChange(ALL_SUBSECTION)}
-                >
-                  All
-                </button>
-                ${subsections.map(
-                  (entry) => html`
-                    <button
-                      class="config-subnav__item ${
-                        effectiveSubsection === entry.key ? "active" : ""
-                      }"
-                      title=${entry.description || entry.label}
-                      @click=${() => props.onSubsectionChange(entry.key)}
-                    >
-                      ${entry.label}
-                    </button>
-                  `,
-                )}
-              </div>
-            `
+              `
             : nothing
         }
 
-        <!-- Form content -->
+        ${
+          showSubnav
+            ? html`
+                <div class="config-subnav">
+                  <button
+                    class="config-subnav__item ${effectiveSubsection === null ? "active" : ""}"
+                    @click=${() => props.onSubsectionChange(ALL_SUBSECTION)}
+                  >
+                    All
+                  </button>
+                  ${subsections.map(
+                    (entry) => html`
+                      <button
+                        class="config-subnav__item ${effectiveSubsection === entry.key ? "active" : ""}"
+                        title=${entry.description || entry.label}
+                        @click=${() => props.onSubsectionChange(entry.key)}
+                      >
+                        ${entry.label}
+                      </button>
+                    `,
+                  )}
+                </div>
+              `
+            : nothing
+        }
+
         <div class="config-content">
           ${
             props.formMode === "form"
               ? html`
-                ${
-                  props.schemaLoading
-                    ? html`
-                        <div class="config-loading">
-                          <div class="config-loading__spinner"></div>
-                          <span>Loading schema…</span>
-                        </div>
-                      `
-                    : renderConfigForm({
-                        schema: analysis.schema,
-                        uiHints: props.uiHints,
-                        value: props.formValue,
-                        disabled: props.loading || !props.formValue,
-                        unsupportedPaths: analysis.unsupportedPaths,
-                        onPatch: props.onFormPatch,
-                        searchQuery: props.searchQuery,
-                        activeSection: props.activeSection,
-                        activeSubsection: effectiveSubsection,
-                      })
-                }
-                ${
-                  formUnsafe
-                    ? html`
-                        <div class="callout danger" style="margin-top: 12px">
-                          Form view can't safely edit some fields. Use Raw to avoid losing config entries.
-                        </div>
-                      `
-                    : nothing
-                }
-              `
+                  ${
+                    props.schemaLoading
+                      ? html`
+                          <div class="config-loading">
+                            <div class="config-loading__spinner"></div>
+                            <span>Loading schema...</span>
+                          </div>
+                        `
+                      : renderConfigForm({
+                          schema: analysis.schema,
+                          uiHints: props.uiHints,
+                          value: props.formValue,
+                          disabled: props.loading || !props.formValue,
+                          unsupportedPaths: analysis.unsupportedPaths,
+                          renderLimit: props.renderLimit,
+                          onPatch: props.onFormPatch,
+                          searchQuery: props.searchQuery,
+                          activeSection,
+                          activeSubsection: effectiveSubsection,
+                        })
+                  }
+                  ${
+                    formUnsafe
+                      ? html`
+                          <div class="callout" style="margin-top: 12px;">
+                            Some advanced fields use JSON5 editors inside Form mode.
+                          </div>
+                        `
+                      : nothing
+                  }
+                `
               : html`
-                <label class="field config-raw-field">
-                  <span>Raw JSON5</span>
-                  <textarea
-                    .value=${props.raw}
-                    @input=${(e: Event) =>
-                      props.onRawChange((e.target as HTMLTextAreaElement).value)}
-                  ></textarea>
-                </label>
-              `
+                  <div class="config-raw-layout">
+                    <section class="config-raw-editor">
+                      <label class="field config-raw-field">
+                        <span>Raw JSON5</span>
+                        <textarea
+                          wrap="soft"
+                          spellcheck="false"
+                          .value=${props.raw}
+                          @input=${(event: Event) => props.onRawChange((event.target as HTMLTextAreaElement).value)}
+                        ></textarea>
+                      </label>
+                      ${
+                        rawValidationError
+                          ? html`
+                              <div class="callout danger config-raw-error">
+                                <strong>JSON5 validation failed:</strong>
+                                <div>${rawValidationError}</div>
+                                ${
+                                  rawParse?.errorLine && rawParse.errorColumn
+                                    ? html`
+                                        <div class="config-raw-error__meta">
+                                          Line ${rawParse.errorLine}, column ${rawParse.errorColumn}
+                                        </div>
+                                      `
+                                    : nothing
+                                }
+                                ${
+                                  rawParse?.errorContext
+                                    ? html`
+                                        <pre class="config-raw-error__context">${rawParse.errorContext}</pre>
+                                      `
+                                    : nothing
+                                }
+                              </div>
+                            `
+                          : nothing
+                      }
+                    </section>
+                    <section class="config-raw-panel">
+                      <div class="config-raw-panel__header">
+                        <div class="config-raw-panel__title">Structured view</div>
+                        <div class="config-raw-panel__actions">
+                          <button
+                            type="button"
+                            class="config-raw-panel__action"
+                            ?disabled=${Boolean(rawTreeUnavailableReason)}
+                            @click=${(event: Event) => setRawTreeExpanded(event.currentTarget, true)}
+                          >
+                            Expand all
+                          </button>
+                          <button
+                            type="button"
+                            class="config-raw-panel__action"
+                            ?disabled=${Boolean(rawTreeUnavailableReason)}
+                            @click=${(event: Event) => setRawTreeExpanded(event.currentTarget, false)}
+                          >
+                            Collapse all
+                          </button>
+                        </div>
+                      </div>
+                      ${
+                        rawTreeUnavailableReason
+                          ? html`<div class="config-raw-panel__empty">${rawTreeUnavailableReason}</div>`
+                          : rawParse?.value
+                            ? html`<div class="config-raw-tree">${renderRawTreeNode({ value: rawParse.value, depth: 0 })}</div>`
+                            : html`<div class="config-raw-panel__empty">No parsed data to display.</div>`
+                      }
+                    </section>
+                  </div>
+                `
           }
         </div>
 
         ${
-          props.issues.length > 0
-            ? html`<div class="callout danger" style="margin-top: 12px;">
-              <pre class="code-block">
-${JSON.stringify(props.issues, null, 2)}</pre
-              >
-            </div>`
+          issues.length > 0
+            ? html`
+                <div class="callout danger config-issues">
+                  <div class="config-issues__title">Validation issues</div>
+                  <ul class="config-issues__list">
+                    ${issues.map(
+                      (issue) => html`
+                        <li class="config-issues__item">
+                          <code>${issue.path}</code>
+                          <span>${issue.message}</span>
+                        </li>
+                      `,
+                    )}
+                  </ul>
+                </div>
+              `
             : nothing
         }
       </main>


### PR DESCRIPTION
## Summary
- redesign config page layout to full-screen workspace with topbar metadata
- fully rework Form mode structure, grouping, icons, search-driven nav sorting, and validation surfaces
- fix unsupported schema handling in form by adding safer JSON5 fallbacks
- improve card/grid packing for compact controls (toggles/numbers/inputs) and reduce wasted space
- add contextual help hints for config sections and fields
- optimize config page rendering with caching and progressive section rendering
- upgrade Raw mode with structured JSON view (syntax colors, collapsible tree), parser error context, and wrapping

## Validation
- `oxlint` passed for touched TS files
- `vitest` UI run was attempted, but this environment lacks `jsdom`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR redesigns the UI config panel into a full-screen workspace: a left sidebar with search + section navigation, a top action bar (Reload/Save/Apply/Update + change badge/diff dropdown), and a main content area that switches between schema-driven Form mode and JSON5 Raw mode with a structured tree view.

The config view is wired from `ui/src/ui/app-render.ts` into `renderConfig()` (`ui/src/ui/views/config.ts`), with progressive form rendering controlled via `state.configRenderLimit`, schema analysis via `analyzeConfigSchema`, and raw-mode validation/parse feedback via JSON5 error extraction.

One merge-blocking issue to address: in form mode, Save/Apply enablement does not account for `schemaLoading`, so users can click Save/Apply while schema reload is in progress (UI shows “Loading schema...”), because schema reload keeps the previous schema value in state while loading.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a user-facing correctness issue in config action enablement during schema reload.
- Most changes are UI/layout and have reasonable test coverage for basic interactions, but Save/Apply can be enabled in form mode while schema reload is in progress due to missing schemaLoading gating in canSaveForm, which is inconsistent with the loading UI and can lead to saving/applying during an in-flight schema refresh.
- ui/src/ui/views/config.ts (Save/Apply enablement logic around schemaLoading)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->