### PR TITLE
fix(telegram): support media attachments in replied Telegram messages

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -27,7 +27,9 @@ describe("stageSandboxMedia", () => {
       const inboundDir = join(home, ".openclaw", "media", "inbound");
       await fs.mkdir(inboundDir, { recursive: true });
       const mediaPath = join(inboundDir, "photo.jpg");
+      const repliedMediaPath = join(inboundDir, "replied.png");
       await fs.writeFile(mediaPath, "test");
+      await fs.writeFile(repliedMediaPath, "test-reply");
 
       const sandboxDir = join(home, "sandboxes", "session");
       vi.mocked(ensureSandboxWorkspaceForSession).mockResolvedValue({
@@ -44,6 +46,8 @@ describe("stageSandboxMedia", () => {
         MediaPath: mediaPath,
         MediaType: "image/jpeg",
         MediaUrl: mediaPath,
+        ReplyToMediaPath: repliedMediaPath,
+        ReplyToMediaUrl: repliedMediaPath,
       };
       const sessionCtx: TemplateContext = { ...ctx };
 
@@ -73,9 +77,16 @@ describe("stageSandboxMedia", () => {
       expect(sessionCtx.MediaPath).toBe(stagedPath);
       expect(ctx.MediaUrl).toBe(stagedPath);
       expect(sessionCtx.MediaUrl).toBe(stagedPath);
+      const stagedReplyPath = `media/inbound/${basename(repliedMediaPath)}`;
+      expect(ctx.ReplyToMediaPath).toBe(stagedReplyPath);
+      expect(sessionCtx.ReplyToMediaPath).toBe(stagedReplyPath);
+      expect(ctx.ReplyToMediaUrl).toBe(stagedReplyPath);
+      expect(sessionCtx.ReplyToMediaUrl).toBe(stagedReplyPath);
 
       const stagedFullPath = join(sandboxDir, "media", "inbound", basename(mediaPath));
       await expect(fs.stat(stagedFullPath)).resolves.toBeTruthy();
+      const stagedReplyFullPath = join(sandboxDir, "media", "inbound", basename(repliedMediaPath));
+      await expect(fs.stat(stagedReplyFullPath)).resolves.toBeTruthy();
     });
   });
 });

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildInboundUserContextPrefix } from "./inbound-meta.js";
+
+function parseFirstJsonBlock(text: string): Record<string, unknown> {
+  const match = text.match(/```json\n([\s\S]+?)\n```/);
+  if (!match?.[1]) {
+    throw new Error("missing json block");
+  }
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
+describe("buildInboundUserContextPrefix", () => {
+  it("includes replied media paths and types in replied-message context", () => {
+    const prefix = buildInboundUserContextPrefix({
+      ReplyToBody: "<media:image>",
+      ReplyToSender: "Ada",
+      ReplyToMediaPaths: ["media/inbound/replied.jpg"],
+      ReplyToMediaTypes: ["image/jpeg"],
+    });
+
+    const block = parseFirstJsonBlock(prefix);
+    expect(block).toEqual({
+      sender_label: "Ada",
+      body: "<media:image>",
+      media_paths: ["media/inbound/replied.jpg"],
+      media_types: ["image/jpeg"],
+    });
+  });
+});

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -59,6 +59,12 @@ export type MsgContext = {
   ReplyToBody?: string;
   ReplyToSender?: string;
   ReplyToIsQuote?: boolean;
+  ReplyToMediaPath?: string;
+  ReplyToMediaUrl?: string;
+  ReplyToMediaType?: string;
+  ReplyToMediaPaths?: string[];
+  ReplyToMediaUrls?: string[];
+  ReplyToMediaTypes?: string[];
   ForwardedFrom?: string;
   ForwardedFromType?: string;
   ForwardedFromId?: string;

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -65,6 +65,7 @@ export type TelegramMediaRef = {
 type TelegramMessageContextOptions = {
   forceWasMentioned?: boolean;
   messageIdOverride?: string;
+  replyMedia?: TelegramMediaRef[];
 };
 
 type TelegramLogger = {
@@ -144,6 +145,7 @@ export const buildTelegramMessageContext = async ({
   resolveGroupRequireMention,
   resolveTelegramGroupConfig,
 }: BuildTelegramMessageContextParams) => {
+  const replyMedia = options?.replyMedia ?? [];
   const msg = primaryCtx.message;
   recordChannelActivity({
     channel: "telegram",
@@ -604,6 +606,15 @@ export const buildTelegramMessageContext = async ({
     ReplyToBody: replyTarget?.body,
     ReplyToSender: replyTarget?.sender,
     ReplyToIsQuote: replyTarget?.kind === "quote" ? true : undefined,
+    ReplyToMediaPath: replyMedia[0]?.path,
+    ReplyToMediaType: replyMedia[0]?.contentType,
+    ReplyToMediaUrl: replyMedia[0]?.path,
+    ReplyToMediaPaths: replyMedia.length > 0 ? replyMedia.map((entry) => entry.path) : undefined,
+    ReplyToMediaUrls: replyMedia.length > 0 ? replyMedia.map((entry) => entry.path) : undefined,
+    ReplyToMediaTypes:
+      replyMedia.length > 0
+        ? (replyMedia.map((entry) => entry.contentType).filter(Boolean) as string[])
+        : undefined,
     ForwardedFrom: forwardOrigin?.from,
     ForwardedFromType: forwardOrigin?.fromType,
     ForwardedFromId: forwardOrigin?.fromId,

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -22,6 +22,7 @@ type TelegramMessageProcessorDeps = Omit<
   textLimit: number;
   opts: Pick<TelegramBotOptions, "token">;
   resolveBotTopicsEnabled: (ctx: TelegramContext) => boolean | Promise<boolean>;
+  resolveReplyMedia?: (msg: TelegramContext["message"]) => Promise<TelegramMediaRef[]>;
 };
 
 export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
@@ -46,6 +47,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     textLimit,
     opts,
     resolveBotTopicsEnabled,
+    resolveReplyMedia,
   } = deps;
 
   return async (
@@ -54,11 +56,12 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     storeAllowFrom: string[],
     options?: { messageIdOverride?: string; forceWasMentioned?: boolean },
   ) => {
+    const replyMedia = resolveReplyMedia ? await resolveReplyMedia(primaryCtx.message) : [];
     const context = await buildTelegramMessageContext({
       primaryCtx,
       allMedia,
       storeAllowFrom,
-      options,
+      options: { ...options, replyMedia },
       bot,
       cfg,
       account,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -38,6 +38,7 @@ import {
   resolveTelegramUpdateId,
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
+import { resolveReplyMedia } from "./bot/delivery.js";
 import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
@@ -360,6 +361,9 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     textLimit,
     opts,
     resolveBotTopicsEnabled,
+    resolveReplyMedia: async (msg) => {
+      return await resolveReplyMedia(msg, mediaMaxBytes, opts.token, opts.proxyFetch);
+    },
   });
 
   registerTelegramNativeCommands({


### PR DESCRIPTION
## Problem
Currently, the agent has no context to media attachments in a replied Telegram message.

Example:
1. User/bot sent a message containing an image in the session
2. User reply to that message, asking about that image
3. The bot is unable to access or read that image

## Fix
This PR adds several metadata about ReplyToMedia into MsgContext, making the bot able to access and read the media attachments in replied messages.

## Test
Added a test file (src/auto-reply/reply/inbound-meta.test.ts) and modified two test cases in existing tests to ensure the new behavior works as expected.

The patch is built and verified manually in my local deployment.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for staging and exposing media attachments from replied Telegram messages by:
- Downloading media from `reply_to_message`/`external_reply` in Telegram delivery, and passing it into message-context construction.
- Extending `MsgContext`/templating metadata with `ReplyToMedia*` fields.
- Updating sandbox media staging to copy replied media into the sandbox workspace and rewrite paths/URLs.
- Including replied-media paths/types in the inbound “replied message” context block.

Main issue to address before merge: the new unit test for `buildInboundUserContextPrefix` is brittle because it parses the first JSON block, but the function may emit other JSON blocks before the replied-message block depending on inputs.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the failing/brittle unit test is fixed.
- Behavioral changes are localized and covered by new tests for reply-media download and sandbox staging, but the new inbound-meta test is structured in a way that will fail under common inputs because it assumes the first JSON block is the reply context.
- src/auto-reply/reply/inbound-meta.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->