### PR TITLE
fix(agents): suppress low context window warning for explicitly configured models

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -146,4 +146,25 @@ describe("context-window-guard", () => {
     expect(CONTEXT_WINDOW_HARD_MIN_TOKENS).toBe(16_000);
     expect(CONTEXT_WINDOW_WARN_BELOW_TOKENS).toBe(32_000);
   });
+
+  it("suppresses warning when contextWindow is explicitly configured in modelsConfig", () => {
+    const info = { tokens: 20_000, source: "modelsConfig" as const };
+    const guard = evaluateContextWindowGuard({ info });
+    expect(guard.shouldWarn).toBe(false);
+    expect(guard.shouldBlock).toBe(false);
+  });
+
+  it("still warns for low context from auto-detected source", () => {
+    const info = { tokens: 20_000, source: "model" as const };
+    const guard = evaluateContextWindowGuard({ info });
+    expect(guard.shouldWarn).toBe(true);
+    expect(guard.shouldBlock).toBe(false);
+  });
+
+  it("still blocks modelsConfig values below hard minimum", () => {
+    const info = { tokens: 1000, source: "modelsConfig" as const };
+    const guard = evaluateContextWindowGuard({ info, hardMinTokens: 2000 });
+    expect(guard.shouldWarn).toBe(false);
+    expect(guard.shouldBlock).toBe(true);
+  });
 });

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -68,7 +68,7 @@ export function evaluateContextWindowGuard(params: {
   return {
     ...params.info,
     tokens,
-    shouldWarn: tokens > 0 && tokens < warnBelow,
+    shouldWarn: tokens > 0 && tokens < warnBelow && params.info.source !== "modelsConfig",
     shouldBlock: tokens > 0 && tokens < hardMin,
   };
 }


### PR DESCRIPTION
## Problem

When `contextWindow` is explicitly set in `models.providers` config (e.g., `2048` for a lightweight heartbeat model), OpenClaw still warns:

```
warn agent/embedded low context window: ollama/qwen2.5:7b-2k ctx=2048 (warn<32000) source=modelsConfig
```

This is misleading — the user deliberately chose this value. The warning should only fire for auto-detected or defaulted values.

Fixes #13933

## Solution

One-line change in `evaluateContextWindowGuard()`: skip `shouldWarn` when the context window source is `"modelsConfig"` (explicitly configured by user).

```diff
- shouldWarn: tokens > 0 && tokens < warnBelow,
+ shouldWarn: tokens > 0 && tokens < warnBelow && params.info.source !== "modelsConfig",
```

`shouldBlock` is unchanged — even explicit configs should be blocked below the hard minimum (16k) as a safety net.

## Tests

3 new test cases:
- Explicit modelsConfig value → no warning ✅
- Auto-detected `model` source with same value → still warns ✅
- Explicit modelsConfig below hard min → still blocks ✅

All 12 tests pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Suppresses the misleading "low context window" warning when the user has explicitly set `contextWindow` in `models.providers` config (source `"modelsConfig"`). The hard-block safety net (`shouldBlock` below 16k) remains unchanged, so misconfigured values are still caught.

- One-line guard in `evaluateContextWindowGuard()`: skips `shouldWarn` when `source === "modelsConfig"`
- Three new test cases cover: explicit config suppresses warning, auto-detected source still warns, explicit config below hard minimum still blocks
- All existing tests continue to pass with no behavioral change for non-`modelsConfig` sources

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — a minimal, well-scoped one-line logic change with thorough test coverage.
- The change is a single additional condition on a boolean expression, with clear intent (suppress warning for explicit config), no risk to the blocking path, and three new targeted tests. The existing test suite is unaffected. The logic aligns with how the source values are produced in `resolveContextWindowInfo`.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->