### PR TITLE
fix(ui): escape raw HTML in chat messages instead of rendering it

### DIFF
--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -112,7 +112,9 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
     }
     return sanitized;
   }
-  const rendered = marked.parse(`${truncated.text}${suffix}`) as string;
+  const rendered = marked.parse(`${truncated.text}${suffix}`, {
+    renderer: htmlEscapeRenderer,
+  }) as string;
   const sanitized = DOMPurify.sanitize(rendered, {
     ALLOWED_TAGS: allowedTags,
     ALLOWED_ATTR: allowedAttrs,
@@ -122,6 +124,13 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
   }
   return sanitized;
 }
+
+// Prevent raw HTML in chat messages from being rendered as formatted HTML.
+// Display it as escaped text so users see the literal markup.
+// Security is handled by DOMPurify, but rendering pasted HTML (e.g. error
+// pages) as formatted output is confusing UX (#13937).
+const htmlEscapeRenderer = new marked.Renderer();
+htmlEscapeRenderer.html = ({ text }: { text: string }) => escapeHtml(text);
 
 function escapeHtml(value: string): string {
   return value


### PR DESCRIPTION
## Problem

When users paste HTML content into the web chat (e.g., error pages, HTML snippets), the `marked` parser passes raw HTML through, and DOMPurify's allowlist permits tags like `<h1>`, `<p>`, `<table>` to render as formatted HTML. This is confusing when users expect to see literal markup.

While DOMPurify prevents XSS (no `<script>` or event handlers), the visual result is misleading — error pages render as formatted headings and paragraphs instead of showing as code/text.

Fixes #13937

## Solution

Override marked's `html` renderer to escape raw HTML blocks via `escapeHtml()`, so they display as visible text instead of being interpreted as formatting.

```ts
const htmlEscapeRenderer = new marked.Renderer();
htmlEscapeRenderer.html = ({ text }) => escapeHtml(text);
```

This only affects raw HTML blocks in the markdown input — standard markdown formatting (`**bold**`, `# headings`, etc.) still works normally.

## AI Disclosure

This PR was authored with AI assistance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Overrides `marked`'s HTML renderer to escape raw HTML blocks instead of rendering them, preventing confusing UX when users paste HTML content (like error pages) into chat. The fix adds a custom renderer that calls `escapeHtml()` on raw HTML, so pasted markup displays as visible text rather than formatted output. Standard markdown formatting continues to work normally.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-scoped, and addresses a specific UX issue. The implementation correctly uses marked's renderer API, the escapeHtml function follows standard HTML escaping practices, and the fix preserves existing markdown functionality while only affecting raw HTML blocks. No test coverage was added, but the change is straightforward enough that existing security tests (which verify script stripping) should catch any major regressions.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->