### PR TITLE
feat: add Gossip channel extension

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,11 @@
       - any-glob-to-any-file:
           - "extensions/googlechat/**"
           - "docs/channels/googlechat.md"
+"channel: gossip":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/gossip/**"
+          - "docs/channels/gossip.md"
 "channel: imessage":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/channels/gossip.md
+++ b/docs/channels/gossip.md
@@ -1,0 +1,220 @@
+---
+summary: "Gossip decentralized messenger with post-quantum encryption"
+read_when:
+  - You want OpenClaw to use privacy-focused messaging
+  - You want decentralized messaging without a phone number
+  - You need post-quantum encryption
+---
+
+# Gossip
+
+**Status:** Optional plugin (disabled by default).
+
+Gossip is a privacy-focused, decentralized messenger that enables OpenClaw to send and receive encrypted direct messages without requiring a phone number or relying on centralized servers. For more details, see the official Gossip site at https://usegossip.massa.network/.
+
+## Why Gossip?
+
+- **Open Source** - Fully auditable codebase; no hidden backdoors.
+- **Privacy Focused** - Post-quantum encryption with deniable plausibility protects your conversations even against future quantum computers.
+- **Decentralized** - No central server owns your data; messages are routed through a distributed network.
+- **No Phone Number Required** - Identity is based on cryptographic keys, not phone numbers or email addresses.
+
+## Install (on demand)
+
+### Onboarding (recommended)
+
+- The onboarding wizard (`openclaw onboard`) and `openclaw channels add` list optional channel plugins.
+- Selecting Gossip prompts you to install the plugin on demand.
+
+Install defaults:
+
+- **Dev channel + git checkout available:** uses the local plugin path.
+- **Stable/Beta:** downloads from npm.
+
+You can always override the choice in the prompt.
+
+### Manual install
+
+```bash
+openclaw plugins install gossip
+```
+
+Or with the full npm spec: `openclaw plugins install @openclaw/gossip`.
+
+Use a local checkout (dev workflows):
+
+```bash
+openclaw plugins install --link <path-to-openclaw>/extensions/gossip
+```
+
+Restart the Gateway after installing or enabling plugins.
+
+## Quick setup
+
+1. Enable the Gossip channel in your config:
+
+```json
+{
+  "channels": {
+    "gossip": {
+      "enabled": true
+    }
+  }
+}
+```
+
+2. Restart the Gateway. On first run, OpenClaw will automatically:
+   - Generate a new BIP39 mnemonic for your account
+   - Create cryptographic keys for encryption
+   - Register with the Gossip network
+
+3. Note the user ID from the logs - share this with users who want to message your bot.
+   User id will be written in: `~/.openclaw/sessions/gossip/<username>/session.json`
+
+## Configuration reference
+
+| Key           | Type     | Default                         | Description                                |
+| ------------- | -------- | ------------------------------- | ------------------------------------------ |
+| `enabled`     | boolean  | `false`                         | Enable/disable channel                     |
+| `mnemonic`    | string   | auto-generated                  | BIP39 mnemonic phrase for account recovery |
+| `username`    | string   | `openclaw`                      | Display name for the account               |
+| `protocolUrl` | string   | `https://api.usegossip.com/api` | Gossip protocol API endpoint               |
+| `dmPolicy`    | string   | `pairing`                       | DM access policy                           |
+| `allowFrom`   | string[] | `[]`                            | Allowed sender user IDs                    |
+| `name`        | string   | -                               | Display name for this account              |
+
+## Backup your mnemonic
+
+Your mnemonic phrase is the only way to recover your Gossip identity. On first run, OpenClaw stores it at:
+
+```
+~/.openclaw/sessions/gossip/<username>/session.json
+```
+
+**Back up this file securely.** If you lose it, you will need to create a new identity.
+
+To use an existing mnemonic (restore an account):
+
+Add this to your main OpenClaw config file (by default `~/.openclaw/config.json5`, or whatever `OPENCLAW_CONFIG_PATH` points to):
+
+```json
+{
+  "channels": {
+    "gossip": {
+      "mnemonic": "${GOSSIP_MNEMONIC}"
+    }
+  }
+}
+```
+
+Then set the environment variable:
+
+```bash
+export GOSSIP_MNEMONIC="word1 word2 word3 ... word12"
+```
+
+You can also restore an existing account directly via the Gossip channel onboarding flow (`openclaw onboard` or `openclaw channels add`), which will prompt you to paste an existing BIP39 mnemonic instead of generating a new one.
+
+## Access control
+
+### DM policies
+
+- **pairing** (default): unknown senders get a pairing code.
+- **allowlist**: only user IDs in `allowFrom` can DM.
+- **open**: public inbound DMs (requires `allowFrom: ["*"]`).
+- **disabled**: ignore inbound DMs.
+
+### Contact requests and auto-accept
+
+Gossip uses "discussion requests" when someone tries to DM your bot for the first time. The OpenClaw Gossip plugin **automatically accepts all discussion requests** so you do not need to manually approve each new contact in the Gossip app.
+
+Auto-accepting contacts does **not** bypass OpenClaw's own access control:
+
+- **DM policy still applies**: after a contact is auto-accepted, inbound messages are checked against your configured `dmPolicy` and `allowFrom` list.
+  - With `dmPolicy: "allowlist"`, only user IDs in `allowFrom` are allowed to talk to your agent (a whitelist).
+  - With `dmPolicy: "pairing"`, unknown senders must complete the pairing flow before their messages reach your agent.
+  - With `dmPolicy: "open"` and `allowFrom: ["*"]`, any Gossip user can reach your agent unless they are blocked by higher-level routing rules.
+- **Blocklist-style filtering**: to effectively block specific Gossip user IDs, keep them **out** of your `allowFrom` list (when using the `allowlist` policy) or add them to your global routing block rules; their messages will be dropped even though the underlying Gossip contact exists.
+
+In practice, for a locked-down production bot you will typically:
+
+```json
+{
+  "channels": {
+    "gossip": {
+      "dmPolicy": "allowlist",
+      "allowFrom": ["gossip1a23...", "gossip1x89..."]
+    }
+  }
+}
+```
+
+This configuration lets Gossip auto-accept contact requests while still enforcing a strict allowlist for who can actually reach your agent.
+
+### Allowlist example
+
+```json
+{
+  "channels": {
+    "gossip": {
+      "dmPolicy": "allowlist",
+      "allowFrom": ["abc123...", "xyz789..."]
+    }
+  }
+}
+```
+
+## How it works
+
+Gossip uses a unique cryptographic protocol:
+
+1. **Identity**: Your identity is a cryptographic key pair derived from a BIP39 mnemonic.
+2. **Sessions**: When you start a conversation, both parties establish an encrypted session using post-quantum key exchange.
+3. **Messages**: All messages are end-to-end encrypted; only the intended recipient can read them.
+4. **Deniability**: The protocol provides deniable authentication - you can prove a message came from someone, but cannot prove it to a third party.
+
+## Testing
+
+### Manual test
+
+1. Note the bot user ID from logs after starting the Gateway.
+2. Open the Gossip app on your phone or computer.
+3. Add the bot as a contact using its user ID.
+4. Start a conversation and send a message.
+5. Verify the bot responds.
+
+## Troubleshooting
+
+### Not receiving messages
+
+- Verify the channel is enabled (`enabled: true`).
+- Check that the Gateway is running.
+- Confirm the sender has an active session with your bot.
+- Check Gateway logs for connection errors.
+
+### Not sending responses
+
+- Verify outbound network connectivity to `api.usegossip.com` (API path `/api`).
+- Check if the session with the recipient is active.
+- Look for errors in the Gateway logs.
+
+### Session issues
+
+If you see "session broken" or similar errors:
+
+- The SDK automatically attempts to renew broken sessions.
+- Messages are queued and sent when the session becomes active.
+- If problems persist, the other party may need to reinitiate the conversation.
+
+## Security
+
+- **Never share your mnemonic** - it controls your entire identity.
+- Use environment variables for sensitive values.
+- Consider `allowlist` policy for production bots.
+- Session data is stored encrypted on disk.
+
+## Limitations (initial release)
+
+- Direct messages only (no group chats yet).
+- No media attachments (text only).
+- Single account per OpenClaw instance.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -28,6 +28,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Nextcloud Talk](/channels/nextcloud-talk) — Self-hosted chat via Nextcloud Talk (plugin, installed separately).
 - [Matrix](/channels/matrix) — Matrix protocol (plugin, installed separately).
 - [Nostr](/channels/nostr) — Decentralized DMs via NIP-04 (plugin, installed separately).
+- [Gossip](/channels/gossip) — Privacy-focused decentralized messenger with post-quantum encryption; no phone number required (plugin, installed separately).
 - [Tlon](/channels/tlon) — Urbit-based messenger (plugin, installed separately).
 - [Twitch](/channels/twitch) — Twitch chat via IRC connection (plugin, installed separately).
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (plugin, installed separately).

--- a/extensions/gossip/index.ts
+++ b/extensions/gossip/index.ts
@@ -1,0 +1,20 @@
+// IndexedDB polyfill for Node (SDK uses Dexie). Must run before any gossip code.
+import "fake-indexeddb/auto";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { gossipPlugin } from "./src/channel.js";
+import { setGossipResolvePath, setGossipRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "gossip",
+  name: "Gossip",
+  description: "Gossip decentralized messenger channel plugin with post-quantum encryption",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setGossipRuntime(api.runtime);
+    setGossipResolvePath(api.resolvePath);
+    api.registerChannel({ plugin: gossipPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/gossip/openclaw.plugin.json
+++ b/extensions/gossip/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "gossip",
+  "channels": ["gossip"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/gossip/package.json
+++ b/extensions/gossip/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/gossip",
+  "version": "2026.1.27",
+  "description": "OpenClaw Gossip channel plugin for post-quantum encrypted decentralized messaging",
+  "type": "module",
+  "dependencies": {
+    "@massalabs/gossip-sdk": "0.0.2-dev.20260211172752",
+    "dexie": "^4.0.0",
+    "fake-indexeddb": "^6.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "gossip",
+      "label": "Gossip",
+      "selectionLabel": "Gossip Chat",
+      "docsPath": "/channels/gossip",
+      "docsLabel": "gossip",
+      "blurb": "Privacy-focused decentralized messenger with post-quantum encryption.",
+      "order": 56,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/gossip",
+      "localPath": "extensions/gossip",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/gossip/src/channel.ts
+++ b/extensions/gossip/src/channel.ts
@@ -1,0 +1,382 @@
+import { isValidUserId } from "@massalabs/gossip-sdk";
+import {
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  setAccountEnabledInConfigSection,
+  type ChannelPlugin,
+  type OpenClawConfig,
+  type ReplyPayload,
+} from "openclaw/plugin-sdk";
+import { GossipConfigSchema } from "./config-schema.js";
+
+/** Strip channel-prefixed form so we validate and store raw Gossip user ID only. */
+function stripGossipPrefix(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.toLowerCase().startsWith("gossip:")) {
+    return trimmed.slice(7).trim();
+  }
+  return trimmed;
+}
+import { startGossipBus, type GossipBusHandle } from "./gossip-bus.js";
+import { gossipOnboardingAdapter } from "./onboarding.js";
+import { getGossipRuntime } from "./runtime.js";
+import {
+  listGossipAccountIds,
+  resolveDefaultGossipAccountId,
+  resolveGossipAccount,
+  type ResolvedGossipAccount,
+} from "./types.js";
+
+// Store active bus handles per account
+const activeBuses = new Map<string, GossipBusHandle>();
+
+export const gossipPlugin: ChannelPlugin<ResolvedGossipAccount> = {
+  id: "gossip",
+  meta: {
+    id: "gossip",
+    label: "Gossip",
+    selectionLabel: "Gossip",
+    docsPath: "/channels/gossip",
+    docsLabel: "gossip",
+    blurb: "Privacy-focused decentralized messenger with post-quantum encryption",
+    order: 100,
+  },
+  capabilities: {
+    chatTypes: ["direct"], // DMs only for now
+    media: false, // No media for initial release
+  },
+  reload: { configPrefixes: ["channels.gossip"] },
+  configSchema: buildChannelConfigSchema(GossipConfigSchema),
+  onboarding: gossipOnboardingAdapter,
+
+  config: {
+    listAccountIds: (cfg) => listGossipAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveGossipAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultGossipAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "gossip",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "gossip",
+        accountId,
+        clearBaseFields: [
+          "name",
+          "mnemonic",
+          "username",
+          "protocolUrl",
+          "dmPolicy",
+          "allowFrom",
+          "enabled",
+          "markdown",
+        ],
+      }),
+    isConfigured: (account) => account.configured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      userId: account.userId,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveGossipAccount({ cfg, accountId }).config.allowFrom ?? []).map((entry) =>
+        String(entry),
+      ),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry).trim())
+        .filter(Boolean)
+        .map((entry) => {
+          if (entry === "*") {
+            return "*";
+          }
+          const raw = stripGossipPrefix(entry);
+          if (!isValidUserId(raw)) {
+            console.warn(`Invalid Gossip user ID "${entry}" in allowFrom`);
+          }
+          return raw;
+        })
+        .filter(Boolean),
+  },
+
+  pairing: {
+    idLabel: "gossipUserId",
+    normalizeAllowEntry: (entry) => {
+      const raw = stripGossipPrefix(entry);
+      if (!isValidUserId(raw)) {
+        console.warn(`Invalid Gossip user ID "${entry}" in allowFrom`);
+      }
+      return raw;
+    },
+    notifyApproval: async ({ id }) => {
+      // Get the default account's bus and send approval message
+      const bus = activeBuses.get(DEFAULT_ACCOUNT_ID);
+      if (bus) {
+        await bus.sendDm(id, "Your pairing request has been approved!");
+      }
+    },
+  },
+
+  security: {
+    resolveDmPolicy: ({ account }) => {
+      return {
+        policy: account.config.dmPolicy ?? "pairing",
+        allowFrom: account.config.allowFrom ?? [],
+        policyPath: "channels.gossip.dmPolicy",
+        allowFromPath: "channels.gossip.allowFrom",
+        approveHint: formatPairingApproveHint("gossip"),
+        normalizeEntry: (raw) => {
+          const rawId = stripGossipPrefix(raw);
+          if (!isValidUserId(rawId)) {
+            console.warn(`Invalid Gossip user ID "${raw}"`);
+          }
+          return rawId;
+        },
+      };
+    },
+  },
+
+  messaging: {
+    normalizeTarget: (target) => {
+      const raw = stripGossipPrefix(target);
+      if (!isValidUserId(raw)) {
+        console.warn(`Invalid Gossip user ID "${target}" in target`);
+      }
+      return raw;
+    },
+    targetResolver: {
+      looksLikeId: (input) => {
+        const raw = stripGossipPrefix(input.trim());
+        return isValidUserId(raw);
+      },
+      hint: "<gossip user ID>",
+    },
+  },
+
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 4000,
+    sendText: async ({ to, text, accountId }) => {
+      const core = getGossipRuntime();
+      const aid = accountId ?? DEFAULT_ACCOUNT_ID;
+      const bus = activeBuses.get(aid);
+      if (!bus) {
+        throw new Error(`Gossip bus not running for account ${aid}`);
+      }
+      const tableMode = core.channel.text.resolveMarkdownTableMode({
+        cfg: core.config.loadConfig(),
+        channel: "gossip",
+        accountId: aid,
+      });
+      const message = core.channel.text.convertMarkdownTables(text ?? "", tableMode);
+      const normalizedTo = stripGossipPrefix(to);
+      if (!isValidUserId(normalizedTo)) {
+        console.warn(`Invalid Gossip user ID "${to}" in target`);
+      }
+      await bus.sendDm(normalizedTo, message);
+      return { channel: "gossip", to: normalizedTo };
+    },
+  },
+
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: (accounts) =>
+      accounts.flatMap((account) => {
+        const lastError = typeof account.lastError === "string" ? account.lastError.trim() : "";
+        if (!lastError) {
+          return [];
+        }
+        return [
+          {
+            channel: "gossip",
+            accountId: account.accountId,
+            kind: "runtime" as const,
+            message: `Channel error: ${lastError}`,
+          },
+        ];
+      }),
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      userId: snapshot.userId ?? null,
+      running: snapshot.running ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+    }),
+    buildAccountSnapshot: ({ account, runtime }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      userId: account.userId,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+    }),
+  },
+
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.setStatus({
+        accountId: account.accountId,
+        userId: account.userId,
+      });
+      ctx.log?.info(`[${account.accountId}] starting Gossip provider`);
+
+      if (!account.configured) {
+        throw new Error("Gossip channel not configured");
+      }
+
+      const runtime = getGossipRuntime();
+
+      const bus = await startGossipBus({
+        accountId: account.accountId,
+        mnemonic: account.mnemonic || undefined,
+        username: account.username,
+        protocolUrl: account.protocolUrl,
+        log: ctx.log,
+        onMessage: async (senderId, text, reply) => {
+          ctx.log?.debug(`[${account.accountId}] DM from ${senderId}: ${text.slice(0, 50)}...`);
+
+          const cfg = runtime.config.loadConfig() as OpenClawConfig;
+
+          // Resolve agent route for this DM
+          const route = runtime.channel.routing.resolveAgentRoute({
+            cfg,
+            channel: "gossip",
+            accountId: account.accountId,
+            peer: { kind: "dm", id: senderId },
+          });
+
+          const rawBody = text;
+          const body = runtime.channel.reply.formatAgentEnvelope({
+            channel: "Gossip",
+            from: senderId,
+            envelope: runtime.channel.reply.resolveEnvelopeFormatOptions(cfg),
+            body: rawBody,
+          });
+
+          // To/OriginatingTo = reply destination (peer), not our identity; session lastTo is used for outbound.
+          const replyTo = `gossip:${senderId}`;
+          const ctxPayload = runtime.channel.reply.finalizeInboundContext({
+            Body: body,
+            RawBody: rawBody,
+            CommandBody: rawBody,
+            From: `gossip:${senderId}`,
+            To: replyTo,
+            SessionKey: route.sessionKey,
+            AccountId: route.accountId,
+            ChatType: "direct",
+            SenderName: senderId,
+            SenderId: senderId,
+            Provider: "gossip",
+            Surface: "gossip",
+            OriginatingChannel: "gossip",
+            OriginatingTo: replyTo,
+          });
+
+          // Record session metadata
+          const storePath = runtime.channel.session.resolveStorePath(cfg.session?.store, {
+            agentId: route.agentId,
+          });
+          await runtime.channel.session.recordInboundSession({
+            storePath,
+            sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+            ctx: ctxPayload,
+            onRecordError: (err) => {
+              ctx.log?.error(`[${account.accountId}] Failed updating session meta: ${String(err)}`);
+            },
+          });
+
+          const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+            cfg,
+            channel: "gossip",
+            accountId: account.accountId,
+          });
+
+          // Dispatch through the standard reply pipeline
+          await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+            ctx: ctxPayload,
+            cfg,
+            dispatcherOptions: {
+              deliver: async (payload: ReplyPayload) => {
+                if (!payload.text) {
+                  return;
+                }
+                const message = runtime.channel.text.convertMarkdownTables(payload.text, tableMode);
+                await reply(message);
+                ctx.setStatus({ lastOutboundAt: Date.now() });
+              },
+            },
+          });
+        },
+        onError: (error, context) => {
+          const base = `[${account.accountId}] Gossip error (${context}): ${error.message}`;
+          if (error?.stack) {
+            ctx.log?.error(`${base}\n${error.stack}`);
+          } else {
+            ctx.log?.error(base);
+          }
+        },
+        onReady: (userId) => {
+          ctx.log?.info(`[${account.accountId}] Gossip provider ready, user ID: ${userId}`);
+          ctx.setStatus({ userId });
+        },
+        onDiscussionRequest: (discussion, contact) => {
+          ctx.log?.debug(
+            `[${account.accountId}] Discussion request from ${contact.userId} (auto-accepting)`,
+          );
+        },
+      });
+
+      // Store the bus handle
+      activeBuses.set(account.accountId, bus);
+
+      ctx.log?.info(`[${account.accountId}] Gossip provider started`);
+
+      // Return cleanup function
+      return {
+        stop: async () => {
+          await bus.close();
+          activeBuses.delete(account.accountId);
+          ctx.log?.info(`[${account.accountId}] Gossip provider stopped`);
+        },
+      };
+    },
+  },
+};
+
+/**
+ * Get an active Gossip bus handle.
+ * Returns undefined if account is not running.
+ */
+export function getGossipBus(accountId: string = DEFAULT_ACCOUNT_ID): GossipBusHandle | undefined {
+  return activeBuses.get(accountId);
+}
+
+/**
+ * Get all active Gossip bus handles.
+ * Useful for debugging and status reporting.
+ */
+export function getActiveGossipBuses(): Map<string, GossipBusHandle> {
+  return new Map(activeBuses);
+}

