### PR TITLE
fix(agents): enable tool call ID sanitization for Anthropic provider

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -76,7 +76,7 @@ describe("sanitizeSessionHistory", () => {
     );
   });
 
-  it("does not sanitize tool call ids for non-Google APIs", async () => {
+  it("sanitizes tool call ids for Anthropic APIs", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     await sanitizeSessionHistory({
@@ -90,7 +90,7 @@ describe("sanitizeSessionHistory", () => {
     expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
       "session:history",
-      expect.objectContaining({ sanitizeMode: "full", sanitizeToolCallIds: false }),
+      expect.objectContaining({ sanitizeMode: "full", sanitizeToolCallIds: true }),
     );
   });
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveTranscriptPolicy } from "./transcript-policy.js";
+
+describe("resolveTranscriptPolicy", () => {
+  it("enables sanitizeToolCallIds for Anthropic provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+      modelApi: "anthropic-messages",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("enables sanitizeToolCallIds for Google provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "google",
+      modelId: "gemini-2.0-flash",
+      modelApi: "google-generative-ai",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+  });
+
+  it("enables sanitizeToolCallIds for Mistral provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "mistral",
+      modelId: "mistral-large-latest",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict9");
+  });
+
+  it("disables sanitizeToolCallIds for OpenAI provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-4o",
+      modelApi: "openai",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(false);
+  });
+});

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -95,7 +95,7 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds


### PR DESCRIPTION
## Problem

`sanitizeToolCallIds` in `resolveTranscriptPolicy()` only covers Google and Mistral providers. Anthropic requires tool_use IDs to match `^[a-zA-Z0-9-]+$`, but was excluded from sanitization.

When tool call IDs contain underscores (e.g., `toolu_01XYZ` from cross-provider contexts or synthetic results), Anthropic rejects the request with:
```
messages.370.content.1.tooluse.id: String should match pattern '^[a-zA-Z0-9-]+$'
```

The gateway logs "Tool calls will be sanitized on retry" but no sanitization runs for Anthropic, causing a loop.

Fixes #13799

## Solution

One-line fix: add `isAnthropic` to the `sanitizeToolCallIds` condition in `transcript-policy.ts`:

```diff
- const sanitizeToolCallIds = isGoogle || isMistral;
+ const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
```

The existing `"strict"` mode (alphanumeric + hyphens only) already satisfies Anthropic's `^[a-zA-Z0-9-]+$` pattern.

## Tests

Added `transcript-policy.test.ts` with coverage for Anthropic, Google, Mistral (enabled), and OpenAI (disabled).

## AI Disclosure

This PR was authored with AI assistance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Anthropic to the list of providers that require tool call ID sanitization. Previously, only Google and Mistral providers had `sanitizeToolCallIds` enabled, which caused Anthropic requests to fail when tool call IDs contained underscores (e.g., `toolu_01XYZ`). Anthropic requires tool IDs to match the pattern `^[a-zA-Z0-9-]+$`, which is already satisfied by the existing `"strict"` mode sanitization (alphanumeric + hyphens only).

Key changes:
- Modified `src/agents/transcript-policy.ts:98` to include `isAnthropic` in the `sanitizeToolCallIds` condition
- Added comprehensive test coverage in `src/agents/transcript-policy.test.ts` for Anthropic, Google, Mistral (enabled), and OpenAI (disabled)

The fix is minimal, well-tested, and directly addresses the issue described in #13799 where the gateway logged "Tool calls will be sanitized on retry" but no sanitization ran for Anthropic, causing a retry loop.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a one-line change that adds Anthropic to an existing provider list, following the exact same pattern as Google and Mistral. The logic is straightforward, well-tested with comprehensive test coverage, and the existing `"strict"` mode already satisfies Anthropic's ID pattern requirements. The change is well-scoped and directly addresses a documented bug.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->