### PR TITLE
fix(ui): preserve structured config validation error details

### DIFF
--- a/ui/src/ui/controllers/config.node.test.ts
+++ b/ui/src/ui/controllers/config.node.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { formatUiError } from "./config.ts";
+
+describe("formatUiError", () => {
+  it("serializes object errors to JSON", () => {
+    const msg = formatUiError({
+      action: "config.set",
+      errors: [{ path: "models.providers.openai.models.0.maxTokens", message: "expected number" }],
+    });
+    expect(msg).toContain('"action":"config.set"');
+    expect(msg).toContain("maxTokens");
+    expect(msg).not.toContain("[object Object]");
+  });
+
+  it("prefers Error.message for Error instances", () => {
+    expect(formatUiError(new Error("invalid config"))).toBe("invalid config");
+  });
+});

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -127,6 +127,20 @@ function serializeFormForSubmit(state: ConfigState): string {
   return serializeConfigForm(form);
 }
 
+export function formatUiError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
 export async function saveConfig(state: ConfigState) {
   if (!state.client || !state.connected) {
     return;
@@ -144,7 +158,7 @@ export async function saveConfig(state: ConfigState) {
     state.configFormDirty = false;
     await loadConfig(state);
   } catch (err) {
-    state.lastError = String(err);
+    state.lastError = formatUiError(err);
   } finally {
     state.configSaving = false;
   }
@@ -171,7 +185,7 @@ export async function applyConfig(state: ConfigState) {
     state.configFormDirty = false;
     await loadConfig(state);
   } catch (err) {
-    state.lastError = String(err);
+    state.lastError = formatUiError(err);
   } finally {
     state.configApplying = false;
   }
@@ -188,7 +202,7 @@ export async function runUpdate(state: ConfigState) {
       sessionKey: state.applySessionKey,
     });
   } catch (err) {
-    state.lastError = String(err);
+    state.lastError = formatUiError(err);
   } finally {
     state.updateRunning = false;
   }

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatGatewayError } from "./gateway.ts";
+
+describe("formatGatewayError", () => {
+  it("returns message when details are absent", () => {
+    expect(formatGatewayError({ code: "invalid_config", message: "invalid config" })).toBe(
+      "invalid config",
+    );
+  });
+
+  it("appends object details as JSON", () => {
+    const message = formatGatewayError({
+      code: "invalid_config",
+      message: "invalid config",
+      details: [
+        { path: "models.providers.openai.models.0.maxTokens", message: "expected number" },
+      ],
+    });
+    expect(message).toContain("invalid config:");
+    expect(message).toContain("maxTokens");
+  });
+});

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -59,6 +59,26 @@ export type GatewayBrowserClientOptions = {
   onGap?: (info: { expected: number; received: number }) => void;
 };
 
+export function formatGatewayError(error?: {
+  code: string;
+  message: string;
+  details?: unknown;
+}): string {
+  const message = error?.message ?? "request failed";
+  const details = error?.details;
+  if (details === undefined || details === null) {
+    return message;
+  }
+  if (typeof details === "string") {
+    return `${message}: ${details}`;
+  }
+  try {
+    return `${message}: ${JSON.stringify(details)}`;
+  } catch {
+    return `${message}: ${String(details)}`;
+  }
+}
+
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
 
@@ -280,7 +300,7 @@ export class GatewayBrowserClient {
       if (res.ok) {
         pending.resolve(res.payload);
       } else {
-        pending.reject(new Error(res.error?.message ?? "request failed"));
+        pending.reject(new Error(formatGatewayError(res.error)));
       }
       return;
     }


### PR DESCRIPTION
## What this fixes
This PR improves Control UI error surfacing for config saves/updates.

In failure cases, the gateway can return structured validation details (`error.details`, often array/object with `path` + `message`). Previously, the browser client and config controller could collapse those details into opaque text, making troubleshooting much harder.

## Root cause
- `ui/src/ui/gateway.ts` rejected failed requests with only `error.message`, dropping `error.details`.
- `ui/src/ui/controllers/config.ts` used `String(err)` in catch blocks, which can turn object-shaped errors into `[object Object]`.

## Changes
1. `ui/src/ui/gateway.ts`
   - Added `formatGatewayError(...)`.
   - Includes `error.details` in the thrown message.
   - Serializes object/array details as JSON.

2. `ui/src/ui/controllers/config.ts`
   - Added `formatUiError(...)`.
   - Uses `Error.message` for `Error` instances.
   - JSON-serializes unknown object errors instead of `String(err)`.

3. Tests
   - `ui/src/ui/gateway.node.test.ts`
   - `ui/src/ui/controllers/config.node.test.ts`

## Why this helps real users
When users edit one section (e.g. `channels.qq`) but validation fails due to another section (e.g. `models.providers.*.models[].maxTokens`), the UI now shows actionable error details instead of opaque messages.

Closes #13959

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improved error surfacing for config operations by preserving structured validation details from gateway responses.

**Key changes:**
- Added `formatGatewayError` in `gateway.ts` to serialize `error.details` (object/array) as JSON instead of dropping them
- Added `formatUiError` in `config.ts` to JSON-serialize object errors instead of converting to `[object Object]`
- Updated error handlers in `saveConfig`, `applyConfig`, and `runUpdate` to use `formatUiError`
- Added comprehensive test coverage for both formatting functions

**Why this matters:**
When validation fails, the gateway returns structured error details (e.g., `{path: "models.providers.*.models[].maxTokens", message: "expected number"}`). Previously, these details were lost, making debugging difficult. Now they're preserved in the UI error messages.

**Scope is correct:**
Only `config.set`, `config.apply`, and `update.run` return structured validation details. The PR correctly targets only these operations. Read-only operations (`config.get`, `config.schema`) were intentionally left unchanged as they only return simple parameter validation errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped, defensive, and thoroughly tested. Both new formatting functions have proper error handling (try-catch with fallback to String()). The PR correctly identifies and fixes only the error handlers that can receive structured validation details. Test coverage validates the core functionality. No breaking changes or risky refactoring.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->