### PR TITLE
macOS: force session preview submenu repaint after async load

### DIFF
--- a/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
+++ b/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
@@ -585,34 +585,38 @@ extension MenuSessionsInjector {
         let item = NSMenuItem()
         item.tag = self.tag
         item.isEnabled = false
-        let view = AnyView(SessionMenuPreviewView(
-            width: width,
-            maxLines: maxLines,
-            title: title,
-            items: [],
-            status: .loading))
-        let hosting = NSHostingView(rootView: view)
-        hosting.frame.size.width = max(1, width)
-        let size = hosting.fittingSize
-        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: size.height))
-        item.view = hosting
+        let view = AnyView(
+            SessionMenuPreviewView(
+                width: width,
+                maxLines: maxLines,
+                title: title,
+                items: [],
+                status: .loading)
+                .environment(\.isEnabled, true))
+        let hosted = HighlightedMenuItemHostView(rootView: view, width: width)
+        item.view = hosted
 
-        let task = Task { [weak hosting] in
+        let task = Task { [weak hosted, weak item] in
             let snapshot = await SessionMenuPreviewLoader.load(sessionKey: sessionKey, maxItems: 10)
             guard !Task.isCancelled else { return }
+
             await MainActor.run {
-                guard let hosting else { return }
-                let nextView = AnyView(SessionMenuPreviewView(
-                    width: width,
-                    maxLines: maxLines,
-                    title: title,
-                    items: snapshot.items,
-                    status: snapshot.status))
-                hosting.rootView = nextView
-                hosting.invalidateIntrinsicContentSize()
-                hosting.frame.size.width = max(1, width)
-                let size = hosting.fittingSize
-                hosting.frame.size.height = size.height
+                let nextView = AnyView(
+                    SessionMenuPreviewView(
+                        width: width,
+                        maxLines: maxLines,
+                        title: title,
+                        items: snapshot.items,
+                        status: snapshot.status)
+                        .environment(\.isEnabled, true))
+
+                if let item {
+                    item.view = HighlightedMenuItemHostView(rootView: nextView, width: width)
+                    return
+                }
+
+                guard let hosted else { return }
+                hosted.update(rootView: nextView, width: width)
             }
         }
         self.previewTasks.append(task)


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> conversation history fucked in mac app. panel doesnt populate

_The rest of this PR was written by GPT-5-default, running in the pi harness. Full environment + prompt history appear at the end._

# Changes
- Replace async preview update path in `MenuSessionsInjector.makeSessionPreviewItem(...)` to reassign `NSMenuItem.view` with a fresh `HighlightedMenuItemHostView` after snapshot load.
- Keep fallback hosted-view update path for safety when the menu item is no longer available.
- Preserve enabled-state environment for preview rows so loaded content renders immediately in submenu.

# Tests
- `cd apps/macos && swift build -c debug` ✅ pass
- `pnpm build` ✅ pass
- `pnpm check` ❌ fails at `extensions/memory-lancedb/index.ts:320` with a pre-existing TypeScript schema error unrelated to this macOS Swift change.

# Risks
- Low: localized to macOS menubar preview rendering path.

# Follow-ups
- Consider deduplicating preview task churn on repeated submenu reinjection (separate change).

# Prompt History

## Environment
Harness: pi
Model: GPT-5
Thinking level: default
Terminal: zsh (pi tool harness)
System: Darwin 25.1.0 arm64

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-02-10T21:08:00-08:00 | `well cool i guess. can we surgically commit the fix, then open PR, then land PR?` |
| 2026-02-10T21:09:00-08:00 | `conversation history fucked in mac app. panel doesnt populate` |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the macOS status bar session preview submenu rendering path so that, after the async snapshot load completes, the code replaces `NSMenuItem.view` with a fresh `HighlightedMenuItemHostView` instead of only updating the existing hosting view. It also forces a SwiftUI `isEnabled` environment of `true` for the preview view while keeping the underlying `NSMenuItem` disabled, to avoid the loaded content rendering as disabled.

The change is localized to `MenuSessionsInjector.makeSessionPreviewItem(...)`, which constructs the submenu preview rows used by `buildSubmenu(...)` / `buildPreviewSubmenu(...)`. No other menu injection, cache refresh, or node/usage sections are modified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to macOS menu preview rendering and uses an existing view wrapper (`HighlightedMenuItemHostView`). Verified that the host view recomputes sizing correctly on init/update and the async update runs on MainActor. No definite functional regressions or crashes were identified from the diff and related view code.
- apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->