### PR TITLE
fix(process): add shell option on Windows for .cmd file execution

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -116,6 +116,9 @@ export async function runCommandWithTimeout(
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
+    // Windows requires shell: true to spawn .cmd/.bat files (e.g., npm.cmd).
+    // Without it, newer Node versions throw EINVAL.
+    shell: process.platform === "win32",
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -117,8 +117,9 @@ export async function runCommandWithTimeout(
     env: resolvedEnv,
     windowsVerbatimArguments,
     // Windows requires shell: true to spawn .cmd/.bat files (e.g., npm.cmd).
-    // Without it, newer Node versions throw EINVAL.
-    shell: process.platform === "win32",
+    // Without it, newer Node versions throw EINVAL. Only enable for .cmd/.bat
+    // to avoid changing exit-code semantics for normal executables.
+    shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(resolveCommand(argv[0])),
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Problem

On Windows, `openclaw plugins install` fails with `spawn EINVAL` because Node.js's `spawn()` and `execFile()` cannot directly execute `.cmd`/`.bat` files without `{ shell: true }`.

The existing `resolveCommand()` correctly appends `.cmd` for npm-related commands on Windows, but newer Node.js versions require the `shell` option to actually execute them.

Fixes #13936

## Solution

Add `shell: process.platform === 'win32'` to both `spawn()` and `execFile()` calls in `src/process/exec.ts`.

This only enables shell mode on Windows — Unix platforms are unaffected.

## AI Disclosure

This PR was authored with AI assistance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `shell: true` option to `spawn()` and `execFile()` calls on Windows to fix `EINVAL` errors when executing `.cmd`/`.bat` files (e.g., `npm.cmd`). The fix is platform-specific and only enables shell mode on Windows, leaving Unix systems unaffected.

- Resolves Windows plugin installation failures by enabling shell execution for `.cmd` files
- Consistent application across both `runExec` (execFile) and `runCommandWithTimeout` (spawn)
- Clear inline comments explaining the Windows-specific requirement

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted Windows-only fix with clear comments and minimal scope
- This is a well-scoped, platform-specific fix that addresses a documented Node.js requirement. The change is isolated to Windows (`process.platform === "win32"`), preserves Unix behavior, and includes clear explanatory comments. The fix aligns with Node.js documentation and resolves a real issue without introducing new risks.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->