### PR TITLE
fix(feishu): card rendering for tables, blockquotes, images, and outbound path

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,7 +1,20 @@
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
 import { sendMediaFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu } from "./send.js";
+import { sendMessageFeishu, sendMarkdownCardFeishu, processMarkdownImages } from "./send.js";
+
+/**
+ * Detect if text contains markdown elements that benefit from card rendering.
+ */
+function shouldUseCard(text: string): boolean {
+  // Code blocks (fenced)
+  if (/```[\s\S]*?```/.test(text)) return true;
+  // Tables (at least header + separator row with |)
+  if (/\|.+\|[\r\n]+\|[-:| ]+\|/.test(text)) return true;
+  // Blockquotes
+  if (/^>\s+/m.test(text)) return true;
+  return false;
+}
 
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
@@ -9,13 +22,36 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId }) => {
-    const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
+    const acct = accountId ?? undefined;
+
+    if (shouldUseCard(text)) {
+      try {
+        // Pre-process images for card rendering
+        const processed = await processMarkdownImages({ text, cfg, accountId: acct });
+        const result = await sendMarkdownCardFeishu({ cfg, to, text: processed, accountId: acct });
+        return { channel: "feishu", ...result };
+      } catch {
+        // Card failed, fall back to post message
+      }
+    }
+
+    const result = await sendMessageFeishu({ cfg, to, text, accountId: acct });
     return { channel: "feishu", ...result };
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
     // Send text first if provided
     if (text?.trim()) {
-      await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
+      const acct = accountId ?? undefined;
+      if (shouldUseCard(text)) {
+        try {
+          const processed = await processMarkdownImages({ text, cfg, accountId: acct });
+          await sendMarkdownCardFeishu({ cfg, to, text: processed, accountId: acct });
+        } catch {
+          await sendMessageFeishu({ cfg, to, text, accountId: acct });
+        }
+      } else {
+        await sendMessageFeishu({ cfg, to, text, accountId: acct });
+      }
     }
 
     // Upload and send media if URL provided
@@ -32,7 +68,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         // Log the error for debugging
         console.error(`[feishu] sendMediaFeishu failed:`, err);
         // Fallback to URL link if upload fails
-        const fallbackText = `📎 ${mediaUrl}`;
+        const fallbackText = `\u{1F4CE} ${mediaUrl}`;
         const result = await sendMessageFeishu({
           cfg,
           to,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -279,23 +279,252 @@ export async function updateCardFeishu(params: {
 }
 
 /**
+ * Extract markdown image references ![alt](url) from text.
+ * Returns array of { full, alt, url } matches.
+ */
+function extractMarkdownImages(text: string): Array<{ full: string; alt: string; url: string }> {
+  const results: Array<{ full: string; alt: string; url: string }> = [];
+  const regex = /!\[([^\]]*)\]\(([^)]+)\)/g;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const url = match[2].trim();
+    // Only match remote URLs (not already an image_key)
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      results.push({ full: match[0], alt: match[1], url });
+    }
+  }
+  return results;
+}
+
+/**
+ * Download an image from a URL and upload it to Feishu to get an image_key.
+ * Returns the image_key on success, or null on failure.
+ */
+async function uploadImageFromUrl(params: {
+  cfg: ClawdbotConfig;
+  url: string;
+  accountId?: string;
+}): Promise<string | null> {
+  const { uploadImageFeishu } = await import("./media.js");
+  try {
+    const response = await fetch(params.url, { signal: AbortSignal.timeout(15000) });
+    if (!response.ok) return null;
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.length === 0 || buffer.length > 10 * 1024 * 1024) return null; // skip empty or >10MB
+    const { imageKey } = await uploadImageFeishu({
+      cfg: params.cfg,
+      image: buffer,
+      imageType: "message",
+      accountId: params.accountId,
+    });
+    return imageKey;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Process markdown text: upload remote images and replace URLs with image_keys.
+ * Images that fail to upload are converted to links: ![alt](url) -> [img alt](url)
+ */
+export async function processMarkdownImages(params: {
+  text: string;
+  cfg: ClawdbotConfig;
+  accountId?: string;
+}): Promise<string> {
+  const images = extractMarkdownImages(params.text);
+  if (images.length === 0) return params.text;
+
+  let result = params.text;
+
+  // Upload images in parallel (max 5 concurrent)
+  const uploadResults = await Promise.all(
+    images.slice(0, 5).map(async (img) => {
+      const imageKey = await uploadImageFromUrl({
+        cfg: params.cfg,
+        url: img.url,
+        accountId: params.accountId,
+      });
+      return { ...img, imageKey };
+    }),
+  );
+
+  for (const { full, alt, url, imageKey } of uploadResults) {
+    if (imageKey) {
+      // Replace URL with image_key (Feishu card markdown supports ![hover](image_key))
+      result = result.replace(full, `![${alt || "image"}](${imageKey})`);
+    } else {
+      // Fallback: convert to link
+      result = result.replace(full, `[\u{1F5BC} ${alt || "\u56FE\u7247"}](${url})`);
+    }
+  }
+
+  // Any remaining images beyond the first 5: convert to links
+  for (const img of images.slice(5)) {
+    result = result.replace(img.full, `[\u{1F5BC} ${img.alt || "\u56FE\u7247"}](${img.url})`);
+  }
+
+  return result;
+}
+
+/**
+ * Parse a pipe-delimited row: "| A | B | C |" -> ["A", "B", "C"]
+ */
+function parsePipeRow(line: string): string[] {
+  let s = line.trim();
+  if (s.startsWith("|")) s = s.slice(1);
+  if (s.endsWith("|")) s = s.slice(0, -1);
+  return s.split("|").map((c) => c.trim());
+}
+
+/**
+ * Build a Feishu native table element from header + rows.
+ * Uses Feishu's tag:"table" which renders properly (unlike markdown tables).
+ */
+function buildTableElement(headers: string[], rows: string[][]): Record<string, unknown> {
+  const columns = headers.map((h, i) => ({
+    name: "c" + i,
+    display_name: h,
+    data_type: "text",
+    width: "auto",
+  }));
+  const rowObjs = rows.map((r) => {
+    const obj: Record<string, string> = {};
+    columns.forEach((col, i) => {
+      obj[col.name] = r[i] || "";
+    });
+    return obj;
+  });
+  return {
+    tag: "table",
+    page_size: Math.max(rowObjs.length, 1),
+    row_height: "low",
+    header_style: {
+      text_align: "left",
+      text_size: "normal",
+      background_style: "grey",
+      bold: true,
+      lines: 1,
+    },
+    columns,
+    rows: rowObjs,
+  };
+}
+
+/**
  * Build a Feishu interactive card with markdown content.
- * Cards render markdown properly (code blocks, tables, links, etc.)
  * Uses schema 2.0 format for proper markdown rendering.
+ *
+ * Feishu card markdown (lark_md) does NOT support standard markdown tables
+ * or blockquotes. This function parses the input and converts:
+ *   - Standard markdown tables -> native Feishu tag:"table" elements
+ *   - Blockquotes (> text)     -> visual bar format: **▎** *text*
+ *   - Images ![alt](url)       -> should be pre-processed by processMarkdownImages
+ *   - Everything else          -> tag:"markdown" elements
  */
 export function buildMarkdownCard(text: string): Record<string, unknown> {
+  const lines = text.trim().split("\n");
+  const elements: Record<string, unknown>[] = [];
+  let mdBuf: string[] = [];
+  let tableBuf: string[] = [];
+  let inCode = false;
+
+  const flushMd = () => {
+    const content = mdBuf.join("\n").trim();
+    if (content) elements.push({ tag: "markdown", content });
+    mdBuf = [];
+  };
+
+  const flushTable = () => {
+    if (tableBuf.length < 2) {
+      // Not a real table, push as markdown
+      mdBuf.push(...tableBuf);
+      tableBuf = [];
+      return;
+    }
+    flushMd();
+    const headers = parsePipeRow(tableBuf[0]);
+    const rows: string[][] = [];
+    for (let i = 2; i < tableBuf.length; i++) {
+      // skip separator at [1]
+      const line = tableBuf[i].trim();
+      if (!line) continue;
+      rows.push(parsePipeRow(line));
+    }
+    if (headers.length > 0 && rows.length > 0) {
+      elements.push(buildTableElement(headers, rows));
+    } else {
+      mdBuf.push(...tableBuf);
+    }
+    tableBuf = [];
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trimStart();
+
+    // Track fenced code blocks
+    if (trimmed.startsWith("```")) {
+      if (tableBuf.length > 0) flushTable();
+      inCode = !inCode;
+      mdBuf.push(line);
+      continue;
+    }
+
+    if (inCode) {
+      mdBuf.push(line);
+      continue;
+    }
+
+    // Table detection: line starts and ends with |
+    const isTableLine = /^\s*\|.*\|\s*$/.test(line);
+
+    if (isTableLine) {
+      if (tableBuf.length === 0) {
+        flushMd(); // flush any markdown before table
+      }
+      tableBuf.push(line);
+      continue;
+    }
+
+    if (tableBuf.length > 0) flushTable();
+
+    // Blockquote conversion: > text -> **▎** *text*
+    const quoteMatch = line.match(/^(>{1,3})\s*(.*)/);
+    if (quoteMatch) {
+      const depth = quoteMatch[1].length;
+      const content = quoteMatch[2].trim();
+      if (content) {
+        const bar = "\u258E".repeat(depth);
+        mdBuf.push("**" + bar + "** *" + content + "*");
+      }
+      continue;
+    }
+
+    // Normalize unordered list markers: * item -> - item (lark_md prefers -)
+    const listMatch = line.match(/^(\s*)\*\s+(.*)/);
+    if (listMatch) {
+      mdBuf.push(listMatch[1] + "- " + listMatch[2]);
+      continue;
+    }
+
+    mdBuf.push(line);
+  }
+
+  if (tableBuf.length > 0) flushTable();
+  flushMd();
+
+  if (elements.length === 0) {
+    elements.push({ tag: "markdown", content: text.trim() });
+  }
+
   return {
     schema: "2.0",
     config: {
       wide_screen_mode: true,
     },
     body: {
-      elements: [
-        {
-          tag: "markdown",
-          content: text,
-        },
-      ],
+      elements,
     },
   };
 }


### PR DESCRIPTION
## Summary

- **Card image crash fix**: Feishu card API rejects `![alt](url)` with error 230099 because it requires uploaded `image_key`, not raw URLs. Added `processMarkdownImages()` that auto-downloads remote images, uploads to Feishu via `im.image.create` to get `image_key`s, and replaces URLs in the markdown before card rendering. Falls back to link format on failure.
- **Table & blockquote rendering**: Rewrote `buildMarkdownCard()` to parse markdown and convert pipe tables to native Feishu `tag:"table"` elements and blockquotes to visual `▎` bar format, since Feishu card markdown (lark_md) does not support standard markdown tables or `>` syntax.
- **Outbound path card support**: The outbound adapter (used by the `message` tool) always sent via `post` message type, bypassing card rendering. Now detects markdown-rich content and sends via interactive card.
- **Fallback safety**: All card send paths wrapped in try/catch — on failure, automatically falls back to `post` plain text so messages are never silently lost.

## Files changed

| File | Change |
|---|---|
| `extensions/feishu/src/send.ts` | `buildMarkdownCard()` rewrite + `processMarkdownImages()` |
| `extensions/feishu/src/reply-dispatcher.ts` | Image pre-processing + card-to-text fallback |
| `extensions/feishu/src/outbound.ts` | Card rendering for outbound/message-tool path |

## Test plan

- [x] Send interactive card with tables → renders as native Feishu table component
- [x] Send card with blockquotes → renders with `▎` visual bar
- [x] Send card with `![alt](url)` images → images uploaded and displayed (or gracefully degraded to links)
- [x] Card send failure → falls back to post message, no message loss
- [x] Outbound/message-tool path → uses card rendering for markdown-rich content
- [x] Simple text messages → still sent as `post` (no unnecessary card overhead)


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enhances Feishu card rendering by adding support for tables, blockquotes, and images, plus enables card rendering for the outbound/message-tool path. The implementation includes proper fallback mechanisms when card sending fails.

**Key changes:**
- Image processing pipeline that downloads remote images and uploads to Feishu for `image_key` conversion (with fallback to links)
- Markdown parser that converts pipe tables to native Feishu `tag:"table"` elements and blockquotes to visual bar format
- Outbound adapter now detects markdown-rich content and uses card rendering instead of always sending plain text
- Try-catch wrappers ensure messages fall back to plain text on card send failures

**Issues found:**
- String replacement logic for image URLs doesn't escape regex metacharacters, which will fail on markdown containing special characters like `[`, `]`, `(`, `)`
- SSRF vulnerability: arbitrary user-provided image URLs are fetched without validation
- Blockquote regex requires whitespace after `>`, but markdown allows `>text` without space
- Edge case in table parsing where header-only tables without separators may lose content

<h3>Confidence Score: 2/5</h3>

- This PR has critical logic errors in string replacement and a security vulnerability that need to be resolved before merging
- Score reflects multiple critical issues: the string replacement logic for images will fail on common markdown patterns (since matched strings contain regex metacharacters that aren't escaped), there's an SSRF vulnerability in image fetching, and edge cases in parsing logic that could cause data loss
- Pay close attention to `extensions/feishu/src/send.ts` - the image processing and string replacement logic needs fixes before this can safely merge

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->