### PR TITLE
perf(docker): optimize Docker image size and build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM node:22-bookworm
 
 # Install Bun (required for build scripts)
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash
 
 RUN corepack enable
-
-WORKDIR /app
 
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
 RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
@@ -16,10 +13,17 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY ui/package.json ./ui/package.json
-COPY patches ./patches
-COPY scripts ./scripts
+# Security hardening: Run as non-root user
+# The node:22-bookworm image includes a 'node' user (uid 1000)
+# This reduces the attack surface by preventing container escape via root privileges
+USER node
+
+WORKDIR /app
+
+COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY --chown=node:node ui/package.json ./ui/package.json
+COPY --chown=node:node patches ./patches
+COPY --chown=node:node scripts ./scripts
 
 RUN pnpm install --frozen-lockfile
 
@@ -36,21 +40,13 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
-COPY . .
+COPY --chown=node:node . .
 RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build
 
 ENV NODE_ENV=production
-
-# Allow non-root user to write temp files during runtime/tests.
-RUN chown -R node:node /app
-
-# Security hardening: Run as non-root user
-# The node:22-bookworm image includes a 'node' user (uid 1000)
-# This reduces the attack surface by preventing container escape via root privileges
-USER node
 
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.


### PR DESCRIPTION
Install bun to /usr/local/bin as root
Switch to node user before copying files to prevent costly metadata changes
- Eliminate need for chown, speed up image build
- Decrease final image size, from 4.25G to 2.74G

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Optimized Docker build by installing bun to `/usr/local/bin` as root and switching to node user before COPY operations, eliminating the need for expensive `chown -R` commands. This reduces final image size from 4.25GB to 2.74GB (~35% reduction) and speeds up build times by avoiding metadata changes on copied files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a pure optimization with no functional changes
- The changes are well-designed and follow Docker best practices. Installing bun to `/usr/local/bin` makes it globally accessible, and switching to the node user early with `--chown` flags is more efficient than the previous approach of copying as root then running `chown -R`. The optimizations are sound and the approach is standard for multi-user Docker images.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->