### PR TITLE
fix(discord): fall back to guild_id check for DM classification

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -102,7 +102,9 @@ export async function preflightDiscordMessage(
 
   const isGuildMessage = Boolean(params.data.guild_id);
   const channelInfo = await resolveDiscordChannelInfo(params.client, message.channelId);
-  const isDirectMessage = channelInfo?.type === ChannelType.DM;
+  // Use guild_id as primary signal: if no guild_id, it's a DM regardless of
+  // channelInfo resolution (which can fail or return stale cache data).
+  const isDirectMessage = channelInfo?.type === ChannelType.DM || (!isGuildMessage && !channelInfo);
   const isGroupDm = channelInfo?.type === ChannelType.GroupDM;
 
   if (isGroupDm && !params.groupDmEnabled) {


### PR DESCRIPTION
## Problem

Discord DMs can be misclassified as guild channel messages, creating duplicate sessions for the same conversation. The user sees some messages routed to `agent:main:main` (correct) and others to `agent:main:discord:channel:<id>` (wrong).

**Root cause:** In `message-handler.preflight.ts`, DM detection relies solely on `channelInfo?.type === ChannelType.DM`. If `resolveDiscordChannelInfo()` returns `null` (cache miss, API failure, or migration edge case), both `isDirectMessage` and `isGroupDm` are `false`, causing the message to fall through to `"channel"` classification.

Meanwhile, `agent-components.ts` correctly uses `!rawGuildId` as the primary DM signal — the two code paths are inconsistent.

Fixes #13963

## Solution

Use `guild_id` absence as a fallback: if there's no `guild_id` in the raw message data AND `channelInfo` is unavailable, treat it as a DM.

```diff
- const isDirectMessage = channelInfo?.type === ChannelType.DM;
+ const isDirectMessage = channelInfo?.type === ChannelType.DM || (!isGuildMessage && !channelInfo);
```

This aligns with the existing `isGuildMessage` variable (already computed on the previous line but unused for DM classification) and matches the approach in `agent-components.ts`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a defensive fallback for DM classification when `channelInfo` is unavailable. The change aligns `message-handler.preflight.ts` with the existing pattern in `agent-components.ts` (line 235), which uses `!rawGuildId` as the primary signal for DM detection. This prevents messages from being misclassified as guild channel messages when `resolveDiscordChannelInfo()` returns `null` due to cache misses, API failures, or edge cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple defensive addition that adds a fallback condition without changing existing logic paths. It aligns with established patterns in the codebase (agent-components.ts:235), addresses a real bug with duplicate sessions, and has clear logical reasoning backed by the PR description.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->