### PR TITLE
fix: suppress low context window warning for explicitly configured models

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -142,6 +142,43 @@ describe("context-window-guard", () => {
     expect(guard.shouldBlock).toBe(false);
   });
 
+  it("does not warn when context window is explicitly configured via modelsConfig", () => {
+    const cfg = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434/v1",
+            apiKey: "x",
+            models: [
+              {
+                id: "qwen2.5:7b-2k",
+                name: "Qwen 2.5 7B 2k",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 2_048,
+                maxTokens: 2_048,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "ollama",
+      modelId: "qwen2.5:7b-2k",
+      modelContextWindow: undefined,
+      defaultTokens: 200_000,
+    });
+    const guard = evaluateContextWindowGuard({ info });
+    expect(info.source).toBe("modelsConfig");
+    expect(guard.tokens).toBe(2_048);
+    expect(guard.shouldWarn).toBe(false);
+    expect(guard.shouldBlock).toBe(true);
+  });
+
   it("exports thresholds as expected", () => {
     expect(CONTEXT_WINDOW_HARD_MIN_TOKENS).toBe(16_000);
     expect(CONTEXT_WINDOW_WARN_BELOW_TOKENS).toBe(32_000);

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -68,7 +68,7 @@ export function evaluateContextWindowGuard(params: {
   return {
     ...params.info,
     tokens,
-    shouldWarn: tokens > 0 && tokens < warnBelow,
+    shouldWarn: tokens > 0 && tokens < warnBelow && params.info.source !== "modelsConfig",
     shouldBlock: tokens > 0 && tokens < hardMin,
   };
 }


### PR DESCRIPTION
## Problem

When a model's `contextWindow` is explicitly set in `openclaw.json` (e.g., `2048` for a cheap heartbeat model), OpenClaw still logs:

```
warn agent/embedded low context window: ollama/qwen2.5:7b-2k ctx=2048 (warn<32000) source=modelsConfig
```

This is noise — the user deliberately chose that value.

## Fix

Skip the warning when `source === "modelsConfig"` (user explicitly configured it). The warning still fires for auto-detected (`model` metadata) and `default` sources where the value might be wrong.

`shouldBlock` is **unaffected** — the hard minimum is still enforced regardless of source, so genuinely broken configs are still caught.

## Changes

- `src/agents/context-window-guard.ts`: Added `source !== "modelsConfig"` condition to `shouldWarn`
- `src/agents/context-window-guard.test.ts`: Added test case for explicit modelsConfig with small context window

Closes #13933

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Suppresses low context window warnings when `contextWindow` is explicitly configured in `openclaw.json` via `models.providers.<provider>.models[].contextWindow`. The warning still fires for auto-detected (`model` metadata) and `default` sources where the value might be incorrect.

- Modified `shouldWarn` logic to skip warnings when `source === "modelsConfig"`
- Added test case validating the new behavior
- `shouldBlock` remains unchanged, preserving hard minimum enforcement

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is focused and well-tested with a new test case that validates the fix. The logic correctly suppresses warnings only for explicitly configured models while preserving the hard minimum blocking behavior and warnings for other sources.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->