### PR TITLE
feat: Add Databricks AI Gateway as a model provider

### DIFF
--- a/src/agents/databricks-auth.live.test.ts
+++ b/src/agents/databricks-auth.live.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Live integration test for Databricks service principal OAuth token exchange.
+ *
+ * Requires real credentials exported in the environment:
+ *   export DATABRICKS_CLIENT_ID="your-client-id"
+ *   export DATABRICKS_CLIENT_SECRET="your-client-secret"
+ *   export DATABRICKS_HOST="https://your-workspace.cloud.databricks.com"
+ *
+ * Run with: LIVE=1 npx vitest run src/agents/databricks-auth.live.test.ts
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearDatabricksTokenCache,
+  exchangeDatabricksServicePrincipalToken,
+  resolveDatabricksServicePrincipalEnv,
+} from "./databricks-auth.js";
+
+const isLive = process.env.LIVE === "1" || process.env.CLAWDBOT_LIVE_TEST === "1";
+
+describe.skipIf(!isLive)("Databricks service principal (LIVE)", () => {
+  beforeEach(() => {
+    clearDatabricksTokenCache();
+  });
+
+  afterEach(() => {
+    clearDatabricksTokenCache();
+  });
+
+  it("resolves service principal config from env", () => {
+    const config = resolveDatabricksServicePrincipalEnv();
+    expect(config).not.toBeNull();
+    expect(config!.clientId).toBeTruthy();
+    expect(config!.clientSecret).toBeTruthy();
+    expect(config!.workspaceUrl).toMatch(/^https:\/\//);
+    console.log(`  Workspace: ${config!.workspaceUrl}`);
+    console.log(`  Client ID: ${config!.clientId.slice(0, 8)}...`);
+  });
+
+  it("exchanges client credentials for a real access token", async () => {
+    const config = resolveDatabricksServicePrincipalEnv();
+    expect(config).not.toBeNull();
+
+    const token = await exchangeDatabricksServicePrincipalToken(config!);
+
+    expect(token).toBeTruthy();
+    expect(typeof token).toBe("string");
+    expect(token.length).toBeGreaterThan(10);
+    console.log(`  Token obtained: ${token.slice(0, 12)}... (${token.length} chars)`);
+  });
+
+  it("returns cached token on second call", async () => {
+    const config = resolveDatabricksServicePrincipalEnv();
+    expect(config).not.toBeNull();
+
+    const token1 = await exchangeDatabricksServicePrincipalToken(config!);
+    const token2 = await exchangeDatabricksServicePrincipalToken(config!);
+
+    expect(token1).toBe(token2);
+    console.log("  Cache hit confirmed: second call returned same token");
+  });
+
+  it("can use the token to call a serving endpoint (smoke test)", async () => {
+    const config = resolveDatabricksServicePrincipalEnv();
+    expect(config).not.toBeNull();
+
+    const token = await exchangeDatabricksServicePrincipalToken(config!);
+
+    // Try listing serving endpoints — this is a lightweight API call that
+    // validates the token works against the Databricks workspace.
+    const response = await fetch(`${config!.workspaceUrl}/api/2.0/serving-endpoints`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    // 200 = success, 403 = token works but SP lacks permissions (still valid auth)
+    expect([200, 403]).toContain(response.status);
+    console.log(`  Serving endpoints API: ${response.status} ${response.statusText}`);
+
+    if (response.status === 200) {
+      const data = (await response.json()) as { endpoints?: Array<{ name: string }> };
+      const count = data.endpoints?.length ?? 0;
+      console.log(`  Found ${count} serving endpoint(s)`);
+      if (data.endpoints && data.endpoints.length > 0) {
+        for (const ep of data.endpoints.slice(0, 5)) {
+          console.log(`    - ${ep.name}`);
+        }
+        if (data.endpoints.length > 5) {
+          console.log(`    ... and ${data.endpoints.length - 5} more`);
+        }
+      }
+    }
+  });
+});

--- a/src/agents/databricks-auth.live.test.ts
+++ b/src/agents/databricks-auth.live.test.ts
@@ -94,6 +94,9 @@ describe.skipIf(!isLive)("Databricks service principal (LIVE)", () => {
 
   it(
     "calls databricks-claude-opus-4-6 via OpenAI-compatible chat completions",
+    {
+      timeout: 60_000,
+    },
     async () => {
       const config = resolveDatabricksServicePrincipalEnv();
       expect(config).not.toBeNull();
@@ -156,6 +159,5 @@ describe.skipIf(!isLive)("Databricks service principal (LIVE)", () => {
       // The response should contain the expected phrase
       expect(reply.toLowerCase()).toContain("hello from databricks");
     },
-    { timeout: 60_000 },
   );
 });

--- a/src/agents/databricks-auth.live.test.ts
+++ b/src/agents/databricks-auth.live.test.ts
@@ -1,12 +1,14 @@
 /**
- * Live integration test for Databricks service principal OAuth token exchange.
+ * Live integration test for Databricks service principal OAuth token exchange
+ * and model invocation via the OpenAI-compatible serving endpoint.
  *
  * Requires real credentials exported in the environment:
  *   export DATABRICKS_CLIENT_ID="your-client-id"
  *   export DATABRICKS_CLIENT_SECRET="your-client-secret"
  *   export DATABRICKS_HOST="https://your-workspace.cloud.databricks.com"
  *
- * Run with: LIVE=1 npx vitest run src/agents/databricks-auth.live.test.ts
+ * Run with:
+ *   pnpm test:live -- src/agents/databricks-auth.live.test.ts
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -16,6 +18,7 @@ import {
 } from "./databricks-auth.js";
 
 const isLive = process.env.LIVE === "1" || process.env.CLAWDBOT_LIVE_TEST === "1";
+const DATABRICKS_TEST_MODEL = "databricks-claude-opus-4-6";
 
 describe.skipIf(!isLive)("Databricks service principal (LIVE)", () => {
   beforeEach(() => {
@@ -59,22 +62,18 @@ describe.skipIf(!isLive)("Databricks service principal (LIVE)", () => {
     console.log("  Cache hit confirmed: second call returned same token");
   });
 
-  it("can use the token to call a serving endpoint (smoke test)", async () => {
+  it("can list serving endpoints with the token", async () => {
     const config = resolveDatabricksServicePrincipalEnv();
     expect(config).not.toBeNull();
 
     const token = await exchangeDatabricksServicePrincipalToken(config!);
 
-    // Try listing serving endpoints — this is a lightweight API call that
-    // validates the token works against the Databricks workspace.
     const response = await fetch(`${config!.workspaceUrl}/api/2.0/serving-endpoints`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(15_000),
     });
 
-    // 200 = success, 403 = token works but SP lacks permissions (still valid auth)
+    // 200 = success, 403 = token works but SP lacks list permission (still valid auth)
     expect([200, 403]).toContain(response.status);
     console.log(`  Serving endpoints API: ${response.status} ${response.statusText}`);
 
@@ -92,4 +91,71 @@ describe.skipIf(!isLive)("Databricks service principal (LIVE)", () => {
       }
     }
   });
+
+  it(
+    "calls databricks-claude-opus-4-6 via OpenAI-compatible chat completions",
+    async () => {
+      const config = resolveDatabricksServicePrincipalEnv();
+      expect(config).not.toBeNull();
+
+      const token = await exchangeDatabricksServicePrincipalToken(config!);
+      const endpointUrl = `${config!.workspaceUrl}/serving-endpoints/${DATABRICKS_TEST_MODEL}/invocations`;
+
+      console.log(`  Endpoint: ${endpointUrl}`);
+      console.log(`  Model: ${DATABRICKS_TEST_MODEL}`);
+
+      const payload = {
+        messages: [
+          {
+            role: "user",
+            content: "Reply with exactly: Hello from Databricks",
+          },
+        ],
+        max_tokens: 50,
+        temperature: 0,
+      };
+
+      const response = await fetch(endpointUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      console.log(`  Response status: ${response.status} ${response.statusText}`);
+      expect(response.ok).toBe(true);
+
+      const data = (await response.json()) as {
+        id?: string;
+        object?: string;
+        choices?: Array<{
+          message?: { role?: string; content?: string };
+          index?: number;
+          finish_reason?: string;
+        }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+      };
+
+      // Validate OpenAI-compatible response structure
+      expect(data.choices).toBeDefined();
+      expect(data.choices!.length).toBeGreaterThan(0);
+
+      const reply = data.choices![0]?.message?.content ?? "";
+      expect(reply.length).toBeGreaterThan(0);
+      console.log(`  Model reply: ${reply}`);
+
+      if (data.usage) {
+        console.log(
+          `  Usage: ${data.usage.prompt_tokens} prompt + ${data.usage.completion_tokens} completion = ${data.usage.total_tokens} total tokens`,
+        );
+      }
+
+      // The response should contain the expected phrase
+      expect(reply.toLowerCase()).toContain("hello from databricks");
+    },
+    { timeout: 60_000 },
+  );
 });

--- a/src/agents/databricks-auth.test.ts
+++ b/src/agents/databricks-auth.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearDatabricksTokenCache,
+  exchangeDatabricksServicePrincipalToken,
+  hasDatabricksServicePrincipalEnv,
+  resolveDatabricksServicePrincipalEnv,
+} from "./databricks-auth.js";
+
+describe("resolveDatabricksServicePrincipalEnv", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = ["DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"];
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it("returns null when no env vars are set", () => {
+    expect(resolveDatabricksServicePrincipalEnv()).toBeNull();
+  });
+
+  it("returns null when only client_id is set", () => {
+    process.env.DATABRICKS_CLIENT_ID = "test-client-id";
+    expect(resolveDatabricksServicePrincipalEnv()).toBeNull();
+  });
+
+  it("returns null when only client_id and secret are set (no host)", () => {
+    process.env.DATABRICKS_CLIENT_ID = "test-client-id";
+    process.env.DATABRICKS_CLIENT_SECRET = "test-secret";
+    expect(resolveDatabricksServicePrincipalEnv()).toBeNull();
+  });
+
+  it("returns config when all three env vars are set", () => {
+    process.env.DATABRICKS_CLIENT_ID = "test-client-id";
+    process.env.DATABRICKS_CLIENT_SECRET = "test-secret";
+    process.env.DATABRICKS_HOST = "https://my-workspace.cloud.databricks.com";
+
+    const result = resolveDatabricksServicePrincipalEnv();
+    expect(result).not.toBeNull();
+    expect(result?.clientId).toBe("test-client-id");
+    expect(result?.clientSecret).toBe("test-secret");
+    expect(result?.workspaceUrl).toBe("https://my-workspace.cloud.databricks.com");
+  });
+
+  it("strips trailing slashes from host URL", () => {
+    process.env.DATABRICKS_CLIENT_ID = "test-client-id";
+    process.env.DATABRICKS_CLIENT_SECRET = "test-secret";
+    process.env.DATABRICKS_HOST = "https://my-workspace.cloud.databricks.com///";
+
+    const result = resolveDatabricksServicePrincipalEnv();
+    expect(result?.workspaceUrl).toBe("https://my-workspace.cloud.databricks.com");
+  });
+
+  it("trims whitespace from all values", () => {
+    process.env.DATABRICKS_CLIENT_ID = "  test-client-id  ";
+    process.env.DATABRICKS_CLIENT_SECRET = "  test-secret  ";
+    process.env.DATABRICKS_HOST = "  https://workspace.cloud.databricks.com  ";
+
+    const result = resolveDatabricksServicePrincipalEnv();
+    expect(result?.clientId).toBe("test-client-id");
+    expect(result?.clientSecret).toBe("test-secret");
+    expect(result?.workspaceUrl).toBe("https://workspace.cloud.databricks.com");
+  });
+
+  it("returns null when values are whitespace-only", () => {
+    process.env.DATABRICKS_CLIENT_ID = "   ";
+    process.env.DATABRICKS_CLIENT_SECRET = "test-secret";
+    process.env.DATABRICKS_HOST = "https://workspace.cloud.databricks.com";
+    expect(resolveDatabricksServicePrincipalEnv()).toBeNull();
+  });
+
+  it("accepts explicit env parameter", () => {
+    const env = {
+      DATABRICKS_CLIENT_ID: "custom-id",
+      DATABRICKS_CLIENT_SECRET: "custom-secret",
+      DATABRICKS_HOST: "https://custom.cloud.databricks.com",
+    } as NodeJS.ProcessEnv;
+
+    const result = resolveDatabricksServicePrincipalEnv(env);
+    expect(result?.clientId).toBe("custom-id");
+    expect(result?.workspaceUrl).toBe("https://custom.cloud.databricks.com");
+  });
+});
+
+describe("hasDatabricksServicePrincipalEnv", () => {
+  afterEach(() => {
+    delete process.env.DATABRICKS_CLIENT_ID;
+    delete process.env.DATABRICKS_CLIENT_SECRET;
+    delete process.env.DATABRICKS_HOST;
+  });
+
+  it("returns false when env vars are not set", () => {
+    expect(hasDatabricksServicePrincipalEnv()).toBe(false);
+  });
+
+  it("returns true when all env vars are set", () => {
+    process.env.DATABRICKS_CLIENT_ID = "id";
+    process.env.DATABRICKS_CLIENT_SECRET = "secret";
+    process.env.DATABRICKS_HOST = "https://workspace.cloud.databricks.com";
+    expect(hasDatabricksServicePrincipalEnv()).toBe(true);
+  });
+});
+
+describe("exchangeDatabricksServicePrincipalToken", () => {
+  beforeEach(() => {
+    clearDatabricksTokenCache();
+  });
+
+  afterEach(() => {
+    clearDatabricksTokenCache();
+    vi.restoreAllMocks();
+  });
+
+  it("exchanges client credentials for an access token", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: "dapi-exchanged-token-123",
+        token_type: "Bearer",
+        expires_in: 3600,
+      }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(mockResponse as Response);
+
+    const token = await exchangeDatabricksServicePrincipalToken({
+      workspaceUrl: "https://my-workspace.cloud.databricks.com",
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+    });
+
+    expect(token).toBe("dapi-exchanged-token-123");
+
+    // Verify the fetch was called with correct parameters
+    expect(fetch).toHaveBeenCalledWith(
+      "https://my-workspace.cloud.databricks.com/oidc/v1/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+        body: "grant_type=client_credentials&scope=all-apis",
+      }),
+    );
+
+    // Verify Basic auth header
+    const callArgs = vi.mocked(fetch).mock.calls[0];
+    const headers = (callArgs?.[1] as RequestInit)?.headers as Record<string, string>;
+    const expectedBasic = Buffer.from("test-client-id:test-client-secret").toString("base64");
+    expect(headers.Authorization).toBe(`Basic ${expectedBasic}`);
+  });
+
+  it("caches the token for subsequent calls", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: "dapi-cached-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as Response);
+
+    const config = {
+      workspaceUrl: "https://workspace.cloud.databricks.com",
+      clientId: "id",
+      clientSecret: "secret",
+    };
+
+    const token1 = await exchangeDatabricksServicePrincipalToken(config);
+    const token2 = await exchangeDatabricksServicePrincipalToken(config);
+
+    expect(token1).toBe("dapi-cached-token");
+    expect(token2).toBe("dapi-cached-token");
+    // Should only call fetch once due to caching
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on non-OK response", async () => {
+    const mockResponse = {
+      ok: false,
+      status: 401,
+      text: async () => '{"error": "invalid_client"}',
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(mockResponse as Response);
+
+    await expect(
+      exchangeDatabricksServicePrincipalToken({
+        workspaceUrl: "https://workspace.cloud.databricks.com",
+        clientId: "bad-id",
+        clientSecret: "bad-secret",
+      }),
+    ).rejects.toThrow("Databricks OAuth token exchange failed (401)");
+  });
+
+  it("throws when response is missing access_token", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ token_type: "Bearer" }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(mockResponse as Response);
+
+    await expect(
+      exchangeDatabricksServicePrincipalToken({
+        workspaceUrl: "https://workspace.cloud.databricks.com",
+        clientId: "id",
+        clientSecret: "secret",
+      }),
+    ).rejects.toThrow("Databricks OAuth response missing access_token");
+  });
+
+  it("handles missing expires_in with default TTL", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: "dapi-no-expiry-token",
+        token_type: "Bearer",
+        // No expires_in field — should default to 3600
+      }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as Response);
+
+    const token = await exchangeDatabricksServicePrincipalToken({
+      workspaceUrl: "https://workspace.cloud.databricks.com",
+      clientId: "id",
+      clientSecret: "secret",
+    });
+
+    expect(token).toBe("dapi-no-expiry-token");
+
+    // Second call should still use cache (token defaults to 1hr TTL)
+    const token2 = await exchangeDatabricksServicePrincipalToken({
+      workspaceUrl: "https://workspace.cloud.databricks.com",
+      clientId: "id",
+      clientSecret: "secret",
+    });
+    expect(token2).toBe("dapi-no-expiry-token");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearDatabricksTokenCache forces a re-exchange", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: "dapi-first-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      }),
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as Response);
+
+    const config = {
+      workspaceUrl: "https://workspace.cloud.databricks.com",
+      clientId: "id",
+      clientSecret: "secret",
+    };
+
+    await exchangeDatabricksServicePrincipalToken(config);
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    clearDatabricksTokenCache();
+
+    await exchangeDatabricksServicePrincipalToken(config);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/databricks-auth.ts
+++ b/src/agents/databricks-auth.ts
@@ -1,0 +1,106 @@
+/**
+ * Databricks authentication utilities.
+ *
+ * Supports two authentication modes:
+ * 1. **PAT (Personal Access Token)**: Set `DATABRICKS_TOKEN` or `DATABRICKS_API_KEY`.
+ * 2. **Service Principal (OAuth client_credentials)**: Set `DATABRICKS_CLIENT_ID`,
+ *    `DATABRICKS_CLIENT_SECRET`, and `DATABRICKS_HOST`. The module exchanges the
+ *    credentials for a short-lived access token via the workspace OIDC endpoint.
+ */
+
+// In-memory token cache to avoid re-exchanging on every call.
+let cachedToken: { accessToken: string; expiresAt: number } | null = null;
+
+/** Clear the cached token (useful for tests). */
+export function clearDatabricksTokenCache(): void {
+  cachedToken = null;
+}
+
+export interface DatabricksServicePrincipalConfig {
+  workspaceUrl: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+/**
+ * Resolve Databricks service principal credentials from environment variables.
+ * Returns `null` if the required env vars are not all set.
+ */
+export function resolveDatabricksServicePrincipalEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): DatabricksServicePrincipalConfig | null {
+  const clientId = env.DATABRICKS_CLIENT_ID?.trim();
+  const clientSecret = env.DATABRICKS_CLIENT_SECRET?.trim();
+  const host = env.DATABRICKS_HOST?.trim();
+  if (!clientId || !clientSecret || !host) {
+    return null;
+  }
+  // Normalize: strip trailing slashes from the host URL.
+  const workspaceUrl = host.replace(/\/+$/, "");
+  return { workspaceUrl, clientId, clientSecret };
+}
+
+/**
+ * Exchange Databricks service principal client credentials for an OAuth access token.
+ *
+ * Uses the standard OAuth 2.0 client_credentials grant against the workspace OIDC endpoint:
+ *   POST {workspaceUrl}/oidc/v1/token
+ *   Authorization: Basic base64(client_id:client_secret)
+ *   Body: grant_type=client_credentials&scope=all-apis
+ *
+ * Returns the access_token string. Caches the token in memory and reuses it until
+ * 60 seconds before expiry.
+ */
+export async function exchangeDatabricksServicePrincipalToken(
+  config: DatabricksServicePrincipalConfig,
+): Promise<string> {
+  // Return cached token if still valid (with 60-second safety margin).
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.accessToken;
+  }
+
+  const tokenUrl = `${config.workspaceUrl}/oidc/v1/token`;
+  const basicAuth = Buffer.from(`${config.clientId}:${config.clientSecret}`).toString("base64");
+
+  const response = await fetch(tokenUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${basicAuth}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: "grant_type=client_credentials&scope=all-apis",
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "(no body)");
+    throw new Error(`Databricks OAuth token exchange failed (${response.status}): ${body}`);
+  }
+
+  const data = (await response.json()) as {
+    access_token: string;
+    token_type: string;
+    expires_in?: number;
+  };
+
+  if (!data.access_token) {
+    throw new Error("Databricks OAuth response missing access_token");
+  }
+
+  // Cache the token. Default TTL: 1 hour if expires_in is not provided.
+  const expiresInMs = (data.expires_in ?? 3600) * 1000;
+  cachedToken = {
+    accessToken: data.access_token,
+    expiresAt: Date.now() + expiresInMs,
+  };
+
+  return data.access_token;
+}
+
+/**
+ * Check whether Databricks service principal env vars are configured.
+ * This is a fast synchronous check (no network calls).
+ */
+export function hasDatabricksServicePrincipalEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveDatabricksServicePrincipalEnv(env) !== null;
+}

--- a/src/agents/model-auth.databricks.test.ts
+++ b/src/agents/model-auth.databricks.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveEnvApiKey, resolveModelAuthMode } from "./model-auth.js";
+
+describe("resolveEnvApiKey for databricks", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = [
+    "DATABRICKS_TOKEN",
+    "DATABRICKS_API_KEY",
+    "DATABRICKS_CLIENT_ID",
+    "DATABRICKS_CLIENT_SECRET",
+    "DATABRICKS_HOST",
+  ];
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  function saveAndClearEnv() {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  }
+
+  it("should return null when no Databricks env vars are set", () => {
+    saveAndClearEnv();
+    const result = resolveEnvApiKey("databricks");
+    expect(result).toBeNull();
+  });
+
+  it("should resolve DATABRICKS_TOKEN when set", () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-test-token-123";
+    const result = resolveEnvApiKey("databricks");
+    expect(result).not.toBeNull();
+    expect(result?.apiKey).toBe("dapi-test-token-123");
+    expect(result?.source).toContain("DATABRICKS_TOKEN");
+  });
+
+  it("should resolve DATABRICKS_API_KEY as fallback", () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_API_KEY = "dapi-api-key-456";
+    const result = resolveEnvApiKey("databricks");
+    expect(result).not.toBeNull();
+    expect(result?.apiKey).toBe("dapi-api-key-456");
+    expect(result?.source).toContain("DATABRICKS_API_KEY");
+  });
+
+  it("should prefer DATABRICKS_TOKEN over DATABRICKS_API_KEY", () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-pat-preferred";
+    process.env.DATABRICKS_API_KEY = "dapi-api-fallback";
+    const result = resolveEnvApiKey("databricks");
+    expect(result).not.toBeNull();
+    expect(result?.apiKey).toBe("dapi-pat-preferred");
+    expect(result?.source).toContain("DATABRICKS_TOKEN");
+  });
+
+  it("should handle whitespace-only values as unset", () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "   ";
+    const result = resolveEnvApiKey("databricks");
+    // normalizeOptionalSecretInput trims whitespace, so empty => null
+    expect(result).toBeNull();
+  });
+});
+
+describe("resolveModelAuthMode for databricks", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = [
+    "DATABRICKS_TOKEN",
+    "DATABRICKS_API_KEY",
+    "DATABRICKS_CLIENT_ID",
+    "DATABRICKS_CLIENT_SECRET",
+    "DATABRICKS_HOST",
+  ];
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  function saveAndClearEnv() {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  }
+
+  it("should return unknown when no databricks env vars are set", () => {
+    saveAndClearEnv();
+    expect(resolveModelAuthMode("databricks")).toBe("unknown");
+  });
+
+  it("should return api-key when DATABRICKS_TOKEN is set", () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-pat-token";
+    expect(resolveModelAuthMode("databricks")).toBe("api-key");
+  });
+
+  it("should return oauth when service principal env vars are set", () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_CLIENT_ID = "sp-client-id";
+    process.env.DATABRICKS_CLIENT_SECRET = "sp-secret";
+    process.env.DATABRICKS_HOST = "https://workspace.cloud.databricks.com";
+    expect(resolveModelAuthMode("databricks")).toBe("oauth");
+  });
+
+  it("should prefer PAT token (api-key) when both PAT and SP are set", () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-pat-token";
+    process.env.DATABRICKS_CLIENT_ID = "sp-client-id";
+    process.env.DATABRICKS_CLIENT_SECRET = "sp-secret";
+    process.env.DATABRICKS_HOST = "https://workspace.cloud.databricks.com";
+    // PAT is found first by resolveEnvApiKey, so mode is api-key
+    expect(resolveModelAuthMode("databricks")).toBe("api-key");
+  });
+});

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -207,14 +207,11 @@ export async function resolveApiKeyForProvider(params: {
     };
   }
 
