### PR TITLE
Fix: chrome-extension: make relay reconnect reliable with one tab

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -178,7 +178,6 @@ async function runAutoReconnectPass() {
 
   try {
     const candidate = reconnectCandidate
-    if (!candidate) return
 
     const tabId = candidate.tabId
 

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -23,6 +23,12 @@ const tabBySession = new Map()
 /** @type {Map<string, number>} */
 const childSessionToTab = new Map()
 
+/** @type {{tabId:number, retryCount:number}|null} */
+let reconnectCandidate = null
+
+let autoReconnectTimer = null
+let autoReconnectInFlight = false
+
 /** @type {Map<number, {resolve:(v:any)=>void, reject:(e:Error)=>void}>} */
 const pending = new Map()
 
@@ -109,17 +115,110 @@ function onRelayClosed(reason) {
     p.reject(new Error(`Relay disconnected (${reason})`))
   }
 
-  for (const tabId of tabs.keys()) {
-    void chrome.debugger.detach({ tabId }).catch(() => {})
-    setBadge(tabId, 'connecting')
-    void chrome.action.setTitle({
-      tabId,
-      title: 'OpenClaw Browser Relay: disconnected (click to re-attach)',
-    })
+  let candidateTabId = null
+  let candidateAttachOrder = -1
+
+  // Choose one connected tab to keep reconnecting (most recently attached).
+  for (const [tabId, tab] of tabs.entries()) {
+    if (tab.state !== 'connected') continue
+    const order = tab.attachOrder || 0
+    if (order > candidateAttachOrder) {
+      candidateAttachOrder = order
+      candidateTabId = tabId
+    }
   }
+
+  for (const [tabId] of tabs.entries()) {
+    void chrome.debugger.detach({ tabId }).catch(() => {})
+    if (tabId === candidateTabId) {
+      setBadge(tabId, 'connecting')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay: disconnected (auto-reconnecting…)',
+      })
+    } else {
+      setBadge(tabId, 'off')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay (click to attach/detach)',
+      })
+    }
+  }
+
+  // Now safe to clear active tracking
   tabs.clear()
   tabBySession.clear()
   childSessionToTab.clear()
+
+  reconnectCandidate = candidateTabId !== null ? { tabId: candidateTabId, retryCount: 0 } : null
+  scheduleAutoReconnect()
+}
+
+function scheduleAutoReconnect(delayMs = 2000) {
+  if (!reconnectCandidate) return
+  if (autoReconnectTimer) return
+  autoReconnectTimer = setTimeout(() => {
+    autoReconnectTimer = null
+    void runAutoReconnectPass()
+  }, delayMs)
+}
+
+function cancelAutoReconnect() {
+  reconnectCandidate = null
+  if (autoReconnectTimer) {
+    clearTimeout(autoReconnectTimer)
+    autoReconnectTimer = null
+  }
+}
+
+async function runAutoReconnectPass() {
+  if (!reconnectCandidate) return
+  if (autoReconnectInFlight) return
+  autoReconnectInFlight = true
+
+  try {
+    const candidate = reconnectCandidate
+    if (!candidate) return
+
+    const tabId = candidate.tabId
+
+    // Stop retrying if tab no longer exists.
+    const tabExists = await chrome.tabs.get(tabId).catch(() => null)
+    if (!tabExists) {
+      reconnectCandidate = null
+      return
+    }
+
+    if (candidate.retryCount >= 5) {
+      setBadge(tabId, 'error')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay: reconnect failed (click to attach again)',
+      })
+      reconnectCandidate = null
+      return
+    }
+
+    // Quick liveness probe before opening WebSocket connection.
+    try {
+      const port = await getRelayPort()
+      await fetch(`http://127.0.0.1:${port}/`, { method: 'HEAD', signal: AbortSignal.timeout(1000) })
+    } catch {
+      scheduleAutoReconnect()
+      return
+    }
+
+    try {
+      await ensureRelayConnection()
+      await attachTab(tabId)
+      reconnectCandidate = null
+    } catch {
+      candidate.retryCount += 1
+      scheduleAutoReconnect()
+    }
+  } finally {
+    autoReconnectInFlight = false
+  }
 }
 
 function sendToRelay(payload) {
@@ -242,11 +341,21 @@ async function attachTab(tabId, opts = {}) {
     })
   }
 
