### PR TITLE
fix: use openclaw-gateway network for cli

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    network_mode: "service:openclaw-gateway"
     environment:
       HOME: /home/node
       TERM: xterm-256color


### PR DESCRIPTION
During docker-setup workflow, the openclaw-cli container does not work with the openclaw-gateway container with below error:

```
 Error: gateway closed (1006 abnormal closure (no close frame)): no close reason
 Gateway target: ws://127.0.0.1:18789
 Source: local loopback
```

This is because the openclaw-cli container is started as a new one and can not connect to the gateway container by localhost::18789. By setting the `network_mode: "service:openclaw-gateway"`, it will use the same network of the container and thus is capable of connecting to the gateway.

Tested: Verify below command works fine for docker setup:

```
 docker compose run --rm openclaw-cli health
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes Docker networking for `openclaw-cli` container by using the gateway's network namespace. Previously, the CLI container couldn't connect to the gateway at `127.0.0.1:18789` because they were in separate network namespaces. Setting `network_mode: "service:openclaw-gateway"` makes the CLI container share the gateway's network stack, allowing localhost connections to work correctly.

- Resolves "gateway closed (1006 abnormal closure)" errors during docker-setup
- Enables commands like `docker compose run --rm openclaw-cli health` to work properly
- Aligns with standard Docker Compose pattern for service-to-service localhost communication

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line configuration change that correctly fixes a documented networking bug. The `network_mode: "service:..."` pattern is a standard Docker Compose feature for sharing network namespaces. No logic changes, no security implications, and the author has tested the fix successfully.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->