### PR TITLE
fix: auto-recover on event gap instead of showing error

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -691,7 +691,9 @@ export async function runTui(opts: TuiOptions) {
   };
 
   client.onGap = (info) => {
-    setConnectionStatus(`event gap: expected ${info.expected}, got ${info.received}`, 5000);
+    // Auto-recover: reload history instead of just showing warning
+    setConnectionStatus(`resyncing (event gap ${info.expected}→${info.received})`, 2000);
+    void loadHistory();
     tui.requestRender();
   };
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -155,7 +155,9 @@ export function connectGateway(host: GatewayHost) {
     },
     onEvent: (evt) => handleGatewayEvent(host, evt),
     onGap: ({ expected, received }) => {
-      host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;
+      // Auto-recover: refresh chat history instead of showing error
+      console.info(`[gateway] event gap detected (expected seq ${expected}, got ${received}); auto-resyncing...`);
+      void loadChatHistory(host as unknown as OpenClawApp);
     },
   });
   host.client.start();


### PR DESCRIPTION
## Problem
When WebSocket events arrive with a sequence gap (missed events), the UI and TUI previously showed an error message asking the user to refresh manually. This was disruptive and unnecessary.

## Solution
Auto-recover by reloading chat history instead of showing an error.

### Changes
- **UI (app-gateway.ts)**: Call `loadChatHistory()` instead of setting `lastError`
- **TUI (tui.ts)**: Call `loadHistory()` with a brief 'resyncing...' status (2s instead of 5s)

### Before
- UI: Error banner "event gap detected... refresh recommended"
- TUI: Status "event gap: expected X, got Y" for 5 seconds

### After
- UI: Silently reloads chat history (logs to console only for debugging)
- TUI: Brief "resyncing (event gap X→Y)" status while reloading

The gap is logged to console for debugging but no longer surfaces as a user-visible error.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes how the UI and TUI react to WebSocket sequence gaps: instead of surfacing an error prompting a manual refresh, both clients attempt to self-heal by reloading chat history (`loadChatHistory()` in the web UI and `loadHistory()` in the TUI). The web UI also logs a console info line for debugging, while the TUI shows a short-lived “resyncing…” status message during the reload.

These changes plug into the existing gateway client gap callback (`onGap`) alongside the existing reconnect logic in `connectGateway()` and the TUI’s `GatewayChatClient` event loop.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but there is one correctness concern around TUI state consistency during mid-stream gap recovery.
- The changes are small and localized to gap handling, and the recovery path reuses existing history-loading code. The main risk is the TUI leaving in-flight run/status state intact while replacing history, which can produce inconsistent UI behavior when gaps occur during streaming.
- src/tui/tui.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->