### PR TITLE
fix(cron): prevent one-shot at jobs from re-firing on restart after skip/error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
 - CI: Implement pipeline and workflow order. Thanks @quotentiroler.

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -297,6 +297,99 @@ describe("Cron issue regressions", () => {
     await store.cleanup();
   });
 
+  it("#13845: one-shot job with lastStatus=skipped does not re-fire on restart", async () => {
+    const store = await makeStorePath();
+    const pastAt = Date.parse("2026-02-06T09:00:00.000Z");
+    // Simulate a one-shot job that was previously skipped (e.g. main session busy).
+    // On the old code, runMissedJobs only checked lastStatus === "ok", so a
+    // skipped job would pass through and fire again on every restart.
+    const skippedJob: CronJob = {
+      id: "oneshot-skipped",
+      name: "reminder",
+      enabled: true,
+      deleteAfterRun: true,
+      createdAtMs: pastAt - 60_000,
+      updatedAtMs: pastAt,
+      schedule: { kind: "at", at: new Date(pastAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "⏰ Reminder" },
+      state: {
+        nextRunAtMs: pastAt,
+        lastStatus: "skipped",
+        lastRunAtMs: pastAt,
+      },
+    };
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({ version: 1, jobs: [skippedJob] }, null, 2),
+      "utf-8",
+    );
+
+    const enqueueSystemEvent = vi.fn();
+    const cron = new CronService({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn().mockResolvedValue({ status: "ok" }),
+    });
+
+    // start() calls runMissedJobs internally
+    await cron.start();
+
+    // The skipped one-shot job must NOT be re-enqueued
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("#13845: one-shot job with lastStatus=error does not re-fire on restart", async () => {
+    const store = await makeStorePath();
+    const pastAt = Date.parse("2026-02-06T09:00:00.000Z");
+    const errorJob: CronJob = {
+      id: "oneshot-errored",
+      name: "reminder",
+      enabled: true,
+      deleteAfterRun: true,
+      createdAtMs: pastAt - 60_000,
+      updatedAtMs: pastAt,
+      schedule: { kind: "at", at: new Date(pastAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "⏰ Reminder" },
+      state: {
+        nextRunAtMs: pastAt,
+        lastStatus: "error",
+        lastRunAtMs: pastAt,
+        lastError: "heartbeat failed",
+      },
+    };
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({ version: 1, jobs: [errorJob] }, null, 2),
+      "utf-8",
+    );
+
+    const enqueueSystemEvent = vi.fn();
+    const cron = new CronService({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn().mockResolvedValue({ status: "ok" }),
+    });
+
+    await cron.start();
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("records per-job start time and duration for batched due jobs", async () => {
     const store = await makeStorePath();
     const dueAt = Date.parse("2026-02-06T10:05:01.000Z");

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -349,7 +349,10 @@ export async function runMissedJobs(state: CronServiceState) {
       return false;
     }
     const next = j.state.nextRunAtMs;
-    if (j.schedule.kind === "at" && j.state.lastStatus === "ok") {
+    if (j.schedule.kind === "at" && j.state.lastStatus) {
+      // Any terminal status (ok, error, skipped) means the job already
+      // ran at least once.  Don't re-fire it on restart — applyJobResult
+      // disables one-shot jobs, but guard here defensively (#13845).
       return false;
     }
     return typeof next === "number" && now >= next;


### PR DESCRIPTION
## Summary

Fixes #13845.

One-shot cron jobs (`schedule.kind: "at"`) that were previously skipped (e.g. main session busy) or errored would re-fire on every gateway restart, causing duplicate reminders.

## Root Cause

`runMissedJobs` only checked `lastStatus === "ok"` when deciding whether to skip a one-shot job. Jobs with `lastStatus: "skipped"` or `lastStatus: "error"` passed through the guard and were re-executed on restart.

While `applyJobResult` already disables one-shot jobs after any terminal status (`enabled = false`), the `runMissedJobs` guard was not aligned — if the store was externally edited or the `enabled` state was inconsistent, the job would still re-fire.

## Fix

Expand the `runMissedJobs` guard from `lastStatus === "ok"` to `lastStatus` being any truthy value (ok/error/skipped). Any terminal status means the job already ran at least once and should not be re-fired.

## Changes

- **`src/cron/service/timer.ts`**: Widen the one-shot guard in `runMissedJobs` to skip jobs with any `lastStatus`.
- **`src/cron/service.issue-regressions.test.ts`**: Add two regression tests verifying skipped and errored one-shot jobs do not re-fire on restart.
- **`CHANGELOG.md`**: Add entry under Fixes.

## Testing

- 109 cron tests pass (including 2 new regression tests).
- `pnpm check` passes on modified files.