### PR TITLE
fix(sandbox): prevent Windows PATH from poisoning docker exec

### DIFF
--- a/src/agents/bash-tools.build-docker-exec-args.test.ts
+++ b/src/agents/bash-tools.build-docker-exec-args.test.ts
@@ -76,7 +76,7 @@ describe("buildDockerExecArgs", () => {
       tty: false,
     });
 
-    expect(args).toContain("sh");
+    expect(args).toContain("/bin/sh");
     expect(args).toContain("-lc");
   });
 

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -61,6 +61,10 @@ export function buildDockerExecArgs(params: {
     args.push("-w", params.workdir);
   }
   for (const [key, value] of Object.entries(params.env)) {
+    // Skip PATH — passing a host PATH (e.g. Windows paths) via -e poisons
+    // Docker's executable lookup, causing "sh: not found" on Windows hosts.
+    // PATH is handled separately via OPENCLAW_PREPEND_PATH below.
+    if (key === "PATH") continue;
     args.push("-e", `${key}=${value}`);
   }
   const hasCustomPath = typeof params.env.PATH === "string" && params.env.PATH.length > 0;
@@ -75,7 +79,8 @@ export function buildDockerExecArgs(params: {
   const pathExport = hasCustomPath
     ? 'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; '
     : "";
-  args.push(params.containerName, "sh", "-lc", `${pathExport}${params.command}`);
+  // Use absolute path for sh to avoid dependency on PATH resolution during exec.
+  args.push(params.containerName, "/bin/sh", "-lc", `${pathExport}${params.command}`);
   return args;
 }
 

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -64,7 +64,9 @@ export function buildDockerExecArgs(params: {
     // Skip PATH — passing a host PATH (e.g. Windows paths) via -e poisons
     // Docker's executable lookup, causing "sh: not found" on Windows hosts.
     // PATH is handled separately via OPENCLAW_PREPEND_PATH below.
-    if (key === "PATH") continue;
+    if (key === "PATH") {
+      continue;
+    }
     args.push("-e", `${key}=${value}`);
   }
   const hasCustomPath = typeof params.env.PATH === "string" && params.env.PATH.length > 0;

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -469,7 +469,7 @@ async function createSandboxContainer(params: {
   await execDocker(["start", name]);
 
   if (cfg.setupCommand?.trim()) {
-    await execDocker(["exec", "-i", name, "sh", "-lc", cfg.setupCommand]);
+    await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand]);
   }
 }
 


### PR DESCRIPTION
## Summary

- On Windows hosts, `buildDockerExecArgs` passes the host `PATH` env var (e.g. `C:\Windows\System32;C:\Users\...`) to `docker exec -e PATH=...`. Docker uses this PATH to resolve the executable argument (`sh`), which fails because Windows paths don't exist inside the Linux container — producing:
  ```
  OCI runtime exec failed: exec: "sh": executable file not found in $PATH: unknown
  ```
- Skip `PATH` in the `-e` env loop — it's already handled separately via `OPENCLAW_PREPEND_PATH` + shell-level export, so passing it raw via `-e` was redundant and harmful on Windows
- Use absolute `/bin/sh` instead of bare `sh` to eliminate PATH dependency during Docker's exec lookup entirely

## Reproduction

1. Run openclaw on a Windows host with Docker Desktop (WSL2 backend)
2. Configure a sandbox with `mode: "all"` and any Docker image
3. Trigger any exec tool call — every call fails with exit code 127

## Test plan

- [x] Verified `docker exec -e "PATH=C:\Windows" container sh -c "echo test"` reproduces the exact error
- [x] Verified `docker exec container /bin/sh -c "echo test"` works on Debian bookworm-slim containers
- [x] `/bin/sh` is POSIX-required and exists on all Linux container images (Debian, Alpine, Ubuntu, etc.)
- [ ] CI tests pass
- [ ] Verify no regression on macOS/Linux hosts (PATH is already handled via OPENCLAW_PREPEND_PATH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens Docker sandbox exec on Windows hosts by avoiding leakage of the host `PATH` into `docker exec -e` (which can break Docker’s executable lookup when the PATH contains Windows-style entries). It also switches docker exec to invoke the shell via an absolute path (`/bin/sh`) both in `buildDockerExecArgs` (used by the exec tool) and in sandbox container setup (`createSandboxContainer`), removing dependency on PATH resolution inside Docker’s exec implementation.

These changes live in the sandbox execution plumbing (`src/agents/bash-tools.shared.ts` and `src/agents/sandbox/docker.ts`) and should improve cross-platform reliability when running Linux containers from Windows.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the failing test expectation is updated.
- The functional change is narrowly scoped (PATH handling + absolute shell path) and aligns with the reported Windows/Docker failure mode. The only definite merge-blocker found is a now-stale unit test that still asserts `sh` instead of `/bin/sh`, which should fail CI until updated.
- src/agents/bash-tools.test.ts (update the assertion in the buildDockerExecArgs test)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->