### PR TITLE
fix(commands): handle "/model default" as reset to configured default

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -336,6 +336,17 @@ export function resolveModelSelectionFromDirective(params: {
   const raw = params.directives.rawModelDirective.trim();
   let modelSelection: ModelDirectiveSelection | undefined;
 
+  // "/model default" resets to the configured default model
+  if (raw.toLowerCase() === "default") {
+    return {
+      modelSelection: {
+        provider: params.defaultProvider,
+        model: params.defaultModel,
+        isDefault: true,
+      },
+    };
+  }
+
   if (/^[0-9]+$/.test(raw)) {
     return {
       errorText: [


### PR DESCRIPTION
## Problem

`/model default` is interpreted as a model name, resolving to `anthropic/default` which fails the allowlist check:

```
Model "anthropic/default" is not allowed. Use /models to list providers, or /models <provider> to list models.
```

Users expect `/model default` to reset their model override back to the configured default.

Fixes #13982

## Solution

Add an early return in `resolveModelDirectiveFromInline()` that handles `"default"` (case-insensitive) by returning the configured default provider and model with `isDefault: true`, which clears the model override.

This matches the existing behavior of `session_status` tool with `model=default`.

## AI Disclosure

This PR was authored with AI assistance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts chat `/model` directive parsing so that `/model default` is treated as “reset to configured default” rather than a literal model name (which previously resolved to `anthropic/default` and failed allowlist validation). The change is implemented as an early return in `resolveModelSelectionFromDirective`, returning the configured default provider/model with `isDefault: true` so session overrides are cleared (matching the existing `session_status` tool behavior for `model=default`).

Main gap: the new behavior isn’t covered by the existing directive-handling tests, so it’s easy for a future refactor to regress back to the allowlist error path.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge once basic regression coverage is added.
- The code change is small, consistent with existing `session_status` semantics, and uses the existing `isDefault` mechanism to clear overrides. The main risk is behavioral regression without tests for `/model default` (including case-insensitivity).
- src/auto-reply/reply/directive-handling.model.ts (add/adjust tests in src/auto-reply/reply/directive-handling.model.test.ts)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->