-  const customKey = getCustomProviderApiKey(cfg, provider);
-  if (customKey) {
-    return { apiKey: customKey, source: "models.json", mode: "api-key" };
-  }
-
   const normalized = normalizeProviderId(provider);
 
   // Databricks service principal: exchange client_id + client_secret for an access token.
+  // Must run before the generic custom-key check so the placeholder "databricks-sp-oauth"
+  // written by resolveImplicitProviders doesn't short-circuit the real token exchange.
   if (normalized === "databricks") {
     const spConfig = resolveDatabricksServicePrincipalEnv();
     if (spConfig) {
@@ -225,6 +222,11 @@ export async function resolveApiKeyForProvider(params: {
         mode: "oauth",
       };
     }
+  }
+
+  const customKey = getCustomProviderApiKey(cfg, provider);
+  if (customKey) {
+    return { apiKey: customKey, source: "models.json", mode: "api-key" };
   }
 
   if (authOverride === undefined && normalized === "amazon-bedrock") {

--- a/src/agents/models-config.providers.databricks.test.ts
+++ b/src/agents/models-config.providers.databricks.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildDatabricksProvider,
+  DATABRICKS_DEFAULT_MODEL_ID,
+  resolveImplicitProviders,
+} from "./models-config.providers.js";
+
+describe("Databricks provider", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = ["DATABRICKS_TOKEN", "DATABRICKS_API_KEY", "DATABRICKS_HOST"];
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  function saveAndClearEnv() {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  }
+
+  it("should not include databricks when no API key is configured", async () => {
+    saveAndClearEnv();
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    expect(providers?.databricks).toBeUndefined();
+  });
+
+  it("should not include databricks when API key is set but DATABRICKS_HOST is missing", async () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-test-token-123";
+    // No DATABRICKS_HOST set
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    // Should not be added without a host URL
+    expect(providers?.databricks).toBeUndefined();
+  });
+
+  it("should include databricks when both DATABRICKS_TOKEN and DATABRICKS_HOST are set", async () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-test-token-123";
+    process.env.DATABRICKS_HOST = "https://my-workspace.cloud.databricks.com";
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    expect(providers?.databricks).toBeDefined();
+    expect(providers?.databricks?.apiKey).toBe("DATABRICKS_TOKEN");
+    expect(providers?.databricks?.baseUrl).toBe(
+      "https://my-workspace.cloud.databricks.com/serving-endpoints",
+    );
+    expect(providers?.databricks?.api).toBe("openai-completions");
+  });
+
+  it("should include databricks with DATABRICKS_API_KEY fallback", async () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_API_KEY = "dapi-fallback-key";
+    process.env.DATABRICKS_HOST = "https://workspace.cloud.databricks.com";
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    expect(providers?.databricks).toBeDefined();
+    expect(providers?.databricks?.apiKey).toBe("DATABRICKS_API_KEY");
+  });
+
+  it("should normalize host URL that already ends with /serving-endpoints", async () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-test-token";
+    process.env.DATABRICKS_HOST = "https://my-workspace.cloud.databricks.com/serving-endpoints";
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    expect(providers?.databricks?.baseUrl).toBe(
+      "https://my-workspace.cloud.databricks.com/serving-endpoints",
+    );
+  });
+
+  it("should strip trailing slashes from host URL", async () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-test-token";
+    process.env.DATABRICKS_HOST = "https://my-workspace.cloud.databricks.com/";
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    expect(providers?.databricks?.baseUrl).toBe(
+      "https://my-workspace.cloud.databricks.com/serving-endpoints",
+    );
+  });
+
+  it("should prefer DATABRICKS_TOKEN over DATABRICKS_API_KEY", async () => {
+    saveAndClearEnv();
+    process.env.DATABRICKS_TOKEN = "dapi-pat-token";
+    process.env.DATABRICKS_API_KEY = "dapi-api-key";
+    process.env.DATABRICKS_HOST = "https://workspace.cloud.databricks.com";
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    expect(providers?.databricks).toBeDefined();
+    // DATABRICKS_TOKEN should take precedence
+    expect(providers?.databricks?.apiKey).toBe("DATABRICKS_TOKEN");
+  });
+});
+
+describe("buildDatabricksProvider", () => {
+  it("should return a valid provider config with correct base URL", () => {
+    const baseUrl = "https://workspace.cloud.databricks.com/serving-endpoints";
+    const provider = buildDatabricksProvider(baseUrl);
+
+    expect(provider.baseUrl).toBe(baseUrl);
+    expect(provider.api).toBe("openai-completions");
+    expect(provider.models).toHaveLength(3);
+  });
+
+  it("should include default model IDs", () => {
+    const provider = buildDatabricksProvider("https://test.cloud.databricks.com/serving-endpoints");
+
+    const modelIds = provider.models.map((m) => m.id);
+    expect(modelIds).toContain(DATABRICKS_DEFAULT_MODEL_ID);
+    expect(modelIds).toContain("databricks-dbrx-instruct");
+    expect(modelIds).toContain("databricks-mixtral-8x7b-instruct");
+  });
+
+  it("should set all models to text input only", () => {
+    const provider = buildDatabricksProvider("https://test.cloud.databricks.com/serving-endpoints");
+
+    for (const model of provider.models) {
+      expect(model.input).toEqual(["text"]);
+      expect(model.reasoning).toBe(false);
+    }
+  });
+
+  it("should set zero costs (pay-per-use via Databricks billing)", () => {
+    const provider = buildDatabricksProvider("https://test.cloud.databricks.com/serving-endpoints");
+
+    for (const model of provider.models) {
+      expect(model.cost.input).toBe(0);
+      expect(model.cost.output).toBe(0);
+      expect(model.cost.cacheRead).toBe(0);
+      expect(model.cost.cacheWrite).toBe(0);
+    }
+  });
+});

