### PR TITLE
feat: add agents.defaults.responseUsage config option

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -466,7 +466,8 @@ export async function runReplyAgent(params: {
 
     const responseUsageRaw =
       activeSessionEntry?.responseUsage ??
-      (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined);
+      (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined) ??
+      cfg.agents?.defaults?.responseUsage;
     const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
     if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
       const authMode = resolveModelAuthMode(providerUsed, cfg);

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -119,6 +119,9 @@ export const AgentDefaultsSchema = z
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),
+    responseUsage: z
+      .union([z.literal("off"), z.literal("tokens"), z.literal("full")])
+      .optional(),
     blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
     blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> Add a config option agents.defaults.responseUsage so users can set token display to 'full' by default instead of typing /usage full every session.

_The rest of this PR was written by Kimi K2.5, running in the OpenClaw harness. Full environment + prompt history appear at the end._

# Changes
- Added `responseUsage` field to `AgentDefaultsSchema` in `zod-schema.agent-defaults.ts` (accepts: "off" | "tokens" | "full")
- Updated `agent-runner.ts` to check `cfg.agents?.defaults?.responseUsage` when resolving usage display mode

# Tests
- Manual verification: Set `agents.defaults.responseUsage: "full"` in config, verified new sessions default to full usage display without running `/usage full`

# Risks
- None: Simple additive change, existing behavior unchanged when config option is not set (still defaults to "off")

# Follow-ups
- Documentation update to reference/config.md to document the new option

# Prompt History

## Environment
Harness: OpenClaw
Model: venice/kimi-k2-5
Thinking level: high
Terminal: telegram
System: Linux 6.14.0-37-generic (x64)

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-02-10T23:40:00-03:00 | `For some reason I'm not able to see token usage on telegram, even tho I run /usage and select "full". Can you look into it? Should also be as default` |
| 2026-02-10T23:41:00-03:00 | `what is a PR, should i do that?` |
| 2026-02-10T23:43:00-03:00 | `"Add a config option agents.defaults.responseUsage so users can set token display to 'full' by default instead of typing /usage full every session." Do it.` |
