### PR TITLE
fix(gateway): drain active turns before restart to prevent message loss

### DIFF
--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -16,7 +16,12 @@ vi.mock("../logging/diagnostic.js", () => ({
   diagnosticLogger: diagnosticMocks.diag,
 }));
 
-import { enqueueCommand, getQueueSize } from "./command-queue.js";
+import {
+  enqueueCommand,
+  getActiveTaskCount,
+  getQueueSize,
+  waitForActiveTasks,
+} from "./command-queue.js";
 
 describe("command queue", () => {
   beforeEach(() => {
@@ -84,5 +89,72 @@ describe("command queue", () => {
     expect(waited).not.toBeNull();
     expect(waited as number).toBeGreaterThanOrEqual(5);
     expect(queuedAhead).toBe(0);
+  });
+
+  it("getActiveTaskCount returns count of currently executing tasks", async () => {
+    let resolve1!: () => void;
+    const blocker = new Promise<void>((r) => {
+      resolve1 = r;
+    });
+
+    const task = enqueueCommand(async () => {
+      await blocker;
+    });
+
+    // Give the event loop a tick for the task to start.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(getActiveTaskCount()).toBe(1);
+
+    resolve1();
+    await task;
+    expect(getActiveTaskCount()).toBe(0);
+  });
+
+  it("waitForActiveTasks resolves immediately when no tasks are active", async () => {
+    const { drained } = await waitForActiveTasks(1000);
+    expect(drained).toBe(true);
+  });
+
+  it("waitForActiveTasks waits for active tasks to finish", async () => {
+    let resolve1!: () => void;
+    const blocker = new Promise<void>((r) => {
+      resolve1 = r;
+    });
+
+    const task = enqueueCommand(async () => {
+      await blocker;
+    });
+
+    // Give the task a tick to start.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const drainPromise = waitForActiveTasks(5000);
+
+    // Resolve the blocker after a short delay.
+    setTimeout(() => resolve1(), 50);
+
+    const { drained } = await drainPromise;
+    expect(drained).toBe(true);
+
+    await task;
+  });
+
+  it("waitForActiveTasks returns drained=false on timeout", async () => {
+    let resolve1!: () => void;
+    const blocker = new Promise<void>((r) => {
+      resolve1 = r;
+    });
+
+    const task = enqueueCommand(async () => {
+      await blocker;
+    });
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    const { drained } = await waitForActiveTasks(50);
+    expect(drained).toBe(false);
+
+    resolve1();
+    await task;
   });
 });

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -18,8 +18,10 @@ vi.mock("../logging/diagnostic.js", () => ({
 
 import {
   enqueueCommand,
+  enqueueCommandInLane,
   getActiveTaskCount,
   getQueueSize,
+  setCommandLaneConcurrency,
   waitForActiveTasks,
 } from "./command-queue.js";
 
@@ -156,5 +158,40 @@ describe("command queue", () => {
 
     resolve1();
     await task;
+  });
+
+  it("waitForActiveTasks ignores tasks that start after the call", async () => {
+    const lane = `drain-snapshot-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 2);
+
+    let resolve1!: () => void;
+    const blocker1 = new Promise<void>((r) => {
+      resolve1 = r;
+    });
+    let resolve2!: () => void;
+    const blocker2 = new Promise<void>((r) => {
+      resolve2 = r;
+    });
+
+    const first = enqueueCommandInLane(lane, async () => {
+      await blocker1;
+    });
+    await new Promise((r) => setTimeout(r, 5));
+
+    const drainPromise = waitForActiveTasks(2000);
+
+    // Starts after waitForActiveTasks snapshot and should not block drain completion.
+    const second = enqueueCommandInLane(lane, async () => {
+      await blocker2;
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(getActiveTaskCount()).toBeGreaterThanOrEqual(2);
+
+    resolve1();
+    const { drained } = await drainPromise;
+    expect(drained).toBe(true);
+
+    resolve2();
+    await Promise.all([first, second]);
   });
 });


### PR DESCRIPTION
## Problem

When the gateway restarts via SIGUSR1 (triggered by `config.patch`, `update.run`, etc.), active agent turns are killed immediately. Any buffered messages that haven't been delivered yet are lost — the user sees no response at all.

Fixes #13883

## Solution

Add a **drain phase** before restart:

1. When SIGUSR1 fires, check for active tasks across all command lanes
2. Wait up to 30s for in-flight turns to complete and deliver their messages
3. Only then proceed with server shutdown
4. If timeout expires, log warning and force-proceed

## Changes

- **`src/process/command-queue.ts`**: Add `getActiveTaskCount()` and `waitForActiveTasks(timeoutMs)` helpers
- **`src/cli/gateway-cli/run-loop.ts`**: On restart, drain active tasks before `server.close()`; extend force-exit timer
- **`src/process/command-queue.test.ts`**: Update imports

| Scenario | Before | After |
|----------|--------|-------|
| Restart with active turn | Turn killed, message lost | Waits up to 30s for completion |
| Restart with no active turns | Immediate | Immediate (no delay) |
| Turn exceeds 30s | N/A | Logs warning, force-restarts |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds graceful restart functionality that prevents message loss during gateway restarts triggered by SIGUSR1. The implementation introduces a drain phase that waits up to 30 seconds for active agent turns to complete before shutting down the server.

**Key changes:**
- Added `getActiveTaskCount()` helper to count actively executing tasks across all command lanes
- Added `waitForActiveTasks(timeoutMs)` to poll for active task completion with configurable timeout
- Integrated drain logic into the SIGUSR1 restart flow in `run-loop.ts`
- Extended force-exit timer from 5s to 35s (30s drain + 5s shutdown) for restart scenarios
- Comprehensive test coverage for new helpers

The solution correctly handles the race condition where tasks transition from queued to active during the drain period, ensuring any task that starts executing gets a chance to complete. If no active tasks exist, restart proceeds immediately with no delay.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper timeout handling, comprehensive test coverage, and clear comments. The polling approach is simple and correct, avoiding complex state tracking. The drain logic only affects restart scenarios (not shutdown), and includes proper timeout fallback. Tests verify all edge cases including immediate completion, successful drain, and timeout scenarios.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->