### PR TITLE
fix(gateway): forward threadId in resolveFallbackSession for plugin channels

### DIFF
--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -883,7 +883,13 @@ function resolveFallbackSession(
   if (!peerId) {
     return null;
   }
-  const peer: RoutePeer = { kind: peerKind, id: peerId };
+  const threadId = normalizeThreadId(params.threadId);
+  // Encode threadId into peer ID for group/channel contexts so that
+  // topic-scoped conversations get their own session key.
+  // See: https://github.com/openclaw/openclaw/issues/13880
+  const topicAwarePeerId =
+    threadId && peerKind !== "direct" ? `${peerId}:topic:${threadId}` : peerId;
+  const peer: RoutePeer = { kind: peerKind, id: topicAwarePeerId };
   const baseSessionKey = buildBaseSessionKey({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -903,6 +909,7 @@ function resolveFallbackSession(
     chatType,
     from,
     to: `${toPrefix}:${peerId}`,
+    threadId,
   };
 }
 


### PR DESCRIPTION
## Problem

`resolveFallbackSession()` in `outbound-session.ts` ignores the `threadId` parameter entirely. This breaks topic isolation for any channel that uses the fallback session resolver (i.e., all plugin-based channels like Feishu).

When a sub-agent delivers results to a topic group:
1. The announce flow correctly passes `threadId`
2. `resolveOutboundSessionRoute()` dispatches to `resolveFallbackSession()` for plugin channels
3. `resolveFallbackSession()` ignores `threadId`
4. The resulting route has no `threadId` → outbound adapter sends without reply context → new topic is created instead of replying in the existing one

## Fix

- Forward `threadId` in the returned route object
- Encode `threadId` into peer ID for group/channel contexts as `peerId:topic:threadId` so session keys are topic-scoped (consistent with how Telegram handles `messageThreadId`)
- DM sessions are not affected (threadId is not encoded into peer ID for direct chats)

## Tests

Added two test cases:
- Plugin channel group context: verifies threadId is forwarded and encoded into peer ID
- Plugin channel direct context: verifies threadId is forwarded but NOT encoded into peer ID

Fixes #13880

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed topic isolation for plugin channels by forwarding `threadId` in `resolveFallbackSession()`. Previously, the function ignored the `threadId` parameter, causing all messages to be routed to the default topic instead of maintaining separate conversations per topic (issue #13880).

**Changes:**
- Forwards `threadId` in the returned route object
- Encodes `threadId` into peer ID as `peerId:topic:threadId` for group/channel contexts (matches Telegram's pattern)
- Direct message sessions remain unchanged (threadId not encoded into peer ID)
- Added comprehensive test coverage for both group and direct message scenarios

**Issue found:**
- The `from` field uses base `peerId` instead of `topicAwarePeerId` for groups/channels, which may cause session key resolution issues. Telegram's reference implementation encodes the topic in the `from` field.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical issue that should be addressed
- The fix correctly forwards threadId and encodes it into peer.id for session key scoping. Tests verify the behavior. However, the `from` field construction doesn't match the Telegram pattern (which is the reference for topic-aware messaging), potentially causing issues with session key resolution and group ID extraction.
- src/infra/outbound/outbound-session.ts (lines 900-903) - verify `from` field should use topicAwarePeerId

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->