### PR TITLE
fix(agents): suppress low context window warning for explicitly configured values

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -83,6 +83,8 @@ describe("context-window-guard", () => {
     const guard = evaluateContextWindowGuard({ info });
     expect(info.source).toBe("modelsConfig");
     expect(guard.shouldBlock).toBe(true);
+    // Explicit config should not warn (user knows what they're doing)
+    expect(guard.shouldWarn).toBe(false);
   });
 
   it("caps with agents.defaults.contextTokens", () => {
@@ -98,6 +100,21 @@ describe("context-window-guard", () => {
     });
     const guard = evaluateContextWindowGuard({ info });
     expect(info.source).toBe("agentContextTokens");
+    // Explicit config should not warn
+    expect(guard.shouldWarn).toBe(false);
+    expect(guard.shouldBlock).toBe(false);
+  });
+
+  it("does not warn when modelsConfig sets low context window explicitly", () => {
+    const info = { tokens: 2048, source: "modelsConfig" as const };
+    const guard = evaluateContextWindowGuard({ info });
+    expect(guard.shouldWarn).toBe(false);
+    expect(guard.shouldBlock).toBe(true);
+  });
+
+  it("still warns when model metadata reports low context window", () => {
+    const info = { tokens: 24_000, source: "model" as const };
+    const guard = evaluateContextWindowGuard({ info });
     expect(guard.shouldWarn).toBe(true);
     expect(guard.shouldBlock).toBe(false);
   });

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -65,10 +65,15 @@ export function evaluateContextWindowGuard(params: {
   );
   const hardMin = Math.max(1, Math.floor(params.hardMinTokens ?? CONTEXT_WINDOW_HARD_MIN_TOKENS));
   const tokens = Math.max(0, Math.floor(params.info.tokens));
+  // Don't warn when the user explicitly configured the context window
+  // (via models.providers[].models[].contextWindow or agents.defaults.contextTokens).
+  // The warning should only fire for auto-detected or default values.
+  const isExplicit =
+    params.info.source === "modelsConfig" || params.info.source === "agentContextTokens";
   return {
     ...params.info,
     tokens,
-    shouldWarn: tokens > 0 && tokens < warnBelow,
+    shouldWarn: tokens > 0 && tokens < warnBelow && !isExplicit,
     shouldBlock: tokens > 0 && tokens < hardMin,
   };
 }


### PR DESCRIPTION
## Problem

When users deliberately configure a small `contextWindow` in their model config (e.g., `2048` for lightweight heartbeat checks with a local model), OpenClaw still emits:

```
warn agent/embedded low context window: ollama/qwen2.5:7b-2k ctx=2048 (warn<32000) source=modelsConfig
```

This is misleading — the user intentionally chose this value.

Fixes #13933

## Solution

Skip `shouldWarn` when the context window source is explicitly configured:
- `modelsConfig` — set via `models.providers[].models[].contextWindow`
- `agentContextTokens` — set via `agents.defaults.contextTokens`

`shouldBlock` (hard minimum) is unchanged — still enforced regardless of source.

## Tests

Updated existing tests + added 2 new test cases confirming:
- Explicit `modelsConfig` source → no warning
- Auto-detected `model` source → still warns

All 11 tests pass.

## AI Disclosure

This PR was authored with AI assistance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Suppressed low context window warnings when users explicitly configure `contextWindow` via `models.providers[].models[].contextWindow` or `agents.defaults.contextTokens`. The warning now only fires for auto-detected (`model`) or default values, preventing misleading warnings when users deliberately choose small context windows (e.g., 2048 tokens for lightweight heartbeat checks).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is focused and well-tested with 11 passing tests covering all scenarios (explicit config sources don't warn, auto-detected sources still warn). The logic is straightforward: a single boolean check prevents warnings for user-configured values while preserving `shouldBlock` enforcement. No breaking changes or side effects.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->