### PR TITLE
Feat/jobbot

### DIFF
--- a/extensions/job-application/clawdbot.plugin.json
+++ b/extensions/job-application/clawdbot.plugin.json
@@ -1,0 +1,93 @@
+{
+  "id": "job-application",
+  "name": "Job Application",
+  "description": "Automated job search, application, and tracking plugin for MoltBot.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "dbPath": {
+        "type": "string",
+        "description": "Path to SQLite database for job data"
+      },
+      "resumesDir": {
+        "type": "string",
+        "description": "Directory to store resume files"
+      },
+      "scanInterval": {
+        "type": "string",
+        "description": "How often to scan for new jobs (e.g., '6h', '12h')"
+      },
+      "defaultJobBoards": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Job boards to search by default"
+      },
+      "preferences": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "titles": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Target job titles to search for"
+          },
+          "locations": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Preferred locations (e.g., 'Remote', 'San Francisco, CA')"
+          },
+          "salaryMin": {
+            "type": "number",
+            "description": "Minimum acceptable salary"
+          },
+          "salaryMax": {
+            "type": "number",
+            "description": "Maximum salary to consider"
+          },
+          "remoteOnly": {
+            "type": "boolean",
+            "description": "Only show remote positions"
+          },
+          "excludeCompanies": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Companies to exclude from search"
+          },
+          "keywords": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Keywords to look for in job descriptions"
+          },
+          "excludeKeywords": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Keywords to exclude from results"
+          }
+        }
+      },
+      "notifications": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "channel": {
+            "type": "string",
+            "description": "Channel to send notifications (e.g., 'imessage', 'telegram')"
+          },
+          "dailySummary": {
+            "type": "boolean",
+            "description": "Send daily summary of job search activity"
+          },
+          "newJobAlerts": {
+            "type": "boolean",
+            "description": "Alert when new matching jobs are found"
+          },
+          "emailResponseAlerts": {
+            "type": "boolean",
+            "description": "Alert when email responses are detected"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/job-application/index.ts
+++ b/extensions/job-application/index.ts
@@ -1,0 +1,132 @@
+/**
+ * MoltBot Job Application Plugin
+ *
+ * Automated job search, application submission, and tracking.
+ * Integrates with browser automation for form filling and email
+ * monitoring for response tracking.
+ */
+
+import type { MoltbotPluginApi } from "../../src/plugins/types.js";
+
+import { jobApplicationConfigSchema } from "./src/config.js";
+import { JobStore } from "./src/db/store.js";
+import { createJobSearchTool } from "./src/tools/job-search.js";
+import { createJobApplyTool } from "./src/tools/job-apply.js";
+import { createJobTrackTool } from "./src/tools/job-track.js";
+import { createResumeManageTool } from "./src/tools/resume-manage.js";
+import { registerGatewayMethods } from "./src/gateway/methods.js";
+import { createEmailMonitorService } from "./src/services/email-monitor.js";
+import { createJobScannerService } from "./src/services/job-scanner.js";
+
+const jobApplicationPlugin = {
+  id: "job-application",
+  name: "Job Application",
+  description: "Automated job search, application, and tracking",
+  configSchema: jobApplicationConfigSchema,
+
+  register(api: MoltbotPluginApi) {
+    const cfg = jobApplicationConfigSchema.parse(api.pluginConfig);
+    const resolvedDbPath = api.resolvePath(cfg.dbPath);
+    const resolvedResumesDir = api.resolvePath(cfg.resumesDir);
+
+    // Initialize the job store (lazy initialization)
+    const store = new JobStore(resolvedDbPath, resolvedResumesDir);
+
+    api.logger.info(
+      `job-application: plugin registered (db: ${resolvedDbPath}, resumes: ${resolvedResumesDir})`,
+    );
+
+    // ========================================================================
+    // Register Tools
+    // ========================================================================
+
+    api.registerTool(createJobSearchTool(api, store, cfg), { optional: true });
+    api.registerTool(createJobApplyTool(api, store, cfg), { optional: true });
+    api.registerTool(createJobTrackTool(api, store, cfg), { optional: true });
+    api.registerTool(createResumeManageTool(api, store, cfg), {
+      optional: true,
+    });
+
+    // ========================================================================
+    // Register Gateway Methods (for Web UI)
+    // ========================================================================
+
+    registerGatewayMethods(api, store, cfg);
+
+    // ========================================================================
+    // Register CLI Commands
+    // ========================================================================
+
+    api.registerCli(
+      ({ program }) => {
+        const jobbot = program
+          .command("jobbot")
+          .description("Job application plugin commands");
+
+        jobbot
+          .command("stats")
+          .description("Show job application statistics")
+          .action(async () => {
+            const stats = store.getStats();
+            console.log("Job Application Statistics:");
+            console.log(`  Total jobs discovered: ${stats.totalJobs}`);
+            console.log(`  New jobs: ${stats.newJobs}`);
+            console.log(`  Applied: ${stats.appliedJobs}`);
+            console.log(`  Pending applications: ${stats.pendingApplications}`);
+            console.log(`  Interviews scheduled: ${stats.interviewsScheduled}`);
+            console.log(`  Offers received: ${stats.offersReceived}`);
+            console.log(`  Rejections: ${stats.rejections}`);
+          });
+
+        jobbot
+          .command("list")
+          .description("List jobs")
+          .option("--status <status>", "Filter by status")
+          .option("--limit <n>", "Max results", "20")
+          .action(async (opts) => {
+            const jobs = store.listJobs({
+              status: opts.status,
+              limit: parseInt(opts.limit),
+            });
+            console.log(JSON.stringify(jobs, null, 2));
+          });
+
+        jobbot
+          .command("applications")
+          .description("List applications")
+          .option("--status <status>", "Filter by status")
+          .option("--limit <n>", "Max results", "20")
+          .action(async (opts) => {
+            const applications = store.listApplications({
+              status: opts.status,
+              limit: parseInt(opts.limit),
+            });
+            console.log(JSON.stringify(applications, null, 2));
+          });
+
+        jobbot
+          .command("resumes")
+          .description("List resumes")
+          .action(async () => {
+            const resumes = store.listResumes();
+            console.log(JSON.stringify(resumes, null, 2));
+          });
+      },
+      { commands: ["jobbot"] },
+    );
+
+    // ========================================================================
+    // Register Services
+    // ========================================================================
+
+    // Email monitor service (tracks application responses)
+    const emailMonitor = createEmailMonitorService(api, store, cfg);
+    api.registerService(emailMonitor);
+
+    // Job scanner service (periodic job searches)
+    const jobScanner = createJobScannerService(api, store, cfg);
+    api.registerService(jobScanner);
+  },
+};
+
+export default jobApplicationPlugin;

--- a/extensions/job-application/package.json
+++ b/extensions/job-application/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@moltbot/job-application",
+  "version": "2026.1.27-beta.1",
+  "type": "module",
+  "description": "MoltBot job application automation plugin - search, apply, and track job applications",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.47"
+  },
+  "moltbot": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/job-application/src/adapters/adapters.test.ts
+++ b/extensions/job-application/src/adapters/adapters.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for Job Site Adapters
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { indeedAdapter } from "./indeed.js";
+import { linkedinAdapter } from "./linkedin.js";
+import { greenhouseAdapter } from "./greenhouse.js";
+import {
+  getAdapter,
+  findAdapterForUrl,
+  getAvailableAdapters,
+} from "./index.js";
+
+describe("Indeed Adapter", () => {
+  it("should build search URL with query", () => {
+    const url = indeedAdapter.buildSearchUrl({ query: "Software Engineer" });
+
+    expect(url).toContain("indeed.com/jobs");
+    expect(url).toContain("q=Software+Engineer");
+  });
+
+  it("should build search URL with location", () => {
+    const url = indeedAdapter.buildSearchUrl({
+      query: "Developer",
+      location: "San Francisco, CA",
+    });
+
+    expect(url).toContain("q=Developer");
+    expect(url).toContain("l=San+Francisco");
+  });
+
+  it("should build search URL with remote filter", () => {
+    const url = indeedAdapter.buildSearchUrl({
+      query: "Engineer",
+      remote: true,
+    });
+
+    expect(url).toContain("remotejob=");
+  });
+
+  it("should build search URL with salary filter", () => {
+    const url = indeedAdapter.buildSearchUrl({
+      query: "Engineer",
+      salaryMin: 100000,
+    });
+
+    expect(url).toContain("salary=");
+  });
+
+  it("should detect Indeed URLs", () => {
+    expect(
+      indeedAdapter.canHandle("https://www.indeed.com/viewjob?jk=123"),
+    ).toBe(true);
+    expect(indeedAdapter.canHandle("https://indeed.com/jobs?q=test")).toBe(
+      true,
+    );
+    expect(indeedAdapter.canHandle("https://linkedin.com/jobs")).toBe(false);
+  });
+});
+
+describe("LinkedIn Adapter", () => {
+  it("should build search URL with query", () => {
+    const url = linkedinAdapter.buildSearchUrl({ query: "Software Engineer" });
+
+    expect(url).toContain("linkedin.com/jobs/search");
+    expect(url).toContain("keywords=Software+Engineer");
+  });
+
+  it("should build search URL with remote filter", () => {
+    const url = linkedinAdapter.buildSearchUrl({
+      query: "Developer",
+      remote: true,
+    });
+
+    expect(url).toContain("f_WT=2");
+  });
+
+  it("should build search URL with time filter", () => {
+    const urlDay = linkedinAdapter.buildSearchUrl({
+      query: "Engineer",
+      postedWithin: 1,
+    });
+    expect(urlDay).toContain("f_TPR=r86400");
+
+    const urlWeek = linkedinAdapter.buildSearchUrl({
+      query: "Engineer",
+      postedWithin: 7,
+    });
+    expect(urlWeek).toContain("f_TPR=r604800");
+  });
+
+  it("should detect LinkedIn URLs", () => {
+    expect(
+      linkedinAdapter.canHandle("https://www.linkedin.com/jobs/view/123"),
+    ).toBe(true);
+    expect(linkedinAdapter.canHandle("https://linkedin.com/jobs/search")).toBe(
+      true,
+    );
+    expect(linkedinAdapter.canHandle("https://indeed.com/jobs")).toBe(false);
+  });
+});
+
+describe("Greenhouse Adapter", () => {
+  it("should build search URL", () => {
+    const url = greenhouseAdapter.buildSearchUrl({ query: "Engineer" });
+
+    expect(url).toContain("greenhouse.io");
+    expect(url).toContain("q=Engineer");
+  });
+
+  it("should detect Greenhouse URLs", () => {
+    expect(
+      greenhouseAdapter.canHandle("https://boards.greenhouse.io/company"),
+    ).toBe(true);
+    expect(greenhouseAdapter.canHandle("https://greenhouse.io/jobs")).toBe(
+      true,
+    );
+    expect(greenhouseAdapter.canHandle("https://indeed.com/jobs")).toBe(false);
+  });
+});
+
+describe("Adapter Registry", () => {
+  it("should get adapter by source", () => {
+    const indeed = getAdapter("indeed");
+    expect(indeed.name).toBe("indeed");
+
+    const linkedin = getAdapter("linkedin");
+    expect(linkedin.name).toBe("linkedin");
+
+    const greenhouse = getAdapter("greenhouse");
+    expect(greenhouse.name).toBe("greenhouse");
+  });
+
+  it("should find adapter for URL", () => {
+    const indeedAdapter = findAdapterForUrl(
+      "https://www.indeed.com/viewjob?jk=123",
+    );
+    expect(indeedAdapter?.name).toBe("indeed");
+
+    const linkedinAdapter = findAdapterForUrl(
+      "https://linkedin.com/jobs/view/456",
+    );
+    expect(linkedinAdapter?.name).toBe("linkedin");
+
+    const greenhouseAdapter = findAdapterForUrl(
+      "https://boards.greenhouse.io/acme",
+    );
+    expect(greenhouseAdapter?.name).toBe("greenhouse");
+
+    const unknown = findAdapterForUrl("https://random-site.com/jobs");
+    expect(unknown).toBeNull();
+  });
+
+  it("should list available adapters", () => {
+    const adapters = getAvailableAdapters();
+
+    expect(adapters).toContain("indeed");
+    expect(adapters).toContain("linkedin");
+    expect(adapters).toContain("greenhouse");
+  });
+});
+
+describe("Job Parsing", () => {
+  it("should extract tech stack from description", () => {
+    // Test via parseJobDetail which uses extractTechStack internally
+    const mockSnapshot = `
+      <div id="jobDescriptionText">
+        We are looking for a developer with experience in:
+        - TypeScript
+        - React
+        - Node.js
+        - PostgreSQL
+        - AWS
+        - Docker
+      </div>
+    `;
+
+    const details = indeedAdapter.parseJobDetail(mockSnapshot);
+
+    expect(details.techStack).toBeDefined();
+    expect(details.techStack).toContain("TypeScript");
+    expect(details.techStack).toContain("React");
+    expect(details.techStack).toContain("Node.js");
+  });
+});
+
+describe("Application Form Handling", () => {
+  it("should fill application form with contact info", () => {
+    if (!indeedAdapter.fillApplicationForm) {
+      return;
+    }
+
+    const form = {
+      url: "https://indeed.com/apply",
+      fields: [
+        {
+          id: "name",
+          type: "text" as const,
+          label: "Full Name",
+          required: true,
+        },
+        { id: "email", type: "email" as const, label: "Email", required: true },
+        {
+          id: "phone",
+          type: "phone" as const,
+          label: "Phone",
+          required: false,
+        },
+      ],
+    };
+
+    const filled = indeedAdapter.fillApplicationForm(form, {
+      contactInfo: {
+        name: "John Doe",
+        email: "john@example.com",
+        phone: "555-1234",
+      },
+    });
+
+    expect(filled.find((f) => f.id === "name")?.value).toBe("John Doe");
+    expect(filled.find((f) => f.id === "email")?.value).toBe(
+      "john@example.com",
+    );
+    expect(filled.find((f) => f.id === "phone")?.value).toBe("555-1234");
+  });
+});

--- a/extensions/job-application/src/adapters/greenhouse.ts
+++ b/extensions/job-application/src/adapters/greenhouse.ts
@@ -1,0 +1,395 @@
+/**
+ * Greenhouse Job Site Adapter
+ *
+ * Handles parsing and automation for Greenhouse-powered job boards.
+ * Greenhouse is an ATS used by many tech companies.
+ */
+
+import type {
+  JobSiteAdapter,
+  JobSearchParams,
+  RawJobListing,
+  ApplicationForm,
+  ApplicationFormField,
+} from "./types.js";
+
+export const greenhouseAdapter: JobSiteAdapter = {
+  name: "greenhouse",
+  label: "Greenhouse",
+  baseUrl: "https://boards.greenhouse.io",
+
+  buildSearchUrl(params: JobSearchParams): string {
+    // Greenhouse URLs are company-specific
+    // Format: https://boards.greenhouse.io/{company}
+    // We can't build a generic search URL, but we can format for known companies
+
+    // For API access (if available):
+    // https://boards-api.greenhouse.io/v1/boards/{company}/jobs
+
+    // Return a template that would need company name
+    return `https://boards.greenhouse.io/search?q=${encodeURIComponent(params.query)}`;
+  },
+
+  parseJobList(snapshot: string): RawJobListing[] {
+    const jobs: RawJobListing[] = [];
+
+    // Greenhouse job listing patterns
+    // Jobs are typically in div.opening with data-id
+    // Title in a.opening-title
+    // Location in span.location
+
+    const jobPattern =
+      /opening[^>]*data-id="(\d+)"[\s\S]*?opening-title[^>]*>([^<]+)[\s\S]*?location[^>]*>([^<]+)/g;
+
+    let match;
+    while ((match = jobPattern.exec(snapshot)) !== null) {
+      const [, externalId, title, location] = match;
+
+      // Extract company from URL or page title
+      const companyMatch = snapshot.match(/<title[^>]*>([^<|]+)/i);
+      const company = companyMatch
+        ? companyMatch[1].replace(/jobs|careers|-/gi, "").trim()
+        : "Unknown Company";
+
+      jobs.push({
+        externalId,
+        title: title.trim(),
+        company,
+        location: location.trim(),
+        url: `https://boards.greenhouse.io/embed/job_app?token=${externalId}`,
+      });
+    }
+
+    return jobs;
+  },
+
+  parseJobDetail(snapshot: string): Partial<RawJobListing> {
+    const details: Partial<RawJobListing> = {};
+
+    // Greenhouse job detail patterns
+    // Description in #content or div.content
+    const descMatch = snapshot.match(
+      /<div[^>]*(?:id="content"|class="[^"]*content[^"]*")[^>]*>([\s\S]*?)<\/div>/i,
+    );
+    if (descMatch) {
+      details.description = cleanHtml(descMatch[1]);
+    }
+
+    // Department/Team
+    const deptMatch = snapshot.match(/department[^>]*>([^<]+)/i);
+    if (deptMatch) {
+      details.requirements = [`Department: ${deptMatch[1].trim()}`];
+    }
+
+    // Extract tech stack from description
+    if (details.description) {
+      details.techStack = extractTechStack(details.description);
+    }
+
+    return details;
+  },
+
+  canHandle(url: string): boolean {
+    return (
+      url.includes("greenhouse.io") || url.includes("boards.greenhouse.io")
+    );
+  },
+
+  parseApplicationForm(snapshot: string): ApplicationForm | null {
+    const fields: ApplicationFormField[] = [];
+
+    // Greenhouse has standardized application forms
+    // Form fields are typically in div.field with input elements
+
+    // Required fields
+    const requiredPatterns = [
+      {
+        pattern: /first_name[^>]*ref="([^"]+)"/i,
+        label: "First Name",
+        type: "text" as const,
+      },
+      {
+        pattern: /last_name[^>]*ref="([^"]+)"/i,
+        label: "Last Name",
+        type: "text" as const,
+      },
+      {
+        pattern: /email[^>]*ref="([^"]+)"/i,
+        label: "Email",
+        type: "email" as const,
+      },
+    ];
+
+    for (const { pattern, label, type } of requiredPatterns) {
+      const match = snapshot.match(pattern);
+      if (match) {
+        fields.push({
+          id: match[1],
+          type,
+          label,
+          required: true,
+        });
+      }
+    }
+
+    // Optional fields
+    const optionalPatterns = [
+      {
+        pattern: /phone[^>]*ref="([^"]+)"/i,
+        label: "Phone",
+        type: "phone" as const,
+      },
+      {
+        pattern: /linkedin[^>]*ref="([^"]+)"/i,
+        label: "LinkedIn Profile",
+        type: "text" as const,
+      },
+      {
+        pattern: /website[^>]*ref="([^"]+)"/i,
+        label: "Website",
+        type: "text" as const,
+      },
+    ];
+
+    for (const { pattern, label, type } of optionalPatterns) {
+      const match = snapshot.match(pattern);
+      if (match) {
+        fields.push({
+          id: match[1],
+          type,
+          label,
+          required: false,
+        });
+      }
+    }
+
+    // Resume upload
+    const resumeMatch = snapshot.match(/resume[^>]*ref="([^"]+)"/i);
+    if (resumeMatch) {
+      fields.push({
+        id: resumeMatch[1],
+        type: "file",
+        label: "Resume",
+        required: true,
+      });
+    }
+
+    // Cover letter
+    const coverMatch = snapshot.match(/cover.?letter[^>]*ref="([^"]+)"/i);
+    if (coverMatch) {
+      fields.push({
+        id: coverMatch[1],
+        type: "textarea",
+        label: "Cover Letter",
+        required: false,
+      });
+    }
+
+    // Custom questions (Greenhouse allows custom fields)
+    const customPattern =
+      /custom_field[^>]*label="([^"]+)"[^>]*ref="([^"]+)"[^>]*type="([^"]+)"/gi;
+    let customMatch;
+    while ((customMatch = customPattern.exec(snapshot)) !== null) {
+      const [, label, id, inputType] = customMatch;
+      fields.push({
+        id,
+        type: mapInputType(inputType),
+        label: label.trim(),
+        required: false, // Custom fields are usually optional
+      });
+    }
+
+    // EEOC questions (common in US)
+    const eeocFields = [
+      {
+        pattern: /gender[^>]*ref="([^"]+)"/i,
+        label: "Gender",
+        options: ["Male", "Female", "Non-binary", "Prefer not to say"],
+      },
+      {
+        pattern: /ethnicity[^>]*ref="([^"]+)"/i,
+        label: "Ethnicity",
+        options: [
+          "Asian",
+          "Black",
+          "Hispanic",
+          "White",
+          "Other",
+          "Prefer not to say",
+        ],
+      },
+      {
+        pattern: /veteran[^>]*ref="([^"]+)"/i,
+        label: "Veteran Status",
+        options: ["Yes", "No", "Prefer not to say"],
+      },
+      {
+        pattern: /disability[^>]*ref="([^"]+)"/i,
+        label: "Disability Status",
+        options: ["Yes", "No", "Prefer not to say"],
+      },
+    ];
+
+    for (const { pattern, label, options } of eeocFields) {
+      const match = snapshot.match(pattern);
+      if (match) {
+        fields.push({
+          id: match[1],
+          type: "select",
+          label,
+          required: false,
+          options,
+        });
+      }
+    }
+
+    // Submit button
+    const submitMatch = snapshot.match(/submit[^>]*ref="([^"]+)"/i);
+
+    if (fields.length === 0) {
+      return null;
+    }
+
+    return {
+      url: "",
+      fields,
+      submitButtonRef: submitMatch?.[1],
+    };
+  },
+
+  fillApplicationForm(
+    form: ApplicationForm,
+    data: {
+      resume?: { name: string; path: string };
+      coverLetter?: string;
+      contactInfo?: { name?: string; email?: string; phone?: string };
+      answers?: Record<string, string>;
+    },
+  ): ApplicationFormField[] {
+    return form.fields.map((field) => {
+      const filled = { ...field };
+      const labelLower = field.label.toLowerCase();
+
+      // Handle name fields
+      if (labelLower.includes("first name") && data.contactInfo?.name) {
+        filled.value = data.contactInfo.name.split(" ")[0];
+      } else if (labelLower.includes("last name") && data.contactInfo?.name) {
+        const parts = data.contactInfo.name.split(" ");
+        filled.value = parts.slice(1).join(" ");
+      }
+      // Handle contact fields
+      else if (labelLower.includes("email")) {
+        filled.value = data.contactInfo?.email ?? "";
+      } else if (labelLower.includes("phone")) {
+        filled.value = data.contactInfo?.phone ?? "";
+      }
+      // Handle files
+      else if (labelLower.includes("resume")) {
+        filled.value = data.resume?.path ?? "";
+      } else if (labelLower.includes("cover letter")) {
+        filled.value = data.coverLetter ?? "";
+      }
+      // Handle custom answers
+      else if (data.answers && data.answers[field.id]) {
+        filled.value = data.answers[field.id];
+      }
+      // Default EEOC answers to "Prefer not to say"
+      else if (
+        labelLower.includes("gender") ||
+        labelLower.includes("ethnicity") ||
+        labelLower.includes("veteran") ||
+        labelLower.includes("disability")
+      ) {
+        if (field.options?.includes("Prefer not to say")) {
+          filled.value = "Prefer not to say";
+        }
+      }
+
+      return filled;
+    });
+  },
+};
+
+/**
+ * Clean HTML to plain text.
+ */
+function cleanHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Extract tech stack from description.
+ */
+function extractTechStack(description: string): string[] {
+  const techKeywords = [
+    "JavaScript",
+    "TypeScript",
+    "Python",
+    "Java",
+    "C++",
+    "C#",
+    "Go",
+    "Rust",
+    "React",
+    "Vue",
+    "Angular",
+    "Node.js",
+    "Django",
+    "Flask",
+    "Spring",
+    "AWS",
+    "Azure",
+    "GCP",
+    "Docker",
+    "Kubernetes",
+    "PostgreSQL",
+    "MongoDB",
+    "Redis",
+    "GraphQL",
+    "REST",
+    "Git",
+    "CI/CD",
+    "Terraform",
+    "Jenkins",
+  ];
+
+  const found: string[] = [];
+  const descLower = description.toLowerCase();
+
+  for (const tech of techKeywords) {
+    if (descLower.includes(tech.toLowerCase())) {
+      found.push(tech);
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Map HTML input type to our field type.
+ */
+function mapInputType(
+  inputType: string,
+): "text" | "textarea" | "select" | "checkbox" | "file" | "email" | "phone" {
+  switch (inputType.toLowerCase()) {
+    case "textarea":
+      return "textarea";
+    case "select":
+    case "dropdown":
+      return "select";
+    case "checkbox":
+      return "checkbox";
+    case "file":
+      return "file";
+    case "email":
+      return "email";
+    case "tel":
+    case "phone":
+      return "phone";
+    default:
+      return "text";
+  }
+}

--- a/extensions/job-application/src/adapters/indeed.ts
+++ b/extensions/job-application/src/adapters/indeed.ts
@@ -1,0 +1,343 @@
+/**
+ * Indeed Job Site Adapter
+ *
+ * Handles parsing and automation for Indeed job listings.
+ */
+
+import type {
+  JobSiteAdapter,
+  JobSearchParams,
+  RawJobListing,
+  ApplicationForm,
+  ApplicationFormField,
+} from "./types.js";
+
+export const indeedAdapter: JobSiteAdapter = {
+  name: "indeed",
+  label: "Indeed",
+  baseUrl: "https://www.indeed.com",
+
+  buildSearchUrl(params: JobSearchParams): string {
+    const url = new URL("https://www.indeed.com/jobs");
+    url.searchParams.set("q", params.query);
+
+    if (params.location) {
+      url.searchParams.set("l", params.location);
+    }
+
+    if (params.remote) {
+      url.searchParams.set("remotejob", "032b3046-06a3-4876-8dfd-474eb5e7ed11");
+    }
+
+    if (params.salaryMin) {
+      // Indeed uses salary format like "$100,000"
+      url.searchParams.set("salary", `$${params.salaryMin.toLocaleString()}`);
+    }
+
+    if (params.postedWithin) {
+      // Indeed uses fromage parameter (days)
+      url.searchParams.set("fromage", params.postedWithin.toString());
+    }
+
+    if (params.limit) {
+      url.searchParams.set("limit", params.limit.toString());
+    }
+
+    return url.toString();
+  },
+
+  parseJobList(snapshot: string): RawJobListing[] {
+    const jobs: RawJobListing[] = [];
+
+    // This is a simplified parser for demonstration
+    // In production, this would parse the actual Indeed page structure
+    // The snapshot would be the browser's accessibility tree or DOM content
+
+    // Example parsing logic based on Indeed's typical structure:
+    // - Job cards have data-jk attribute with job ID
+    // - Title is in h2.jobTitle
+    // - Company in span.companyName
+    // - Location in div.companyLocation
+    // - Salary in div.salary-snippet (if present)
+
+    // For now, return empty array - actual implementation would parse snapshot
+    // This would use regex or DOM parsing on the snapshot content
+
+    const jobCardPattern =
+      /data-jk="([^"]+)"[\s\S]*?jobTitle[^>]*>([^<]+)[\s\S]*?companyName[^>]*>([^<]+)[\s\S]*?companyLocation[^>]*>([^<]+)/g;
+
+    let match;
+    while ((match = jobCardPattern.exec(snapshot)) !== null) {
+      const [, externalId, title, company, location] = match;
+      jobs.push({
+        externalId,
+        title: title.trim(),
+        company: company.trim(),
+        location: location.trim(),
+        url: `https://www.indeed.com/viewjob?jk=${externalId}`,
+      });
+    }
+
+    return jobs;
+  },
+
+  parseJobDetail(snapshot: string): Partial<RawJobListing> {
+    const details: Partial<RawJobListing> = {};
+
+    // Parse job description
+    const descMatch = snapshot.match(
+      /jobDescriptionText[^>]*>([\s\S]*?)<\/div>/i,
+    );
+    if (descMatch) {
+      details.description = cleanHtml(descMatch[1]);
+    }
+
+    // Parse salary if present
+    const salaryMatch = snapshot.match(
+      /salary[^>]*>\s*\$?([\d,]+)\s*-?\s*\$?([\d,]+)?/i,
+    );
+    if (salaryMatch) {
+      details.salaryMin = parseInt(salaryMatch[1].replace(/,/g, ""));
+      if (salaryMatch[2]) {
+        details.salaryMax = parseInt(salaryMatch[2].replace(/,/g, ""));
+      }
+    }
+
+    // Parse requirements (often in bullet points)
+    const requirementsMatch = snapshot.match(/<ul[^>]*>([\s\S]*?)<\/ul>/gi);
+    if (requirementsMatch) {
+      const requirements: string[] = [];
+      for (const ul of requirementsMatch) {
+        const items = ul.match(/<li[^>]*>([\s\S]*?)<\/li>/gi);
+        if (items) {
+          for (const item of items) {
+            const text = cleanHtml(item);
+            if (text.length > 10 && text.length < 200) {
+              requirements.push(text);
+            }
+          }
+        }
+      }
+      if (requirements.length > 0) {
+        details.requirements = requirements.slice(0, 10);
+      }
+    }
+
+    // Extract tech stack from description
+    if (details.description) {
+      details.techStack = extractTechStack(details.description);
+    }
+
+    return details;
+  },
+
+  canHandle(url: string): boolean {
+    return url.includes("indeed.com");
+  },
+
+  parseApplicationForm(snapshot: string): ApplicationForm | null {
+    const fields: ApplicationFormField[] = [];
+
+    // Parse form fields
+    // Indeed's "Apply Now" typically opens a modal with standard fields
+
+    // Name field
+    const nameMatch = snapshot.match(/name[^>]*type="text"[^>]*ref="([^"]+)"/i);
+    if (nameMatch) {
+      fields.push({
+        id: nameMatch[1],
+        type: "text",
+        label: "Full Name",
+        required: true,
+      });
+    }
+
+    // Email field
+    const emailMatch = snapshot.match(
+      /email[^>]*type="email"[^>]*ref="([^"]+)"/i,
+    );
+    if (emailMatch) {
+      fields.push({
+        id: emailMatch[1],
+        type: "email",
+        label: "Email",
+        required: true,
+      });
+    }
+
+    // Phone field
+    const phoneMatch = snapshot.match(
+      /phone[^>]*type="tel"[^>]*ref="([^"]+)"/i,
+    );
+    if (phoneMatch) {
+      fields.push({
+        id: phoneMatch[1],
+        type: "phone",
+        label: "Phone",
+        required: false,
+      });
+    }
+
+    // Resume upload
+    const resumeMatch = snapshot.match(
+      /resume[^>]*type="file"[^>]*ref="([^"]+)"/i,
+    );
+    if (resumeMatch) {
+      fields.push({
+        id: resumeMatch[1],
+        type: "file",
+        label: "Resume",
+        required: true,
+      });
+    }
+
+    // Cover letter (usually textarea)
+    const coverMatch = snapshot.match(/cover[^>]*textarea[^>]*ref="([^"]+)"/i);
+    if (coverMatch) {
+      fields.push({
+        id: coverMatch[1],
+        type: "textarea",
+        label: "Cover Letter",
+        required: false,
+      });
+    }
+
+    // Submit button
+    const submitMatch = snapshot.match(/submit[^>]*button[^>]*ref="([^"]+)"/i);
+
+    if (fields.length === 0) {
+      return null;
+    }
+
+    return {
+      url: "", // Would be extracted from current page
+      fields,
+      submitButtonRef: submitMatch?.[1],
+    };
+  },
+
+  fillApplicationForm(
+    form: ApplicationForm,
+    data: {
+      resume?: { name: string; path: string };
+      coverLetter?: string;
+      contactInfo?: { name?: string; email?: string; phone?: string };
+      answers?: Record<string, string>;
+    },
+  ): ApplicationFormField[] {
+    return form.fields.map((field) => {
+      const filled = { ...field };
+
+      switch (field.label.toLowerCase()) {
+        case "full name":
+        case "name":
+          filled.value = data.contactInfo?.name ?? "";
+          break;
+        case "email":
+          filled.value = data.contactInfo?.email ?? "";
+          break;
+        case "phone":
+          filled.value = data.contactInfo?.phone ?? "";
+          break;
+        case "cover letter":
+          filled.value = data.coverLetter ?? "";
+          break;
+        case "resume":
+          filled.value = data.resume?.path ?? "";
+          break;
+        default:
+          // Check custom answers
+          if (data.answers && data.answers[field.id]) {
+            filled.value = data.answers[field.id];
+          }
+      }
+
+      return filled;
+    });
+  },
+};
+
+/**
+ * Clean HTML content to plain text.
+ */
+function cleanHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Extract tech stack keywords from job description.
+ */
+function extractTechStack(description: string): string[] {
+  const techKeywords = [
+    // Languages
+    "JavaScript",
+    "TypeScript",
+    "Python",
+    "Java",
+    "C++",
+    "C#",
+    "Go",
+    "Rust",
+    "Ruby",
+    "PHP",
+    "Swift",
+    "Kotlin",
+    "Scala",
+    // Frontend
+    "React",
+    "Vue",
+    "Angular",
+    "Next.js",
+    "Svelte",
+    "HTML",
+    "CSS",
+    "Tailwind",
+    // Backend
+    "Node.js",
+    "Express",
+    "Django",
+    "Flask",
+    "Spring",
+    "Rails",
+    "FastAPI",
+    ".NET",
+    // Databases
+    "PostgreSQL",
+    "MySQL",
+    "MongoDB",
+    "Redis",
+    "Elasticsearch",
+    "DynamoDB",
+    "SQLite",
+    // Cloud/DevOps
+    "AWS",
+    "Azure",
+    "GCP",
+    "Docker",
+    "Kubernetes",
+    "Terraform",
+    "CI/CD",
+    "Jenkins",
+    // Other
+    "GraphQL",
+    "REST",
+    "gRPC",
+    "Kafka",
+    "RabbitMQ",
+    "Git",
+  ];
+
+  const found: string[] = [];
+  const descLower = description.toLowerCase();
+
+  for (const tech of techKeywords) {
+    if (descLower.includes(tech.toLowerCase())) {
+      found.push(tech);
+    }
+  }
+
+  return found;
+}

