### PR TITLE
feat(docker): add .env template and improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM node:22-bookworm
 
 # Install Bun (required for build scripts)
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+# Pin to a specific version for reproducible builds (see: #9479)
+ARG BUN_VERSION=1.2.4
+RUN curl -fsSL https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-$(uname -m | sed 's/x86_64/x64/;s/aarch64/aarch64/').zip -o /tmp/bun.zip \
+    && unzip -q /tmp/bun.zip -d /tmp/bun \
+    && mv /tmp/bun/bun-*/bun /usr/local/bin/bun \
+    && chmod +x /usr/local/bin/bun \
+    && rm -rf /tmp/bun /tmp/bun.zip
+ENV PATH="/usr/local/bin:${PATH}"
 
 RUN corepack enable
 
@@ -38,6 +44,10 @@ RUN chown -R node:node /app
 # The node:22-bookworm image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
+
+# Health check: verify gateway is responding
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD node -e "fetch('http://localhost:18789').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,9 @@ RUN chown -R node:node /app
 USER node
 
 # Health check: verify gateway is responding
+# Uses OPENCLAW_GATEWAY_PORT env var with fallback to default port
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD node -e "fetch('http://localhost:18789').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+  CMD node -e "fetch('http://localhost:'+(process.env.OPENCLAW_GATEWAY_PORT||18789)).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-bookworm
 
 # Install Bun (required for build scripts)
 # Pin to a specific version for reproducible builds (see: #9479)
-ARG BUN_VERSION=1.2.4
+ARG BUN_VERSION=1.3.9
 RUN curl -fsSL https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-$(uname -m | sed 's/x86_64/x64/;s/aarch64/aarch64/').zip -o /tmp/bun.zip \
     && unzip -q /tmp/bun.zip -d /tmp/bun \
     && mv /tmp/bun/bun-*/bun /usr/local/bin/bun \

--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -1,0 +1,54 @@
+# ==============================================================================
+# OpenClaw Docker Compose Environment
+# Copy this file to .env and configure as needed
+# ==============================================================================
+
+# --- Gateway Configuration ---
+
+# Authentication token for external access (recommended for security)
+# Generate one with: openssl rand -hex 32
+OPENCLAW_GATEWAY_TOKEN=
+
+# Bind mode: "localhost" (default, local only) or "lan" (accept external connections)
+# Use "lan" when running in Docker so other containers can reach the gateway
+OPENCLAW_GATEWAY_BIND=lan
+
+# Gateway ports
+OPENCLAW_GATEWAY_PORT=18789
+OPENCLAW_BRIDGE_PORT=18790
+
+# --- Data Directories ---
+
+# Path to OpenClaw config & state (sessions, cron, etc.)
+OPENCLAW_CONFIG_DIR=./data/openclaw
+
+# Path to workspace (project files accessible to agents)
+OPENCLAW_WORKSPACE_DIR=./data/workspace
+
+# --- Docker Image ---
+
+# Use a pre-built GHCR image or build locally
+# Default: ghcr.io/openclaw/openclaw:main
+# For local builds: openclaw:local
+OPENCLAW_IMAGE=ghcr.io/openclaw/openclaw:main
+
+# --- Browser Sidecar (optional) ---
+
+# Run browser in headless mode (1) or with display/noVNC (0)
+OPENCLAW_BROWSER_HEADLESS=1
+
+# Enable noVNC web viewer for debugging (0=disabled, 1=enabled)
+OPENCLAW_BROWSER_ENABLE_NOVNC=0
+
+# Browser ports (only needed when debugging)
+OPENCLAW_BROWSER_CDP_PORT=9222
+OPENCLAW_BROWSER_NOVNC_PORT=6080
+
+# --- AI Provider Keys (optional) ---
+# Configure the providers you use. OpenClaw supports many providers natively.
+# See: https://docs.openclaw.com/docs/configuration/ai-providers
+
+# Claude (Anthropic)
+CLAUDE_AI_SESSION_KEY=
+CLAUDE_WEB_SESSION_KEY=
+CLAUDE_WEB_COOKIE=


### PR DESCRIPTION
## Summary

Improves Docker deployment experience with a documented .env template and Dockerfile hardening.

### Changes

#### docker-compose.env.example (NEW)
- Complete .env template with all Docker Compose variables
- Documented defaults and explanations for each variable
- Covers: gateway config, data dirs, image selection, browser sidecar, AI provider keys

#### Dockerfile improvements
- **Security**: Replace `curl | bash` Bun installer with pinned version downloaded from GitHub releases (addresses #9479)
- **Orchestration**: Add `HEALTHCHECK` instruction so container runtimes can monitor gateway health
- Pin Bun to v1.2.4 via `BUN_VERSION` build arg for reproducible builds

### Motivation
Lowers the barrier to Docker deployment. New users can copy the .env template and get started without reading source code.
Related to #6900 (Docker support improvements).

### Testing
- `docker compose config` validates with the .env template
- Dockerfile builds successfully on amd64

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a comprehensive `.env` template (`docker-compose.env.example`) documenting all Docker Compose configuration variables and hardens the Dockerfile by replacing the insecure `curl | bash` Bun installer with a pinned release download. Also adds a `HEALTHCHECK` instruction for container orchestration monitoring.

**Key improvements:**
- **Security**: Replaces `curl | bash` pattern with explicit Bun v1.2.4 download from GitHub releases (addresses security concern #9479)
- **Usability**: New `.env` template provides clear documentation for gateway config, data directories, image selection, browser sidecar, and AI provider keys
- **Reliability**: Pinned Bun version via `BUN_VERSION` build arg ensures reproducible builds
- **Observability**: `HEALTHCHECK` allows container runtimes to monitor gateway health

**Note**: The browser sidecar env vars in `docker-compose.env.example` are documented but not referenced in `docker-compose.yml` - these appear to be passed to browser containers spawned by the gateway at runtime rather than docker-compose services.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped improvements to Docker deployment: removing a security anti-pattern (curl pipe to bash), adding useful documentation, and improving container health monitoring. The Bun installation is now deterministic and verifiable. The .env template is purely documentation. One minor suggestion about healthcheck port configurability doesn't affect functionality.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->