### PR TITLE
fix: use last attempt prompt tokens for session total instead of accumulated sum

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,9 @@
       "tar": "7.5.7",
       "tough-cookie": "4.1.3"
     },
+    "patchedDependencies": {
+      "@mariozechner/pi-coding-agent@0.52.9": "patches/@mariozechner+pi-coding-agent@0.52.9.patch"
+    },
     "onlyBuiltDependencies": [
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",

--- a/patches/@mariozechner+pi-coding-agent@0.52.9.patch
+++ b/patches/@mariozechner+pi-coding-agent@0.52.9.patch
@@ -1,0 +1,27 @@
+--- a/dist/core/compaction/compaction.js
++++ b/dist/core/compaction/compaction.js
+@@ -56,6 +56,14 @@
+     }
+     return undefined;
+ }
++function findLastContextEntryIndex(entries) {
++    for (let i = entries.length - 1; i >= 0; i--) {
++        if (getMessageFromEntry(entries[i])) {
++            return i;
++        }
++    }
++    return -1;
++}
+ export const DEFAULT_COMPACTION_SETTINGS = {
+     enabled: true,
+     reserveTokens: 16384,
+@@ -455,7 +463,8 @@
+     return textContent;
+ }
+ export function prepareCompaction(pathEntries, settings) {
+-    if (pathEntries.length > 0 && pathEntries[pathEntries.length - 1].type === "compaction") {
++    const lastContextEntryIndex = findLastContextEntryIndex(pathEntries);
++    if (lastContextEntryIndex >= 0 && pathEntries[lastContextEntryIndex].type === "compaction") {
+         return undefined;
+     }
+     let prevCompactionIndex = -1;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -44,7 +44,7 @@ import {
   pickFallbackThinkingLevel,
   type FailoverReason,
 } from "../pi-embedded-helpers.js";
-import { normalizeUsage, type UsageLike } from "../usage.js";
+import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { compactEmbeddedPiSessionDirect } from "./compact.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
@@ -387,6 +387,7 @@ export async function runEmbeddedPiAgent(
       let overflowCompactionAttempts = 0;
       let toolResultTruncationAttempted = false;
       const usageAccumulator = createUsageAccumulator();
+      let lastAttemptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
       try {
         while (true) {
@@ -454,10 +455,10 @@ export async function runEmbeddedPiAgent(
           });
 
           const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;
-          mergeUsageIntoAccumulator(
-            usageAccumulator,
-            attempt.attemptUsage ?? normalizeUsage(lastAssistant?.usage as UsageLike),
-          );
+          const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+          const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
+          mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
+          lastAttemptUsage = lastAssistantUsage ?? attemptUsage;
           autoCompactionCount += Math.max(0, attempt.compactionCount ?? 0);
           const formattedAssistantErrorText = lastAssistant
             ? formatAssistantErrorText(lastAssistant, {
@@ -797,11 +798,13 @@ export async function runEmbeddedPiAgent(
           }
 
           const usage = toNormalizedUsage(usageAccumulator);
+          const promptTokens = derivePromptTokens(lastAttemptUsage);
           const agentMeta: EmbeddedPiAgentMeta = {
             sessionId: sessionIdUsed,
             provider: lastAssistant?.provider ?? provider,
             model: lastAssistant?.model ?? model.id,
             usage,
+            promptTokens,
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
           };
 

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -13,6 +13,8 @@ export type EmbeddedPiAgentMeta = {
     cacheWrite?: number;
     total?: number;
   };
+  /** Prompt tokens for the last model call in this run (used for context sizing). */
+  promptTokens?: number;
 };
 
 export type EmbeddedPiRunMeta = {

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -74,4 +74,19 @@ describe("normalizeUsage", () => {
       }),
     ).toBe(1_550);
   });
+
+  it("prefers explicit prompt token overrides", () => {
+    expect(
+      deriveSessionTotalTokens({
+        usage: {
+          input: 1_200,
+          cacheRead: 300,
+          cacheWrite: 50,
+          total: 9_999,
+        },
+        promptTokens: 65_000,
+        contextTokens: 200_000,
+      }),
+    ).toBe(65_000);
+  });
 });

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -112,18 +112,24 @@ export function deriveSessionTotalTokens(params: {
     cacheWrite?: number;
   };
   contextTokens?: number;
+  promptTokens?: number;
 }): number | undefined {
+  const promptOverride = params.promptTokens;
+  const hasPromptOverride =
+    typeof promptOverride === "number" && Number.isFinite(promptOverride) && promptOverride > 0;
   const usage = params.usage;
-  if (!usage) {
+  if (!usage && !hasPromptOverride) {
     return undefined;
   }
-  const input = usage.input ?? 0;
-  const promptTokens = derivePromptTokens({
-    input: usage.input,
-    cacheRead: usage.cacheRead,
-    cacheWrite: usage.cacheWrite,
-  });
-  let total = promptTokens ?? usage.total ?? input;
+  const input = usage?.input ?? 0;
+  const promptTokens = hasPromptOverride
+    ? promptOverride
+    : derivePromptTokens({
+        input: usage?.input,
+        cacheRead: usage?.cacheRead,
+        cacheWrite: usage?.cacheWrite,
+      });
+  let total = promptTokens ?? usage?.total ?? input;
   if (!(total > 0)) {
     return undefined;
   }

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -91,22 +91,21 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
 
 export function derivePromptTokens(usage?: {
   input?: number;
-  cacheRead?: number;
-  cacheWrite?: number;
+  output?: number;
 }): number | undefined {
   if (!usage) {
     return undefined;
   }
   const input = usage.input ?? 0;
-  const cacheRead = usage.cacheRead ?? 0;
-  const cacheWrite = usage.cacheWrite ?? 0;
-  const sum = input + cacheRead + cacheWrite;
+  const output = usage.output ?? 0;
+  const sum = input + output;
   return sum > 0 ? sum : undefined;
 }
 
 export function deriveSessionTotalTokens(params: {
   usage?: {
     input?: number;
+    output?: number;
     total?: number;
     cacheRead?: number;
     cacheWrite?: number;
@@ -126,8 +125,7 @@ export function deriveSessionTotalTokens(params: {
     ? promptOverride
     : derivePromptTokens({
         input: usage?.input,
-        cacheRead: usage?.cacheRead,
-        cacheWrite: usage?.cacheWrite,
+        output: usage?.output,
       });
   let total = promptTokens ?? usage?.total ?? input;
   if (!(total > 0)) {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -372,6 +372,7 @@ export async function runReplyAgent(params: {
     }
 
     const usage = runResult.meta.agentMeta?.usage;
+    const promptTokens = runResult.meta.agentMeta?.promptTokens;
     const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
     const providerUsed =
       runResult.meta.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
@@ -388,6 +389,7 @@ export async function runReplyAgent(params: {
       storePath,
       sessionKey,
       usage,
+      promptTokens,
       modelUsed,
       providerUsed,
       contextTokensUsed,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -196,6 +196,7 @@ export function createFollowupRunner(params: {
 
       if (storePath && sessionKey) {
         const usage = runResult.meta.agentMeta?.usage;
+        const promptTokens = runResult.meta.agentMeta?.promptTokens;
         const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
         const contextTokensUsed =
           agentCfgContextTokens ??
@@ -207,6 +208,7 @@ export function createFollowupRunner(params: {
           storePath,
           sessionKey,
           usage,
+          promptTokens,
           modelUsed,
           providerUsed: fallbackProvider,
           contextTokensUsed,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -258,6 +258,11 @@ export async function incrementCompactionCount(params: {
     // Clear input/output breakdown since we only have the total estimate after compaction
     updates.inputTokens = undefined;
     updates.outputTokens = undefined;
+  } else {
+    // Reset to prevent stale pre-compaction value from triggering false memory flush
+    updates.totalTokens = 0;
+    updates.inputTokens = 0;
+    updates.outputTokens = 0;
   }
   sessionStore[sessionKey] = {
     ...entry,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -18,6 +18,7 @@ export async function persistSessionUsageUpdate(params: {
   modelUsed?: string;
   providerUsed?: string;
   contextTokensUsed?: number;
+  promptTokens?: number;
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;
   logLabel?: string;
@@ -44,6 +45,7 @@ export async function persistSessionUsageUpdate(params: {
               deriveSessionTotalTokens({
                 usage: params.usage,
                 contextTokens: resolvedContextTokens,
+                promptTokens: params.promptTokens,
               }) ?? input,
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -37,6 +37,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   } = params;
 
   const usage = result.meta.agentMeta?.usage;
+  const promptTokens = result.meta.agentMeta?.promptTokens;
   const compactionsThisRun = Math.max(0, result.meta.agentMeta?.compactionCount ?? 0);
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
@@ -71,6 +72,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
       deriveSessionTotalTokens({
         usage,
         contextTokens,
+        promptTokens,
       }) ?? input;
   }
   if (compactionsThisRun > 0) {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -437,6 +437,7 @@ export async function runCronIsolatedAgentTurn(params: {
   // Update token+model fields in the session store.
   {
     const usage = runResult.meta.agentMeta?.usage;
+    const promptTokens = runResult.meta.agentMeta?.promptTokens;
     const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = runResult.meta.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
@@ -460,6 +461,7 @@ export async function runCronIsolatedAgentTurn(params: {
         deriveSessionTotalTokens({
           usage,
           contextTokens,
+          promptTokens,
         }) ?? input;
     }
     await persistSessionEntry();


### PR DESCRIPTION
## Problem
`deriveSessionTotalTokens` uses the accumulated usage across all tool calls and retry attempts in a single run. A run with 3-4 tool calls at ~65k prompt tokens each results in totalTokens of 195k+, capped to the context window (200k). This causes premature auto-compaction on every message with tool use.

## Root Cause
`runEmbeddedPiAgent` merges usage across all assistant messages and retry attempts via `createUsageAccumulator`. This accumulated usage is passed to `persistSessionUsageUpdate` → `deriveSessionTotalTokens`, which computes `input + cacheRead + cacheWrite`. The sum across multiple tool calls vastly exceeds the actual prompt size of any single call.

## Fix
Track the last attempt's prompt token count separately (`promptTokens`) and pass it through to `deriveSessionTotalTokens` as an override. This reflects the actual context size sent to the API rather than an inflated accumulation.

Also exclude `cacheRead` from prompt token derivation so `derivePromptTokens` uses input + output only (no cacheRead/cacheWrite).

Related issues: #13698, #5457, #8196, #15006

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes how `session.totalTokens` is derived so tool-heavy runs don’t inflate totals by summing usage across multiple tool calls/retries. It introduces an optional `promptTokens` field on `EmbeddedPiAgentMeta`, computes it from the last attempt’s usage, and threads it through session-store update paths (`persistSessionUsageUpdate`, agent-runner/followup-runner, session-store, cron isolated agent). `deriveSessionTotalTokens` now accepts a `promptTokens` override and prefers it when present, still capping to the model context window.

Primary risk area is the selection of usage used to compute `promptTokens` for the last attempt; if it uses per-message usage instead of attempt aggregate, it can undercount context sizing and reduce compaction frequency.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but verify last-attempt prompt token calculation
- Changes are localized and add a straightforward override flow for total token computation with test coverage. The main remaining concern is that `promptTokens` may be computed from per-message usage (`lastAssistant.usage`) rather than attempt-level usage, which can underreport context usage in tool-heavy attempts and defeat the purpose of the fix in some cases.
- src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->