### PR TITLE
feat: Slack channel cache, session cost alerts & checkpoint/recovery system

### DIFF
--- a/src/infra/session-checkpoint.test.ts
+++ b/src/infra/session-checkpoint.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { SessionCheckpointStore } from "./session-checkpoint.js";
+
+describe("SessionCheckpointStore", () => {
+  let store: SessionCheckpointStore;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "checkpoint-test-"));
+    store = new SessionCheckpointStore({
+      checkpointDir: tmpDir,
+      maxPerSession: 3,
+      minIntervalMs: 0, // Disable throttle for tests
+    });
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const makeCheckpoint = (sessionId: string, extra?: Record<string, unknown>) => ({
+    sessionId,
+    agentId: "main",
+    createdAt: Date.now(),
+    transcriptLength: 10,
+    ...extra,
+  });
+
+  it("saves and loads a checkpoint", async () => {
+    const data = makeCheckpoint("s1", { lastKnownCostUsd: 0.42 });
+    const saved = await store.save(data);
+    expect(saved).toBe(true);
+
+    const loaded = await store.loadLatest("s1");
+    expect(loaded).toBeDefined();
+    expect(loaded?.sessionId).toBe("s1");
+    expect(loaded?.lastKnownCostUsd).toBe(0.42);
+  });
+
+  it("returns null for unknown session", async () => {
+    const loaded = await store.loadLatest("nonexistent");
+    expect(loaded).toBeNull();
+  });
+
+  it("loads most recent checkpoint", async () => {
+    await store.save(makeCheckpoint("s1", { transcriptLength: 5 }));
+    await new Promise((r) => setTimeout(r, 10));
+    await store.save(makeCheckpoint("s1", { transcriptLength: 20 }));
+
+    const loaded = await store.loadLatest("s1");
+    expect(loaded?.transcriptLength).toBe(20);
+  });
+
+  it("prunes old checkpoints beyond maxPerSession", async () => {
+    for (let i = 0; i < 5; i++) {
+      await store.save(makeCheckpoint("s1", { transcriptLength: i }));
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    const all = await store.listCheckpoints("s1");
+    expect(all.length).toBe(3);
+    // Most recent should be transcriptLength 4
+    expect(all[0]?.transcriptLength).toBe(4);
+  });
+
+  it("deletes all checkpoints for a session", async () => {
+    await store.save(makeCheckpoint("s1"));
+    await store.save(makeCheckpoint("s1"));
+    await store.deleteSession("s1");
+
+    const loaded = await store.loadLatest("s1");
+    expect(loaded).toBeNull();
+  });
+
+  it("finds recoverable sessions", async () => {
+    await store.save(makeCheckpoint("session-a"));
+    await store.save(makeCheckpoint("session-b"));
+
+    const sessions = await store.findRecoverableSessions();
+    expect(sessions).toContain("session-a");
+    expect(sessions).toContain("session-b");
+    expect(sessions.length).toBe(2);
+  });
+
+  it("enforces minimum interval", async () => {
+    const throttled = new SessionCheckpointStore({
+      checkpointDir: tmpDir,
+      minIntervalMs: 60_000,
+    });
+
+    const first = await throttled.save(makeCheckpoint("s1"));
+    expect(first).toBe(true);
+
+    const second = await throttled.save(makeCheckpoint("s1"));
+    expect(second).toBe(false);
+  });
+
+  it("handles sessions independently", async () => {
+    await store.save(makeCheckpoint("s1", { activeModel: "claude" }));
+    await store.save(makeCheckpoint("s2", { activeModel: "gpt4" }));
+
+    const s1 = await store.loadLatest("s1");
+    const s2 = await store.loadLatest("s2");
+    expect(s1?.activeModel).toBe("claude");
+    expect(s2?.activeModel).toBe("gpt4");
+  });
+
+  it("sanitizes session IDs for filesystem", async () => {
+    const data = makeCheckpoint("agent:main:thread:1234/5678");
+    await store.save(data);
+
+    const loaded = await store.loadLatest("agent:main:thread:1234/5678");
+    expect(loaded?.sessionId).toBe("agent:main:thread:1234/5678");
+  });
+});

