### PR TITLE
fix(feishu-doc): batch docx children inserts (max 50) to avoid 400

### DIFF
--- a/extensions/feishu/skills/feishu-doc/SKILL.md
+++ b/extensions/feishu/skills/feishu-doc/SKILL.md
@@ -30,7 +30,9 @@ Returns: title, plain text content, block statistics. Check `hint` field - if pr
 
 Replaces entire document with markdown content. Supports: headings, lists, code blocks, quotes, links, images (`![](url)` auto-uploaded), bold/italic/strikethrough.
 
-**Limitation:** Markdown tables are NOT supported.
+**Limitations:**
+- Markdown tables are NOT supported.
+- **Feishu API batch insert limit:** when writing/appending, the implementation calls `docx.documentBlockChildren.create` to insert converted blocks. The API enforces `children` **max len = 50 per request** (error: `field validation failed`, violation: `children: the max len is 50`). For large markdown, you must **insert in batches of <= 50 blocks**.
 
 ### Append Content
 


### PR DESCRIPTION
### Problem
Feishu Docx OpenAPI `docx.documentBlockChildren.create` enforces a hard limit: `children` max len is 50 per request.
When markdown converts into >50 blocks, `feishu_doc.write/append` fails with HTTP 400:
`code: 99992402`
`msg: field validation failed`
`field_violations: children: the max len is 50`
### Fix
Batch insert converted blocks in chunks of <= 50 children per request, preserving order and preventing validation errors.

### Docs
Document this limitation in `extensions/feishu/skills/feishu-doc/SKILL.md`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Implements batching for Feishu docx block insertion to handle the API's hard limit of 50 children per request. The fix addresses HTTP 400 errors (`field validation failed: children: the max len is 50`) when converting markdown with >50 blocks by splitting inserts into chunks of 50 blocks each, processed sequentially to maintain order.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward fix for a documented API limitation with minimal risk
- The implementation correctly addresses the Feishu API's 50-child limit by batching inserts sequentially. The logic is simple, preserves order through sequential awaits, and includes proper error handling. Documentation accurately describes the limitation. No breaking changes or complex edge cases.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->