--- a/extensions/gossip/src/config-schema.ts
+++ b/extensions/gossip/src/config-schema.ts
@@ -1,0 +1,50 @@
+import { MarkdownConfigSchema, buildChannelConfigSchema } from "openclaw/plugin-sdk";
+import { z } from "zod";
+
+const allowFromEntry = z.union([z.string(), z.number()]);
+
+/**
+ * Zod schema for channels.gossip.* configuration
+ */
+export const GossipConfigSchema = z.object({
+  /** Account name (optional display name) */
+  name: z.string().optional(),
+
+  /** Whether this channel is enabled */
+  enabled: z.boolean().optional(),
+
+  /** Markdown formatting overrides (tables). */
+  markdown: MarkdownConfigSchema,
+
+  /**
+   * BIP39 mnemonic phrase for account recovery.
+   * If not provided, a new account will be generated on first run.
+   * Supports environment variable substitution (e.g., "${GOSSIP_MNEMONIC}").
+   */
+  mnemonic: z.string().optional(),
+
+  /**
+   * Username for the Gossip account.
+   * Used when creating a new account.
+   */
+  username: z.string().optional(),
+
+  /**
+   * Gossip protocol API base URL.
+   * Defaults to the official Gossip API endpoint.
+   */
+  protocolUrl: z.string().url().optional(),
+
+  /** DM access policy: pairing, allowlist, open, or disabled */
+  dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
+
+  /** Allowed sender user IDs (Gossip user ID format) */
+  allowFrom: z.array(allowFromEntry).optional(),
+});
+
+export type GossipConfig = z.infer<typeof GossipConfigSchema>;
+
+/**
+ * JSON Schema for Control UI (converted from Zod)
+ */
+export const gossipChannelConfigSchema = buildChannelConfigSchema(GossipConfigSchema);

--- a/extensions/gossip/src/gossip-bus.ts
+++ b/extensions/gossip/src/gossip-bus.ts
@@ -1,0 +1,391 @@
+/**
+ * Gossip SDK Bus - Wrapper for SDK lifecycle and event handling
+ *
+ * This module provides a clean interface for OpenClaw to interact with the
+ * Gossip SDK, handling initialization, session management, and message routing.
+ */
+
+// Must run before any code that uses IndexedDB (SDK uses Dexie).
+import "fake-indexeddb/auto";
+import type Dexie from "dexie";
+import {
+  gossipSdk,
+  GossipDatabase,
+  generateMnemonic,
+  generateEncryptionKey,
+  encryptionKeyFromBytes,
+  type Message,
+  type Discussion,
+  type Contact,
+  MessageDirection,
+  MessageStatus,
+  MessageType,
+  encodeUserId,
+  decodeFromBase64,
+} from "@massalabs/gossip-sdk";
+import {
+  createGossipStorageAdapter,
+  type GossipStorageAdapter,
+  uint8ArrayToBase64,
+  base64ToUint8Array,
+} from "./storage.js";
+
+export interface GossipBusOptions {
+  /** Account ID for state persistence */
+  accountId: string;
+  /** BIP39 mnemonic phrase (auto-generated if not provided) */
+  mnemonic?: string;
+  /** Username for the account */
+  username: string;
+  /** Gossip protocol API base URL */
+  protocolUrl: string;
+  /** Called when a message is received */
+  onMessage: (
+    senderId: string,
+    text: string,
+    reply: (text: string) => Promise<void>,
+  ) => Promise<void>;
+  /** Called on errors (optional) */
+  onError?: (error: Error, context: string) => void;
+  /** Called when SDK is ready (optional) */
+  onReady?: (userId: string) => void;
+  /** Called on discussion requests (optional) */
+  onDiscussionRequest?: (discussion: Discussion, contact: Contact) => void;
+  /** Optional debug logger (e.g. ctx.log from channel gateway) */
+  log?: { debug?(message: string): void };
+}
+
+export interface GossipBusHandle {
+  /** Stop the bus and cleanup */
+  close: () => Promise<void>;
+  /** Get the user's ID (bech32-encoded gossip1… string) */
+  userId: string;
+  /** Send a DM to a user */
+  sendDm: (toUserId: string, text: string) => Promise<void>;
+  /** Get the storage adapter */
+  storage: GossipStorageAdapter;
+  /** Get the mnemonic (for backup purposes) */
+  getMnemonic: () => string;
+}
+
+/**
+ * Start the Gossip bus - initializes SDK and handles message routing
+ */
+export async function startGossipBus(options: GossipBusOptions): Promise<GossipBusHandle> {
+  const {
+    accountId,
+    username,
+    protocolUrl,
+    onMessage,
+    onError,
+    onReady,
+    onDiscussionRequest,
+    log,
+  } = options;
+
+  const debug = (msg: string) => log?.debug?.(msg);
+
+  const storage = createGossipStorageAdapter(log);
+
+  // Load or create session data
+  let sessionData = storage.loadSessionData(accountId);
+  let mnemonic = options.mnemonic;
+  let existingSession: { blob: Uint8Array; encryptionKey: Uint8Array } | null = null;
+
+  debug(`gossip session data: ${JSON.stringify(sessionData)}`);
+  if (sessionData) {
+    // Restore existing session
+    mnemonic = sessionData.mnemonic;
+    existingSession = storage.loadSessionBlob(accountId);
+    debug(`gossip session restored for account ${accountId}`);
+  } else {
+    debug(`gossip no session data found for account ${accountId}`);
+    // Generate new account if no mnemonic provided
+    if (!mnemonic) {
+      mnemonic = generateMnemonic();
+    }
+    // Save the new session data
+    sessionData = {
+      mnemonic,
+      username,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    storage.saveSessionData(accountId, sessionData);
+    debug(`gossip new session created with account ${accountId}`);
+  }
+
+  // Initialize the SDK with a fresh database instance
+  const db = new GossipDatabase();
+  await db.open();
+
+  // Restore Dexie DB state from disk (discussions, contacts, messages).
+  // fake-indexeddb is in-memory so this data would otherwise be lost on restart.
+  const savedJson = await storage.loadDexieDb(accountId);
+  if (savedJson) {
+    try {
+      await importDexieDb(db, savedJson);
+      debug(`gossip Dexie DB restored from disk for account ${accountId}`);
+    } catch (err) {
+      onError?.(err as Error, "dexie db restore");
+    }
+  } else {
+    debug(`gossip no saved Dexie DB found for account ${accountId}`);
+  }
+
+  await gossipSdk.init({
+    db,
+    protocolBaseUrl: protocolUrl,
+    config: {
+      polling: {
+        enabled: false,
+        messagesIntervalMs: 5000,
+        announcementsIntervalMs: 5000,
+        sessionRefreshIntervalMs: 30000,
+      },
+    },
+  });
+
+  // SDK is a singleton; close any existing session (e.g. from onboarding) before opening
+  if (gossipSdk.isSessionOpen) {
+    debug(`gossip closing existing session before open`);
+    await gossipSdk.closeSession();
+  }
+
+  // Open session with persistence
+  debug(`gossip opening session for account ${accountId}`);
+
+  await gossipSdk.openSession({
+    mnemonic,
+    encryptedSession: existingSession?.blob,
+    onPersist: async (blob, key) => {
+      storage.saveSessionBlob(accountId, blob, key.to_bytes());
+      debug(`gossip session persisted accountId=${accountId} blobSize=${blob.length}`);
+    },
+  });
+
+  const gossipUserId = gossipSdk.userId;
+  debug(`gossip userId=${gossipUserId}`);
+  // Log existing discussions to verify persistence across restarts
+  const discussions = await gossipSdk.discussions.list(gossipUserId);
+  debug(
+    `gossip existing discussions: ${discussions.length} → ${discussions.map((d) => `${d.contactUserId.slice(0, 16)}… (status=${d.status})`).join(", ") || "none"}`,
+  );
+
+  // Update session data with userId
+  if (sessionData && !sessionData.userId) {
+    sessionData.userId = gossipUserId;
+    sessionData.updatedAt = new Date().toISOString();
+    storage.saveSessionData(accountId, sessionData);
+  }
+
+  // Set up event handlers
+  gossipSdk.on("messageReceived", async (message: Message) => {
+    debug(`gossip incoming message: ${JSON.stringify(message)}`);
+    // Only handle incoming messages
+    if (message.direction !== MessageDirection.INCOMING) {
+      return;
+    }
+
+    const senderId = message.contactUserId;
+    const text = message.content;
+    debug(`gossip incoming message from=${senderId} len=${text?.length ?? 0}`);
+
+    // Create reply function
+    const reply = async (responseText: string): Promise<void> => {
+      await sendMessage(senderId, responseText);
+    };
+
+    try {
+      await onMessage(senderId, text, reply);
+    } catch (err) {
+      onError?.(err as Error, `handling message from ${senderId}`);
+    }
+  });
+
+  gossipSdk.on("sessionRequested", (discussion: Discussion, contact: Contact) => {
+    debug(`gossip discussion request from=${contact.userId}`);
+    onDiscussionRequest?.(discussion, contact);
+
+    // Auto-accept discussion requests for contacts
+    gossipSdk.discussions.accept(discussion).catch((err) => {
+      onError?.(err as Error, `accepting discussion from ${contact.userId}`);
+    });
+  });
+
+  gossipSdk.on("error", (error: Error, context: string) => {
+    debug(`gossip error: ${error.message} context=${context}`);
+    onError?.(error, context);
+  });
+
+  debug(`gossip notifying that SDK is ready for account ${accountId}`);
+  // Notify that SDK is ready
+  onReady?.(accountId);
+
+  // Fetch announcements (discussion requests) before starting polling so that
+  // discussions are established before the first message poll. Without this,
+  // messages can arrive before their discussion exists → "no discussion" error.
+  debug(`gossip fetching announcements before starting polls (protocolUrl=${protocolUrl})`);
+  try {
+    const result = await gossipSdk.announcements.fetch();
+    const count = result?.newAnnouncementsCount ?? 0;
+    const ok = result?.success;
+    debug(
+      `gossip initial announcements fetch done: newCount=${count} success=${ok}` +
+        (count === 0 && ok ? "" : ""),
+    );
+  } catch (err) {
+    onError?.(err as Error, "initial announcements fetch");
+  }
+
+  // Now safe to start polling (discussions are established for known contacts)
+  debug(`gossip starting polling`);
+  gossipSdk.polling.start();
+
+  /** Persist the Dexie DB to disk (discussions, contacts, messages). */
+  async function persistDexieDb(): Promise<void> {
+    try {
+      const json = await exportDexieDb(db);
+      await storage.saveDexieDb(accountId, json);
+      debug(`gossip Dexie DB persisted to disk for accountId=${accountId}`);
+    } catch (err) {
+      debug(`gossip Dexie DB persist failed: ${(err as Error).message}`);
+      onError?.(err as Error, "dexie db persist");
+    }
+  }
+
+  // Periodic save for crash safety (every 60 s)
+  const persistInterval = setInterval(() => {
+    void persistDexieDb();
+  }, 60_000);
+
+  /**
+   * Send a message to a user
+   */
+  async function sendMessage(toUserId: string, text: string): Promise<void> {
+    debug(`gossip sendDm to=${toUserId} len=${text.length}`);
+    // Ensure contact exists locally before sending.
+    let contact = await gossipSdk.contacts.get(gossipUserId, toUserId);
+    if (!contact) {
+      debug(`gossip contact missing for ${toUserId}, fetching public key and creating contact`);
+      const keyResult = await gossipSdk.auth.fetchPublicKeyByUserId(toUserId);
+      if (!("publicKey" in keyResult) || !keyResult.publicKey) {
+        throw new Error(
+          `No contact found for ${toUserId} and failed to fetch public key: ${keyResult.error}`,
+        );
+      }
+
+      const addResult = await gossipSdk.contacts.add(
+        gossipUserId,
+        toUserId,
+        toUserId,
+        keyResult.publicKey,
+      );
+      if (!addResult.success && addResult.error !== "Contact already exists") {
+        throw new Error(`Failed to add contact ${toUserId}: ${addResult.error}`);
+      }
+
+      contact = await gossipSdk.contacts.get(gossipUserId, toUserId);
+      if (!contact) {
+        throw new Error(`Contact ${toUserId} is still missing after add attempt`);
+      }
+      debug(`gossip contact created for ${toUserId}`);
+    }
+
+    // Ensure discussion exists. SDK queues outgoing messages until session is ready.
+    const discussion = await gossipSdk.discussions.get(gossipUserId, toUserId);
+    if (!discussion) {
+      debug(`gossip discussion missing for ${toUserId}, creating discussion`);
+      const startResult = await gossipSdk.discussions.start(contact);
+      if (!startResult.success) {
+        throw new Error(
+          `Failed to create discussion with ${toUserId}: ${startResult.error.message}`,
+        );
+      }
+      debug(`gossip discussion created for ${toUserId}`);
+    }
+
+    const sendResult = await gossipSdk.messages.send({
+      ownerUserId: gossipUserId,
+      contactUserId: toUserId,
+      content: text,
+      type: MessageType.TEXT,
+      direction: MessageDirection.OUTGOING,
+      status: MessageStatus.WAITING_SESSION,
+      timestamp: new Date(),
+    });
+    if (!sendResult.success) {
+      throw new Error(`Failed to queue gossip message to ${toUserId}: ${sendResult.error}`);
+    }
+  }
+
+  return {
+    close: async () => {
+      debug(`gossip closing session accountId=${accountId}`);
+      clearInterval(persistInterval);
+      // Final DB export before shutdown so state survives the next restart
+      await persistDexieDb();
+      await gossipSdk.closeSession();
+      db.close();
+    },
+    userId: gossipUserId,
+    sendDm: sendMessage,
+    storage,
+    getMnemonic: () => mnemonic,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Manual Dexie DB export/import (avoids dexie-export-import which needs `self`)
+// ---------------------------------------------------------------------------
+
+/**
+ * JSON replacer that tags Date and Uint8Array values so they survive round-trips.
+ * Uses `this[key]` to read the original value before Date.toJSON() converts it.
+ */
+function typedReplacer(this: unknown, key: string, value: unknown): unknown {
+  const raw = (this as Record<string, unknown>)[key];
+  if (raw instanceof Date) {
+    return { __$t: "D", v: raw.toISOString() };
+  }
+  if (raw instanceof Uint8Array) {
+    return { __$t: "U", v: Buffer.from(raw).toString("base64") };
+  }
+  return value;
+}
+
+/** JSON reviver that restores tagged Date and Uint8Array values. */
+function typedReviver(_key: string, value: unknown): unknown {
+  if (value && typeof value === "object" && "__$t" in (value as Record<string, unknown>)) {
+    const tagged = value as { __$t: string; v: string };
+    if (tagged.__$t === "D") {
+      return new Date(tagged.v);
+    }
+    if (tagged.__$t === "U") {
+      const buf = Buffer.from(tagged.v, "base64");
+      return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    }
+  }
+  return value;
+}
+
+/** Serialise every table in a Dexie DB to a JSON string. */
+async function exportDexieDb(db: Dexie): Promise<string> {
+  const snapshot: Record<string, unknown[]> = {};
+  for (const table of db.tables) {
+    snapshot[table.name] = await table.toArray();
+  }
+  return JSON.stringify(snapshot, typedReplacer);
+}
+
+/** Restore a previously exported JSON snapshot into a Dexie DB. */
+async function importDexieDb(db: Dexie, json: string): Promise<void> {
+  const snapshot = JSON.parse(json, typedReviver) as Record<string, unknown[]>;
+  for (const [tableName, records] of Object.entries(snapshot)) {
+    const table = db.table(tableName);
+    await table.clear();
+    if (records.length > 0) {
+      await table.bulkPut(records);
+    }
+  }
+}

--- a/extensions/gossip/src/onboarding.ts
+++ b/extensions/gossip/src/onboarding.ts
@@ -1,0 +1,330 @@
+import type {
+  ChannelOnboardingAdapter,
+  ChannelOnboardingDmPolicy,
+  DmPolicy,
+  OpenClawConfig,
+  WizardPrompter,
+} from "openclaw/plugin-sdk";
+import { isValidUserId } from "@massalabs/gossip-sdk";
+import {
+  addWildcardAllowFrom,
+  formatDocsLink,
+  normalizeAccountId,
+  promptAccountId,
+} from "openclaw/plugin-sdk";
+import { startGossipBus } from "./gossip-bus.js";
+import { getGossipRuntime } from "./runtime.js";
+import { getGossipSessionsBaseDir } from "./storage.js";
+import {
+  listGossipAccountIds,
+  resolveDefaultGossipAccountId,
+  resolveGossipAccount,
+} from "./types.js";
+
+const channel = "gossip" as const;
+
+export const DEFAULT_PROTOCOL_URL = "https://api.usegossip.com/api";
+export const DEFAULT_USERNAME = "openclaw";
+
+function setGossipDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy): OpenClawConfig {
+  const base = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | Record<string, unknown>
+    | undefined;
+  const allowFrom =
+    dmPolicy === "open" ? addWildcardAllowFrom(base?.allowFrom as string[] | undefined) : undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gossip: {
+        ...base,
+        dmPolicy,
+        ...(allowFrom ? { allowFrom } : {}),
+      },
+    } as OpenClawConfig["channels"],
+  };
+}
+
+function setGossipAllowFrom(cfg: OpenClawConfig, allowFrom: string[]): OpenClawConfig {
+  const base = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | Record<string, unknown>
+    | undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gossip: {
+        ...base,
+        allowFrom,
+      },
+    } as OpenClawConfig["channels"],
+  };
+}
+
+function stripGossipPrefix(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.toLowerCase().startsWith("gossip:")) {
+    return trimmed.slice(7).trim();
+  }
+  return trimmed;
+}
+
+function parseAllowFromInput(raw: string): string[] {
+  return raw
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => (entry === "*" ? "*" : stripGossipPrefix(entry)))
+    .filter((entry) => entry === "*" || isValidUserId(entry));
+}
+
+async function promptGossipAllowFrom(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  accountId?: string;
+}): Promise<OpenClawConfig> {
+  const accountId = params.accountId ?? resolveDefaultGossipAccountId(params.cfg);
+  const resolved = resolveGossipAccount({ cfg: params.cfg, accountId });
+  const existing = (resolved.config.allowFrom ?? []).map(String);
+
+  await params.prompter.note(
+    [
+      "Allowlist DMs by Gossip user ID (e.g. gossip1sw8cvs4vy6k...).",
+      "Leave blank to skip. Multiple IDs: comma-separated.",
+      `Docs: ${formatDocsLink("/channels/gossip", "gossip")}`,
+    ].join("\n"),
+    "Gossip allowlist",
+  );
+
+  const entry = await params.prompter.text({
+    message: "Gossip allowFrom (user IDs)",
+    placeholder: "paste one or more Gossip user IDs",
+    initialValue: existing[0] ?? undefined,
+    validate: (value) => {
+      const raw = String(value ?? "").trim();
+      if (!raw) {
+        return undefined;
+      }
+      const parts = parseAllowFromInput(raw);
+      for (const part of parts) {
+        if (part === "*") {
+          continue;
+        }
+        if (!isValidUserId(part)) {
+          return `Invalid Gossip user ID: ${part}`;
+        }
+      }
+      return undefined;
+    },
+  });
+
+  const parts = parseAllowFromInput(String(entry ?? ""));
+  const normalized = [...new Set(parts)];
+  return setGossipAllowFrom(params.cfg, normalized);
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "Gossip",
+  channel,
+  policyKey: "channels.gossip.dmPolicy",
+  allowFromKey: "channels.gossip.allowFrom",
+  getCurrent: (cfg): DmPolicy => {
+    const raw = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+      | Record<string, unknown>
+      | undefined;
+    const p = raw?.dmPolicy;
+    if (p === "pairing" || p === "allowlist" || p === "open" || p === "disabled") {
+      return p;
+    }
+    return "pairing";
+  },
+  setPolicy: (cfg, policy) => setGossipDmPolicy(cfg, policy),
+  promptAllowFrom: promptGossipAllowFrom,
+};
+
+async function noteGossipHelp(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "Gossip uses a mnemonic for identity. Leave mnemonic blank to auto-generate on first run.",
+      "Username is your display name. Protocol URL defaults to the official Gossip API.",
+      `Docs: ${formatDocsLink("/channels/gossip", "gossip")}`,
+    ].join("\n"),
+    "Gossip setup",
+  );
+}
+
+function applyGossipConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  input: {
+    name?: string;
+    username?: string;
+    protocolUrl?: string;
+    mnemonic?: string;
+  };
+}): OpenClawConfig {
+  const { cfg, input } = params;
+  const base = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | Record<string, unknown>
+    | undefined;
+
+  const gossip = {
+    ...base,
+    enabled: true,
+    ...(input.name !== undefined ? { name: input.name } : {}),
+    ...(input.username !== undefined ? { username: input.username } : {}),
+    ...(input.protocolUrl !== undefined ? { protocolUrl: input.protocolUrl } : {}),
+    ...(input.mnemonic !== undefined ? { mnemonic: input.mnemonic } : {}),
+  };
+
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gossip,
+    } as OpenClawConfig["channels"],
+  };
+}
+
+export const gossipOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  dmPolicy,
+
+  getStatus: async ({ cfg }) => {
+    const accountIds = listGossipAccountIds(cfg);
+    const configured = accountIds.some(
+      (id) => resolveGossipAccount({ cfg, accountId: id }).configured,
+    );
+
+    return {
+      channel,
+      configured,
+      statusLines: [`Gossip: ${configured ? "configured" : "needs setup"}`],
+      selectionHint: configured ? "configured" : "decentralized messenger",
+      quickstartScore: configured ? 1 : 4,
+    };
+  },
+
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const override = accountOverrides[channel]?.trim();
+    const defaultAccountId = resolveDefaultGossipAccountId(cfg);
+    let accountId = override ? normalizeAccountId(override) : defaultAccountId;
+
+    if (shouldPromptAccountIds && !override) {
+      accountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "Gossip",
+        currentId: accountId,
+        listAccountIds: listGossipAccountIds,
+        defaultAccountId,
+      });
+    }
+
+    const resolved = resolveGossipAccount({ cfg, accountId });
+    await noteGossipHelp(prompter);
+
+    const username = await prompter.text({
+      message: "Username (display name)",
+      placeholder: DEFAULT_USERNAME,
+      initialValue: resolved.username || undefined,
+    });
+
+    const protocolUrl = await prompter.text({
+      message: "Protocol API URL (blank for default)",
+      placeholder: DEFAULT_PROTOCOL_URL,
+      initialValue:
+        resolved.protocolUrl !== DEFAULT_PROTOCOL_URL ? resolved.protocolUrl : undefined,
+    });
+
+    const wantsMnemonic = await prompter.confirm({
+      message: "Set an existing mnemonic? (blank = auto-generate on first run)",
+      initialValue: Boolean(resolved.mnemonic?.trim()),
+    });
+
+    let mnemonic: string | undefined;
+    if (wantsMnemonic) {
+      const raw = await prompter.text({
+        message: "BIP39 mnemonic (12/24 words)",
+        placeholder: "word1 word2 ...",
+        initialValue: resolved.mnemonic || undefined,
+      });
+      mnemonic = raw?.trim() || undefined;
+    }
+
+    const name = await prompter.text({
+      message: "Account name (optional)",
+      initialValue: resolved.name ?? undefined,
+    });
+
+    const next = applyGossipConfig({
+      cfg,
+      accountId,
+      input: {
+        name: name?.trim() || undefined,
+        username: (username?.trim() || DEFAULT_USERNAME).trim(),
+        protocolUrl: (protocolUrl?.trim() || DEFAULT_PROTOCOL_URL).trim(),
+        mnemonic,
+      },
+    });
+
+    // Start the bus briefly to obtain and display the Gossip user ID (saved to session.json).
+    const gossipCfg = (next.channels as Record<string, unknown> | undefined)?.gossip as
+      | { mnemonic?: string; username?: string; protocolUrl?: string }
+      | undefined;
+    const busMnemonic = gossipCfg?.mnemonic?.trim() || undefined;
+    const busUsername = (gossipCfg?.username?.trim() || DEFAULT_USERNAME).trim();
+    const busProtocolUrl = (gossipCfg?.protocolUrl?.trim() || DEFAULT_PROTOCOL_URL).trim();
+
+    let onboardingLog: { debug?(message: string): void } | undefined;
+    try {
+      onboardingLog = getGossipRuntime().logging.getChildLogger({
+        module: "gossip-onboarding",
+      });
+    } catch {
+      // Runtime not set (unusual during onboarding)
+    }
+    const debug = (msg: string) => onboardingLog?.debug?.(msg);
+
+    try {
+      debug("gossip onboarding: starting bus to fetch userId");
+      const bus = await startGossipBus({
+        accountId,
+        mnemonic: busMnemonic,
+        username: busUsername,
+        protocolUrl: busProtocolUrl,
+        log: onboardingLog,
+        onMessage: async () => {},
+        onError: () => {},
+      });
+      const userId = bus.userId;
+      debug(`gossip onboarding: got userId=${userId}`);
+      await bus.close();
+      debug("gossip onboarding: closed bus");
+
+      const sessionPath = `${getGossipSessionsBaseDir()}/${accountId}/session.json`;
+      await prompter.note(
+        [
+          `Your Gossip user ID (share this so others can message your bot):`,
+          ``,
+          userId,
+          ``,
+          `It is also saved in: ${sessionPath}`,
+        ].join("\n"),
+        "Gossip user ID",
+      );
+    } catch (err) {
+      debug(`gossip onboarding: failed to fetch userId: ${String(err)}`);
+      await prompter.note(
+        [
+          "Could not fetch your Gossip user ID now (e.g. network).",
+          "After you start the gateway, your ID will appear in the logs and be saved in:",
+          `${getGossipSessionsBaseDir()}/${accountId}/session.json`,
+        ].join("\n"),
+        "Gossip user ID",
+      );
+    }
+
+    return { cfg: next, accountId };
+  },
+};

