### PR TITLE
fix(docker): add browser sidecar service and health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,13 @@ services:
       openclaw-browser:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:18789').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:18789').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     init: true
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:9222/json/version"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:9222/json/version"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,46 +1,79 @@
 services:
   openclaw-gateway:
-    image: ${OPENCLAW_IMAGE:-openclaw:local}
+    image: ${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:main}
     environment:
       HOME: /home/node
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      # AI provider keys (configure the ones you use)
+      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY:-}
+      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY:-}
+      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE:-}
+      # Browser: point to the sidecar CDP endpoint
+      OPENCLAW_BROWSER_CDP_ENDPOINT: ws://openclaw-browser:9222
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR:-./data/openclaw}:/home/node/.openclaw
+      - ${OPENCLAW_WORKSPACE_DIR:-./data/workspace}:/home/node/.openclaw/workspace
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
     init: true
     restart: unless-stopped
+    depends_on:
+      openclaw-browser:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:18789').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     command:
       [
         "node",
         "dist/index.js",
         "gateway",
+        "--allow-unconfigured",
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",
         "18789",
       ]
 
+  openclaw-browser:
+    build:
+      context: .
+      dockerfile: Dockerfile.sandbox-browser
+    environment:
+      OPENCLAW_BROWSER_HEADLESS: ${OPENCLAW_BROWSER_HEADLESS:-1}
+      OPENCLAW_BROWSER_ENABLE_NOVNC: ${OPENCLAW_BROWSER_ENABLE_NOVNC:-0}
+    ports:
+      # CDP port (optional, for debugging)
+      - "${OPENCLAW_BROWSER_CDP_PORT:-9222}:9222"
+      # noVNC web UI (optional, disabled by default)
+      - "${OPENCLAW_BROWSER_NOVNC_PORT:-6080}:6080"
+    init: true
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:9222/json/version"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   openclaw-cli:
-    image: ${OPENCLAW_IMAGE:-openclaw:local}
+    image: ${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:main}
     environment:
       HOME: /home/node
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
       BROWSER: echo
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR:-./data/openclaw}:/home/node/.openclaw
+      - ${OPENCLAW_WORKSPACE_DIR:-./data/workspace}:/home/node/.openclaw/workspace
     stdin_open: true
     tty: true
     init: true
+    profiles:
+      - cli
     entrypoint: ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Improves docker-compose.yml with a browser sidecar service and production-ready defaults.

### Changes
- Add openclaw-browser service built from Dockerfile.sandbox-browser with configurable headless/noVNC modes
- Add health checks for both gateway (HTTP) and browser (CDP) services
- Use GHCR image as default instead of requiring local build
- Wire CDP endpoint from browser to gateway via OPENCLAW_BROWSER_CDP_ENDPOINT env var
- Add default volume paths so it works without an .env file
- Move CLI to cli profile to avoid auto-start with docker compose up

### Motivation
Fixes issues identified in #11553 (invalid YAML syntax, missing health checks).
Related to #6900 (Docker deployment improvements).

### Testing
- docker compose config validates successfully
- Services start with docker compose up and health checks pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-compose.yml` to use the GHCR image by default, adds an `openclaw-browser` sidecar built from `Dockerfile.sandbox-browser`, wires the gateway to the sidecar via `OPENCLAW_BROWSER_CDP_ENDPOINT`, and adds healthchecks + `depends_on` gating so the gateway waits for the browser to become healthy. It also moves the CLI service behind a `cli` profile and adds default host volume paths so compose works without an `.env` file.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and primarily adjusts docker-compose wiring and health checks.
- Review focused on verifying that the new healthchecks match the browser sidecar behavior and that compose syntax is valid. The browser healthcheck is consistent with `Dockerfile.sandbox-browser` (curl is installed and `/json/version` exists). No definite must-fix functional issues were found in the changed file based on repository evidence, though runtime behavior still depends on the GHCR image shipping a Node version with global `fetch`.
- docker-compose.yml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->