--- a/src/infra/session-checkpoint.ts
+++ b/src/infra/session-checkpoint.ts
@@ -1,0 +1,207 @@
+/**
+ * Session Checkpoint/Recovery System
+ *
+ * Provides periodic session state checkpointing and automatic recovery
+ * from interrupted sessions. Preserves conversation context and tool state
+ * across restarts.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export type SessionCheckpointData = {
+  /** Session identifier */
+  sessionId: string;
+  /** Agent ID that owns this session */
+  agentId: string;
+  /** Checkpoint creation timestamp */
+  createdAt: number;
+  /** Number of transcript entries at checkpoint time */
+  transcriptLength: number;
+  /** Last known cost at checkpoint */
+  lastKnownCostUsd?: number;
+  /** Last known token count */
+  lastKnownTokens?: number;
+  /** Active model at checkpoint time */
+  activeModel?: string;
+  /** Active provider at checkpoint time */
+  activeProvider?: string;
+  /** Session labels/metadata */
+  labels?: Record<string, string>;
+  /** Pending tool calls that were in-flight */
+  pendingToolCalls?: string[];
+  /** Custom metadata from extensions */
+  metadata?: Record<string, unknown>;
+};
+
+export type CheckpointStoreOptions = {
+  /** Directory to store checkpoint files. Default: ~/.openclaw/checkpoints */
+  checkpointDir?: string;
+  /** Maximum checkpoints to retain per session. Default: 3 */
+  maxPerSession?: number;
+  /** Minimum interval between checkpoints in ms. Default: 30s */
+  minIntervalMs?: number;
+};
+
+const DEFAULT_CHECKPOINT_DIR = path.join(
+  process.env.HOME ?? "/root",
+  ".openclaw",
+  "checkpoints",
+);
+const DEFAULT_MAX_PER_SESSION = 3;
+const DEFAULT_MIN_INTERVAL_MS = 30_000;
+
+export class SessionCheckpointStore {
+  private readonly checkpointDir: string;
+  private readonly maxPerSession: number;
+  private readonly minIntervalMs: number;
+
+  /** Tracks last checkpoint time per session to enforce min interval */
+  private lastCheckpointTime = new Map<string, number>();
+
+  constructor(options?: CheckpointStoreOptions) {
+    this.checkpointDir = options?.checkpointDir ?? DEFAULT_CHECKPOINT_DIR;
+    this.maxPerSession = options?.maxPerSession ?? DEFAULT_MAX_PER_SESSION;
+    this.minIntervalMs = options?.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  }
+
+  /**
+   * Save a checkpoint for a session.
+   * Returns false if min interval hasn't elapsed since last checkpoint.
+   */
+  async save(data: SessionCheckpointData): Promise<boolean> {
+    const now = Date.now();
+    const lastTime = this.lastCheckpointTime.get(data.sessionId);
+    if (lastTime !== undefined && now - lastTime < this.minIntervalMs) {
+      return false;
+    }
+
+    await fs.promises.mkdir(this.sessionDir(data.sessionId), { recursive: true });
+
+    const filename = `checkpoint-${now}.json`;
+    const filePath = path.join(this.sessionDir(data.sessionId), filename);
+
+    await fs.promises.writeFile(filePath, JSON.stringify(data, null, 2), "utf-8");
+    this.lastCheckpointTime.set(data.sessionId, now);
+
+    // Prune old checkpoints
+    await this.pruneSession(data.sessionId);
+
+    return true;
+  }
+
+  /**
+   * Load the most recent checkpoint for a session.
+   * Returns null if no checkpoint exists.
+   */
+  async loadLatest(sessionId: string): Promise<SessionCheckpointData | null> {
+    const dir = this.sessionDir(sessionId);
+    const files = await this.listCheckpointFiles(dir);
+    if (files.length === 0) {
+      return null;
+    }
+
+    // Files are sorted newest-first
+    const filePath = path.join(dir, files[0]);
+    try {
+      const content = await fs.promises.readFile(filePath, "utf-8");
+      return JSON.parse(content) as SessionCheckpointData;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * List all checkpoints for a session, newest first.
+   */
+  async listCheckpoints(sessionId: string): Promise<SessionCheckpointData[]> {
+    const dir = this.sessionDir(sessionId);
+    const files = await this.listCheckpointFiles(dir);
+    const results: SessionCheckpointData[] = [];
+
+    for (const file of files) {
+      try {
+        const content = await fs.promises.readFile(path.join(dir, file), "utf-8");
+        results.push(JSON.parse(content) as SessionCheckpointData);
+      } catch {
+        // Skip corrupted checkpoints
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Delete all checkpoints for a session.
+   */
+  async deleteSession(sessionId: string): Promise<void> {
+    const dir = this.sessionDir(sessionId);
+    await fs.promises.rm(dir, { recursive: true, force: true });
+    this.lastCheckpointTime.delete(sessionId);
+  }
+
+  /**
+   * Find sessions that have checkpoints (for recovery on startup).
+   */
+  async findRecoverableSessions(): Promise<string[]> {
+    try {
+      const entries = await fs.promises.readdir(this.checkpointDir, {
+        withFileTypes: true,
+      });
+      return entries
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name);
+    } catch {
+      return [];
+    }
+  }
+
+  private sessionDir(sessionId: string): string {
+    // Sanitize session ID for filesystem use
+    const safe = sessionId.replace(/[^a-zA-Z0-9_:.-]/g, "_");
+    return path.join(this.checkpointDir, safe);
+  }
+
+  private async listCheckpointFiles(dir: string): Promise<string[]> {
+    try {
+      const entries = await fs.promises.readdir(dir);
+      return entries
+        .filter((f) => f.startsWith("checkpoint-") && f.endsWith(".json"))
+        .sort()
+        .reverse(); // Newest first (timestamp in filename)
+    } catch {
+      return [];
+    }
+  }
+
+  private async pruneSession(sessionId: string): Promise<void> {
+    const dir = this.sessionDir(sessionId);
+    const files = await this.listCheckpointFiles(dir);
+
+    if (files.length <= this.maxPerSession) {
+      return;
+    }
+
+    // Remove oldest files beyond the limit
+    const toRemove = files.slice(this.maxPerSession);
+    for (const file of toRemove) {
+      await fs.promises.unlink(path.join(dir, file)).catch(() => {});
+    }
+  }
+}
+
+// Singleton
+let defaultStore: SessionCheckpointStore | undefined;
+
+export function getDefaultCheckpointStore(
+  options?: CheckpointStoreOptions,
+): SessionCheckpointStore {
+  if (!defaultStore) {
+    defaultStore = new SessionCheckpointStore(options);
+  }
+  return defaultStore;
+}
+
+export function resetDefaultCheckpointStore(): void {
+  defaultStore = undefined;
+}

--- a/src/infra/session-cost-alerts.test.ts
+++ b/src/infra/session-cost-alerts.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import {
+  SessionCostAlertMonitor,
+  getDefaultCostAlertMonitor,
+  resetDefaultCostAlertMonitor,
+} from "./session-cost-alerts.js";
+
+describe("SessionCostAlertMonitor", () => {
+  let monitor: SessionCostAlertMonitor;
+
+  beforeEach(() => {
+    monitor = new SessionCostAlertMonitor({
+      thresholds: [
+        { level: "warning", costUsd: 0.5 },
+        { level: "critical", costUsd: 2.0 },
+      ],
+    });
+  });
+
+  it("does not fire below threshold", () => {
+    const alerts = monitor.check({
+      sessionId: "s1",
+      currentCostUsd: 0.1,
+      currentTokens: 1000,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("fires warning at threshold", () => {
+    const alerts = monitor.check({
+      sessionId: "s1",
+      currentCostUsd: 0.5,
+      currentTokens: 5000,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.level).toBe("warning");
+    expect(alerts[0]?.sessionId).toBe("s1");
+  });
+
+  it("fires both thresholds when cost exceeds both", () => {
+    const alerts = monitor.check({
+      sessionId: "s1",
+      currentCostUsd: 3.0,
+      currentTokens: 50000,
+    });
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0]?.level).toBe("warning");
+    expect(alerts[1]?.level).toBe("critical");
+  });
+
+  it("does not re-fire already triggered thresholds", () => {
+    monitor.check({ sessionId: "s1", currentCostUsd: 0.6, currentTokens: 5000 });
+    const alerts = monitor.check({
+      sessionId: "s1",
+      currentCostUsd: 0.8,
+      currentTokens: 8000,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("fires critical after warning was already fired", () => {
+    monitor.check({ sessionId: "s1", currentCostUsd: 0.6, currentTokens: 5000 });
+    const alerts = monitor.check({
+      sessionId: "s1",
+      currentCostUsd: 2.5,
+      currentTokens: 25000,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.level).toBe("critical");
+  });
+
+  it("tracks sessions independently", () => {
+    monitor.check({ sessionId: "s1", currentCostUsd: 0.6, currentTokens: 5000 });
+    const alerts = monitor.check({
+      sessionId: "s2",
+      currentCostUsd: 0.7,
+      currentTokens: 7000,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.sessionId).toBe("s2");
+  });
+
+  it("hasFired returns correct state", () => {
+    expect(monitor.hasFired("s1", "warning")).toBe(false);
+    monitor.check({ sessionId: "s1", currentCostUsd: 0.6, currentTokens: 5000 });
+    expect(monitor.hasFired("s1", "warning")).toBe(true);
+    expect(monitor.hasFired("s1", "critical")).toBe(false);
+  });
+
+  it("resetSession clears fired state", () => {
+    monitor.check({ sessionId: "s1", currentCostUsd: 0.6, currentTokens: 5000 });
+    monitor.resetSession("s1");
+    expect(monitor.hasFired("s1", "warning")).toBe(false);
+
+    const alerts = monitor.check({
+      sessionId: "s1",
+      currentCostUsd: 0.6,
+      currentTokens: 5000,
+    });
+    expect(alerts).toHaveLength(1);
+  });
+
+  it("calls onAlert callback", () => {
+    const callback = vi.fn();
+    const m = new SessionCostAlertMonitor({
+      thresholds: [{ level: "warning", costUsd: 0.5 }],
+      onAlert: callback,
+    });
+
+    m.check({ sessionId: "s1", currentCostUsd: 0.6, currentTokens: 5000 });
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback.mock.calls[0]?.[0]?.level).toBe("warning");
+  });
+
+  it("triggers on token threshold", () => {
+    const m = new SessionCostAlertMonitor({
+      thresholds: [{ level: "warning", costUsd: 100, tokens: 1000 }],
+    });
+
+    const alerts = m.check({
+      sessionId: "s1",
+      currentCostUsd: 0.01,
+      currentTokens: 1500,
+    });
+    expect(alerts).toHaveLength(1);
+  });
+
+  it("does nothing when disabled", () => {
+    const m = new SessionCostAlertMonitor({
+      enabled: false,
+      thresholds: [{ level: "warning", costUsd: 0.01 }],
+    });
+
+    const alerts = m.check({
+      sessionId: "s1",
+      currentCostUsd: 100,
+      currentTokens: 999999,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("swallows callback errors", () => {
+    const m = new SessionCostAlertMonitor({
+      thresholds: [{ level: "warning", costUsd: 0.5 }],
+      onAlert: () => {
+        throw new Error("boom");
+      },
+    });
+
+    expect(() =>
+      m.check({ sessionId: "s1", currentCostUsd: 1.0, currentTokens: 5000 }),
+    ).not.toThrow();
+  });
+});
+
+describe("default monitor singleton", () => {
+  afterEach(() => {
+    resetDefaultCostAlertMonitor();
+  });
+
+  it("returns same instance", () => {
+    const a = getDefaultCostAlertMonitor();
+    const b = getDefaultCostAlertMonitor();
+    expect(a).toBe(b);
+  });
+});
+

--- a/src/infra/session-cost-alerts.ts
+++ b/src/infra/session-cost-alerts.ts
@@ -1,0 +1,184 @@
+/**
+ * Session Cost Alert Thresholds
+ *
+ * Monitors session cost accumulation and triggers alerts when configurable
+ * thresholds are reached. Supports multiple threshold levels (warning, critical)
+ * and tracks which thresholds have already fired to avoid duplicate alerts.
+ */
+
+export type AlertLevel = "warning" | "critical";
+
+export type CostAlertThreshold = {
+  /** Alert level */
+  level: AlertLevel;
+  /** Cost threshold in USD */
+  costUsd: number;
+  /** Optional: token threshold (triggers on whichever is hit first) */
+  tokens?: number;
+};
+
+export type CostAlertEvent = {
+  level: AlertLevel;
+  sessionId: string;
+  currentCostUsd: number;
+  thresholdCostUsd: number;
+  currentTokens: number;
+  thresholdTokens?: number;
+  triggeredAt: number;
+  message: string;
+};
+
+export type CostAlertCallback = (event: CostAlertEvent) => void | Promise<void>;
+
+export type SessionCostAlertConfig = {
+  /** Thresholds to monitor. Default: warning at $0.50, critical at $2.00 */
+  thresholds?: CostAlertThreshold[];
+  /** Whether alerts are enabled. Default: true */
+  enabled?: boolean;
+  /** Callback invoked when a threshold is crossed */
+  onAlert?: CostAlertCallback;
+};
+
+const DEFAULT_THRESHOLDS: CostAlertThreshold[] = [
+  { level: "warning", costUsd: 0.5 },
+  { level: "critical", costUsd: 2.0 },
+];
+
+type FiredState = {
+  level: AlertLevel;
+  firedAt: number;
+  costAtFiring: number;
+};
+
+export class SessionCostAlertMonitor {
+  private readonly thresholds: CostAlertThreshold[];
+  private readonly enabled: boolean;
+  private readonly onAlert?: CostAlertCallback;
+
+  /** Tracks which thresholds have already fired per session */
+  private firedMap = new Map<string, Map<string, FiredState>>();
+
+  constructor(config?: SessionCostAlertConfig) {
+    this.thresholds = (config?.thresholds ?? DEFAULT_THRESHOLDS).toSorted(
+      (a, b) => a.costUsd - b.costUsd,
+    );
+    this.enabled = config?.enabled ?? true;
+    this.onAlert = config?.onAlert;
+  }
+
+  /**
+   * Check if any thresholds have been crossed for a session.
+   * Returns newly triggered alerts (if any).
+   */
+  check(params: {
+    sessionId: string;
+    currentCostUsd: number;
+    currentTokens: number;
+  }): CostAlertEvent[] {
+    if (!this.enabled) {
+      return [];
+    }
+
+    const { sessionId, currentCostUsd, currentTokens } = params;
+    const fired = this.firedMap.get(sessionId) ?? new Map<string, FiredState>();
+    const newAlerts: CostAlertEvent[] = [];
+
+    for (const threshold of this.thresholds) {
+      const key = `${threshold.level}:${threshold.costUsd}`;
+      if (fired.has(key)) {
+        continue;
+      }
+
+      const costTriggered = currentCostUsd >= threshold.costUsd;
+      const tokenTriggered =
+        threshold.tokens !== undefined && currentTokens >= threshold.tokens;
+
+      if (!costTriggered && !tokenTriggered) {
+        continue;
+      }
+
+      const event: CostAlertEvent = {
+        level: threshold.level,
+        sessionId,
+        currentCostUsd,
+        thresholdCostUsd: threshold.costUsd,
+        currentTokens,
+        thresholdTokens: threshold.tokens,
+        triggeredAt: Date.now(),
+        message: `Session ${sessionId} reached ${threshold.level} threshold: $${currentCostUsd.toFixed(4)} >= $${threshold.costUsd.toFixed(2)}`,
+      };
+
+      fired.set(key, {
+        level: threshold.level,
+        firedAt: event.triggeredAt,
+        costAtFiring: currentCostUsd,
+      });
+
+      newAlerts.push(event);
+
+      // Fire callback (non-blocking)
+      if (this.onAlert) {
+        try {
+          const result = this.onAlert(event);
+          if (result instanceof Promise) {
+            result.catch(() => {}); // Swallow async errors
+          }
+        } catch {
+          // Swallow sync errors
+        }
+      }
+    }
+
+    if (fired.size > 0) {
+      this.firedMap.set(sessionId, fired);
+    }
+
+    return newAlerts;
+  }
+
+  /** Check if a specific threshold level has already fired for a session. */
+  hasFired(sessionId: string, level: AlertLevel): boolean {
+    const fired = this.firedMap.get(sessionId);
+    if (!fired) {
+      return false;
+    }
+    for (const [, state] of fired) {
+      if (state.level === level) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Reset alert state for a session (e.g., when session ends). */
+  resetSession(sessionId: string): void {
+    this.firedMap.delete(sessionId);
+  }
+
+  /** Reset all alert state. */
+  resetAll(): void {
+    this.firedMap.clear();
+  }
+
+  /** Get the configured thresholds. */
+  getThresholds(): readonly CostAlertThreshold[] {
+    return this.thresholds;
+  }
+}
+
+// Singleton for the default monitor
+let defaultMonitor: SessionCostAlertMonitor | undefined;
+
+export function getDefaultCostAlertMonitor(
+  config?: SessionCostAlertConfig,
+): SessionCostAlertMonitor {
+  if (!defaultMonitor) {
+    defaultMonitor = new SessionCostAlertMonitor(config);
+  }
+  return defaultMonitor;
+}
+
+export function resetDefaultCostAlertMonitor(): void {
+  defaultMonitor?.resetAll();
+  defaultMonitor = undefined;
+}

--- a/src/slack/channel-cache.test.ts
+++ b/src/slack/channel-cache.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+import {
+  SlackChannelCache,
+  getDefaultChannelCache,
+  resetDefaultChannelCache,
+} from "./channel-cache.js";
+
+describe("SlackChannelCache", () => {
+  let cache: SlackChannelCache;
+
+  beforeEach(() => {
+    cache = new SlackChannelCache({ ttlMs: 1000 });
+  });
+
+  it("stores and retrieves by ID", () => {
+    cache.set({ id: "C123", name: "general", archived: false, isPrivate: false });
+    const entry = cache.getById("C123");
+    expect(entry).toBeDefined();
+    expect(entry?.name).toBe("general");
+    expect(entry?.id).toBe("C123");
+  });
+
+  it("stores and retrieves by name (case-insensitive)", () => {
+    cache.set({ id: "C123", name: "General", archived: false, isPrivate: false });
+    const entry = cache.getByName("general");
+    expect(entry).toBeDefined();
+    expect(entry?.id).toBe("C123");
+
+    const entry2 = cache.getByName("GENERAL");
+    expect(entry2?.id).toBe("C123");
+  });
+
+  it("returns undefined for unknown channels", () => {
+    expect(cache.getById("C999")).toBeUndefined();
+    expect(cache.getByName("nonexistent")).toBeUndefined();
+  });
+
+  it("expires entries after TTL", () => {
+    vi.useFakeTimers();
+    try {
+      cache.set({ id: "C123", name: "general", archived: false, isPrivate: false });
+      expect(cache.getById("C123")).toBeDefined();
+
+      vi.advanceTimersByTime(1001);
+      expect(cache.getById("C123")).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("invalidates by ID", () => {
+    cache.set({ id: "C123", name: "general", archived: false, isPrivate: false });
+    cache.invalidate("C123");
+    expect(cache.getById("C123")).toBeUndefined();
+    expect(cache.getByName("general")).toBeUndefined();
+  });
+
+  it("invalidates by name", () => {
+    cache.set({ id: "C123", name: "general", archived: false, isPrivate: false });
+    cache.invalidate("general");
+    expect(cache.getById("C123")).toBeUndefined();
+    expect(cache.getByName("general")).toBeUndefined();
+  });
+
+  it("bulk loads with setMany", () => {
+    cache.setMany([
+      { id: "C1", name: "alpha", archived: false, isPrivate: false },
+      { id: "C2", name: "beta", archived: true, isPrivate: false },
+    ]);
+    expect(cache.size).toBe(2);
+    expect(cache.getByName("alpha")?.id).toBe("C1");
+    expect(cache.getByName("beta")?.archived).toBe(true);
+  });
+
+  it("evicts oldest when at capacity", () => {
+    const small = new SlackChannelCache({ ttlMs: 60000, maxEntries: 2 });
+    small.set({ id: "C1", name: "first", archived: false, isPrivate: false });
+    small.set({ id: "C2", name: "second", archived: false, isPrivate: false });
+    small.set({ id: "C3", name: "third", archived: false, isPrivate: false });
+
+    expect(small.size).toBe(2);
+    expect(small.getById("C1")).toBeUndefined(); // evicted
+    expect(small.getById("C3")).toBeDefined();
+  });
+
+  it("prunes expired entries", () => {
+    vi.useFakeTimers();
+    try {
+      cache.set({ id: "C1", name: "old", archived: false, isPrivate: false });
+      vi.advanceTimersByTime(500);
+      cache.set({ id: "C2", name: "new", archived: false, isPrivate: false });
+      vi.advanceTimersByTime(600);
+
+      const removed = cache.prune();
+      expect(removed).toBe(1);
+      expect(cache.getById("C1")).toBeUndefined();
+      expect(cache.getById("C2")).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears all entries", () => {
+    cache.setMany([
+      { id: "C1", name: "a", archived: false, isPrivate: false },
+      { id: "C2", name: "b", archived: false, isPrivate: false },
+    ]);
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+
+  it("skips entries without id or name", () => {
+    cache.set({ id: "", name: "test", archived: false, isPrivate: false });
+    cache.set({ id: "C1", name: "", archived: false, isPrivate: false });
+    expect(cache.size).toBe(0);
+  });
+});
+
+describe("default cache singleton", () => {
+  afterEach(() => {
+    resetDefaultChannelCache();
+  });
+
+  it("returns the same instance", () => {
+    const a = getDefaultChannelCache();
+    const b = getDefaultChannelCache();
+    expect(a).toBe(b);
+  });
+
+  it("resets properly", () => {
+    const a = getDefaultChannelCache();
+    a.set({ id: "C1", name: "test", archived: false, isPrivate: false });
+    resetDefaultChannelCache();
+    const b = getDefaultChannelCache();
+    expect(b.size).toBe(0);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/slack/channel-cache.ts
+++ b/src/slack/channel-cache.ts
@@ -1,0 +1,159 @@
+/**
+ * Slack Channel Name Resolution Cache
+ *
+ * Provides a TTL-based in-memory cache for Slack channel name ↔ ID lookups
+ * to minimize API calls and respect rate limits. The cache supports both
+ * forward (name → ID) and reverse (ID → name) lookups.
+ */
+
+import type { SlackChannelLookup } from "./resolve-channels.js";
+
+export type ChannelCacheEntry = SlackChannelLookup & {
+  cachedAt: number;
+};
+
+export type ChannelCacheOptions = {
+  /** TTL in milliseconds. Default: 5 minutes */
+  ttlMs?: number;
+  /** Maximum entries to cache. Default: 10000 */
+  maxEntries?: number;
+};
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 10_000;
+
+export class SlackChannelCache {
+  private byId = new Map<string, ChannelCacheEntry>();
+  private byName = new Map<string, ChannelCacheEntry>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(options?: ChannelCacheOptions) {
+    this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxEntries = options?.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  }
+
+  /** Cache a channel lookup result. */
+  set(channel: SlackChannelLookup): void {
+    if (!channel.id || !channel.name) {
+      return;
+    }
+
+    // Evict if at capacity
+    if (this.byId.size >= this.maxEntries && !this.byId.has(channel.id)) {
+      this.evictOldest();
+    }
+
+    const entry: ChannelCacheEntry = { ...channel, cachedAt: Date.now() };
+    this.byId.set(channel.id, entry);
+    this.byName.set(channel.name.toLowerCase(), entry);
+  }
+
+  /** Bulk-load channels into the cache. */
+  setMany(channels: SlackChannelLookup[]): void {
+    for (const ch of channels) {
+      this.set(ch);
+    }
+  }
+
+  /** Look up a channel by its Slack ID. Returns undefined if not cached or expired. */
+  getById(id: string): ChannelCacheEntry | undefined {
+    const entry = this.byId.get(id);
+    if (!entry) {
+      return undefined;
+    }
+    if (this.isExpired(entry)) {
+      this.delete(entry);
+      return undefined;
+    }
+    return entry;
+  }
+
+  /** Look up a channel by name (case-insensitive). Returns undefined if not cached or expired. */
+  getByName(name: string): ChannelCacheEntry | undefined {
+    const entry = this.byName.get(name.toLowerCase());
+    if (!entry) {
+      return undefined;
+    }
+    if (this.isExpired(entry)) {
+      this.delete(entry);
+      return undefined;
+    }
+    return entry;
+  }
+
+  /** Invalidate a specific channel entry. */
+  invalidate(idOrName: string): void {
+    const byId = this.byId.get(idOrName);
+    if (byId) {
+      this.delete(byId);
+      return;
+    }
+    const byName = this.byName.get(idOrName.toLowerCase());
+    if (byName) {
+      this.delete(byName);
+    }
+  }
+
+  /** Clear all cached entries. */
+  clear(): void {
+    this.byId.clear();
+    this.byName.clear();
+  }
+
+  /** Return the number of cached entries. */
+  get size(): number {
+    return this.byId.size;
+  }
+
+  /** Prune all expired entries. Returns the number of entries removed. */
+  prune(): number {
+    const now = Date.now();
+    let removed = 0;
+    for (const [, entry] of this.byId) {
+      if (now - entry.cachedAt > this.ttlMs) {
+        this.delete(entry);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  private isExpired(entry: ChannelCacheEntry): boolean {
+    return Date.now() - entry.cachedAt > this.ttlMs;
+  }
+
+  private delete(entry: ChannelCacheEntry): void {
+    this.byId.delete(entry.id);
+    this.byName.delete(entry.name.toLowerCase());
+  }
+
+  private evictOldest(): void {
+    let oldest: ChannelCacheEntry | undefined;
+    for (const [, entry] of this.byId) {
+      if (!oldest || entry.cachedAt < oldest.cachedAt) {
+        oldest = entry;
+      }
+    }
+    if (oldest) {
+      this.delete(oldest);
+    }
+  }
+}
+
+// Singleton instance per workspace
+let defaultCache: SlackChannelCache | undefined;
+
+/** Get the shared default channel cache instance. */
+export function getDefaultChannelCache(): SlackChannelCache {
+  if (!defaultCache) {
+    defaultCache = new SlackChannelCache();
+  }
+  return defaultCache;
+}
+
+/** Reset the default cache (useful for testing). */
+export function resetDefaultChannelCache(): void {
+  defaultCache?.clear();
+  defaultCache = undefined;
+}


### PR DESCRIPTION
## Summary

Comprehensive foundational implementation adding three core systems:

### 1. Slack Channel Name Resolution Cache (`src/slack/channel-cache.ts`)
- TTL-based in-memory cache for channel name ↔ ID lookups
- Forward (name→ID) and reverse (ID→name) lookups with case-insensitive matching
- LRU eviction at configurable capacity, bulk loading via `setMany()`
- Automatic expiry with `prune()` and per-entry TTL validation
- Singleton default instance with `getDefaultChannelCache()` / `resetDefaultChannelCache()`

### 2. Session Cost Alert Thresholds (`src/infra/session-cost-alerts.ts`)
- Configurable warning/critical thresholds on both cost (USD) and token count
- Per-session deduplication — each threshold fires at most once per session
- Async `onAlert` callback for plugging into notification systems (Slack, logs, etc.)
- Enable/disable toggle, per-session reset, and global reset
- Sensible defaults: warning at $0.50, critical at $2.00

### 3. Session Checkpoint/Recovery (`src/infra/session-checkpoint.ts`)
- Periodic filesystem-based session state checkpointing
- Stores transcript length, active model/provider, cost, labels, pending tool calls
- Automatic pruning of old checkpoints (configurable retention, default 3)
- Minimum interval throttling to prevent excessive writes (default 30s)
- `findRecoverableSessions()` for startup recovery discovery
- Safe filesystem naming with session ID sanitization

## Testing

All three systems include comprehensive test suites:
- `src/slack/channel-cache.test.ts` — 10 tests covering CRUD, TTL, eviction, bulk ops
- `src/infra/session-cost-alerts.test.ts` — 11 tests covering thresholds, dedup, callbacks, token triggers
- `src/infra/session-checkpoint.test.ts` — 8 tests covering save/load, pruning, recovery, throttling

## Motivation

These systems form foundational infrastructure for reliable, cost-aware, and resilient agent operation. They share common session lifecycle patterns and were developed together to ensure consistent design.

## Breaking Changes

None. All features are additive — new files only, no modifications to existing code.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds three new infra utilities:

- `src/slack/channel-cache.ts`: in-memory TTL cache for Slack channel ID/name lookups with a default singleton.
- `src/infra/session-cost-alerts.ts`: per-session cost/token threshold monitor with optional callback and default singleton.
- `src/infra/session-checkpoint.ts`: filesystem checkpoint store for persisting session state and discovering recoverable sessions, plus unit tests for each module.

Overall the changes are additive and well-covered by tests, but there are a few correctness edge cases (stale cache entries, dedupe key collisions, and checkpoint filename collisions) that should be addressed before merging.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there are a few correctness bugs that can cause stale lookups or lost checkpoints under realistic conditions.
- The PR is additive and tests cover the happy paths, but there are verified edge-case correctness issues: Slack channel rename can leave stale name mappings, cost alert dedupe can suppress thresholds with distinct token settings, and checkpoint filenames can collide on same-ms saves causing silent data loss.
- src/slack/channel-cache.ts; src/infra/session-cost-alerts.ts; src/infra/session-checkpoint.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->