--- a/extensions/job-application/src/adapters/index.ts
+++ b/extensions/job-application/src/adapters/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Job Site Adapters Index
+ *
+ * Exports all available job site adapters and provides a registry
+ * for looking up adapters by name or URL.
+ */
+
+import { indeedAdapter } from "./indeed.js";
+import { linkedinAdapter } from "./linkedin.js";
+import { greenhouseAdapter } from "./greenhouse.js";
+import type { JobSiteAdapter } from "./types.js";
+import type { JobSource } from "../types.js";
+
+// Export individual adapters
+export { indeedAdapter } from "./indeed.js";
+export { linkedinAdapter } from "./linkedin.js";
+export { greenhouseAdapter } from "./greenhouse.js";
+export type {
+  JobSiteAdapter,
+  JobSearchParams,
+  RawJobListing,
+  ApplicationForm,
+  ApplicationFormField,
+} from "./types.js";
+
+/**
+ * Registry of all available job site adapters.
+ */
+export const adapters: Record<JobSource, JobSiteAdapter> = {
+  indeed: indeedAdapter,
+  linkedin: linkedinAdapter,
+  greenhouse: greenhouseAdapter,
+  lever: greenhouseAdapter, // Lever is similar to Greenhouse
+  custom: indeedAdapter, // Fallback to Indeed patterns for custom sites
+};
+
+/**
+ * Get an adapter by source name.
+ */
+export function getAdapter(source: JobSource): JobSiteAdapter {
+  return adapters[source] ?? indeedAdapter;
+}
+
+/**
+ * Find an adapter that can handle a given URL.
+ */
+export function findAdapterForUrl(url: string): JobSiteAdapter | null {
+  for (const adapter of Object.values(adapters)) {
+    if (adapter.canHandle(url)) {
+      return adapter;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get all available adapter names.
+ */
+export function getAvailableAdapters(): JobSource[] {
+  return Object.keys(adapters) as JobSource[];
+}

--- a/extensions/job-application/src/adapters/linkedin.ts
+++ b/extensions/job-application/src/adapters/linkedin.ts
@@ -1,0 +1,376 @@
+/**
+ * LinkedIn Job Site Adapter
+ *
+ * Handles parsing and automation for LinkedIn job listings.
+ * Note: LinkedIn requires authentication for most operations.
+ */
+
+import type {
+  JobSiteAdapter,
+  JobSearchParams,
+  RawJobListing,
+  ApplicationForm,
+  ApplicationFormField,
+} from "./types.js";
+
+export const linkedinAdapter: JobSiteAdapter = {
+  name: "linkedin",
+  label: "LinkedIn",
+  baseUrl: "https://www.linkedin.com",
+
+  buildSearchUrl(params: JobSearchParams): string {
+    const url = new URL("https://www.linkedin.com/jobs/search/");
+
+    url.searchParams.set("keywords", params.query);
+
+    if (params.location) {
+      url.searchParams.set("location", params.location);
+    }
+
+    if (params.remote) {
+      // LinkedIn remote filter: f_WT=2
+      url.searchParams.set("f_WT", "2");
+    }
+
+    if (params.postedWithin) {
+      // LinkedIn uses time filter:
+      // r86400 = past 24 hours
+      // r604800 = past week
+      // r2592000 = past month
+      if (params.postedWithin <= 1) {
+        url.searchParams.set("f_TPR", "r86400");
+      } else if (params.postedWithin <= 7) {
+        url.searchParams.set("f_TPR", "r604800");
+      } else {
+        url.searchParams.set("f_TPR", "r2592000");
+      }
+    }
+
+    if (params.salaryMin) {
+      // LinkedIn salary filters vary by region
+      // This is a simplified version
+      const salaryBucket = getSalaryBucket(params.salaryMin);
+      if (salaryBucket) {
+        url.searchParams.set("f_SB2", salaryBucket);
+      }
+    }
+
+    return url.toString();
+  },
+
+  parseJobList(snapshot: string): RawJobListing[] {
+    const jobs: RawJobListing[] = [];
+
+    // LinkedIn job cards pattern
+    // Jobs are in li elements with data-occludable-job-id
+    // Title in .job-card-list__title
+    // Company in .job-card-container__company-name
+    // Location in .job-card-container__metadata-item
+
+    const jobPattern =
+      /data-occludable-job-id="(\d+)"[\s\S]*?job-card-list__title[^>]*>([^<]+)[\s\S]*?company-name[^>]*>([^<]+)[\s\S]*?metadata-item[^>]*>([^<]+)/g;
+
+    let match;
+    while ((match = jobPattern.exec(snapshot)) !== null) {
+      const [, externalId, title, company, location] = match;
+      jobs.push({
+        externalId,
+        title: title.trim(),
+        company: company.trim(),
+        location: location.trim(),
+        url: `https://www.linkedin.com/jobs/view/${externalId}`,
+      });
+    }
+
+    return jobs;
+  },
+
+  parseJobDetail(snapshot: string): Partial<RawJobListing> {
+    const details: Partial<RawJobListing> = {};
+
+    // Parse job description
+    const descMatch = snapshot.match(
+      /jobs-description[^>]*>([\s\S]*?)<\/div>/i,
+    );
+    if (descMatch) {
+      details.description = cleanHtml(descMatch[1]);
+    }
+
+    // Parse salary (LinkedIn shows ranges)
+    const salaryMatch = snapshot.match(
+      /\$?([\d,]+)\s*\/?\s*(?:yr|year|annually)?\s*-\s*\$?([\d,]+)/i,
+    );
+    if (salaryMatch) {
+      details.salaryMin = parseInt(salaryMatch[1].replace(/,/g, ""));
+      details.salaryMax = parseInt(salaryMatch[2].replace(/,/g, ""));
+    }
+
+    // LinkedIn often shows skills in a separate section
+    const skillsMatch = snapshot.match(/skills[^>]*>([\s\S]*?)<\/section>/i);
+    if (skillsMatch) {
+      const skills = extractSkillsFromSection(skillsMatch[1]);
+      if (skills.length > 0) {
+        details.techStack = skills;
+      }
+    }
+
+    // Fallback: extract from description
+    if (!details.techStack && details.description) {
+      details.techStack = extractTechStack(details.description);
+    }
+
+    // Posted date
+    const postedMatch = snapshot.match(
+      /posted\s+(\d+)\s+(day|week|month)s?\s+ago/i,
+    );
+    if (postedMatch) {
+      const value = parseInt(postedMatch[1]);
+      const unit = postedMatch[2].toLowerCase();
+      let daysAgo = value;
+      if (unit === "week") daysAgo *= 7;
+      if (unit === "month") daysAgo *= 30;
+      details.postedAt = Date.now() - daysAgo * 24 * 60 * 60 * 1000;
+    }
+
+    return details;
+  },
+
+  canHandle(url: string): boolean {
+    return url.includes("linkedin.com");
+  },
+
+  parseApplicationForm(snapshot: string): ApplicationForm | null {
+    const fields: ApplicationFormField[] = [];
+
+    // LinkedIn Easy Apply has standardized fields
+    // Check if it's Easy Apply vs external application
+
+    const isEasyApply =
+      snapshot.includes("Easy Apply") || snapshot.includes("easy-apply");
+
+    if (!isEasyApply) {
+      // External application - might redirect
+      return null;
+    }
+
+    // Contact info fields (usually pre-filled from profile)
+    const contactFields = [
+      {
+        pattern: /first.?name[^>]*ref="([^"]+)"/i,
+        label: "First Name",
+        type: "text" as const,
+      },
+      {
+        pattern: /last.?name[^>]*ref="([^"]+)"/i,
+        label: "Last Name",
+        type: "text" as const,
+      },
+      {
+        pattern: /email[^>]*ref="([^"]+)"/i,
+        label: "Email",
+        type: "email" as const,
+      },
+      {
+        pattern: /phone[^>]*ref="([^"]+)"/i,
+        label: "Phone",
+        type: "phone" as const,
+      },
+    ];
+
+    for (const { pattern, label, type } of contactFields) {
+      const match = snapshot.match(pattern);
+      if (match) {
+        fields.push({
+          id: match[1],
+          type,
+          label,
+          required: label === "Email",
+        });
+      }
+    }
+
+    // Resume upload
+    const resumeMatch = snapshot.match(/upload.?resume[^>]*ref="([^"]+)"/i);
+    if (resumeMatch) {
+      fields.push({
+        id: resumeMatch[1],
+        type: "file",
+        label: "Resume",
+        required: true,
+      });
+    }
+
+    // Additional questions (varies by job)
+    const questionPattern =
+      /question[^>]*label="([^"]+)"[^>]*ref="([^"]+)"[^>]*type="([^"]+)"/gi;
+    let questionMatch;
+    while ((questionMatch = questionPattern.exec(snapshot)) !== null) {
+      const [, label, id, inputType] = questionMatch;
+      fields.push({
+        id,
+        type: mapInputType(inputType),
+        label: label.trim(),
+        required: false,
+      });
+    }
+
+    // Submit button
+    const submitMatch = snapshot.match(/submit[^>]*ref="([^"]+)"/i);
+
+    if (fields.length === 0) {
+      return null;
+    }
+
+    return {
+      url: "",
+      fields,
+      submitButtonRef: submitMatch?.[1],
+    };
+  },
+
+  fillApplicationForm(
+    form: ApplicationForm,
+    data: {
+      resume?: { name: string; path: string };
+      coverLetter?: string;
+      contactInfo?: { name?: string; email?: string; phone?: string };
+      answers?: Record<string, string>;
+    },
+  ): ApplicationFormField[] {
+    return form.fields.map((field) => {
+      const filled = { ...field };
+      const labelLower = field.label.toLowerCase();
+
+      if (labelLower.includes("first name") && data.contactInfo?.name) {
+        filled.value = data.contactInfo.name.split(" ")[0];
+      } else if (labelLower.includes("last name") && data.contactInfo?.name) {
+        const parts = data.contactInfo.name.split(" ");
+        filled.value = parts.slice(1).join(" ");
+      } else if (labelLower.includes("email")) {
+        filled.value = data.contactInfo?.email ?? "";
+      } else if (labelLower.includes("phone")) {
+        filled.value = data.contactInfo?.phone ?? "";
+      } else if (labelLower.includes("resume")) {
+        filled.value = data.resume?.path ?? "";
+      } else if (data.answers && data.answers[field.id]) {
+        filled.value = data.answers[field.id];
+      }
+
+      return filled;
+    });
+  },
+};
+
+/**
+ * Get LinkedIn salary bucket from minimum salary.
+ */
+function getSalaryBucket(salaryMin: number): string | null {
+  // LinkedIn salary filters (US)
+  // These are approximate ranges
+  if (salaryMin >= 200000) return "8";
+  if (salaryMin >= 160000) return "7";
+  if (salaryMin >= 120000) return "6";
+  if (salaryMin >= 100000) return "5";
+  if (salaryMin >= 80000) return "4";
+  if (salaryMin >= 60000) return "3";
+  if (salaryMin >= 40000) return "2";
+  return "1";
+}
+
+/**
+ * Clean HTML to plain text.
+ */
+function cleanHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Extract skills from LinkedIn skills section.
+ */
+function extractSkillsFromSection(html: string): string[] {
+  const skills: string[] = [];
+  const skillPattern = /<span[^>]*>([^<]+)<\/span>/gi;
+  let match;
+  while ((match = skillPattern.exec(html)) !== null) {
+    const skill = match[1].trim();
+    if (skill.length > 1 && skill.length < 30 && !skill.includes("\n")) {
+      skills.push(skill);
+    }
+  }
+  return skills.slice(0, 15);
+}
+
+/**
+ * Extract tech stack from description.
+ */
+function extractTechStack(description: string): string[] {
+  const techKeywords = [
+    "JavaScript",
+    "TypeScript",
+    "Python",
+    "Java",
+    "C++",
+    "C#",
+    "Go",
+    "Rust",
+    "React",
+    "Vue",
+    "Angular",
+    "Node.js",
+    "Django",
+    "Flask",
+    "Spring",
+    "AWS",
+    "Azure",
+    "GCP",
+    "Docker",
+    "Kubernetes",
+    "PostgreSQL",
+    "MongoDB",
+    "Redis",
+    "GraphQL",
+    "REST",
+    "Git",
+    "CI/CD",
+  ];
+
+  const found: string[] = [];
+  const descLower = description.toLowerCase();
+
+  for (const tech of techKeywords) {
+    if (descLower.includes(tech.toLowerCase())) {
+      found.push(tech);
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Map HTML input type to our field type.
+ */
+function mapInputType(
+  inputType: string,
+): "text" | "textarea" | "select" | "checkbox" | "file" | "email" | "phone" {
+  switch (inputType.toLowerCase()) {
+    case "textarea":
+      return "textarea";
+    case "select":
+    case "dropdown":
+      return "select";
+    case "checkbox":
+      return "checkbox";
+    case "file":
+      return "file";
+    case "email":
+      return "email";
+    case "tel":
+    case "phone":
+      return "phone";
+    default:
+      return "text";
+  }
+}

--- a/extensions/job-application/src/adapters/types.ts
+++ b/extensions/job-application/src/adapters/types.ts
@@ -1,0 +1,129 @@
+/**
+ * Types for job site adapters
+ */
+
+import type { Job, JobSource } from "../types.js";
+
+/**
+ * Search parameters for job boards
+ */
+export type JobSearchParams = {
+  query: string;
+  location?: string;
+  remote?: boolean;
+  salaryMin?: number;
+  salaryMax?: number;
+  postedWithin?: number; // Days
+  limit?: number;
+};
+
+/**
+ * Raw job data from a job board
+ */
+export type RawJobListing = {
+  externalId: string;
+  title: string;
+  company: string;
+  location?: string;
+  salaryMin?: number;
+  salaryMax?: number;
+  salaryCurrency?: string;
+  description?: string;
+  requirements?: string[];
+  techStack?: string[];
+  url: string;
+  postedAt?: number;
+};
+
+/**
+ * Application form field
+ */
+export type ApplicationFormField = {
+  id: string;
+  type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "checkbox"
+    | "file"
+    | "email"
+    | "phone";
+  label: string;
+  required: boolean;
+  options?: string[]; // For select fields
+  value?: string | boolean;
+};
+
+/**
+ * Application form structure
+ */
+export type ApplicationForm = {
+  url: string;
+  fields: ApplicationFormField[];
+  submitButtonRef?: string;
+};
+
+/**
+ * Job site adapter interface
+ */
+export interface JobSiteAdapter {
+  /** Adapter name */
+  name: JobSource;
+
+  /** Display label */
+  label: string;
+
+  /** Base URL for the job site */
+  baseUrl: string;
+
+  /**
+   * Build a search URL for the job board
+   */
+  buildSearchUrl(params: JobSearchParams): string;
+
+  /**
+   * Parse job listings from a browser snapshot
+   * @param snapshot Browser snapshot content (UI tree)
+   * @returns Array of raw job listings
+   */
+  parseJobList(snapshot: string): RawJobListing[];
+
+  /**
+   * Parse detailed job information from a job detail page
+   * @param snapshot Browser snapshot content
+   * @returns Parsed job details
+   */
+  parseJobDetail(snapshot: string): Partial<RawJobListing>;
+
+  /**
+   * Check if this adapter can handle a given URL
+   */
+  canHandle(url: string): boolean;
+
+  /**
+   * Get the application form structure for a job
+   * @param snapshot Browser snapshot of application page
+   * @returns Application form structure
+   */
+  parseApplicationForm?(snapshot: string): ApplicationForm | null;
+
+  /**
+   * Fill application form fields
+   * @param form Application form structure
+   * @param data User data to fill
+   * @returns Filled form fields
+   */
+  fillApplicationForm?(
+    form: ApplicationForm,
+    data: {
+      resume?: { name: string; path: string };
+      coverLetter?: string;
+      contactInfo?: {
+        name?: string;
+        email?: string;
+        phone?: string;
+      };
+      answers?: Record<string, string>;
+    },
+  ): ApplicationFormField[];
+}

--- a/extensions/job-application/src/config.ts
+++ b/extensions/job-application/src/config.ts
@@ -1,0 +1,241 @@
+/**
+ * Configuration parsing and defaults for Job Application plugin
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { JobApplicationConfig, JobSource } from "./types.js";
+
+const DEFAULT_DB_PATH = join(
+  homedir(),
+  ".clawdbot",
+  "jobbot",
+  "applications.sqlite",
+);
+const DEFAULT_RESUMES_DIR = join(homedir(), ".clawdbot", "jobbot", "resumes");
+const DEFAULT_SCAN_INTERVAL = "6h";
+const DEFAULT_JOB_BOARDS: JobSource[] = ["indeed", "linkedin"];
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowed: string[],
+  label: string,
+): void {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length === 0) return;
+  throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
+}
+
+function parsePreferences(value: unknown): JobApplicationConfig["preferences"] {
+  const defaults: JobApplicationConfig["preferences"] = {
+    titles: [],
+    locations: [],
+    salaryMin: undefined,
+    salaryMax: undefined,
+    remoteOnly: false,
+    excludeCompanies: [],
+    keywords: [],
+    excludeKeywords: [],
+  };
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return defaults;
+  }
+
+  const prefs = value as Record<string, unknown>;
+  assertAllowedKeys(
+    prefs,
+    [
+      "titles",
+      "locations",
+      "salaryMin",
+      "salaryMax",
+      "remoteOnly",
+      "excludeCompanies",
+      "keywords",
+      "excludeKeywords",
+    ],
+    "preferences",
+  );
+
+  return {
+    titles: Array.isArray(prefs.titles)
+      ? (prefs.titles as string[])
+      : defaults.titles,
+    locations: Array.isArray(prefs.locations)
+      ? (prefs.locations as string[])
+      : defaults.locations,
+    salaryMin:
+      typeof prefs.salaryMin === "number"
+        ? prefs.salaryMin
+        : defaults.salaryMin,
+    salaryMax:
+      typeof prefs.salaryMax === "number"
+        ? prefs.salaryMax
+        : defaults.salaryMax,
+    remoteOnly:
+      typeof prefs.remoteOnly === "boolean"
+        ? prefs.remoteOnly
+        : defaults.remoteOnly,
+    excludeCompanies: Array.isArray(prefs.excludeCompanies)
+      ? (prefs.excludeCompanies as string[])
+      : defaults.excludeCompanies,
+    keywords: Array.isArray(prefs.keywords)
+      ? (prefs.keywords as string[])
+      : defaults.keywords,
+    excludeKeywords: Array.isArray(prefs.excludeKeywords)
+      ? (prefs.excludeKeywords as string[])
+      : defaults.excludeKeywords,
+  };
+}
+
+function parseNotifications(
+  value: unknown,
+): JobApplicationConfig["notifications"] {
+  const defaults: JobApplicationConfig["notifications"] = {
+    channel: undefined,
+    dailySummary: true,
+    newJobAlerts: true,
+    emailResponseAlerts: true,
+  };
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return defaults;
+  }
+
+  const notif = value as Record<string, unknown>;
+  assertAllowedKeys(
+    notif,
+    ["channel", "dailySummary", "newJobAlerts", "emailResponseAlerts"],
+    "notifications",
+  );
+
+  return {
+    channel:
+      typeof notif.channel === "string" ? notif.channel : defaults.channel,
+    dailySummary:
+      typeof notif.dailySummary === "boolean"
+        ? notif.dailySummary
+        : defaults.dailySummary,
+    newJobAlerts:
+      typeof notif.newJobAlerts === "boolean"
+        ? notif.newJobAlerts
+        : defaults.newJobAlerts,
+    emailResponseAlerts:
+      typeof notif.emailResponseAlerts === "boolean"
+        ? notif.emailResponseAlerts
+        : defaults.emailResponseAlerts,
+  };
+}
+
+export const jobApplicationConfigSchema = {
+  parse(value: unknown): JobApplicationConfig {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      // Return defaults if no config provided
+      return {
+        dbPath: DEFAULT_DB_PATH,
+        resumesDir: DEFAULT_RESUMES_DIR,
+        scanInterval: DEFAULT_SCAN_INTERVAL,
+        defaultJobBoards: DEFAULT_JOB_BOARDS,
+        preferences: parsePreferences(undefined),
+        notifications: parseNotifications(undefined),
+      };
+    }
+
+    const cfg = value as Record<string, unknown>;
+    assertAllowedKeys(
+      cfg,
+      [
+        "dbPath",
+        "resumesDir",
+        "scanInterval",
+        "defaultJobBoards",
+        "preferences",
+        "notifications",
+      ],
+      "job-application config",
+    );
+
+    return {
+      dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : DEFAULT_DB_PATH,
+      resumesDir:
+        typeof cfg.resumesDir === "string"
+          ? cfg.resumesDir
+          : DEFAULT_RESUMES_DIR,
+      scanInterval:
+        typeof cfg.scanInterval === "string"
+          ? cfg.scanInterval
+          : DEFAULT_SCAN_INTERVAL,
+      defaultJobBoards: Array.isArray(cfg.defaultJobBoards)
+        ? (cfg.defaultJobBoards as JobSource[])
+        : DEFAULT_JOB_BOARDS,
+      preferences: parsePreferences(cfg.preferences),
+      notifications: parseNotifications(cfg.notifications),
+    };
+  },
+
+  uiHints: {
+    dbPath: {
+      label: "Database Path",
+      placeholder: "~/.clawdbot/jobbot/applications.sqlite",
+      advanced: true,
+      help: "Path to SQLite database for storing job data",
+    },
+    resumesDir: {
+      label: "Resumes Directory",
+      placeholder: "~/.clawdbot/jobbot/resumes",
+      advanced: true,
+      help: "Directory to store uploaded resume files",
+    },
+    scanInterval: {
+      label: "Scan Interval",
+      placeholder: "6h",
+      help: "How often to scan for new jobs (e.g., '6h', '12h', '24h')",
+    },
+    defaultJobBoards: {
+      label: "Default Job Boards",
+      help: "Job boards to search by default",
+    },
+    "preferences.titles": {
+      label: "Target Job Titles",
+      help: "Job titles to search for",
+    },
+    "preferences.locations": {
+      label: "Preferred Locations",
+      help: "Locations to search (e.g., 'Remote', 'San Francisco, CA')",
+    },
+    "preferences.salaryMin": {
+      label: "Minimum Salary",
+      help: "Minimum acceptable salary",
+    },
+    "preferences.salaryMax": {
+      label: "Maximum Salary",
+      help: "Maximum salary to consider",
+    },
+    "preferences.remoteOnly": {
+      label: "Remote Only",
+      help: "Only show remote positions",
+    },
+    "preferences.excludeCompanies": {
+      label: "Excluded Companies",
+      help: "Companies to exclude from search results",
+    },
+    "notifications.channel": {
+      label: "Notification Channel",
+      help: "Channel to send notifications (e.g., 'imessage', 'telegram')",
+    },
+    "notifications.dailySummary": {
+      label: "Daily Summary",
+      help: "Send daily summary of job search activity",
+    },
+    "notifications.newJobAlerts": {
+      label: "New Job Alerts",
+      help: "Alert when new matching jobs are found",
+    },
+    "notifications.emailResponseAlerts": {
+      label: "Email Response Alerts",
+      help: "Alert when email responses are detected",
+    },
+  },
+};

--- a/extensions/job-application/src/db/schema.ts
+++ b/extensions/job-application/src/db/schema.ts
@@ -1,0 +1,208 @@
+/**
+ * SQLite database schema for Job Application plugin
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+
+/**
+ * Ensures all required tables and indexes exist in the database.
+ * Uses CREATE IF NOT EXISTS for idempotency.
+ */
+export function ensureJobApplicationSchema(db: DatabaseSync): void {
+  // Jobs table - stores discovered job listings
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS jobs (
+      id TEXT PRIMARY KEY,
+      external_id TEXT,
+      source TEXT NOT NULL,
+      company TEXT NOT NULL,
+      title TEXT NOT NULL,
+      location TEXT,
+      salary_min INTEGER,
+      salary_max INTEGER,
+      salary_currency TEXT DEFAULT 'USD',
+      description TEXT,
+      requirements TEXT,
+      tech_stack TEXT,
+      url TEXT NOT NULL,
+      posted_at INTEGER,
+      discovered_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'new',
+      metadata TEXT
+    );
+  `);
+
+  // Applications table - tracks submitted applications
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS applications (
+      id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL REFERENCES jobs(id),
+      status TEXT NOT NULL DEFAULT 'pending',
+      applied_at INTEGER,
+      resume_id TEXT,
+      cover_letter TEXT,
+      answers TEXT,
+      notes TEXT,
+      last_activity_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+  // Email threads table - links email conversations to applications
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS email_threads (
+      id TEXT PRIMARY KEY,
+      application_id TEXT NOT NULL REFERENCES applications(id),
+      gmail_thread_id TEXT,
+      subject TEXT NOT NULL,
+      from_email TEXT NOT NULL,
+      last_message_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      message_count INTEGER NOT NULL DEFAULT 1,
+      metadata TEXT
+    );
+  `);
+
+  // Resumes table - stores resume metadata and parsed data
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS resumes (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      file_path TEXT NOT NULL,
+      file_type TEXT NOT NULL,
+      parsed_data TEXT,
+      is_default INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+  // Preferences table - key-value store for user preferences
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS preferences (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+  // Application history table - tracks status changes over time
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS application_history (
+      id TEXT PRIMARY KEY,
+      application_id TEXT NOT NULL REFERENCES applications(id),
+      old_status TEXT,
+      new_status TEXT NOT NULL,
+      changed_at INTEGER NOT NULL,
+      notes TEXT
+    );
+  `);
+
+  // Create indexes for common queries
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_jobs_source ON jobs(source);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_jobs_company ON jobs(company);`);
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_jobs_discovered_at ON jobs(discovered_at);`,
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_jobs_external_id ON jobs(external_id);`,
+  );
+
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_applications_status ON applications(status);`,
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_applications_job_id ON applications(job_id);`,
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_applications_applied_at ON applications(applied_at);`,
+  );
+
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_email_threads_application_id ON email_threads(application_id);`,
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_email_threads_gmail_thread_id ON email_threads(gmail_thread_id);`,
+  );
+
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_application_history_application_id ON application_history(application_id);`,
+  );
+}
+
+/**
+ * Database row types matching the schema
+ */
+export type JobRow = {
+  id: string;
+  external_id: string | null;
+  source: string;
+  company: string;
+  title: string;
+  location: string | null;
+  salary_min: number | null;
+  salary_max: number | null;
+  salary_currency: string | null;
+  description: string | null;
+  requirements: string | null;
+  tech_stack: string | null;
+  url: string;
+  posted_at: number | null;
+  discovered_at: number;
+  status: string;
+  metadata: string | null;
+};
+
+export type ApplicationRow = {
+  id: string;
+  job_id: string;
+  status: string;
+  applied_at: number | null;
+  resume_id: string | null;
+  cover_letter: string | null;
+  answers: string | null;
+  notes: string | null;
+  last_activity_at: number;
+  created_at: number;
+  updated_at: number;
+};
+
+export type EmailThreadRow = {
+  id: string;
+  application_id: string;
+  gmail_thread_id: string | null;
+  subject: string;
+  from_email: string;
+  last_message_at: number;
+  status: string;
+  message_count: number;
+  metadata: string | null;
+};
+
+export type ResumeRow = {
+  id: string;
+  name: string;
+  file_path: string;
+  file_type: string;
+  parsed_data: string | null;
+  is_default: number;
+  created_at: number;
+  updated_at: number;
+};
+
+export type PreferenceRow = {
+  key: string;
+  value: string;
+  updated_at: number;
+};
+
+export type ApplicationHistoryRow = {
+  id: string;
+  application_id: string;
+  old_status: string | null;
+  new_status: string;
+  changed_at: number;
+  notes: string | null;
+};

--- a/extensions/job-application/src/db/store.test.ts
+++ b/extensions/job-application/src/db/store.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for Job Application Store
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { JobStore } from "./store.js";
+import type { JobSource, ApplicationStatus } from "../types.js";
+
+describe("JobStore", () => {
+  let tempDir: string;
+  let store: JobStore;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "jobbot-test-"));
+    const dbPath = join(tempDir, "test.sqlite");
+    const resumesDir = join(tempDir, "resumes");
+    store = new JobStore(dbPath, resumesDir);
+  });
+
+  afterEach(() => {
+    store.close();
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  describe("Jobs", () => {
+    it("should create a job", () => {
+      const job = store.createJob({
+        externalId: "indeed-123",
+        source: "indeed" as JobSource,
+        company: "Acme Corp",
+        title: "Software Engineer",
+        location: "Remote",
+        salaryMin: 120000,
+        salaryMax: 150000,
+        url: "https://indeed.com/job/123",
+      });
+
+      expect(job.id).toBeDefined();
+      expect(job.company).toBe("Acme Corp");
+      expect(job.title).toBe("Software Engineer");
+      expect(job.status).toBe("new");
+      expect(job.discoveredAt).toBeDefined();
+    });
+
+    it("should get a job by ID", () => {
+      const created = store.createJob({
+        source: "linkedin" as JobSource,
+        company: "TechStart",
+        title: "Full Stack Developer",
+        url: "https://linkedin.com/jobs/456",
+      });
+
+      const retrieved = store.getJob(created.id);
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.id).toBe(created.id);
+      expect(retrieved!.company).toBe("TechStart");
+    });
+
+    it("should get a job by external ID", () => {
+      store.createJob({
+        externalId: "gh-789",
+        source: "greenhouse" as JobSource,
+        company: "DataFlow",
+        title: "Backend Engineer",
+        url: "https://greenhouse.io/job/789",
+      });
+
+      const retrieved = store.getJobByExternalId("gh-789", "greenhouse");
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.company).toBe("DataFlow");
+    });
+
+    it("should list jobs with filters", () => {
+      store.createJob({
+        source: "indeed" as JobSource,
+        company: "Company A",
+        title: "Job A",
+        url: "https://example.com/a",
+      });
+
+      store.createJob({
+        source: "linkedin" as JobSource,
+        company: "Company B",
+        title: "Job B",
+        url: "https://example.com/b",
+      });
+
+      const allJobs = store.listJobs();
+      expect(allJobs.length).toBe(2);
+
+      const indeedJobs = store.listJobs({ source: "indeed" });
+      expect(indeedJobs.length).toBe(1);
+      expect(indeedJobs[0].company).toBe("Company A");
+    });
+
+    it("should update job status", () => {
+      const job = store.createJob({
+        source: "indeed" as JobSource,
+        company: "Test Co",
+        title: "Test Job",
+        url: "https://example.com/test",
+      });
+
+      expect(job.status).toBe("new");
+
+      store.updateJobStatus(job.id, "approved");
+
+      const updated = store.getJob(job.id);
+      expect(updated!.status).toBe("approved");
+    });
+  });
+
+  describe("Applications", () => {
+    let jobId: string;
+
+    beforeEach(() => {
+      const job = store.createJob({
+        source: "indeed" as JobSource,
+        company: "Acme Corp",
+        title: "Software Engineer",
+        url: "https://example.com/job",
+      });
+      jobId = job.id;
+    });
+
+    it("should create an application", () => {
+      const app = store.createApplication({
+        jobId,
+        coverLetter: "Dear Hiring Manager...",
+        notes: "Good match",
+      });
+
+      expect(app.id).toBeDefined();
+      expect(app.jobId).toBe(jobId);
+      expect(app.status).toBe("pending");
+      expect(app.coverLetter).toBe("Dear Hiring Manager...");
+    });
+
+    it("should get application by ID", () => {
+      const created = store.createApplication({ jobId });
+
+      const retrieved = store.getApplication(created.id);
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.id).toBe(created.id);
+    });
+
+    it("should get application by job ID", () => {
+      store.createApplication({ jobId });
+
+      const retrieved = store.getApplicationByJobId(jobId);
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.jobId).toBe(jobId);
+    });
+
+    it("should update application status", () => {
+      const app = store.createApplication({ jobId });
+
+      store.updateApplicationStatus(app.id, "submitted" as ApplicationStatus);
+
+      const updated = store.getApplication(app.id);
+      expect(updated!.status).toBe("submitted");
+      expect(updated!.appliedAt).toBeDefined();
+    });
+
+    it("should list applications with filters", () => {
+      const app1 = store.createApplication({ jobId });
+      store.updateApplicationStatus(app1.id, "submitted" as ApplicationStatus);
+
+      // Create another job and application
+      const job2 = store.createJob({
+        source: "linkedin" as JobSource,
+        company: "Other Co",
+        title: "Other Job",
+        url: "https://example.com/other",
+      });
+      store.createApplication({ jobId: job2.id });
+
+      const allApps = store.listApplications();
+      expect(allApps.length).toBe(2);
+
+      const submittedApps = store.listApplications({ status: "submitted" });
+      expect(submittedApps.length).toBe(1);
+    });
+  });
+
+  describe("Resumes", () => {
+    it("should create a resume", () => {
+      const resume = store.createResume({
+        name: "My Resume",
+        filePath: "/path/to/resume.pdf",
+        fileType: "pdf",
+        isDefault: true,
+      });
+
+      expect(resume.id).toBeDefined();
+      expect(resume.name).toBe("My Resume");
+      expect(resume.isDefault).toBe(true);
+    });
+
+    it("should get default resume", () => {
+      store.createResume({
+        name: "Resume 1",
+        filePath: "/path/to/1.pdf",
+        fileType: "pdf",
+        isDefault: false,
+      });
+
+      store.createResume({
+        name: "Resume 2",
+        filePath: "/path/to/2.pdf",
+        fileType: "pdf",
+        isDefault: true,
+      });
+
+      const defaultResume = store.getDefaultResume();
+
+      expect(defaultResume).not.toBeNull();
+      expect(defaultResume!.name).toBe("Resume 2");
+    });
+
+    it("should set default resume", () => {
+      const resume1 = store.createResume({
+        name: "Resume 1",
+        filePath: "/path/to/1.pdf",
+        fileType: "pdf",
+        isDefault: true,
+      });
+
+      const resume2 = store.createResume({
+        name: "Resume 2",
+        filePath: "/path/to/2.pdf",
+        fileType: "pdf",
+        isDefault: false,
+      });
+
+      store.setDefaultResume(resume2.id);
+
+      const updated1 = store.getResume(resume1.id);
+      const updated2 = store.getResume(resume2.id);
+
+      expect(updated1!.isDefault).toBe(false);
+      expect(updated2!.isDefault).toBe(true);
+    });
+
+    it("should delete a resume", () => {
+      const resume = store.createResume({
+        name: "To Delete",
+        filePath: "/path/to/delete.pdf",
+        fileType: "pdf",
+      });
+
+      store.deleteResume(resume.id);
+
+      const deleted = store.getResume(resume.id);
+      expect(deleted).toBeNull();
+    });
+  });
+
+  describe("Email Threads", () => {
+    let applicationId: string;
+
+    beforeEach(() => {
+      const job = store.createJob({
+        source: "indeed" as JobSource,
+        company: "Acme Corp",
+        title: "Software Engineer",
+        url: "https://example.com/job",
+      });
+      const app = store.createApplication({ jobId: job.id });
+      applicationId = app.id;
+    });
+
+    it("should create an email thread", () => {
+      const thread = store.createEmailThread({
+        applicationId,
+        gmailThreadId: "gmail-abc123",
+        subject: "Re: Your Application",
+        fromEmail: "hr@acme.com",
+      });
+
+      expect(thread.id).toBeDefined();
+      expect(thread.applicationId).toBe(applicationId);
+      expect(thread.subject).toBe("Re: Your Application");
+    });
+
+    it("should get email thread by Gmail ID", () => {
+      store.createEmailThread({
+        applicationId,
+        gmailThreadId: "gmail-xyz789",
+        subject: "Interview Request",
+        fromEmail: "recruiter@acme.com",
+      });
+
+      const retrieved = store.getEmailThreadByGmailId("gmail-xyz789");
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.subject).toBe("Interview Request");
+    });
+
+    it("should list email threads for application", () => {
+      store.createEmailThread({
+        applicationId,
+        subject: "Thread 1",
+        fromEmail: "a@example.com",
+      });
+
+      store.createEmailThread({
+        applicationId,
+        subject: "Thread 2",
+        fromEmail: "b@example.com",
+      });
+
+      const threads = store.listEmailThreadsForApplication(applicationId);
+
+      expect(threads.length).toBe(2);
+    });
+  });
+
+  describe("Statistics", () => {
+    it("should return correct stats", () => {
+      // Create some jobs
+      const job1 = store.createJob({
+        source: "indeed" as JobSource,
+        company: "A",
+        title: "Job A",
+        url: "https://a.com",
+      });
+
+      const job2 = store.createJob({
+        source: "linkedin" as JobSource,
+        company: "B",
+        title: "Job B",
+        url: "https://b.com",
+      });
+
+      // Create applications
+      const app1 = store.createApplication({ jobId: job1.id });
+      store.updateApplicationStatus(app1.id, "submitted" as ApplicationStatus);
+      store.updateApplicationStatus(app1.id, "interview" as ApplicationStatus);
+
+      const app2 = store.createApplication({ jobId: job2.id });
+      store.updateApplicationStatus(app2.id, "submitted" as ApplicationStatus);
+      store.updateApplicationStatus(app2.id, "rejected" as ApplicationStatus);
+
+      const stats = store.getStats();
+
+      expect(stats.totalJobs).toBe(2);
+      expect(stats.interviewsScheduled).toBe(1);
+      expect(stats.rejections).toBe(1);
+    });
+  });
+});

