### PR TITLE
fix(discord): harden gateway reconnect recovery

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,24 +185,27 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
-    socket.emitOpen();
-    socket.emitMessage(
-      Buffer.from(
-        JSON.stringify({
-          event: "reaction_added",
-          data: {
-            reaction: JSON.stringify({
-              user_id: "user-1",
-              post_id: "post-1",
-              emoji_name: "thumbsup",
-            }),
-          },
-        }),
-      ),
-    );
-    socket.emitClose(1000);
+    const connected = connectOnce();
+    queueMicrotask(() => {
+      socket.emitOpen();
+      socket.emitMessage(
+        Buffer.from(
+          JSON.stringify({
+            event: "reaction_added",
+            data: {
+              reaction: JSON.stringify({
+                user_id: "user-1",
+                post_id: "post-1",
+                emoji_name: "thumbsup",
+              }),
+            },
+          }),
+        ),
+      );
+      socket.emitClose(1000);
+    });
 
-    await connectOnce();
+    await connected;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/discord/gateway-logging.test.ts
+++ b/src/discord/gateway-logging.test.ts
@@ -17,7 +17,7 @@ describe("attachDiscordGatewayLogging", () => {
     vi.clearAllMocks();
   });
 
-  it("logs debug events and promotes reconnect/close to info", () => {
+  it("logs debug events and promotes reconnect/close/stable to info", () => {
     const emitter = new EventEmitter();
     const runtime = makeRuntime();
 
@@ -29,10 +29,11 @@ describe("attachDiscordGatewayLogging", () => {
     emitter.emit("debug", "WebSocket connection opened");
     emitter.emit("debug", "WebSocket connection closed with code 1001");
     emitter.emit("debug", "Reconnecting with backoff: 1000ms after code 1001");
+    emitter.emit("debug", "connection stable after 30s");
 
     const logVerboseMock = vi.mocked(logVerbose);
-    expect(logVerboseMock).toHaveBeenCalledTimes(3);
-    expect(runtime.log).toHaveBeenCalledTimes(2);
+    expect(logVerboseMock).toHaveBeenCalledTimes(4);
+    expect(runtime.log).toHaveBeenCalledTimes(3);
     expect(runtime.log).toHaveBeenNthCalledWith(
       1,
       "discord gateway: WebSocket connection closed with code 1001",
@@ -41,6 +42,7 @@ describe("attachDiscordGatewayLogging", () => {
       2,
       "discord gateway: Reconnecting with backoff: 1000ms after code 1001",
     );
+    expect(runtime.log).toHaveBeenNthCalledWith(3, "discord gateway: connection stable after 30s");
 
     cleanup();
   });

--- a/src/discord/gateway-logging.ts
+++ b/src/discord/gateway-logging.ts
@@ -1,6 +1,6 @@
 import type { EventEmitter } from "node:events";
-import type { RuntimeEnv } from "../runtime.js";
 import { logVerbose } from "../globals.js";
+import type { RuntimeEnv } from "../runtime.js";
 
 type GatewayEmitter = Pick<EventEmitter, "on" | "removeListener">;
 

--- a/src/discord/gateway-logging.ts
+++ b/src/discord/gateway-logging.ts
@@ -1,6 +1,6 @@
 import type { EventEmitter } from "node:events";
-import { logVerbose } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { logVerbose } from "../globals.js";
 
 type GatewayEmitter = Pick<EventEmitter, "on" | "removeListener">;
 
@@ -8,6 +8,7 @@ const INFO_DEBUG_MARKERS = [
   "WebSocket connection closed",
   "Reconnecting with backoff",
   "Attempting resume with backoff",
+  "connection stable",
 ];
 
 const shouldPromoteGatewayDebug = (message: string) =>

--- a/src/discord/monitor/gateway-recovery.test.ts
+++ b/src/discord/monitor/gateway-recovery.test.ts
@@ -1,0 +1,279 @@
+import type { GatewayPlugin } from "@buape/carbon/gateway";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  attachDiscordGatewayRecovery,
+  DiscordGatewayRecoveryTracker,
+  runDiscordGatewayWithOuterRetry,
+  shouldRetryDiscordGatewayError,
+  shouldStopDiscordGatewayError,
+} from "./gateway-recovery.js";
+
+const makeRuntime = () => ({
+  log: vi.fn(),
+  error: vi.fn(),
+});
+
+describe("DiscordGatewayRecoveryTracker", () => {
+  it("trips after 3 consecutive resume failures and forces fresh identify", () => {
+    const disconnect = vi.fn();
+    const connect = vi.fn();
+    const mutableGateway = {
+      disconnect,
+      connect,
+      state: {
+        sessionId: "session",
+        resumeGatewayUrl: "wss://resume.discord.gg",
+        sequence: 88,
+      },
+      sequence: 88,
+      pings: [12, 40],
+    };
+    const gateway = mutableGateway as unknown as GatewayPlugin;
+
+    const tracker = new DiscordGatewayRecoveryTracker({
+      gateway,
+      policy: { maxConsecutiveResumeFailures: 3, resetWindowMs: 60_000 },
+    });
+
+    expect(tracker.handleDebugMessage("Attempting resume with backoff: 1000ms").tripped).toBe(
+      false,
+    );
+    expect(tracker.handleDebugMessage("WebSocket connection closed with code 1005").tripped).toBe(
+      false,
+    );
+    expect(tracker.handleDebugMessage("Attempting resume with backoff: 2000ms").tripped).toBe(
+      false,
+    );
+    expect(tracker.handleDebugMessage("WebSocket connection closed with code 1005").tripped).toBe(
+      false,
+    );
+    expect(tracker.handleDebugMessage("Attempting resume with backoff: 4000ms").tripped).toBe(
+      false,
+    );
+    expect(tracker.handleDebugMessage("WebSocket connection closed with code 1005").tripped).toBe(
+      true,
+    );
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith(false);
+    expect(mutableGateway.state.sessionId).toBeNull();
+    expect(mutableGateway.state.resumeGatewayUrl).toBeNull();
+    expect(mutableGateway.state.sequence).toBeNull();
+    expect(mutableGateway.sequence).toBeNull();
+    expect(mutableGateway.pings).toEqual([]);
+    expect(tracker.getState().consecutiveResumeFailures).toBe(0);
+  });
+
+  it("resets failures when connection is marked stable", () => {
+    const gateway = {
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      state: { sessionId: "s", resumeGatewayUrl: "u", sequence: 1 },
+      sequence: 1,
+      pings: [],
+    } as unknown as GatewayPlugin;
+
+    const tracker = new DiscordGatewayRecoveryTracker({ gateway });
+
+    tracker.handleDebugMessage("Attempting resume with backoff: 1000ms");
+    tracker.handleDebugMessage("WebSocket connection closed with code 1005");
+    expect(tracker.getState().consecutiveResumeFailures).toBe(1);
+
+    tracker.handleDebugMessage("connection stable after 30s");
+    expect(tracker.getState().consecutiveResumeFailures).toBe(0);
+    expect(tracker.getState().isResuming).toBe(false);
+  });
+
+  it("resets failure window after expiry", () => {
+    let nowMs = 0;
+    const gateway = {
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      state: { sessionId: "s", resumeGatewayUrl: "u", sequence: 1 },
+      sequence: 1,
+      pings: [],
+    } as unknown as GatewayPlugin;
+
+    const tracker = new DiscordGatewayRecoveryTracker({
+      gateway,
+      policy: { maxConsecutiveResumeFailures: 3, resetWindowMs: 100 },
+      now: () => nowMs,
+    });
+
+    tracker.handleDebugMessage("Attempting resume with backoff: 1000ms");
+    tracker.handleDebugMessage("WebSocket connection closed with code 1005");
+    expect(tracker.getState().consecutiveResumeFailures).toBe(1);
+
+    nowMs = 150;
+    tracker.handleDebugMessage("Attempting resume with backoff: 2000ms");
+    tracker.handleDebugMessage("WebSocket connection closed with code 1005");
+    expect(tracker.getState().consecutiveResumeFailures).toBe(1);
+  });
+
+  it("counts rollover resume attempts as failures when close marker is missing", () => {
+    const gateway = {
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      state: { sessionId: "s", resumeGatewayUrl: "u", sequence: 1 },
+      sequence: 1,
+      pings: [],
+    } as unknown as GatewayPlugin;
+
+    const tracker = new DiscordGatewayRecoveryTracker({ gateway });
+
+    tracker.handleDebugMessage("Attempting resume with backoff: 1000ms");
+    tracker.handleDebugMessage("Attempting resume with backoff: 2000ms");
+
+    expect(tracker.getState().consecutiveResumeFailures).toBe(1);
+    expect(tracker.getState().isResuming).toBe(true);
+  });
+
+  it("ignores recovery messages while shutdown is in progress", () => {
+    const emitter = new EventEmitter();
+    let shuttingDown = true;
+    const disconnect = vi.fn();
+    const connect = vi.fn();
+    const gateway = {
+      disconnect,
+      connect,
+      state: { sessionId: "s", resumeGatewayUrl: "u", sequence: 1 },
+      sequence: 1,
+      pings: [],
+    } as unknown as GatewayPlugin;
+
+    const stopRecovery = attachDiscordGatewayRecovery({
+      emitter,
+      gateway,
+      runtime: makeRuntime(),
+      shouldIgnoreMessage: () => shuttingDown,
+    });
+
+    emitter.emit("debug", "Attempting resume with backoff: 1000ms");
+    emitter.emit("debug", "WebSocket connection closed with code 1005");
+    emitter.emit("debug", "Attempting resume with backoff: 2000ms");
+    emitter.emit("debug", "WebSocket connection closed with code 1005");
+    emitter.emit("debug", "Attempting resume with backoff: 4000ms");
+    emitter.emit("debug", "WebSocket connection closed with code 1005");
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+
+    shuttingDown = false;
+    stopRecovery();
+  });
+});
+
+describe("runDiscordGatewayWithOuterRetry", () => {
+  it("retries only on max-reconnect errors, not fatal gateway errors", () => {
+    expect(shouldRetryDiscordGatewayError(new Error("Max reconnect attempts (50) reached"))).toBe(
+      true,
+    );
+    expect(shouldRetryDiscordGatewayError(new Error("Fatal Gateway error: 4014"))).toBe(false);
+    expect(shouldStopDiscordGatewayError(new Error("Max reconnect attempts (50) reached"))).toBe(
+      true,
+    );
+    expect(shouldStopDiscordGatewayError(new Error("Fatal Gateway error: 4014"))).toBe(true);
+  });
+
+  it("retries with backoff and succeeds before exhaustion", async () => {
+    const runtime = makeRuntime();
+    const runOnce = vi
+      .fn(async (_outerAttempt: number) => {})
+      .mockRejectedValueOnce(new Error("Max reconnect attempts"))
+      .mockRejectedValueOnce(new Error("Max reconnect attempts"))
+      .mockResolvedValueOnce(undefined);
+    const sleep = vi
+      .fn(async (_ms: number, _signal?: AbortSignal) => {})
+      .mockResolvedValue(undefined);
+    const computeDelay = vi
+      .fn(
+        (
+          _policy: { initialMs: number; maxMs: number; factor: number; jitter: number },
+          _attempt: number,
+        ) => 0,
+      )
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(2000);
+
+    await runDiscordGatewayWithOuterRetry({
+      runtime,
+      runOnce,
+      sleep,
+      computeDelay,
+      policy: {
+        maxOuterRetries: 5,
+      },
+    });
+
+    expect(runOnce).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(computeDelay).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        initialMs: 10_000,
+        maxMs: 120_000,
+        factor: 1.8,
+        jitter: 0.2,
+      }),
+      1,
+    );
+    expect(computeDelay).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        initialMs: 10_000,
+        maxMs: 120_000,
+        factor: 1.8,
+        jitter: 0.2,
+      }),
+      2,
+    );
+  });
+
+  it("exits cleanly when abort happens during backoff sleep", async () => {
+    const runtime = makeRuntime();
+    const abort = new AbortController();
+    const runOnce = vi
+      .fn(async (_outerAttempt: number) => {})
+      .mockRejectedValue(new Error("Max reconnect attempts"));
+    const sleep = vi
+      .fn(async (_ms: number, _signal?: AbortSignal) => {})
+      .mockImplementationOnce(async () => {
+        abort.abort();
+        throw new Error("aborted");
+      });
+
+    await expect(
+      runDiscordGatewayWithOuterRetry({
+        runtime,
+        runOnce,
+        sleep,
+        abortSignal: abort.signal,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws deterministic exhaustion error after max retries", async () => {
+    const runtime = makeRuntime();
+    const runOnce = vi
+      .fn(async (_outerAttempt: number) => {})
+      .mockRejectedValue(new Error("Max reconnect attempts"));
+    const sleep = vi
+      .fn(async (_ms: number, _signal?: AbortSignal) => {})
+      .mockResolvedValue(undefined);
+
+    await expect(
+      runDiscordGatewayWithOuterRetry({
+        runtime,
+        runOnce,
+        sleep,
+        policy: { maxOuterRetries: 2 },
+      }),
+    ).rejects.toThrow("discord: gateway failed after 2 outer retries — marking channel as dead");
+
+    expect(runOnce).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/discord/monitor/gateway-recovery.test.ts
+++ b/src/discord/monitor/gateway-recovery.test.ts
@@ -1,5 +1,5 @@
-import type { GatewayPlugin } from "@buape/carbon/gateway";
 import { EventEmitter } from "node:events";
+import type { GatewayPlugin } from "@buape/carbon/gateway";
 import { describe, expect, it, vi } from "vitest";
 import {
   attachDiscordGatewayRecovery,

--- a/src/discord/monitor/gateway-recovery.ts
+++ b/src/discord/monitor/gateway-recovery.ts
@@ -1,8 +1,8 @@
-import type { GatewayPlugin } from "@buape/carbon/gateway";
 import type { EventEmitter } from "node:events";
-import type { RuntimeEnv } from "../../runtime.js";
+import type { GatewayPlugin } from "@buape/carbon/gateway";
 import { danger, warn } from "../../globals.js";
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
+import type { RuntimeEnv } from "../../runtime.js";
 
 const RESUME_ATTEMPT_MARKER = "Attempting resume with backoff";
 const RECONNECT_MARKER = "Reconnecting with backoff";

--- a/src/discord/monitor/gateway-recovery.ts
+++ b/src/discord/monitor/gateway-recovery.ts
@@ -1,0 +1,283 @@
+import type { GatewayPlugin } from "@buape/carbon/gateway";
+import type { EventEmitter } from "node:events";
+import type { RuntimeEnv } from "../../runtime.js";
+import { danger, warn } from "../../globals.js";
+import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
+
+const RESUME_ATTEMPT_MARKER = "Attempting resume with backoff";
+const RECONNECT_MARKER = "Reconnecting with backoff";
+const CLOSE_MARKER = "WebSocket connection closed with code";
+const STABLE_MARKER = "connection stable";
+
+export type DiscordGatewayRecoveryPolicy = {
+  maxConsecutiveResumeFailures: number;
+  resetWindowMs: number;
+};
+
+export type DiscordGatewayOuterRetryPolicy = {
+  maxOuterRetries: number;
+  backoff: BackoffPolicy;
+};
+
+export type DiscordGatewayRecoveryState = {
+  consecutiveResumeFailures: number;
+  isResuming: boolean;
+  shouldTrip: boolean;
+};
+
+type GatewayEmitter = Pick<EventEmitter, "on" | "removeListener">;
+
+type MutableGatewayState = {
+  sessionId: string | null;
+  resumeGatewayUrl: string | null;
+  sequence: number | null;
+};
+
+type MutableGatewayInternals = {
+  state?: MutableGatewayState;
+  sequence?: number | null;
+  pings?: unknown[];
+  disconnect?: () => void;
+  connect?: (resume?: boolean) => void;
+};
+
+type SleepFn = (ms: number, abortSignal?: AbortSignal) => Promise<void>;
+type ComputeDelayFn = (policy: BackoffPolicy, attempt: number) => number;
+
+const DEFAULT_RECOVERY_POLICY: DiscordGatewayRecoveryPolicy = {
+  maxConsecutiveResumeFailures: 3,
+  resetWindowMs: 60_000,
+};
+
+const DEFAULT_OUTER_RETRY_POLICY: DiscordGatewayOuterRetryPolicy = {
+  maxOuterRetries: 5,
+  backoff: {
+    initialMs: 10_000,
+    maxMs: 120_000,
+    factor: 1.8,
+    jitter: 0.2,
+  },
+};
+
+function mergeRecoveryPolicy(
+  policy?: Partial<DiscordGatewayRecoveryPolicy>,
+): DiscordGatewayRecoveryPolicy {
+  return {
+    ...DEFAULT_RECOVERY_POLICY,
+    ...policy,
+  };
+}
+
+function mergeOuterRetryPolicy(
+  policy?: Partial<DiscordGatewayOuterRetryPolicy>,
+): DiscordGatewayOuterRetryPolicy {
+  return {
+    ...DEFAULT_OUTER_RETRY_POLICY,
+    ...policy,
+    backoff: {
+      ...DEFAULT_OUTER_RETRY_POLICY.backoff,
+      ...policy?.backoff,
+    },
+  };
+}
+
+export class DiscordGatewayRecoveryTracker {
+  private readonly gateway: MutableGatewayInternals;
+  private readonly policy: DiscordGatewayRecoveryPolicy;
+  private readonly now: () => number;
+  private isResuming = false;
+  private consecutiveResumeFailures = 0;
+  private lastFailureMs: number | undefined;
+
+  constructor(params: {
+    gateway: GatewayPlugin;
+    policy?: Partial<DiscordGatewayRecoveryPolicy>;
+    now?: () => number;
+  }) {
+    this.gateway = params.gateway as unknown as MutableGatewayInternals;
+    this.policy = mergeRecoveryPolicy(params.policy);
+    this.now = params.now ?? Date.now;
+  }
+
+  handleDebugMessage(message: string): { tripped: boolean } {
+    if (message.includes(STABLE_MARKER)) {
+      this.reset();
+      return { tripped: false };
+    }
+
+    if (message.includes(RESUME_ATTEMPT_MARKER)) {
+      // If we see another resume attempt while still marked resuming,
+      // the previous resume failed without an explicit close marker.
+      if (this.isResuming) {
+        const result = this.recordResumeFailure();
+        if (result.tripped) {
+          return result;
+        }
+      }
+      this.isResuming = true;
+      return { tripped: false };
+    }
+
+    if (this.isResuming && (message.includes(CLOSE_MARKER) || message.includes(RECONNECT_MARKER))) {
+      return this.recordResumeFailure();
+    }
+
+    return { tripped: false };
+  }
+
+  getState(): DiscordGatewayRecoveryState {
+    return {
+      consecutiveResumeFailures: this.consecutiveResumeFailures,
+      isResuming: this.isResuming,
+      shouldTrip: this.consecutiveResumeFailures >= this.policy.maxConsecutiveResumeFailures,
+    };
+  }
+
+  private resetIfWindowExpired() {
+    if (this.lastFailureMs === undefined) {
+      return;
+    }
+    if (this.now() - this.lastFailureMs > this.policy.resetWindowMs) {
+      this.consecutiveResumeFailures = 0;
+    }
+  }
+
+  private reset() {
+    this.isResuming = false;
+    this.consecutiveResumeFailures = 0;
+    this.lastFailureMs = undefined;
+  }
+
+  private forceFreshIdentify() {
+    const state = this.gateway.state;
+    if (state) {
+      state.sessionId = null;
+      state.resumeGatewayUrl = null;
+      state.sequence = null;
+    }
+    this.gateway.sequence = null;
+    if (Array.isArray(this.gateway.pings)) {
+      this.gateway.pings.length = 0;
+    }
+    this.gateway.disconnect?.();
+    this.gateway.connect?.(false);
+  }
+
+  private recordResumeFailure(): { tripped: boolean } {
+    this.isResuming = false;
+    this.resetIfWindowExpired();
+    this.consecutiveResumeFailures += 1;
+    this.lastFailureMs = this.now();
+    if (this.consecutiveResumeFailures >= this.policy.maxConsecutiveResumeFailures) {
+      this.forceFreshIdentify();
+      this.reset();
+      return { tripped: true };
+    }
+    return { tripped: false };
+  }
+}
+
+export function attachDiscordGatewayRecovery(params: {
+  emitter?: GatewayEmitter;
+  gateway?: GatewayPlugin;
+  runtime: RuntimeEnv;
+  policy?: Partial<DiscordGatewayRecoveryPolicy>;
+  now?: () => number;
+  shouldIgnoreMessage?: () => boolean;
+}) {
+  const { emitter, gateway, runtime } = params;
+  if (!emitter || !gateway) {
+    return () => {};
+  }
+
+  const tracker = new DiscordGatewayRecoveryTracker({
+    gateway,
+    policy: params.policy,
+    now: params.now,
+  });
+
+  const onDebug = (msg: unknown) => {
+    if (params.shouldIgnoreMessage?.()) {
+      return;
+    }
+    const message = String(msg);
+    const result = tracker.handleDebugMessage(message);
+    if (result.tripped) {
+      runtime.log?.(
+        warn(
+          "discord: resume circuit breaker tripped after consecutive failures; forcing fresh identify",
+        ),
+      );
+      runtime.log?.(
+        danger("discord: cleared stale gateway session and reconnected without resume"),
+      );
+    }
+  };
+
+  emitter.on("debug", onDebug);
+  return () => emitter.removeListener("debug", onDebug);
+}
+
+export function shouldRetryDiscordGatewayError(err: unknown): boolean {
+  const message = String(err);
+  return message.includes("Max reconnect attempts");
+}
+
+export function shouldStopDiscordGatewayError(err: unknown): boolean {
+  const message = String(err);
+  return message.includes("Max reconnect attempts") || message.includes("Fatal Gateway error");
+}
+
+export async function runDiscordGatewayWithOuterRetry(params: {
+  runtime: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  policy?: Partial<DiscordGatewayOuterRetryPolicy>;
+  runOnce: (outerAttempt: number) => Promise<void>;
+  shouldRetryOnError?: (err: unknown) => boolean;
+  sleep?: SleepFn;
+  computeDelay?: ComputeDelayFn;
+}) {
+  const policy = mergeOuterRetryPolicy(params.policy);
+  const shouldRetryOnError = params.shouldRetryOnError ?? shouldRetryDiscordGatewayError;
+  const sleep = params.sleep ?? sleepWithAbort;
+  const computeDelay = params.computeDelay ?? computeBackoff;
+  let lastRetryableError: unknown;
+
+  for (let outerAttempt = 0; outerAttempt <= policy.maxOuterRetries; outerAttempt++) {
+    if (params.abortSignal?.aborted) {
+      return;
+    }
+    try {
+      await params.runOnce(outerAttempt);
+      return;
+    } catch (err) {
+      if (!shouldRetryOnError(err)) {
+        throw err;
+      }
+      lastRetryableError = err;
+      if (outerAttempt >= policy.maxOuterRetries) {
+        break;
+      }
+
+      const delayMs = computeDelay(policy.backoff, outerAttempt + 1);
+      params.runtime.log?.(
+        danger(
+          `discord: gateway exhausted reconnect attempts, outer retry ${outerAttempt + 1}/${policy.maxOuterRetries} in ${Math.round(delayMs / 1000)}s`,
+        ),
+      );
+      try {
+        await sleep(delayMs, params.abortSignal);
+      } catch (sleepErr) {
+        if (params.abortSignal?.aborted) {
+          return;
+        }
+        throw sleepErr;
+      }
+    }
+  }
+
+  throw new Error(
+    `discord: gateway failed after ${policy.maxOuterRetries} outer retries — marking channel as dead`,
+    { cause: lastRetryableError },
+  );
+}

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -1,16 +1,17 @@
-import { inspect } from "node:util";
+import type { GatewayPlugin } from "@buape/carbon/gateway";
 import {
   Client,
   ReadyListener,
   type BaseMessageInteractiveComponent,
   type Modal,
 } from "@buape/carbon";
-import type { GatewayPlugin } from "@buape/carbon/gateway";
 import { Routes } from "discord-api-types/v10";
+import { inspect } from "node:util";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
+import type { HistoryEntry } from "../../auto-reply/reply/history.js";
+import type { OpenClawConfig, ReplyToMode } from "../../config/config.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { listNativeCommandSpecsForConfig } from "../../auto-reply/commands-registry.js";
-import type { HistoryEntry } from "../../auto-reply/reply/history.js";
 import { listSkillCommandsForAgents } from "../../auto-reply/skill-commands.js";
 import {
   addAllowlistUserEntriesFromConfigEntry,
@@ -25,7 +26,6 @@ import {
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
 } from "../../config/commands.js";
-import type { OpenClawConfig, ReplyToMode } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { danger, logVerbose, shouldLogVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -53,6 +53,11 @@ import {
 } from "./agent-components.js";
 import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-approvals.js";
 import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
+import {
+  attachDiscordGatewayRecovery,
+  runDiscordGatewayWithOuterRetry,
+  shouldStopDiscordGatewayError,
+} from "./gateway-recovery.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
 import {
   DiscordMessageListener,
@@ -517,184 +522,206 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     }
   }
 
-  const client = new Client(
-    {
-      baseUrl: "http://localhost",
-      deploySecret: "a",
-      clientId: applicationId,
-      publicKey: "a",
-      token,
-      autoDeploy: false,
-    },
-    {
-      commands,
-      listeners: [new DiscordStatusReadyListener()],
-      components,
-      modals,
-    },
-    [createDiscordGatewayPlugin({ discordConfig: discordCfg, runtime })],
-  );
-
-  await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
-
   const logger = createSubsystemLogger("discord/monitor");
   const guildHistories = new Map<string, HistoryEntry[]>();
-  let botUserId: string | undefined;
+  const abortSignal = opts.abortSignal;
+  let startupLogged = false;
 
-  if (nativeDisabledExplicit) {
-    await clearDiscordNativeCommands({
-      client,
-      applicationId,
+  const runDiscordGatewayAttempt = async (outerAttempt: number) => {
+    const client = new Client(
+      {
+        baseUrl: "http://localhost",
+        deploySecret: "a",
+        clientId: applicationId,
+        publicKey: "a",
+        token,
+        autoDeploy: false,
+      },
+      {
+        commands,
+        listeners: [new DiscordStatusReadyListener()],
+        components,
+        modals,
+      },
+      [createDiscordGatewayPlugin({ discordConfig: discordCfg, runtime })],
+    );
+
+    if (outerAttempt === 0) {
+      await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
+      if (nativeDisabledExplicit) {
+        await clearDiscordNativeCommands({
+          client,
+          applicationId,
+          runtime,
+        });
+      }
+    }
+
+    let botUserId: string | undefined;
+    try {
+      const botUser = await client.fetchUser("@me");
+      botUserId = botUser?.id;
+    } catch (err) {
+      runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
+    }
+
+    const messageHandler = createDiscordMessageHandler({
+      cfg,
+      discordConfig: discordCfg,
+      accountId: account.accountId,
+      token,
       runtime,
+      botUserId,
+      guildHistories,
+      historyLimit,
+      mediaMaxBytes,
+      textLimit,
+      replyToMode,
+      dmEnabled,
+      groupDmEnabled,
+      groupDmChannels,
+      allowFrom,
+      guildEntries,
     });
-  }
 
-  try {
-    const botUser = await client.fetchUser("@me");
-    botUserId = botUser?.id;
-  } catch (err) {
-    runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
-  }
-
-  const messageHandler = createDiscordMessageHandler({
-    cfg,
-    discordConfig: discordCfg,
-    accountId: account.accountId,
-    token,
-    runtime,
-    botUserId,
-    guildHistories,
-    historyLimit,
-    mediaMaxBytes,
-    textLimit,
-    replyToMode,
-    dmEnabled,
-    groupDmEnabled,
-    groupDmChannels,
-    allowFrom,
-    guildEntries,
-  });
-
-  registerDiscordListener(client.listeners, new DiscordMessageListener(messageHandler, logger));
-  registerDiscordListener(
-    client.listeners,
-    new DiscordReactionListener({
-      cfg,
-      accountId: account.accountId,
-      runtime,
-      botUserId,
-      guildEntries,
-      logger,
-    }),
-  );
-  registerDiscordListener(
-    client.listeners,
-    new DiscordReactionRemoveListener({
-      cfg,
-      accountId: account.accountId,
-      runtime,
-      botUserId,
-      guildEntries,
-      logger,
-    }),
-  );
-
-  if (discordCfg.intents?.presence) {
+    registerDiscordListener(client.listeners, new DiscordMessageListener(messageHandler, logger));
     registerDiscordListener(
       client.listeners,
-      new DiscordPresenceListener({ logger, accountId: account.accountId }),
+      new DiscordReactionListener({
+        cfg,
+        accountId: account.accountId,
+        runtime,
+        botUserId,
+        guildEntries,
+        logger,
+      }),
     );
-    runtime.log?.("discord: GuildPresences intent enabled — presence listener registered");
-  }
+    registerDiscordListener(
+      client.listeners,
+      new DiscordReactionRemoveListener({
+        cfg,
+        accountId: account.accountId,
+        runtime,
+        botUserId,
+        guildEntries,
+        logger,
+      }),
+    );
 
-  runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
+    if (discordCfg.intents?.presence) {
+      registerDiscordListener(
+        client.listeners,
+        new DiscordPresenceListener({ logger, accountId: account.accountId }),
+      );
+    }
 
-  // Start exec approvals handler after client is ready
-  if (execApprovalsHandler) {
-    await execApprovalsHandler.start();
-  }
-
-  const gateway = client.getPlugin<GatewayPlugin>("gateway");
-  if (gateway) {
-    registerGateway(account.accountId, gateway);
-  }
-  const gatewayEmitter = getDiscordGatewayEmitter(gateway);
-  const stopGatewayLogging = attachDiscordGatewayLogging({
-    emitter: gatewayEmitter,
-    runtime,
-  });
-  const abortSignal = opts.abortSignal;
-  const onAbort = () => {
-    if (!gateway) {
-      return;
-    }
-    // Carbon emits an error when maxAttempts is 0; keep a one-shot listener to avoid
-    // an unhandled error after we tear down listeners during abort.
-    gatewayEmitter?.once("error", () => {});
-    gateway.options.reconnect = { maxAttempts: 0 };
-    gateway.disconnect();
-  };
-  if (abortSignal?.aborted) {
-    onAbort();
-  } else {
-    abortSignal?.addEventListener("abort", onAbort, { once: true });
-  }
-  // Timeout to detect zombie connections where HELLO is never received.
-  const HELLO_TIMEOUT_MS = 30000;
-  let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
-  const onGatewayDebug = (msg: unknown) => {
-    const message = String(msg);
-    if (!message.includes("WebSocket connection opened")) {
-      return;
-    }
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
-    }
-    helloTimeoutId = setTimeout(() => {
-      if (!gateway?.isConnected) {
-        runtime.log?.(
-          danger(
-            `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
-          ),
-        );
-        gateway?.disconnect();
-        gateway?.connect(false);
+    if (!startupLogged) {
+      runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
+      if (discordCfg.intents?.presence) {
+        runtime.log?.("discord: GuildPresences intent enabled — presence listener registered");
       }
-      helloTimeoutId = undefined;
-    }, HELLO_TIMEOUT_MS);
-  };
-  gatewayEmitter?.on("debug", onGatewayDebug);
-  try {
-    await waitForDiscordGatewayStop({
-      gateway: gateway
-        ? {
-            emitter: gatewayEmitter,
-            disconnect: () => gateway.disconnect(),
-          }
-        : undefined,
-      abortSignal,
-      onGatewayError: (err) => {
-        runtime.error?.(danger(`discord gateway error: ${String(err)}`));
-      },
-      shouldStopOnError: (err) => {
-        const message = String(err);
-        return (
-          message.includes("Max reconnect attempts") || message.includes("Fatal Gateway error")
-        );
-      },
-    });
-  } finally {
-    unregisterGateway(account.accountId);
-    stopGatewayLogging();
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
+      startupLogged = true;
     }
-    gatewayEmitter?.removeListener("debug", onGatewayDebug);
-    abortSignal?.removeEventListener("abort", onAbort);
+
+    // Start exec approvals handler after client is ready
     if (execApprovalsHandler) {
-      await execApprovalsHandler.stop();
+      await execApprovalsHandler.start();
     }
-  }
+
+    const gateway = client.getPlugin<GatewayPlugin>("gateway");
+    if (gateway) {
+      registerGateway(account.accountId, gateway);
+    }
+    let isStopping = false;
+    const gatewayEmitter = getDiscordGatewayEmitter(gateway);
+    const stopGatewayLogging = attachDiscordGatewayLogging({
+      emitter: gatewayEmitter,
+      runtime,
+    });
+    const stopGatewayRecovery = attachDiscordGatewayRecovery({
+      emitter: gatewayEmitter,
+      gateway,
+      runtime,
+      shouldIgnoreMessage: () => isStopping || abortSignal?.aborted === true,
+    });
+    const onAbort = () => {
+      isStopping = true;
+      if (!gateway) {
+        return;
+      }
+      // Carbon emits an error when maxAttempts is 0; keep a one-shot listener to avoid
+      // an unhandled error after we tear down listeners during abort.
+      gatewayEmitter?.once("error", () => {});
+      gateway.options.reconnect = { maxAttempts: 0 };
+      gateway.disconnect();
+    };
+    if (abortSignal?.aborted) {
+      onAbort();
+    } else {
+      abortSignal?.addEventListener("abort", onAbort, { once: true });
+    }
+    // Timeout to detect zombie connections where HELLO is never received.
+    const HELLO_TIMEOUT_MS = 30_000;
+    let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    const onGatewayDebug = (msg: unknown) => {
+      const message = String(msg);
+      if (!message.includes("WebSocket connection opened")) {
+        return;
+      }
+      if (helloTimeoutId) {
+        clearTimeout(helloTimeoutId);
+      }
+      helloTimeoutId = setTimeout(() => {
+        if (!gateway?.isConnected) {
+          runtime.log?.(
+            danger(
+              `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
+            ),
+          );
+          gateway?.disconnect();
+          gateway?.connect(false);
+        } else {
+          gatewayEmitter?.emit("debug", `connection stable after ${HELLO_TIMEOUT_MS / 1000}s`);
+        }
+        helloTimeoutId = undefined;
+      }, HELLO_TIMEOUT_MS);
+    };
+    gatewayEmitter?.on("debug", onGatewayDebug);
+    try {
+      await waitForDiscordGatewayStop({
+        gateway: gateway
+          ? {
+              emitter: gatewayEmitter,
+              disconnect: () => gateway.disconnect(),
+            }
+          : undefined,
+        abortSignal,
+        onGatewayError: (err) => {
+          runtime.error?.(danger(`discord gateway error: ${String(err)}`));
+        },
+        shouldStopOnError: shouldStopDiscordGatewayError,
+      });
+    } finally {
+      isStopping = true;
+      unregisterGateway(account.accountId);
+      stopGatewayRecovery();
+      stopGatewayLogging();
+      if (helloTimeoutId) {
+        clearTimeout(helloTimeoutId);
+      }
+      gatewayEmitter?.removeListener("debug", onGatewayDebug);
+      abortSignal?.removeEventListener("abort", onAbort);
+      if (execApprovalsHandler) {
+        await execApprovalsHandler.stop();
+      }
+    }
+  };
+
+  await runDiscordGatewayWithOuterRetry({
+    runtime,
+    abortSignal,
+    runOnce: runDiscordGatewayAttempt,
+  });
 }
 
 async function clearDiscordNativeCommands(params: {

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -1,17 +1,16 @@
-import type { GatewayPlugin } from "@buape/carbon/gateway";
+import { inspect } from "node:util";
 import {
   Client,
   ReadyListener,
   type BaseMessageInteractiveComponent,
   type Modal,
 } from "@buape/carbon";
+import type { GatewayPlugin } from "@buape/carbon/gateway";
 import { Routes } from "discord-api-types/v10";
-import { inspect } from "node:util";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
-import type { HistoryEntry } from "../../auto-reply/reply/history.js";
-import type { OpenClawConfig, ReplyToMode } from "../../config/config.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { listNativeCommandSpecsForConfig } from "../../auto-reply/commands-registry.js";
+import type { HistoryEntry } from "../../auto-reply/reply/history.js";
 import { listSkillCommandsForAgents } from "../../auto-reply/skill-commands.js";
 import {
   addAllowlistUserEntriesFromConfigEntry,
@@ -26,6 +25,7 @@ import {
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
 } from "../../config/commands.js";
+import type { OpenClawConfig, ReplyToMode } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { danger, logVerbose, shouldLogVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";


### PR DESCRIPTION
## Summary
Paired upstream fix in the Carbon library as well:
https://github.com/buape/carbon/pull/353

I was seeing OC hang repeatedly when running a bot in one of my Discord servers. Traced it down using dumped logs:
```
# DNS/network trigger
41  2026-02-10T04:52:04.753Z [discord] gateway error: Error: getaddrinfo ENOTFOUND gateway-us-east1-d.discord.gg

# Repeated resume-loop pattern (1000ms + 1005 close)
184 2026-02-09T17:53:19.421Z [discord] gateway: Attempting resume with backoff: 1000ms after code 1006
185 2026-02-09T17:53:59.115Z [discord] gateway: Attempting resume with backoff: 1000ms
186 2026-02-09T17:53:59.203Z [discord] gateway: WebSocket connection closed with code 1005
187 2026-02-09T17:54:22.462Z [discord] gateway: Attempting resume with backoff: 1000ms
188 2026-02-09T17:54:22.545Z [discord] gateway: WebSocket connection closed with code 1005
189 2026-02-09T17:54:41.568Z [discord] gateway: Attempting resume with backoff: 1000ms
190 2026-02-09T17:54:41.654Z [discord] gateway: WebSocket connection closed with code 1005

# HELLO stall during same failure window
261 2026-02-09T18:06:56.095Z [discord] gateway: Attempting resume with backoff: 1000ms
262 2026-02-09T18:06:56.097Z [discord] connection stalled: no HELLO received within 30000ms, forcing reconnect
263 2026-02-09T18:06:56.184Z [discord] gateway: WebSocket connection closed with code 1005
```

- add a Discord gateway recovery helper to detect repeated failed resume cycles and force a fresh IDENTIFY after consecutive failures
- add an outer retry supervisor with bounded retries/backoff and deterministic exhaustion behavior
- keep abort/shutdown safe by ignoring recovery events during teardown
- promote `connection stable` gateway debug markers to info logs for operational visibility

## Why
Issue [#13180](https://github.com/openclaw/openclaw/issues/13180) showed a long-running resume-loop failure mode where the bot could appear online but stop processing messages. This change makes recovery bounded and explicit instead of looping indefinitely.

## Key implementation details
- new recovery module: `src/discord/monitor/gateway-recovery.ts`
  - tracks resume attempts/failures from gateway debug stream
  - trips after 3 consecutive resume failures (default)
  - clears stale session state and reconnects with fresh identify
  - separates stop-vs-retry error predicates
- provider integration in `src/discord/monitor/provider.ts`
  - wraps gateway run in outer supervisor loop (defaults: max retries 5, 10s initial backoff, 1.8 factor, 120s cap, jitter 0.2)
  - preserves existing HELLO watchdog and emits `connection stable after 30s`
  - guards against reconnect races during abort/shutdown
- logging update in `src/discord/gateway-logging.ts` (+ test)

## Tests
Fully tested for touched behavior.

Ran:
- `pnpm test src/discord/monitor/gateway-recovery.test.ts src/discord/gateway-logging.test.ts src/discord/monitor.gateway.test.ts src/discord/monitor.test.ts src/discord/monitor.slash.test.ts`

Results:
- 5 files passed
- 57 tests passed

Additional in-progress validation:
- Currently testing this branch against my local OpenClaw assistant setup for a day or two to validate the issue doesn't happen anymore.

## AI-assisted
- AI-assisted: yes (Codex)
- Degree of testing: fully tested (targeted suite above)
- I understand and reviewed the final code paths and failure modes
- Session logs/prompts: available on request

Closes https://github.com/openclaw/openclaw/issues/13688
