### PR TITLE
fix(agents): re-run tool_use pairing repair after history truncation

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -48,6 +48,7 @@ import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
 import { acquireSessionWriteLock } from "../../session-write-lock.js";
 import { detectRuntimeShell } from "../../shell-utils.js";
 import {
@@ -556,10 +557,16 @@ export async function runEmbeddedAttempt(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        const limited = limitHistoryTurns(
+        const truncated = limitHistoryTurns(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
+        // Re-run tool_use/tool_result pairing repair after truncation, since
+        // limitHistoryTurns can orphan tool_result blocks by removing the
+        // assistant message that contained the matching tool_use.
+        const limited = transcriptPolicy.repairToolUseResultPairing
+          ? sanitizeToolUseResultPairing(truncated)
+          : truncated;
         cacheTrace?.recordStage("session:limited", { messages: limited });
         if (limited.length > 0) {
           activeSession.agent.replaceMessages(limited);


### PR DESCRIPTION
## Problem

`limitHistoryTurns()` can orphan `tool_result` blocks by removing the assistant message containing the corresponding `tool_use`, while keeping the user message with the `tool_result`. This causes the Anthropic API to reject requests with:

```
HTTP 400 invalid_request_error: messages.14.content.1: unexpected tool_use_id found in
tool_result blocks: toolu_01JRe7vPiWiFCUPwUaYWKyaF
```

The session preparation pipeline runs `sanitizeSessionHistory()` (which calls `repairToolUseResultPairing()`) **before** `limitHistoryTurns()`. When truncation removes a `tool_use` assistant message but keeps its `tool_result`, orphaned blocks are reintroduced.

Fixes #13896

## Solution

Re-run `sanitizeToolUseResultPairing()` after `limitHistoryTurns()` in both affected code paths:

1. **Main reply flow** (`run/attempt.ts`)
2. **Compaction flow** (`compact.ts`)

Only runs when `transcriptPolicy.repairToolUseResultPairing` is enabled (Anthropic, Google).

## Changes

- `src/agents/pi-embedded-runner/run/attempt.ts`: Add post-truncation repair
- `src/agents/pi-embedded-runner/compact.ts`: Add post-truncation repair

## AI Disclosure

This PR was authored with AI assistance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR re-runs tool_use/tool_result pairing repair after `limitHistoryTurns()` truncation in both the embedded runner’s main reply path (`src/agents/pi-embedded-runner/run/attempt.ts`) and compaction path (`src/agents/pi-embedded-runner/compact.ts`). This aligns with the existing session preparation pipeline, where `sanitizeSessionHistory()` (which can already repair pairing) runs before truncation; truncation can reintroduce orphaned `toolResult` messages by slicing away the corresponding assistant `toolUse` message. Re-applying `sanitizeToolUseResultPairing()` after truncation prevents strict providers (notably Anthropic-compatible and Google) from rejecting requests due to unexpected/orphan tool_result ids.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and targeted: it re-applies an existing transcript repair function after a truncation step that is verified to potentially orphan tool_result messages. It is gated by the existing transcript policy flag, and uses an already-tested repair routine without changing its behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->