### PR TITLE
fix(cron): use requested agentId for isolated job auth resolution

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -124,7 +124,10 @@ export async function runCronIsolatedAgentTurn(params: {
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
   const { model: overrideModel, ...agentOverrideRest } = agentConfigOverride ?? {};
-  const agentId = agentConfigOverride ? (normalizedRequested ?? defaultAgentId) : defaultAgentId;
+  // Use the requested agentId even when there is no explicit agent config entry.
+  // This ensures auth-profiles, workspace, and agentDir all resolve to the
+  // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).
+  const agentId = normalizedRequested ?? defaultAgentId;
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,


### PR DESCRIPTION
## Problem

Isolated cron jobs with a custom `agentId` (e.g. `"oc-claude"`) incorrectly read API keys from the `main` agent's auth store instead of the specified agent's.

**Root cause:** In `isolated-agent/run.ts`, the `agentId` variable falls back to `defaultAgentId` (`"main"`) when the requested agent has no explicit config entry under `agents.instances`. This means `resolveAgentDir()` returns `~/.openclaw/agents/main/agent/` instead of `~/.openclaw/agents/oc-claude/agent/`.

Fixes #13964

## Solution

Always use the requested `agentId` when provided, regardless of whether it has an explicit config block:

```diff
- const agentId = agentConfigOverride ? (normalizedRequested ?? defaultAgentId) : defaultAgentId;
+ const agentId = normalizedRequested ?? defaultAgentId;
```

Agent config overrides (model, thinking level, etc.) still apply when an `agents.instances` entry exists. The only change is that `agentDir`, workspace, and auth resolution now correctly use the requested agent's paths even without an explicit config block.

## Impact

| Before | After |
|--------|-------|
| Cron job `agentId: "oc-claude"` → reads from `agents/main/` | Reads from `agents/oc-claude/` |
| Auth error: "No API key found" (wrong store) | Correct auth store used |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes isolated cron jobs to use the correct agent directory for auth resolution when a custom `agentId` is specified. Previously, cron jobs with `agentId: "oc-claude"` would incorrectly read API keys from `~/.openclaw/agents/main/` instead of `~/.openclaw/agents/oc-claude/` when no explicit config entry existed in `agents.list`.

The root cause was the conditional logic that fell back to `defaultAgentId` when `agentConfigOverride` was undefined (i.e., when the requested agent had no explicit config block). The fix simplifies the logic to always use the requested `agentId`, ensuring `resolveAgentDir()`, workspace resolution, and auth store lookups all use the correct per-agent paths.

Agent config overrides (model, thinking level, etc.) still apply correctly when an `agents.list` entry exists - the change only affects path resolution.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, well-scoped one-line change that removes unnecessary conditional logic. The change is logically correct: it ensures the requested `agentId` is always used for path resolution (via `resolveAgentDir`, `resolveAgentWorkspaceDir`), which is exactly what's needed. The previous fallback to `defaultAgentId` when no explicit config existed was the bug. The added comment clearly explains the intent, and the fix aligns with how `resolveAgentDir()` works (it constructs paths based on the `agentId` parameter).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->