+  // A successful manual/automatic attach for this tab cancels any pending retry state.
+  if (reconnectCandidate?.tabId === tabId) {
+    cancelAutoReconnect()
+  }
+
   setBadge(tabId, 'on')
   return { sessionId, targetId }
 }
 
 async function detachTab(tabId, reason) {
+  // If manual toggle, remove from auto-reconnect queue
+  if (reason === 'toggle' && reconnectCandidate?.tabId === tabId) {
+    cancelAutoReconnect()
+  }
+
   const tab = tabs.get(tabId)
   if (tab?.sessionId && tab?.targetId) {
     try {


### PR DESCRIPTION
## Summary
- simplify browser extension recovery to a single reconnect candidate tab instead of per-tab queueing
- detach existing debugger sessions on relay close and reconnect only the most recently attached tab
- replace async interval retries with a serialized retry pass to avoid overlapping attach attempts and race conditions

## Test plan
[V] restart gateway and confirm tab transitions to connecting and auto-recovers back to ON  
[V] attach extension to a tab and confirm badge shows ON  
[V] close the candidate tab during reconnect window and confirm retries stop cleanly  
[V] manual click attach/detach still works as expected  

## Checklist
**[Title]** Mark as AI-assisted in the PR title or description  
**[fully]** Note the degree of testing (untested / lightly tested / fully tested)  
**[included planning and files changed]** Include prompts or session logs if possible (super helpful!)  
**[I confirm]** Confirm you understand what the code does  


# Session Plan
```
## Problem

When the OpenClaw Gateway restarts (browser relay), the Chrome extension loses connection and goes into a "connecting" state (yellow `…` badge). Currently requires manual clicking the extension icon on each tab to re-attach. This is annoying during development when the gateway restarts frequently.

## Conversation Context

**Date:** 2026-02-10  
**User Question:** "Why not automate the relay attachment automatic?"  
**Finding:** Manual attachment is intentional security design, but auto-reconnect after transient failures is reasonable.

From reviewing `background.js` and `extension-relay.ts`:


### What Happens on Restart
1. Gateway stops → WebSocket closes
2. `onRelayClosed()` fires → clears all tab attachments
3. Extension shows yellow `…` badge
4. **Gap:** No auto-retry for previously-attached tabs

### Why Not Fully Automatic (Security)
- `chrome.debugger.attach()` grants CDP access (network intercept, JS execution)
- Chrome requires user gesture per tab
- Extension doesn't know if YOU want that specific tab re-attached

**However:** Re-attaching previously-authorized tabs after transient disconnect is reasonable.

---

## Proposed Solution

Add persistent attachment tracking with auto-reconnect:

### Changes to `background.js`

1. **Track attachment history:**

// Store tab IDs that were attached before disconnect
const recentlyDetached = new Map<number, {targetId: string, retryCount: number}>()

2. **On disconnect, queue for retry:**

function onRelayClosed(reason) {
  // ... existing cleanup ...
  
  // Queue recently-attached tabs for auto-retry
  for (const [tabId, tab] of tabs.entries()) {
    if (tab.state === 'connected') {
      recentlyDetached.set(tabId, { targetId: tab.targetId, retryCount: 0 })
    }
  }
  
  // Start auto-reconnect loop
  startAutoReconnect()
}


3. **Auto-reconnect loop:**

let autoReconnectTimer: number | null = null

function startAutoReconnect() {
  if (autoReconnectTimer) return
  
  autoReconnectTimer = setInterval(async () => {
    // Check if relay is back
    try {
      await fetch(`http://127.0.0.1:${await getRelayPort()}/`, 
        { method: 'HEAD', signal: AbortSignal.timeout(1000) })
    } catch {
      return // Relay still down
    }
    
    // Try re-attaching queued tabs
    for (const [tabId, state] of recentlyDetached.entries()) {
      if (state.retryCount > 3) {
        recentlyDetached.delete(tabId) // Give up
        continue
      }
      
      try {
        await attachTab(tabId, { skipAttachedEvent: false })
        recentlyDetached.delete(tabId) // Success
      } catch {
        state.retryCount++
      }
    }
    
    if (recentlyDetached.size === 0) {
      clearInterval(autoReconnectTimer!)
      autoReconnectTimer = null
    }
  }, 2000) // Check every 2 seconds
}


### Optional: Per-Tab Setting
Add to `options.js`:

// Allow users to disable auto-reconnect
const settings = {
  autoReconnect: true,  // Default: enabled
  maxRetries: 3,
  retryDelayMs: 2000
}


---

## Implementation Notes

### Files to Modify
- `assets/chrome-extension/background.js` - Core logic
- `assets/chrome-extension/options.js` - Settings UI
- `assets/chrome-extension/options.html` - Toggle checkbox

### Security Considerations
- Only re-attach tabs that were previously attached in this session
- Don't auto-attach tabs that were never manually attached
- Respect Chrome's debugger permission model (no bypass)
- Clear retry queue on browser restart (don't persist)

### Edge Cases
- Tab closed while retry queued → skip gracefully
- Tab navigated to different URL → still re-attach (user intent)
- Multiple tabs attached → retry all
- Relay flapping (start/stop rapidly) → exponential backoff

---

## Tab Lifecycle & Authorization

**Key Principle:** Authorization is **per tab instance**, not per URL or browser session.
```