### PR TITLE
Cursor/cloud agent 1770777391345 yc4re

### DIFF
--- a/.cursor/rules/openclaw-patterns.mdc
+++ b/.cursor/rules/openclaw-patterns.mdc
@@ -1,0 +1,78 @@
+---
+description: OpenClaw 项目全局规则与代码规范（语言、复用、技术栈、CLI/终端约定）
+alwaysApply: true
+---
+
+# OpenClaw Codebase Patterns
+
+## 全局规则
+
+**重要：所有回答和交互必须使用中文。**
+
+- 代码注释使用中文
+- 文档和说明使用中文
+- 错误信息和日志使用中文
+- 与用户的所有交流使用中文
+
+**Always reuse existing code - no redundancy!**
+
+## Tech Stack
+
+- **Runtime**: Node 22+ (Bun also supported for dev/scripts)
+- **Language**: TypeScript (ESM, strict mode)
+- **Package Manager**: pnpm (keep `pnpm-lock.yaml` in sync)
+- **Lint/Format**: Oxlint, Oxfmt (`pnpm check`)
+- **Tests**: Vitest with V8 coverage
+- **CLI Framework**: Commander + clack/prompts
+- **Build**: tsdown (outputs to `dist/`)
+
+## Anti-Redundancy Rules
+
+- Avoid files that just re-export from another file. Import directly from the original source.
+- If a function already exists, import it - do NOT create a duplicate in another file.
+- Before creating any formatter, utility, or helper, search for existing implementations first.
+
+## Source of Truth Locations
+
+### Formatting Utilities (`src/infra/`)
+
+- **Time formatting**: `src/infra/format-time`
+
+**NEVER create local `formatAge`, `formatDuration`, `formatElapsedTime` functions - import from centralized modules.**
+
+### Terminal Output (`src/terminal/`)
+
+- Tables: `src/terminal/table.ts` (`renderTable`)
+- Themes/colors: `src/terminal/theme.ts` (`theme.success`, `theme.muted`, etc.)
+- Progress: `src/cli/progress.ts` (spinners, progress bars)
+
+### CLI Patterns
+
+- CLI option wiring: `src/cli/`
+- Commands: `src/commands/`
+- Dependency injection via `createDefaultDeps`
+
+## Import Conventions
+
+- Use `.js` extension for cross-package imports (ESM)
+- Direct imports only - no re-export wrapper files
+- Types: `import type { X }` for type-only imports
+
+## Code Quality
+
+- TypeScript (ESM), strict typing, avoid `any`
+- Keep files under ~700 LOC - extract helpers when larger
+- Colocated tests: `*.test.ts` next to source files
+- Run `pnpm check` before commits (lint + format)
+- Run `pnpm tsgo` for type checking
+
+## Stack & Commands
+
+- **Package manager**: pnpm (`pnpm install`)
+- **Dev**: `pnpm openclaw ...` or `pnpm dev`
+- **Type-check**: `pnpm tsgo`
+- **Lint/format**: `pnpm check`
+- **Tests**: `pnpm test`
+- **Build**: `pnpm build`
+
+If you are coding together with a human, do NOT use scripts/committer, but git directly and run the above commands manually to ensure quality.

--- a/.github/instructions/copilot.instructions.md
+++ b/.github/instructions/copilot.instructions.md
@@ -1,5 +1,14 @@
 # OpenClaw Codebase Patterns
 
+## 全局规则
+
+**重要：所有回答和交互必须使用中文。**
+
+- 代码注释使用中文
+- 文档和说明使用中文
+- 错误信息和日志使用中文
+- 与用户的所有交流使用中文
+
 **Always reuse existing code - no redundancy!**
 
 ## Tech Stack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,190 +1,229 @@
-# Repository Guidelines
+# OpenClaw Repository Guidelines
 
-- Repo: https://github.com/openclaw/openclaw
-- GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or $'...') for real newlines; never embed "\\n".
+Repository: https://github.com/openclaw/openclaw
 
