### PR TITLE
fix(googlechat): detect bot @mentions via user.type when botUser not configured

### DIFF
--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -100,4 +100,15 @@ describe("extractMentionInfo", () => {
     const result = extractMentionInfo(annotations);
     expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
   });
+
+  it("detects same bot mentioned twice (duplicate annotations, one distinct bot)", () => {
+    // Same bot mentioned twice in one message — should still trigger since
+    // there is only one distinct BOT user, not two different bots.
+    const annotations = [
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+    ];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
 });

--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { isSenderAllowed } from "./monitor.js";
+import type { GoogleChatAnnotation } from "./types.js";
+import { isSenderAllowed, extractMentionInfo } from "./monitor.js";
 
 describe("isSenderAllowed", () => {
   it("matches allowlist entries with raw email", () => {
@@ -18,5 +19,85 @@ describe("isSenderAllowed", () => {
 
   it("rejects non-matching raw email entries", () => {
     expect(isSenderAllowed("users/123", "jane@example.com", ["other@example.com"])).toBe(false);
+  });
+});
+
+describe("extractMentionInfo", () => {
+  function mentionAnnotation(userName: string, userType?: string): GoogleChatAnnotation {
+    return {
+      type: "USER_MENTION",
+      userMention: {
+        user: { name: userName, type: userType },
+      },
+    };
+  }
+
+  it("detects mention via users/app alias", () => {
+    const annotations = [mentionAnnotation("users/app")];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
+
+  it("detects mention via explicit botUser config", () => {
+    const annotations = [mentionAnnotation("users/112986094383820258709")];
+    const result = extractMentionInfo(annotations, "users/112986094383820258709");
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
+
+  it("detects mention via BOT user type when botUser is not configured", () => {
+    // This is the core bug (#12323): Google Chat webhook sends numeric user IDs
+    // like "users/112986094383820258709" instead of "users/app". Without botUser
+    // configured, the only way to detect the bot mention is via user.type === "BOT".
+    const annotations = [mentionAnnotation("users/112986094383820258709", "BOT")];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
+
+  it("skips BOT-type fallback when multiple BOT mentions exist (multi-bot safety)", () => {
+    // In multi-bot Spaces, we can't distinguish which bot is ours without botUser config.
+    // When multiple BOT-type mentions exist, require explicit botUser configuration.
+    const annotations = [
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+      mentionAnnotation("users/998877665544332211", "BOT"),
+    ];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: false });
+  });
+
+  it("uses explicit botUser even when multiple BOT mentions exist", () => {
+    const annotations = [
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+      mentionAnnotation("users/998877665544332211", "BOT"),
+    ];
+    const result = extractMentionInfo(annotations, "users/112986094383820258709");
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
+
+  it("returns wasMentioned false for non-bot numeric user ID without config", () => {
+    // Human mentions should not trigger the bot
+    const annotations = [mentionAnnotation("users/112986094383820258709", "HUMAN")];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: false });
+  });
+
+  it("returns hasAnyMention false for empty annotations", () => {
+    const result = extractMentionInfo([]);
+    expect(result).toEqual({ hasAnyMention: false, wasMentioned: false });
+  });
+
+  it("ignores non-USER_MENTION annotations", () => {
+    const annotations: GoogleChatAnnotation[] = [{ type: "SLASH_COMMAND" }, { type: "RICH_LINK" }];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: false, wasMentioned: false });
+  });
+
+  it("detects BOT-type mention alongside human mentions", () => {
+    // One BOT mention + one human mention: BOT fallback should still work
+    const annotations = [
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+      mentionAnnotation("users/555666777888999", "HUMAN"),
+    ];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
   });
 });

--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { GoogleChatAnnotation } from "./types.js";
 import { isSenderAllowed, extractMentionInfo } from "./monitor.js";
+import type { GoogleChatAnnotation } from "./types.js";
 
 describe("isSenderAllowed", () => {
   it("matches allowlist entries with raw email", () => {

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -345,10 +345,11 @@ function resolveGroupConfig(params: {
   return { entry: entry ?? fallback, allowlistConfigured: true, fallback };
 }
 
-function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: string | null) {
+export function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: string | null) {
   const mentionAnnotations = annotations.filter((entry) => entry.type === "USER_MENTION");
   const hasAnyMention = mentionAnnotations.length > 0;
-  const botTargets = new Set(["users/app", botUser?.trim()].filter(Boolean) as string[]);
+  const trimmedBotUser = botUser?.trim() || null;
+  const botTargets = new Set(["users/app", trimmedBotUser].filter(Boolean) as string[]);
   const wasMentioned = mentionAnnotations.some((entry) => {
     const userName = entry.userMention?.user?.name;
     if (!userName) {
@@ -357,7 +358,22 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
     if (botTargets.has(userName)) {
       return true;
     }
-    return normalizeUserId(userName) === "app";
+    if (normalizeUserId(userName) === "app") {
+      return true;
+    }
+    // When botUser is not explicitly configured, fall back to checking the
+    // user.type field. Google Chat sends numeric user IDs (e.g. "users/123...")
+    // instead of "users/app" for webhook-based bots, so the type field is the
+    // only reliable signal. For multi-bot safety, only use this fallback when
+    // exactly one BOT-type mention exists — with multiple bots we can't tell
+    // which one is ours without an explicit botUser configuration.
+    if (!trimmedBotUser && entry.userMention?.user?.type?.toUpperCase() === "BOT") {
+      const botTypeMentionCount = mentionAnnotations.filter(
+        (m) => m.userMention?.user?.type?.toUpperCase() === "BOT",
+      ).length;
+      return botTypeMentionCount === 1;
+    }
+    return false;
   });
   return { hasAnyMention, wasMentioned };
 }

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -365,13 +365,16 @@ export function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?
     // user.type field. Google Chat sends numeric user IDs (e.g. "users/123...")
     // instead of "users/app" for webhook-based bots, so the type field is the
     // only reliable signal. For multi-bot safety, only use this fallback when
-    // exactly one BOT-type mention exists — with multiple bots we can't tell
-    // which one is ours without an explicit botUser configuration.
+    // exactly one distinct BOT-type user exists — with multiple bots we can't
+    // tell which one is ours without an explicit botUser configuration.
     if (!trimmedBotUser && entry.userMention?.user?.type?.toUpperCase() === "BOT") {
-      const botTypeMentionCount = mentionAnnotations.filter(
-        (m) => m.userMention?.user?.type?.toUpperCase() === "BOT",
-      ).length;
-      return botTypeMentionCount === 1;
+      const distinctBotUsers = new Set(
+        mentionAnnotations
+          .filter((m) => m.userMention?.user?.type?.toUpperCase() === "BOT")
+          .map((m) => m.userMention?.user?.name)
+          .filter(Boolean),
+      );
+      return distinctBotUsers.size === 1;
     }
     return false;
   });


### PR DESCRIPTION
## Summary

Fixes #12323

Google Chat webhooks send numeric user IDs (e.g. `users/112986094383820258709`) instead of the `users/app` alias for bot @mentions. Without `botUser` explicitly configured, `extractMentionInfo()` failed to recognize these mentions, causing the bot to silently ignore messages where it was @mentioned.

**Root cause:** `extractMentionInfo()` only checked `botTargets` (containing `users/app` and optional `botUser`) and the `normalizeUserId() === "app"` path. Numeric user IDs don't match either check.

**Fix:** When `botUser` is not configured and existing checks fail, fall back to checking `user.type === "BOT"` from the annotation metadata. For multi-bot Space safety, this fallback only triggers when exactly one distinct BOT-type user exists in the annotations — if multiple different bots are mentioned, the ambiguity requires explicit `botUser` configuration.

## Changes

- `extensions/googlechat/src/monitor.ts`: Added BOT user type fallback in `extractMentionInfo()` with distinct-user multi-bot safety guard
- `extensions/googlechat/src/monitor.test.ts`: Added 10 new tests covering all mention detection paths

## Test plan

- [x] `users/app` alias detection still works
- [x] Explicit `botUser` config detection still works
- [x] BOT user type fallback detects mentions when `botUser` not configured
- [x] Multi-bot safety: rejects when multiple distinct BOT users exist
- [x] Explicit `botUser` overrides multi-bot guard
- [x] HUMAN-type mentions don't trigger bot
- [x] Empty and non-USER_MENTION annotations handled correctly
- [x] Same bot mentioned twice (duplicate annotations) still detected
- [x] BOT mention alongside human mentions still detected
- [x] All 14 tests fail before fix, pass after fix

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Google Chat bot @mention detection when webhooks send numeric user IDs (e.g. `users/112...`) instead of the `users/app` alias and `botUser` is not configured.

It does this by exporting and enhancing `extractMentionInfo()` in `extensions/googlechat/src/monitor.ts` to fall back to `annotation.userMention.user.type === "BOT"` when the existing `users/app` / `botUser` matching fails. To avoid incorrect triggering in multi-bot spaces, the fallback only applies when there is exactly one distinct BOT user in the message annotations. The accompanying tests in `extensions/googlechat/src/monitor.test.ts` cover alias matching, explicit `botUser`, BOT-type fallback, multi-bot guard behavior, and ignoring non-mention annotations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to mention detection logic and are guarded to avoid multi-bot ambiguity; added unit tests cover the new fallback and existing mention paths. No breaking internal usage was found beyond exporting a helper that is only used within the module and tests.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->