### PR TITLE
perf(cli): skip plugin loading during completion generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
+- CLI: skip plugin loading during completion generation to avoid ~24s jiti transpilation overhead on every shell startup. (#13810)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
 - CI: Implement pipeline and workflow order. Thanks @quotentiroler.

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -236,7 +236,9 @@ export function registerCompletionCli(program: Command) {
     .option("-y, --yes", "Skip confirmation (non-interactive)", false)
     .action(async (options) => {
       const shell = options.shell ?? "zsh";
-      // Eagerly register all subcommands to build the full tree
+      // Eagerly register all subcommands to build the full tree.
+      // Signal completion mode so plugin-heavy registrations can skip plugin loading.
+      process.env.OPENCLAW_COMPLETION_MODE = "1";
       const entries = getSubCliEntries();
       for (const entry of entries) {
         // Skip completion command itself to avoid cycle if we were to add it to the list
@@ -245,6 +247,7 @@ export function registerCompletionCli(program: Command) {
         }
         await registerSubCliByName(program, entry.name);
       }
+      delete process.env.OPENCLAW_COMPLETION_MODE;
 
       if (options.writeState) {
         const writeShells = options.shell ? [shell] : [...COMPLETION_SHELLS];

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -175,8 +175,11 @@ const entries: SubCliEntry[] = [
       // Initialize plugins before registering pairing CLI.
       // The pairing CLI calls listPairingChannels() at registration time,
       // which requires the plugin registry to be populated with channel plugins.
-      const { registerPluginCliCommands } = await import("../../plugins/cli.js");
-      registerPluginCliCommands(program, await loadConfig());
+      // Skip plugin loading in completion mode to avoid jiti transpilation overhead.
+      if (!isTruthyEnvValue(process.env.OPENCLAW_COMPLETION_MODE)) {
+        const { registerPluginCliCommands } = await import("../../plugins/cli.js");
+        registerPluginCliCommands(program, await loadConfig());
+      }
       const mod = await import("../pairing-cli.js");
       mod.registerPairingCli(program);
     },
@@ -187,8 +190,11 @@ const entries: SubCliEntry[] = [
     register: async (program) => {
       const mod = await import("../plugins-cli.js");
       mod.registerPluginsCli(program);
-      const { registerPluginCliCommands } = await import("../../plugins/cli.js");
-      registerPluginCliCommands(program, await loadConfig());
+      // Skip plugin loading in completion mode to avoid jiti transpilation overhead.
+      if (!isTruthyEnvValue(process.env.OPENCLAW_COMPLETION_MODE)) {
+        const { registerPluginCliCommands } = await import("../../plugins/cli.js");
+        registerPluginCliCommands(program, await loadConfig());
+      }
     },
   },
   {


### PR DESCRIPTION
## Summary
Fixes #13810

## Problem
`openclaw completion --shell bash` (and zsh) takes ~24 seconds because it eagerly registers all subcommands, including `pairing` and `plugins` which call `registerPluginCliCommands()`. This triggers the full plugin loader via `jiti`, which Babel-transpiles ~423 files at runtime.

This makes `source <(openclaw completion --shell bash)` in `.bashrc`/`.zshrc` add ~24s to every new shell session.

**Root cause** in `src/cli/program/register.subclis.ts`:
```typescript
// pairing entry (line 178-179)
const { registerPluginCliCommands } = await import("../../plugins/cli.js");
registerPluginCliCommands(program, await loadConfig()); // ~24s jiti hit

// plugins entry (line 190-191)
const { registerPluginCliCommands } = await import("../../plugins/cli.js");
registerPluginCliCommands(program, await loadConfig()); // ~24s jiti hit
```

## Fix
Set `OPENCLAW_COMPLETION_MODE=1` during completion generation and check it in the `pairing` and `plugins` registration entries to skip plugin loading. The core CLI structure (`pairing-cli`, `plugins-cli`) is still registered so completion includes those commands.

**completion-cli.ts:**
```typescript
process.env.OPENCLAW_COMPLETION_MODE = "1";
// ... register all subcommands ...
delete process.env.OPENCLAW_COMPLETION_MODE;
```

**register.subclis.ts (pairing & plugins entries):**
```typescript
if (!isTruthyEnvValue(process.env.OPENCLAW_COMPLETION_MODE)) {
  const { registerPluginCliCommands } = await import("../../plugins/cli.js");
  registerPluginCliCommands(program, await loadConfig());
}
```

## Effect on User Experience

**Before fix:**
```bash
time openclaw completion --shell bash > /dev/null
# real  0m23.991s
```

**After fix:**
```bash
time openclaw completion --shell bash > /dev/null
# real  ~2s (no jiti transpilation)
```

- `openclaw pairing` and `openclaw plugins` commands work normally (plugins load as before)
- Shell startup with `source <(openclaw completion --shell bash)` drops from ~24s to ~2s

## Testing
- ✅ 6 tests pass (pnpm vitest run src/cli/program/register.subclis.test.ts)
- ✅ Lint passes
- ✅ New tests verify plugin loading is skipped in completion mode
- ✅ New tests verify plugin loading works normally outside completion mode

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Performance optimization that reduces shell completion generation time from ~24s to ~2s by skipping plugin loading during `openclaw completion` execution. Uses `OPENCLAW_COMPLETION_MODE` environment variable to conditionally bypass `registerPluginCliCommands()` calls in `pairing` and `plugins` subcommand registration. The command structure is still registered for completion purposes, but the expensive jiti transpilation of ~423 plugin files is avoided. Normal command execution outside completion mode remains unchanged with full plugin loading.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-scoped performance fix with comprehensive test coverage, clear problem/solution description, and no logical errors. The environment variable approach is thread-safe within the synchronous registration flow, and the optimization only affects completion generation without impacting normal command execution.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->