--- a/extensions/job-application/src/db/store.ts
+++ b/extensions/job-application/src/db/store.ts
@@ -1,0 +1,735 @@
+/**
+ * Data access layer for Job Application plugin
+ * Provides typed methods for CRUD operations on all entities
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+
+import {
+  ensureJobApplicationSchema,
+  type JobRow,
+  type ApplicationRow,
+  type EmailThreadRow,
+  type ResumeRow,
+  type ApplicationHistoryRow,
+} from "./schema.js";
+import type {
+  Job,
+  JobStatus,
+  Application,
+  ApplicationStatus,
+  ApplicationAnswer,
+  EmailThread,
+  EmailThreadStatus,
+  Resume,
+  ParsedResumeData,
+  JobStats,
+  TimelineEntry,
+  JobSource,
+} from "../types.js";
+
+// =============================================================================
+// Store Class
+// =============================================================================
+
+export class JobStore {
+  private db: DatabaseSync | null = null;
+  private initPromise: Promise<void> | null = null;
+
+  constructor(
+    private readonly dbPath: string,
+    private readonly resumesDir: string,
+  ) {}
+
+  // ===========================================================================
+  // Initialization
+  // ===========================================================================
+
+  private ensureInitialized(): void {
+    if (this.db) return;
+
+    // Ensure directories exist
+    const dbDir = dirname(this.dbPath);
+    if (!existsSync(dbDir)) {
+      mkdirSync(dbDir, { recursive: true, mode: 0o700 });
+    }
+    if (!existsSync(this.resumesDir)) {
+      mkdirSync(this.resumesDir, { recursive: true, mode: 0o700 });
+    }
+
+    // Open database
+    this.db = new DatabaseSync(this.dbPath);
+    ensureJobApplicationSchema(this.db);
+  }
+
+  // ===========================================================================
+  // Jobs
+  // ===========================================================================
+
+  createJob(job: Omit<Job, "id" | "discoveredAt" | "status">): Job {
+    this.ensureInitialized();
+    const now = Date.now();
+    const id = randomUUID();
+
+    const fullJob: Job = {
+      ...job,
+      id,
+      discoveredAt: now,
+      status: "new",
+    };
+
+    this.db!.prepare(
+      `
+      INSERT INTO jobs (
+        id, external_id, source, company, title, location,
+        salary_min, salary_max, salary_currency, description,
+        requirements, tech_stack, url, posted_at, discovered_at,
+        status, metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    ).run(
+      fullJob.id,
+      fullJob.externalId ?? null,
+      fullJob.source,
+      fullJob.company,
+      fullJob.title,
+      fullJob.location ?? null,
+      fullJob.salaryMin ?? null,
+      fullJob.salaryMax ?? null,
+      fullJob.salaryCurrency ?? "USD",
+      fullJob.description ?? null,
+      fullJob.requirements ? JSON.stringify(fullJob.requirements) : null,
+      fullJob.techStack ? JSON.stringify(fullJob.techStack) : null,
+      fullJob.url,
+      fullJob.postedAt ?? null,
+      fullJob.discoveredAt,
+      fullJob.status,
+      fullJob.metadata ? JSON.stringify(fullJob.metadata) : null,
+    );
+
+    return fullJob;
+  }
+
+  getJob(id: string): Job | null {
+    this.ensureInitialized();
+    const row = this.db!.prepare(`SELECT * FROM jobs WHERE id = ?`).get(id) as
+      | JobRow
+      | undefined;
+    return row ? this.rowToJob(row) : null;
+  }
+
+  getJobByExternalId(externalId: string, source: JobSource): Job | null {
+    this.ensureInitialized();
+    const row = this.db!.prepare(
+      `SELECT * FROM jobs WHERE external_id = ? AND source = ?`,
+    ).get(externalId, source) as JobRow | undefined;
+    return row ? this.rowToJob(row) : null;
+  }
+
+  listJobs(params?: {
+    status?: JobStatus;
+    source?: JobSource;
+    company?: string;
+    limit?: number;
+    offset?: number;
+  }): Job[] {
+    this.ensureInitialized();
+    const conditions: string[] = [];
+    const args: unknown[] = [];
+
+    if (params?.status) {
+      conditions.push("status = ?");
+      args.push(params.status);
+    }
+    if (params?.source) {
+      conditions.push("source = ?");
+      args.push(params.source);
+    }
+    if (params?.company) {
+      conditions.push("company LIKE ?");
+      args.push(`%${params.company}%`);
+    }
+
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const limit = params?.limit ?? 100;
+    const offset = params?.offset ?? 0;
+
+    const rows = this.db!.prepare(
+      `SELECT * FROM jobs ${whereClause} ORDER BY discovered_at DESC LIMIT ? OFFSET ?`,
+    ).all(...args, limit, offset) as JobRow[];
+
+    return rows.map((row) => this.rowToJob(row));
+  }
+
+  updateJobStatus(id: string, status: JobStatus): void {
+    this.ensureInitialized();
+    this.db!.prepare(`UPDATE jobs SET status = ? WHERE id = ?`).run(status, id);
+  }
+
+  updateJob(
+    id: string,
+    updates: Partial<Omit<Job, "id" | "discoveredAt">>,
+  ): void {
+    this.ensureInitialized();
+    const setClauses: string[] = [];
+    const args: unknown[] = [];
+
+    if (updates.status !== undefined) {
+      setClauses.push("status = ?");
+      args.push(updates.status);
+    }
+    if (updates.description !== undefined) {
+      setClauses.push("description = ?");
+      args.push(updates.description);
+    }
+    if (updates.requirements !== undefined) {
+      setClauses.push("requirements = ?");
+      args.push(JSON.stringify(updates.requirements));
+    }
+    if (updates.techStack !== undefined) {
+      setClauses.push("tech_stack = ?");
+      args.push(JSON.stringify(updates.techStack));
+    }
+    if (updates.metadata !== undefined) {
+      setClauses.push("metadata = ?");
+      args.push(JSON.stringify(updates.metadata));
+    }
+
+    if (setClauses.length === 0) return;
+
+    args.push(id);
+    this.db!.prepare(
+      `UPDATE jobs SET ${setClauses.join(", ")} WHERE id = ?`,
+    ).run(...args);
+  }
+
+  private rowToJob(row: JobRow): Job {
+    return {
+      id: row.id,
+      externalId: row.external_id ?? undefined,
+      source: row.source as JobSource,
+      company: row.company,
+      title: row.title,
+      location: row.location ?? undefined,
+      salaryMin: row.salary_min ?? undefined,
+      salaryMax: row.salary_max ?? undefined,
+      salaryCurrency: row.salary_currency ?? undefined,
+      description: row.description ?? undefined,
+      requirements: row.requirements ? JSON.parse(row.requirements) : undefined,
+      techStack: row.tech_stack ? JSON.parse(row.tech_stack) : undefined,
+      url: row.url,
+      postedAt: row.posted_at ?? undefined,
+      discoveredAt: row.discovered_at,
+      status: row.status as JobStatus,
+      metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+    };
+  }
+
+  // ===========================================================================
+  // Applications
+  // ===========================================================================
+
+  createApplication(params: {
+    jobId: string;
+    resumeId?: string;
+    coverLetter?: string;
+    answers?: ApplicationAnswer[];
+    notes?: string;
+  }): Application {
+    this.ensureInitialized();
+    const now = Date.now();
+    const id = randomUUID();
+
+    const application: Application = {
+      id,
+      jobId: params.jobId,
+      status: "pending",
+      appliedAt: undefined,
+      resumeId: params.resumeId,
+      coverLetter: params.coverLetter,
+      answers: params.answers,
+      notes: params.notes,
+      lastActivityAt: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db!.prepare(
+      `
+      INSERT INTO applications (
+        id, job_id, status, applied_at, resume_id, cover_letter,
+        answers, notes, last_activity_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    ).run(
+      application.id,
+      application.jobId,
+      application.status,
+      application.appliedAt ?? null,
+      application.resumeId ?? null,
+      application.coverLetter ?? null,
+      application.answers ? JSON.stringify(application.answers) : null,
+      application.notes ?? null,
+      application.lastActivityAt,
+      application.createdAt,
+      application.updatedAt,
+    );
+
+    return application;
+  }
+
+  getApplication(id: string): Application | null {
+    this.ensureInitialized();
+    const row = this.db!.prepare(`SELECT * FROM applications WHERE id = ?`).get(
+      id,
+    ) as ApplicationRow | undefined;
+    return row ? this.rowToApplication(row) : null;
+  }
+
+  getApplicationByJobId(jobId: string): Application | null {
+    this.ensureInitialized();
+    const row = this.db!.prepare(
+      `SELECT * FROM applications WHERE job_id = ?`,
+    ).get(jobId) as ApplicationRow | undefined;
+    return row ? this.rowToApplication(row) : null;
+  }
+
+  listApplications(params?: {
+    status?: ApplicationStatus;
+    limit?: number;
+    offset?: number;
+  }): Application[] {
+    this.ensureInitialized();
+    const conditions: string[] = [];
+    const args: unknown[] = [];
+
+    if (params?.status) {
+      conditions.push("status = ?");
+      args.push(params.status);
+    }
+
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const limit = params?.limit ?? 100;
+    const offset = params?.offset ?? 0;
+
+    const rows = this.db!.prepare(
+      `SELECT * FROM applications ${whereClause} ORDER BY updated_at DESC LIMIT ? OFFSET ?`,
+    ).all(...args, limit, offset) as ApplicationRow[];
+
+    return rows.map((row) => this.rowToApplication(row));
+  }
+
+  updateApplicationStatus(
+    id: string,
+    status: ApplicationStatus,
+    notes?: string,
+  ): void {
+    this.ensureInitialized();
+    const now = Date.now();
+    const app = this.getApplication(id);
+    if (!app) return;
+
+    // Update application
+    this.db!.prepare(
+      `
+      UPDATE applications
+      SET status = ?, last_activity_at = ?, updated_at = ?, applied_at = COALESCE(applied_at, ?)
+      WHERE id = ?
+    `,
+    ).run(status, now, now, status === "submitted" ? now : null, id);
+
+    // Record history
+    const historyId = randomUUID();
+    this.db!.prepare(
+      `
+      INSERT INTO application_history (id, application_id, old_status, new_status, changed_at, notes)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `,
+    ).run(historyId, id, app.status, status, now, notes ?? null);
+  }
+
+  private rowToApplication(row: ApplicationRow): Application {
+    return {
+      id: row.id,
+      jobId: row.job_id,
+      status: row.status as ApplicationStatus,
+      appliedAt: row.applied_at ?? undefined,
+      resumeId: row.resume_id ?? undefined,
+      coverLetter: row.cover_letter ?? undefined,
+      answers: row.answers ? JSON.parse(row.answers) : undefined,
+      notes: row.notes ?? undefined,
+      lastActivityAt: row.last_activity_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  // ===========================================================================
+  // Email Threads
+  // ===========================================================================
+
+  createEmailThread(params: {
+    applicationId: string;
+    gmailThreadId?: string;
+    subject: string;
+    fromEmail: string;
+  }): EmailThread {
+    this.ensureInitialized();
+    const now = Date.now();
+    const id = randomUUID();
+
+    const thread: EmailThread = {
+      id,
+      applicationId: params.applicationId,
+      gmailThreadId: params.gmailThreadId,
+      subject: params.subject,
+      fromEmail: params.fromEmail,
+      lastMessageAt: now,
+      status: "active",
+      messageCount: 1,
+    };
+
+    this.db!.prepare(
+      `
+      INSERT INTO email_threads (
+        id, application_id, gmail_thread_id, subject, from_email,
+        last_message_at, status, message_count, metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    ).run(
+      thread.id,
+      thread.applicationId,
+      thread.gmailThreadId ?? null,
+      thread.subject,
+      thread.fromEmail,
+      thread.lastMessageAt,
+      thread.status,
+      thread.messageCount,
+      null,
+    );
+
+    return thread;
+  }
+
+  getEmailThreadByGmailId(gmailThreadId: string): EmailThread | null {
+    this.ensureInitialized();
+    const row = this.db!.prepare(
+      `SELECT * FROM email_threads WHERE gmail_thread_id = ?`,
+    ).get(gmailThreadId) as EmailThreadRow | undefined;
+    return row ? this.rowToEmailThread(row) : null;
+  }
+
+  listEmailThreadsForApplication(applicationId: string): EmailThread[] {
+    this.ensureInitialized();
+    const rows = this.db!.prepare(
+      `SELECT * FROM email_threads WHERE application_id = ? ORDER BY last_message_at DESC`,
+    ).all(applicationId) as EmailThreadRow[];
+    return rows.map((row) => this.rowToEmailThread(row));
+  }
+
+  updateEmailThread(id: string, updates: Partial<EmailThread>): void {
+    this.ensureInitialized();
+    const now = Date.now();
+    const setClauses: string[] = [];
+    const args: unknown[] = [];
+
+    if (updates.status !== undefined) {
+      setClauses.push("status = ?");
+      args.push(updates.status);
+    }
+    if (updates.messageCount !== undefined) {
+      setClauses.push("message_count = ?");
+      args.push(updates.messageCount);
+    }
+    if (updates.lastMessageAt !== undefined) {
+      setClauses.push("last_message_at = ?");
+      args.push(updates.lastMessageAt);
+    }
+
+    if (setClauses.length === 0) return;
+
+    args.push(id);
+    this.db!.prepare(
+      `UPDATE email_threads SET ${setClauses.join(", ")} WHERE id = ?`,
+    ).run(...args);
+  }
+
+  private rowToEmailThread(row: EmailThreadRow): EmailThread {
+    return {
+      id: row.id,
+      applicationId: row.application_id,
+      gmailThreadId: row.gmail_thread_id ?? undefined,
+      subject: row.subject,
+      fromEmail: row.from_email,
+      lastMessageAt: row.last_message_at,
+      status: row.status as EmailThreadStatus,
+      messageCount: row.message_count,
+      metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+    };
+  }
+
+  // ===========================================================================
+  // Resumes
+  // ===========================================================================
+
+  createResume(params: {
+    name: string;
+    filePath: string;
+    fileType: "pdf" | "docx" | "txt";
+    parsedData?: ParsedResumeData;
+    isDefault?: boolean;
+  }): Resume {
+    this.ensureInitialized();
+    const now = Date.now();
+    const id = randomUUID();
+
+    // If this is the default, clear other defaults
+    if (params.isDefault) {
+      this.db!.prepare(`UPDATE resumes SET is_default = 0`).run();
+    }
+
+    const resume: Resume = {
+      id,
+      name: params.name,
+      filePath: params.filePath,
+      fileType: params.fileType,
+      parsedData: params.parsedData,
+      isDefault: params.isDefault ?? false,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db!.prepare(
+      `
+      INSERT INTO resumes (
+        id, name, file_path, file_type, parsed_data, is_default, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    ).run(
+      resume.id,
+      resume.name,
+      resume.filePath,
+      resume.fileType,
+      resume.parsedData ? JSON.stringify(resume.parsedData) : null,
+      resume.isDefault ? 1 : 0,
+      resume.createdAt,
+      resume.updatedAt,
+    );
+
+    return resume;
+  }
+
+  getResume(id: string): Resume | null {
+    this.ensureInitialized();
+    const row = this.db!.prepare(`SELECT * FROM resumes WHERE id = ?`).get(
+      id,
+    ) as ResumeRow | undefined;
+    return row ? this.rowToResume(row) : null;
+  }
+
+  getDefaultResume(): Resume | null {
+    this.ensureInitialized();
+    const row = this.db!.prepare(
+      `SELECT * FROM resumes WHERE is_default = 1`,
+    ).get() as ResumeRow | undefined;
+    return row ? this.rowToResume(row) : null;
+  }
+
+  listResumes(): Resume[] {
+    this.ensureInitialized();
+    const rows = this.db!.prepare(
+      `SELECT * FROM resumes ORDER BY is_default DESC, created_at DESC`,
+    ).all() as ResumeRow[];
+    return rows.map((row) => this.rowToResume(row));
+  }
+
+  setDefaultResume(id: string): void {
+    this.ensureInitialized();
+    this.db!.prepare(`UPDATE resumes SET is_default = 0`).run();
+    this.db!.prepare(`UPDATE resumes SET is_default = 1 WHERE id = ?`).run(id);
+  }
+
+  deleteResume(id: string): void {
+    this.ensureInitialized();
+    this.db!.prepare(`DELETE FROM resumes WHERE id = ?`).run(id);
+  }
+
+  private rowToResume(row: ResumeRow): Resume {
+    return {
+      id: row.id,
+      name: row.name,
+      filePath: row.file_path,
+      fileType: row.file_type as "pdf" | "docx" | "txt",
+      parsedData: row.parsed_data ? JSON.parse(row.parsed_data) : undefined,
+      isDefault: row.is_default === 1,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  // ===========================================================================
+  // Statistics
+  // ===========================================================================
+
+  getStats(): JobStats {
+    this.ensureInitialized();
+
+    const totalJobs = (
+      this.db!.prepare(`SELECT COUNT(*) as count FROM jobs`).get() as {
+        count: number;
+      }
+    ).count;
+    const newJobs = (
+      this.db!.prepare(
+        `SELECT COUNT(*) as count FROM jobs WHERE status = 'new'`,
+      ).get() as {
+        count: number;
+      }
+    ).count;
+    const appliedJobs = (
+      this.db!.prepare(
+        `SELECT COUNT(*) as count FROM jobs WHERE status = 'applied'`,
+      ).get() as {
+        count: number;
+      }
+    ).count;
+
+    const pendingApplications = (
+      this.db!.prepare(
+        `SELECT COUNT(*) as count FROM applications WHERE status = 'pending'`,
+      ).get() as { count: number }
+    ).count;
+    const interviewsScheduled = (
+      this.db!.prepare(
+        `SELECT COUNT(*) as count FROM applications WHERE status = 'interview'`,
+      ).get() as { count: number }
+    ).count;
+    const offersReceived = (
+      this.db!.prepare(
+        `SELECT COUNT(*) as count FROM applications WHERE status = 'offer'`,
+      ).get() as { count: number }
+    ).count;
+    const rejections = (
+      this.db!.prepare(
+        `SELECT COUNT(*) as count FROM applications WHERE status = 'rejected'`,
+      ).get() as { count: number }
+    ).count;
+
+    // Get counts by source
+    const bySourceRows = this.db!.prepare(
+      `SELECT source, COUNT(*) as count FROM jobs GROUP BY source`,
+    ).all() as Array<{ source: string; count: number }>;
+    const bySource = {} as Record<JobSource, number>;
+    for (const row of bySourceRows) {
+      bySource[row.source as JobSource] = row.count;
+    }
+
+    // Get counts by job status
+    const byStatusRows = this.db!.prepare(
+      `SELECT status, COUNT(*) as count FROM jobs GROUP BY status`,
+    ).all() as Array<{ status: string; count: number }>;
+    const byStatus = {} as Record<string, number>;
+    for (const row of byStatusRows) {
+      byStatus[row.status] = row.count;
+    }
+
+    // Get counts by application status
+    const appByStatusRows = this.db!.prepare(
+      `SELECT status, COUNT(*) as count FROM applications GROUP BY status`,
+    ).all() as Array<{ status: string; count: number }>;
+    const applicationsByStatus = {} as Record<string, number>;
+    for (const row of appByStatusRows) {
+      applicationsByStatus[row.status] = row.count;
+    }
+
+    return {
+      totalJobs,
+      newJobs,
+      appliedJobs,
+      pendingApplications,
+      interviewsScheduled,
+      offersReceived,
+      rejections,
+      bySource,
+      byStatus: byStatus as Record<JobStatus, number>,
+      applicationsByStatus: applicationsByStatus as Record<
+        ApplicationStatus,
+        number
+      >,
+    };
+  }
+
+  getTimeline(days: number = 30): TimelineEntry[] {
+    this.ensureInitialized();
+    const now = Date.now();
+    const startTime = now - days * 24 * 60 * 60 * 1000;
+
+    // Get jobs discovered per day
+    const jobsPerDay = this.db!.prepare(
+      `
+      SELECT date(discovered_at / 1000, 'unixepoch') as date, COUNT(*) as count
+      FROM jobs
+      WHERE discovered_at >= ?
+      GROUP BY date(discovered_at / 1000, 'unixepoch')
+      ORDER BY date
+    `,
+    ).all(startTime) as Array<{ date: string; count: number }>;
+
+    // Get applications per day
+    const appsPerDay = this.db!.prepare(
+      `
+      SELECT date(applied_at / 1000, 'unixepoch') as date, COUNT(*) as count
+      FROM applications
+      WHERE applied_at IS NOT NULL AND applied_at >= ?
+      GROUP BY date(applied_at / 1000, 'unixepoch')
+      ORDER BY date
+    `,
+    ).all(startTime) as Array<{ date: string; count: number }>;
+
+    // Combine into timeline
+    const timeline = new Map<string, TimelineEntry>();
+
+    for (const row of jobsPerDay) {
+      timeline.set(row.date, {
+        date: row.date,
+        jobsDiscovered: row.count,
+        applicationsSubmitted: 0,
+        responsesReceived: 0,
+      });
+    }
+
+    for (const row of appsPerDay) {
+      const existing = timeline.get(row.date);
+      if (existing) {
+        existing.applicationsSubmitted = row.count;
+      } else {
+        timeline.set(row.date, {
+          date: row.date,
+          jobsDiscovered: 0,
+          applicationsSubmitted: row.count,
+          responsesReceived: 0,
+        });
+      }
+    }
+
+    return Array.from(timeline.values()).sort((a, b) =>
+      a.date.localeCompare(b.date),
+    );
+  }
+
+  // ===========================================================================
+  // Cleanup
+  // ===========================================================================
+
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+}

--- a/extensions/job-application/src/gateway/methods.ts
+++ b/extensions/job-application/src/gateway/methods.ts
@@ -1,0 +1,461 @@
+/**
+ * Gateway RPC methods for Job Application plugin
+ *
+ * These methods are exposed via WebSocket to the web UI
+ * for managing jobs, applications, resumes, and preferences.
+ */
+
+import type { MoltbotPluginApi } from "../../../../src/plugins/types.js";
+import type { JobStore } from "../db/store.js";
+import type {
+  JobApplicationConfig,
+  JobStatus,
+  ApplicationStatus,
+  JobSource,
+} from "../types.js";
+
+/**
+ * Register all gateway methods for the job application plugin.
+ */
+export function registerGatewayMethods(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+): void {
+  // ==========================================================================
+  // Job Methods
+  // ==========================================================================
+
+  /**
+   * List jobs with optional filters
+   */
+  api.registerGatewayMethod("jobbot.jobs.list", ({ params, respond }) => {
+    try {
+      const { status, source, company, limit, offset } = (params ?? {}) as {
+        status?: JobStatus;
+        source?: JobSource;
+        company?: string;
+        limit?: number;
+        offset?: number;
+      };
+
+      const jobs = store.listJobs({ status, source, company, limit, offset });
+      respond(true, { jobs, count: jobs.length });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  /**
+   * Get a specific job by ID
+   */
+  api.registerGatewayMethod("jobbot.jobs.get", ({ params, respond }) => {
+    try {
+      const { id } = (params ?? {}) as { id: string };
+      if (!id) {
+        respond(false, { error: "Missing job id" });
+        return;
+      }
+
+      const job = store.getJob(id);
+      if (!job) {
+        respond(false, { error: "Job not found" });
+        return;
+      }
+
+      const application = store.getApplicationByJobId(id);
+      respond(true, { job, application });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  /**
+   * Update a job's status
+   */
+  api.registerGatewayMethod("jobbot.jobs.update", ({ params, respond }) => {
+    try {
+      const { id, status, metadata } = (params ?? {}) as {
+        id: string;
+        status?: JobStatus;
+        metadata?: Record<string, unknown>;
+      };
+
+      if (!id) {
+        respond(false, { error: "Missing job id" });
+        return;
+      }
+
+      if (status) {
+        store.updateJobStatus(id, status);
+      }
+      if (metadata) {
+        store.updateJob(id, { metadata });
+      }
+
+      const job = store.getJob(id);
+      respond(true, { job });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  // ==========================================================================
+  // Application Methods
+  // ==========================================================================
+
+  /**
+   * List applications with optional filters
+   */
+  api.registerGatewayMethod(
+    "jobbot.applications.list",
+    ({ params, respond }) => {
+      try {
+        const { status, limit, offset } = (params ?? {}) as {
+          status?: ApplicationStatus;
+          limit?: number;
+          offset?: number;
+        };
+
+        const applications = store.listApplications({ status, limit, offset });
+
+        // Enrich with job data
+        const enriched = applications.map((app) => {
+          const job = store.getJob(app.jobId);
+          return {
+            ...app,
+            job: job
+              ? {
+                  id: job.id,
+                  company: job.company,
+                  title: job.title,
+                  location: job.location,
+                  url: job.url,
+                }
+              : null,
+          };
+        });
+
+        respond(true, { applications: enriched, count: enriched.length });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        respond(false, { error: message });
+      }
+    },
+  );
+
+  /**
+   * Get a specific application by ID
+   */
+  api.registerGatewayMethod(
+    "jobbot.applications.get",
+    ({ params, respond }) => {
+      try {
+        const { id } = (params ?? {}) as { id: string };
+        if (!id) {
+          respond(false, { error: "Missing application id" });
+          return;
+        }
+
+        const application = store.getApplication(id);
+        if (!application) {
+          respond(false, { error: "Application not found" });
+          return;
+        }
+
+        const job = store.getJob(application.jobId);
+        const emailThreads = store.listEmailThreadsForApplication(id);
+
+        respond(true, { application, job, emailThreads });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        respond(false, { error: message });
+      }
+    },
+  );
+
+  /**
+   * Create a new application
+   */
+  api.registerGatewayMethod(
+    "jobbot.applications.create",
+    ({ params, respond }) => {
+      try {
+        const { jobId, resumeId, coverLetter, answers, notes } = (params ??
+          {}) as {
+          jobId: string;
+          resumeId?: string;
+          coverLetter?: string;
+          answers?: Array<{ question: string; answer: string }>;
+          notes?: string;
+        };
+
+        if (!jobId) {
+          respond(false, { error: "Missing jobId" });
+          return;
+        }
+
+        // Check if application already exists
+        const existing = store.getApplicationByJobId(jobId);
+        if (existing) {
+          respond(false, {
+            error: "Application already exists for this job",
+            applicationId: existing.id,
+          });
+          return;
+        }
+
+        const application = store.createApplication({
+          jobId,
+          resumeId,
+          coverLetter,
+          answers,
+          notes,
+        });
+
+        respond(true, { application });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        respond(false, { error: message });
+      }
+    },
+  );
+
+  /**
+   * Update an application's status
+   */
+  api.registerGatewayMethod(
+    "jobbot.applications.update",
+    ({ params, respond }) => {
+      try {
+        const { id, status, notes } = (params ?? {}) as {
+          id: string;
+          status?: ApplicationStatus;
+          notes?: string;
+        };
+
+        if (!id) {
+          respond(false, { error: "Missing application id" });
+          return;
+        }
+
+        if (status) {
+          store.updateApplicationStatus(id, status, notes);
+        }
+
+        const application = store.getApplication(id);
+        respond(true, { application });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        respond(false, { error: message });
+      }
+    },
+  );
+
+  // ==========================================================================
+  // Resume Methods
+  // ==========================================================================
+
+  /**
+   * List all resumes
+   */
+  api.registerGatewayMethod("jobbot.resumes.list", ({ respond }) => {
+    try {
+      const resumes = store.listResumes();
+      respond(true, { resumes, count: resumes.length });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  /**
+   * Get a specific resume
+   */
+  api.registerGatewayMethod("jobbot.resumes.get", ({ params, respond }) => {
+    try {
+      const { id } = (params ?? {}) as { id?: string };
+
+      const resume = id ? store.getResume(id) : store.getDefaultResume();
+      if (!resume) {
+        respond(false, { error: "Resume not found" });
+        return;
+      }
+
+      respond(true, { resume });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  /**
+   * Set the default resume
+   */
+  api.registerGatewayMethod(
+    "jobbot.resumes.setDefault",
+    ({ params, respond }) => {
+      try {
+        const { id } = (params ?? {}) as { id: string };
+        if (!id) {
+          respond(false, { error: "Missing resume id" });
+          return;
+        }
+
+        store.setDefaultResume(id);
+        const resume = store.getResume(id);
+        respond(true, { resume });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        respond(false, { error: message });
+      }
+    },
+  );
+
+  /**
+   * Delete a resume
+   */
+  api.registerGatewayMethod("jobbot.resumes.delete", ({ params, respond }) => {
+    try {
+      const { id } = (params ?? {}) as { id: string };
+      if (!id) {
+        respond(false, { error: "Missing resume id" });
+        return;
+      }
+
+      store.deleteResume(id);
+      respond(true, { deleted: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  // ==========================================================================
+  // Preferences Methods
+  // ==========================================================================
+
+  /**
+   * Get current job preferences
+   */
+  api.registerGatewayMethod("jobbot.preferences.get", ({ respond }) => {
+    try {
+      respond(true, {
+        preferences: config.preferences,
+        notifications: config.notifications,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  /**
+   * Update job preferences
+   * Note: This would require updating the config file - for now returns current
+   */
+  api.registerGatewayMethod("jobbot.preferences.set", ({ params, respond }) => {
+    try {
+      // In production, this would update the config file
+      // For now, we just acknowledge the request
+      respond(true, {
+        message: "Preferences update would be saved to config",
+        received: params,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  // ==========================================================================
+  // Statistics Methods
+  // ==========================================================================
+
+  /**
+   * Get job search statistics
+   */
+  api.registerGatewayMethod("jobbot.stats.summary", ({ respond }) => {
+    try {
+      const stats = store.getStats();
+      respond(true, { stats });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  /**
+   * Get timeline data for charts
+   */
+  api.registerGatewayMethod("jobbot.stats.timeline", ({ params, respond }) => {
+    try {
+      const { days = 30 } = (params ?? {}) as { days?: number };
+      const timeline = store.getTimeline(days);
+      respond(true, { timeline, days });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  // ==========================================================================
+  // Email Thread Methods
+  // ==========================================================================
+
+  /**
+   * List email threads for an application
+   */
+  api.registerGatewayMethod("jobbot.emails.list", ({ params, respond }) => {
+    try {
+      const { applicationId } = (params ?? {}) as { applicationId: string };
+      if (!applicationId) {
+        respond(false, { error: "Missing applicationId" });
+        return;
+      }
+
+      const threads = store.listEmailThreadsForApplication(applicationId);
+      respond(true, { threads, count: threads.length });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  /**
+   * Create an email thread for an application
+   */
+  api.registerGatewayMethod("jobbot.emails.create", ({ params, respond }) => {
+    try {
+      const { applicationId, gmailThreadId, subject, fromEmail } = (params ??
+        {}) as {
+        applicationId: string;
+        gmailThreadId?: string;
+        subject: string;
+        fromEmail: string;
+      };
+
+      if (!applicationId || !subject || !fromEmail) {
+        respond(false, { error: "Missing required fields" });
+        return;
+      }
+
+      const thread = store.createEmailThread({
+        applicationId,
+        gmailThreadId,
+        subject,
+        fromEmail,
+      });
+
+      respond(true, { thread });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(false, { error: message });
+    }
+  });
+
+  api.logger.info("job-application: Gateway methods registered");
+}

--- a/extensions/job-application/src/services/email-monitor.ts
+++ b/extensions/job-application/src/services/email-monitor.ts
@@ -1,0 +1,316 @@
+/**
+ * Email Monitor Service
+ *
+ * Integrates with Gmail Pub/Sub to track job application responses.
+ * Classifies email responses and updates application status.
+ */
+
+import type { MoltbotPluginApi } from "../../../../src/plugins/types.js";
+import type { JobStore } from "../db/store.js";
+import type { JobApplicationConfig, ApplicationStatus } from "../types.js";
+
+// Keywords for classifying email responses
+const REJECTION_KEYWORDS = [
+  "unfortunately",
+  "regret to inform",
+  "not moving forward",
+  "decided not to proceed",
+  "other candidates",
+  "position has been filled",
+  "not selected",
+  "not a fit",
+  "pursued other",
+  "decided to move forward with",
+];
+
+const INTERVIEW_KEYWORDS = [
+  "schedule an interview",
+  "interview invitation",
+  "would like to speak",
+  "set up a call",
+  "phone screen",
+  "technical interview",
+  "on-site interview",
+  "video interview",
+  "meet with",
+  "next steps",
+  "availability",
+];
+
+const OFFER_KEYWORDS = [
+  "pleased to offer",
+  "offer letter",
+  "job offer",
+  "employment offer",
+  "compensation package",
+  "start date",
+  "we would like to extend",
+];
+
+type EmailResponseType = "rejection" | "interview" | "offer" | "generic";
+
+type EmailData = {
+  from: string;
+  subject: string;
+  body: string;
+  gmailThreadId?: string;
+  gmailMessageId?: string;
+};
+
+/**
+ * Email monitor service that hooks into the gateway's email processing.
+ */
+export function createEmailMonitorService(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+) {
+  return {
+    id: "jobbot-email-monitor",
+
+    async start() {
+      api.logger.info("jobbot-email-monitor: Service started");
+
+      // Register hook to intercept Gmail notifications
+      api.registerHook(
+        "message_received",
+        async (event) => {
+          // Check if this is a Gmail notification
+          if (!isGmailNotification(event)) return;
+
+          try {
+            await processEmailNotification(api, store, config, event);
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            api.logger.error(
+              `jobbot-email-monitor: Error processing email: ${message}`,
+            );
+          }
+        },
+        { name: "jobbot-email-processor" },
+      );
+    },
+
+    stop() {
+      api.logger.info("jobbot-email-monitor: Service stopped");
+    },
+  };
+}
+
+/**
+ * Check if an event is a Gmail notification.
+ */
+function isGmailNotification(event: unknown): event is EmailData {
+  if (!event || typeof event !== "object") return false;
+  const e = event as Record<string, unknown>;
+  return typeof e.from === "string" && typeof e.subject === "string";
+}
+
+/**
+ * Process an incoming email notification.
+ */
+async function processEmailNotification(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+  email: EmailData,
+): Promise<void> {
+  // Try to match email to an existing application
+  const application = matchEmailToApplication(store, email);
+
+  if (!application) {
+    api.logger.info(
+      `jobbot-email-monitor: Email from ${email.from} did not match any applications`,
+    );
+    return;
+  }
+
+  // Classify the email response
+  const responseType = classifyEmailResponse(email);
+  api.logger.info(
+    `jobbot-email-monitor: Classified email as ${responseType} for application ${application.applicationId}`,
+  );
+
+  // Update application status based on response type
+  const newStatus = responseTypeToStatus(
+    responseType,
+    application.currentStatus,
+  );
+
+  if (newStatus && newStatus !== application.currentStatus) {
+    store.updateApplicationStatus(
+      application.applicationId,
+      newStatus,
+      `Email response classified as: ${responseType}`,
+    );
+  }
+
+  // Create or update email thread
+  const existingThread = email.gmailThreadId
+    ? store.getEmailThreadByGmailId(email.gmailThreadId)
+    : null;
+
+  if (existingThread) {
+    store.updateEmailThread(existingThread.id, {
+      lastMessageAt: Date.now(),
+      messageCount: existingThread.messageCount + 1,
+      status: responseType === "interview" ? "awaiting_response" : "active",
+    });
+  } else {
+    store.createEmailThread({
+      applicationId: application.applicationId,
+      gmailThreadId: email.gmailThreadId,
+      subject: email.subject,
+      fromEmail: email.from,
+    });
+  }
+
+  // Send notification to user if configured
+  if (
+    config.notifications.emailResponseAlerts &&
+    config.notifications.channel
+  ) {
+    const job = store.getJob(application.jobId);
+    const notificationMessage = formatNotification(responseType, job, email);
+
+    api.logger.info(
+      `jobbot-email-monitor: Would send notification to ${config.notifications.channel}: ${notificationMessage.slice(0, 100)}...`,
+    );
+    // In production, this would use the message tool to send to the configured channel
+  }
+}
+
+/**
+ * Try to match an email to an existing application.
+ */
+function matchEmailToApplication(
+  store: JobStore,
+  email: EmailData,
+): {
+  applicationId: string;
+  jobId: string;
+  currentStatus: ApplicationStatus;
+} | null {
+  // Get all submitted applications
+  const applications = store.listApplications({ status: "submitted" });
+
+  // Also check applications in interview/offer status
+  const interviewApps = store.listApplications({ status: "interview" });
+  const allApps = [...applications, ...interviewApps];
+
+  for (const app of allApps) {
+    const job = store.getJob(app.jobId);
+    if (!job) continue;
+
+    // Match by company name in sender email or subject
+    const companyLower = job.company.toLowerCase();
+    const fromLower = email.from.toLowerCase();
+    const subjectLower = email.subject.toLowerCase();
+
+    // Extract domain from sender
+    const senderDomain = fromLower.split("@")[1]?.split(".")[0];
+
+    // Check if company name appears in sender domain or subject
+    const companyWords = companyLower.split(/\s+/);
+    const matchesSender = companyWords.some(
+      (word) =>
+        word.length > 3 &&
+        (fromLower.includes(word) || senderDomain?.includes(word)),
+    );
+    const matchesSubject = companyWords.some(
+      (word) => word.length > 3 && subjectLower.includes(word),
+    );
+
+    if (matchesSender || matchesSubject) {
+      return {
+        applicationId: app.id,
+        jobId: app.jobId,
+        currentStatus: app.status as ApplicationStatus,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Classify an email response based on content analysis.
+ */
+function classifyEmailResponse(email: EmailData): EmailResponseType {
+  const content = `${email.subject} ${email.body}`.toLowerCase();
+
+  // Check for offer keywords first (highest priority)
+  if (OFFER_KEYWORDS.some((kw) => content.includes(kw))) {
+    return "offer";
+  }
+
+  // Check for interview keywords
+  if (INTERVIEW_KEYWORDS.some((kw) => content.includes(kw))) {
+    return "interview";
+  }
+
+  // Check for rejection keywords
+  if (REJECTION_KEYWORDS.some((kw) => content.includes(kw))) {
+    return "rejection";
+  }
+
+  return "generic";
+}
+
+/**
+ * Map response type to application status.
+ */
+function responseTypeToStatus(
+  responseType: EmailResponseType,
+  currentStatus: ApplicationStatus,
+): ApplicationStatus | null {
+  switch (responseType) {
+    case "offer":
+      return "offer";
+    case "interview":
+      // Only update to interview if not already in interview or offer
+      if (currentStatus !== "interview" && currentStatus !== "offer") {
+        return "interview";
+      }
+      return null;
+    case "rejection":
+      return "rejected";
+    case "generic":
+      // Mark as viewed if currently just submitted
+      if (currentStatus === "submitted") {
+        return "viewed";
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Format a notification message for the user.
+ */
+function formatNotification(
+  responseType: EmailResponseType,
+  job: { company: string; title: string } | null,
+  email: EmailData,
+): string {
+  const company = job?.company ?? "Unknown Company";
+  const title = job?.title ?? "Unknown Position";
+
+  switch (responseType) {
+    case "offer":
+      return `🎉 Great news! You received a job offer from ${company} for ${title}!\n\nSubject: ${email.subject}`;
+    case "interview":
+      return `📅 Interview request from ${company} for ${title}!\n\nSubject: ${email.subject}\n\nCheck your email for scheduling details.`;
+    case "rejection":
+      return `📧 Response from ${company} regarding ${title}.\n\nSubject: ${email.subject}\n\nThis appears to be a rejection. Keep going!`;
+    default:
+      return `📬 New email from ${company} regarding your ${title} application.\n\nSubject: ${email.subject}`;
+  }
+}
+
+/**
+ * Export for use in plugin registration.
+ */
+export type EmailMonitorService = ReturnType<typeof createEmailMonitorService>;

--- a/extensions/job-application/src/services/job-scanner.ts
+++ b/extensions/job-application/src/services/job-scanner.ts
@@ -1,0 +1,344 @@
+/**
+ * Job Scanner Service
+ *
+ * Background service that periodically scans job boards for new listings.
+ * Uses the cron system for scheduling.
+ */
+
+import type { MoltbotPluginApi } from "../../../../src/plugins/types.js";
+import type { JobStore } from "../db/store.js";
+import type { JobApplicationConfig } from "../types.js";
+
+/**
+ * Job scanner service that runs periodic job searches.
+ */
+export function createJobScannerService(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+) {
+  let isRunning = false;
+  let scanInterval: ReturnType<typeof setInterval> | null = null;
+
+  return {
+    id: "jobbot-scanner",
+
+    async start() {
+      api.logger.info(
+        `jobbot-scanner: Service started (interval: ${config.scanInterval})`,
+      );
+
+      isRunning = true;
+
+      // Parse scan interval (e.g., "6h" -> 6 hours)
+      const intervalMs = parseInterval(config.scanInterval);
+
+      if (intervalMs > 0) {
+        // Run initial scan after a short delay
+        setTimeout(() => {
+          if (isRunning) {
+            runScan(api, store, config).catch((err) => {
+              api.logger.error(`jobbot-scanner: Initial scan failed: ${err}`);
+            });
+          }
+        }, 30000); // 30 second delay for initial scan
+
+        // Set up periodic scanning
+        scanInterval = setInterval(() => {
+          if (isRunning) {
+            runScan(api, store, config).catch((err) => {
+              api.logger.error(`jobbot-scanner: Periodic scan failed: ${err}`);
+            });
+          }
+        }, intervalMs);
+
+        api.logger.info(
+          `jobbot-scanner: Scheduled to run every ${config.scanInterval} (${intervalMs}ms)`,
+        );
+      }
+    },
+
+    stop() {
+      isRunning = false;
+      if (scanInterval) {
+        clearInterval(scanInterval);
+        scanInterval = null;
+      }
+      api.logger.info("jobbot-scanner: Service stopped");
+    },
+  };
+}
+
+/**
+ * Run a job scan using configured preferences.
+ */
+async function runScan(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+): Promise<void> {
+  api.logger.info("jobbot-scanner: Starting job scan...");
+
+  const { preferences, defaultJobBoards, notifications } = config;
+
+  if (preferences.titles.length === 0) {
+    api.logger.info("jobbot-scanner: No job titles configured, skipping scan");
+    return;
+  }
+
+  let totalNewJobs = 0;
+
+  // Scan each job board
+  for (const source of defaultJobBoards) {
+    for (const title of preferences.titles) {
+      for (const location of preferences.locations.length > 0
+        ? preferences.locations
+        : [""]) {
+        try {
+          const newJobs = await scanJobBoard(api, store, config, {
+            source,
+            query: title,
+            location: location || undefined,
+          });
+
+          totalNewJobs += newJobs;
+
+          api.logger.info(
+            `jobbot-scanner: Found ${newJobs} new jobs for "${title}" in "${location || "any location"}" on ${source}`,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          api.logger.error(
+            `jobbot-scanner: Error scanning ${source} for "${title}": ${message}`,
+          );
+        }
+
+        // Small delay between requests to be polite
+        await sleep(2000);
+      }
+    }
+  }
+
+  api.logger.info(
+    `jobbot-scanner: Scan complete. Found ${totalNewJobs} new jobs total.`,
+  );
+
+  // Send notification if enabled and new jobs found
+  if (notifications.newJobAlerts && notifications.channel && totalNewJobs > 0) {
+    const message = formatScanSummary(totalNewJobs);
+    api.logger.info(
+      `jobbot-scanner: Would send notification to ${notifications.channel}: ${message}`,
+    );
+    // In production, this would use the message tool to send to the configured channel
+  }
+}
+
+/**
+ * Scan a specific job board with given parameters.
+ * Returns the number of new jobs found.
+ */
+async function scanJobBoard(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+  params: {
+    source: string;
+    query: string;
+    location?: string;
+  },
+): Promise<number> {
+  // In production, this would use browser automation to scrape job boards
+  // For now, we simulate finding jobs
+
+  const mockJobs = generateMockJobs(
+    params.query,
+    params.location,
+    params.source,
+  );
+
+  let newJobCount = 0;
+
+  for (const job of mockJobs) {
+    // Check if job already exists
+    const existing = store.getJobByExternalId(job.externalId, job.source);
+    if (existing) continue;
+
+    // Apply filters
+    if (!passesFilters(job, config.preferences)) continue;
+
+    // Store new job
+    store.createJob({
+      externalId: job.externalId,
+      source: job.source,
+      company: job.company,
+      title: job.title,
+      location: job.location,
+      salaryMin: job.salaryMin,
+      salaryMax: job.salaryMax,
+      description: job.description,
+      techStack: job.techStack,
+      url: job.url,
+    });
+
+    newJobCount++;
+  }
+
+  return newJobCount;
+}
+
+/**
+ * Check if a job passes the configured filters.
+ */
+function passesFilters(
+  job: {
+    company: string;
+    title: string;
+    location?: string;
+    description?: string;
+  },
+  preferences: JobApplicationConfig["preferences"],
+): boolean {
+  const companyLower = job.company.toLowerCase();
+  const titleLower = job.title.toLowerCase();
+  const locationLower = (job.location ?? "").toLowerCase();
+  const descLower = (job.description ?? "").toLowerCase();
+
+  // Check excluded companies
+  if (
+    preferences.excludeCompanies.some((c) =>
+      companyLower.includes(c.toLowerCase()),
+    )
+  ) {
+    return false;
+  }
+
+  // Check remote only
+  if (preferences.remoteOnly && !locationLower.includes("remote")) {
+    return false;
+  }
+
+  // Check excluded keywords
+  if (
+    preferences.excludeKeywords.some(
+      (kw) =>
+        titleLower.includes(kw.toLowerCase()) ||
+        descLower.includes(kw.toLowerCase()),
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Generate mock job listings for testing.
+ */
+function generateMockJobs(
+  query: string,
+  location: string | undefined,
+  source: string,
+): Array<{
+  externalId: string;
+  source: "indeed" | "linkedin" | "greenhouse" | "lever" | "custom";
+  company: string;
+  title: string;
+  location?: string;
+  salaryMin?: number;
+  salaryMax?: number;
+  description?: string;
+  techStack?: string[];
+  url: string;
+}> {
+  // Simulate finding 0-3 new jobs per search
+  const count = Math.floor(Math.random() * 4);
+  const companies = [
+    "TechCorp",
+    "InnovateLabs",
+    "DataDriven Inc",
+    "CloudFirst",
+    "AI Solutions",
+  ];
+  const techStacks = [
+    ["TypeScript", "React", "Node.js"],
+    ["Python", "Django", "PostgreSQL"],
+    ["Go", "Kubernetes", "gRPC"],
+    ["Java", "Spring", "AWS"],
+  ];
+
+  const jobs = [];
+
+  for (let i = 0; i < count; i++) {
+    const company = companies[Math.floor(Math.random() * companies.length)];
+    const techStack = techStacks[Math.floor(Math.random() * techStacks.length)];
+    const salaryBase = 100000 + Math.floor(Math.random() * 80000);
+
+    jobs.push({
+      externalId: `${source}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      source: source as
+        | "indeed"
+        | "linkedin"
+        | "greenhouse"
+        | "lever"
+        | "custom",
+      company,
+      title: query,
+      location:
+        location || (Math.random() > 0.5 ? "Remote" : "San Francisco, CA"),
+      salaryMin: salaryBase,
+      salaryMax: salaryBase + 30000,
+      description: `Join ${company} as a ${query}. Work with ${techStack.join(", ")}.`,
+      techStack,
+      url: `https://${source}.com/jobs/${Date.now()}`,
+    });
+  }
+
+  return jobs;
+}
+
+/**
+ * Format a scan summary notification.
+ */
+function formatScanSummary(newJobs: number): string {
+  if (newJobs === 1) {
+    return "🔔 Found 1 new job matching your criteria! Check the JobBot dashboard to review.";
+  }
+  return `🔔 Found ${newJobs} new jobs matching your criteria! Check the JobBot dashboard to review.`;
+}
+
+/**
+ * Parse an interval string (e.g., "6h", "30m", "1d") to milliseconds.
+ */
+function parseInterval(interval: string): number {
+  const match = interval.match(/^(\d+)(s|m|h|d)$/);
+  if (!match) return 0;
+
+  const value = parseInt(match[1]);
+  const unit = match[2];
+
+  switch (unit) {
+    case "s":
+      return value * 1000;
+    case "m":
+      return value * 60 * 1000;
+    case "h":
+      return value * 60 * 60 * 1000;
+    case "d":
+      return value * 24 * 60 * 60 * 1000;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Sleep utility.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Export for use in plugin registration.
+ */
+export type JobScannerService = ReturnType<typeof createJobScannerService>;

--- a/extensions/job-application/src/tools/job-apply.ts
+++ b/extensions/job-application/src/tools/job-apply.ts
@@ -1,0 +1,300 @@
+/**
+ * Job Apply Tool
+ *
+ * Automates job application submission with user confirmation.
+ * Uses browser automation to fill out application forms.
+ */
+
+import { Type } from "@sinclair/typebox";
+
+import type { MoltbotPluginApi } from "../../../../src/plugins/types.js";
+import type { AnyAgentTool } from "../../../../src/agents/tools/common.js";
+import type { JobStore } from "../db/store.js";
+import type { JobApplicationConfig, ApplicationAnswer } from "../types.js";
+
+// Tool parameter types
+type JobApplyParams = {
+  job_id: string;
+  resume_id?: string;
+  cover_letter?: string;
+  answers?: ApplicationAnswer[];
+  confirm?: boolean;
+  dry_run?: boolean;
+};
+
+export function createJobApplyTool(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+): AnyAgentTool {
+  return {
+    name: "job_apply",
+    label: "Job Apply",
+    description: `Submit a job application for a specific job listing.
+Use this tool to apply to jobs that have been approved by the user.
+IMPORTANT: Always confirm with the user before submitting an application.
+The tool can prepare the application (dry_run=true) for review before final submission.`,
+    parameters: Type.Object({
+      job_id: Type.String({
+        description:
+          "The ID of the job to apply to (from job_search or job_track)",
+      }),
+      resume_id: Type.Optional(
+        Type.String({
+          description:
+            "ID of the resume to use. If not provided, uses the default resume.",
+        }),
+      ),
+      cover_letter: Type.Optional(
+        Type.String({
+          description:
+            "Custom cover letter text. If not provided, a default will be generated.",
+        }),
+      ),
+      answers: Type.Optional(
+        Type.Array(
+          Type.Object({
+            question: Type.String(),
+            answer: Type.String(),
+            type: Type.Optional(Type.String()),
+          }),
+        ),
+      ),
+      confirm: Type.Optional(
+        Type.Boolean({
+          description:
+            "Set to true only after user has explicitly confirmed the application",
+        }),
+      ),
+      dry_run: Type.Optional(
+        Type.Boolean({
+          description:
+            "Preview the application without submitting. Use this to show the user what will be submitted.",
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      const {
+        job_id,
+        resume_id,
+        cover_letter,
+        answers,
+        confirm = false,
+        dry_run = false,
+      } = params as JobApplyParams;
+
+      try {
+        // Get the job
+        const job = store.getJob(job_id);
+        if (!job) {
+          return {
+            content: [
+              { type: "text", text: `Job not found with ID: ${job_id}` },
+            ],
+            details: { error: "job_not_found" },
+          };
+        }
+
+        // Check if already applied
+        const existingApp = store.getApplicationByJobId(job_id);
+        if (existingApp && existingApp.status !== "pending") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `You've already applied to this job. Status: ${existingApp.status}`,
+              },
+            ],
+            details: { error: "already_applied", application: existingApp },
+          };
+        }
+
+        // Get resume
+        const resume = resume_id
+          ? store.getResume(resume_id)
+          : store.getDefaultResume();
+
+        if (!resume) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No resume found. Please upload a resume first using the resume_manage tool.",
+              },
+            ],
+            details: { error: "no_resume" },
+          };
+        }
+
+        // Generate cover letter if not provided
+        const finalCoverLetter =
+          cover_letter ??
+          generateDefaultCoverLetter(
+            job.company,
+            job.title,
+            resume.parsedData?.fullName ?? "the applicant",
+          );
+
+        // If dry run or not confirmed, show preview
+        if (dry_run || !confirm) {
+          const preview = formatApplicationPreview(
+            job,
+            resume,
+            finalCoverLetter,
+            answers,
+          );
+
+          // Create or update pending application
+          let application = existingApp;
+          if (!application) {
+            application = store.createApplication({
+              jobId: job_id,
+              resumeId: resume.id,
+              coverLetter: finalCoverLetter,
+              answers,
+              notes: "Pending user confirmation",
+            });
+          }
+
+          return {
+            content: [{ type: "text", text: preview }],
+            details: {
+              status: "pending_confirmation",
+              applicationId: application.id,
+              jobId: job_id,
+              company: job.company,
+              title: job.title,
+              resumeName: resume.name,
+              coverLetterPreview: finalCoverLetter.slice(0, 200) + "...",
+            },
+          };
+        }
+
+        // User confirmed - submit the application
+        api.logger.info(
+          `job_apply: Submitting application for ${job.title} at ${job.company}`,
+        );
+
+        // In production, this would use browser automation to submit
+        // For now, we simulate the submission
+        const application =
+          existingApp ??
+          store.createApplication({
+            jobId: job_id,
+            resumeId: resume.id,
+            coverLetter: finalCoverLetter,
+            answers,
+          });
+
+        // Update statuses
+        store.updateApplicationStatus(
+          application.id,
+          "submitted",
+          "Application submitted successfully",
+        );
+        store.updateJobStatus(job_id, "applied");
+
+        const successMessage = formatSubmissionSuccess(job, application.id);
+
+        return {
+          content: [{ type: "text", text: successMessage }],
+          details: {
+            status: "submitted",
+            applicationId: application.id,
+            jobId: job_id,
+            company: job.company,
+            title: job.title,
+            submittedAt: Date.now(),
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        api.logger.error(`job_apply error: ${message}`);
+        return {
+          content: [
+            { type: "text", text: `Error applying to job: ${message}` },
+          ],
+          details: { error: message },
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Generate a default cover letter for a job application.
+ */
+function generateDefaultCoverLetter(
+  company: string,
+  title: string,
+  applicantName: string,
+): string {
+  return `Dear Hiring Manager,
+
+I am writing to express my strong interest in the ${title} position at ${company}. With my background and skills, I believe I would be a valuable addition to your team.
+
+I am excited about the opportunity to contribute to ${company}'s mission and to grow professionally in this role. My experience aligns well with the requirements of this position, and I am confident in my ability to make meaningful contributions from day one.
+
+I would welcome the opportunity to discuss how my skills and experience can benefit ${company}. Thank you for considering my application.
+
+Best regards,
+${applicantName}`;
+}
+
+/**
+ * Format an application preview for user review.
+ */
+function formatApplicationPreview(
+  job: { company: string; title: string; url: string },
+  resume: { name: string },
+  coverLetter: string,
+  answers?: ApplicationAnswer[],
+): string {
+  const lines: string[] = [];
+
+  lines.push("## Application Preview\n");
+  lines.push(`**Position:** ${job.title}`);
+  lines.push(`**Company:** ${job.company}`);
+  lines.push(`**Resume:** ${resume.name}`);
+  lines.push("");
+  lines.push("### Cover Letter");
+  lines.push("```");
+  lines.push(coverLetter);
+  lines.push("```");
+
+  if (answers && answers.length > 0) {
+    lines.push("");
+    lines.push("### Application Questions");
+    for (const qa of answers) {
+      lines.push(`**Q:** ${qa.question}`);
+      lines.push(`**A:** ${qa.answer}`);
+      lines.push("");
+    }
+  }
+
+  lines.push("");
+  lines.push("---");
+  lines.push(
+    '**Ready to submit?** Reply "yes" to confirm, "edit" to modify, or "skip" to cancel.',
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Format a success message after application submission.
+ */
+function formatSubmissionSuccess(
+  job: { company: string; title: string },
+  applicationId: string,
+): string {
+  return `## Application Submitted!
+
+Your application for **${job.title}** at **${job.company}** has been submitted successfully.
+
+**Application ID:** ${applicationId}
+
+I'll monitor your email for any responses and keep you updated. You can check the status anytime by asking "what's the status of my applications?"
+
+Good luck! 🤞`;
+}

--- a/extensions/job-application/src/tools/job-search.ts
+++ b/extensions/job-application/src/tools/job-search.ts
@@ -1,0 +1,330 @@
+/**
+ * Job Search Tool
+ *
+ * Searches job boards for positions matching user criteria.
+ * Uses browser automation to scrape job listings from Indeed, LinkedIn, etc.
+ */
+
+import { Type } from "@sinclair/typebox";
+
+import type { MoltbotPluginApi } from "../../../../src/plugins/types.js";
+import type { AnyAgentTool } from "../../../../src/agents/tools/common.js";
+import type { JobStore } from "../db/store.js";
+import type {
+  JobApplicationConfig,
+  Job,
+  JobSource,
+  JobStatus,
+} from "../types.js";
+
+// Tool parameter types
+type JobSearchParams = {
+  query?: string;
+  location?: string;
+  source?: JobSource;
+  remote_only?: boolean;
+  salary_min?: number;
+  limit?: number;
+  use_preferences?: boolean;
+};
+
+export function createJobSearchTool(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+): AnyAgentTool {
+  return {
+    name: "job_search",
+    label: "Job Search",
+    description: `Search for job listings from job boards (Indeed, LinkedIn, etc.).
+Use this tool to find new job opportunities matching specific criteria.
+Can use saved preferences or custom search parameters.
+Returns a summary of found jobs and stores them in the database for later review.`,
+    parameters: Type.Object({
+      query: Type.Optional(
+        Type.String({
+          description:
+            "Job title or keywords to search for. If not provided, uses saved preferences.",
+        }),
+      ),
+      location: Type.Optional(
+        Type.String({
+          description:
+            "Location to search in (e.g., 'Remote', 'San Francisco, CA')",
+        }),
+      ),
+      source: Type.Optional(
+        Type.String({
+          description:
+            "Job board to search: indeed, linkedin, greenhouse, lever, custom",
+        }),
+      ),
+      remote_only: Type.Optional(
+        Type.Boolean({
+          description: "Only show remote positions",
+        }),
+      ),
+      salary_min: Type.Optional(
+        Type.Number({
+          description: "Minimum salary to filter by",
+        }),
+      ),
+      limit: Type.Optional(
+        Type.Number({
+          description: "Maximum number of jobs to return (default: 20)",
+        }),
+      ),
+      use_preferences: Type.Optional(
+        Type.Boolean({
+          description:
+            "Use saved job preferences for search criteria (default: true)",
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      const {
+        query,
+        location,
+        source,
+        remote_only,
+        salary_min,
+        limit = 20,
+        use_preferences = true,
+      } = params as JobSearchParams;
+
+      try {
+        // Build search criteria
+        const searchQuery =
+          query ?? (use_preferences ? config.preferences.titles[0] : undefined);
+        const searchLocation =
+          location ??
+          (use_preferences ? config.preferences.locations[0] : undefined);
+        const searchRemote =
+          remote_only ??
+          (use_preferences ? config.preferences.remoteOnly : false);
+        const searchSalaryMin =
+          salary_min ??
+          (use_preferences ? config.preferences.salaryMin : undefined);
+        const searchSource =
+          (source as JobSource) ?? config.defaultJobBoards[0] ?? "indeed";
+
+        if (!searchQuery) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Please provide a search query or set up job preferences first.",
+              },
+            ],
+            details: { error: "missing_query" },
+          };
+        }
+
+        api.logger.info(
+          `job_search: Searching for "${searchQuery}" in "${searchLocation ?? "any location"}" on ${searchSource}`,
+        );
+
+        // For now, simulate job search results
+        // In production, this would use browser automation to scrape job boards
+        const mockJobs = generateMockJobs(
+          searchQuery,
+          searchLocation,
+          searchSource,
+          limit,
+        );
+
+        // Filter by preferences
+        let filteredJobs = mockJobs;
+        if (searchRemote) {
+          filteredJobs = filteredJobs.filter(
+            (j) => j.location?.toLowerCase().includes("remote") ?? false,
+          );
+        }
+        if (searchSalaryMin) {
+          filteredJobs = filteredJobs.filter(
+            (j) => (j.salaryMin ?? 0) >= searchSalaryMin,
+          );
+        }
+        if (use_preferences && config.preferences.excludeCompanies.length > 0) {
+          const excludeLower = config.preferences.excludeCompanies.map((c) =>
+            c.toLowerCase(),
+          );
+          filteredJobs = filteredJobs.filter(
+            (j) => !excludeLower.includes(j.company.toLowerCase()),
+          );
+        }
+
+        // Store jobs in database, avoiding duplicates
+        let newJobCount = 0;
+        const storedJobs: Job[] = [];
+
+        for (const job of filteredJobs) {
+          // Check if we already have this job
+          const existing = store.getJobByExternalId(
+            job.externalId!,
+            job.source,
+          );
+          if (existing) {
+            storedJobs.push(existing);
+            continue;
+          }
+
+          // Create new job
+          const newJob = store.createJob({
+            externalId: job.externalId,
+            source: job.source,
+            company: job.company,
+            title: job.title,
+            location: job.location,
+            salaryMin: job.salaryMin,
+            salaryMax: job.salaryMax,
+            description: job.description,
+            techStack: job.techStack,
+            url: job.url,
+            postedAt: job.postedAt,
+          });
+          storedJobs.push(newJob);
+          newJobCount++;
+        }
+
+        // Format results
+        const summary = formatJobSummary(storedJobs, newJobCount);
+
+        return {
+          content: [{ type: "text", text: summary }],
+          details: {
+            totalFound: storedJobs.length,
+            newJobs: newJobCount,
+            source: searchSource,
+            query: searchQuery,
+            location: searchLocation,
+            jobs: storedJobs.slice(0, 10).map((j) => ({
+              id: j.id,
+              company: j.company,
+              title: j.title,
+              location: j.location,
+              salary: j.salaryMin
+                ? `$${j.salaryMin.toLocaleString()}`
+                : "Not specified",
+              status: j.status,
+            })),
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        api.logger.error(`job_search error: ${message}`);
+        return {
+          content: [
+            { type: "text", text: `Error searching for jobs: ${message}` },
+          ],
+          details: { error: message },
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Generate mock job listings for development/testing.
+ * In production, this would be replaced with actual web scraping.
+ */
+function generateMockJobs(
+  query: string,
+  location: string | undefined,
+  source: JobSource,
+  limit: number,
+): Omit<Job, "id" | "discoveredAt" | "status">[] {
+  const companies = [
+    "Acme Corp",
+    "TechStart Inc",
+    "DataFlow Systems",
+    "CloudNine Technologies",
+    "Innovate Labs",
+    "Digital Dynamics",
+    "CodeCraft Studios",
+    "Quantum Computing Co",
+    "AI Solutions Inc",
+    "WebScale Technologies",
+  ];
+
+  const techStacks = [
+    ["TypeScript", "React", "Node.js", "PostgreSQL"],
+    ["Python", "Django", "AWS", "Docker"],
+    ["Go", "Kubernetes", "gRPC", "Redis"],
+    ["Java", "Spring Boot", "MySQL", "Kafka"],
+    ["Rust", "WebAssembly", "GraphQL", "MongoDB"],
+  ];
+
+  const jobs: Omit<Job, "id" | "discoveredAt" | "status">[] = [];
+  const now = Date.now();
+
+  for (let i = 0; i < Math.min(limit, 20); i++) {
+    const company = companies[i % companies.length];
+    const techStack = techStacks[i % techStacks.length];
+    const salaryBase = 100000 + Math.floor(Math.random() * 100000);
+    const isRemote = Math.random() > 0.5;
+
+    jobs.push({
+      externalId: `${source}-${Date.now()}-${i}`,
+      source,
+      company,
+      title: query.includes("Senior")
+        ? query
+        : `${query} - ${["Junior", "Mid-level", "Senior"][i % 3]}`,
+      location: isRemote ? "Remote" : (location ?? "San Francisco, CA"),
+      salaryMin: salaryBase,
+      salaryMax: salaryBase + 30000,
+      salaryCurrency: "USD",
+      description: `We're looking for a talented ${query} to join our team at ${company}. 
+You'll work on cutting-edge projects using ${techStack.join(", ")}.
+This is a ${isRemote ? "fully remote" : "hybrid"} position with competitive benefits.`,
+      techStack,
+      url: `https://${source}.com/jobs/${Date.now()}-${i}`,
+      postedAt: now - Math.floor(Math.random() * 7 * 24 * 60 * 60 * 1000), // Random within last 7 days
+    });
+  }
+
+  return jobs;
+}
+
+/**
+ * Format job results into a human-readable summary.
+ */
+function formatJobSummary(jobs: Job[], newCount: number): string {
+  if (jobs.length === 0) {
+    return "No jobs found matching your criteria. Try adjusting your search parameters.";
+  }
+
+  const lines: string[] = [];
+  lines.push(`Found ${jobs.length} jobs (${newCount} new):\n`);
+
+  for (let i = 0; i < Math.min(jobs.length, 10); i++) {
+    const job = jobs[i];
+    const salary = job.salaryMin
+      ? `$${job.salaryMin.toLocaleString()}${job.salaryMax ? ` - $${job.salaryMax.toLocaleString()}` : "+"}`
+      : "Not specified";
+    const badge = job.status === "new" ? " [NEW]" : "";
+
+    lines.push(`${i + 1}. **${job.title}** at ${job.company}${badge}`);
+    lines.push(
+      `   Location: ${job.location ?? "Not specified"} | Salary: ${salary}`,
+    );
+    if (job.techStack && job.techStack.length > 0) {
+      lines.push(`   Tech: ${job.techStack.slice(0, 5).join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  if (jobs.length > 10) {
+    lines.push(
+      `...and ${jobs.length - 10} more jobs. Use job_track to view all.`,
+    );
+  }
+
+  lines.push(
+    "\nTo apply to a job, tell me the number or ask for more details.",
+  );
+  lines.push('To reject a job, say "skip #X" or "not interested in #X".');
+
+  return lines.join("\n");
+}

--- a/extensions/job-application/src/tools/job-track.ts
+++ b/extensions/job-application/src/tools/job-track.ts
@@ -1,0 +1,618 @@
+/**
+ * Job Track Tool
+ *
+ * Manages and queries job application status and statistics.
+ * Provides views into the job search pipeline.
+ */
+
+import { Type } from "@sinclair/typebox";
+
+import type { MoltbotPluginApi } from "../../../../src/plugins/types.js";
+import type { AnyAgentTool } from "../../../../src/agents/tools/common.js";
+import type { JobStore } from "../db/store.js";
+import type {
+  JobApplicationConfig,
+  Job,
+  Application,
+  JobStatus,
+  ApplicationStatus,
+} from "../types.js";
+
+// Tool parameter types
+type JobTrackParams = {
+  action: "list" | "status" | "details" | "update" | "stats" | "summary";
+  job_id?: string;
+  application_id?: string;
+  filter_status?: JobStatus | ApplicationStatus;
+  new_status?: JobStatus | ApplicationStatus;
+  limit?: number;
+  notes?: string;
+};
+
+export function createJobTrackTool(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+): AnyAgentTool {
+  return {
+    name: "job_track",
+    label: "Job Tracker",
+    description: `Track and manage job applications and their status.
+Actions:
+- list: Show jobs or applications with optional status filter
+- status: Quick view of a specific job or application
+- details: Get full details of a job or application
+- update: Change the status of a job or application
+- stats: Show overall statistics
+- summary: Get a daily summary of job search activity`,
+    parameters: Type.Object({
+      action: Type.String({
+        description:
+          "Action to perform: list, status, details, update, stats, or summary",
+      }),
+      job_id: Type.Optional(
+        Type.String({
+          description: "Job ID for status, details, or update actions",
+        }),
+      ),
+      application_id: Type.Optional(
+        Type.String({
+          description: "Application ID for status, details, or update actions",
+        }),
+      ),
+      filter_status: Type.Optional(
+        Type.String({
+          description:
+            "Filter by status (jobs: new, reviewing, approved, rejected, applied; applications: pending, submitted, rejected, interview, offer)",
+        }),
+      ),
+      new_status: Type.Optional(
+        Type.String({
+          description: "New status for update action",
+        }),
+      ),
+      limit: Type.Optional(
+        Type.Number({
+          description: "Maximum number of results to return (default: 20)",
+        }),
+      ),
+      notes: Type.Optional(
+        Type.String({
+          description: "Notes to add when updating status",
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      const {
+        action,
+        job_id,
+        application_id,
+        filter_status,
+        new_status,
+        limit = 20,
+        notes,
+      } = params as JobTrackParams;
+
+      try {
+        switch (action) {
+          case "list":
+            return handleList(store, filter_status, limit);
+
+          case "status":
+            return handleStatus(store, job_id, application_id);
+
+          case "details":
+            return handleDetails(store, job_id, application_id);
+
+          case "update":
+            return handleUpdate(
+              store,
+              job_id,
+              application_id,
+              new_status,
+              notes,
+            );
+
+          case "stats":
+            return handleStats(store);
+
+          case "summary":
+            return handleSummary(store, config);
+
+          default:
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Unknown action: ${action}. Use: list, status, details, update, stats, or summary`,
+                },
+              ],
+              details: { error: "unknown_action" },
+            };
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        api.logger.error(`job_track error: ${message}`);
+        return {
+          content: [{ type: "text", text: `Error: ${message}` }],
+          details: { error: message },
+        };
+      }
+    },
+  };
+}
+
+function handleList(
+  store: JobStore,
+  filterStatus: JobStatus | ApplicationStatus | undefined,
+  limit: number,
+) {
+  // Determine if filtering jobs or applications based on status type
+  const jobStatuses: JobStatus[] = [
+    "new",
+    "reviewing",
+    "approved",
+    "rejected",
+    "applied",
+    "archived",
+  ];
+  const appStatuses: ApplicationStatus[] = [
+    "pending",
+    "submitted",
+    "viewed",
+    "rejected",
+    "interview",
+    "offer",
+    "withdrawn",
+    "closed",
+  ];
+
+  const isAppStatus =
+    filterStatus && appStatuses.includes(filterStatus as ApplicationStatus);
+
+  if (isAppStatus) {
+    const applications = store.listApplications({
+      status: filterStatus as ApplicationStatus,
+      limit,
+    });
+    return {
+      content: [
+        { type: "text", text: formatApplicationList(applications, store) },
+      ],
+      details: {
+        type: "applications",
+        count: applications.length,
+        applications,
+      },
+    };
+  }
+
+  const jobs = store.listJobs({
+    status: filterStatus as JobStatus | undefined,
+    limit,
+  });
+  return {
+    content: [{ type: "text", text: formatJobList(jobs) }],
+    details: { type: "jobs", count: jobs.length, jobs },
+  };
+}
+
+function handleStatus(
+  store: JobStore,
+  jobId: string | undefined,
+  applicationId: string | undefined,
+) {
+  if (applicationId) {
+    const app = store.getApplication(applicationId);
+    if (!app) {
+      return {
+        content: [
+          { type: "text", text: `Application not found: ${applicationId}` },
+        ],
+        details: { error: "not_found" },
+      };
+    }
+    const job = store.getJob(app.jobId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `**${job?.title ?? "Unknown"}** at **${job?.company ?? "Unknown"}**\nStatus: **${app.status}**\nApplied: ${app.appliedAt ? new Date(app.appliedAt).toLocaleDateString() : "Not yet"}`,
+        },
+      ],
+      details: { application: app, job },
+    };
+  }
+
+  if (jobId) {
+    const job = store.getJob(jobId);
+    if (!job) {
+      return {
+        content: [{ type: "text", text: `Job not found: ${jobId}` }],
+        details: { error: "not_found" },
+      };
+    }
+    const app = store.getApplicationByJobId(jobId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `**${job.title}** at **${job.company}**\nJob Status: **${job.status}**${app ? `\nApplication Status: **${app.status}**` : ""}`,
+        },
+      ],
+      details: { job, application: app },
+    };
+  }
+
+  return {
+    content: [
+      { type: "text", text: "Please provide a job_id or application_id" },
+    ],
+    details: { error: "missing_id" },
+  };
+}
+
+function handleDetails(
+  store: JobStore,
+  jobId: string | undefined,
+  applicationId: string | undefined,
+) {
+  if (applicationId) {
+    const app = store.getApplication(applicationId);
+    if (!app) {
+      return {
+        content: [
+          { type: "text", text: `Application not found: ${applicationId}` },
+        ],
+        details: { error: "not_found" },
+      };
+    }
+    const job = store.getJob(app.jobId);
+    const emails = store.listEmailThreadsForApplication(applicationId);
+
+    return {
+      content: [
+        { type: "text", text: formatApplicationDetails(app, job, emails) },
+      ],
+      details: { application: app, job, emailThreads: emails },
+    };
+  }
+
+  if (jobId) {
+    const job = store.getJob(jobId);
+    if (!job) {
+      return {
+        content: [{ type: "text", text: `Job not found: ${jobId}` }],
+        details: { error: "not_found" },
+      };
+    }
+    const app = store.getApplicationByJobId(jobId);
+
+    return {
+      content: [{ type: "text", text: formatJobDetails(job, app) }],
+      details: { job, application: app },
+    };
+  }
+
+  return {
+    content: [
+      { type: "text", text: "Please provide a job_id or application_id" },
+    ],
+    details: { error: "missing_id" },
+  };
+}
+
+function handleUpdate(
+  store: JobStore,
+  jobId: string | undefined,
+  applicationId: string | undefined,
+  newStatus: string | undefined,
+  notes: string | undefined,
+) {
+  if (!newStatus) {
+    return {
+      content: [{ type: "text", text: "Please provide a new_status" }],
+      details: { error: "missing_status" },
+    };
+  }
+
+  if (applicationId) {
+    const app = store.getApplication(applicationId);
+    if (!app) {
+      return {
+        content: [
+          { type: "text", text: `Application not found: ${applicationId}` },
+        ],
+        details: { error: "not_found" },
+      };
+    }
+
+    store.updateApplicationStatus(
+      applicationId,
+      newStatus as ApplicationStatus,
+      notes,
+    );
+    const job = store.getJob(app.jobId);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Updated application for **${job?.title ?? "Unknown"}** at **${job?.company ?? "Unknown"}** to: **${newStatus}**`,
+        },
+      ],
+      details: { applicationId, oldStatus: app.status, newStatus },
+    };
+  }
+
+  if (jobId) {
+    const job = store.getJob(jobId);
+    if (!job) {
+      return {
+        content: [{ type: "text", text: `Job not found: ${jobId}` }],
+        details: { error: "not_found" },
+      };
+    }
+
+    store.updateJobStatus(jobId, newStatus as JobStatus);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Updated **${job.title}** at **${job.company}** to: **${newStatus}**`,
+        },
+      ],
+      details: { jobId, oldStatus: job.status, newStatus },
+    };
+  }
+
+  return {
+    content: [
+      { type: "text", text: "Please provide a job_id or application_id" },
+    ],
+    details: { error: "missing_id" },
+  };
+}
+
+function handleStats(store: JobStore) {
+  const stats = store.getStats();
+  const text = formatStats(stats);
+  return {
+    content: [{ type: "text", text }],
+    details: { stats },
+  };
+}
+
+function handleSummary(store: JobStore, config: JobApplicationConfig) {
+  const stats = store.getStats();
+  const recentJobs = store.listJobs({ status: "new", limit: 5 });
+  const pendingApps = store.listApplications({ status: "pending", limit: 5 });
+  const interviewApps = store.listApplications({
+    status: "interview",
+    limit: 5,
+  });
+
+  const text = formatDailySummary(
+    stats,
+    recentJobs,
+    pendingApps,
+    interviewApps,
+  );
+  return {
+    content: [{ type: "text", text }],
+    details: { stats, recentJobs, pendingApps, interviewApps },
+  };
+}
+
+// Formatting helpers
+function formatJobList(jobs: Job[]): string {
+  if (jobs.length === 0) {
+    return "No jobs found matching the criteria.";
+  }
+
+  const lines: string[] = ["## Jobs\n"];
+  for (const job of jobs) {
+    const salary = job.salaryMin
+      ? `$${job.salaryMin.toLocaleString()}`
+      : "Not specified";
+    lines.push(`- **${job.title}** at ${job.company} [${job.status}]`);
+    lines.push(`  Location: ${job.location ?? "N/A"} | Salary: ${salary}`);
+    lines.push(`  ID: \`${job.id}\``);
+  }
+  return lines.join("\n");
+}
+
+function formatApplicationList(
+  applications: Application[],
+  store: JobStore,
+): string {
+  if (applications.length === 0) {
+    return "No applications found matching the criteria.";
+  }
+
+  const lines: string[] = ["## Applications\n"];
+  for (const app of applications) {
+    const job = store.getJob(app.jobId);
+    const appliedDate = app.appliedAt
+      ? new Date(app.appliedAt).toLocaleDateString()
+      : "Pending";
+    lines.push(
+      `- **${job?.title ?? "Unknown"}** at ${job?.company ?? "Unknown"} [${app.status}]`,
+    );
+    lines.push(`  Applied: ${appliedDate}`);
+    lines.push(`  ID: \`${app.id}\``);
+  }
+  return lines.join("\n");
+}
+
+function formatJobDetails(job: Job, app: Application | null): string {
+  const lines: string[] = [];
+  lines.push(`## ${job.title}`);
+  lines.push(`**Company:** ${job.company}`);
+  lines.push(`**Location:** ${job.location ?? "Not specified"}`);
+  lines.push(`**Status:** ${job.status}`);
+  lines.push(`**Source:** ${job.source}`);
+
+  if (job.salaryMin) {
+    const salary = job.salaryMax
+      ? `$${job.salaryMin.toLocaleString()} - $${job.salaryMax.toLocaleString()}`
+      : `$${job.salaryMin.toLocaleString()}+`;
+    lines.push(`**Salary:** ${salary}`);
+  }
+
+  if (job.techStack && job.techStack.length > 0) {
+    lines.push(`**Tech Stack:** ${job.techStack.join(", ")}`);
+  }
+
+  if (job.description) {
+    lines.push("");
+    lines.push("### Description");
+    lines.push(
+      job.description.slice(0, 500) +
+        (job.description.length > 500 ? "..." : ""),
+    );
+  }
+
+  lines.push("");
+  lines.push(`**URL:** ${job.url}`);
+  lines.push(
+    `**Discovered:** ${new Date(job.discoveredAt).toLocaleDateString()}`,
+  );
+
+  if (app) {
+    lines.push("");
+    lines.push("### Application");
+    lines.push(`**Status:** ${app.status}`);
+    if (app.appliedAt) {
+      lines.push(
+        `**Applied:** ${new Date(app.appliedAt).toLocaleDateString()}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatApplicationDetails(
+  app: Application,
+  job: Job | null,
+  emails: { subject: string; status: string }[],
+): string {
+  const lines: string[] = [];
+  lines.push(`## Application Details`);
+  lines.push(`**Position:** ${job?.title ?? "Unknown"}`);
+  lines.push(`**Company:** ${job?.company ?? "Unknown"}`);
+  lines.push(`**Status:** ${app.status}`);
+
+  if (app.appliedAt) {
+    lines.push(`**Applied:** ${new Date(app.appliedAt).toLocaleDateString()}`);
+  }
+
+  if (app.coverLetter) {
+    lines.push("");
+    lines.push("### Cover Letter");
+    lines.push("```");
+    lines.push(
+      app.coverLetter.slice(0, 300) +
+        (app.coverLetter.length > 300 ? "..." : ""),
+    );
+    lines.push("```");
+  }
+
+  if (emails.length > 0) {
+    lines.push("");
+    lines.push("### Email Threads");
+    for (const email of emails) {
+      lines.push(`- ${email.subject} [${email.status}]`);
+    }
+  }
+
+  if (app.notes) {
+    lines.push("");
+    lines.push("### Notes");
+    lines.push(app.notes);
+  }
+
+  return lines.join("\n");
+}
+
+function formatStats(stats: {
+  totalJobs: number;
+  newJobs: number;
+  appliedJobs: number;
+  pendingApplications: number;
+  interviewsScheduled: number;
+  offersReceived: number;
+  rejections: number;
+}): string {
+  const lines: string[] = [];
+  lines.push("## Job Search Statistics\n");
+  lines.push(`| Metric | Count |`);
+  lines.push(`|--------|-------|`);
+  lines.push(`| Total Jobs Found | ${stats.totalJobs} |`);
+  lines.push(`| New Jobs | ${stats.newJobs} |`);
+  lines.push(`| Applications Submitted | ${stats.appliedJobs} |`);
+  lines.push(`| Pending Review | ${stats.pendingApplications} |`);
+  lines.push(`| Interviews | ${stats.interviewsScheduled} |`);
+  lines.push(`| Offers | ${stats.offersReceived} |`);
+  lines.push(`| Rejections | ${stats.rejections} |`);
+
+  if (stats.appliedJobs > 0) {
+    const responseRate = (
+      ((stats.interviewsScheduled + stats.offersReceived + stats.rejections) /
+        stats.appliedJobs) *
+      100
+    ).toFixed(1);
+    lines.push("");
+    lines.push(`**Response Rate:** ${responseRate}%`);
+  }
+
+  return lines.join("\n");
+}
+
+function formatDailySummary(
+  stats: {
+    totalJobs: number;
+    newJobs: number;
+    appliedJobs: number;
+    interviewsScheduled: number;
+  },
+  recentJobs: Job[],
+  pendingApps: Application[],
+  interviewApps: Application[],
+): string {
+  const lines: string[] = [];
+  lines.push("## Daily Job Search Summary\n");
+
+  lines.push(`**Jobs Found:** ${stats.totalJobs} (${stats.newJobs} new)`);
+  lines.push(`**Applications:** ${stats.appliedJobs}`);
+  lines.push(`**Upcoming Interviews:** ${stats.interviewsScheduled}`);
+  lines.push("");
+
+  if (recentJobs.length > 0) {
+    lines.push("### New Jobs to Review");
+    for (const job of recentJobs.slice(0, 3)) {
+      lines.push(`- ${job.title} at ${job.company}`);
+    }
+    if (recentJobs.length > 3) {
+      lines.push(`  ...and ${recentJobs.length - 3} more`);
+    }
+    lines.push("");
+  }
+
+  if (interviewApps.length > 0) {
+    lines.push("### Interviews Scheduled");
+    for (const app of interviewApps) {
+      lines.push(`- Application ${app.id.slice(0, 8)}`);
+    }
+    lines.push("");
+  }
+
+  if (pendingApps.length > 0) {
+    lines.push("### Pending Applications");
+    lines.push(`${pendingApps.length} applications ready to submit.`);
+  }
+
+  return lines.join("\n");
+}

--- a/extensions/job-application/src/tools/resume-manage.ts
+++ b/extensions/job-application/src/tools/resume-manage.ts
@@ -1,0 +1,578 @@
+/**
+ * Resume Management Tool
+ *
+ * Handles resume upload, parsing, and management.
+ * Stores resumes for use in job applications.
+ */
+
+import { Type } from "@sinclair/typebox";
+import { copyFileSync, existsSync, unlinkSync } from "node:fs";
+import { basename, join, extname } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type { MoltbotPluginApi } from "../../../../src/plugins/types.js";
+import type { AnyAgentTool } from "../../../../src/agents/tools/common.js";
+import type { JobStore } from "../db/store.js";
+import type {
+  JobApplicationConfig,
+  ParsedResumeData,
+  Resume,
+} from "../types.js";
+
+// Tool parameter types
+type ResumeManageParams = {
+  action: "upload" | "list" | "set_default" | "delete" | "view" | "parse";
+  file_path?: string;
+  resume_id?: string;
+  name?: string;
+};
+
+export function createResumeManageTool(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+): AnyAgentTool {
+  return {
+    name: "resume_manage",
+    label: "Resume Manager",
+    description: `Manage resumes for job applications.
+Actions:
+- upload: Add a new resume from a file path
+- list: Show all saved resumes
+- set_default: Set a resume as the default for applications
+- delete: Remove a resume
+- view: View resume details and parsed data
+- parse: Re-parse a resume to extract information`,
+    parameters: Type.Object({
+      action: Type.String({
+        description:
+          "Action to perform: upload, list, set_default, delete, view, or parse",
+      }),
+      file_path: Type.Optional(
+        Type.String({
+          description:
+            "Path to resume file for upload action (PDF, DOCX, or TXT)",
+        }),
+      ),
+      resume_id: Type.Optional(
+        Type.String({
+          description:
+            "Resume ID for set_default, delete, view, or parse actions",
+        }),
+      ),
+      name: Type.Optional(
+        Type.String({
+          description: "Custom name for the resume (optional for upload)",
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      const { action, file_path, resume_id, name } =
+        params as ResumeManageParams;
+
+      try {
+        switch (action) {
+          case "upload":
+            return handleUpload(api, store, config, file_path, name);
+
+          case "list":
+            return handleList(store);
+
+          case "set_default":
+            return handleSetDefault(store, resume_id);
+
+          case "delete":
+            return handleDelete(store, resume_id);
+
+          case "view":
+            return handleView(store, resume_id);
+
+          case "parse":
+            return handleParse(api, store, resume_id);
+
+          default:
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Unknown action: ${action}. Use: upload, list, set_default, delete, view, or parse`,
+                },
+              ],
+              details: { error: "unknown_action" },
+            };
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        api.logger.error(`resume_manage error: ${message}`);
+        return {
+          content: [{ type: "text", text: `Error: ${message}` }],
+          details: { error: message },
+        };
+      }
+    },
+  };
+}
+
+function handleUpload(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  config: JobApplicationConfig,
+  filePath: string | undefined,
+  customName: string | undefined,
+) {
+  if (!filePath) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: "Please provide a file_path to the resume file (PDF, DOCX, or TXT)",
+        },
+      ],
+      details: { error: "missing_file_path" },
+    };
+  }
+
+  // Validate file exists
+  if (!existsSync(filePath)) {
+    return {
+      content: [{ type: "text", text: `File not found: ${filePath}` }],
+      details: { error: "file_not_found" },
+    };
+  }
+
+  // Validate file type
+  const ext = extname(filePath).toLowerCase();
+  const validTypes: Record<string, "pdf" | "docx" | "txt"> = {
+    ".pdf": "pdf",
+    ".docx": "docx",
+    ".txt": "txt",
+  };
+
+  const fileType = validTypes[ext];
+  if (!fileType) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Invalid file type: ${ext}. Supported types: PDF, DOCX, TXT`,
+        },
+      ],
+      details: { error: "invalid_file_type" },
+    };
+  }
+
+  // Copy file to resumes directory
+  const resumeId = randomUUID();
+  const fileName = `${resumeId}${ext}`;
+  const destPath = join(api.resolvePath(config.resumesDir), fileName);
+
+  try {
+    copyFileSync(filePath, destPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        { type: "text", text: `Failed to copy resume file: ${message}` },
+      ],
+      details: { error: "copy_failed", message },
+    };
+  }
+
+  // Parse resume (basic parsing - in production would use ML/NLP)
+  const parsedData = parseResume(filePath, fileType);
+
+  // Determine if this should be the default
+  const existingResumes = store.listResumes();
+  const isDefault = existingResumes.length === 0;
+
+  // Create resume record
+  const resumeName = customName ?? basename(filePath, ext) ?? "My Resume";
+  const resume = store.createResume({
+    name: resumeName,
+    filePath: destPath,
+    fileType,
+    parsedData,
+    isDefault,
+  });
+
+  api.logger.info(
+    `resume_manage: Uploaded resume "${resumeName}" (${resume.id})`,
+  );
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: formatResumeUploaded(resume, isDefault),
+      },
+    ],
+    details: { resume, parsedData },
+  };
+}
+
+function handleList(store: JobStore) {
+  const resumes = store.listResumes();
+
+  if (resumes.length === 0) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: 'No resumes uploaded yet. Use `resume_manage` with action "upload" and a file_path to add one.',
+        },
+      ],
+      details: { count: 0 },
+    };
+  }
+
+  return {
+    content: [{ type: "text", text: formatResumeList(resumes) }],
+    details: { count: resumes.length, resumes },
+  };
+}
+
+function handleSetDefault(store: JobStore, resumeId: string | undefined) {
+  if (!resumeId) {
+    return {
+      content: [{ type: "text", text: "Please provide a resume_id" }],
+      details: { error: "missing_resume_id" },
+    };
+  }
+
+  const resume = store.getResume(resumeId);
+  if (!resume) {
+    return {
+      content: [{ type: "text", text: `Resume not found: ${resumeId}` }],
+      details: { error: "not_found" },
+    };
+  }
+
+  store.setDefaultResume(resumeId);
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Set **${resume.name}** as the default resume for applications.`,
+      },
+    ],
+    details: { resumeId, name: resume.name },
+  };
+}
+
+function handleDelete(store: JobStore, resumeId: string | undefined) {
+  if (!resumeId) {
+    return {
+      content: [{ type: "text", text: "Please provide a resume_id" }],
+      details: { error: "missing_resume_id" },
+    };
+  }
+
+  const resume = store.getResume(resumeId);
+  if (!resume) {
+    return {
+      content: [{ type: "text", text: `Resume not found: ${resumeId}` }],
+      details: { error: "not_found" },
+    };
+  }
+
+  // Delete the file
+  if (existsSync(resume.filePath)) {
+    try {
+      unlinkSync(resume.filePath);
+    } catch {
+      // File deletion failed, continue anyway
+    }
+  }
+
+  // Delete from database
+  store.deleteResume(resumeId);
+
+  return {
+    content: [{ type: "text", text: `Deleted resume: **${resume.name}**` }],
+    details: { resumeId, name: resume.name },
+  };
+}
+
+function handleView(store: JobStore, resumeId: string | undefined) {
+  if (!resumeId) {
+    // Show default resume if no ID provided
+    const defaultResume = store.getDefaultResume();
+    if (!defaultResume) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No default resume set. Please provide a resume_id or upload a resume.",
+          },
+        ],
+        details: { error: "no_default" },
+      };
+    }
+    return {
+      content: [{ type: "text", text: formatResumeDetails(defaultResume) }],
+      details: { resume: defaultResume },
+    };
+  }
+
+  const resume = store.getResume(resumeId);
+  if (!resume) {
+    return {
+      content: [{ type: "text", text: `Resume not found: ${resumeId}` }],
+      details: { error: "not_found" },
+    };
+  }
+
+  return {
+    content: [{ type: "text", text: formatResumeDetails(resume) }],
+    details: { resume },
+  };
+}
+
+function handleParse(
+  api: MoltbotPluginApi,
+  store: JobStore,
+  resumeId: string | undefined,
+) {
+  if (!resumeId) {
+    return {
+      content: [{ type: "text", text: "Please provide a resume_id to parse" }],
+      details: { error: "missing_resume_id" },
+    };
+  }
+
+  const resume = store.getResume(resumeId);
+  if (!resume) {
+    return {
+      content: [{ type: "text", text: `Resume not found: ${resumeId}` }],
+      details: { error: "not_found" },
+    };
+  }
+
+  // Re-parse the resume
+  const parsedData = parseResume(resume.filePath, resume.fileType);
+
+  // Update in database (would need to add update method)
+  // For now, just return the parsed data
+  return {
+    content: [
+      {
+        type: "text",
+        text: formatParsedResume(resume.name, parsedData),
+      },
+    ],
+    details: { resumeId, parsedData },
+  };
+}
+
+/**
+ * Parse a resume file to extract structured data.
+ * This is a simplified implementation - production would use ML/NLP.
+ */
+function parseResume(
+  filePath: string,
+  fileType: "pdf" | "docx" | "txt",
+): ParsedResumeData {
+  // In production, this would:
+  // 1. Extract text from PDF/DOCX using appropriate libraries
+  // 2. Use NLP to identify entities (name, email, phone, etc.)
+  // 3. Classify sections (experience, education, skills)
+  // 4. Extract structured data
+
+  // For now, return placeholder data
+  return {
+    fullName: "John Doe",
+    email: "john.doe@example.com",
+    phone: "(555) 123-4567",
+    location: "San Francisco, CA",
+    summary:
+      "Experienced software engineer with expertise in full-stack development and cloud technologies.",
+    skills: [
+      "TypeScript",
+      "React",
+      "Node.js",
+      "Python",
+      "AWS",
+      "Docker",
+      "PostgreSQL",
+      "GraphQL",
+    ],
+    experience: [
+      {
+        company: "Tech Company Inc",
+        title: "Senior Software Engineer",
+        startDate: "2020-01",
+        endDate: "Present",
+        description:
+          "Led development of cloud-native applications serving millions of users.",
+      },
+      {
+        company: "Startup Co",
+        title: "Software Engineer",
+        startDate: "2017-06",
+        endDate: "2019-12",
+        description: "Built and maintained core platform services.",
+      },
+    ],
+    education: [
+      {
+        institution: "University of California",
+        degree: "Bachelor of Science",
+        field: "Computer Science",
+        graduationDate: "2017",
+      },
+    ],
+  };
+}
+
+// Formatting helpers
+function formatResumeUploaded(resume: Resume, isDefault: boolean): string {
+  const lines: string[] = [];
+  lines.push("## Resume Uploaded Successfully\n");
+  lines.push(`**Name:** ${resume.name}`);
+  lines.push(`**Type:** ${resume.fileType.toUpperCase()}`);
+  lines.push(`**ID:** \`${resume.id}\``);
+
+  if (isDefault) {
+    lines.push(
+      "\nThis resume has been set as your default for job applications.",
+    );
+  }
+
+  if (resume.parsedData) {
+    lines.push("\n### Extracted Information");
+    if (resume.parsedData.fullName) {
+      lines.push(`**Name:** ${resume.parsedData.fullName}`);
+    }
+    if (resume.parsedData.email) {
+      lines.push(`**Email:** ${resume.parsedData.email}`);
+    }
+    if (resume.parsedData.skills && resume.parsedData.skills.length > 0) {
+      lines.push(
+        `**Skills:** ${resume.parsedData.skills.slice(0, 8).join(", ")}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatResumeList(resumes: Resume[]): string {
+  const lines: string[] = [];
+  lines.push("## Your Resumes\n");
+
+  for (const resume of resumes) {
+    const defaultBadge = resume.isDefault ? " ⭐ (default)" : "";
+    lines.push(`### ${resume.name}${defaultBadge}`);
+    lines.push(`- **Type:** ${resume.fileType.toUpperCase()}`);
+    lines.push(`- **ID:** \`${resume.id}\``);
+    lines.push(
+      `- **Added:** ${new Date(resume.createdAt).toLocaleDateString()}`,
+    );
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function formatResumeDetails(resume: Resume): string {
+  const lines: string[] = [];
+  const defaultBadge = resume.isDefault ? " (Default)" : "";
+  lines.push(`## ${resume.name}${defaultBadge}\n`);
+  lines.push(`**Type:** ${resume.fileType.toUpperCase()}`);
+  lines.push(`**ID:** \`${resume.id}\``);
+  lines.push(`**File:** ${resume.filePath}`);
+  lines.push(`**Added:** ${new Date(resume.createdAt).toLocaleDateString()}`);
+
+  if (resume.parsedData) {
+    lines.push("\n### Extracted Information");
+
+    if (resume.parsedData.fullName) {
+      lines.push(`**Name:** ${resume.parsedData.fullName}`);
+    }
+    if (resume.parsedData.email) {
+      lines.push(`**Email:** ${resume.parsedData.email}`);
+    }
+    if (resume.parsedData.phone) {
+      lines.push(`**Phone:** ${resume.parsedData.phone}`);
+    }
+    if (resume.parsedData.location) {
+      lines.push(`**Location:** ${resume.parsedData.location}`);
+    }
+
+    if (resume.parsedData.summary) {
+      lines.push("\n**Summary:**");
+      lines.push(resume.parsedData.summary);
+    }
+
+    if (resume.parsedData.skills && resume.parsedData.skills.length > 0) {
+      lines.push("\n**Skills:**");
+      lines.push(resume.parsedData.skills.join(", "));
+    }
+
+    if (
+      resume.parsedData.experience &&
+      resume.parsedData.experience.length > 0
+    ) {
+      lines.push("\n**Experience:**");
+      for (const exp of resume.parsedData.experience) {
+        lines.push(
+          `- ${exp.title} at ${exp.company} (${exp.startDate} - ${exp.endDate ?? "Present"})`,
+        );
+      }
+    }
+
+    if (resume.parsedData.education && resume.parsedData.education.length > 0) {
+      lines.push("\n**Education:**");
+      for (const edu of resume.parsedData.education) {
+        lines.push(
+          `- ${edu.degree}${edu.field ? ` in ${edu.field}` : ""} from ${edu.institution}`,
+        );
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatParsedResume(
+  name: string,
+  parsedData: ParsedResumeData,
+): string {
+  const lines: string[] = [];
+  lines.push(`## Parsed Resume: ${name}\n`);
+
+  if (parsedData.fullName) lines.push(`**Name:** ${parsedData.fullName}`);
+  if (parsedData.email) lines.push(`**Email:** ${parsedData.email}`);
+  if (parsedData.phone) lines.push(`**Phone:** ${parsedData.phone}`);
+  if (parsedData.location) lines.push(`**Location:** ${parsedData.location}`);
+
+  if (parsedData.summary) {
+    lines.push("\n**Summary:**");
+    lines.push(parsedData.summary);
+  }
+
+  if (parsedData.skills && parsedData.skills.length > 0) {
+    lines.push("\n**Skills:**");
+    lines.push(parsedData.skills.join(", "));
+  }
+
+  if (parsedData.experience && parsedData.experience.length > 0) {
+    lines.push("\n**Experience:**");
+    for (const exp of parsedData.experience) {
+      lines.push(`- ${exp.title} at ${exp.company}`);
+      if (exp.description) {
+        lines.push(`  ${exp.description.slice(0, 100)}...`);
+      }
+    }
+  }
+
+  if (parsedData.education && parsedData.education.length > 0) {
+    lines.push("\n**Education:**");
+    for (const edu of parsedData.education) {
+      lines.push(`- ${edu.degree} from ${edu.institution}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/extensions/job-application/src/types.ts
+++ b/extensions/job-application/src/types.ts
@@ -1,0 +1,197 @@
+/**
+ * Core types for the Job Application plugin
+ */
+
+// =============================================================================
+// Job Types
+// =============================================================================
+
+export type JobSource =
+  | "indeed"
+  | "linkedin"
+  | "greenhouse"
+  | "lever"
+  | "custom";
+
+export type JobStatus =
+  | "new" // Just discovered
+  | "reviewing" // User is reviewing
+  | "approved" // User approved for application
+  | "rejected" // User rejected
+  | "applied" // Application submitted
+  | "archived"; // No longer relevant
+
+export type Job = {
+  id: string;
+  externalId?: string; // ID from job board
+  source: JobSource;
+  company: string;
+  title: string;
+  location?: string;
+  salaryMin?: number;
+  salaryMax?: number;
+  salaryCurrency?: string;
+  description?: string;
+  requirements?: string[];
+  techStack?: string[];
+  url: string;
+  postedAt?: number;
+  discoveredAt: number;
+  status: JobStatus;
+  metadata?: Record<string, unknown>;
+};
+
+// =============================================================================
+// Application Types
+// =============================================================================
+
+export type ApplicationStatus =
+  | "pending" // Ready to apply but not submitted
+  | "submitted" // Application sent
+  | "viewed" // Company viewed application
+  | "rejected" // Received rejection
+  | "interview" // Interview requested
+  | "offer" // Received offer
+  | "withdrawn" // User withdrew
+  | "closed"; // Position closed
+
+export type Application = {
+  id: string;
+  jobId: string;
+  status: ApplicationStatus;
+  appliedAt?: number;
+  resumeId?: string;
+  coverLetter?: string;
+  answers?: ApplicationAnswer[]; // Q&A from application form
+  notes?: string;
+  lastActivityAt: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ApplicationAnswer = {
+  question: string;
+  answer: string;
+  type?: "text" | "select" | "checkbox" | "textarea";
+};
+
+// =============================================================================
+// Email Thread Types
+// =============================================================================
+
+export type EmailThreadStatus =
+  | "active" // Ongoing conversation
+  | "awaiting_response" // Waiting for reply
+  | "responded" // User responded
+  | "closed"; // Thread concluded
+
+export type EmailThread = {
+  id: string;
+  applicationId: string;
+  gmailThreadId?: string;
+  subject: string;
+  fromEmail: string;
+  lastMessageAt: number;
+  status: EmailThreadStatus;
+  messageCount: number;
+  metadata?: Record<string, unknown>;
+};
+
+// =============================================================================
+// Resume Types
+// =============================================================================
+
+export type Resume = {
+  id: string;
+  name: string;
+  filePath: string;
+  fileType: "pdf" | "docx" | "txt";
+  parsedData?: ParsedResumeData;
+  isDefault: boolean;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ParsedResumeData = {
+  fullName?: string;
+  email?: string;
+  phone?: string;
+  location?: string;
+  summary?: string;
+  skills?: string[];
+  experience?: ResumeExperience[];
+  education?: ResumeEducation[];
+};
+
+export type ResumeExperience = {
+  company: string;
+  title: string;
+  startDate?: string;
+  endDate?: string;
+  description?: string;
+};
+
+export type ResumeEducation = {
+  institution: string;
+  degree: string;
+  field?: string;
+  graduationDate?: string;
+};
+
+// =============================================================================
+// Preferences Types
+// =============================================================================
+
+export type JobPreferences = {
+  titles: string[];
+  locations: string[];
+  salaryMin?: number;
+  salaryMax?: number;
+  remoteOnly: boolean;
+  excludeCompanies: string[];
+  keywords: string[];
+  excludeKeywords: string[];
+};
+
+// =============================================================================
+// Plugin Config Types
+// =============================================================================
+
+export type JobApplicationConfig = {
+  dbPath: string;
+  resumesDir: string;
+  scanInterval: string;
+  defaultJobBoards: JobSource[];
+  preferences: JobPreferences;
+  notifications: {
+    channel?: string;
+    dailySummary: boolean;
+    newJobAlerts: boolean;
+    emailResponseAlerts: boolean;
+  };
+};
+
+// =============================================================================
+// Statistics Types
+// =============================================================================
+
+export type JobStats = {
+  totalJobs: number;
+  newJobs: number;
+  appliedJobs: number;
+  pendingApplications: number;
+  interviewsScheduled: number;
+  offersReceived: number;
+  rejections: number;
+  bySource: Record<JobSource, number>;
+  byStatus: Record<JobStatus, number>;
+  applicationsByStatus: Record<ApplicationStatus, number>;
+  averageResponseTime?: number; // Days
+};
+
+export type TimelineEntry = {
+  date: string; // ISO date string
+  jobsDiscovered: number;
+  applicationsSubmitted: number;
+  responsesReceived: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,13 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    optionalDependencies:
+      '@napi-rs/canvas':
+        specifier: ^0.1.88
+        version: 0.1.88
+      node-llama-cpp:
+        specifier: 3.15.0
+        version: 3.15.0(typescript@5.9.3)
     devDependencies:
       '@grammyjs/types':
         specifier: ^3.23.0
@@ -254,13 +261,6 @@ importers:
       wireit:
         specifier: ^0.14.12
         version: 0.14.12
-    optionalDependencies:
-      '@napi-rs/canvas':
-        specifier: ^0.1.88
-        version: 0.1.88
-      node-llama-cpp:
-        specifier: 3.15.0
-        version: 3.15.0(typescript@5.9.3)
 
   extensions/bluebubbles: {}
 
@@ -319,6 +319,12 @@ importers:
         version: link:../..
 
   extensions/imessage: {}
+
+  extensions/job-application:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.47
+        version: 0.34.47
 
   extensions/line:
     devDependencies:
@@ -383,12 +389,12 @@ importers:
       '@microsoft/agents-hosting-extensions-teams':
         specifier: ^1.2.2
         version: 1.2.2
-      moltbot:
-        specifier: workspace:*
-        version: link:../..
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      moltbot:
+        specifier: workspace:*
+        version: link:../..
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -1322,7 +1328,6 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -3213,11 +3218,6 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
-
-  clawdbot@2026.1.24-3:
-    resolution: {integrity: sha512-zt9BzhWXduq8ZZR4rfzQDurQWAgmijTTyPZCQGrn5ew6wCEwhxxEr2/NHG7IlCwcfRsKymsY4se9KMhoNz0JtQ==}
-    engines: {node: '>=22.12.0'}
-    hasBin: true
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -9097,84 +9097,6 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
-
-  clawdbot@2026.1.24-3(@types/express@5.0.6)(audio-decode@2.2.3)(devtools-protocol@0.0.1561482)(typescript@5.9.3):
-    dependencies:
-      '@agentclientprotocol/sdk': 0.13.1(zod@4.3.6)
-      '@aws-sdk/client-bedrock': 3.975.0
-      '@buape/carbon': 0.14.0(hono@4.11.4)
-      '@clack/prompts': 0.11.0
-      '@grammyjs/runner': 2.0.3(grammy@1.39.3)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.39.3)
-      '@homebridge/ciao': 1.3.4
-      '@line/bot-sdk': 10.6.0
-      '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.49.3
-      '@mozilla/readability': 0.6.0
-      '@sinclair/typebox': 0.34.47
-      '@slack/bolt': 4.6.0(@types/express@5.0.6)
-      '@slack/web-api': 7.13.0
-      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
-      ajv: 8.17.1
-      body-parser: 2.2.2
-      chalk: 5.6.2
-      chokidar: 5.0.0
-      chromium-bidi: 13.0.1(devtools-protocol@0.0.1561482)
-      cli-highlight: 2.1.11
-      commander: 14.0.2
-      croner: 9.1.0
-      detect-libc: 2.1.2
-      discord-api-types: 0.38.37
-      dotenv: 17.2.3
-      express: 5.2.1
-      file-type: 21.3.0
-      grammy: 1.39.3
-      hono: 4.11.4
-      jiti: 2.6.1
-      json5: 2.2.3
-      jszip: 3.10.1
-      linkedom: 0.18.12
-      long: 5.3.2
-      markdown-it: 14.1.0
-      node-edge-tts: 1.2.9
-      osc-progress: 0.3.0
-      pdfjs-dist: 5.4.530
-      playwright-core: 1.58.0
-      proper-lockfile: 4.1.2
-      qrcode-terminal: 0.12.0
-      sharp: 0.34.5
-      sqlite-vec: 0.1.7-alpha.2
-      tar: 7.5.4
-      tslog: 4.10.2
-      undici: 7.19.0
-      ws: 8.19.0
-      yaml: 2.8.2
-      zod: 4.3.6
-    optionalDependencies:
-      '@napi-rs/canvas': 0.1.88
-      node-llama-cpp: 3.15.0(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@discordjs/opus'
-      - '@modelcontextprotocol/sdk'
-      - '@types/express'
-      - audio-decode
-      - aws-crt
-      - bufferutil
-      - canvas
-      - debug
-      - devtools-protocol
-      - encoding
-      - ffmpeg-static
-      - jimp
-      - link-preview-js
-      - node-opus
-      - opusscript
-      - supports-color
-      - typescript
-      - utf-8-validate
 
   cli-cursor@5.0.0:
     dependencies:

--- a/skills/jobbot/SKILL.md
+++ b/skills/jobbot/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: jobbot
+description: "Job application assistant for automated job searching, applying, and tracking"
+metadata:
+  moltbot:
+    emoji: "💼"
+    requires:
+      bins: []
+      config:
+        - plugins.entries.job-application.enabled
+---
+
+# JobBot Skill
+
+You are a job application assistant. Your primary role is to help the user find, evaluate, and apply to job opportunities efficiently.
+
+## Core Responsibilities
+
+1. **Job Discovery**: Search for jobs matching the user's preferences and criteria
+2. **Job Evaluation**: Help users review job details, requirements, and fit
+3. **Application Submission**: Prepare and submit applications with user approval
+4. **Progress Tracking**: Monitor application status and email responses
+5. **Status Updates**: Provide summaries and actionable updates
+
+## Communication Style
+
+- Be concise but informative
+- Use numbered lists when presenting multiple jobs
+- Always confirm before submitting applications
+- Proactively share relevant updates and insights
+- Summarize key information (company, role, salary, tech stack)
+
+## Available Tools
+
+### job_search
+
+Search for jobs matching specific criteria or saved preferences.
+
+**When to use**: When the user asks to find jobs, search for positions, or wants to see what's available.
+
+**Example prompts**:
+
+- "Find me React developer jobs in San Francisco"
+- "Search for remote Python positions paying over $150k"
+- "What new jobs match my preferences?"
+
+### job_apply
+
+Submit an application to a specific job. Always use `dry_run=true` first to preview.
+
+**When to use**: When the user wants to apply to a job they've reviewed and approved.
+
+**Important**: NEVER submit without explicit user confirmation. Always:
+
+1. Show the application preview first (dry_run=true)
+2. Wait for user to say "yes", "confirm", or similar
+3. Only then submit with confirm=true
+
+**Example flow**:
+
+```
+User: "Apply to job #3"
+You: [Use job_apply with dry_run=true, show preview]
+User: "Looks good, submit it"
+You: [Use job_apply with confirm=true]
+```
+
+### job_track
+
+Query and manage job application status. Supports multiple actions.
+
+**When to use**:
+
+- `list`: Show jobs or applications by status
+- `status`: Quick check on a specific job/application
+- `details`: Get full information about a job/application
+- `update`: Change status (approve, reject, etc.)
+- `stats`: Show overall statistics
+- `summary`: Get a daily summary
+
+**Example prompts**:
+
+- "Show me my pending applications"
+- "What's the status of my Google application?"
+- "Give me my job search stats"
+- "Mark job #5 as rejected"
+
+### resume_manage
+
+Manage resumes for applications.
+
+**When to use**: When working with resumes (upload, list, set default, view details).
+
+**Example prompts**:
+
+- "Show my resumes"
+- "Use my updated resume as default"
+- "Delete my old resume"
+
+## Conversation Patterns
+
+### Daily Check-in
+
+When the user asks for updates or what's new:
+
+1. Check for new matching jobs
+2. Check for application responses
+3. Provide a brief summary
+4. Suggest next actions
+
+Example response:
+
+```
+Good morning! Here's your job search update:
+
+📥 **New Jobs**: 5 new positions matching your criteria
+📤 **Applications**: 3 pending, 2 submitted
+✉️ **Responses**: 1 new email from TechCorp
+
+Top new jobs:
+1. Senior Developer at Acme - $160k - Remote
+2. Full Stack at StartupX - $140k - SF
+
+Would you like details on any of these, or should I search for more?
+```
+
+### Job Review Flow
+
+When presenting jobs for review:
+
+1. Show key details (title, company, salary, location, tech stack)
+2. Highlight matching criteria and potential concerns
+3. Ask for approval/rejection
+
+Example:
+
+```
+**#3: Backend Engineer at DataFlow**
+- Salary: $150k - $180k
+- Location: Remote (US)
+- Tech: Python, PostgreSQL, AWS, Kubernetes
+- Posted: 2 days ago
+
+✅ Matches: Remote, salary range, Python
+⚠️ Note: Requires 5+ years (you have 4)
+
+Interested? Say "apply to #3" or "skip #3"
+```
+
+### Application Confirmation
+
+Before submitting any application:
+
+1. Show complete application preview
+2. Include cover letter draft
+3. List any questions to answer
+4. Wait for explicit confirmation
+
+Example:
+
+```
+Ready to submit your application for Backend Engineer at DataFlow.
+
+**Resume**: Professional_Resume_2024.pdf
+**Cover Letter Preview**:
+> Dear Hiring Manager...
+> [first 200 chars]
+
+Reply "yes" to submit, "edit" to modify, or "skip" to cancel.
+```
+
+## Safety Rules
+
+1. **Never auto-submit**: Always require explicit user confirmation for applications
+2. **Respect preferences**: Follow user's excluded companies and keywords
+3. **Be honest**: If a job seems like a poor match, mention concerns
+4. **Privacy**: Don't share sensitive information from resumes externally
+5. **Verify actions**: Confirm destructive actions (delete, withdraw)
+
+## Error Handling
+
+If something goes wrong:
+
+1. Explain what happened clearly
+2. Suggest alternative actions
+3. Don't retry automatically without permission
+
+Example:
+
+```
+I couldn't submit the application - the job posting seems to have been removed.
+
+Options:
+1. Search for similar positions at this company
+2. Find other Backend Engineer roles
+3. Skip and move on
+
+What would you prefer?
+```

--- a/ui/src/styles/jobs.css
+++ b/ui/src/styles/jobs.css
@@ -1,0 +1,683 @@
+/* ==========================================================================
+   Jobs View
+   ========================================================================== */
+
+.jobs-view .jobs-layout {
+  display: flex;
+  gap: 20px;
+}
+
+.jobs-view .jobs-list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.jobs-view .job-detail-panel {
+  width: 400px;
+  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+}
+
+.job-card {
+  padding: 16px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  background: var(--card-bg, #fff);
+}
+
+.job-card:hover {
+  border-color: var(--primary-color, #3b82f6);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.job-card.selected {
+  border-color: var(--primary-color, #3b82f6);
+  background: var(--selected-bg, #f0f9ff);
+}
+
+.job-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.job-title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-primary, #111827);
+}
+
+.job-company {
+  color: var(--text-secondary, #6b7280);
+  margin-top: 4px;
+}
+
+.job-meta {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 0.875rem;
+  color: var(--text-tertiary, #9ca3af);
+}
+
+.job-footer {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 12px;
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #9ca3af);
+}
+
+.job-source {
+  text-transform: capitalize;
+}
+
+.job-status {
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.job-status.status-new {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.job-status.status-reviewing {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.job-status.status-approved {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.job-status.status-rejected {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.job-status.status-applied {
+  background: #e0e7ff;
+  color: #3730a3;
+}
+
+/* Job Detail Panel */
+.job-detail {
+  padding: 20px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  background: var(--card-bg, #fff);
+}
+
+.job-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.job-detail-header h2 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.job-detail-meta {
+  margin-top: 16px;
+}
+
+.meta-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.meta-row .label {
+  color: var(--text-secondary, #6b7280);
+  min-width: 80px;
+}
+
+.job-tech-stack {
+  margin-top: 20px;
+}
+
+.job-tech-stack h4 {
+  margin: 0 0 12px 0;
+  font-size: 0.875rem;
+}
+
+.tech-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tech-tag {
+  padding: 4px 10px;
+  background: var(--tag-bg, #f3f4f6);
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+.job-description {
+  margin-top: 20px;
+}
+
+.job-description h4 {
+  margin: 0 0 8px 0;
+  font-size: 0.875rem;
+}
+
+.job-description p {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--text-secondary, #6b7280);
+}
+
+.job-actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* ==========================================================================
+   Applications View
+   ========================================================================== */
+
+.applications-view .view-toggle {
+  display: flex;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.applications-view .view-toggle .btn {
+  border-radius: 0;
+  border: none;
+}
+
+.applications-view .view-toggle .btn.active {
+  background: var(--primary-color, #3b82f6);
+  color: white;
+}
+
+/* Pipeline View */
+.pipeline-container {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  padding-bottom: 16px;
+}
+
+.pipeline-column {
+  flex: 1;
+  min-width: 220px;
+  max-width: 280px;
+}
+
+.pipeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px;
+  background: var(--header-bg, #f9fafb);
+  border-radius: 8px 8px 0 0;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-bottom: none;
+}
+
+.pipeline-title {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.pipeline-count {
+  padding: 2px 8px;
+  background: var(--count-bg, #e5e7eb);
+  border-radius: 10px;
+  font-size: 0.75rem;
+}
+
+.pipeline-cards {
+  background: var(--pipeline-bg, #f9fafb);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 0 0 8px 8px;
+  min-height: 400px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pipeline-empty {
+  text-align: center;
+  color: var(--text-tertiary, #9ca3af);
+  padding: 20px;
+  font-size: 0.875rem;
+}
+
+.pipeline-card {
+  padding: 12px;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.pipeline-card:hover {
+  border-color: var(--primary-color, #3b82f6);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.pipeline-card-title {
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+.pipeline-card-company {
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.75rem;
+  margin-top: 4px;
+}
+
+.pipeline-card-meta {
+  color: var(--text-tertiary, #9ca3af);
+  font-size: 0.75rem;
+  margin-top: 8px;
+}
+
+/* Status Badge */
+.status-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: white;
+}
+
+/* ==========================================================================
+   Resumes View
+   ========================================================================== */
+
+.resumes-view .resumes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.resume-upload-card {
+  position: relative;
+  min-height: 200px;
+  border: 2px dashed var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.resume-upload-card:hover {
+  border-color: var(--primary-color, #3b82f6);
+  background: var(--hover-bg, #f0f9ff);
+}
+
+.resume-upload-card .file-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.upload-content {
+  text-align: center;
+  padding: 20px;
+}
+
+.upload-icon {
+  font-size: 2rem;
+  color: var(--text-tertiary, #9ca3af);
+  margin-bottom: 8px;
+}
+
+.upload-text {
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.upload-hint {
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #9ca3af);
+}
+
+.upload-progress {
+  width: 100%;
+  padding: 20px;
+  text-align: center;
+}
+
+.progress-bar {
+  height: 4px;
+  background: var(--primary-color, #3b82f6);
+  border-radius: 2px;
+  margin-bottom: 8px;
+}
+
+.resume-card {
+  position: relative;
+  padding: 20px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: center;
+  background: var(--card-bg, #fff);
+}
+
+.resume-card:hover {
+  border-color: var(--primary-color, #3b82f6);
+}
+
+.resume-card.selected {
+  border-color: var(--primary-color, #3b82f6);
+  background: var(--selected-bg, #f0f9ff);
+}
+
+.resume-card.default {
+  border-color: var(--success-color, #10b981);
+}
+
+.resume-card .default-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 2px 6px;
+  background: var(--success-color, #10b981);
+  color: white;
+  font-size: 0.625rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+}
+
+.resume-icon {
+  font-size: 2rem;
+  margin-bottom: 12px;
+}
+
+.resume-name {
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.resume-type {
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #9ca3af);
+  margin-bottom: 12px;
+}
+
+.resume-skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+
+.resume-skills .skill-tag {
+  padding: 2px 6px;
+  background: var(--tag-bg, #f3f4f6);
+  border-radius: 3px;
+  font-size: 0.625rem;
+}
+
+.resume-skills .skill-tag.more {
+  background: var(--primary-light, #dbeafe);
+  color: var(--primary-color, #3b82f6);
+}
+
+.resume-date {
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #9ca3af);
+}
+
+/* ==========================================================================
+   Preferences View
+   ========================================================================== */
+
+.preferences-view .form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.preferences-view .field textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.preferences-view .hint {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #9ca3af);
+  margin-top: 4px;
+}
+
+.preferences-view .field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ==========================================================================
+   Modal Styles
+   ========================================================================== */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: var(--card-bg, #fff);
+  border-radius: 12px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.modal-body {
+  padding: 20px;
+}
+
+.modal-footer {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-color, #e5e7eb);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.btn-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--text-tertiary, #9ca3af);
+  padding: 0;
+  line-height: 1;
+}
+
+.btn-close:hover {
+  color: var(--text-primary, #111827);
+}
+
+/* ==========================================================================
+   Utility Classes
+   ========================================================================== */
+
+.btn.primary {
+  background: var(--primary-color, #3b82f6);
+  color: white;
+  border-color: var(--primary-color, #3b82f6);
+}
+
+.btn.primary:hover {
+  background: var(--primary-dark, #2563eb);
+}
+
+.btn.danger {
+  background: var(--danger-color, #ef4444);
+  color: white;
+  border-color: var(--danger-color, #ef4444);
+}
+
+.btn.danger:hover {
+  background: var(--danger-dark, #dc2626);
+}
+
+.btn.small {
+  padding: 4px 8px;
+  font-size: 0.75rem;
+}
+
+.detail-section {
+  margin-bottom: 20px;
+}
+
+.detail-section h3 {
+  margin: 0 0 4px 0;
+  font-size: 1.125rem;
+}
+
+.detail-section h4 {
+  margin: 0 0 8px 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary, #6b7280);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.detail-item .label {
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #9ca3af);
+  text-transform: uppercase;
+}
+
+.company-name {
+  color: var(--text-secondary, #6b7280);
+  margin: 4px 0;
+}
+
+.location {
+  color: var(--text-tertiary, #9ca3af);
+  font-size: 0.875rem;
+}
+
+.cover-letter {
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  background: var(--code-bg, #f9fafb);
+  padding: 12px;
+  border-radius: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.email-threads {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.email-thread {
+  padding: 12px;
+  background: var(--thread-bg, #f9fafb);
+  border-radius: 6px;
+}
+
+.thread-subject {
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.thread-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #9ca3af);
+}
+
+.status-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .jobs-view .jobs-layout {
+    flex-direction: column;
+  }
+
+  .jobs-view .job-detail-panel {
+    width: 100%;
+  }
+
+  .pipeline-container {
+    overflow-x: scroll;
+  }
+
+  .preferences-view .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/ui/src/ui/views/applications.ts
+++ b/ui/src/ui/views/applications.ts
@@ -1,0 +1,346 @@
+import { html, nothing } from "lit";
+
+import { formatAgo } from "../format";
+
+export type Application = {
+  id: string;
+  jobId: string;
+  status: string;
+  appliedAt?: number;
+  resumeId?: string;
+  coverLetter?: string;
+  notes?: string;
+  lastActivityAt: number;
+  createdAt: number;
+  updatedAt: number;
+  job?: {
+    id: string;
+    company: string;
+    title: string;
+    location?: string;
+    url: string;
+  } | null;
+};
+
+export type EmailThread = {
+  id: string;
+  subject: string;
+  fromEmail: string;
+  lastMessageAt: number;
+  status: string;
+  messageCount: number;
+};
+
+export type ApplicationsProps = {
+  loading: boolean;
+  applications: Application[];
+  error: string | null;
+  viewMode: "pipeline" | "list";
+  selectedApplication: Application | null;
+  emailThreads: EmailThread[];
+  onRefresh: () => void;
+  onViewModeChange: (mode: "pipeline" | "list") => void;
+  onSelectApplication: (app: Application | null) => void;
+  onUpdateStatus: (appId: string, status: string, notes?: string) => void;
+};
+
+const APPLICATION_STATUSES = [
+  { value: "pending", label: "Pending", color: "#f59e0b" },
+  { value: "submitted", label: "Submitted", color: "#3b82f6" },
+  { value: "viewed", label: "Viewed", color: "#8b5cf6" },
+  { value: "interview", label: "Interview", color: "#10b981" },
+  { value: "offer", label: "Offer", color: "#22c55e" },
+  { value: "rejected", label: "Rejected", color: "#ef4444" },
+  { value: "withdrawn", label: "Withdrawn", color: "#6b7280" },
+  { value: "closed", label: "Closed", color: "#6b7280" },
+];
+
+const PIPELINE_COLUMNS = [
+  "pending",
+  "submitted",
+  "interview",
+  "offer",
+  "rejected",
+];
+
+export function renderApplications(props: ApplicationsProps) {
+  return html`
+    <section class="applications-view">
+      <div class="card">
+        <div
+          class="row"
+          style="justify-content: space-between; align-items: center;"
+        >
+          <div>
+            <div class="card-title">Application Tracker</div>
+            <div class="card-sub">
+              ${props.applications.length} applications
+            </div>
+          </div>
+          <div class="row" style="gap: 8px;">
+            <div class="view-toggle">
+              <button
+                class="btn ${props.viewMode === "pipeline" ? "active" : ""}"
+                @click=${() => props.onViewModeChange("pipeline")}
+              >
+                Pipeline
+              </button>
+              <button
+                class="btn ${props.viewMode === "list" ? "active" : ""}"
+                @click=${() => props.onViewModeChange("list")}
+              >
+                List
+              </button>
+            </div>
+            <button
+              class="btn"
+              ?disabled=${props.loading}
+              @click=${props.onRefresh}
+            >
+              ${props.loading ? "Loading…" : "Refresh"}
+            </button>
+          </div>
+        </div>
+
+        ${props.error
+          ? html`<div class="callout danger" style="margin-top: 12px;">
+              ${props.error}
+            </div>`
+          : nothing}
+
+        <div class="applications-content" style="margin-top: 16px;">
+          ${props.viewMode === "pipeline"
+            ? renderPipelineView(props)
+            : renderListView(props)}
+        </div>
+      </div>
+
+      ${props.selectedApplication ? renderApplicationModal(props) : nothing}
+    </section>
+  `;
+}
+
+function renderPipelineView(props: ApplicationsProps) {
+  const columns = PIPELINE_COLUMNS.map((status) => ({
+    status,
+    label:
+      APPLICATION_STATUSES.find((s) => s.value === status)?.label ?? status,
+    applications: props.applications.filter((app) => app.status === status),
+  }));
+
+  return html`
+    <div class="pipeline-container">
+      ${columns.map(
+        (col) => html`
+          <div class="pipeline-column">
+            <div class="pipeline-header">
+              <span class="pipeline-title">${col.label}</span>
+              <span class="pipeline-count">${col.applications.length}</span>
+            </div>
+            <div class="pipeline-cards">
+              ${col.applications.length === 0
+                ? html`<div class="pipeline-empty">No applications</div>`
+                : col.applications.map((app) => renderPipelineCard(app, props))}
+            </div>
+          </div>
+        `,
+      )}
+    </div>
+  `;
+}
+
+function renderPipelineCard(app: Application, props: ApplicationsProps) {
+  return html`
+    <div class="pipeline-card" @click=${() => props.onSelectApplication(app)}>
+      <div class="pipeline-card-title">
+        ${app.job?.title ?? "Unknown Position"}
+      </div>
+      <div class="pipeline-card-company">
+        ${app.job?.company ?? "Unknown Company"}
+      </div>
+      <div class="pipeline-card-meta">
+        ${app.appliedAt ? formatAgo(app.appliedAt) : "Not submitted"}
+      </div>
+    </div>
+  `;
+}
+
+function renderListView(props: ApplicationsProps) {
+  if (props.applications.length === 0) {
+    return html`
+      <div class="muted" style="padding: 20px; text-align: center;">
+        No applications yet. Start by approving jobs from the Jobs tab.
+      </div>
+    `;
+  }
+
+  return html`
+    <div class="table">
+      <div class="table-head">
+        <div>Position</div>
+        <div>Company</div>
+        <div>Status</div>
+        <div>Applied</div>
+        <div>Last Activity</div>
+        <div>Actions</div>
+      </div>
+      ${props.applications.map((app) => renderApplicationRow(app, props))}
+    </div>
+  `;
+}
+
+function renderApplicationRow(app: Application, props: ApplicationsProps) {
+  const statusInfo = APPLICATION_STATUSES.find((s) => s.value === app.status);
+
+  return html`
+    <div class="table-row">
+      <div>${app.job?.title ?? "Unknown"}</div>
+      <div>${app.job?.company ?? "Unknown"}</div>
+      <div>
+        <span
+          class="status-badge"
+          style="background-color: ${statusInfo?.color ?? "#6b7280"}"
+        >
+          ${statusInfo?.label ?? app.status}
+        </span>
+      </div>
+      <div>${app.appliedAt ? formatAgo(app.appliedAt) : "—"}</div>
+      <div>${formatAgo(app.lastActivityAt)}</div>
+      <div>
+        <button
+          class="btn small"
+          @click=${() => props.onSelectApplication(app)}
+        >
+          View
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+function renderApplicationModal(props: ApplicationsProps) {
+  const app = props.selectedApplication!;
+  const statusInfo = APPLICATION_STATUSES.find((s) => s.value === app.status);
+
+  return html`
+    <div class="modal-overlay" @click=${() => props.onSelectApplication(null)}>
+      <div class="modal" @click=${(e: Event) => e.stopPropagation()}>
+        <div class="modal-header">
+          <h2>Application Details</h2>
+          <button
+            class="btn-close"
+            @click=${() => props.onSelectApplication(null)}
+          >
+            ×
+          </button>
+        </div>
+
+        <div class="modal-body">
+          <div class="detail-section">
+            <h3>${app.job?.title ?? "Unknown Position"}</h3>
+            <p class="company-name">${app.job?.company ?? "Unknown Company"}</p>
+            ${app.job?.location
+              ? html`<p class="location">${app.job.location}</p>`
+              : nothing}
+          </div>
+
+          <div class="detail-grid">
+            <div class="detail-item">
+              <span class="label">Status</span>
+              <span
+                class="status-badge"
+                style="background-color: ${statusInfo?.color ?? "#6b7280"}"
+              >
+                ${statusInfo?.label ?? app.status}
+              </span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Applied</span>
+              <span
+                >${app.appliedAt
+                  ? new Date(app.appliedAt).toLocaleDateString()
+                  : "Not yet"}</span
+              >
+            </div>
+            <div class="detail-item">
+              <span class="label">Last Activity</span>
+              <span>${formatAgo(app.lastActivityAt)}</span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Created</span>
+              <span>${new Date(app.createdAt).toLocaleDateString()}</span>
+            </div>
+          </div>
+
+          ${app.coverLetter
+            ? html`
+                <div class="detail-section">
+                  <h4>Cover Letter</h4>
+                  <pre class="cover-letter">${app.coverLetter}</pre>
+                </div>
+              `
+            : nothing}
+          ${props.emailThreads.length > 0
+            ? html`
+                <div class="detail-section">
+                  <h4>Email Threads</h4>
+                  <div class="email-threads">
+                    ${props.emailThreads.map(
+                      (thread) => html`
+                        <div class="email-thread">
+                          <div class="thread-subject">${thread.subject}</div>
+                          <div class="thread-meta">
+                            <span>${thread.fromEmail}</span>
+                            <span>${thread.messageCount} messages</span>
+                            <span>${formatAgo(thread.lastMessageAt)}</span>
+                          </div>
+                        </div>
+                      `,
+                    )}
+                  </div>
+                </div>
+              `
+            : nothing}
+          ${app.notes
+            ? html`
+                <div class="detail-section">
+                  <h4>Notes</h4>
+                  <p>${app.notes}</p>
+                </div>
+              `
+            : nothing}
+
+          <div class="detail-section">
+            <h4>Update Status</h4>
+            <div class="status-actions">
+              ${APPLICATION_STATUSES.filter(
+                (s) => s.value !== app.status && s.value !== "closed",
+              ).map(
+                (s) => html`
+                  <button
+                    class="btn small"
+                    style="border-color: ${s.color}; color: ${s.color};"
+                    @click=${() => props.onUpdateStatus(app.id, s.value)}
+                  >
+                    ${s.label}
+                  </button>
+                `,
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          ${app.job?.url
+            ? html`<a href=${app.job.url} target="_blank" class="btn"
+                >View Job</a
+              >`
+            : nothing}
+          <button class="btn" @click=${() => props.onSelectApplication(null)}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui/views/job-preferences.ts
+++ b/ui/src/ui/views/job-preferences.ts
@@ -1,0 +1,302 @@
+import { html, nothing } from "lit";
+
+export type JobPreferences = {
+  titles: string[];
+  locations: string[];
+  salaryMin?: number;
+  salaryMax?: number;
+  remoteOnly: boolean;
+  excludeCompanies: string[];
+  keywords: string[];
+  excludeKeywords: string[];
+};
+
+export type NotificationSettings = {
+  channel?: string;
+  dailySummary: boolean;
+  newJobAlerts: boolean;
+  emailResponseAlerts: boolean;
+};
+
+export type JobPreferencesProps = {
+  loading: boolean;
+  saving: boolean;
+  preferences: JobPreferences;
+  notifications: NotificationSettings;
+  availableChannels: string[];
+  error: string | null;
+  success: string | null;
+  onPreferencesChange: (prefs: Partial<JobPreferences>) => void;
+  onNotificationsChange: (notifs: Partial<NotificationSettings>) => void;
+  onSave: () => void;
+  onReset: () => void;
+};
+
+export function renderJobPreferences(props: JobPreferencesProps) {
+  return html`
+    <section class="preferences-view">
+      <div class="grid grid-cols-2">
+        ${renderSearchPreferences(props)} ${renderNotificationSettings(props)}
+      </div>
+
+      <div class="card" style="margin-top: 16px;">
+        <div
+          class="row"
+          style="justify-content: space-between; align-items: center;"
+        >
+          ${props.error
+            ? html`<div class="callout danger">${props.error}</div>`
+            : props.success
+              ? html`<div class="callout success">${props.success}</div>`
+              : html`<div></div>`}
+
+          <div class="row" style="gap: 8px;">
+            <button
+              class="btn"
+              ?disabled=${props.loading || props.saving}
+              @click=${props.onReset}
+            >
+              Reset
+            </button>
+            <button
+              class="btn primary"
+              ?disabled=${props.loading || props.saving}
+              @click=${props.onSave}
+            >
+              ${props.saving ? "Saving…" : "Save Preferences"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderSearchPreferences(props: JobPreferencesProps) {
+  const { preferences } = props;
+
+  return html`
+    <div class="card">
+      <div class="card-title">Search Preferences</div>
+      <div class="card-sub">Configure what types of jobs to search for</div>
+
+      <div class="form-grid" style="margin-top: 16px;">
+        <label class="field">
+          <span>Job Titles</span>
+          <textarea
+            placeholder="Software Engineer&#10;Full Stack Developer&#10;Backend Developer"
+            .value=${preferences.titles.join("\n")}
+            @input=${(e: Event) => {
+              const value = (e.target as HTMLTextAreaElement).value;
+              props.onPreferencesChange({
+                titles: value.split("\n").filter((t) => t.trim()),
+              });
+            }}
+            rows="3"
+          ></textarea>
+          <span class="hint">One title per line</span>
+        </label>
+
+        <label class="field">
+          <span>Locations</span>
+          <textarea
+            placeholder="Remote&#10;San Francisco, CA&#10;New York, NY"
+            .value=${preferences.locations.join("\n")}
+            @input=${(e: Event) => {
+              const value = (e.target as HTMLTextAreaElement).value;
+              props.onPreferencesChange({
+                locations: value.split("\n").filter((l) => l.trim()),
+              });
+            }}
+            rows="3"
+          ></textarea>
+          <span class="hint">One location per line</span>
+        </label>
+
+        <label class="field">
+          <span>Minimum Salary</span>
+          <input
+            type="number"
+            placeholder="100000"
+            .value=${preferences.salaryMin?.toString() ?? ""}
+            @input=${(e: Event) => {
+              const value = (e.target as HTMLInputElement).value;
+              props.onPreferencesChange({
+                salaryMin: value ? parseInt(value) : undefined,
+              });
+            }}
+          />
+        </label>
+
+        <label class="field">
+          <span>Maximum Salary</span>
+          <input
+            type="number"
+            placeholder="200000"
+            .value=${preferences.salaryMax?.toString() ?? ""}
+            @input=${(e: Event) => {
+              const value = (e.target as HTMLInputElement).value;
+              props.onPreferencesChange({
+                salaryMax: value ? parseInt(value) : undefined,
+              });
+            }}
+          />
+        </label>
+
+        <label class="field checkbox">
+          <span>Remote Only</span>
+          <input
+            type="checkbox"
+            .checked=${preferences.remoteOnly}
+            @change=${(e: Event) => {
+              props.onPreferencesChange({
+                remoteOnly: (e.target as HTMLInputElement).checked,
+              });
+            }}
+          />
+        </label>
+      </div>
+
+      <div class="form-grid" style="margin-top: 16px;">
+        <label class="field">
+          <span>Keywords to Include</span>
+          <textarea
+            placeholder="TypeScript&#10;React&#10;Node.js"
+            .value=${preferences.keywords.join("\n")}
+            @input=${(e: Event) => {
+              const value = (e.target as HTMLTextAreaElement).value;
+              props.onPreferencesChange({
+                keywords: value.split("\n").filter((k) => k.trim()),
+              });
+            }}
+            rows="3"
+          ></textarea>
+          <span class="hint">Jobs must contain at least one keyword</span>
+        </label>
+
+        <label class="field">
+          <span>Keywords to Exclude</span>
+          <textarea
+            placeholder="Senior&#10;Manager&#10;Lead"
+            .value=${preferences.excludeKeywords.join("\n")}
+            @input=${(e: Event) => {
+              const value = (e.target as HTMLTextAreaElement).value;
+              props.onPreferencesChange({
+                excludeKeywords: value.split("\n").filter((k) => k.trim()),
+              });
+            }}
+            rows="3"
+          ></textarea>
+          <span class="hint">Jobs with these keywords will be hidden</span>
+        </label>
+
+        <label class="field" style="grid-column: span 2;">
+          <span>Excluded Companies</span>
+          <textarea
+            placeholder="Company A&#10;Company B"
+            .value=${preferences.excludeCompanies.join("\n")}
+            @input=${(e: Event) => {
+              const value = (e.target as HTMLTextAreaElement).value;
+              props.onPreferencesChange({
+                excludeCompanies: value.split("\n").filter((c) => c.trim()),
+              });
+            }}
+            rows="2"
+          ></textarea>
+          <span class="hint">Jobs from these companies will be hidden</span>
+        </label>
+      </div>
+    </div>
+  `;
+}
+
+function renderNotificationSettings(props: JobPreferencesProps) {
+  const { notifications, availableChannels } = props;
+
+  return html`
+    <div class="card">
+      <div class="card-title">Notifications</div>
+      <div class="card-sub">Configure how you receive job updates</div>
+
+      <div class="form-grid" style="margin-top: 16px;">
+        <label class="field">
+          <span>Notification Channel</span>
+          <select
+            .value=${notifications.channel ?? ""}
+            @change=${(e: Event) => {
+              const value = (e.target as HTMLSelectElement).value;
+              props.onNotificationsChange({
+                channel: value || undefined,
+              });
+            }}
+          >
+            <option value="">Select a channel</option>
+            ${availableChannels.map(
+              (ch) => html`<option value=${ch}>${ch}</option>`,
+            )}
+          </select>
+          <span class="hint">Where to send job alerts</span>
+        </label>
+
+        <div class="field-group">
+          <label class="field checkbox">
+            <input
+              type="checkbox"
+              .checked=${notifications.dailySummary}
+              @change=${(e: Event) => {
+                props.onNotificationsChange({
+                  dailySummary: (e.target as HTMLInputElement).checked,
+                });
+              }}
+            />
+            <span>Daily Summary</span>
+          </label>
+          <span class="hint"
+            >Receive a daily summary of job search activity</span
+          >
+        </div>
+
+        <div class="field-group">
+          <label class="field checkbox">
+            <input
+              type="checkbox"
+              .checked=${notifications.newJobAlerts}
+              @change=${(e: Event) => {
+                props.onNotificationsChange({
+                  newJobAlerts: (e.target as HTMLInputElement).checked,
+                });
+              }}
+            />
+            <span>New Job Alerts</span>
+          </label>
+          <span class="hint"
+            >Get notified when new matching jobs are found</span
+          >
+        </div>
+
+        <div class="field-group">
+          <label class="field checkbox">
+            <input
+              type="checkbox"
+              .checked=${notifications.emailResponseAlerts}
+              @change=${(e: Event) => {
+                props.onNotificationsChange({
+                  emailResponseAlerts: (e.target as HTMLInputElement).checked,
+                });
+              }}
+            />
+            <span>Email Response Alerts</span>
+          </label>
+          <span class="hint"
+            >Get notified when you receive responses from employers</span
+          >
+        </div>
+      </div>
+
+      <div class="callout info" style="margin-top: 16px;">
+        <strong>Tip:</strong> Connect a messaging channel like iMessage or
+        Telegram to receive real-time job alerts on your phone.
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui/views/jobs.ts
+++ b/ui/src/ui/views/jobs.ts
@@ -1,0 +1,322 @@
+/**
+ * Jobs Dashboard View
+ *
+ * Displays discovered job listings with filtering, sorting, and actions.
+ */
+
+import { html, nothing } from "lit";
+
+import { formatAgo } from "../format";
+
+export type Job = {
+  id: string;
+  externalId?: string;
+  source: string;
+  company: string;
+  title: string;
+  location?: string;
+  salaryMin?: number;
+  salaryMax?: number;
+  salaryCurrency?: string;
+  description?: string;
+  techStack?: string[];
+  url: string;
+  discoveredAt: number;
+  status: string;
+};
+
+export type JobsProps = {
+  loading: boolean;
+  jobs: Job[];
+  error: string | null;
+  filters: {
+    status: string;
+    source: string;
+    search: string;
+  };
+  selectedJob: Job | null;
+  onFiltersChange: (filters: JobsProps["filters"]) => void;
+  onRefresh: () => void;
+  onSelectJob: (job: Job | null) => void;
+  onUpdateStatus: (jobId: string, status: string) => void;
+  onApply: (jobId: string) => void;
+};
+
+const JOB_STATUSES = [
+  { value: "", label: "All Statuses" },
+  { value: "new", label: "New" },
+  { value: "reviewing", label: "Reviewing" },
+  { value: "approved", label: "Approved" },
+  { value: "rejected", label: "Rejected" },
+  { value: "applied", label: "Applied" },
+  { value: "archived", label: "Archived" },
+];
+
+const JOB_SOURCES = [
+  { value: "", label: "All Sources" },
+  { value: "indeed", label: "Indeed" },
+  { value: "linkedin", label: "LinkedIn" },
+  { value: "greenhouse", label: "Greenhouse" },
+  { value: "lever", label: "Lever" },
+  { value: "custom", label: "Custom" },
+];
+
+export function renderJobs(props: JobsProps) {
+  const filteredJobs = filterJobs(props.jobs, props.filters);
+
+  return html`
+    <section class="jobs-view">
+      <div class="card">
+        <div
+          class="row"
+          style="justify-content: space-between; align-items: center;"
+        >
+          <div>
+            <div class="card-title">Job Listings</div>
+            <div class="card-sub">
+              ${props.jobs.length} jobs found
+              ${filteredJobs.length !== props.jobs.length
+                ? ` (${filteredJobs.length} matching filters)`
+                : ""}
+            </div>
+          </div>
+          <button
+            class="btn"
+            ?disabled=${props.loading}
+            @click=${props.onRefresh}
+          >
+            ${props.loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
+
+        ${renderFilters(props)}
+        ${props.error
+          ? html`<div class="callout danger" style="margin-top: 12px;">
+              ${props.error}
+            </div>`
+          : nothing}
+
+        <div class="jobs-layout" style="margin-top: 16px;">
+          <div class="jobs-list">
+            ${filteredJobs.length === 0
+              ? html`<div
+                  class="muted"
+                  style="padding: 20px; text-align: center;"
+                >
+                  No jobs found matching your criteria.
+                </div>`
+              : filteredJobs.map((job) => renderJobCard(job, props))}
+          </div>
+
+          ${props.selectedJob
+            ? html`<div class="job-detail-panel">
+                ${renderJobDetail(props.selectedJob, props)}
+              </div>`
+            : nothing}
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderFilters(props: JobsProps) {
+  return html`
+    <div
+      class="filters"
+      style="margin-top: 14px; display: flex; gap: 12px; flex-wrap: wrap;"
+    >
+      <label class="field">
+        <span>Status</span>
+        <select
+          .value=${props.filters.status}
+          @change=${(e: Event) =>
+            props.onFiltersChange({
+              ...props.filters,
+              status: (e.target as HTMLSelectElement).value,
+            })}
+        >
+          ${JOB_STATUSES.map(
+            (s) => html`<option value=${s.value}>${s.label}</option>`,
+          )}
+        </select>
+      </label>
+
+      <label class="field">
+        <span>Source</span>
+        <select
+          .value=${props.filters.source}
+          @change=${(e: Event) =>
+            props.onFiltersChange({
+              ...props.filters,
+              source: (e.target as HTMLSelectElement).value,
+            })}
+        >
+          ${JOB_SOURCES.map(
+            (s) => html`<option value=${s.value}>${s.label}</option>`,
+          )}
+        </select>
+      </label>
+
+      <label class="field" style="flex: 1; min-width: 200px;">
+        <span>Search</span>
+        <input
+          type="text"
+          placeholder="Company, title, or keywords..."
+          .value=${props.filters.search}
+          @input=${(e: Event) =>
+            props.onFiltersChange({
+              ...props.filters,
+              search: (e.target as HTMLInputElement).value,
+            })}
+        />
+      </label>
+    </div>
+  `;
+}
+
+function renderJobCard(job: Job, props: JobsProps) {
+  const isSelected = props.selectedJob?.id === job.id;
+  const salary = formatSalary(job.salaryMin, job.salaryMax, job.salaryCurrency);
+  const statusClass = `status-${job.status}`;
+
+  return html`
+    <div
+      class="job-card ${isSelected ? "selected" : ""}"
+      @click=${() => props.onSelectJob(isSelected ? null : job)}
+    >
+      <div class="job-card-header">
+        <div class="job-title">${job.title}</div>
+        <span class="job-status ${statusClass}">${job.status}</span>
+      </div>
+      <div class="job-company">${job.company}</div>
+      <div class="job-meta">
+        <span>${job.location ?? "Location not specified"}</span>
+        <span>${salary}</span>
+      </div>
+      <div class="job-footer">
+        <span class="job-source">${job.source}</span>
+        <span class="job-date">${formatAgo(job.discoveredAt)}</span>
+      </div>
+    </div>
+  `;
+}
+
+function renderJobDetail(job: Job, props: JobsProps) {
+  const salary = formatSalary(job.salaryMin, job.salaryMax, job.salaryCurrency);
+
+  return html`
+    <div class="job-detail">
+      <div class="job-detail-header">
+        <h2>${job.title}</h2>
+        <button class="btn-close" @click=${() => props.onSelectJob(null)}>
+          ×
+        </button>
+      </div>
+
+      <div class="job-detail-meta">
+        <div class="meta-row">
+          <span class="label">Company:</span>
+          <span>${job.company}</span>
+        </div>
+        <div class="meta-row">
+          <span class="label">Location:</span>
+          <span>${job.location ?? "Not specified"}</span>
+        </div>
+        <div class="meta-row">
+          <span class="label">Salary:</span>
+          <span>${salary}</span>
+        </div>
+        <div class="meta-row">
+          <span class="label">Source:</span>
+          <span>${job.source}</span>
+        </div>
+        <div class="meta-row">
+          <span class="label">Status:</span>
+          <span class="status-${job.status}">${job.status}</span>
+        </div>
+      </div>
+
+      ${job.techStack && job.techStack.length > 0
+        ? html`
+            <div class="job-tech-stack">
+              <h4>Tech Stack</h4>
+              <div class="tech-tags">
+                ${job.techStack.map(
+                  (tech) => html`<span class="tech-tag">${tech}</span>`,
+                )}
+              </div>
+            </div>
+          `
+        : nothing}
+      ${job.description
+        ? html`
+            <div class="job-description">
+              <h4>Description</h4>
+              <p>${job.description}</p>
+            </div>
+          `
+        : nothing}
+
+      <div class="job-actions">
+        ${job.status === "new" || job.status === "reviewing"
+          ? html`
+              <button
+                class="btn primary"
+                @click=${() => props.onUpdateStatus(job.id, "approved")}
+              >
+                Approve
+              </button>
+              <button
+                class="btn danger"
+                @click=${() => props.onUpdateStatus(job.id, "rejected")}
+              >
+                Reject
+              </button>
+            `
+          : nothing}
+        ${job.status === "approved"
+          ? html`
+              <button class="btn primary" @click=${() => props.onApply(job.id)}>
+                Apply Now
+              </button>
+            `
+          : nothing}
+        <a href=${job.url} target="_blank" class="btn">View Original</a>
+      </div>
+    </div>
+  `;
+}
+
+function filterJobs(jobs: Job[], filters: JobsProps["filters"]): Job[] {
+  return jobs.filter((job) => {
+    if (filters.status && job.status !== filters.status) return false;
+    if (filters.source && job.source !== filters.source) return false;
+    if (filters.search) {
+      const search = filters.search.toLowerCase();
+      const matchesCompany = job.company.toLowerCase().includes(search);
+      const matchesTitle = job.title.toLowerCase().includes(search);
+      const matchesTech = job.techStack?.some((t) =>
+        t.toLowerCase().includes(search),
+      );
+      if (!matchesCompany && !matchesTitle && !matchesTech) return false;
+    }
+    return true;
+  });
+}
+
+function formatSalary(min?: number, max?: number, currency?: string): string {
+  if (!min && !max) return "Not specified";
+  const curr = currency ?? "USD";
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: curr,
+    maximumFractionDigits: 0,
+  });
+  if (min && max) {
+    return `${formatter.format(min)} - ${formatter.format(max)}`;
+  }
+  if (min) {
+    return `${formatter.format(min)}+`;
+  }
+  return `Up to ${formatter.format(max!)}`;
+}

--- a/ui/src/ui/views/resumes.ts
+++ b/ui/src/ui/views/resumes.ts
@@ -1,0 +1,362 @@
+/**
+ * Resumes Management View
+ *
+ * Upload, manage, and preview resumes for job applications.
+ */
+
+import { html, nothing } from "lit";
+
+export type Resume = {
+  id: string;
+  name: string;
+  filePath: string;
+  fileType: string;
+  parsedData?: ParsedResumeData;
+  isDefault: boolean;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ParsedResumeData = {
+  fullName?: string;
+  email?: string;
+  phone?: string;
+  location?: string;
+  summary?: string;
+  skills?: string[];
+  experience?: Array<{
+    company: string;
+    title: string;
+    startDate?: string;
+    endDate?: string;
+    description?: string;
+  }>;
+  education?: Array<{
+    institution: string;
+    degree: string;
+    field?: string;
+    graduationDate?: string;
+  }>;
+};
+
+export type ResumesProps = {
+  loading: boolean;
+  resumes: Resume[];
+  error: string | null;
+  selectedResume: Resume | null;
+  uploadProgress: number | null;
+  onRefresh: () => void;
+  onSelectResume: (resume: Resume | null) => void;
+  onSetDefault: (resumeId: string) => void;
+  onDelete: (resumeId: string) => void;
+  onUpload: (file: File) => void;
+};
+
+export function renderResumes(props: ResumesProps) {
+  return html`
+    <section class="resumes-view">
+      <div class="card">
+        <div
+          class="row"
+          style="justify-content: space-between; align-items: center;"
+        >
+          <div>
+            <div class="card-title">Resumes</div>
+            <div class="card-sub">
+              Manage your resume versions for job applications
+            </div>
+          </div>
+          <button
+            class="btn"
+            ?disabled=${props.loading}
+            @click=${props.onRefresh}
+          >
+            ${props.loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
+
+        ${props.error
+          ? html`<div class="callout danger" style="margin-top: 12px;">
+              ${props.error}
+            </div>`
+          : nothing}
+
+        <div class="resumes-content" style="margin-top: 16px;">
+          <div class="resumes-grid">
+            ${renderUploadCard(props)}
+            ${props.resumes.map((resume) => renderResumeCard(resume, props))}
+          </div>
+        </div>
+      </div>
+
+      ${props.selectedResume ? renderResumeDetail(props) : nothing}
+    </section>
+  `;
+}
+
+function renderUploadCard(props: ResumesProps) {
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer?.files[0];
+    if (file) props.onUpload(file);
+  };
+
+  const handleFileInput = (e: Event) => {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) props.onUpload(file);
+  };
+
+  return html`
+    <div
+      class="resume-upload-card"
+      @dragover=${(e: DragEvent) => e.preventDefault()}
+      @drop=${handleDrop}
+    >
+      ${props.uploadProgress !== null
+        ? html`
+            <div class="upload-progress">
+              <div
+                class="progress-bar"
+                style="width: ${props.uploadProgress}%"
+              ></div>
+              <span>Uploading... ${props.uploadProgress}%</span>
+            </div>
+          `
+        : html`
+            <div class="upload-content">
+              <div class="upload-icon">+</div>
+              <div class="upload-text">Upload Resume</div>
+              <div class="upload-hint">PDF, DOCX, or TXT</div>
+              <input
+                type="file"
+                accept=".pdf,.docx,.txt"
+                class="file-input"
+                @change=${handleFileInput}
+              />
+            </div>
+          `}
+    </div>
+  `;
+}
+
+function renderResumeCard(resume: Resume, props: ResumesProps) {
+  const isSelected = props.selectedResume?.id === resume.id;
+
+  return html`
+    <div
+      class="resume-card ${isSelected ? "selected" : ""} ${resume.isDefault
+        ? "default"
+        : ""}"
+      @click=${() => props.onSelectResume(isSelected ? null : resume)}
+    >
+      ${resume.isDefault
+        ? html`<div class="default-badge">Default</div>`
+        : nothing}
+
+      <div class="resume-icon">${getFileIcon(resume.fileType)}</div>
+      <div class="resume-name">${resume.name}</div>
+      <div class="resume-type">${resume.fileType.toUpperCase()}</div>
+
+      ${resume.parsedData?.skills
+        ? html`
+            <div class="resume-skills">
+              ${resume.parsedData.skills
+                .slice(0, 3)
+                .map((skill) => html`<span class="skill-tag">${skill}</span>`)}
+              ${resume.parsedData.skills.length > 3
+                ? html`<span class="skill-tag more">
+                    +${resume.parsedData.skills.length - 3}
+                  </span>`
+                : nothing}
+            </div>
+          `
+        : nothing}
+
+      <div class="resume-date">
+        Added ${new Date(resume.createdAt).toLocaleDateString()}
+      </div>
+    </div>
+  `;
+}
+
+function renderResumeDetail(props: ResumesProps) {
+  const resume = props.selectedResume!;
+  const parsed = resume.parsedData;
+
+  return html`
+    <div class="modal-overlay" @click=${() => props.onSelectResume(null)}>
+      <div
+        class="modal resume-modal"
+        @click=${(e: Event) => e.stopPropagation()}
+      >
+        <div class="modal-header">
+          <h2>${resume.name}</h2>
+          <button class="btn-close" @click=${() => props.onSelectResume(null)}>
+            ×
+          </button>
+        </div>
+
+        <div class="modal-body">
+          <div class="resume-info">
+            <div class="info-row">
+              <span class="label">File Type:</span>
+              <span>${resume.fileType.toUpperCase()}</span>
+            </div>
+            <div class="info-row">
+              <span class="label">Added:</span>
+              <span>${new Date(resume.createdAt).toLocaleDateString()}</span>
+            </div>
+            <div class="info-row">
+              <span class="label">Default:</span>
+              <span>${resume.isDefault ? "Yes" : "No"}</span>
+            </div>
+          </div>
+
+          ${parsed
+            ? html`
+                <div class="parsed-resume">
+                  <h3>Extracted Information</h3>
+
+                  ${parsed.fullName || parsed.email || parsed.phone
+                    ? html`
+                        <div class="section contact-info">
+                          <h4>Contact</h4>
+                          ${parsed.fullName
+                            ? html`<div class="contact-name">
+                                ${parsed.fullName}
+                              </div>`
+                            : nothing}
+                          ${parsed.email
+                            ? html`<div class="contact-item">
+                                ${parsed.email}
+                              </div>`
+                            : nothing}
+                          ${parsed.phone
+                            ? html`<div class="contact-item">
+                                ${parsed.phone}
+                              </div>`
+                            : nothing}
+                          ${parsed.location
+                            ? html`<div class="contact-item">
+                                ${parsed.location}
+                              </div>`
+                            : nothing}
+                        </div>
+                      `
+                    : nothing}
+                  ${parsed.summary
+                    ? html`
+                        <div class="section">
+                          <h4>Summary</h4>
+                          <p>${parsed.summary}</p>
+                        </div>
+                      `
+                    : nothing}
+                  ${parsed.skills && parsed.skills.length > 0
+                    ? html`
+                        <div class="section">
+                          <h4>Skills</h4>
+                          <div class="skills-list">
+                            ${parsed.skills.map(
+                              (skill) =>
+                                html`<span class="skill-tag">${skill}</span>`,
+                            )}
+                          </div>
+                        </div>
+                      `
+                    : nothing}
+                  ${parsed.experience && parsed.experience.length > 0
+                    ? html`
+                        <div class="section">
+                          <h4>Experience</h4>
+                          ${parsed.experience.map(
+                            (exp) => html`
+                              <div class="experience-item">
+                                <div class="exp-title">${exp.title}</div>
+                                <div class="exp-company">${exp.company}</div>
+                                <div class="exp-dates">
+                                  ${exp.startDate} - ${exp.endDate ?? "Present"}
+                                </div>
+                                ${exp.description
+                                  ? html`<div class="exp-desc">
+                                      ${exp.description}
+                                    </div>`
+                                  : nothing}
+                              </div>
+                            `,
+                          )}
+                        </div>
+                      `
+                    : nothing}
+                  ${parsed.education && parsed.education.length > 0
+                    ? html`
+                        <div class="section">
+                          <h4>Education</h4>
+                          ${parsed.education.map(
+                            (edu) => html`
+                              <div class="education-item">
+                                <div class="edu-degree">
+                                  ${edu.degree}${edu.field
+                                    ? ` in ${edu.field}`
+                                    : ""}
+                                </div>
+                                <div class="edu-institution">
+                                  ${edu.institution}
+                                </div>
+                                ${edu.graduationDate
+                                  ? html`<div class="edu-date">
+                                      ${edu.graduationDate}
+                                    </div>`
+                                  : nothing}
+                              </div>
+                            `,
+                          )}
+                        </div>
+                      `
+                    : nothing}
+                </div>
+              `
+            : html`
+                <div class="callout info">
+                  Resume content has not been parsed yet. Use the CLI to parse
+                  this resume.
+                </div>
+              `}
+        </div>
+
+        <div class="modal-footer">
+          ${!resume.isDefault
+            ? html`
+                <button
+                  class="btn primary"
+                  @click=${() => props.onSetDefault(resume.id)}
+                >
+                  Set as Default
+                </button>
+              `
+            : nothing}
+          <button class="btn danger" @click=${() => props.onDelete(resume.id)}>
+            Delete
+          </button>
+          <button class="btn" @click=${() => props.onSelectResume(null)}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function getFileIcon(fileType: string): string {
+  switch (fileType.toLowerCase()) {
+    case "pdf":
+      return "📄";
+    case "docx":
+      return "📝";
+    case "txt":
+      return "📃";
+    default:
+      return "📎";
+  }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `job-application`/JobBot extension: SQLite-backed store + adapters, agent tools (`job_search`, `job_apply`, `job_track`, `resume_manage`), gateway methods for the UI, and background services for periodic job scanning and email response monitoring. The UI gains new views/styles for jobs, applications, preferences, and resumes; lockfile updated for dependencies.

Main integration points are via the plugin registry (`api.registerTool`, `api.registerService`, `api.registerGatewayMethod`, `api.registerCli`) and a new per-plugin SQLite schema/store in `extensions/job-application/src/db`.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but one integration bug prevents the email monitor service from functioning.
- Most changes are additive and self-contained (new plugin, store, tools, UI). However, the email monitor’s hook wiring is currently incompatible with the core `message_received` event shape, so response tracking won’t work until fixed.
- extensions/job-application/src/services/email-monitor.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->