### PR TITLE
fix(gateway): include export name in hook transform cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Hooks: include transform export name in hook-transform cache keys so distinct exports from the same module do not reuse the wrong cached transform function. (#13855) thanks @mcaxtr.
 - Gateway/Control UI: return 404 for missing static-asset paths instead of serving SPA fallback HTML, while preserving client-route fallback behavior for extensionless and non-asset dotted paths. (#12060) thanks @mcaxtr.
 - Gateway/Pairing: prevent device-token rotate scope escalation by enforcing an approved-scope baseline, preserving approved scopes across metadata updates, and rejecting rotate requests that exceed approved role scope implications. (#20703) thanks @coygeek.
 - Gateway/Security: require secure context and paired-device checks for Control UI auth even when `gateway.controlUi.allowInsecureAuth` is set, and align audit messaging with the hardened behavior. (#20684) thanks @coygeek.

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -325,14 +325,15 @@ function validateAction(action: HookAction): HookMappingResult {
 }
 
 async function loadTransform(transform: HookMappingTransformResolved): Promise<HookTransformFn> {
-  const cached = transformCache.get(transform.modulePath);
+  const cacheKey = `${transform.modulePath}::${transform.exportName ?? "default"}`;
+  const cached = transformCache.get(cacheKey);
   if (cached) {
     return cached;
   }
   const url = pathToFileURL(transform.modulePath).href;
   const mod = (await import(url)) as Record<string, unknown>;
   const fn = resolveTransformFn(mod, transform.exportName);
-  transformCache.set(transform.modulePath, fn);
+  transformCache.set(cacheKey, fn);
   return fn;
 }
 


### PR DESCRIPTION
## Summary

Fixes #10152

`loadTransform()` cached hook transform functions using only `modulePath` as the key. When two hook mappings referenced different named exports from the same module file, the first loaded export was silently reused for all subsequent lookups — the `exportName` was ignored during cache hits.

**Fix:** Use a composite cache key `${modulePath}::${exportName ?? "default"}` so each distinct export is cached independently.

## Test plan

- [x] Add test: two mappings reference same module with different named exports (`transformA` / `transformB`)
- [x] Before fix: test fails — both mappings return `transformA`'s result (`"from-A"`)
- [x] After fix: test passes — each mapping returns its own export's result
- [x] All 10 tests fail before, pass after
- [x] `pnpm build && pnpm check` passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a correctness issue in the gateway hook transform loader cache: previously, `loadTransform()` cached by `modulePath` only, causing different named exports from the same module to incorrectly reuse the first-loaded transform function.

The change updates the cache key to include both `modulePath` and `exportName` (with a stable default sentinel), and adds a regression test that creates a module with multiple exports (`transformA` / `transformB`) and verifies each hook mapping resolves and executes the correct export.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to the transform cache key and is covered by a targeted regression test that reproduces the prior bug (two named exports from the same module). No behavior changes outside the intended caching semantics were observed in the reviewed code.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->