--- a/src/agents/models-config.providers.databricks.test.ts
+++ b/src/agents/models-config.providers.databricks.test.ts
@@ -119,25 +119,28 @@ describe("buildDatabricksProvider", () => {
 
     expect(provider.baseUrl).toBe(baseUrl);
     expect(provider.api).toBe("openai-completions");
-    expect(provider.models).toHaveLength(3);
+    expect(provider.models).toHaveLength(4);
   });
 
   it("should include default model IDs", () => {
     const provider = buildDatabricksProvider("https://test.cloud.databricks.com/serving-endpoints");
 
     const modelIds = provider.models.map((m) => m.id);
+    expect(modelIds).toContain("databricks-claude-opus-4-6");
     expect(modelIds).toContain(DATABRICKS_DEFAULT_MODEL_ID);
     expect(modelIds).toContain("databricks-dbrx-instruct");
     expect(modelIds).toContain("databricks-mixtral-8x7b-instruct");
   });
 
-  it("should set all models to text input only", () => {
+  it("should mark claude-opus-4-6 as reasoning with image input", () => {
     const provider = buildDatabricksProvider("https://test.cloud.databricks.com/serving-endpoints");
+    const claude = provider.models.find((m) => m.id === "databricks-claude-opus-4-6");
 
-    for (const model of provider.models) {
-      expect(model.input).toEqual(["text"]);
-      expect(model.reasoning).toBe(false);
-    }
+    expect(claude).toBeDefined();
+    expect(claude!.reasoning).toBe(true);
+    expect(claude!.input).toEqual(["text", "image"]);
+    expect(claude!.contextWindow).toBe(200000);
+    expect(claude!.maxTokens).toBe(16384);
   });
 
   it("should set zero costs (pay-per-use via Databricks billing)", () => {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -637,9 +637,12 @@ export async function resolveImplicitProviders(params: {
       const baseUrl = normalizedHost.endsWith("/serving-endpoints")
         ? normalizedHost
         : `${normalizedHost}/serving-endpoints`;
-      // For PAT: apiKey is the env var name; for service principal: use a placeholder
-      // since the actual token is exchanged at runtime via resolveApiKeyForProvider.
-      const apiKey = databricksKey ?? "databricks-sp-oauth";
+      // For PAT: apiKey is the env var name (standard pattern).
+      // For service principal: use the DATABRICKS_CLIENT_ID env var name as the
+      // placeholder — pi-coding-agent's ModelRegistry requires a non-empty apiKey
+      // to register the provider. The real token is exchanged at runtime via
+      // resolveApiKeyForProvider → exchangeDatabricksServicePrincipalToken.
+      const apiKey = databricksKey ?? "DATABRICKS_CLIENT_ID";
       providers.databricks = { ...buildDatabricksProvider(baseUrl), apiKey };
     }
   }

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -480,6 +480,15 @@ export function buildDatabricksProvider(baseUrl: string): ProviderConfig {
     api: "openai-completions",
     models: [
       {
+        id: "databricks-claude-opus-4-6",
+        name: "Claude Opus 4 (via Databricks)",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: DATABRICKS_DEFAULT_COST,
+        contextWindow: 200000,
+        maxTokens: 16384,
+      },
+      {
         id: DATABRICKS_DEFAULT_MODEL_ID,
         name: "Llama 3.3 70B Instruct",
         reasoning: false,

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -25,6 +25,7 @@ export type AuthChoiceGroupId =
   | "qwen"
   | "together"
   | "qianfan"
+  | "databricks"
   | "xai"
   | "custom";
 
@@ -100,6 +101,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     label: "Qianfan",
     hint: "API key",
     choices: ["qianfan-api-key"],
+  },
+  {
+    value: "databricks",
+    label: "Databricks",
+    hint: "AI Gateway (PAT token or service principal)",
+    choices: ["databricks-api-key"],
   },
   {
     value: "copilot",
@@ -258,6 +265,11 @@ export function buildAuthChoiceOptions(params: {
     value: "minimax-api-lightning",
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
+  });
+  options.push({
+    value: "databricks-api-key",
+    label: "Databricks AI Gateway",
+    hint: "PAT token or service principal (OAuth client_credentials)",
   });
   options.push({ value: "custom-api-key", label: "Custom Provider" });
 

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -976,8 +976,10 @@ export async function applyAuthChoiceApiProviders(
         });
         if (useSp) {
           // Service principal auth is resolved at runtime via the OIDC token exchange.
-          // Store a placeholder so the profile is registered.
-          await setDatabricksApiKey("databricks-sp-oauth", params.agentDir);
+          // Store DATABRICKS_CLIENT_ID as placeholder so the profile is registered;
+          // resolveApiKeyForProvider detects service principal env vars and exchanges
+          // for a real access token before this placeholder is ever sent to Databricks.
+          await setDatabricksApiKey("DATABRICKS_CLIENT_ID", params.agentDir);
           hasCredential = true;
         }
       }

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -115,6 +115,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
   });
 }
 
+export const DATABRICKS_DEFAULT_MODEL_REF = "databricks/databricks-meta-llama-3-3-70b-instruct";
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
@@ -224,6 +225,18 @@ export function setQianfanApiKey(key: string, agentDir?: string) {
     credential: {
       type: "api_key",
       provider: "qianfan",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
+export async function setDatabricksApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "databricks:default",
+    credential: {
+      type: "api_key",
+      provider: "databricks",
       key,
     },
     agentDir: resolveAuthAgentDir(agentDir),

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -7,6 +7,8 @@ export {
   applyAuthProfileConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
+  applyDatabricksConfig,
+  applyDatabricksProviderConfig,
   applyQianfanConfig,
   applyQianfanProviderConfig,
   applyKimiCodeConfig,
@@ -46,9 +48,11 @@ export {
 } from "./onboard-auth.config-opencode.js";
 export {
   CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
+  DATABRICKS_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
+  setDatabricksApiKey,
   setQianfanApiKey,
   setGeminiApiKey,
   setKimiCodingApiKey,
@@ -88,3 +92,4 @@ export {
   MOONSHOT_DEFAULT_MODEL_ID,
   MOONSHOT_DEFAULT_MODEL_REF,
 } from "./onboard-auth.models.js";
+export { DATABRICKS_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -38,6 +38,7 @@ export type AuthChoice =
   | "qwen-portal"
   | "xai-api-key"
   | "qianfan-api-key"
+  | "databricks-api-key"
   | "custom-api-key"
   | "skip";
 export type AuthChoiceGroupId =
@@ -57,6 +58,7 @@ export type AuthChoiceGroupId =
   | "venice"
   | "qwen"
   | "qianfan"
+  | "databricks"
   | "xai"
   | "custom";
 export type GatewayAuthChoice = "token" | "password";
@@ -105,6 +107,8 @@ export type OnboardOptions = {
   opencodeZenApiKey?: string;
   xaiApiKey?: string;
   qianfanApiKey?: string;
+  databricksApiKey?: string;
+  databricksHost?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
Add Databricks as a first-class model provider using the OpenAI-compatible serving endpoints API. Supports two authentication modes:

1. PAT token: via DATABRICKS_TOKEN or DATABRICKS_API_KEY env vars
2. Service principal OAuth: via DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET with automatic client_credentials token exchange against the workspace OIDC endpoint, including in-memory token caching with TTL-aware refresh.

Both modes require DATABRICKS_HOST for the workspace URL. The provider is auto-discovered when env vars are set, and fully wired into onboarding, auth profiles, and CLI configuration.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Databricks as a first-class model provider with dual authentication support: PAT tokens via `DATABRICKS_TOKEN`/`DATABRICKS_API_KEY` and service principal OAuth via `DATABRICKS_CLIENT_ID` + `DATABRICKS_CLIENT_SECRET`. The OAuth implementation exchanges credentials for short-lived access tokens using the workspace OIDC endpoint with automatic token caching and TTL-aware refresh.

**Key changes:**
- New `databricks-auth.ts` module handles OAuth client_credentials flow and in-memory token caching
- Integration into `model-auth.ts` for provider discovery and authentication resolution
- Added to `models-config.providers.ts` with OpenAI-compatible API configuration
- Full CLI onboarding support in `auth-choice.apply.api-providers.ts` and related files
- Comprehensive test coverage across auth, provider config, and model selection

**Critical issue found:**
The token cache doesn't validate workspace/client credentials match between calls. If environment variables change (different workspace or service principal), the cached token for the previous workspace could be returned, causing authentication to fail or potentially access the wrong workspace.

<h3>Confidence Score: 3/5</h3>

- This PR is functional but has a token caching bug that could cause authentication failures
- The implementation is well-structured with good test coverage and follows existing patterns. However, the token cache lacks validation of workspace/client credentials, which could return stale tokens for different workspaces when environment variables change. This is a logical error that should be fixed before merge.
- src/agents/databricks-auth.ts requires immediate attention for the token cache validation issue

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->