### PR TITLE
fix(agents): re-run tool_use pairing after limitHistoryTurns truncation

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -44,6 +44,7 @@ import { createOpenClawCodingTools } from "../pi-tools.js";
 import { resolveSandboxContext } from "../sandbox.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
 import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
+import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { acquireSessionWriteLock } from "../session-write-lock.js";
 import { detectRuntimeShell } from "../shell-utils.js";
 import {
@@ -429,10 +430,15 @@ export async function compactEmbeddedPiSessionDirect(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        const limited = limitHistoryTurns(
+        const truncated = limitHistoryTurns(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
+        // Re-run tool_use/tool_result pairing after truncation — limitHistoryTurns
+        // can orphan tool_result blocks by removing their matching tool_use messages.
+        const limited = transcriptPolicy.repairToolUseResultPairing
+          ? sanitizeToolUseResultPairing(truncated)
+          : truncated;
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -48,6 +48,7 @@ import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
 import { acquireSessionWriteLock } from "../../session-write-lock.js";
 import { detectRuntimeShell } from "../../shell-utils.js";
 import {
@@ -556,10 +557,15 @@ export async function runEmbeddedAttempt(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        const limited = limitHistoryTurns(
+        const truncated = limitHistoryTurns(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
+        // Re-run tool_use/tool_result pairing after truncation — limitHistoryTurns
+        // can orphan tool_result blocks by removing their matching tool_use messages.
+        const limited = transcriptPolicy.repairToolUseResultPairing
+          ? sanitizeToolUseResultPairing(truncated)
+          : truncated;
         cacheTrace?.recordStage("session:limited", { messages: limited });
         if (limited.length > 0) {
           activeSession.agent.replaceMessages(limited);


### PR DESCRIPTION
## Problem

`limitHistoryTurns()` runs **after** `sanitizeSessionHistory()` (which includes `repairToolUseResultPairing()`). When `limitHistoryTurns()` slices the history by user-turn count, it can remove an assistant message containing a `tool_use` block while keeping the corresponding `tool_result` in a later user message — re-introducing orphaned tool results after the repair already ran.

This causes HTTP 400 from the Anthropic API:
```
messages.14.content.1: unexpected tool_use_id found in tool_result blocks:
toolu_01JRe7vPiWiFCUPwUaYWKyaF
```

Fixes #13896

## Solution

Re-run `sanitizeToolUseResultPairing()` after `limitHistoryTurns()` in both affected code paths:

1. **Compaction flow** (`compact.ts`)
2. **Main reply flow** (`run/attempt.ts`)

Both are gated behind the existing `transcriptPolicy.repairToolUseResultPairing` flag, so this only runs for providers that need it (Anthropic, Google).

## Changes

- `src/agents/pi-embedded-runner/compact.ts`: Add post-truncation repair
- `src/agents/pi-embedded-runner/run/attempt.ts`: Add post-truncation repair

## AI Disclosure

This PR was authored with AI assistance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR re-runs `sanitizeToolUseResultPairing()` after `limitHistoryTurns()` in both the embedded compaction flow (`src/agents/pi-embedded-runner/compact.ts`) and the main embedded run attempt flow (`src/agents/pi-embedded-runner/run/attempt.ts`). The intent is to prevent `limitHistoryTurns()` from re-introducing orphaned `toolResult` entries (by truncating away the matching assistant `tool_use`) after the transcript has already been sanitized, which can trigger strict-provider API 400s (e.g., Anthropic).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and gated behind the existing transcript policy flag. The added repair step uses an existing transcript-repair utility and addresses a concrete failure mode where truncation can orphan tool_result entries after initial sanitization.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->