### PR TITLE
memory-lancedb: fix TypeBox Optional+enum schema typecheck on main

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -11,7 +11,6 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import { randomUUID } from "node:crypto";
 import OpenAI from "openai";
-import { stringEnum } from "openclaw/plugin-sdk";
 import {
   MEMORY_CATEGORIES,
   type MemoryCategory,
@@ -317,7 +316,12 @@ const memoryPlugin = {
         parameters: Type.Object({
           text: Type.String({ description: "Information to remember" }),
           importance: Type.Optional(Type.Number({ description: "Importance 0-1 (default: 0.7)" })),
-          category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
+          category: Type.Optional(
+            Type.Unsafe<MemoryCategory>({
+              type: "string",
+              enum: [...MEMORY_CATEGORIES],
+            }),
+          ),
         }),
         async execute(_toolCallId, params) {
           const {


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> but where did it come from? lets just bundle in our PR. can you bisect or whatever to find where it originateD?

_The rest of this PR was written by GPT-5-default, running in the pi harness. Full environment + prompt history appear at the end._

# Changes
- Replace `Type.Optional(stringEnum(MEMORY_CATEGORIES))` in `extensions/memory-lancedb/index.ts` with a local `Type.Unsafe<MemoryCategory>` enum schema.
- Remove the `stringEnum` import from `openclaw/plugin-sdk` in that extension to avoid cross-module TypeBox schema type incompatibility.

# Tests
- `pnpm check` ✅

# Risks
- Low: schema construction remains equivalent (`type: "string"`, enum over `MEMORY_CATEGORIES`) and change is scoped to one extension tool parameter.

# Follow-ups
- None.

# Prompt History

## Environment
Harness: pi
Model: GPT-5
Thinking level: default
Terminal: zsh (pi harness)
System: Darwin 25.1.0 arm64

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-02-10T21:16:00-08:00 | `- pnpm check ❌ (unrelated pre-existing TS error in extensions/memory-lancedb/index.ts:320) -> whats goin on on main?` |
| 2026-02-10T21:18:00-08:00 | `but where did it come from? lets just bundle in our PR. can you bisect or whatever to find where it originateD?` |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes TypeBox schema type incompatibility by inlining enum schema construction in the `memory-lancedb` extension. The change removes the `stringEnum` import from `openclaw/plugin-sdk` and replaces it with a local `Type.Unsafe<MemoryCategory>` construction that uses the extension's own TypeBox instance.

**Root cause**: Extensions with their own `@sinclair/typebox` dependency (even at the same version) create separate TypeBox instances, causing TypeScript type incompatibility when wrapping schemas from different instances.

**Changes**:
- Removed `stringEnum` helper import from `openclaw/plugin-sdk`
- Inlined equivalent schema: `Type.Unsafe<MemoryCategory>({ type: "string", enum: [...MEMORY_CATEGORIES] })`
- Schema behavior remains identical (same JSON schema output)
- Type safety preserved via generic parameter

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward fix for a TypeBox schema type incompatibility. The inlined schema construction is functionally identical to the helper it replaces, maintaining the same JSON schema output while resolving cross-module TypeScript type issues. Tests pass (`pnpm check` ✅), the change is scoped to a single tool parameter, and there are no other extensions using `stringEnum`, eliminating any ripple effects
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->