### PR TITLE
fix(web-search): fix grok web search returning empty content

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -132,10 +132,17 @@ type PerplexitySearchResponse = {
 type PerplexityBaseUrlHint = "direct" | "openrouter";
 
 function extractGrokContent(data: GrokSearchResponse): string | undefined {
-  // xAI Responses API format: output[0].content[0].text
-  const fromResponses = data.output?.[0]?.content?.[0]?.text;
-  if (typeof fromResponses === "string" && fromResponses) {
-    return fromResponses;
+  // xAI Responses API: output[] contains web_search_call + message items.
+  // Find the "message" output item (not the web_search_call).
+  const msgItem = data.output?.find((o) => o.type === "message");
+  const fromMessage = msgItem?.content?.[0]?.text;
+  if (typeof fromMessage === "string" && fromMessage) {
+    return fromMessage;
+  }
+  // Fallback: try first output item's content (non-search responses)
+  const firstText = data.output?.[0]?.content?.[0]?.text;
+  if (typeof firstText === "string" && firstText) {
+    return firstText;
   }
   return typeof data.output_text === "string" ? data.output_text : undefined;
 }


### PR DESCRIPTION
## Problem
Grok web search via `tools.web.search.provider: grok` always returned 'No response'.

## Root Cause
The xAI `/v1/responses` API returns multiple output items when web search is used:
- `output[0]`: `web_search_call` (tool invocation, no text)
- `output[1]`: `message` (actual response with text)

`extractGrokContent()` was hardcoded to read `output[0].content[0].text`, which is the web search tool call — it has no text content.

## Fix
Find the `message` type output item via `.find()` instead of assuming index 0. Added fallbacks for non-search responses and the legacy `output_text` field.

## Testing
Verified with live xAI API — search queries now return full content with citations.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates Grok (xAI `/v1/responses`) web-search parsing to pull the assistant text from the `output[]` item with `type === "message"`, instead of assuming `output[0]` contains text. It also keeps a fallback to the first output item for non-search responses and preserves support for the legacy `output_text` field.

Overall, the change is localized to `extractGrokContent()` in `src/agents/tools/web-search.ts` and aligns with the described xAI response shape when web search is enabled (tool call item followed by message item).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, isolated to Grok response text extraction, and adds a more correct selection of the message output item while preserving existing fallbacks. No breaking interface changes or broader behavioral changes were found in the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->