-## Project Structure & Module Organization
+## Quick Reference: Build, Test, Lint
 
-- Source code: `src/` (CLI wiring in `src/cli`, commands in `src/commands`, web provider in `src/provider-web.ts`, infra in `src/infra`, media pipeline in `src/media`).
-- Tests: colocated `*.test.ts`.
-- Docs: `docs/` (images, queue, Pi config). Built output lives in `dist/`.
-- Plugins/extensions: live under `extensions/*` (workspace packages). Keep plugin-only deps in the extension `package.json`; do not add them to the root `package.json` unless core uses them.
-- Plugins: install runs `npm install --omit=dev` in plugin dir; runtime deps must live in `dependencies`. Avoid `workspace:*` in `dependencies` (npm install breaks); put `openclaw` in `devDependencies` or `peerDependencies` instead (runtime resolves `openclaw/plugin-sdk` via jiti alias).
-- Installers served from `https://openclaw.ai/*`: live in the sibling repo `../openclaw.ai` (`public/install.sh`, `public/install-cli.sh`, `public/install.ps1`).
-- Messaging channels: always consider **all** built-in + extension channels when refactoring shared logic (routing, allowlists, pairing, command gating, onboarding, docs).
-  - Core channel docs: `docs/channels/`
-  - Core channel code: `src/telegram`, `src/discord`, `src/slack`, `src/signal`, `src/imessage`, `src/web` (WhatsApp web), `src/channels`, `src/routing`
-  - Extensions (channel plugins): `extensions/*` (e.g. `extensions/msteams`, `extensions/matrix`, `extensions/zalo`, `extensions/zalouser`, `extensions/voice-call`)
-- When adding channels/extensions/apps/docs, update `.github/labeler.yml` and create matching GitHub labels (use existing channel/extension label colors).
+```bash
+# Install dependencies
+pnpm install
 
-## Docs Linking (Mintlify)
+# Development
+pnpm dev                    # Run CLI in dev mode
+pnpm openclaw <command>     # Run specific CLI command
 
-- Docs are hosted on Mintlify (docs.openclaw.ai).
-- Internal doc links in `docs/**/*.md`: root-relative, no `.md`/`.mdx` (example: `[Config](/configuration)`).
-- Section cross-references: use anchors on root-relative paths (example: `[Hooks](/configuration#hooks)`).
-- Doc headings and anchors: avoid em dashes and apostrophes in headings because they break Mintlify anchor links.
-- When Peter asks for links, reply with full `https://docs.openclaw.ai/...` URLs (not root-relative).
-- When you touch docs, end the reply with the `https://docs.openclaw.ai/...` URLs you referenced.
-- README (GitHub): keep absolute docs URLs (`https://docs.openclaw.ai/...`) so links work on GitHub.
-- Docs content must be generic: no personal device names/hostnames/paths; use placeholders like `user@gateway-host` and “gateway host”.
+# Build & Type Checking
+pnpm build                  # Full build (includes bundling, protocol gen, etc.)
+pnpm tsgo                   # TypeScript type checking only
 
-## Docs i18n (zh-CN)
+# Linting & Formatting
+pnpm check                  # Run lint + format checks (run before commits)
+pnpm lint                   # Oxlint only
+pnpm format                 # Format with Oxfmt
+pnpm lint:fix               # Auto-fix lint issues and format
 
-- `docs/zh-CN/**` is generated; do not edit unless the user explicitly asks.
-- Pipeline: update English docs → adjust glossary (`docs/.i18n/glossary.zh-CN.json`) → run `scripts/docs-i18n` → apply targeted fixes only if instructed.
-- Translation memory: `docs/.i18n/zh-CN.tm.jsonl` (generated).
-- See `docs/.i18n/README.md`.
-- The pipeline can be slow/inefficient; if it’s dragging, ping @jospalmbier on Discord instead of hacking around it.
+# Testing
+pnpm test                   # Run all unit tests (vitest)
+pnpm test:coverage          # Run tests with coverage report
+pnpm test:watch             # Watch mode for development
+pnpm test:e2e               # End-to-end tests
 
-## exe.dev VM ops (general)
+# Run a single test file
+pnpm vitest src/path/to/file.test.ts
 
-- Access: stable path is `ssh exe.dev` then `ssh vm-name` (assume SSH key already set).
-- SSH flaky: use exe.dev web terminal or Shelley (web agent); keep a tmux session for long ops.
-- Update: `sudo npm i -g openclaw@latest` (global install needs root on `/usr/lib/node_modules`).
-- Config: use `openclaw config set ...`; ensure `gateway.mode=local` is set.
-- Discord: store raw token only (no `DISCORD_BOT_TOKEN=` prefix).
-- Restart: stop old gateway and run:
-  `pkill -9 -f openclaw-gateway || true; nohup openclaw gateway run --bind loopback --port 18789 --force > /tmp/openclaw-gateway.log 2>&1 &`
-- Verify: `openclaw channels status --probe`, `ss -ltnp | rg 18789`, `tail -n 120 /tmp/openclaw-gateway.log`.
+# Run tests matching a pattern
+pnpm vitest src/infra/**/*.test.ts
 
-## Build, Test, and Development Commands
+# Run a specific test by name
+pnpm vitest -t "test name pattern"
 
-- Runtime baseline: Node **22+** (keep Node + Bun paths working).
-- Install deps: `pnpm install`
-- Pre-commit hooks: `prek install` (runs same checks as CI)
-- Also supported: `bun install` (keep `pnpm-lock.yaml` + Bun patching in sync when touching deps/patches).
-- Prefer Bun for TypeScript execution (scripts, dev, tests): `bun <file.ts>` / `bunx <tool>`.
-- Run CLI in dev: `pnpm openclaw ...` (bun) or `pnpm dev`.
-- Node remains supported for running built output (`dist/*`) and production installs.
-- Mac packaging (dev): `scripts/package-mac-app.sh` defaults to current arch. Release checklist: `docs/platforms/mac/release.md`.
-- Type-check/build: `pnpm build`
-- TypeScript checks: `pnpm tsgo`
-- Lint/format: `pnpm check`
-- Tests: `pnpm test` (vitest); coverage: `pnpm test:coverage`
+# Mobile/Platform-Specific
+pnpm ios:build              # Build iOS app
+pnpm android:run            # Build and run Android app
+pnpm mac:package            # Package macOS app
+```
 
-## Coding Style & Naming Conventions
+## Project Structure
 
-- Language: TypeScript (ESM). Prefer strict typing; avoid `any`.
-- Formatting/linting via Oxlint and Oxfmt; run `pnpm check` before commits.
-- Add brief code comments for tricky or non-obvious logic.
-- Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
-- Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
-- Naming: use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, and config keys.
+- **Source**: `src/` (CLI: `src/cli`, commands: `src/commands`, channels: `src/telegram`, `src/discord`, etc.)
+- **Tests**: Colocated `*.test.ts` files next to source
+- **Docs**: `docs/` (hosted on Mintlify at docs.openclaw.ai)
+- **Build output**: `dist/`
+- **Extensions/Plugins**: `extensions/*` (workspace packages)
+- **Mobile apps**: `apps/ios`, `apps/android`, `apps/macos`
 
-## Release Channels (Naming)
+## Code Style & Conventions
 
-- stable: tagged releases only (e.g. `vYYYY.M.D`), npm dist-tag `latest`.
-- beta: prerelease tags `vYYYY.M.D-beta.N`, npm dist-tag `beta` (may ship without macOS app).
-- dev: moving head on `main` (no tag; git checkout main).
+### Language & Types
+- **TypeScript ESM** with strict mode (`target: es2023`, `module: NodeNext`)
+- **NO `any` types** - use proper typing (enforced by oxlint)
+- Use `import type { X }` for type-only imports
+- Prefer explicit types over inference for function signatures
+
+### Imports
+- **Use `.js` extensions** for cross-package imports (ESM requirement)
+- **Import directly** - no re-export wrapper files
+- **Import order**: sorted automatically by Oxfmt (no newlines between)
+- Example: `import { foo } from "../infra/foo.js"`
+
+### Formatting & Linting
+- **Auto-formatted** by Oxfmt (4 spaces, double quotes, trailing commas)
+- **Linted** by Oxlint with TypeScript-aware rules
+- Run `pnpm check` before committing
+- Curly braces required for all blocks (enforced)
+
+### Naming Conventions
+- **Product name**: "OpenClaw" (in docs, UI, headings)
+- **CLI/binary**: `openclaw` (lowercase, in commands, paths, config keys)
+- **Files**: kebab-case (e.g., `format-time.ts`, `agent-events.ts`)
+- **Functions/variables**: camelCase
+- **Types/Interfaces**: PascalCase
+- **Constants**: UPPER_SNAKE_CASE (for true constants)
+
+### File Organization
+- Keep files **under ~700 LOC** (guideline, not strict)
+- Extract helpers instead of creating "V2" files
+- Colocate tests: `foo.ts` → `foo.test.ts`
+- E2E tests: `*.e2e.test.ts`
+
+### Error Handling
+- Use explicit error handling with try/catch
+- Return `undefined` or result types instead of throwing when appropriate
+- Validate inputs early (guard clauses)
+- Log errors with context using `tslog`
+
+### Comments
+- Add **brief comments** for tricky or non-obvious logic
+- Avoid redundant comments that just restate the code
+- Document complex algorithms or business logic
+
+## Anti-Redundancy Rules
+
+**CRITICAL: Always reuse existing code - never duplicate!**
+
+Before creating utilities, formatters, or helpers:
+1. **Search for existing implementations first**
+2. Import from the source of truth (see below)
+3. Do NOT create local copies of utilities
+
+### Source of Truth Locations
+
+#### Formatting (`src/infra/format-time/`)
+- **Time/duration**: `src/infra/format-time/format-duration.ts` (`formatDurationCompact`, `formatDurationHuman`, `formatDurationPrecise`)
+- **Relative time**: `src/infra/format-time/format-relative.ts`
+- **Date/time**: `src/infra/format-time/format-datetime.ts`
+
+Never create local `formatAge`, `formatDuration`, `formatElapsedTime` - import from centralized modules.
+
+#### Terminal Output (`src/terminal/`)
+- **Tables**: `src/terminal/table.ts` (`renderTable`)
+- **Themes/colors**: `src/terminal/theme.ts` (`theme.success`, `theme.muted`, etc.)
+- **Progress/spinners**: `src/cli/progress.ts` (uses `osc-progress` + `@clack/prompts`)
+
+#### CLI Patterns
+- **Option wiring**: `src/cli/command-options.ts`
+- **Commands**: `src/commands/`
+- **Dependency injection**: via `createDefaultDeps`
 
 ## Testing Guidelines
 
-- Framework: Vitest with V8 coverage thresholds (70% lines/branches/functions/statements).
-- Naming: match source names with `*.test.ts`; e2e in `*.e2e.test.ts`.
-- Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
-- Do not set test workers above 16; tried already.
-- Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
-- Full kit + what’s covered: `docs/testing.md`.
-- Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
-- Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
+- **Framework**: Vitest with V8 coverage (70% threshold for lines/functions/statements, 55% branches)
+- **Naming**: Match source file name (`foo.ts` → `foo.test.ts`)
+- **Timeout**: 120s default (configurable per test)
+- **Workers**: Max 16 workers (already optimized)
+- Always run `pnpm test` before pushing when touching logic
+- Pure test additions generally don't need changelog entries
 
-## Commit & Pull Request Guidelines
+### Test Patterns
+```typescript
+import { describe, it, expect } from "vitest";
 
-- Create commits with `scripts/committer "<msg>" <file...>`; avoid manual `git add`/`git commit` so staging stays scoped.
-- Follow concise, action-oriented commit messages (e.g., `CLI: add verbose flag to send`).
-- Group related changes; avoid bundling unrelated refactors.
-- Changelog workflow: keep latest released version at top (no `Unreleased`); after publishing, bump version and start a new top section.
-- PRs should summarize scope, note testing performed, and mention any user-facing changes or new flags.
-- Read this when submitting a PR: `docs/help/submitting-a-pr.md` ([Submitting a PR](https://docs.openclaw.ai/help/submitting-a-pr))
-- Read this when submitting an issue: `docs/help/submitting-an-issue.md` ([Submitting an Issue](https://docs.openclaw.ai/help/submitting-an-issue))
-- PR review flow: when given a PR link, review via `gh pr view`/`gh pr diff` and do **not** change branches.
-- PR review calls: prefer a single `gh pr view --json ...` to batch metadata/comments; run `gh pr diff` only when needed.
-- Before starting a review when a GH Issue/PR is pasted: run `git pull`; if there are local changes or unpushed commits, stop and alert the user before reviewing.
-- Goal: merge PRs. Prefer **rebase** when commits are clean; **squash** when history is messy.
-- PR merge flow: create a temp branch from `main`, merge the PR branch into it (prefer squash unless commit history is important; use rebase/merge when it is). Always try to merge the PR unless it’s truly difficult, then use another approach. If we squash, add the PR author as a co-contributor. Apply fixes, add changelog entry (include PR # + thanks), run full gate before the final commit, commit, merge back to `main`, delete the temp branch, and end on `main`.
-- If you review a PR and later do work on it, land via merge/squash (no direct-main commits) and always add the PR author as a co-contributor.
-- When working on a PR: add a changelog entry with the PR number and thank the contributor.
-- When working on an issue: reference the issue in the changelog entry.
-- When merging a PR: leave a PR comment that explains exactly what we did and include the SHA hashes.
-- When merging a PR from a new contributor: add their avatar to the README “Thanks to all clawtributors” thumbnail list.
-- After merging a PR: run `bun scripts/update-clawtributors.ts` if the contributor is missing, then commit the regenerated README.
+describe("myFunction", () => {
+  it("should handle basic case", () => {
+    expect(myFunction(input)).toBe(expected);
+  });
+});
+```
 
-## Shorthand Commands
+## Commit & PR Guidelines
 
-- `sync`: if working tree is dirty, commit all changes (pick a sensible Conventional Commit message), then `git pull --rebase`; if rebase conflicts and cannot resolve, stop; otherwise `git push`.
+- Use `scripts/committer "<msg>" <file...>` for commits (avoids staging issues)
+- **Commit message style**: Concise, action-oriented (e.g., "CLI: add verbose flag to send")
+- **Changelog**: Keep latest released version at top (no "Unreleased" section)
+- **PR workflow**: Prefer rebase for clean history, squash when messy
+- When working on PR: add changelog entry with PR # and thank contributor
+- Run full gate before merging: `pnpm build && pnpm check && pnpm test`
 
-### PR Workflow (Review vs Land)
+## Configuration & Dependencies
 
-- **Review mode (PR link only):** read `gh pr view/diff`; **do not** switch branches; **do not** change code.
-- **Landing mode:** create an integration branch from `main`, bring in PR commits (**prefer rebase** for linear history; **merge allowed** when complexity/conflicts make it safer), apply fixes, add changelog (+ thanks + PR #), run full gate **locally before committing** (`pnpm build && pnpm check && pnpm test`), commit, merge back to `main`, then `git switch main` (never stay on a topic branch after landing). Important: contributor needs to be in git graph after this!
+- **Node**: 22+ required (Bun also supported for dev/scripts)
+- **Package manager**: pnpm 10.23.0
+- **Never update** the `@buape/carbon` dependency without approval
+- Patched dependencies must use **exact versions** (no `^` or `~`)
+- New patches require explicit approval
 
-## Security & Configuration Tips
+## Common Patterns
 
-- Web provider stores creds at `~/.openclaw/credentials/`; rerun `openclaw login` if logged out.
-- Pi sessions live under `~/.openclaw/sessions/` by default; the base directory is not configurable.
-- Environment variables: see `~/.profile`.
-- Never commit or publish real phone numbers, videos, or live configuration values. Use obviously fake placeholders in docs, tests, and examples.
-- Release flow: always read `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md` before any release work; do not ask routine questions once those docs answer them.
+### CLI Progress
+```typescript
+import { createSpinner } from "../cli/progress.js";
+const spinner = createSpinner("Loading...");
+// ... work
+spinner.stop("Done!");
+```
 
-## Troubleshooting
+### Dependency Injection
+```typescript
+import { createDefaultDeps } from "../cli/deps.js";
+const deps = createDefaultDeps();
+```
 
-- Rebrand/migration issues or legacy config/service warnings: run `openclaw doctor` (see `docs/gateway/doctor.md`).
+### Theme Colors
+```typescript
+import { theme } from "../terminal/theme.js";
+console.log(theme.success("Success!"));
+console.log(theme.error("Error!"));
+```
 
-## Agent-Specific Notes
+## Channel/Extension Development
 
-- Vocabulary: "makeup" = "mac app".
-- Never edit `node_modules` (global/Homebrew/npm/git installs too). Updates overwrite. Skill notes go in `tools.md` or `AGENTS.md`.
-- When adding a new `AGENTS.md` anywhere in the repo, also add a `CLAUDE.md` symlink pointing to it (example: `ln -s AGENTS.md CLAUDE.md`).
-- Signal: "update fly" => `fly ssh console -a flawd-bot -C "bash -lc 'cd /data/clawd/openclaw && git pull --rebase origin main'"` then `fly machines restart e825232f34d058 -a flawd-bot`.
-- When working on a GitHub Issue or PR, print the full URL at the end of the task.
-- When answering questions, respond with high-confidence answers only: verify in code; do not guess.
-- Never update the Carbon dependency.
-- Any dependency with `pnpm.patchedDependencies` must use an exact version (no `^`/`~`).
-- Patching dependencies (pnpm patches, overrides, or vendored changes) requires explicit approval; do not do this by default.
-- CLI progress: use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner); don’t hand-roll spinners/bars.
-- Status output: keep tables + ANSI-safe wrapping (`src/terminal/table.ts`); `status --all` = read-only/pasteable, `status --deep` = probes.
-- Gateway currently runs only as the menubar app; there is no separate LaunchAgent/helper label installed. Restart via the OpenClaw Mac app or `scripts/restart-mac.sh`; to verify/kill use `launchctl print gui/$UID | grep openclaw` rather than assuming a fixed label. **When debugging on macOS, start/stop the gateway via the app, not ad-hoc tmux sessions; kill any temporary tunnels before handoff.**
-- macOS logs: use `./scripts/clawlog.sh` to query unified logs for the OpenClaw subsystem; it supports follow/tail/category filters and expects passwordless sudo for `/usr/bin/log`.
-- If shared guardrails are available locally, review them; otherwise follow this repo's guidance.
-- SwiftUI state management (iOS/macOS): prefer the `Observation` framework (`@Observable`, `@Bindable`) over `ObservableObject`/`@StateObject`; don’t introduce new `ObservableObject` unless required for compatibility, and migrate existing usages when touching related code.
-- Connection providers: when adding a new connection, update every UI surface and docs (macOS app, web UI, mobile if applicable, onboarding/overview docs) and add matching status + configuration forms so provider lists and settings stay in sync.
-- Version locations: `package.json` (CLI), `apps/android/app/build.gradle.kts` (versionName/versionCode), `apps/ios/Sources/Info.plist` + `apps/ios/Tests/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `apps/macos/Sources/OpenClaw/Resources/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `docs/install/updating.md` (pinned npm version), `docs/platforms/mac/release.md` (APP_VERSION/APP_BUILD examples), Peekaboo Xcode projects/Info.plists (MARKETING_VERSION/CURRENT_PROJECT_VERSION).
-- **Restart apps:** “restart iOS/Android apps” means rebuild (recompile/install) and relaunch, not just kill/launch.
-- **Device checks:** before testing, verify connected real devices (iOS/Android) before reaching for simulators/emulators.
-- iOS Team ID lookup: `security find-identity -p codesigning -v` → use Apple Development (…) TEAMID. Fallback: `defaults read com.apple.dt.Xcode IDEProvisioningTeamIdentifiers`.
-- A2UI bundle hash: `src/canvas-host/a2ui/.bundle.hash` is auto-generated; ignore unexpected changes, and only regenerate via `pnpm canvas:a2ui:bundle` (or `scripts/bundle-a2ui.sh`) when needed. Commit the hash as a separate commit.
-- Release signing/notary keys are managed outside the repo; follow internal release docs.
-- Notary auth env vars (`APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_API_KEY_P8`) are expected in your environment (per internal release docs).
-- **Multi-agent safety:** do **not** create/apply/drop `git stash` entries unless explicitly requested (this includes `git pull --rebase --autostash`). Assume other agents may be working; keep unrelated WIP untouched and avoid cross-cutting state changes.
-- **Multi-agent safety:** when the user says "push", you may `git pull --rebase` to integrate latest changes (never discard other agents' work). When the user says "commit", scope to your changes only. When the user says "commit all", commit everything in grouped chunks.
-- **Multi-agent safety:** do **not** create/remove/modify `git worktree` checkouts (or edit `.worktrees/*`) unless explicitly requested.
-- **Multi-agent safety:** do **not** switch branches / check out a different branch unless explicitly requested.
-- **Multi-agent safety:** running multiple agents is OK as long as each agent has its own session.
-- **Multi-agent safety:** when you see unrecognized files, keep going; focus on your changes and commit only those.
-- Lint/format churn:
-  - If staged+unstaged diffs are formatting-only, auto-resolve without asking.
-  - If commit/push already requested, auto-stage and include formatting-only follow-ups in the same commit (or a tiny follow-up commit if needed), no extra confirmation.
-  - Only ask when changes are semantic (logic/data/behavior).
-- Lobster seam: use the shared CLI palette in `src/terminal/palette.ts` (no hardcoded colors); apply palette to onboarding/config prompts and other TTY UI output as needed.
-- **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
-- Bug investigations: read source code of relevant npm dependencies and all related local code before concluding; aim for high-confidence root cause.
-- Code style: add brief comments for tricky logic; keep files under ~500 LOC when feasible (split/refactor as needed).
-- Tool schema guardrails (google-antigravity): avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`. Use `stringEnum`/`optionalStringEnum` (Type.Unsafe enum) for string lists, and `Type.Optional(...)` instead of `... | null`. Keep top-level tool schema as `type: "object"` with `properties`.
-- Tool schema guardrails: avoid raw `format` property names in tool schemas; some validators treat `format` as a reserved keyword and reject the schema.
-- When asked to open a “session” file, open the Pi session logs under `~/.openclaw/agents/<agentId>/sessions/*.jsonl` (use the `agent=<id>` value in the Runtime line of the system prompt; newest unless a specific ID is given), not the default `sessions.json`. If logs are needed from another machine, SSH via Tailscale and read the same path there.
-- Do not rebuild the macOS app over SSH; rebuilds must be run directly on the Mac.
-- Never send streaming/partial replies to external messaging surfaces (WhatsApp, Telegram); only final replies should be delivered there. Streaming/tool events may still go to internal UIs/control channel.
-- Voice wake forwarding tips:
-  - Command template should stay `openclaw-mac agent --message "${text}" --thinking low`; `VoiceWakeForwarder` already shell-escapes `${text}`. Don’t add extra quotes.
-  - launchd PATH is minimal; ensure the app’s launch agent PATH includes standard system paths plus your pnpm bin (typically `$HOME/Library/pnpm`) so `pnpm`/`openclaw` binaries resolve when invoked via `openclaw-mac`.
-- For manual `openclaw message send` messages that include `!`, use the heredoc pattern noted below to avoid the Bash tool’s escaping.
-- Release guardrails: do not change version numbers without operator’s explicit consent; always ask permission before running any npm publish/release step.
+When adding/modifying channels:
+- Update **all** channel surfaces (docs, UI, status commands)
+- Core channels: `src/telegram`, `src/discord`, `src/slack`, `src/signal`, `src/imessage`, `src/web`
+- Extensions: `extensions/msteams`, `extensions/matrix`, etc.
+- Update `.github/labeler.yml` and create matching labels
 
-## NPM + 1Password (publish/verify)
+## Documentation
 
-- Use the 1password skill; all `op` commands must run inside a fresh tmux session.
-- Sign in: `eval "$(op signin --account my.1password.com)"` (app unlocked + integration on).
-- OTP: `op read 'op://Private/Npmjs/one-time password?attribute=otp'`.
-- Publish: `npm publish --access public --otp="<otp>"` (run from the package dir).
-- Verify without local npmrc side effects: `npm view <pkg> version --userconfig "$(mktemp)"`.
-- Kill the tmux session after publish.
+- **Docs hosted**: Mintlify (docs.openclaw.ai)
+- **Internal links**: Root-relative without `.md` (e.g., `[Config](/configuration)`)
+- **Anchors**: Root-relative with hash (e.g., `[Hooks](/configuration#hooks)`)
+- **No em dashes or apostrophes** in headings (breaks Mintlify anchors)
+- Use generic placeholders (no personal device names/paths)
+
+## Platform-Specific Notes
+
+### macOS
+- Gateway runs as menubar app (restart via app or `scripts/restart-mac.sh`)
+- Logs: `./scripts/clawlog.sh` for unified logs
+- Packaging: `scripts/package-mac-app.sh`
+
+### iOS/Android
+- Check for connected real devices before using simulators
+- "Restart app" means rebuild and relaunch (not just kill/reopen)
+
+## Security
+
+- Never commit real credentials, phone numbers, or config values
+- Use fake/placeholder values in docs and tests
+- Web provider creds: `~/.openclaw/credentials/`
+- Pi sessions: `~/.openclaw/sessions/`
+
+## Multi-Agent Safety
+
+- **Do NOT** create/apply/drop git stash unless requested
+- **Do NOT** switch branches unless explicitly requested
+- **Do NOT** modify git worktrees unless requested
+- When user says "commit", scope to your changes only
+- When user says "commit all", commit everything in grouped chunks
+- Auto-resolve formatting-only changes without asking

--- a/zhch/README.md
+++ b/zhch/README.md
@@ -1,0 +1,2 @@
+git config --local user.name "zhch158"
+git config --local user.email "zhch158@sina.com"


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds AI assistant configuration files and reorganizes developer documentation.

**Key changes:**
- Added Cursor AI rules file (`.cursor/rules/openclaw-patterns.mdc`) with Chinese language requirements and coding standards
- Updated GitHub Copilot instructions to include Chinese language communication rules
- Significantly improved `AGENTS.md` with better structure, quick reference commands, and expanded guidelines
- Added `zhch/` directory with personal git configuration (should not be committed)

**Issues found:**
- `zhch/README.md` contains personal git configuration and should be removed or added to `.gitignore`
- Minor path separator inconsistency in `.github/instructions/copilot.instructions.md`

The documentation improvements in `AGENTS.md` are helpful, but the personal configuration directory raises concerns about repository hygiene.

<h3>Confidence Score: 3/5</h3>

- This PR has documentation improvements but includes personal configuration that should not be in the repository
- The PR contains valuable documentation reorganization and AI assistant configuration, but commits a user-specific directory (`zhch/`) with personal git configuration that violates repository best practices. This is not a critical security or functional issue, but it pollutes the repository with personal settings and sets a bad precedent. The documentation changes themselves are well-structured and helpful.
- Pay close attention to `zhch/README.md` which should be removed from the repository

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->