### PR TITLE
(fix): allow params in model config and harden system prompt

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -410,6 +410,7 @@ export function buildAgentSystemPrompt(params: {
     "Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.",
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
     "Use plain human language for narration unless in a technical context.",
+    "Do NOT output raw JSON as your response. If you need to use a tool, use the tool call format. If you are answering the user, use plain text. NEVER output a JSON object as your final answer unless the user strictly asked for a JSON file content.",
     "",
     ...safetySection,
     "## OpenClaw CLI Quick Reference",

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -30,6 +30,7 @@ export type ModelDefinitionConfig = {
   contextWindow: number;
   maxTokens: number;
   headers?: Record<string, string>;
+  params?: Record<string, unknown>;
   compat?: ModelCompatConfig;
 };
 

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -41,6 +41,7 @@ export const ModelDefinitionSchema = z
     contextWindow: z.number().positive().optional(),
     maxTokens: z.number().positive().optional(),
     headers: z.record(z.string(), z.string()).optional(),
+    params: z.record(z.string(), z.any()).optional(),
     compat: ModelCompatSchema,
   })
   .strict();


### PR DESCRIPTION
* fix: allow params in model config to support streaming

- Add `params` record to `ModelDefinitionSchema` in `zod-schema.core.ts`
- Enable configuration of provider-specific parameters (e.g., `streaming: true`) for manually defined models (Ollama, local)

* fix: harden system prompt against raw JSON output

- Update `system-prompt.ts` to explicitly forbid raw JSON responses
- Fix issues where coder models output raw JSON instead of natural language or tool calls

* fix: allow params in model config and harden system prompt (thanks @RonnyMejiaZ)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the models config schema to allow provider-specific per-model parameters via a new `params` record on `ModelDefinitionSchema`, and hardens the agent system prompt with an explicit instruction to avoid emitting raw JSON as the assistant’s final response.

The schema change fits into the existing models configuration pipeline (`cfg.models.providers.*.models[]` feeding the embedded runner and provider normalization), and aligns with existing usage of `params` on model definitions (e.g., the Ollama streaming default). The system-prompt change is purely instructional text in `buildAgentSystemPrompt` and doesn’t alter runtime parsing.

**Issue to address before merge:** the TypeScript config types (notably `ModelDefinitionConfig`) are now out of sync with the schema by lacking the newly-supported `params` field, which can lead to TS errors/unsafe casts or `params` being lost during model normalization/copying.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but has a concrete type/schema inconsistency that should be corrected first.
- The functional changes are small (one schema field and one system-prompt instruction), but adding `params` to the Zod schema without updating the corresponding TypeScript config types leaves the codebase in an inconsistent state and encourages unsafe casts or dropping `params` during normalization/copying.
- src/config/zod-schema.core.ts (and the associated TS config types in src/config/types.models.ts)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->