### PR TITLE
feat(telegram): add entity-based formatting with custom emoji support

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -44,7 +44,7 @@ function splitTextWithEntities(
   if (text.length <= limit) {
     return [{ text, entities }];
   }
-  const sorted = [...entities].sort((a, b) => a.offset - b.offset);
+  const sorted = [...entities].toSorted((a, b) => a.offset - b.offset);
   const chunks: Array<{ text: string; entities: MessageEntity[] }> = [];
   let offset = 0;
   while (offset < text.length) {
@@ -61,10 +61,14 @@ function splitTextWithEntities(
       const nl = text.lastIndexOf("\n", end - 1);
       if (nl > offset) {
         const nlSafe = sorted.every((e) => !(e.offset <= nl && e.offset + e.length > nl));
-        if (nlSafe) end = nl + 1;
+        if (nlSafe) {
+          end = nl + 1;
+        }
       }
       // Safeguard: ensure forward progress.
-      if (end <= offset) end = Math.min(offset + limit, text.length);
+      if (end <= offset) {
+        end = Math.min(offset + limit, text.length);
+      }
     }
     const chunkEntities: MessageEntity[] = [];
     for (const e of sorted) {

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -60,9 +60,7 @@ function splitTextWithEntities(
       // Prefer splitting at a newline (if one exists after offset).
       const nl = text.lastIndexOf("\n", end - 1);
       if (nl > offset) {
-        const nlSafe = sorted.every(
-          (e) => !(e.offset <= nl && e.offset + e.length > nl),
-        );
+        const nlSafe = sorted.every((e) => !(e.offset <= nl && e.offset + e.length > nl));
         if (nlSafe) end = nl + 1;
       }
       // Safeguard: ensure forward progress.

--- a/src/telegram/formattable.test.ts
+++ b/src/telegram/formattable.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import {
+  FormattableString,
+  bold,
+  italic,
+  underline,
+  strikethrough,
+  spoiler,
+  code,
+  blockquote,
+  pre,
+  link,
+  customEmoji,
+  format,
+  join,
+} from "./formattable.js";
+
+describe("FormattableString", () => {
+  it("constructs with text and no entities", () => {
+    const fs = new FormattableString("hello");
+    expect(fs.text).toBe("hello");
+    expect(fs.entities).toEqual([]);
+  });
+
+  it("toString returns text", () => {
+    const fs = new FormattableString("hello");
+    expect(fs.toString()).toBe("hello");
+  });
+});
+
+describe("customEmoji", () => {
+  it("creates a FormattableString with custom_emoji entity", () => {
+    const result = customEmoji("⚔️", "5222106016283378623");
+    expect(result).toBeInstanceOf(FormattableString);
+    expect(result.text).toBe("⚔️");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]).toEqual({
+      type: "custom_emoji",
+      offset: 0,
+      length: 2, // ⚔️ is 2 UTF-16 code units (base char + variation selector)
+      custom_emoji_id: "5222106016283378623",
+    });
+  });
+});
+
+describe("simple formatters", () => {
+  it("bold wraps text", () => {
+    const result = bold("hello");
+    expect(result.text).toBe("hello");
+    expect(result.entities).toEqual([{ type: "bold", offset: 0, length: 5 }]);
+  });
+
+  it("italic wraps text", () => {
+    const result = italic("world");
+    expect(result.text).toBe("world");
+    expect(result.entities).toEqual([{ type: "italic", offset: 0, length: 5 }]);
+  });
+
+  it("underline wraps text", () => {
+    const result = underline("test");
+    expect(result.text).toBe("test");
+    expect(result.entities).toEqual([{ type: "underline", offset: 0, length: 4 }]);
+  });
+
+  it("strikethrough wraps text", () => {
+    const result = strikethrough("old");
+    expect(result.text).toBe("old");
+    expect(result.entities).toEqual([{ type: "strikethrough", offset: 0, length: 3 }]);
+  });
+
+  it("spoiler wraps text", () => {
+    const result = spoiler("secret");
+    expect(result.text).toBe("secret");
+    expect(result.entities).toEqual([{ type: "spoiler", offset: 0, length: 6 }]);
+  });
+
+  it("code wraps text", () => {
+    const result = code("x = 1");
+    expect(result.text).toBe("x = 1");
+    expect(result.entities).toEqual([{ type: "code", offset: 0, length: 5 }]);
+  });
+
+  it("blockquote wraps text", () => {
+    const result = blockquote("quoted");
+    expect(result.text).toBe("quoted");
+    expect(result.entities).toEqual([{ type: "blockquote", offset: 0, length: 6 }]);
+  });
+
+  it("accepts FormattableString as input", () => {
+    const inner = new FormattableString("text", [{ type: "italic", offset: 0, length: 4 }]);
+    const result = bold(inner);
+    expect(result.text).toBe("text");
+    expect(result.entities).toHaveLength(2);
+    expect(result.entities[0]).toEqual({ type: "bold", offset: 0, length: 4 });
+    expect(result.entities[1]).toEqual({ type: "italic", offset: 0, length: 4 });
+  });
+});
+
+describe("formatters with arguments", () => {
+  it("pre creates pre entity with language", () => {
+    const result = pre("console.log(1)", "javascript");
+    expect(result.text).toBe("console.log(1)");
+    expect(result.entities).toEqual([
+      { type: "pre", offset: 0, length: 14, language: "javascript" },
+    ]);
+  });
+
+  it("link creates text_link entity with url", () => {
+    const result = link("click here", "https://example.com");
+    expect(result.text).toBe("click here");
+    expect(result.entities).toEqual([
+      { type: "text_link", offset: 0, length: 10, url: "https://example.com" },
+    ]);
+  });
+});
+
+describe("format template tag", () => {
+  it("composes plain strings", () => {
+    const result = format`hello world`;
+    expect(result.text).toBe("hello world");
+    expect(result.entities).toEqual([]);
+  });
+
+  it("composes with formatted parts", () => {
+    const result = format`Hello ${bold("world")}!`;
+    expect(result.text).toBe("Hello world!");
+    expect(result.entities).toEqual([{ type: "bold", offset: 6, length: 5 }]);
+  });
+
+  it("computes offsets correctly with multiple parts", () => {
+    const result = format`${bold("A")} and ${italic("B")}`;
+    expect(result.text).toBe("A and B");
+    expect(result.entities).toEqual([
+      { type: "bold", offset: 0, length: 1 },
+      { type: "italic", offset: 6, length: 1 },
+    ]);
+  });
+
+  it("handles customEmoji in format tag", () => {
+    const result = format`Hello ${customEmoji("⚔️", "123")}!`;
+    expect(result.text).toBe("Hello ⚔️!");
+    expect(result.entities).toEqual([
+      { type: "custom_emoji", offset: 6, length: 2, custom_emoji_id: "123" },
+    ]);
+  });
+
+  it("accepts plain strings as interpolated values", () => {
+    const name = "Alice";
+    const result = format`Hello ${name}`;
+    expect(result.text).toBe("Hello Alice");
+    expect(result.entities).toEqual([]);
+  });
+
+  it("skips null/undefined values", () => {
+    const result = format`A${null as unknown as string}B`;
+    expect(result.text).toBe("AB");
+    expect(result.entities).toEqual([]);
+  });
+});
+
+describe("nesting", () => {
+  it("bold wrapping customEmoji preserves both entities", () => {
+    const result = bold(customEmoji("⚔️", "id123"));
+    expect(result.text).toBe("⚔️");
+    expect(result.entities).toHaveLength(2);
+    expect(result.entities[0]).toEqual({ type: "bold", offset: 0, length: 2 });
+    expect(result.entities[1]).toEqual({
+      type: "custom_emoji",
+      offset: 0,
+      length: 2,
+      custom_emoji_id: "id123",
+    });
+  });
+
+  it("italic wrapping bold text preserves both entities", () => {
+    const result = italic(bold("text"));
+    expect(result.text).toBe("text");
+    expect(result.entities).toHaveLength(2);
+    expect(result.entities[0]).toEqual({ type: "italic", offset: 0, length: 4 });
+    expect(result.entities[1]).toEqual({ type: "bold", offset: 0, length: 4 });
+  });
+});
+
+describe("join", () => {
+  it("joins items with separator", () => {
+    const result = join(["a", "b", "c"], (item) => bold(item), ", ");
+    expect(result.text).toBe("a, b, c");
+    expect(result.entities).toEqual([
+      { type: "bold", offset: 0, length: 1 },
+      { type: "bold", offset: 3, length: 1 },
+      { type: "bold", offset: 6, length: 1 },
+    ]);
+  });
+
+  it("handles empty array", () => {
+    const result = join([], (item: string) => bold(item), ", ");
+    expect(result.text).toBe("");
+    expect(result.entities).toEqual([]);
+  });
+
+  it("handles single element", () => {
+    const result = join(["only"], (item) => italic(item), ", ");
+    expect(result.text).toBe("only");
+    expect(result.entities).toEqual([{ type: "italic", offset: 0, length: 4 }]);
+  });
+
+  it("handles FormattableString separator", () => {
+    const sep = bold(" | ");
+    const result = join(["a", "b"], (item) => item, sep);
+    expect(result.text).toBe("a | b");
+    expect(result.entities).toEqual([{ type: "bold", offset: 1, length: 3 }]);
+  });
+
+  it("passes index to callback", () => {
+    const result = join([10, 20], (item, idx) => `${idx}:${item}`, " ");
+    expect(result.text).toBe("0:10 1:20");
+    expect(result.entities).toEqual([]);
+  });
+
+  it("recalculates offsets for complex items", () => {
+    const items = [
+      { name: "Sword", emojiId: "111" },
+      { name: "Shield", emojiId: "222" },
+    ];
+    const result = join(
+      items,
+      (item) => format`${customEmoji("⚔️", item.emojiId)} ${bold(item.name)}`,
+      "\n",
+    );
+    // "⚔️ Sword\n⚔️ Shield"
+    const line1 = "⚔️ Sword";
+    const line2 = "⚔️ Shield";
+    expect(result.text).toBe(`${line1}\n${line2}`);
+
+    // Line 1: customEmoji at 0, bold at 3
+    expect(result.entities[0]).toEqual({
+      type: "custom_emoji",
+      offset: 0,
+      length: 2,
+      custom_emoji_id: "111",
+    });
+    expect(result.entities[1]).toEqual({ type: "bold", offset: 3, length: 5 });
+
+    // Line 2: customEmoji at 9 (8 + 1 newline), bold at 12
+    const offset2 = line1.length + 1; // newline separator
+    expect(result.entities[2]).toEqual({
+      type: "custom_emoji",
+      offset: offset2,
+      length: 2,
+      custom_emoji_id: "222",
+    });
+    expect(result.entities[3]).toEqual({
+      type: "bold",
+      offset: offset2 + 3,
+      length: 6,
+    });
+  });
+});

--- a/src/telegram/formattable.ts
+++ b/src/telegram/formattable.ts
@@ -1,0 +1,157 @@
+import type { MessageEntity } from "@grammyjs/types";
+
+/**
+ * A string with associated Telegram message entities for rich formatting.
+ * Inspired by gramio's FormattableString approach — entities-only, no parse_mode.
+ */
+export class FormattableString {
+  readonly text: string;
+  readonly entities: MessageEntity[];
+
+  constructor(text: string, entities: MessageEntity[] = []) {
+    this.text = text;
+    this.entities = entities;
+  }
+
+  toString(): string {
+    return this.text;
+  }
+}
+
+type FormattableInput = string | FormattableString;
+
+function toFormattable(input: FormattableInput): FormattableString {
+  if (input instanceof FormattableString) {
+    return input;
+  }
+  return new FormattableString(String(input));
+}
+
+/**
+ * Shift all entity offsets by a given amount.
+ */
+function shiftEntities(entities: MessageEntity[], offset: number): MessageEntity[] {
+  if (offset === 0) {
+    return entities;
+  }
+  return entities.map((e) => ({ ...e, offset: e.offset + offset }));
+}
+
+/**
+ * Factory for simple formatters (bold, italic, code, etc.) that wrap text
+ * in a single entity with no extra arguments.
+ */
+function buildFormatter(type: MessageEntity["type"]) {
+  return (input: FormattableInput): FormattableString => {
+    const inner = toFormattable(input);
+    const wrapper: MessageEntity = {
+      type,
+      offset: 0,
+      length: inner.text.length,
+    } as MessageEntity;
+    return new FormattableString(inner.text, [wrapper, ...inner.entities]);
+  };
+}
+
+/**
+ * Factory for formatters that need additional arguments beyond the text.
+ */
+function buildFormatterWithArgs<K extends string>(type: MessageEntity["type"], ...keys: K[]) {
+  return (input: FormattableInput, ...args: string[]): FormattableString => {
+    const inner = toFormattable(input);
+    const extra: Record<string, string> = {};
+    for (let i = 0; i < keys.length; i++) {
+      if (args[i] !== undefined) {
+        extra[keys[i]] = args[i];
+      }
+    }
+    const wrapper = {
+      type,
+      offset: 0,
+      length: inner.text.length,
+      ...extra,
+    } as MessageEntity;
+    return new FormattableString(inner.text, [wrapper, ...inner.entities]);
+  };
+}
+
+// Simple formatters
+export const bold = buildFormatter("bold");
+export const italic = buildFormatter("italic");
+export const underline = buildFormatter("underline");
+export const strikethrough = buildFormatter("strikethrough");
+export const spoiler = buildFormatter("spoiler");
+export const code = buildFormatter("code");
+export const blockquote = buildFormatter("blockquote");
+
+// Formatters with extra arguments
+export const pre = buildFormatterWithArgs("pre", "language");
+export const link = buildFormatterWithArgs("text_link", "url");
+export const customEmoji = buildFormatterWithArgs("custom_emoji", "custom_emoji_id");
+
+/**
+ * Template literal tag for composing FormattableString values.
+ *
+ * Usage:
+ * ```ts
+ * const msg = format`Hello ${bold("world")}! ${customEmoji("⚔️", "12345")}`;
+ * ```
+ */
+export function format(
+  strings: TemplateStringsArray,
+  ...values: FormattableInput[]
+): FormattableString {
+  let text = "";
+  const entities: MessageEntity[] = [];
+
+  for (let i = 0; i < strings.length; i++) {
+    text += strings[i];
+
+    if (i < values.length) {
+      const value = values[i];
+      if (value == null) {
+        continue;
+      }
+      const part = toFormattable(value);
+      entities.push(...shiftEntities(part.entities, text.length));
+      text += part.text;
+    }
+  }
+
+  return new FormattableString(text, entities);
+}
+
+/**
+ * Join an array of items into a FormattableString with a separator.
+ *
+ * Usage:
+ * ```ts
+ * const list = join(items, (item) => bold(item.name), "\n");
+ * ```
+ */
+export function join<T>(
+  array: T[],
+  fn: (item: T, index: number) => FormattableInput,
+  separator: FormattableInput = "",
+): FormattableString {
+  if (array.length === 0) {
+    return new FormattableString("");
+  }
+
+  const sep = toFormattable(separator);
+  let text = "";
+  const entities: MessageEntity[] = [];
+
+  for (let i = 0; i < array.length; i++) {
+    if (i > 0 && sep.text) {
+      entities.push(...shiftEntities(sep.entities, text.length));
+      text += sep.text;
+    }
+
+    const part = toFormattable(fn(array[i], i));
+    entities.push(...shiftEntities(part.entities, text.length));
+    text += part.text;
+  }
+
+  return new FormattableString(text, entities);
+}

--- a/src/telegram/index.ts
+++ b/src/telegram/index.ts
@@ -1,4 +1,19 @@
 export { createTelegramBot, createTelegramWebhookCallback } from "./bot.js";
+export {
+  FormattableString,
+  format,
+  join,
+  bold,
+  italic,
+  underline,
+  strikethrough,
+  spoiler,
+  code,
+  blockquote,
+  pre,
+  link,
+  customEmoji,
+} from "./formattable.js";
 export { monitorTelegramProvider } from "./monitor.js";
 export { reactMessageTelegram, sendMessageTelegram } from "./send.js";
 export { startTelegramWebhook } from "./webhook.js";


### PR DESCRIPTION
## Summary

Adds `FormattableString` — a gramio-inspired module for entity-based message formatting. This enables custom emoji support in bot messages (requires bot owner to have Telegram Premium).

When `entities` are provided, messages are sent via the `entities` parameter instead of `parse_mode: "HTML"`, which is the only way to include custom emoji in bot messages.

## Changes

- **New `src/telegram/formattable.ts`**: `FormattableString` class with builder functions (`bold`, `italic`, `customEmoji`, `link`, `pre`, etc.), `format` template literal tag, and `join()` array helper — all with automatic offset calculation
- **New `src/telegram/formattable.test.ts`**: 27 tests covering all formatters, nesting, offset computation, join, and edge cases
- **`src/telegram/send.ts`**: Added `entities` to `TelegramSendOpts`; when provided, `sendMessage` uses `entities` instead of `parse_mode`
- **`src/telegram/bot/delivery.ts`**: `deliverReplies` reads `entities` from `channelData.telegram` and passes them through
- **`src/telegram/index.ts`**: Re-exports all formattable symbols

## Usage

```typescript
import { format, bold, customEmoji } from "./telegram/formattable.js";

const msg = format`${bold("Hello")} ${customEmoji("⭐", "5368324170671202286")}`;
// msg.text = "Hello ⭐"
// msg.entities = [
//   { type: "bold", offset: 0, length: 5 },
//   { type: "custom_emoji", offset: 6, length: 1, custom_emoji_id: "5368324170671202286" }
// ]

await sendMessageTelegram(chatId, msg.text, { entities: msg.entities });
```

## Test Plan

- [x] All 441 existing tests pass
- [x] 27 new tests in `formattable.test.ts` pass
- [x] Manual verification: bot sends custom emoji, bold, and italic via entities

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an entity-based formatting API for Telegram (`FormattableString`, template tag `format`, and helpers like `bold`, `link`, `customEmoji`) and wires support for passing `entities` through Telegram send paths.

Behaviorally, `sendMessageTelegram` and the bot delivery pipeline now prefer sending via `entities` (without `parse_mode: "HTML"`) when entities are provided, enabling features like custom emoji. The rest of the Telegram rendering remains HTML/markdown-based when entities are not supplied.

Key correctness concern: the new entity paths bypass existing text chunking and HTML-parse fallback logic, which can cause long messages or invalid entity offsets to fail delivery rather than degrading gracefully.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after addressing a couple of delivery-reliability regressions in the new entity send paths.
- Entity-based formatting support is well-scoped and tested at the formatter level, but the integration paths in Telegram sending bypass existing safeguards (chunking and parse-error fallbacks). Those gaps can turn previously-deliverable messages into hard failures in common cases (long replies or invalid entity offsets).
- src/telegram/bot/delivery.ts, src/telegram/send.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->