### PR TITLE
fix(docs): update macOS VM installation instructions for clarity and VNC usage

### DIFF
--- a/docs/install/macos-vm.md
+++ b/docs/install/macos-vm.md
@@ -189,7 +189,7 @@ Stop the VM and restart without display:
 
 ```bash
 lume stop openclaw
-lume run openclaw --no-display > /dev/null 2>&1 &
+lume run openclaw --no-display
 ```
 
 The VM runs in the background. OpenClaw's daemon keeps the gateway running.

--- a/docs/install/macos-vm.md
+++ b/docs/install/macos-vm.md
@@ -90,13 +90,19 @@ Docs: [Lume Installation](https://cua.ai/docs/lume/guide/getting-started/install
 lume create openclaw --os macos --ipsw latest
 ```
 
-This downloads macOS and creates the VM. A VNC window opens automatically.
+This downloads macOS and creates the VM.
 
 Note: The download can take a while depending on your connection.
 
 ---
 
 ## 3) Complete Setup Assistant
+
+```bash
+lume run openclaw
+```
+
+This opens a VNC window to the VM's display.
 
 In the VNC window:
 
@@ -137,7 +143,7 @@ Replace `youruser` with the account you created, and the IP with your VM's IP.
 Inside the VM:
 
 ```bash
-npm install -g openclaw@latest
+curl -fsSL https://openclaw.ai/install.sh | bash
 openclaw onboard --install-daemon
 ```
 
@@ -183,7 +189,7 @@ Stop the VM and restart without display:
 
 ```bash
 lume stop openclaw
-lume run openclaw --no-display
+lume run openclaw --no-display > /dev/null 2>&1 &
 ```
 
 The VM runs in the background. OpenClaw's daemon keeps the gateway running.


### PR DESCRIPTION
Quick fix on the macOS VM installation as I just tried it myself.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the macOS VM (Lume) install doc to clarify when the VNC window is opened by adding an explicit `lume run openclaw` step during Setup Assistant, and adjusts the OpenClaw install and headless run instructions.

The main issue to address before merge is the new headless command that backgrounds the VM and discards all output, which makes failures hard to diagnose and is inconsistent with the earlier quick-path instructions.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk (docs-only) but has one copy/paste command that can hinder troubleshooting.
- Changes are limited to documentation and generally improve clarity, but the new headless run command backgrounds the VM and redirects all output to /dev/null, which can hide real startup errors for users following the guide.
- docs/install/macos-vm.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->