### PR TITLE
feat: add Feishu topic auto-threading for message tool

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -83,6 +83,7 @@ export function createOpenClawTools(options?: {
         currentChannelId: options?.currentChannelId,
         currentChannelProvider: options?.agentChannel,
         currentThreadTs: options?.currentThreadTs,
+        currentThreadId: options?.agentThreadId,
         replyToMode: options?.replyToMode,
         hasRepliedRef: options?.hasRepliedRef,
         sandboxRoot: options?.sandboxRoot,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -298,6 +298,7 @@ type MessageToolOptions = {
   currentChannelId?: string;
   currentChannelProvider?: string;
   currentThreadTs?: string;
+  currentThreadId?: string;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   sandboxRoot?: string;
@@ -454,12 +455,14 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         options?.currentChannelId ||
         options?.currentChannelProvider ||
         options?.currentThreadTs ||
+        options?.currentThreadId ||
         options?.replyToMode ||
         options?.hasRepliedRef
           ? {
               currentChannelId: options?.currentChannelId,
               currentChannelProvider: options?.currentChannelProvider,
               currentThreadTs: options?.currentThreadTs,
+              currentThreadId: options?.currentThreadId,
               replyToMode: options?.replyToMode,
               hasRepliedRef: options?.hasRepliedRef,
               // Direct tool invocations should not add cross-context decoration.

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -247,6 +247,8 @@ export type ChannelThreadingToolContext = {
   currentChannelId?: string;
   currentChannelProvider?: ChannelId;
   currentThreadTs?: string;
+  /** Thread/topic ID for channels that use non-timestamp-based threading (e.g., Feishu topic root_id). */
+  currentThreadId?: string;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   /**

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -275,6 +275,39 @@ function resolveTelegramAutoThreadId(params: {
   return context.currentThreadTs;
 }
 
+/**
+ * Auto-inject Feishu topic thread ID when the message tool targets
+ * the same group chat the session originated from.  Mirrors the Slack/Telegram
+ * auto-threading pattern so tool-sent messages land in the correct
+ * topic instead of creating a new one.
+ *
+ * Feishu topic groups use `root_id` (message ID) as the topic identifier.
+ * The session stores this as `currentThreadId` (via `MessageThreadId` in
+ * delivery context). Unlike Slack's `currentThreadTs`, this uses a dedicated
+ * field because Feishu threads are not timestamp-based.
+ */
+function resolveFeishuAutoThreadId(params: {
+  to: string;
+  toolContext?: ChannelThreadingToolContext;
+}): string | undefined {
+  const context = params.toolContext;
+  if (!context?.currentThreadId) {
+    return undefined;
+  }
+  // Only inject when the target matches the current channel (same group)
+  const target = params.to?.trim();
+  const currentId = context.currentChannelId?.trim();
+  if (target && currentId) {
+    // Strip "chat:" prefix for comparison
+    const normalizedTarget = target.replace(/^chat:/, "");
+    const normalizedCurrent = currentId.replace(/^chat:/, "");
+    if (normalizedTarget.toLowerCase() !== normalizedCurrent.toLowerCase()) {
+      return undefined; // Cross-group send, don't inject
+    }
+  }
+  return context.currentThreadId;
+}
+
 function resolveAttachmentMaxBytes(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -817,7 +850,13 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     channel === "telegram" && !threadId
       ? resolveTelegramAutoThreadId({ to, toolContext: input.toolContext })
       : undefined;
-  const resolvedThreadId = threadId ?? slackAutoThreadId ?? telegramAutoThreadId;
+  // Feishu topic auto-threading: inject threadId from session context so messages
+  // stay in the same topic instead of creating new ones.
+  const feishuAutoThreadId =
+    channel === "feishu" && !replyToId && !threadId
+      ? resolveFeishuAutoThreadId({ to, toolContext: input.toolContext })
+      : undefined;
+  const resolvedThreadId = threadId ?? slackAutoThreadId ?? telegramAutoThreadId ?? feishuAutoThreadId;
   // Write auto-resolved threadId back into params so downstream dispatch
   // (plugin `readStringParam(params, "threadId")`) picks it up.
   if (resolvedThreadId && !params.threadId) {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -49,6 +49,8 @@ type MessageSendParams = {
     mediaUrls?: string[];
   };
   abortSignal?: AbortSignal;
+  /** Thread/topic ID to forward to deliverOutboundPayloads (e.g., Feishu topic root_id). */
+  threadId?: string;
 };
 
 export type MessageSendResult = {
@@ -164,6 +166,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       channel: outboundChannel,
       to: resolvedTarget.to,
       accountId: params.accountId,
+      threadId: params.threadId,
       payloads: normalizedPayloads,
       gifPlayback: params.gifPlayback,
       deps: params.deps,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -124,6 +124,7 @@ export async function executeSendAction(params: {
     gateway: params.ctx.gateway,
     mirror: params.ctx.mirror,
     abortSignal: params.ctx.abortSignal,
+    threadId: params.ctx.params?.threadId ?? undefined,
   });
 
   return {


### PR DESCRIPTION
## Problem

When the agent uses the `message` tool from within a Feishu topic session (topic groups with `topicSessionMode: "enabled"`), the `threadId` (topic `root_id`) is not propagated. This causes Feishu to create a new topic for each message sent via the tool, instead of keeping messages within the existing topic thread.

This results in a snowball effect: each new topic creates a new session → agent sends another message via `message` tool → another new topic → etc.

Agent direct replies work correctly because they go through the session's `deliveryContext` which includes `threadId`. The bug is specific to the `message` tool's outbound path.

## Root Cause

The `message` tool's `ChannelThreadingToolContext` only carries `currentThreadTs` (designed for Slack), but Feishu topics use message-ID-based threading (`root_id`), not timestamps. The auto-threading pattern exists for Slack (`resolveSlackAutoThreadId`) and Telegram (`resolveTelegramAutoThreadId`) but was missing for Feishu.

Additionally, the `sendMessage` fallback path in `outbound-send-service.ts` → `message.ts` → `deliverOutboundPayloads` didn't forward `threadId` at all, so even if the auto-threading resolved a threadId, it would be lost downstream.

## Changes

| File | Change |
|------|--------|
| `types.core.ts` | Add `currentThreadId` to `ChannelThreadingToolContext` |
| `openclaw-tools.ts` | Pass `agentThreadId` to `createMessageTool` as `currentThreadId` |
| `message-tool.ts` | Accept `currentThreadId` option, forward in `toolContext` |
| `message-action-runner.ts` | Add `resolveFeishuAutoThreadId()` following the Slack/Telegram pattern |
| `outbound-send-service.ts` | Forward `threadId` from `params` to `sendMessage` |
| `message.ts` | Accept `threadId` param, pass to `deliverOutboundPayloads` |

## How It Works

The fix mirrors the existing Slack and Telegram auto-threading patterns:

1. Session's `MessageThreadId` flows into `agentThreadId` → `currentThreadId` in toolContext
2. When the `message` tool is invoked targeting the same group, `resolveFeishuAutoThreadId()` detects matching targets and injects the threadId
3. The threadId is written back into params and forwarded through the full send pipeline
4. The Feishu outbound adapter uses `threadId` as `replyToMessageId` in the Feishu API call, keeping the message in the correct topic

Closes #13880

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements Feishu topic auto-threading to prevent the message tool from creating new topics instead of replying within existing threads. The approach correctly mirrors the Slack and Telegram auto-threading patterns in `message-action-runner.ts`, but the implementation is incomplete and won't work without critical missing pieces.

**Critical Issues Found:**

1. **Outbound adapter doesn't forward `threadId`** - The Feishu outbound adapter (`extensions/feishu/src/outbound.ts`) receives `threadId` via `ChannelOutboundContext` but doesn't pass it to `sendMessageFeishu()` or `sendMediaFeishu()` as `replyToMessageId`. This breaks the entire threading flow.

2. **Inbound context missing `MessageThreadId`** - The Feishu bot (`extensions/feishu/src/bot.ts`) doesn't set `MessageThreadId` in `finalizeInboundContext()`, so the session won't capture the topic `root_id`.

3. **Missing threading adapter** - Feishu has no `threading.buildToolContext` adapter in the channel plugin, so even if `MessageThreadId` were set, it wouldn't flow into `agentThreadId` → `currentThreadId` → tool context.

**How the fix should work:**
- Session's `MessageThreadId` (topic `root_id`) → threading adapter → `agentThreadId` → `currentThreadId` in tool context
- When message tool targets same group, `resolveFeishuAutoThreadId()` detects match and injects threadId
- threadId flows through `outbound-send-service.ts` → `message.ts` → `deliverOutboundPayloads` → outbound adapter
- Outbound adapter passes threadId as `replyToMessageId` to Feishu API

**What's implemented correctly:**
- Core auto-threading logic in `message-action-runner.ts` follows the established pattern
- Type additions to `ChannelThreadingToolContext` and parameter forwarding through `openclaw-tools.ts` → `message-tool.ts`
- `outbound-send-service.ts` and `message.ts` correctly forward threadId parameter

The PR description is accurate about the problem and solution, but the implementation is missing the Feishu-specific integration points needed to make it work.

<h3>Confidence Score: 1/5</h3>

- This PR has critical implementation gaps that will prevent the feature from working
- Three critical bugs prevent the auto-threading feature from functioning: (1) outbound adapter doesn't forward threadId to send functions, (2) inbound context doesn't set MessageThreadId, and (3) missing threading adapter prevents threadId from flowing into tool context. The core logic is correct but incomplete.
- `extensions/feishu/src/outbound.ts` (must forward threadId), `extensions/feishu/src/bot.ts` (must set MessageThreadId), `extensions/feishu/src/channel.ts` (must add threading adapter)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->