### PR TITLE
fix(configure): preserve custom config keys across wizard sections

### DIFF
--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -440,6 +440,11 @@ describe("runConfigureWizard", () => {
       expect(written.skills).toEqual(rawParsed.skills);
       expect(written.logging).toEqual(rawParsed.logging);
 
+      // Default-only sections (agents) that the user never set are correctly omitted.
+      // They were only in baseConfig because Zod injected defaults — the raw file
+      // never contained them. On next read, Zod will re-inject defaults.
+      expect(written.agents).toBeUndefined();
+
       // gateway was in rawParsed as minimal; since the wizard set mode=local
       // (which creates a new reference), it should use the wizard's value
       expect((written as OpenClawConfig).gateway?.mode).toBe("local");

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
 const mocks = vi.hoisted(() => ({
@@ -96,9 +96,85 @@ vi.mock("./onboard-channels.js", () => ({
 }));
 
 import { WizardCancelledError } from "../wizard/prompts.js";
+import { promptAuthConfig } from "./configure.gateway-auth.js";
+import { promptGatewayConfig } from "./configure.gateway.js";
 import { runConfigureWizard } from "./configure.wizard.js";
 
+/**
+ * A rich config that simulates user-customized settings across many sections.
+ * The wizard should preserve ALL of these when only modifying a single section.
+ */
+function makeRichConfig(): OpenClawConfig {
+  return {
+    gateway: {
+      mode: "local",
+      port: 18789,
+      bind: "loopback",
+      auth: {
+        mode: "token",
+        token: "test-token",
+        allowTailscale: true,
+      },
+      tailscale: { mode: "off", resetOnExit: false },
+    },
+    tools: {
+      media: {
+        audio: { enabled: true, language: "en" },
+      },
+      web: {
+        search: { enabled: true, apiKey: "brave-key-123" },
+        fetch: { enabled: true },
+      },
+    },
+    skills: {
+      entries: {
+        "skill-a": { enabled: false },
+        "skill-b": { enabled: false },
+        "skill-c": { enabled: true, apiKey: "sk-123" },
+      },
+    },
+    agents: {
+      defaults: {
+        workspace: "~/.openclaw/workspace",
+        model: { primary: "anthropic/claude-sonnet-4-5" },
+      },
+    },
+    logging: { level: "info" },
+    web: { enabled: true },
+  } as OpenClawConfig;
+}
+
+function setupCommonMocks(baseConfig: OpenClawConfig) {
+  mocks.readConfigFileSnapshot.mockResolvedValue({
+    exists: true,
+    valid: true,
+    config: baseConfig,
+    issues: [],
+  });
+  mocks.resolveGatewayPort.mockReturnValue(18789);
+  mocks.probeGatewayReachable.mockResolvedValue({ ok: false });
+  mocks.resolveControlUiLinks.mockReturnValue({
+    wsUrl: "ws://127.0.0.1:18789",
+    httpUrl: "http://127.0.0.1:18789",
+  });
+  mocks.summarizeExistingConfig.mockReturnValue("Gateway: local ...");
+  mocks.createClackPrompter.mockReturnValue({});
+  mocks.ensureControlUiAssetsBuilt.mockResolvedValue({ ok: true });
+  mocks.waitForGatewayReachable.mockResolvedValue({ ok: true });
+  mocks.writeConfigFile.mockResolvedValue(undefined);
+}
+
+const testRuntime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
 describe("runConfigureWizard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("persists gateway.mode=local when only the run mode is selected", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: false,
@@ -157,5 +233,164 @@ describe("runConfigureWizard", () => {
     await runConfigureWizard({ command: "configure" }, runtime);
 
     expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  describe("preserves custom keys when configuring a single section", () => {
+    it("preserves tools, skills, and gateway.auth when only 'model' section is configured", async () => {
+      const baseConfig = makeRichConfig();
+      setupCommonMocks(baseConfig);
+
+      // Mock promptAuthConfig to simulate real behavior: spread-preserving
+      vi.mocked(promptAuthConfig).mockImplementation(async (cfg) => ({
+        ...cfg,
+        auth: {
+          ...cfg.auth,
+          profiles: { "anthropic:default": { provider: "anthropic", mode: "api_key" as const } },
+        },
+      }));
+
+      // Mode selection: "local"
+      mocks.clackSelect.mockResolvedValue("local");
+
+      await runConfigureWizard({ command: "configure", sections: ["model"] }, testRuntime);
+
+      expect(mocks.writeConfigFile).toHaveBeenCalledTimes(1);
+      const written = mocks.writeConfigFile.mock.calls[0]?.[0] as OpenClawConfig;
+
+      // Custom tools.media.audio must survive
+      expect(written.tools?.media?.audio).toEqual(
+        expect.objectContaining({ enabled: true, language: "en" }),
+      );
+
+      // Custom tools.web.search.apiKey must survive
+      expect(written.tools?.web?.search?.apiKey).toBe("brave-key-123");
+
+      // gateway.auth.allowTailscale must survive
+      expect(written.gateway?.auth?.allowTailscale).toBe(true);
+      expect(written.gateway?.auth?.token).toBe("test-token");
+
+      // Disabled skill entries must survive
+      expect(written.skills?.entries?.["skill-a"]?.enabled).toBe(false);
+      expect(written.skills?.entries?.["skill-b"]?.enabled).toBe(false);
+      expect(written.skills?.entries?.["skill-c"]?.apiKey).toBe("sk-123");
+
+      // Other top-level sections must survive
+      expect(written.logging).toEqual({ level: "info" });
+      expect(written.web).toEqual({ enabled: true });
+    });
+
+    it("preserves tools and skills when only 'gateway' section is configured", async () => {
+      const baseConfig = makeRichConfig();
+      setupCommonMocks(baseConfig);
+
+      // Mock promptGatewayConfig to simulate real behavior
+      vi.mocked(promptGatewayConfig).mockImplementation(async (cfg) => ({
+        config: {
+          ...cfg,
+          gateway: {
+            ...cfg.gateway,
+            mode: "local" as const,
+            port: 9999,
+            bind: "lan" as const,
+            auth: { mode: "token" as const, token: "new-token", allowTailscale: true },
+            tailscale: { mode: "off" as const, resetOnExit: false },
+          },
+        },
+        port: 9999,
+        token: "new-token",
+      }));
+
+      mocks.clackSelect.mockResolvedValue("local");
+
+      await runConfigureWizard({ command: "configure", sections: ["gateway"] }, testRuntime);
+
+      expect(mocks.writeConfigFile).toHaveBeenCalledTimes(1);
+      const written = mocks.writeConfigFile.mock.calls[0]?.[0] as OpenClawConfig;
+
+      // tools.media.audio must survive a gateway-only change
+      expect(written.tools?.media?.audio).toEqual(
+        expect.objectContaining({ enabled: true, language: "en" }),
+      );
+
+      // Disabled skills must survive
+      expect(written.skills?.entries?.["skill-a"]?.enabled).toBe(false);
+      expect(written.skills?.entries?.["skill-b"]?.enabled).toBe(false);
+
+      // Gateway was intentionally changed
+      expect(written.gateway?.port).toBe(9999);
+    });
+
+    it("preserves all keys in interactive loop when only one section is picked", async () => {
+      const baseConfig = makeRichConfig();
+      setupCommonMocks(baseConfig);
+
+      // Mock promptAuthConfig to simulate real behavior
+      vi.mocked(promptAuthConfig).mockImplementation(async (cfg) => ({
+        ...cfg,
+        auth: {
+          ...cfg.auth,
+          profiles: { "anthropic:default": { provider: "anthropic", mode: "api_key" as const } },
+        },
+      }));
+
+      // Interactive loop: select "local" mode, then "model", then "__continue"
+      const selectQueue = ["local", "model", "__continue"];
+      mocks.clackSelect.mockImplementation(async () => selectQueue.shift());
+
+      await runConfigureWizard({ command: "configure" }, testRuntime);
+
+      expect(mocks.writeConfigFile).toHaveBeenCalled();
+      const written = mocks.writeConfigFile.mock.calls[0]?.[0] as OpenClawConfig;
+
+      // All custom keys must survive
+      expect(written.tools?.media?.audio).toEqual(
+        expect.objectContaining({ enabled: true, language: "en" }),
+      );
+      expect(written.gateway?.auth?.allowTailscale).toBe(true);
+      expect(written.skills?.entries?.["skill-a"]?.enabled).toBe(false);
+      expect(written.skills?.entries?.["skill-b"]?.enabled).toBe(false);
+      expect(written.logging).toEqual({ level: "info" });
+      expect(written.web).toEqual({ enabled: true });
+    });
+
+    it("recovers dropped top-level keys when a section handler omits them", async () => {
+      const baseConfig = makeRichConfig();
+      setupCommonMocks(baseConfig);
+
+      // Simulate a handler that forgets to spread the full config — returns
+      // only the keys it explicitly sets, dropping tools/skills/logging/web.
+      vi.mocked(promptAuthConfig).mockImplementation(
+        async () =>
+          ({
+            gateway: { mode: "local" as const, port: 18789 },
+            agents: {
+              defaults: {
+                workspace: "~/.openclaw/workspace",
+                model: { primary: "anthropic/claude-sonnet-4-5" },
+              },
+            },
+            auth: {
+              profiles: {
+                "anthropic:default": { provider: "anthropic", mode: "api_key" as const },
+              },
+            },
+          }) as OpenClawConfig,
+      );
+
+      mocks.clackSelect.mockResolvedValue("local");
+
+      await runConfigureWizard({ command: "configure", sections: ["model"] }, testRuntime);
+
+      expect(mocks.writeConfigFile).toHaveBeenCalledTimes(1);
+      const written = mocks.writeConfigFile.mock.calls[0]?.[0] as OpenClawConfig;
+
+      // Base config keys that the handler dropped must be recovered
+      expect(written.tools?.media?.audio).toEqual(
+        expect.objectContaining({ enabled: true, language: "en" }),
+      );
+      expect(written.skills?.entries?.["skill-a"]?.enabled).toBe(false);
+      expect(written.logging).toEqual({ level: "info" });
+      expect(written.web).toEqual({ enabled: true });
+    });
   });
 });

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -60,7 +60,7 @@ export function mergeWizardOutput(
   baseConfig: OpenClawConfig,
   nextConfig: OpenClawConfig,
 ): Record<string, unknown> {
-  if ("$include" in rawParsed) {
+  if (Object.hasOwn(rawParsed, "$include")) {
     return nextConfig as unknown as Record<string, unknown>;
   }
 

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -315,6 +315,15 @@ export async function runConfigureWizard(
       process.env.OPENCLAW_GATEWAY_TOKEN;
 
     const persistConfig = async () => {
+      // Recover top-level keys from the base config that a section handler
+      // may have dropped by not spreading the full config object.
+      for (const key of Object.keys(baseConfig)) {
+        if (!(key in nextConfig)) {
+          (nextConfig as Record<string, unknown>)[key] = (baseConfig as Record<string, unknown>)[
+            key
+          ];
+        }
+      }
       nextConfig = applyWizardMetadata(nextConfig, {
         command: opts.command,
         mode,

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -51,6 +51,10 @@ import { setupSkills } from "./onboard-skills.js";
  * which top-level sections the wizard touched. Unmodified sections
  * keep their raw file values (preserving ${VAR} references, unknown
  * sub-keys, and original formatting).
+ *
+ * Sections that exist only in baseConfig (injected by Zod defaults,
+ * not in the user's raw file) are intentionally omitted — all top-level
+ * schema keys are optional and Zod re-injects defaults on next read.
  */
 export function mergeWizardOutput(
   rawParsed: Record<string, unknown>,

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -6,7 +6,7 @@ import { ensureControlUiAssetsBuilt } from "../infra/control-ui-assets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { note } from "../terminal/note.js";
-import { resolveUserPath } from "../utils.js";
+import { isPlainObject, resolveUserPath } from "../utils.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
 import { removeChannelConfigWizard } from "./configure.channels.js";
@@ -42,6 +42,37 @@ import {
 } from "./onboard-helpers.js";
 import { promptRemoteGatewayConfig } from "./onboard-remote.js";
 import { setupSkills } from "./onboard-skills.js";
+
+/**
+ * Merge wizard changes into the raw parsed config, preserving keys
+ * the wizard didn't modify (#9632).
+ *
+ * Uses reference equality between baseConfig and nextConfig to detect
+ * which top-level sections the wizard touched. Unmodified sections
+ * keep their raw file values (preserving ${VAR} references, unknown
+ * sub-keys, and original formatting).
+ */
+export function mergeWizardOutput(
+  rawParsed: Record<string, unknown>,
+  baseConfig: OpenClawConfig,
+  nextConfig: OpenClawConfig,
+): Record<string, unknown> {
+  if ("$include" in rawParsed) {
+    return nextConfig as unknown as Record<string, unknown>;
+  }
+
+  const result: Record<string, unknown> = { ...rawParsed };
+  const baseRec = baseConfig as unknown as Record<string, unknown>;
+  const nextRec = nextConfig as unknown as Record<string, unknown>;
+
+  for (const key of Object.keys(nextRec)) {
+    if (nextRec[key] !== baseRec[key]) {
+      result[key] = nextRec[key];
+    }
+  }
+
+  return result;
+}
 
 type ConfigureSectionChoice = WizardSection | "__continue";
 
@@ -218,6 +249,8 @@ export async function runConfigureWizard(
 
     const snapshot = await readConfigFileSnapshot();
     const baseConfig: OpenClawConfig = snapshot.valid ? snapshot.config : {};
+    const rawParsed: Record<string, unknown> =
+      snapshot.exists && snapshot.valid && isPlainObject(snapshot.parsed) ? snapshot.parsed : {};
 
     if (snapshot.exists) {
       const title = snapshot.valid ? "Existing config detected" : "Invalid config";
@@ -286,7 +319,8 @@ export async function runConfigureWizard(
         command: opts.command,
         mode,
       });
-      await writeConfigFile(remoteConfig);
+      const merged = mergeWizardOutput(rawParsed, baseConfig, remoteConfig);
+      await writeConfigFile(merged as OpenClawConfig);
       logConfigUpdated(runtime);
       outro("Remote gateway configured.");
       return;
@@ -315,20 +349,12 @@ export async function runConfigureWizard(
       process.env.OPENCLAW_GATEWAY_TOKEN;
 
     const persistConfig = async () => {
-      // Recover top-level keys from the base config that a section handler
-      // may have dropped by not spreading the full config object.
-      for (const key of Object.keys(baseConfig)) {
-        if (!(key in nextConfig)) {
-          (nextConfig as Record<string, unknown>)[key] = (baseConfig as Record<string, unknown>)[
-            key
-          ];
-        }
-      }
       nextConfig = applyWizardMetadata(nextConfig, {
         command: opts.command,
         mode,
       });
-      await writeConfigFile(nextConfig);
+      const merged = mergeWizardOutput(rawParsed, baseConfig, nextConfig);
+      await writeConfigFile(merged as OpenClawConfig);
       logConfigUpdated(runtime);
     };
 


### PR DESCRIPTION
## Summary

Fixes #9632

The configure wizard was overwriting the entire config file when modifying a single section, dropping custom keys the wizard doesn't manage (e.g., `tools.media.audio`, `gateway.auth.allowTailscale`, disabled `skills.entries`).

**Root cause**: The wizard reads config through `readConfigFileSnapshot()`, which returns a Zod-validated + defaults-applied version. This processed config was used as the base for writes, meaning:
- Zod-processed sections replaced raw file values (adding defaults the user never set)
- `${VAR}` env references were substituted with literal values
- `$include` directives were resolved to inline content

**Fix**: Added `mergeWizardOutput()` which uses reference equality between `baseConfig` and `nextConfig` to detect which top-level sections the wizard actually modified. Only wizard-modified sections use the wizard's output; unmodified sections preserve their raw file values from `snapshot.parsed`.

- Unmodified sections keep raw file values (no injected defaults)
- `${VAR}` references preserved in unmodified sections
- `$include` at top level falls back to current behavior (separate concern)
- Both local and remote wizard paths use the merge function

## Test plan

- [x] `mergeWizardOutput` unit tests: preserves raw values, uses wizard values for modified keys, preserves keys not in nextConfig, falls back with `$include`, adds new wizard keys
- [x] Integration tests: preserves tools/skills/logging when configuring only `model`, `gateway`, or interactive loop
- [x] Edge case: handler that drops keys → recovered from rawParsed
- [x] Edge case: rawParsed differs from baseConfig (minimal raw vs defaults-injected) → unmodified sections use raw values
- All 11 tests fail before fix, pass after

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the configure wizard to avoid rewriting the entire config when only one wizard section changes. It introduces `mergeWizardOutput()` and uses it in both local/remote wizard flows so that top‑level sections the wizard didn’t modify are preserved from the raw parsed file (keeping user custom keys, `${VAR}` references, and un-expanded `$include` content), while modified sections come from the wizard output. The accompanying tests expand coverage for preserving raw values, recovering keys dropped by section handlers, and `$include` fallback behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to how the wizard merges its output back into the raw parsed config, with explicit handling for default-only sections and `$include` fallback; unit/integration tests cover the key regressions described in the PR.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->