--- a/extensions/gossip/src/runtime.ts
+++ b/extensions/gossip/src/runtime.ts
@@ -1,0 +1,32 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: unknown = null;
+let resolvePath: ((input: string) => string) | null = null;
+
+export function setGossipRuntime(next: PluginRuntime): void {
+  runtime = next;
+}
+
+export function setGossipResolvePath(fn: (input: string) => string): void {
+  resolvePath = fn;
+}
+
+export function getGossipRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Gossip runtime not initialized");
+  }
+  return runtime as PluginRuntime;
+}
+
+/** Resolve user path (e.g. ~/.openclaw). Uses API resolvePath when set; otherwise falls back to process.env.HOME. */
+export function getGossipResolveUserPath(pathInput: string): string {
+  if (resolvePath) {
+    return resolvePath(pathInput);
+  }
+  const trimmed = pathInput.trim();
+  if (trimmed.startsWith("~/") || trimmed === "~") {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+    return trimmed === "~" ? home : `${home}${trimmed.slice(1)}`;
+  }
+  return trimmed;
+}

--- a/extensions/gossip/src/storage.test.ts
+++ b/extensions/gossip/src/storage.test.ts
@@ -1,0 +1,179 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  createGossipStorageAdapter,
+  uint8ArrayToBase64,
+  base64ToUint8Array,
+  type GossipSessionData,
+  type GossipStorageAdapter,
+} from "./storage.js";
+
+// Mock the runtime module to control the base directory
+vi.mock("./runtime.js", () => ({
+  getGossipResolveUserPath: (p: string) => p.replace("~", os.tmpdir()),
+}));
+
+describe("storage", () => {
+  let storage: GossipStorageAdapter;
+  let testBaseDir: string;
+  const testAccountId = "test-account-123";
+
+  beforeEach(() => {
+    storage = createGossipStorageAdapter();
+    testBaseDir = path.join(os.tmpdir(), ".openclaw", "sessions", "gossip");
+  });
+
+  afterEach(() => {
+    // Clean up test directories
+    const accountDir = path.join(testBaseDir, testAccountId);
+    if (fs.existsSync(accountDir)) {
+      fs.rmSync(accountDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("getSessionDir", () => {
+    it("creates the session directory if it does not exist", () => {
+      const dir = storage.getSessionDir(testAccountId);
+      expect(fs.existsSync(dir)).toBe(true);
+      expect(dir).toContain(testAccountId);
+    });
+
+    it("returns the same directory on subsequent calls", () => {
+      const dir1 = storage.getSessionDir(testAccountId);
+      const dir2 = storage.getSessionDir(testAccountId);
+      expect(dir1).toBe(dir2);
+    });
+  });
+
+  describe("saveSessionData / loadSessionData", () => {
+    it("saves and loads session data correctly", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12",
+        encryptionKey: uint8ArrayToBase64(new Uint8Array([1, 2, 3, 4, 5])),
+        userId: "user-123",
+        username: "testuser",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      };
+
+      storage.saveSessionData(testAccountId, sessionData);
+      const loaded = storage.loadSessionData(testAccountId);
+
+      expect(loaded).toEqual(sessionData);
+    });
+
+    it("returns null for non-existent session", () => {
+      const loaded = storage.loadSessionData("non-existent-account");
+      expect(loaded).toBeNull();
+    });
+
+    it("saves session data with correct file permissions", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "test mnemonic",
+        encryptionKey: "dGVzdA==",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      storage.saveSessionData(testAccountId, sessionData);
+
+      const filePath = path.join(storage.getSessionDir(testAccountId), "session.json");
+      const stats = fs.statSync(filePath);
+      // Check file mode is 0o600 (owner read/write only)
+      const mode = stats.mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+  });
+
+  describe("saveSessionBlob / loadSessionBlob", () => {
+    it("saves and loads session blob correctly", () => {
+      // First create session data (required for blob save to update it)
+      const sessionData: GossipSessionData = {
+        mnemonic: "test mnemonic",
+        encryptionKey: "initial-key",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      storage.saveSessionData(testAccountId, sessionData);
+
+      const blob = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]);
+      const encryptionKey = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+      storage.saveSessionBlob(testAccountId, blob, encryptionKey);
+      const loaded = storage.loadSessionBlob(testAccountId);
+
+      expect(loaded).not.toBeNull();
+      expect(loaded!.blob).toEqual(blob);
+      expect(loaded!.encryptionKey).toEqual(encryptionKey);
+    });
+
+    it("returns null when no blob exists", () => {
+      const loaded = storage.loadSessionBlob("non-existent-account");
+      expect(loaded).toBeNull();
+    });
+
+    it("updates session.json metadata when saving blob", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "test mnemonic",
+        encryptionKey: "initial-key",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      storage.saveSessionData(testAccountId, sessionData);
+
+      const blob = new Uint8Array([10, 20, 30]);
+      const encryptionKey = new Uint8Array([1, 2, 3]);
+
+      storage.saveSessionBlob(testAccountId, blob, encryptionKey);
+
+      const loaded = storage.loadSessionData(testAccountId);
+      expect(loaded!.encryptionKey).toBe(uint8ArrayToBase64(encryptionKey));
+      expect(loaded!.updatedAt).not.toBe(sessionData.updatedAt);
+    });
+  });
+
+  describe("hasSessionData", () => {
+    it("returns false for non-existent session", () => {
+      expect(storage.hasSessionData("non-existent")).toBe(false);
+    });
+
+    it("returns true for existing session", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "test",
+        encryptionKey: "test",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      storage.saveSessionData(testAccountId, sessionData);
+
+      expect(storage.hasSessionData(testAccountId)).toBe(true);
+    });
+  });
+
+  describe("deleteSessionData", () => {
+    it("deletes all session files", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "test",
+        encryptionKey: "test",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      storage.saveSessionData(testAccountId, sessionData);
+      storage.saveSessionBlob(testAccountId, new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6]));
+
+      expect(storage.hasSessionData(testAccountId)).toBe(true);
+
+      storage.deleteSessionData(testAccountId);
+
+      expect(storage.hasSessionData(testAccountId)).toBe(false);
+      expect(storage.loadSessionBlob(testAccountId)).toBeNull();
+    });
+
+    it("handles deletion of non-existent session gracefully", () => {
+      // Should not throw
+      expect(() => storage.deleteSessionData("non-existent")).not.toThrow();
+    });
+  });
+});

