### PR TITLE
fix: prevent double compaction from trailing custom entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,9 @@
       "tar": "7.5.7",
       "tough-cookie": "4.1.3"
     },
+    "patchedDependencies": {
+      "@mariozechner/pi-coding-agent@0.52.9": "patches/@mariozechner+pi-coding-agent@0.52.9.patch"
+    },
     "onlyBuiltDependencies": [
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",

--- a/patches/@mariozechner+pi-coding-agent@0.52.9.patch
+++ b/patches/@mariozechner+pi-coding-agent@0.52.9.patch
@@ -1,0 +1,27 @@
+--- a/dist/core/compaction/compaction.js
++++ b/dist/core/compaction/compaction.js
+@@ -56,6 +56,14 @@
+     }
+     return undefined;
+ }
++function findLastContextEntryIndex(entries) {
++    for (let i = entries.length - 1; i >= 0; i--) {
++        if (getMessageFromEntry(entries[i])) {
++            return i;
++        }
++    }
++    return -1;
++}
+ export const DEFAULT_COMPACTION_SETTINGS = {
+     enabled: true,
+     reserveTokens: 16384,
+@@ -455,7 +463,8 @@
+     return textContent;
+ }
+ export function prepareCompaction(pathEntries, settings) {
+-    if (pathEntries.length > 0 && pathEntries[pathEntries.length - 1].type === "compaction") {
++    const lastContextEntryIndex = findLastContextEntryIndex(pathEntries);
++    if (lastContextEntryIndex >= 0 && pathEntries[lastContextEntryIndex].type === "compaction") {
+         return undefined;
+     }
+     let prevCompactionIndex = -1;


### PR DESCRIPTION
## Problem
After compaction completes, trailing custom session entries (e.g., `openclaw.cache-ttl` pruning markers) cause `prepareCompaction()` to think compaction hasn't happened yet, triggering a second compaction immediately.

## Root Cause
`prepareCompaction()` checks the last entry type to determine if compaction already occurred. Non-context entries (custom markers) inserted after compaction make it appear that the last operation was not a compaction.

## Fix
Add a `findLastContextEntryIndex()` helper that skips non-context-producing entries when checking compaction state. Update `prepareCompaction()` to use this helper instead of checking only the very last entry.

This is a pnpm patch on `@mariozechner/pi-coding-agent@0.52.9`.

Supersedes #9369 (closed due to lockfile/dependency version issues, same underlying fix).

Related issues: #9282, #7594

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `pnpm.patchedDependencies` entry to apply a local patch to `@mariozechner/pi-coding-agent@0.52.9`. The patch changes `dist/core/compaction/compaction.js` by introducing `findLastContextEntryIndex()` and updating `prepareCompaction()` to detect prior compaction based on the last “context-producing” entry rather than the last raw entry, aiming to ignore trailing custom/metadata entries that get appended after compaction.

<h3>Confidence Score: 2/5</h3>

- This PR has a likely logic regression in the compaction guard and should not be merged until verified/fixed.
- The patch changes compaction detection to depend on `getMessageFromEntry()`, but if compaction entries aren’t message-producing, the new guard will never detect a trailing compaction and may re-trigger compaction immediately (the exact bug being fixed). The environment here doesn’t include the patched package sources to conclusively validate `getMessageFromEntry()` behavior, so this needs confirmation against the actual @mariozechner/pi-coding-agent@0.52.9 dist file or targeted test.
- patches/@mariozechner+pi-coding-agent@0.52.9.patch

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->