### PR TITLE
feat(hooks): add session:compaction hook event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Added
 
+- Hooks: add `session:compaction` hook event fired after auto-compaction or `/compact` completes. (#13754)
 - Commands: add `commands.allowFrom` config for separate command authorization, allowing operators to restrict slash commands to specific users while keeping chat open to others. (#12430) Thanks @thewilloftheshadow.
 - Docker: add ClawDock shell helpers for Docker workflows. (#12817) Thanks @Olshansk.
 - iOS: alpha node app + setup-code onboarding. (#11756) Thanks @mbelinky.

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -230,6 +230,33 @@ Triggered when agent commands are issued:
 - **`command:reset`**: When `/reset` command is issued
 - **`command:stop`**: When `/stop` command is issued
 
+### Session Events
+
+- **`session:compaction`**: After auto-compaction or `/compact` completes successfully
+
+The event context includes:
+
+| Field          | Type                  | Description                                                           |
+| -------------- | --------------------- | --------------------------------------------------------------------- |
+| `sessionKey`   | `string`              | Which session was compacted                                           |
+| `trigger`      | `"manual" \| "auto"`  | Whether compaction was triggered by `/compact` or by context overflow |
+| `tokensBefore` | `number`              | Token count before compaction                                         |
+| `tokensAfter`  | `number \| undefined` | Estimated token count after compaction                                |
+
+**Example handler:**
+
+```typescript
+const handler: HookHandler = async (event) => {
+  if (event.type !== "session" || event.action !== "compaction") {
+    return;
+  }
+  const { trigger, tokensBefore, tokensAfter } = event.context;
+  console.log(`[post-compact] ${trigger} compaction: ${tokensBefore} -> ${tokensAfter}`);
+  // Re-inject context, e.g. "Read today's daily log"
+  event.messages.push("Re-reading workspace context after compaction...");
+};
+```
+
 ### Agent Events
 
 - **`agent:bootstrap`**: Before workspace bootstrap files are injected (hooks may mutate `context.bootstrapFiles`)
@@ -253,8 +280,6 @@ Planned event types:
 - **`session:start`**: When a new session begins
 - **`session:end`**: When a session ends
 - **`agent:error`**: When an agent encounters an error
-- **`message:sent`**: When a message is sent
-- **`message:received`**: When a message is received
 
 ## Creating Custom Hooks
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -527,6 +527,7 @@ export async function runEmbeddedPiAgent(
                 bashElevated: params.bashElevated,
                 extraSystemPrompt: params.extraSystemPrompt,
                 ownerNumbers: params.ownerNumbers,
+                trigger: "auto",
               });
               if (compactResult.compacted) {
                 autoCompactionCount += 1;

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -94,6 +94,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     customInstructions,
     senderIsOwner: params.command.senderIsOwner,
     ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
+    trigger: "manual",
   });
 
   const compactLabel = result.ok


### PR DESCRIPTION
## Summary
Fixes #13754

## Problem
No hook event fires after session compaction completes. Agents with persistent memory systems (daily logs, project files) need to re-bootstrap context after compaction, but there is no mechanism to trigger a context re-read.

The `agent:bootstrap` hook only fires on session creation, not after compaction. The planned `session:start` / `session:end` events do not cover this either.

## Fix
Add a `session:compaction` hook event that fires after successful compaction in `compactEmbeddedPiSessionDirect`. The event includes `sessionKey`, `trigger` ("manual" or "auto"), `tokensBefore`, and `tokensAfter` in its context.

### Changes:
- **`src/agents/pi-embedded-runner/compact.ts`**: Add `trigger` param to `CompactEmbeddedPiSessionParams`, fire `session:compaction` hook after successful compaction (best-effort, failures do not break compaction)
- **`src/auto-reply/reply/commands-compact.ts`**: Pass `trigger: "manual"` for `/compact` command
- **`src/agents/pi-embedded-runner/run.ts`**: Pass `trigger: "auto"` for context overflow auto-compaction
- **`docs/automation/hooks.md`**: Document the new Session Events section with `session:compaction` event, context fields, and example handler
- **`src/hooks/internal-hooks.test.ts`**: Add 3 regression tests for the new event
- **`CHANGELOG.md`**: Add entry

## Effect on User Experience

**Before fix:**
After compaction, agents lose awareness of detailed context stored in workspace files (daily logs, project notes). No way to trigger automated re-read. Users rely on AGENTS.md instructions which is unreliable.

**After fix:**
Hooks can listen for `session:compaction` and inject system events (e.g. "Read today's daily log") to recover context after compaction. Both manual `/compact` and auto-compaction on context overflow trigger the hook.

Example hook registration:
```
metadata: { "openclaw": { "events": ["session:compaction"] } }
```

## Testing
- ✅ 21 tests pass (pnpm vitest run src/hooks/internal-hooks.test.ts)
- ✅ Lint passes (oxlint + oxfmt)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new internal hook event `session:compaction` that fires after successful session compaction, with context fields (`sessionKey`, `trigger`, `tokensBefore`, `tokensAfter`). The compaction code (`src/agents/pi-embedded-runner/compact.ts`) now triggers the hook best-effort, and callers set `trigger` to distinguish manual `/compact` vs auto-compaction on context overflow. Documentation and internal hook tests were updated accordingly, and the changelog notes the new event.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized and consistent: a new hook event is emitted best-effort after successful compaction, with call sites explicitly setting the trigger. Tests cover event delivery to both general and specific handlers and message mutation.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->