--- a/extensions/gossip/src/storage.ts
+++ b/extensions/gossip/src/storage.ts
@@ -1,0 +1,229 @@
+/**
+ * File-based storage adapter for Gossip SDK in Node.js environment.
+ *
+ * The Gossip SDK uses IndexedDB (Dexie) for browser storage.
+ * For Node.js, we use fake-indexeddb for in-memory storage and persist
+ * session state to files using the SDK's persistence callbacks.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getGossipResolveUserPath } from "./runtime.js";
+
+export interface GossipSessionData {
+  mnemonic: string;
+  encryptionKey: string; // base64 encoded
+  sessionBlob?: string; // base64 encoded encrypted session
+  userId?: string;
+  username?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GossipStorageAdapter {
+  /** Get the session data directory for an account */
+  getSessionDir(accountId: string): string;
+  /** Load session data from disk */
+  loadSessionData(accountId: string): GossipSessionData | null;
+  /** Save session data to disk */
+  saveSessionData(accountId: string, data: GossipSessionData): void;
+  /** Save encrypted session blob */
+  saveSessionBlob(accountId: string, blob: Uint8Array, encryptionKey: Uint8Array): void;
+  /** Load encrypted session blob */
+  loadSessionBlob(accountId: string): { blob: Uint8Array; encryptionKey: Uint8Array } | null;
+  /** Check if session data exists */
+  hasSessionData(accountId: string): boolean;
+  /** Delete session data */
+  deleteSessionData(accountId: string): void;
+  /** Save exported Dexie database JSON to disk */
+  saveDexieDb(accountId: string, json: string): Promise<void>;
+  /** Load exported Dexie database JSON from disk (returns null if not found) */
+  loadDexieDb(accountId: string): Promise<string | null>;
+}
+
+/**
+ * Get the base directory for Gossip sessions.
+ * Uses ~/.openclaw/sessions/gossip/
+ */
+export function getGossipSessionsBaseDir(): string {
+  const openclawDir = getGossipResolveUserPath("~/.openclaw");
+  return path.join(openclawDir, "sessions", "gossip");
+}
+
+/**
+ * Create a file-based storage adapter for Gossip sessions.
+ */
+export function createGossipStorageAdapter(log?: {
+  debug?(message: string): void;
+}): GossipStorageAdapter {
+  const baseDir = getGossipSessionsBaseDir();
+
+  const debug = (msg: string): void => {
+    log?.debug?.(msg);
+  };
+
+  const ensureDir = (dir: string): void => {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+  };
+
+  const getSessionDir = (accountId: string): string => {
+    const dir = path.join(baseDir, accountId);
+    ensureDir(dir);
+    return dir;
+  };
+
+  const getSessionFilePath = (accountId: string): string => {
+    return path.join(getSessionDir(accountId), "session.json");
+  };
+
+  const getBlobFilePath = (accountId: string): string => {
+    return path.join(getSessionDir(accountId), "session.blob");
+  };
+
+  const getKeyFilePath = (accountId: string): string => {
+    return path.join(getSessionDir(accountId), "encryption.key");
+  };
+
+  return {
+    getSessionDir,
+
+    loadSessionData(accountId: string): GossipSessionData | null {
+      const filePath = getSessionFilePath(accountId);
+      const exists = fs.existsSync(filePath);
+      debug(
+        `gossip storage: loadSessionData accountId=${accountId} path=${filePath} exists=${exists}`,
+      );
+      if (!exists) {
+        return null;
+      }
+      try {
+        const raw = fs.readFileSync(filePath, "utf-8");
+        return JSON.parse(raw) as GossipSessionData;
+      } catch {
+        return null;
+      }
+    },
+
+    saveSessionData(accountId: string, data: GossipSessionData): void {
+      ensureDir(getSessionDir(accountId));
+      const filePath = getSessionFilePath(accountId);
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
+      debug(`gossip storage: saveSessionData accountId=${accountId} path=${filePath}`);
+    },
+
+    saveSessionBlob(accountId: string, blob: Uint8Array, encryptionKey: Uint8Array): void {
+      ensureDir(getSessionDir(accountId));
+
+      // Save the encrypted session blob
+      const blobPath = getBlobFilePath(accountId);
+      fs.writeFileSync(blobPath, Buffer.from(blob), { mode: 0o600 });
+
+      // Save the encryption key
+      const keyPath = getKeyFilePath(accountId);
+      fs.writeFileSync(keyPath, Buffer.from(encryptionKey).toString("base64"), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
+
+      debug(
+        `gossip storage: saveSessionBlob accountId=${accountId} blobPath=${blobPath} keyPath=${keyPath}`,
+      );
+
+      // Also update the session.json metadata (encryption key + timestamp).
+      const sessionData = this.loadSessionData(accountId);
+      if (sessionData) {
+        sessionData.encryptionKey = Buffer.from(encryptionKey).toString("base64");
+        sessionData.updatedAt = new Date().toISOString();
+        this.saveSessionData(accountId, sessionData);
+      }
+    },
+
+    loadSessionBlob(accountId: string): { blob: Uint8Array; encryptionKey: Uint8Array } | null {
+      const blobPath = getBlobFilePath(accountId);
+      const keyPath = getKeyFilePath(accountId);
+      const blobExists = fs.existsSync(blobPath);
+      const keyExists = fs.existsSync(keyPath);
+
+      debug(
+        `gossip storage: loadSessionBlob accountId=${accountId} blobPath=${blobPath} blobExists=${blobExists} keyPath=${keyPath} keyExists=${keyExists}`,
+      );
+
+      if (!blobExists || !keyExists) {
+        return null;
+      }
+
+      try {
+        const blobBuffer = fs.readFileSync(blobPath);
+        const keyBase64 = fs.readFileSync(keyPath, "utf-8").trim();
+        const keyBuffer = Buffer.from(keyBase64, "base64");
+        return {
+          blob: new Uint8Array(blobBuffer.buffer, blobBuffer.byteOffset, blobBuffer.byteLength),
+          encryptionKey: new Uint8Array(
+            keyBuffer.buffer,
+            keyBuffer.byteOffset,
+            keyBuffer.byteLength,
+          ),
+        };
+      } catch {
+        return null;
+      }
+    },
+
+    hasSessionData(accountId: string): boolean {
+      const filePath = getSessionFilePath(accountId);
+      const exists = fs.existsSync(filePath);
+      debug(
+        `gossip storage: hasSessionData accountId=${accountId} path=${filePath} exists=${exists}`,
+      );
+      return exists;
+    },
+
+    deleteSessionData(accountId: string): void {
+      const sessionDir = path.join(baseDir, accountId);
+      if (fs.existsSync(sessionDir)) {
+        fs.rmSync(sessionDir, { recursive: true, force: true });
+      }
+    },
+
+    async saveDexieDb(accountId: string, json: string): Promise<void> {
+      ensureDir(getSessionDir(accountId));
+      const filePath = path.join(getSessionDir(accountId), "dexie-db.json");
+      fs.writeFileSync(filePath, json, { encoding: "utf-8", mode: 0o600 });
+      debug(`gossip storage: saveDexieDb accountId=${accountId} path=${filePath}`);
+    },
+
+    async loadDexieDb(accountId: string): Promise<string | null> {
+      const filePath = path.join(getSessionDir(accountId), "dexie-db.json");
+      const exists = fs.existsSync(filePath);
+      debug(`gossip storage: loadDexieDb accountId=${accountId} path=${filePath} exists=${exists}`);
+      if (!exists) {
+        return null;
+      }
+      try {
+        return fs.readFileSync(filePath, "utf-8");
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Convert Uint8Array to base64 string
+ */
+export function uint8ArrayToBase64(arr: Uint8Array): string {
+  return Buffer.from(arr).toString("base64");
+}
+
+/**
+ * Convert base64 string to Uint8Array
+ */
+export function base64ToUint8Array(base64: string): Uint8Array {
+  const buffer = Buffer.from(base64, "base64");
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+}

--- a/extensions/gossip/src/types.ts
+++ b/extensions/gossip/src/types.ts
@@ -1,0 +1,95 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { decodeFromBase64, encodeUserId, isValidUserId } from "@massalabs/gossip-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { DEFAULT_PROTOCOL_URL, DEFAULT_USERNAME } from "./onboarding.js";
+
+export interface GossipAccountConfig {
+  enabled?: boolean;
+  name?: string;
+  mnemonic?: string;
+  username?: string;
+  protocolUrl?: string;
+  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
+  allowFrom?: Array<string | number>;
+}
+
+export interface ResolvedGossipAccount {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  configured: boolean;
+  mnemonic: string;
+  username: string;
+  protocolUrl: string;
+  userId?: string; // Set after session is opened
+  config: GossipAccountConfig;
+}
+/**
+ * List all configured Gossip account IDs
+ */
+export function listGossipAccountIds(cfg: OpenClawConfig): string[] {
+  const gossipCfg = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | GossipAccountConfig
+    | undefined;
+
+  // If mnemonic is configured at top level, we have a default account
+  // Also consider configured if no mnemonic (will auto-generate)
+  if (gossipCfg?.enabled !== false) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+
+  return [];
+}
+
+/**
+ * Get the default account ID
+ */
+export function resolveDefaultGossipAccountId(cfg: OpenClawConfig): string {
+  const ids = listGossipAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+/**
+ * Resolve a Gossip account from config
+ */
+export function resolveGossipAccount(opts: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedGossipAccount {
+  const accountId = opts.accountId ?? DEFAULT_ACCOUNT_ID;
+  const gossipCfg = (opts.cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | GossipAccountConfig
+    | undefined;
+
+  const baseEnabled = gossipCfg?.enabled !== false;
+  const mnemonic = gossipCfg?.mnemonic ?? "";
+  const username = gossipCfg?.username ?? DEFAULT_USERNAME;
+  const protocolUrl = gossipCfg?.protocolUrl ?? DEFAULT_PROTOCOL_URL;
+
+  // Account is considered "configured" if enabled.
+  // Mnemonic can be auto-generated if not provided.
+  const configured = baseEnabled;
+
+  return {
+    accountId,
+    name: gossipCfg?.name?.trim() || undefined,
+    enabled: baseEnabled,
+    configured,
+    mnemonic,
+    username,
+    protocolUrl,
+    userId: undefined, // Set when session is opened
+    config: {
+      enabled: gossipCfg?.enabled,
+      name: gossipCfg?.name,
+      mnemonic: gossipCfg?.mnemonic,
+      username: gossipCfg?.username,
+      protocolUrl: gossipCfg?.protocolUrl,
+      dmPolicy: gossipCfg?.dmPolicy,
+      allowFrom: gossipCfg?.allowFrom,
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,10 @@ importers:
         version: 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock':
         specifier: ^3.985.0
-        version: 3.985.0
+        version: 3.986.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260130162700
-        version: 0.0.0-beta-20260130162700(hono@4.11.8)
+        version: 0.0.0-beta-20260130162700(bufferutil@4.1.0)(hono@4.11.8)(utf-8-validate@6.0.6)
       '@clack/prompts':
         specifier: ^1.0.0
         version: 1.0.0
@@ -41,7 +41,7 @@ importers:
         version: 1.3.4
       '@larksuiteoapi/node-sdk':
         specifier: ^1.58.0
-        version: 1.58.0
+        version: 1.58.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0
@@ -50,13 +50,13 @@ importers:
         version: 1.2.0-beta.3
       '@mariozechner/pi-agent-core':
         specifier: 0.52.7
-        version: 0.52.7(ws@8.19.0)(zod@4.3.6)
+        version: 0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.52.7
-        version: 0.52.7(ws@8.19.0)(zod@4.3.6)
+        version: 0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.52.7
-        version: 0.52.7(ws@8.19.0)(zod@4.3.6)
+        version: 0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: 0.52.7
         version: 0.52.7
@@ -65,19 +65,19 @@ importers:
         version: 0.6.0
       '@napi-rs/canvas':
         specifier: ^0.1.89
-        version: 0.1.89
+        version: 0.1.91
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
       '@slack/bolt':
         specifier: ^4.6.0
-        version: 4.6.0(@types/express@5.0.6)
+        version: 4.6.0(@types/express@5.0.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@slack/web-api':
         specifier: ^7.13.0
         version: 7.13.0
       '@whiskeysockets/baileys':
         specifier: 7.0.0-rc.9
-        version: 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+        version: 7.0.0-rc.9(audio-decode@2.2.3)(bufferutil@4.1.0)(sharp@0.34.5)(utf-8-validate@6.0.6)
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -134,7 +134,7 @@ importers:
         version: 14.1.0
       node-edge-tts:
         specifier: ^1.2.10
-        version: 1.2.10
+        version: 1.2.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       node-llama-cpp:
         specifier: 3.15.1
         version: 3.15.1(typescript@5.9.3)
@@ -173,7 +173,7 @@ importers:
         version: 7.21.0
       ws:
         specifier: ^8.19.0
-        version: 8.19.0
+        version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
@@ -198,7 +198,7 @@ importers:
         version: 14.1.2
       '@types/node':
         specifier: ^25.2.1
-        version: 25.2.1
+        version: 25.2.3
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -213,7 +213,7 @@ importers:
         version: 7.0.0-dev.20260206.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -225,10 +225,10 @@ importers:
         version: 0.28.0
       oxlint:
         specifier: ^1.43.0
-        version: 1.43.0(oxlint-tsgolint@0.11.4)
+        version: 1.43.0(oxlint-tsgolint@0.11.5)
       oxlint-tsgolint:
         specifier: ^0.11.4
-        version: 0.11.4
+        version: 0.11.5
       rolldown:
         specifier: 1.0.0-rc.3
         version: 1.0.0-rc.3
@@ -243,7 +243,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   extensions/bluebubbles:
     devDependencies:
@@ -307,7 +307,7 @@ importers:
     dependencies:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.58.0
-        version: 1.58.0
+        version: 1.58.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
@@ -336,6 +336,25 @@ importers:
       google-auth-library:
         specifier: ^10.5.0
         version: 10.5.0
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
+  extensions/gossip:
+    dependencies:
+      '@massalabs/gossip-sdk':
+        specifier: 0.0.2-dev.20260211172752
+        version: 0.0.2-dev.20260211172752(dexie@4.2.1)(zustand@5.0.10)
+      dexie:
+        specifier: ^4.0.0
+        version: 4.2.1
+      fake-indexeddb:
+        specifier: ^6.0.0
+        version: 6.2.5
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -378,7 +397,7 @@ importers:
         version: 14.1.0
       music-metadata:
         specifier: ^11.11.2
-        version: 11.11.2
+        version: 11.12.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -409,7 +428,7 @@ importers:
         version: 0.34.48
       openai:
         specifier: ^6.18.0
-        version: 6.18.0(ws@8.19.0)(zod@4.3.6)
+        version: 6.19.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -507,7 +526,7 @@ importers:
         version: 8.0.3
       '@twurple/chat':
         specifier: ^8.0.3
-        version: 8.0.3(@twurple/auth@8.0.3)
+        version: 8.0.3(@twurple/auth@8.0.3)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -523,7 +542,7 @@ importers:
         version: 0.34.48
       ws:
         specifier: ^8.19.0
-        version: 8.19.0
+        version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -584,17 +603,17 @@ importers:
         version: 17.0.1
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     devDependencies:
       '@vitest/browser-playwright':
         specifier: 4.0.18
-        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+        version: 4.0.18(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -629,12 +648,12 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-bedrock-runtime@3.985.0':
-    resolution: {integrity: sha512-jkQ+G+b/6Z6gUsn8jNSjJsFVgxnA4HtyOjrpHfmp8nHWLRFTOIw3HfY2vAlDgg/uUJ7cezVG0/tmbwujFqX25A==}
+  '@aws-sdk/client-bedrock-runtime@3.986.0':
+    resolution: {integrity: sha512-QFWFS8dCydWP1fsinjDo1QNKI9/aYYiD1KqVaWw7J3aYtdtcdyXD/ghnUms6P/IJycea2k+1xvVpvuejRG3SNw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-bedrock@3.985.0':
-    resolution: {integrity: sha512-f2+AnyRQzb0GPwkKsE2lWTchNwnuysYs6GVN1k0PV1w3irFh/m0Hz125LXC6jdogHwzLqQxGHqwiZzVxhF5CvA==}
+  '@aws-sdk/client-bedrock@3.986.0':
+    resolution: {integrity: sha512-xQo4j2vtdwERk/cuKJBN8A4tpoPr9Rr08QU7jRsekjLiJwr4VsWkNhJh+Z4X/dpUFh6Vwpu5GiQr0HPa7xlCFQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sso@3.985.0':
@@ -701,12 +720,16 @@ packages:
     resolution: {integrity: sha512-HUD+geASjXSCyL/DHPQc/Ua7JhldTcIglVAoCV8kiVm99IaFSlAbTvEnyhZwdE6bdFyTL+uIaWLaCFSRsglZBQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-websocket@3.972.5':
-    resolution: {integrity: sha512-BN4A9K71WRIlpQ3+IYGdBC2wVyobZ95g6ZomodmJ8Te772GWo0iDk2Mv6JIHdr842tOTgi1b3npLIFDUS4hl4g==}
+  '@aws-sdk/middleware-websocket@3.972.6':
+    resolution: {integrity: sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==}
     engines: {node: '>= 14.0.0'}
 
   '@aws-sdk/nested-clients@3.985.0':
     resolution: {integrity: sha512-TsWwKzb/2WHafAY0CE7uXgLj0FmnkBTgfioG9HO+7z/zCPcl1+YU+i7dW4o0y+aFxFgxTMG+ExBQpqT/k2ao8g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.986.0':
+    resolution: {integrity: sha512-/yq4hr3KUBIIX/bcccscXOzFoe6NSiAUFTsHaM2VZWYpPw7JwlqnPsfFVONAjuuYovjP/O+qYBx1oj85C7Dplw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.3':
@@ -717,6 +740,10 @@ packages:
     resolution: {integrity: sha512-+hwpHZyEq8k+9JL2PkE60V93v2kNhUIv7STFt+EAez1UJsJOQDhc5LpzEX66pNjclI5OTwBROs/DhJjC/BtMjQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.986.0':
+    resolution: {integrity: sha512-1T2/iqONrISWJPUFyznvjVdoZrpFjuhI0FKjTrA2iSmEFpzWu+ctgGHYdxNoBNVzleO8BFD+w8S+rDQAuAre5g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.1':
     resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
     engines: {node: '>=20.0.0'}
@@ -725,12 +752,16 @@ packages:
     resolution: {integrity: sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/util-endpoints@3.986.0':
+    resolution: {integrity: sha512-Mqi79L38qi1gCG3adlVdbNrSxvcm1IPDLiJPA3OBypY5ewxUyWbaA3DD4goG+EwET6LSFgZJcRSIh6KBNpP5pA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-format-url@3.972.3':
     resolution: {integrity: sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-locate-window@3.965.4':
-    resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
+  '@aws-sdk/util-locate-window@3.965.3':
+    resolution: {integrity: sha512-FNUqAjlKAGA7GM05kywE99q8wiPHPZqrzhq3wXRga6PRD6A0kzT85Pb0AzYBVTBRpSrKyyr6M92Y6bnSBVp2BA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-user-agent-browser@3.972.3':
@@ -793,8 +824,8 @@ packages:
     resolution: {integrity: sha512-I4YnARytXC2RzkLNVnf5qFNFMzp679qZpmtw/V3Jt2uGnWiIxyJtaukjG7R8pSx8nG2NamICpGfljQsogj+FbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+  '@babel/parser@7.28.6':
+    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -807,8 +838,8 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+  '@babel/types@7.28.6':
+    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.0-rc.1':
@@ -832,8 +863,8 @@ packages:
     resolution: {integrity: sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==}
     engines: {node: '>=18'}
 
-  '@cacheable/utils@2.3.4':
-    resolution: {integrity: sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==}
+  '@cacheable/utils@2.3.3':
+    resolution: {integrity: sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==}
 
   '@clack/core@1.0.0':
     resolution: {integrity: sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ==}
@@ -890,158 +921,158 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1098,8 +1129,8 @@ packages:
     peerDependencies:
       hono: 4.11.8
 
-  '@huggingface/jinja@0.5.4':
-    resolution: {integrity: sha512-VoQJywjpjy2D88Oj0BTHRuS8JCbUgoOg5t1UGgbtGh2fRia9Dx/k6Wf8FqrEWIvWK9fAkfJeeLB9fcSpCNPCpw==}
+  '@huggingface/jinja@0.5.3':
+    resolution: {integrity: sha512-asqfZ4GQS0hD876Uw4qiUb7Tr/V5Q+JZuo2L+BtdrD4U40QU58nIRq3ZSgAzJgT874VLjhGVacaYfrdpXtEvtA==}
     engines: {node: '>=18'}
 
   '@img/colour@1.0.0':
@@ -1241,6 +1272,10 @@ packages:
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
     engines: {node: 20 || >=22}
 
   '@isaacs/brace-expansion@5.0.1':
@@ -1467,6 +1502,15 @@ packages:
     resolution: {integrity: sha512-wS9zw4lvUaVU8jAGdk4C2KN/AwEsESrguUGNpZs7g9PD8iDBE9gnXtMvtny4PDbjOk0mZ5D0CEUgMzl/ZhqH8w==}
     engines: {node: '>=20.0.0'}
 
+  '@massalabs/gossip-sdk@0.0.2-dev.20260211172752':
+    resolution: {integrity: sha512-m4noBkXC4wMaPkZg7H8zYr1iA4mFcKXnUuwjEpJmfZh5faftHkd1HdeVRAMPedWG2a5ke2p5I9eI3XwqfUr0Sw==}
+    peerDependencies:
+      dexie: ^4.0.0
+      zustand: ^5.0.0
+
+  '@massalabs/massa-web3@5.3.0':
+    resolution: {integrity: sha512-bct2IwjUXN87KaUL3wBc70s6l4N4gVGweIFnVGnxFpp+uJESfwK1oty89yRbrq5Y0LVL3Y6TYZUH5FxJU5QkvA==}
+
   '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
     resolution: {integrity: sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==}
     engines: {node: '>= 22'}
@@ -1494,144 +1538,74 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
-  '@napi-rs/canvas-android-arm64@0.1.89':
-    resolution: {integrity: sha512-CXxQTXsjtQqKGENS8Ejv9pZOFJhOPIl2goenS+aU8dY4DygvkyagDhy/I07D1YLqrDtPvLEX5zZHt8qUdnuIpQ==}
+  '@napi-rs/canvas-android-arm64@0.1.91':
+    resolution: {integrity: sha512-SLLzXXgSnfct4zy/BVAfweZQkYkPJsNsJ2e5DOE8DFEHC6PufyUrwb12yqeu2So2IOIDpWJJaDAxKY/xpy6MYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-android-arm64@0.1.90':
-    resolution: {integrity: sha512-3JBULVF+BIgr7yy7Rf8UjfbkfFx4CtXrkJFD1MDgKJ83b56o0U9ciT8ZGTCNmwWkzu8RbNKlyqPP3KYRG88y7Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
-  '@napi-rs/canvas-darwin-arm64@0.1.89':
-    resolution: {integrity: sha512-k29cR/Zl20WLYM7M8YePevRu2VQRaKcRedYr1V/8FFHkyIQ8kShEV+MPoPGi+znvmd17Eqjy2Pk2F2kpM2umVg==}
+  '@napi-rs/canvas-darwin-arm64@0.1.91':
+    resolution: {integrity: sha512-bzdbCjIjw3iRuVFL+uxdSoMra/l09ydGNX9gsBxO/zg+5nlppscIpj6gg+nL6VNG85zwUarDleIrUJ+FWHvmuA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-arm64@0.1.90':
-    resolution: {integrity: sha512-L8XVTXl+8vd8u7nPqcX77NyG5RuFdVsJapQrKV9WE3jBayq1aSMht/IH7Dwiz/RNJ86E5ZSg9pyUPFIlx52PZA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/canvas-darwin-x64@0.1.89':
-    resolution: {integrity: sha512-iUragqhBrA5FqU13pkhYBDbUD1WEAIlT8R2+fj6xHICY2nemzwMUI8OENDhRh7zuL06YDcRwENbjAVxOmaX9jg==}
+  '@napi-rs/canvas-darwin-x64@0.1.91':
+    resolution: {integrity: sha512-q3qpkpw0IsG9fAS/dmcGIhCVoNxj8ojbexZKWwz3HwxlEWsLncEQRl4arnxrwbpLc2nTNTyj4WwDn7QR5NDAaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-x64@0.1.90':
-    resolution: {integrity: sha512-h0ukhlnGhacbn798VWYTQZpf6JPDzQYaow+vtQ2Fat7j7ImDdpg6tfeqvOTO1r8wS+s+VhBIFITC7aA1Aik0ZQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.89':
-    resolution: {integrity: sha512-y3SM9sfDWasY58ftoaI09YBFm35Ig8tosZqgahLJ2WGqawCusGNPV9P0/4PsrLOCZqGg629WxexQMY25n7zcvA==}
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.91':
+    resolution: {integrity: sha512-Io3g8wJZVhK8G+Fpg1363BE90pIPqg+ZbeehYNxPWDSzbgwU3xV0l8r/JBzODwC7XHi1RpFEk+xyUTMa2POj6w==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.90':
-    resolution: {integrity: sha512-JCvTl99b/RfdBtgftqrf+5UNF7GIbp7c5YBFZ+Bd6++4Y3phaXG/4vD9ZcF1bw1P4VpALagHmxvodHuQ9/TfTg==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.89':
-    resolution: {integrity: sha512-NEoF9y8xq5fX8HG8aZunBom1ILdTwt7ayBzSBIwrmitk7snj4W6Fz/yN/ZOmlM1iyzHDNX5Xn0n+VgWCF8BEdA==}
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.91':
+    resolution: {integrity: sha512-HBnto+0rxx1bQSl8bCWA9PyBKtlk2z/AI32r3cu4kcNO+M/5SD4b0v1MWBWZyqMQyxFjWgy3ECyDjDKMC6tY1A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.90':
-    resolution: {integrity: sha512-vbWFp8lrP8NIM5L4zNOwnsqKIkJo0+GIRUDcLFV9XEJCptCc1FY6/tM02PT7GN4PBgochUPB1nBHdji6q3ieyQ==}
+  '@napi-rs/canvas-linux-arm64-musl@0.1.91':
+    resolution: {integrity: sha512-/eJtVe2Xw9A86I4kwXpxxoNagdGclu12/NSMsfoL8q05QmeRCbfjhg1PJS7ENAuAvaiUiALGrbVfeY1KU1gztQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.89':
-    resolution: {integrity: sha512-UQQkIEzV12/l60j1ziMjZ+mtodICNUbrd205uAhbyTw0t60CrC/EsKb5/aJWGq1wM0agvcgZV72JJCKfLS6+4w==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.90':
-    resolution: {integrity: sha512-8Bc0BgGEeOaux4EfIfNzcRRw0JE+lO9v6RWQFCJNM9dJFE4QJffTf88hnmbOaI6TEMpgWOKipbha3dpIdUqb/g==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.89':
-    resolution: {integrity: sha512-1/VmEoFaIO6ONeeEMGoWF17wOYZOl5hxDC1ios2Bkz/oQjbJJ8DY/X22vWTmvuUKWWhBVlo63pxLGZbjJU/heA==}
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.91':
+    resolution: {integrity: sha512-floNK9wQuRWevUhhXRcuis7h0zirdytVxPgkonWO+kQlbvxV7gEUHGUFQyq4n55UHYFwgck1SAfJ1HuXv/+ppQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.90':
-    resolution: {integrity: sha512-0iiVDG5IH+gJb/YUrY/pRdbsjcgvwUmeckL/0gShWAA7004ygX2ST69M1wcfyxXrzFYjdF8S/Sn6aCAeBi89XQ==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.89':
-    resolution: {integrity: sha512-ebLuqkCuaPIkKgKH9q4+pqWi1tkPOfiTk5PM1LKR1tB9iO9sFNVSIgwEp+SJreTSbA2DK5rW8lQXiN78SjtcvA==}
+  '@napi-rs/canvas-linux-x64-gnu@0.1.91':
+    resolution: {integrity: sha512-c3YDqBdf7KETuZy2AxsHFMsBBX1dWT43yFfWUq+j1IELdgesWtxf/6N7csi3VPf6VA3PmnT9EhMyb+M1wfGtqw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.90':
-    resolution: {integrity: sha512-SkKmlHMvA5spXuKfh7p6TsScDf7lp5XlMbiUhjdCtWdOS6Qke/A4qGVOciy6piIUCJibL+YX+IgdGqzm2Mpx/w==}
+  '@napi-rs/canvas-linux-x64-musl@0.1.91':
+    resolution: {integrity: sha512-RpZ3RPIwgEcNBHSHSX98adm+4VP8SMT5FN6250s5jQbWpX/XNUX5aLMfAVJS/YnDjS1QlsCgQxFOPU0aCCWgag==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.89':
-    resolution: {integrity: sha512-w+5qxHzplvA4BkHhCaizNMLLXiI+CfP84YhpHm/PqMub4u8J0uOAv+aaGv40rYEYra5hHRWr9LUd6cfW32o9/A==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.90':
-    resolution: {integrity: sha512-o6QgS10gAS4vvELGDOOWYfmERXtkVRYFWBCjomILWfMgCvBVutn8M97fsMW5CrEuJI8YuxuJ7U+/DQ9oG93vDA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.89':
-    resolution: {integrity: sha512-DmyXa5lJHcjOsDC78BM3bnEECqbK3xASVMrKfvtT/7S7Z8NGQOugvu+L7b41V6cexCd34mBWgMOsjoEBceeB1Q==}
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.91':
+    resolution: {integrity: sha512-gF8MBp4X134AgVurxqlCdDA2qO0WaDdi9o6Sd5rWRVXRhWhYQ6wkdEzXNLIrmmros0Tsp2J0hQzx4ej/9O8trQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.90':
-    resolution: {integrity: sha512-2UHO/DC1oyuSjeCAhHA0bTD9qsg58kknRqjJqRfvIEFtdqdtNTcWXMCT9rQCuJ8Yx5ldhyh2SSp7+UDqD2tXZQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.89':
-    resolution: {integrity: sha512-WMej0LZrIqIncQcx0JHaMXlnAG7sncwJh7obs/GBgp0xF9qABjwoRwIooMWCZkSansapKGNUHhamY6qEnFN7gA==}
+  '@napi-rs/canvas-win32-x64-msvc@0.1.91':
+    resolution: {integrity: sha512-++gtW9EV/neKI8TshD8WFxzBYALSPag2kFRahIJV+LYsyt5kBn21b1dBhEUDHf7O+wiZmuFCeUa7QKGHnYRZBA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.90':
-    resolution: {integrity: sha512-48CxEbzua5BP4+OumSZdi3+9fNiRO8cGNBlO2bKwx1PoyD1R2AXzPtqd/no1f1uSl0W2+ihOO1v3pqT3USbmgQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@napi-rs/canvas@0.1.89':
-    resolution: {integrity: sha512-7GjmkMirJHejeALCqUnZY3QwID7bbumOiLrqq2LKgxrdjdmxWQBTc6rcASa2u8wuWrH7qo4/4n/VNrOwCoKlKg==}
-    engines: {node: '>= 10'}
-
-  '@napi-rs/canvas@0.1.90':
-    resolution: {integrity: sha512-vO9j7TfwF9qYCoTOPO39yPLreTRslBVOaeIwhDZkizDvBb0MounnTl0yeWUMBxP4Pnkg9Sv+3eQwpxNUmTwt0w==}
+  '@napi-rs/canvas@0.1.91':
+    resolution: {integrity: sha512-eeIe1GoB74P1B0Nkw6pV8BCQ3hfCfvyYr4BntzlCsnFXzVJiPMDnLeIx3gVB0xQMblHYnjK/0nCLvirEhOjr5g==}
     engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.1':
@@ -1645,8 +1619,15 @@ packages:
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/ed25519@1.7.5':
+    resolution: {integrity: sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==}
+
   '@noble/ed25519@3.0.0':
     resolution: {integrity: sha512-QyteqMNm0GLqfa5SoYbSC3+Pvykwpn95Zgth4MFVSMKBB75ELl9tX1LAVsN4c3HXOrakHsF2gL4zWDAYCcsnzg==}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
@@ -2048,33 +2029,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.11.4':
-    resolution: {integrity: sha512-IhdhiC183s5wdFDZSQC8PaFFq1QROiVT5ahz7ysgEKVnkNDjy82ieM7ZKiUfm2ncXNX2RcFGSSZrQO6plR+VAQ==}
+  '@oxlint-tsgolint/darwin-arm64@0.11.5':
+    resolution: {integrity: sha512-mzsjJVIUgcGJovBXME63VW2Uau7MS/xCe7xdYj2BplSCuRb5Yoy7WuwCIlbD5ISHjnS6rx26oD2kmzHLRV5Wfw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.11.4':
-    resolution: {integrity: sha512-KJmBg10Z1uGpJqxDzETXOytYyeVrKUepo8rCXeVkRlZ2QzZqMElgalFN4BI3ccgIPkQpzzu4SVzWNFz7yiKavQ==}
+  '@oxlint-tsgolint/darwin-x64@0.11.5':
+    resolution: {integrity: sha512-zItUS0qLzSzVy0ZQHc4MOphA9lVeP5jffsgZFLCdo+JqmkbVZ14aDtiVUHSHi2hia+qatbb109CHQ9YIl0x7+A==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.11.4':
-    resolution: {integrity: sha512-P6I3dSSpoEnjFzTMlrbcBHNbErSxceZmcVUslBxrrIUH1NSVS1XfSz6S75vT2Gay7Jv6LI7zTTVAk4cSqkfe+w==}
+  '@oxlint-tsgolint/linux-arm64@0.11.5':
+    resolution: {integrity: sha512-R0r/3QTdMtIjfUOM1oxIaCV0s+j7xrnUe4CXo10ZbBzlXfMesWYNcf/oCrhsy87w0kCPFsg58nAdKaIR8xylFg==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.11.4':
-    resolution: {integrity: sha512-G0eAW3S7cp/vP7Kx6e7+Ze7WfNgSt1tc/rOexfLKnnIi+9BelyOa2wF9bWFPpxk3n3AdkBwKttU1/adDZlD87Q==}
+  '@oxlint-tsgolint/linux-x64@0.11.5':
+    resolution: {integrity: sha512-g23J3T29EHWUQYC6aTwLnhwcFtjQh+VfxyGuFjYGGTLhESdlQH9E/pwsN8K9HaAiYWjI51m3r3BqQjXxEW8Jjg==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.11.4':
-    resolution: {integrity: sha512-prgQEBiwp4TAxarh6dYbVOKw6riRJ6hB49vDD6DxQlOZQky7xHQ9qTec5/rf0JTUZ16YaJ9YfHycbJS3QVpTYw==}
+  '@oxlint-tsgolint/win32-arm64@0.11.5':
+    resolution: {integrity: sha512-MJNT/MPUIZKQCRtCX5s6pCnoe7If/i3RjJzFMe4kSLomRsHrNFYOJBwt4+w/Hqfyg9jNOgR8tbgdx6ofjHaPMQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.11.4':
-    resolution: {integrity: sha512-5xXTzZIT/1meWMmS60Q+FYWvWncc6iTfC8tyQt7GDfPUoqQvE5WVgHm1QjDSJvxTD+6AHphpCqdhXq/KtxagRw==}
+  '@oxlint-tsgolint/win32-x64@0.11.5':
+    resolution: {integrity: sha512-IQmj4EkcZOBlLnj1CdxKFrWT7NAWXZ9ypZ874X/w7S5gRzB2sO4KmE6Z0MWxx05pL9AQF+CWVRjZrKVIYWTzPg==}
     cpu: [x64]
     os: [win32]
 
@@ -2293,128 +2274,128 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
-    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+  '@rollup/rollup-android-arm-eabi@4.55.3':
+    resolution: {integrity: sha512-qyX8+93kK/7R5BEXPC2PjUt0+fS/VO2BVHjEHyIEWiYn88rcRBHmdLgoJjktBltgAf+NY7RfCGB1SoyKS/p9kg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.57.1':
-    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+  '@rollup/rollup-android-arm64@4.55.3':
+    resolution: {integrity: sha512-6sHrL42bjt5dHQzJ12Q4vMKfN+kUnZ0atHHnv4V0Wd9JMTk7FDzSY35+7qbz3ypQYMBPANbpGK7JpnWNnhGt8g==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.57.1':
-    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+  '@rollup/rollup-darwin-arm64@4.55.3':
+    resolution: {integrity: sha512-1ht2SpGIjEl2igJ9AbNpPIKzb1B5goXOcmtD0RFxnwNuMxqkR6AUaaErZz+4o+FKmzxcSNBOLrzsICZVNYa1Rw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.57.1':
-    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+  '@rollup/rollup-darwin-x64@4.55.3':
+    resolution: {integrity: sha512-FYZ4iVunXxtT+CZqQoPVwPhH7549e/Gy7PIRRtq4t5f/vt54pX6eG9ebttRH6QSH7r/zxAFA4EZGlQ0h0FvXiA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.57.1':
-    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+  '@rollup/rollup-freebsd-arm64@4.55.3':
+    resolution: {integrity: sha512-M/mwDCJ4wLsIgyxv2Lj7Len+UMHd4zAXu4GQ2UaCdksStglWhP61U3uowkaYBQBhVoNpwx5Hputo8eSqM7K82Q==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.57.1':
-    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+  '@rollup/rollup-freebsd-x64@4.55.3':
+    resolution: {integrity: sha512-5jZT2c7jBCrMegKYTYTpni8mg8y3uY8gzeq2ndFOANwNuC/xJbVAoGKR9LhMDA0H3nIhvaqUoBEuJoICBudFrA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
-    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.3':
+    resolution: {integrity: sha512-YeGUhkN1oA+iSPzzhEjVPS29YbViOr8s4lSsFaZKLHswgqP911xx25fPOyE9+khmN6W4VeM0aevbDp4kkEoHiA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
-    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.55.3':
+    resolution: {integrity: sha512-eo0iOIOvcAlWB3Z3eh8pVM8hZ0oVkK3AjEM9nSrkSug2l15qHzF3TOwT0747omI6+CJJvl7drwZepT+re6Fy/w==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
-    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+  '@rollup/rollup-linux-arm64-gnu@4.55.3':
+    resolution: {integrity: sha512-DJay3ep76bKUDImmn//W5SvpjRN5LmK/ntWyeJs/dcnwiiHESd3N4uteK9FDLf0S0W8E6Y0sVRXpOCoQclQqNg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
-    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+  '@rollup/rollup-linux-arm64-musl@4.55.3':
+    resolution: {integrity: sha512-BKKWQkY2WgJ5MC/ayvIJTHjy0JUGb5efaHCUiG/39sSUvAYRBaO3+/EK0AZT1RF3pSj86O24GLLik9mAYu0IJg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
-    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+  '@rollup/rollup-linux-loong64-gnu@4.55.3':
+    resolution: {integrity: sha512-Q9nVlWtKAG7ISW80OiZGxTr6rYtyDSkauHUtvkQI6TNOJjFvpj4gcH+KaJihqYInnAzEEUetPQubRwHef4exVg==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
-    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+  '@rollup/rollup-linux-loong64-musl@4.55.3':
+    resolution: {integrity: sha512-2H5LmhzrpC4fFRNwknzmmTvvyJPHwESoJgyReXeFoYYuIDfBhP29TEXOkCJE/KxHi27mj7wDUClNq78ue3QEBQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
-    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+  '@rollup/rollup-linux-ppc64-gnu@4.55.3':
+    resolution: {integrity: sha512-9S542V0ie9LCTznPYlvaeySwBeIEa7rDBgLHKZ5S9DBgcqdJYburabm8TqiqG6mrdTzfV5uttQRHcbKff9lWtA==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
-    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+  '@rollup/rollup-linux-ppc64-musl@4.55.3':
+    resolution: {integrity: sha512-ukxw+YH3XXpcezLgbJeasgxyTbdpnNAkrIlFGDl7t+pgCxZ89/6n1a+MxlY7CegU+nDgrgdqDelPRNQ/47zs0g==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
-    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+  '@rollup/rollup-linux-riscv64-gnu@4.55.3':
+    resolution: {integrity: sha512-Iauw9UsTTvlF++FhghFJjqYxyXdggXsOqGpFBylaRopVpcbfyIIsNvkf9oGwfgIcf57z3m8+/oSYTo6HutBFNw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
-    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+  '@rollup/rollup-linux-riscv64-musl@4.55.3':
+    resolution: {integrity: sha512-3OqKAHSEQXKdq9mQ4eajqUgNIK27VZPW3I26EP8miIzuKzCJ3aW3oEn2pzF+4/Hj/Moc0YDsOtBgT5bZ56/vcA==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
-    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+  '@rollup/rollup-linux-s390x-gnu@4.55.3':
+    resolution: {integrity: sha512-0CM8dSVzVIaqMcXIFej8zZrSFLnGrAE8qlNbbHfTw1EEPnFTg1U1ekI0JdzjPyzSfUsHWtodilQQG/RA55berA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+  '@rollup/rollup-linux-x64-gnu@4.55.3':
+    resolution: {integrity: sha512-+fgJE12FZMIgBaKIAGd45rxf+5ftcycANJRWk8Vz0NnMTM5rADPGuRFTYar+Mqs560xuART7XsX2lSACa1iOmQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.57.1':
-    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+  '@rollup/rollup-linux-x64-musl@4.55.3':
+    resolution: {integrity: sha512-tMD7NnbAolWPzQlJQJjVFh/fNH3K/KnA7K8gv2dJWCwwnaK6DFCYST1QXYWfu5V0cDwarWC8Sf/cfMHniNq21A==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.57.1':
-    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+  '@rollup/rollup-openbsd-x64@4.55.3':
+    resolution: {integrity: sha512-u5KsqxOxjEeIbn7bUK1MPM34jrnPwjeqgyin4/N6e/KzXKfpE9Mi0nCxcQjaM9lLmPcHmn/xx1yOjgTMtu1jWQ==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.57.1':
-    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+  '@rollup/rollup-openharmony-arm64@4.55.3':
+    resolution: {integrity: sha512-vo54aXwjpTtsAnb3ca7Yxs9t2INZg7QdXN/7yaoG7nPGbOBXYXQY41Km+S1Ov26vzOAzLcAjmMdjyEqS1JkVhw==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
-    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.55.3':
+    resolution: {integrity: sha512-HI+PIVZ+m+9AgpnY3pt6rinUdRYrGHvmVdsNQ4odNqQ/eRF78DVpMR7mOq7nW06QxpczibwBmeQzB68wJ+4W4A==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
-    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+  '@rollup/rollup-win32-ia32-msvc@4.55.3':
+    resolution: {integrity: sha512-vRByotbdMo3Wdi+8oC2nVxtc3RkkFKrGaok+a62AT8lz/YBuQjaVYAS5Zcs3tPzW43Vsf9J0wehJbUY5xRSekA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+  '@rollup/rollup-win32-x64-gnu@4.55.3':
+    resolution: {integrity: sha512-POZHq7UeuzMJljC5NjKi8vKMFN6/5EOqcX1yGntNLp7rUTpBAXQ1hW8kWPFxYLv07QMcNM75xqVLGPWQq6TKFA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
-    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+  '@rollup/rollup-win32-x64-msvc@4.55.3':
+    resolution: {integrity: sha512-aPFONczE4fUFKNXszdvnd2GqKEYQdV5oEsIbKPujJmWlCI9zEsv1Otig8RKK+X9bed9gFUN6LAeN4ZcNuu4zjg==}
     cpu: [x64]
     os: [win32]
 
@@ -2660,17 +2641,17 @@ packages:
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
 
-  '@thi.ng/bitstream@2.4.39':
-    resolution: {integrity: sha512-VhdYiBqoSpCXil4BGMgHr6fS0i1uGWTqE2oszd453bDmAdthc24VUvzZoKu7GorLopOJwrnkhpcAl5004hpYaw==}
+  '@thi.ng/bitstream@2.4.38':
+    resolution: {integrity: sha512-Y5vpB2w9zS8a6FE1G3H8QhQYYvT3qmOpXOYmKMCZKwyQXY3XCuZDFeIIm1b23CyjtED5vmdr6+E6HZaAW1GNsA==}
     engines: {node: '>=18'}
 
-  '@thi.ng/errors@2.6.2':
-    resolution: {integrity: sha512-YN89WmgOhAnK5/2gI9LckplmQCYld6adPUgjTo8DozgutAqF7zzYfuzFrCGztbT6zBwaCWUpPyQboiu+OtZIvA==}
+  '@thi.ng/errors@2.6.1':
+    resolution: {integrity: sha512-5kkJ1+JK6OInYMnRXtiJ6qZMt2zNqEuw0ZNwU8bFPfxF3yiWD5tcDNVLwE4EsMm8cGwH1K0h0TI5HIPfHSUWow==}
     engines: {node: '>=18'}
 
-  '@tinyhttp/content-disposition@2.2.3':
-    resolution: {integrity: sha512-0nSvOgFHvq0a15+pZAdbAyHUk0+AGLX6oyo45b7fPdgWdPfHA19IfgUKRECYT0aw86ZP6ZDDLxGQ7FEA1fAVOg==}
-    engines: {node: '>=12.17.0'}
+  '@tinyhttp/content-disposition@2.2.2':
+    resolution: {integrity: sha512-crXw1txzrS36huQOyQGYFvhTeLeG0Si1xu+/l6kXUVYpE0TjFjEZRqTbuadQLfKGZ0jaI+jJoRyqaWwxOSHW2g==}
+    engines: {node: '>=12.20.0'}
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
@@ -2779,14 +2760,14 @@ packages:
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
-  '@types/node@20.19.32':
-    resolution: {integrity: sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==}
+  '@types/node@20.19.30':
+    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
-  '@types/node@24.10.11':
-    resolution: {integrity: sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==}
+  '@types/node@24.10.9':
+    resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
 
-  '@types/node@25.2.1':
-    resolution: {integrity: sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==}
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
   '@types/proper-lockfile@4.1.4':
     resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
@@ -2869,8 +2850,8 @@ packages:
     resolution: {integrity: sha512-863vBkK6A63Xa4P0839GqndGrGDtH4g8I6TQ4mGVJofSyOpPKTMeTrQZ/nyOEn4kvCLuGn4d3rf20Tn1U2wU7g==}
     hasBin: true
 
-  '@typespec/ts-http-runtime@0.3.3':
-    resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
+  '@typespec/ts-http-runtime@0.3.2':
+    resolution: {integrity: sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg==}
     engines: {node: '>=20.0.0'}
 
   '@urbit/aura@3.0.0':
@@ -3080,8 +3061,8 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
-  ast-v8-to-istanbul@0.3.11:
-    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
+  ast-v8-to-istanbul@0.3.10:
+    resolution: {integrity: sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==}
 
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
@@ -3115,11 +3096,17 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@1.13.4:
-    resolution: {integrity: sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==}
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -3170,11 +3157,21 @@ packages:
   browser-or-node@1.3.0:
     resolution: {integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==}
 
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  bs58check@4.0.0:
+    resolution: {integrity: sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
 
   bun-types@1.3.6:
     resolution: {integrity: sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==}
@@ -3228,8 +3225,8 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  ci-info@4.4.0:
-    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+  ci-info@4.3.1:
+    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
 
   cjs-module-lexer@2.2.0:
@@ -3413,6 +3410,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dexie@4.2.1:
+    resolution: {integrity: sha512-Ckej0NS6jxQ4Po3OrSQBFddayRhTCic2DoCAG5zacOfOVB9P2Q5Xc5uL/nVa7ZVs+HdMnvUPzLFCB/JwpB6Csg==}
+
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
@@ -3438,6 +3438,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dotenv@17.2.4:
     resolution: {integrity: sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==}
@@ -3516,8 +3520,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3585,6 +3589,10 @@ packages:
   extsprintf@1.3.0:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -3725,6 +3733,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
@@ -3755,6 +3766,9 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  google-protobuf@3.21.4:
+    resolution: {integrity: sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3765,6 +3779,9 @@ packages:
   grammy@1.39.3:
     resolution: {integrity: sha512-7arRRoOtOh9UwMwANZ475kJrWV6P3/EGNooeHlY0/SwZv4t3ZZ3Uiz9cAXK8Zg9xSdgmm8T21kx6n7SZaWvOcw==}
     engines: {node: ^12.20.0 || >=14.13.1}
+
+  grpc-web@1.5.0:
+    resolution: {integrity: sha512-y1tS3BBIoiVSzKTDF3Hm7E8hV2n7YY7pO0Uo7depfWJqKzWE+SKr0jvHNIJsJJYILQlpYShpi/DRJJMbosgDMQ==}
 
   gtoken@8.0.0:
     resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
@@ -3819,8 +3836,8 @@ packages:
   hookable@6.0.1:
     resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
 
-  hookified@1.15.1:
-    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+  hookified@1.15.0:
+    resolution: {integrity: sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==}
 
   hosted-git-info@9.0.2:
     resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
@@ -3879,8 +3896,8 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
-  import-in-the-middle@2.0.6:
-    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
+  import-in-the-middle@2.0.5:
+    resolution: {integrity: sha512-0InH9/4oDCBRzWXhpOqusspLBrVfK1vPvbn9Wxl8DAQ8yyx5fWJRETICSwkiAMaYntjJAMBP1R4B6cQnEUYVEA==}
 
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
@@ -3983,8 +4000,8 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
-  js-tokens@10.0.0:
-    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
@@ -4177,6 +4194,10 @@ packages:
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
 
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
 
@@ -4226,8 +4247,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.5:
-    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
+  lru-cache@11.2.4:
+    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
     engines: {node: 20 || >=22}
 
   lru-cache@6.0.0:
@@ -4244,8 +4265,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.2:
-    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -4322,6 +4343,10 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
+
   minimatch@10.1.2:
     resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
@@ -4366,8 +4391,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  music-metadata@11.11.2:
-    resolution: {integrity: sha512-tJx+lsDg1bGUOxojKKj12BIvccBBUcVa6oWrvOchCF0WAQ9E5t/hK35ILp1z3wWrUSYtgg57LfRbvVMkxGIyzA==}
+  music-metadata@11.12.0:
+    resolution: {integrity: sha512-9ChYnmVmyHvFxR2g0MWFSHmJfbssRy07457G4gbb4LA9WYvyZea/8EMbqvg5dcv4oXNCNL01m8HXtymLlhhkYg==}
     engines: {node: '>=18'}
 
   mz@2.7.0:
@@ -4399,8 +4424,8 @@ packages:
     resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
     engines: {node: ^18 || ^20 || >= 21}
 
-  node-api-headers@1.8.0:
-    resolution: {integrity: sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==}
+  node-api-headers@1.7.0:
+    resolution: {integrity: sha512-uJMGdkhVwu9+I3UsVvI3KW6ICAy/yDfsu5Br9rSnTtY3WpoaComXvKloiV5wtx0Md2rn0B9n29Ys2WMNwWxj9A==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -4428,6 +4453,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-llama-cpp@3.15.1:
     resolution: {integrity: sha512-/fBNkuLGR2Q8xj2eeV12KXKZ9vCS2+o6aP11lW40pB9H6f0B3wOALi/liFrjhHukAoiH6C9wFTPzv6039+5DRA==}
@@ -4528,8 +4557,8 @@ packages:
       zod:
         optional: true
 
-  openai@6.18.0:
-    resolution: {integrity: sha512-odLRYyz9rlzz6g8gKn61RM2oP5UUm428sE2zOxZqS9MzVfD5/XW8UoEjpnRkzTuScXP7ZbP/m7fC+bl8jCOZZw==}
+  openai@6.19.0:
+    resolution: {integrity: sha512-5uGrF82Ql7TKgIWUnuxh+OyzYbPRPwYDSgGc05JowbXRFsOkuj0dJuCdPCTBZT4mcmp2NEvj/URwDzW+lYgmVw==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -4556,8 +4585,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-tsgolint@0.11.4:
-    resolution: {integrity: sha512-VyQc+69TxQwUdsEPiVFN7vNZdDVO/FHaEcHltnWs3O6rvwxv67uADlknQQO714sbRdEahOjgO5dFf+K9ili0gg==}
+  oxlint-tsgolint@0.11.5:
+    resolution: {integrity: sha512-4uVv43EhkeMvlxDU1GUsR5P5c0q74rB/pQRhjGsTOnMIrDbg3TABTntRyeAkmXItqVEJTcDRv9+Yk+LFXkHKlg==}
     hasBin: true
 
   oxlint@1.43.0:
@@ -4922,8 +4951,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.57.1:
-    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+  rollup@4.55.3:
+    resolution: {integrity: sha512-y9yUpfQvetAjiDLtNMf1hL9NXchIJgWt6zIKeoB+tCd3npX08Eqfzg60V9DhIGVMtQ0AlMkFw5xa+AQ37zxnAA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -4947,16 +4976,14 @@ packages:
   sanitize-html@2.17.0:
     resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
 
+  secure-random@1.1.2:
+    resolution: {integrity: sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ==}
+
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5379,6 +5406,10 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -5402,6 +5433,9 @@ packages:
   validate-npm-package-name@6.0.2:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5596,6 +5630,24 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zustand@5.0.10:
+    resolution: {integrity: sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@agentclientprotocol/sdk@0.14.1(zod@4.3.6)':
@@ -5620,7 +5672,7 @@ snapshots:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-locate-window': 3.965.4
+      '@aws-sdk/util-locate-window': 3.965.3
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -5640,7 +5692,7 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-bedrock-runtime@3.985.0':
+  '@aws-sdk/client-bedrock-runtime@3.986.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
@@ -5652,11 +5704,11 @@ snapshots:
       '@aws-sdk/middleware-logger': 3.972.3
       '@aws-sdk/middleware-recursion-detection': 3.972.3
       '@aws-sdk/middleware-user-agent': 3.972.7
-      '@aws-sdk/middleware-websocket': 3.972.5
+      '@aws-sdk/middleware-websocket': 3.972.6
       '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/token-providers': 3.985.0
+      '@aws-sdk/token-providers': 3.986.0
       '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-endpoints': 3.986.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
       '@aws-sdk/util-user-agent-node': 3.972.5
       '@smithy/config-resolver': 4.4.6
@@ -5692,7 +5744,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-bedrock@3.985.0':
+  '@aws-sdk/client-bedrock@3.986.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
@@ -5703,9 +5755,9 @@ snapshots:
       '@aws-sdk/middleware-recursion-detection': 3.972.3
       '@aws-sdk/middleware-user-agent': 3.972.7
       '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/token-providers': 3.985.0
+      '@aws-sdk/token-providers': 3.986.0
       '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-endpoints': 3.986.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
       '@aws-sdk/util-user-agent-node': 3.972.5
       '@smithy/config-resolver': 4.4.6
@@ -5945,7 +5997,7 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-websocket@3.972.5':
+  '@aws-sdk/middleware-websocket@3.972.6':
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-format-url': 3.972.3
@@ -6003,6 +6055,49 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.986.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.986.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.29
+      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.972.3':
     dependencies:
       '@aws-sdk/types': 3.973.1
@@ -6015,6 +6110,18 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.7
       '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.986.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/nested-clients': 3.986.0
       '@aws-sdk/types': 3.973.1
       '@smithy/property-provider': 4.2.8
       '@smithy/shared-ini-file-loader': 4.4.3
@@ -6036,6 +6143,14 @@ snapshots:
       '@smithy/util-endpoints': 3.2.8
       tslib: 2.8.1
 
+  '@aws-sdk/util-endpoints@3.986.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
   '@aws-sdk/util-format-url@3.972.3':
     dependencies:
       '@aws-sdk/types': 3.973.1
@@ -6043,7 +6158,7 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-locate-window@3.965.4':
+  '@aws-sdk/util-locate-window@3.965.3':
     dependencies:
       tslib: 2.8.1
 
@@ -6085,7 +6200,7 @@ snapshots:
   '@azure/core-util@1.13.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.3.3
+      '@typespec/ts-http-runtime': 0.3.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6115,9 +6230,9 @@ snapshots:
 
   '@babel/helper-validator-identifier@8.0.0-rc.1': {}
 
-  '@babel/parser@7.29.0':
+  '@babel/parser@7.28.6':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.28.6
 
   '@babel/parser@8.0.0-rc.1':
     dependencies:
@@ -6125,7 +6240,7 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
-  '@babel/types@7.29.0':
+  '@babel/types@7.28.6':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
@@ -6139,17 +6254,17 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260130162700(hono@4.11.8)':
+  '@buape/carbon@0.0.0-beta-20260130162700(bufferutil@4.1.0)(hono@4.11.8)(utf-8-validate@6.0.6)':
     dependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
-      '@discordjs/voice': 0.19.0
+      '@discordjs/voice': 0.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@hono/node-server': 1.19.9(hono@4.11.8)
       '@types/bun': 1.3.6
       '@types/ws': 8.18.1
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@discordjs/opus'
       - bufferutil
@@ -6161,18 +6276,18 @@ snapshots:
 
   '@cacheable/memory@2.0.7':
     dependencies:
-      '@cacheable/utils': 2.3.4
+      '@cacheable/utils': 2.3.3
       '@keyv/bigmap': 1.3.1(keyv@5.6.0)
-      hookified: 1.15.1
+      hookified: 1.15.0
       keyv: 5.6.0
 
   '@cacheable/node-cache@1.7.6':
     dependencies:
       cacheable: 2.3.2
-      hookified: 1.15.1
+      hookified: 1.15.0
       keyv: 5.6.0
 
-  '@cacheable/utils@2.3.4':
+  '@cacheable/utils@2.3.3':
     dependencies:
       hashery: 1.4.0
       keyv: 5.6.0
@@ -6196,15 +6311,15 @@ snapshots:
       '@d-fischer/shared-utils': 3.6.4
       tslib: 2.8.1
 
-  '@d-fischer/connection@9.0.0':
+  '@d-fischer/connection@9.0.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
-      '@d-fischer/isomorphic-ws': 7.0.2(ws@8.19.0)
+      '@d-fischer/isomorphic-ws': 7.0.2(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@d-fischer/logger': 4.2.4
       '@d-fischer/shared-utils': 3.6.4
       '@d-fischer/typed-event-emitter': 3.3.3
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6215,9 +6330,9 @@ snapshots:
 
   '@d-fischer/escape-string-regexp@5.0.0': {}
 
-  '@d-fischer/isomorphic-ws@7.0.2(ws@8.19.0)':
+  '@d-fischer/isomorphic-ws@7.0.2(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@d-fischer/logger@4.2.4':
     dependencies:
@@ -6239,13 +6354,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@discordjs/voice@0.19.0':
+  '@discordjs/voice@0.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@types/ws': 8.18.1
       discord-api-types: 0.38.38
       prism-media: 1.3.5
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@discordjs/opus'
       - bufferutil
@@ -6271,92 +6386,92 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/android-arm64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/android-arm@0.27.2':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/android-x64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/linux-arm64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/linux-arm@0.27.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/linux-ia32@0.27.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.3':
+  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
+  '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.3':
+  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
+  '@esbuild/linux-x64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.3':
+  '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
+  '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.3':
+  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
+  '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.3':
+  '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
+  '@esbuild/sunos-x64@0.27.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.3':
+  '@esbuild/win32-arm64@0.27.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
+  '@esbuild/win32-ia32@0.27.2':
     optional: true
 
-  '@esbuild/win32-x64@0.27.3':
+  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google/genai@1.40.0':
+  '@google/genai@1.40.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       google-auth-library: 10.5.0
       protobufjs: 7.5.4
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6406,7 +6521,7 @@ snapshots:
       hono: 4.11.8
     optional: true
 
-  '@huggingface/jinja@0.5.4': {}
+  '@huggingface/jinja@0.5.3': {}
 
   '@img/colour@1.0.0': {}
 
@@ -6506,6 +6621,10 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
@@ -6542,7 +6661,7 @@ snapshots:
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
       hashery: 1.4.0
-      hookified: 1.15.1
+      hookified: 1.15.0
       keyv: 5.6.0
 
   '@keyv/serialize@1.1.1': {}
@@ -6585,15 +6704,15 @@ snapshots:
       '@lancedb/lancedb-win32-arm64-msvc': 0.24.1
       '@lancedb/lancedb-win32-x64-msvc': 0.24.1
 
-  '@larksuiteoapi/node-sdk@1.58.0':
+  '@larksuiteoapi/node-sdk@1.58.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.5
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
       protobufjs: 7.5.4
       qs: 6.14.1
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -6601,9 +6720,9 @@ snapshots:
 
   '@line/bot-sdk@10.6.0':
     dependencies:
-      '@types/node': 24.10.11
+      '@types/node': 24.10.9
     optionalDependencies:
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.2(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6698,9 +6817,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.52.7(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.52.7(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6710,17 +6829,17 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.52.7(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.985.0
-      '@google/genai': 1.40.0
+      '@aws-sdk/client-bedrock-runtime': 3.986.0
+      '@google/genai': 1.40.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       chalk: 5.6.2
-      openai: 6.10.0(ws@8.19.0)(zod@4.3.6)
+      openai: 6.10.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       undici: 7.21.0
@@ -6734,11 +6853,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.52.7(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.52.7(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.52.7(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.52.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-tui': 0.52.7
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -6749,7 +6868,7 @@ snapshots:
       hosted-git-info: 9.0.2
       ignore: 7.0.5
       marked: 15.0.12
-      minimatch: 10.1.2
+      minimatch: 10.1.1
       proper-lockfile: 4.1.2
       yaml: 2.8.2
     optionalDependencies:
@@ -6770,6 +6889,30 @@ snapshots:
       get-east-asian-width: 1.4.0
       marked: 15.0.12
       mime-types: 3.0.2
+
+  '@massalabs/gossip-sdk@0.0.2-dev.20260211172752(dexie@4.2.1)(zustand@5.0.10)':
+    dependencies:
+      '@massalabs/massa-web3': 5.3.0
+      '@scure/base': 2.0.0
+      '@scure/bip39': 2.0.1
+      dexie: 4.2.1
+      zustand: 5.0.10
+
+  '@massalabs/massa-web3@5.3.0':
+    dependencies:
+      '@noble/ed25519': 1.7.5
+      '@noble/hashes': 1.3.2
+      bs58check: 4.0.0
+      dotenv: 16.6.1
+      eventemitter3: 5.0.4
+      google-protobuf: 3.21.4
+      grpc-web: 1.5.0
+      lodash.isequal: 4.5.0
+      secure-random: 1.1.2
+      varint: 6.0.0
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
     dependencies:
@@ -6806,7 +6949,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.2(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -6822,100 +6965,52 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@napi-rs/canvas-android-arm64@0.1.89':
+  '@napi-rs/canvas-android-arm64@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-android-arm64@0.1.90':
+  '@napi-rs/canvas-darwin-arm64@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.89':
+  '@napi-rs/canvas-darwin-x64@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.90':
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.89':
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.90':
+  '@napi-rs/canvas-linux-arm64-musl@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.89':
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.90':
+  '@napi-rs/canvas-linux-x64-gnu@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.89':
+  '@napi-rs/canvas-linux-x64-musl@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.90':
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.89':
+  '@napi-rs/canvas-win32-x64-msvc@0.1.91':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.90':
-    optional: true
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.90':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.90':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.90':
-    optional: true
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.90':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.90':
-    optional: true
-
-  '@napi-rs/canvas@0.1.89':
+  '@napi-rs/canvas@0.1.91':
     optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.89
-      '@napi-rs/canvas-darwin-arm64': 0.1.89
-      '@napi-rs/canvas-darwin-x64': 0.1.89
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.89
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.89
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.89
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.89
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.89
-      '@napi-rs/canvas-linux-x64-musl': 0.1.89
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.89
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.89
-
-  '@napi-rs/canvas@0.1.90':
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.90
-      '@napi-rs/canvas-darwin-arm64': 0.1.90
-      '@napi-rs/canvas-darwin-x64': 0.1.90
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.90
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.90
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.90
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.90
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.90
-      '@napi-rs/canvas-linux-x64-musl': 0.1.90
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.90
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.90
-    optional: true
+      '@napi-rs/canvas-android-arm64': 0.1.91
+      '@napi-rs/canvas-darwin-arm64': 0.1.91
+      '@napi-rs/canvas-darwin-x64': 0.1.91
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.91
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.91
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.91
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.91
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.91
+      '@napi-rs/canvas-linux-x64-musl': 0.1.91
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.91
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.91
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -6930,7 +7025,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.0.1
 
+  '@noble/ed25519@1.7.5': {}
+
   '@noble/ed25519@3.0.0': {}
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@2.0.1': {}
 
@@ -7250,7 +7349,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.211.0
-      import-in-the-middle: 2.0.6
+      import-in-the-middle: 2.0.5
       require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
@@ -7381,22 +7480,22 @@ snapshots:
   '@oxfmt/win32-x64@0.28.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.11.4':
+  '@oxlint-tsgolint/darwin-arm64@0.11.5':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.11.4':
+  '@oxlint-tsgolint/darwin-x64@0.11.5':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.11.4':
+  '@oxlint-tsgolint/linux-arm64@0.11.5':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.11.4':
+  '@oxlint-tsgolint/linux-x64@0.11.5':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.11.4':
+  '@oxlint-tsgolint/win32-arm64@0.11.5':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.11.4':
+  '@oxlint-tsgolint/win32-x64@0.11.5':
     optional: true
 
   '@oxlint/darwin-arm64@1.43.0':
@@ -7536,79 +7635,79 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
+  '@rollup/rollup-android-arm-eabi@4.55.3':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.57.1':
+  '@rollup/rollup-android-arm64@4.55.3':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.57.1':
+  '@rollup/rollup-darwin-arm64@4.55.3':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.57.1':
+  '@rollup/rollup-darwin-x64@4.55.3':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.57.1':
+  '@rollup/rollup-freebsd-arm64@4.55.3':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.57.1':
+  '@rollup/rollup-freebsd-x64@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+  '@rollup/rollup-linux-arm64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
+  '@rollup/rollup-linux-arm64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+  '@rollup/rollup-linux-loong64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
+  '@rollup/rollup-linux-loong64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+  '@rollup/rollup-linux-ppc64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+  '@rollup/rollup-linux-riscv64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+  '@rollup/rollup-linux-s390x-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
+  '@rollup/rollup-linux-x64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.57.1':
+  '@rollup/rollup-linux-x64-musl@4.55.3':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.57.1':
+  '@rollup/rollup-openbsd-x64@4.55.3':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.57.1':
+  '@rollup/rollup-openharmony-arm64@4.55.3':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+  '@rollup/rollup-win32-arm64-msvc@4.55.3':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+  '@rollup/rollup-win32-ia32-msvc@4.55.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
+  '@rollup/rollup-win32-x64-gnu@4.55.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
+  '@rollup/rollup-win32-x64-msvc@4.55.3':
     optional: true
 
   '@scure/base@2.0.0': {}
@@ -7633,15 +7732,15 @@ snapshots:
 
   '@sinclair/typebox@0.34.48': {}
 
-  '@slack/bolt@4.6.0(@types/express@5.0.6)':
+  '@slack/bolt@4.6.0(@types/express@5.0.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/oauth': 3.0.4
-      '@slack/socket-mode': 2.0.5
+      '@slack/socket-mode': 2.0.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.2(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7654,26 +7753,26 @@ snapshots:
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
 
   '@slack/oauth@3.0.4':
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/web-api': 7.13.0
       '@types/jsonwebtoken': 9.0.10
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - debug
 
-  '@slack/socket-mode@2.0.5':
+  '@slack/socket-mode@2.0.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/web-api': 7.13.0
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -7685,9 +7784,9 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/types': 2.19.0
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.2(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8008,15 +8107,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@thi.ng/bitstream@2.4.39':
+  '@thi.ng/bitstream@2.4.38':
     dependencies:
-      '@thi.ng/errors': 2.6.2
+      '@thi.ng/errors': 2.6.1
     optional: true
 
-  '@thi.ng/errors@2.6.2':
+  '@thi.ng/errors@2.6.1':
     optional: true
 
-  '@tinyhttp/content-disposition@2.2.3': {}
+  '@tinyhttp/content-disposition@2.2.2': {}
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -8058,7 +8157,7 @@ snapshots:
       '@twurple/common': 8.0.3
       tslib: 2.8.1
 
-  '@twurple/chat@8.0.3(@twurple/auth@8.0.3)':
+  '@twurple/chat@8.0.3(@twurple/auth@8.0.3)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@d-fischer/cache-decorators': 4.0.1
       '@d-fischer/deprecate': 2.0.2
@@ -8068,7 +8167,7 @@ snapshots:
       '@d-fischer/typed-event-emitter': 3.3.3
       '@twurple/auth': 8.0.3
       '@twurple/common': 8.0.3
-      ircv3: 0.33.0
+      ircv3: 0.33.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
@@ -8090,7 +8189,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
 
   '@types/bun@1.3.6':
     dependencies:
@@ -8110,7 +8209,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
 
   '@types/deep-eql@4.0.2': {}
 
@@ -8118,14 +8217,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -8150,7 +8249,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
 
   '@types/linkify-it@5.0.0': {}
 
@@ -8171,15 +8270,15 @@ snapshots:
 
   '@types/node@10.17.60': {}
 
-  '@types/node@20.19.32':
+  '@types/node@20.19.30':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.10.11':
+  '@types/node@24.10.9':
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.2.1':
+  '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
 
@@ -8196,7 +8295,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.4
 
@@ -8207,22 +8306,22 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -8230,7 +8329,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260206.1':
     optional: true
@@ -8263,7 +8362,7 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260206.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260206.1
 
-  '@typespec/ts-http-runtime@0.3.3':
+  '@typespec/ts-http-runtime@0.3.2':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -8303,51 +8402,51 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      ws: 8.19.0
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
-      ast-v8-to-istanbul: 0.3.11
+      ast-v8-to-istanbul: 0.3.10
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.2
+      magicast: 0.5.1
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -8358,13 +8457,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -8411,19 +8510,19 @@ snapshots:
       '@wasm-audio-decoders/common': 9.0.7
     optional: true
 
-  '@whiskeysockets/baileys@7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)':
+  '@whiskeysockets/baileys@7.0.0-rc.9(audio-decode@2.2.3)(bufferutil@4.1.0)(sharp@0.34.5)(utf-8-validate@6.0.6)':
     dependencies:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
       libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
-      lru-cache: 11.2.5
-      music-metadata: 11.11.2
+      lru-cache: 11.2.4
+      music-metadata: 11.12.0
       p-queue: 9.1.0
       pino: 9.14.0
       protobufjs: 7.5.4
       sharp: 0.34.5
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       audio-decode: 2.2.3
     transitivePeerDependencies:
@@ -8499,7 +8598,7 @@ snapshots:
       '@swc/helpers': 0.5.18
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 20.19.32
+      '@types/node': 20.19.30
       command-line-args: 5.2.1
       command-line-usage: 7.0.3
       flatbuffers: 24.12.23
@@ -8539,11 +8638,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ast-v8-to-istanbul@0.3.11:
+  ast-v8-to-istanbul@0.3.10:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
-      js-tokens: 10.0.0
+      js-tokens: 9.0.1
 
   async-lock@1.4.1: {}
 
@@ -8581,7 +8680,15 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.4(debug@4.4.3):
+  axios@1.13.2(debug@4.4.3):
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.4.3)
+      form-data: 2.5.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.13.5:
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 2.5.4
@@ -8590,6 +8697,8 @@ snapshots:
       - debug
 
   balanced-match@1.0.2: {}
+
+  base-x@5.0.1: {}
 
   base64-js@1.5.1: {}
 
@@ -8654,13 +8763,27 @@ snapshots:
 
   browser-or-node@1.3.0: {}
 
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
+
+  bs58check@4.0.0:
+    dependencies:
+      '@noble/hashes': 1.3.2
+      bs58: 6.0.0
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   bun-types@1.3.6:
     dependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
     optional: true
 
   bytes@3.1.2: {}
@@ -8670,8 +8793,8 @@ snapshots:
   cacheable@2.3.2:
     dependencies:
       '@cacheable/memory': 2.0.7
-      '@cacheable/utils': 2.3.4
-      hookified: 1.15.1
+      '@cacheable/utils': 2.3.3
+      hookified: 1.15.0
       keyv: 5.6.0
       qified: 0.6.0
 
@@ -8708,7 +8831,7 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  ci-info@4.4.0: {}
+  ci-info@4.3.1: {}
 
   cjs-module-lexer@2.2.0: {}
 
@@ -8741,11 +8864,11 @@ snapshots:
 
   cmake-js@7.4.0:
     dependencies:
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.2(debug@4.4.3)
       debug: 4.4.3
       fs-extra: 11.3.3
       memory-stream: 1.0.0
-      node-api-headers: 1.8.0
+      node-api-headers: 1.7.0
       npmlog: 6.0.2
       rc: 1.2.8
       semver: 7.7.3
@@ -8871,6 +8994,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  dexie@4.2.1: {}
+
   diff@8.0.3: {}
 
   discord-api-types@0.38.37: {}
@@ -8898,6 +9023,8 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dotenv@16.6.1: {}
 
   dotenv@17.2.4: {}
 
@@ -8955,34 +9082,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.27.3:
+  esbuild@0.27.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   escalade@3.2.0: {}
 
@@ -9090,6 +9217,8 @@ snapshots:
   extend@3.0.2: {}
 
   extsprintf@1.3.0: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-content-type-parse@3.0.0: {}
 
@@ -9250,6 +9379,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-tsconfig@4.13.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -9297,6 +9430,8 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  google-protobuf@3.21.4: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -9310,6 +9445,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  grpc-web@1.5.0: {}
 
   gtoken@8.0.0:
     dependencies:
@@ -9344,7 +9481,7 @@ snapshots:
 
   hashery@1.4.0:
     dependencies:
-      hookified: 1.15.1
+      hookified: 1.15.0
 
   hasown@2.0.2:
     dependencies:
@@ -9356,11 +9493,11 @@ snapshots:
 
   hookable@6.0.1: {}
 
-  hookified@1.15.1: {}
+  hookified@1.15.0: {}
 
   hosted-git-info@9.0.2:
     dependencies:
-      lru-cache: 11.2.5
+      lru-cache: 11.2.4
 
   html-escaper@2.0.2: {}
 
@@ -9432,7 +9569,7 @@ snapshots:
 
   immediate@3.0.6: {}
 
-  import-in-the-middle@2.0.6:
+  import-in-the-middle@2.0.5:
     dependencies:
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
@@ -9451,10 +9588,10 @@ snapshots:
 
   ipull@3.9.3:
     dependencies:
-      '@tinyhttp/content-disposition': 2.2.3
+      '@tinyhttp/content-disposition': 2.2.2
       async-retry: 1.3.3
       chalk: 5.6.2
-      ci-info: 4.4.0
+      ci-info: 4.3.1
       cli-spinners: 2.9.2
       commander: 10.0.1
       eventemitter3: 5.0.4
@@ -9473,9 +9610,9 @@ snapshots:
     optionalDependencies:
       '@reflink/reflink': 0.1.19
 
-  ircv3@0.33.0:
+  ircv3@0.33.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      '@d-fischer/connection': 9.0.0
+      '@d-fischer/connection': 9.0.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@d-fischer/escape-string-regexp': 5.0.0
       '@d-fischer/logger': 4.2.4
       '@d-fischer/shared-utils': 3.6.4
@@ -9541,7 +9678,7 @@ snapshots:
 
   jose@4.15.9: {}
 
-  js-tokens@10.0.0: {}
+  js-tokens@9.0.1: {}
 
   jsbn@0.1.1: {}
 
@@ -9585,7 +9722,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.4
+      semver: 7.7.3
 
   jsprim@1.4.2:
     dependencies:
@@ -9730,6 +9867,8 @@ snapshots:
 
   lodash.isboolean@3.0.3: {}
 
+  lodash.isequal@4.5.0: {}
+
   lodash.isinteger@4.0.4: {}
 
   lodash.isnumber@3.0.3: {}
@@ -9774,7 +9913,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.5: {}
+  lru-cache@11.2.4: {}
 
   lru-cache@6.0.0:
     dependencies:
@@ -9791,15 +9930,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.2:
+  magicast@0.5.1:
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.7.3
 
   markdown-it@14.1.0:
     dependencies:
@@ -9850,6 +9989,10 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+
   minimatch@10.1.2:
     dependencies:
       '@isaacs/brace-expansion': 5.0.1
@@ -9891,7 +10034,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  music-metadata@11.11.2:
+  music-metadata@11.12.0:
     dependencies:
       '@borewit/text-codec': 0.2.1
       '@tokenizer/token': 0.3.0
@@ -9924,16 +10067,16 @@ snapshots:
 
   node-addon-api@8.5.0: {}
 
-  node-api-headers@1.8.0: {}
+  node-api-headers@1.7.0: {}
 
   node-domexception@1.0.0: {}
 
   node-downloader-helper@2.1.10: {}
 
-  node-edge-tts@1.2.10:
+  node-edge-tts@1.2.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       https-proxy-agent: 7.0.6
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -9950,9 +10093,12 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  node-gyp-build@4.8.4:
+    optional: true
+
   node-llama-cpp@3.15.1(typescript@5.9.3):
     dependencies:
-      '@huggingface/jinja': 0.5.4
+      '@huggingface/jinja': 0.5.3
       async-retry: 1.3.3
       bytes: 3.1.2
       chalk: 5.6.2
@@ -10086,14 +10232,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.10.0(ws@8.19.0)(zod@4.3.6):
+  openai@6.10.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6):
     optionalDependencies:
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.3.6
 
-  openai@6.18.0(ws@8.19.0)(zod@4.3.6):
+  openai@6.19.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6):
     optionalDependencies:
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.3.6
 
   opus-decoder@0.7.11:
@@ -10128,16 +10274,16 @@ snapshots:
       '@oxfmt/win32-arm64': 0.28.0
       '@oxfmt/win32-x64': 0.28.0
 
-  oxlint-tsgolint@0.11.4:
+  oxlint-tsgolint@0.11.5:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.11.4
-      '@oxlint-tsgolint/darwin-x64': 0.11.4
-      '@oxlint-tsgolint/linux-arm64': 0.11.4
-      '@oxlint-tsgolint/linux-x64': 0.11.4
-      '@oxlint-tsgolint/win32-arm64': 0.11.4
-      '@oxlint-tsgolint/win32-x64': 0.11.4
+      '@oxlint-tsgolint/darwin-arm64': 0.11.5
+      '@oxlint-tsgolint/darwin-x64': 0.11.5
+      '@oxlint-tsgolint/linux-arm64': 0.11.5
+      '@oxlint-tsgolint/linux-x64': 0.11.5
+      '@oxlint-tsgolint/win32-arm64': 0.11.5
+      '@oxlint-tsgolint/win32-x64': 0.11.5
 
-  oxlint@1.43.0(oxlint-tsgolint@0.11.4):
+  oxlint@1.43.0(oxlint-tsgolint@0.11.5):
     optionalDependencies:
       '@oxlint/darwin-arm64': 1.43.0
       '@oxlint/darwin-x64': 1.43.0
@@ -10147,7 +10293,7 @@ snapshots:
       '@oxlint/linux-x64-musl': 1.43.0
       '@oxlint/win32-arm64': 1.43.0
       '@oxlint/win32-x64': 1.43.0
-      oxlint-tsgolint: 0.11.4
+      oxlint-tsgolint: 0.11.5
 
   p-finally@1.0.0: {}
 
@@ -10226,7 +10372,7 @@ snapshots:
 
   path-scurry@2.0.1:
     dependencies:
-      lru-cache: 11.2.5
+      lru-cache: 11.2.4
       minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}
@@ -10237,7 +10383,7 @@ snapshots:
 
   pdfjs-dist@5.4.624:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.90
+      '@napi-rs/canvas': 0.1.91
       node-readable-to-web-readable-stream: 0.4.2
 
   peberminta@0.9.0: {}
@@ -10343,7 +10489,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       long: 5.3.2
 
   protobufjs@8.0.0:
@@ -10358,7 +10504,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -10391,11 +10537,11 @@ snapshots:
 
   qified@0.6.0:
     dependencies:
-      hookified: 1.15.1
+      hookified: 1.15.0
 
   qoa-format@1.0.1:
     dependencies:
-      '@thi.ng/bitstream': 2.4.39
+      '@thi.ng/bitstream': 2.4.38
     optional: true
 
   qrcode-terminal@0.12.0: {}
@@ -10556,35 +10702,35 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
 
-  rollup@4.57.1:
+  rollup@4.55.3:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.57.1
-      '@rollup/rollup-android-arm64': 4.57.1
-      '@rollup/rollup-darwin-arm64': 4.57.1
-      '@rollup/rollup-darwin-x64': 4.57.1
-      '@rollup/rollup-freebsd-arm64': 4.57.1
-      '@rollup/rollup-freebsd-x64': 4.57.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
-      '@rollup/rollup-linux-arm64-gnu': 4.57.1
-      '@rollup/rollup-linux-arm64-musl': 4.57.1
-      '@rollup/rollup-linux-loong64-gnu': 4.57.1
-      '@rollup/rollup-linux-loong64-musl': 4.57.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
-      '@rollup/rollup-linux-ppc64-musl': 4.57.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
-      '@rollup/rollup-linux-riscv64-musl': 4.57.1
-      '@rollup/rollup-linux-s390x-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-musl': 4.57.1
-      '@rollup/rollup-openbsd-x64': 4.57.1
-      '@rollup/rollup-openharmony-arm64': 4.57.1
-      '@rollup/rollup-win32-arm64-msvc': 4.57.1
-      '@rollup/rollup-win32-ia32-msvc': 4.57.1
-      '@rollup/rollup-win32-x64-gnu': 4.57.1
-      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      '@rollup/rollup-android-arm-eabi': 4.55.3
+      '@rollup/rollup-android-arm64': 4.55.3
+      '@rollup/rollup-darwin-arm64': 4.55.3
+      '@rollup/rollup-darwin-x64': 4.55.3
+      '@rollup/rollup-freebsd-arm64': 4.55.3
+      '@rollup/rollup-freebsd-x64': 4.55.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.55.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.55.3
+      '@rollup/rollup-linux-arm64-gnu': 4.55.3
+      '@rollup/rollup-linux-arm64-musl': 4.55.3
+      '@rollup/rollup-linux-loong64-gnu': 4.55.3
+      '@rollup/rollup-linux-loong64-musl': 4.55.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.55.3
+      '@rollup/rollup-linux-ppc64-musl': 4.55.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.55.3
+      '@rollup/rollup-linux-riscv64-musl': 4.55.3
+      '@rollup/rollup-linux-s390x-gnu': 4.55.3
+      '@rollup/rollup-linux-x64-gnu': 4.55.3
+      '@rollup/rollup-linux-x64-musl': 4.55.3
+      '@rollup/rollup-openbsd-x64': 4.55.3
+      '@rollup/rollup-openharmony-arm64': 4.55.3
+      '@rollup/rollup-win32-arm64-msvc': 4.55.3
+      '@rollup/rollup-win32-ia32-msvc': 4.55.3
+      '@rollup/rollup-win32-x64-gnu': 4.55.3
+      '@rollup/rollup-win32-x64-msvc': 4.55.3
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -10614,13 +10760,13 @@ snapshots:
       parse-srcset: 1.0.2
       postcss: 8.5.6
 
+  secure-random@1.1.2: {}
+
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
 
   semver@7.7.3: {}
-
-  semver@7.7.4: {}
 
   send@0.19.2:
     dependencies:
@@ -10684,7 +10830,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.7.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -10992,7 +11138,7 @@ snapshots:
       picomatch: 4.0.3
       rolldown: 1.0.0-rc.3
       rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260206.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
-      semver: 7.7.4
+      semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
@@ -11015,8 +11161,8 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.3
-      get-tsconfig: 4.13.6
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -11085,6 +11231,11 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -11097,6 +11248,8 @@ snapshots:
 
   validate-npm-package-name@6.0.2: {}
 
+  varint@6.0.0: {}
+
   vary@1.1.2: {}
 
   verror@1.10.0:
@@ -11105,26 +11258,26 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.57.1
+      rollup: 4.55.3
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.2.1
+      '@types/node': 25.2.3
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -11141,12 +11294,12 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.2.1
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@types/node': 25.2.3
+      '@vitest/browser-playwright': 4.0.18(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
     transitivePeerDependencies:
       - jiti
       - less
@@ -11206,7 +11359,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.19.0: {}
+  ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   y18n@5.0.8: {}
 
@@ -11255,3 +11411,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zustand@5.0.10: {}


### PR DESCRIPTION
## Summary

Adds a new **Gossip** channel extension so OpenClaw can send and receive messages via Gossip alongside the existing channels.

## Details

- Introduces the `extensions/gossip` plugin with channel wiring and configuration
- Hooks Gossip into the standard routing and channel abstractions
- Adds user-facing documentation for configuring and using the Gossip channel

## Testing

- Verified local setup of the Gossip extension
- Sent and received messages through Gossip to confirm end-to-end behavior
- CI passes for core and extension packages

<img width="1476" height="1114" alt="image" src="https://github.com/user-attachments/assets/7afd95a6-d424-4d07-8f05-93ac8a10183e" />
