### PR TITLE
fix: warn when local agent models.json silently overrides central config

### DIFF
--- a/src/agents/models-config-overrides.ts
+++ b/src/agents/models-config-overrides.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import { isRecord } from "../utils.js";
+import { resolveAgentDir } from "./agent-scope.js";
+import { listAgentsForGateway } from "../gateway/session-utils.js";
+
+export type LocalModelOverride = {
+  agentId: string;
+  agentDir: string;
+  modelsJsonPath: string;
+  providerKeys: string[];
+};
+
+/**
+ * Detect per-agent `models.json` files that may silently override central config.
+ *
+ * These files are written by `ensureOpenClawModelsJson` during agent startup and
+ * can accumulate stale provider/model entries that shadow `openclaw.json` settings.
+ * This function scans all configured agents and returns metadata about any local
+ * overrides found, so callers (e.g. `openclaw status`) can surface warnings.
+ */
+export async function detectLocalModelOverrides(
+  cfg: OpenClawConfig,
+): Promise<LocalModelOverride[]> {
+  const agentList = listAgentsForGateway(cfg);
+  const overrides: LocalModelOverride[] = [];
+
+  for (const agent of agentList.agents) {
+    const agentDir = resolveAgentDir(cfg, agent.id);
+    const modelsJsonPath = path.join(agentDir, "models.json");
+
+    try {
+      const raw = await fs.readFile(modelsJsonPath, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (!isRecord(parsed) || !isRecord(parsed.providers)) {
+        continue;
+      }
+      const providerKeys = Object.keys(parsed.providers as Record<string, unknown>).filter(
+        (k) => k.trim().length > 0,
+      );
+      if (providerKeys.length > 0) {
+        overrides.push({
+          agentId: agent.id,
+          agentDir,
+          modelsJsonPath,
+          providerKeys,
+        });
+      }
+    } catch {
+      // No models.json or unreadable — no override, which is the desired state
+      continue;
+    }
+  }
+
+  return overrides;
+}

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -1,5 +1,6 @@
 import type { GatewayService } from "../daemon/service.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { detectLocalModelOverrides } from "../agents/models-config-overrides.js";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { withProgress } from "../cli/progress.js";
@@ -191,6 +192,7 @@ export async function statusAllCommand(
 
     progress.setLabel("Scanning agents…");
     const agentStatus = await getAgentLocalStatuses(cfg);
+    const localModelOverrides = await detectLocalModelOverrides(cfg);
     progress.tick();
     progress.setLabel("Summarizing channels…");
     const channels = await buildChannelsTable(cfg, { showSecrets: false });
@@ -438,6 +440,7 @@ export async function statusAllCommand(
         message: issue.message,
       })),
       agentStatus,
+      localModelOverrides,
       connectionDetailsForReport,
       diagnosis: {
         snap,

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -933,6 +933,26 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...collectSmallModelRiskFindings({ cfg, env }));
   findings.push(...collectExposureMatrixFindings(cfg));
 
+  // Check for local agent models.json overrides that silently shadow central config
+  if (opts.includeFilesystem !== false) {
+    const { detectLocalModelOverrides } = await import("../agents/models-config-overrides.js");
+    const overrides = await detectLocalModelOverrides(cfg);
+    for (const override of overrides) {
+      findings.push({
+        checkId: "local-model-override",
+        severity: "warn",
+        title: `Agent "${override.agentId}" has local models.json override`,
+        detail:
+          `${override.modelsJsonPath} contains providers [${override.providerKeys.join(", ")}] ` +
+          `that silently shadow the central openclaw.json model configuration. ` +
+          `Changes via gateway config.patch will appear to succeed but have no effect on this agent.`,
+        remediation:
+          `Remove the local override: rm "${override.modelsJsonPath}" — ` +
+          `or use agents.list[].model in openclaw.json to configure per-agent models centrally.`,
+      });
+    }
+  }
+
   const configSnapshot =
     opts.includeFilesystem !== false
       ? await readConfigSnapshotForAudit({ env, configPath }).catch(() => null)


### PR DESCRIPTION
## Summary

Adds detection and warnings for per-agent `models.json` files in `~/.openclaw/agents/<id>/agent/` that silently shadow the central `openclaw.json` model configuration.

## Problem

`ensureOpenClawModelsJson` writes a local `models.json` to each agent dir on startup. These files accumulate stale provider/model entries that override central config. When users change models via `gateway config.patch`, the change appears to succeed but the local file wins — with no warning anywhere.

This caused significant debugging time in a multi-agent setup (all agents showing wrong models after multiple config.patch calls). The only fix was manually `rm`-ing each agent's `models.json`.

Related: #13854

## Changes

1. **New utility** `src/agents/models-config-overrides.ts`:
   - `detectLocalModelOverrides(cfg)` — scans all configured agent dirs for `models.json` files and returns metadata (agent id, path, provider keys)

2. **Security audit** (`src/security/audit.ts`):
   - Adds a `warn` severity finding for each agent with a local `models.json` override
   - Includes remediation: remove the file or use `agents.list[].model` in central config

3. **Status --all** (`src/commands/status-all.ts` + `report-lines.ts`):
   - Surfaces override warnings in the Agents section
   - Shows affected file paths and a one-liner fix command

## Example output

```
⚠️  Local model overrides detected (these silently shadow openclaw.json):
  → Agent "my-agent" has local models.json with providers: xai, local
    ~/.openclaw/agents/my-agent/agent/models.json
  Fix: Remove these files so agents inherit from openclaw.json, or use agents.list[].model in central config.
  Run: find ~/.openclaw/agents/ -name models.json -delete
```

Security audit:
```
WARN Agent "my-agent" has local models.json override
  ~/.openclaw/agents/my-agent/agent/models.json contains providers [xai, local] that silently shadow the central openclaw.json...
  Fix: Remove the local override: rm "~/.openclaw/agents/my-agent/agent/models.json"
```

## Testing

- Verified with multiple agents — all had stale local `models.json` files
- After removing local files, agents correctly inherit central config
- Warning only appears when local overrides exist; clean installs show nothing

Closes #13854