### PR TITLE
fix(agents): narrow billing error 402 regex to avoid false positives on issue IDs

### DIFF
--- a/src/agents/live-auth-keys.test.ts
+++ b/src/agents/live-auth-keys.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isAnthropicBillingError } from "./live-auth-keys.js";
+
+describe("isAnthropicBillingError", () => {
+  it("does not false-positive on plain 'a 402' prose", () => {
+    const samples = [
+      "Use a 402 stainless bolt",
+      "Book a 402 room",
+      "There is a 402 near me",
+      "The building at 402 Main Street",
+    ];
+
+    for (const sample of samples) {
+      expect(isAnthropicBillingError(sample)).toBe(false);
+    }
+  });
+
+  it("matches real 402 billing payload contexts including JSON keys", () => {
+    const samples = [
+      "HTTP 402 Payment Required",
+      "status: 402",
+      "error code 402",
+      '{"status":402,"type":"error"}',
+      '{"code":402,"message":"payment required"}',
+      '{"error":{"code":402,"message":"billing hard limit reached"}}',
+      "got a 402 from the API",
+      "returned 402",
+      "received a 402 response",
+    ];
+
+    for (const sample of samples) {
+      expect(isAnthropicBillingError(sample)).toBe(true);
+    }
+  });
+});

--- a/src/agents/live-auth-keys.ts
+++ b/src/agents/live-auth-keys.ts
@@ -90,7 +90,11 @@ export function isAnthropicBillingError(message: string): boolean {
   if (lower.includes("billing") && lower.includes("disabled")) {
     return true;
   }
-  if (lower.includes("402")) {
+  if (
+    /(?:status|code|http|error)\s*[:=]?\s*402\b|(?:got|returned|received|a)\s+(?:a\s+)?402\b|^\s*402\s+payment/i.test(
+      lower,
+    )
+  ) {
     return true;
   }
   return false;

--- a/src/agents/live-auth-keys.ts
+++ b/src/agents/live-auth-keys.ts
@@ -91,7 +91,7 @@ export function isAnthropicBillingError(message: string): boolean {
     return true;
   }
   if (
-    /(?:status|code|http|error)\s*[:=]?\s*402\b|(?:got|returned|received|a)\s+(?:a\s+)?402\b|^\s*402\s+payment/i.test(
+    /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i.test(
       lower,
     )
   ) {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -35,6 +35,9 @@ describe("isBillingErrorMessage", () => {
       "Room 402 is available",
       "Error code 403 was returned, not 402-related",
       "The building at 402 Main Street",
+      "processed 402 records",
+      "402 items found in the database",
+      "port 402 is open",
     ];
     for (const sample of falsePositives) {
       expect(isBillingErrorMessage(sample)).toBe(false);
@@ -47,6 +50,9 @@ describe("isBillingErrorMessage", () => {
       "error code 402",
       "http 402",
       "status=402 payment required",
+      "got a 402 from the API",
+      "returned 402",
+      "received a 402 response",
     ];
     for (const sample of realErrors) {
       expect(isBillingErrorMessage(sample)).toBe(true);

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -27,4 +27,29 @@ describe("isBillingErrorMessage", () => {
     expect(isBillingErrorMessage("invalid api key")).toBe(false);
     expect(isBillingErrorMessage("context length exceeded")).toBe(false);
   });
+  it("does not false-positive on issue IDs or text containing 402", () => {
+    const falsePositives = [
+      "Fixed issue CHE-402 in the latest release",
+      "See ticket #402 for details",
+      "ISSUE-402 has been resolved",
+      "Room 402 is available",
+      "Error code 403 was returned, not 402-related",
+      "The building at 402 Main Street",
+    ];
+    for (const sample of falsePositives) {
+      expect(isBillingErrorMessage(sample)).toBe(false);
+    }
+  });
+  it("still matches real HTTP 402 billing errors", () => {
+    const realErrors = [
+      "HTTP 402 Payment Required",
+      "status: 402",
+      "error code 402",
+      "http 402",
+      "status=402 payment required",
+    ];
+    for (const sample of realErrors) {
+      expect(isBillingErrorMessage(sample)).toBe(true);
+    }
+  });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -38,6 +38,9 @@ describe("isBillingErrorMessage", () => {
       "processed 402 records",
       "402 items found in the database",
       "port 402 is open",
+      "Use a 402 stainless bolt",
+      "Book a 402 room",
+      "There is a 402 near me",
     ];
     for (const sample of falsePositives) {
       expect(isBillingErrorMessage(sample)).toBe(false);
@@ -53,6 +56,9 @@ describe("isBillingErrorMessage", () => {
       "got a 402 from the API",
       "returned 402",
       "received a 402 response",
+      '{"status":402,"type":"error"}',
+      '{"code":402,"message":"payment required"}',
+      '{"error":{"code":402,"message":"billing hard limit reached"}}',
     ];
     for (const sample of realErrors) {
       expect(isBillingErrorMessage(sample)).toBe(true);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -535,7 +535,7 @@ const ERROR_PATTERNS = {
   overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
   timeout: ["timeout", "timed out", "deadline exceeded", "context deadline exceeded"],
   billing: [
-    /(?:status|code|http|error)\s*[:=]?\s*402\b|^\s*402\s+payment/i,
+    /(?:status|code|http|error)\s*[:=]?\s*402\b|(?:got|returned|received|a)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
     "payment required",
     "insufficient credits",
     "credit balance",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -535,7 +535,7 @@ const ERROR_PATTERNS = {
   overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
   timeout: ["timeout", "timed out", "deadline exceeded", "context deadline exceeded"],
   billing: [
-    /(?:status|code|http|error)\s*[:=]?\s*402\b|(?:got|returned|received|a)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
+    /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
     "payment required",
     "insufficient credits",
     "credit balance",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -535,7 +535,7 @@ const ERROR_PATTERNS = {
   overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
   timeout: ["timeout", "timed out", "deadline exceeded", "context deadline exceeded"],
   billing: [
-    /\b402\b/,
+    /(?:status|code|http|error)\s*[:=]?\s*402\b|^\s*402\s+payment/i,
     "payment required",
     "insufficient credits",
     "credit balance",


### PR DESCRIPTION
## Problem

The `/\b402\b/` regex in `ERROR_PATTERNS.billing` matches any text containing `402` as a word boundary — including issue IDs (`CHE-402`), ticket numbers (`#402`), addresses (`402 Main Street`), and room numbers (`Room 402`).

This causes `sanitizeUserFacingText()` to replace **valid agent responses** with the billing error message whenever the response mentions `402` in a non-error context.

Fixes #13822

## Solution

Replace the broad `/\b402\b/` with a context-aware regex that only matches HTTP 402 error patterns:

```js
/(?:status|code|http|error)\s*[:=]?\s*402\b|^\s*402\s+payment/i
```

This matches: `status: 402`, `HTTP 402`, `error code 402`, `status=402`
This ignores: `CHE-402`, `#402`, `Room 402`, `402 Main Street`

## Tests

Added test cases for:
- False positive scenarios (issue IDs, ticket numbers, addresses, room numbers)
- Real HTTP 402 billing errors still detected correctly

All existing + new tests pass.

## AI Disclosure

This PR was authored with AI assistance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a false positive bug where the billing error detector matched any text containing `402` (like issue IDs `CHE-402`, ticket numbers `#402`, or addresses `402 Main Street`), causing legitimate agent responses to be incorrectly replaced with billing error messages.

The fix replaces the overly broad `/\b402\b/` regex with a context-aware pattern that only matches HTTP 402 error patterns like `status: 402`, `HTTP 402`, or `error code 402`, while ignoring non-error mentions of `402`.

- Comprehensive test coverage for both false positive scenarios and real billing errors
- Changes are minimal and focused on the specific issue
- Existing billing error detection still works correctly

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted bug fix with comprehensive test coverage
- The change is a well-scoped bug fix with thorough test coverage. The new regex pattern correctly distinguishes between HTTP 402 billing errors and incidental mentions of `402` in text. All edge cases are covered in tests, and the solution follows existing patterns in the codebase.
- Note: `src/agents/live-auth-keys.ts:93` still uses the broad `lower.includes("402")` check which may have similar false positives, but this is outside the scope of this PR

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->