### PR TITLE
feat(web-search): allow overriding Brave Search base URL

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -158,6 +158,18 @@ function resolveSearchEnabled(params: { search?: WebSearchConfig; sandboxed?: bo
   return true;
 }
 
+function resolveBraveBaseUrl(search?: WebSearchConfig): string {
+  const fromConfig =
+    search && "baseUrl" in search && typeof search.baseUrl === "string"
+      ? search.baseUrl.trim()
+      : "";
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = process.env.BRAVE_SEARCH_BASE_URL?.trim();
+  return fromEnv || BRAVE_SEARCH_ENDPOINT;
+}
+
 function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
   const fromConfig =
     search && "apiKey" in search && typeof search.apiKey === "string"
@@ -516,6 +528,7 @@ async function runWebSearch(params: {
   perplexityModel?: string;
   grokModel?: string;
   grokInlineCitations?: boolean;
+  braveBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
@@ -578,7 +591,7 @@ async function runWebSearch(params: {
     throw new Error("Unsupported web search provider.");
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const url = new URL(params.braveBaseUrl || BRAVE_SEARCH_ENDPOINT);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -716,6 +729,7 @@ export function createWebSearchTool(options?: {
         perplexityModel: resolvePerplexityModel(perplexityConfig),
         grokModel: resolveGrokModel(grokConfig),
         grokInlineCitations: resolveGrokInlineCitations(grokConfig),
+        braveBaseUrl: resolveBraveBaseUrl(search),
       });
       return jsonResult(result);
     },

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -340,6 +340,8 @@ export type ToolsConfig = {
       provider?: "brave" | "perplexity" | "grok";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
+      /** Brave Search base URL override (defaults to BRAVE_SEARCH_BASE_URL env var or "https://api.search.brave.com/res/v1/web/search"). */
+      baseUrl?: string;
       /** Default search results count (1-10). */
       maxResults?: number;
       /** Timeout in seconds for search requests. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -173,6 +173,7 @@ export const ToolsWebSearchSchema = z
     enabled: z.boolean().optional(),
     provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
     apiKey: z.string().optional(),
+    baseUrl: z.string().url().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     cacheTtlMinutes: z.number().nonnegative().optional(),


### PR DESCRIPTION
## Summary
- Add `baseUrl` option for the Brave Search provider to support proxying or custom endpoints
- Resolved from config `tools.web.search.baseUrl` or `BRAVE_SEARCH_BASE_URL` env var
- Defaults to `https://api.search.brave.com/res/v1/web/search` when neither is set
- Follows the same pattern as the existing Perplexity `baseUrl` override

## Configuration

```json
{
  "tools": {
    "web": {
      "search": {
        "provider": "brave",
        "baseUrl": "https://my-proxy.example.com/v1/web/search"
      }
    }
  }
}
```

Or via environment variable:
```
BRAVE_SEARCH_BASE_URL=https://my-proxy.example.com/v1/web/search
```

Priority: config > env > default.

## Changed files
- `src/agents/tools/web-search.ts` — `resolveBraveBaseUrl()` function, wired into `runWebSearch`
- `src/config/types.tools.ts` — `baseUrl` field added to search config
- `src/config/zod-schema.agent-runtime.ts` — `baseUrl: z.string().url().optional()` validation

## Test plan
- [x] All existing tests pass (25 tests)
- [ ] Manual test with custom base URL

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `baseUrl` override for the Brave web search provider, resolved from runtime config (`tools.web.search.baseUrl`) or `BRAVE_SEARCH_BASE_URL`, and threads it through to `runWebSearch` so requests can target a proxy/custom endpoint.

Config typing and runtime schema validation were updated to accept the new optional URL field alongside the existing provider/apiKey settings.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge after fixing a cache key correctness issue for Brave baseUrl overrides.
- The change is small and follows an existing pattern, but the newly introduced `braveBaseUrl` parameter is not included in the Brave cache key, which can return incorrect cached results when the endpoint differs.
- src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->