### PR TITLE
fix(agents): re-run tool_use pairing repair after limitHistoryTurns truncation

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -44,6 +44,7 @@ import { createOpenClawCodingTools } from "../pi-tools.js";
 import { resolveSandboxContext } from "../sandbox.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
 import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
+import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { acquireSessionWriteLock } from "../session-write-lock.js";
 import { detectRuntimeShell } from "../shell-utils.js";
 import {
@@ -429,10 +430,17 @@ export async function compactEmbeddedPiSessionDirect(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        const limited = limitHistoryTurns(
+        const truncated = limitHistoryTurns(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
+        // Re-run tool_use/tool_result pairing repair after truncation.
+        // limitHistoryTurns() can slice away assistant tool_use messages while
+        // keeping their orphaned tool_result blocks, causing API 400 errors.
+        // See: https://github.com/openclaw/openclaw/issues/13896
+        const limited = transcriptPolicy.repairToolUseResultPairing
+          ? sanitizeToolUseResultPairing(truncated)
+          : truncated;
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }


### PR DESCRIPTION
## Problem

`limitHistoryTurns()` runs **after** `sanitizeSessionHistory()` (which calls `repairToolUseResultPairing()`). When `limitHistoryTurns()` slices the history, it can remove an assistant message containing a `tool_use` block while keeping the corresponding `tool_result` — re-orphaning tool results that were already repaired. This causes Anthropic API to reject the request:

```
HTTP 400 invalid_request_error: messages.14.content.1: unexpected tool_use_id found in tool_result blocks
```

## Fix

Re-run `sanitizeToolUseResultPairing()` after `limitHistoryTurns()` in both code paths:

1. **Main reply flow** (`run/attempt.ts`)
2. **Compaction flow** (`compact.ts`)

The repair is guarded by the transcript policy's `repairToolUseResultPairing` flag, so it only runs for providers that need it.

## Repro conditions

- Long-running DM session with tool use
- `dmHistoryLimit` configured
- Conversation grows long enough for `limitHistoryTurns()` to truncate
- Truncation boundary falls between a `tool_use` assistant message and its `tool_result`

Fixes #13896

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a transcript integrity issue where `limitHistoryTurns()` can truncate away an assistant `tool_use`/tool-call message while leaving its corresponding `tool_result`, causing strict Anthropic-compatible APIs to reject the payload (400: unexpected `tool_use_id`).

Changes in both the main embedded run flow (`src/agents/pi-embedded-runner/run/attempt.ts`) and the compaction flow (`src/agents/pi-embedded-runner/compact.ts`) now re-run `sanitizeToolUseResultPairing()` *after* truncation, gated by `transcriptPolicy.repairToolUseResultPairing`, so the extra repair only runs for providers that require strict tool pairing.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to re-run an existing transcript repair step after history truncation in two code paths, and it is gated by an existing transcript policy flag. I did not find any incorrect imports, logic regressions, or mismatches with the repair function’s behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->