### PR TITLE
fix(feishu): sort blocks by first_level_block_ids in appendDoc and writeDoc

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -92,16 +92,9 @@ async function convertMarkdown(client: Lark.Client, markdown: string) {
   };
 }
 
-function sortBlocksByFirstLevel(
-  blocks: any[],
-  firstLevelIds: string[],
-): any[] {
-  if (!firstLevelIds || firstLevelIds.length === 0) {
-    return blocks;
-  }
-  const sorted = firstLevelIds
-    .map((id) => blocks.find((b) => b.block_id === id))
-    .filter(Boolean);
+function sortBlocksByFirstLevel(blocks: any[], firstLevelIds: string[]): any[] {
+  if (!firstLevelIds || firstLevelIds.length === 0) return blocks;
+  const sorted = firstLevelIds.map((id) => blocks.find((b) => b.block_id === id)).filter(Boolean);
   const sortedIds = new Set(firstLevelIds);
   const remaining = blocks.filter((b) => !sortedIds.has(b.block_id));
   return [...sorted, ...remaining];

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -92,6 +92,21 @@ async function convertMarkdown(client: Lark.Client, markdown: string) {
   };
 }
 
+function sortBlocksByFirstLevel(
+  blocks: any[],
+  firstLevelIds: string[],
+): any[] {
+  if (!firstLevelIds || firstLevelIds.length === 0) {
+    return blocks;
+  }
+  const sorted = firstLevelIds
+    .map((id) => blocks.find((b) => b.block_id === id))
+    .filter(Boolean);
+  const sortedIds = new Set(firstLevelIds);
+  const remaining = blocks.filter((b) => !sortedIds.has(b.block_id));
+  return [...sorted, ...remaining];
+}
+
 /* eslint-disable @typescript-eslint/no-explicit-any -- SDK block types */
 async function insertBlocks(
   client: Lark.Client,
@@ -279,12 +294,13 @@ async function createDoc(client: Lark.Client, title: string, folderToken?: strin
 async function writeDoc(client: Lark.Client, docToken: string, markdown: string) {
   const deleted = await clearDocumentContent(client, docToken);
 
-  const { blocks } = await convertMarkdown(client, markdown);
+  const { blocks, firstLevelBlockIds } = await convertMarkdown(client, markdown);
   if (blocks.length === 0) {
     return { success: true, blocks_deleted: deleted, blocks_added: 0, images_processed: 0 };
   }
+  const sortedBlocks = sortBlocksByFirstLevel(blocks, firstLevelBlockIds);
 
-  const { children: inserted, skipped } = await insertBlocks(client, docToken, blocks);
+  const { children: inserted, skipped } = await insertBlocks(client, docToken, sortedBlocks);
   const imagesProcessed = await processImages(client, docToken, markdown, inserted);
 
   return {
@@ -299,12 +315,13 @@ async function writeDoc(client: Lark.Client, docToken: string, markdown: string)
 }
 
 async function appendDoc(client: Lark.Client, docToken: string, markdown: string) {
-  const { blocks } = await convertMarkdown(client, markdown);
+  const { blocks, firstLevelBlockIds } = await convertMarkdown(client, markdown);
   if (blocks.length === 0) {
     throw new Error("Content is empty");
   }
+  const sortedBlocks = sortBlocksByFirstLevel(blocks, firstLevelBlockIds);
 
-  const { children: inserted, skipped } = await insertBlocks(client, docToken, blocks);
+  const { children: inserted, skipped } = await insertBlocks(client, docToken, sortedBlocks);
   const imagesProcessed = await processImages(client, docToken, markdown, inserted);
 
   return {


### PR DESCRIPTION
## Summary
Sort blocks by first_level_block_ids in appendDoc and writeDoc functions to maintain correct content order when inserting Markdown into Feishu documents.

## Problem
When converting Markdown to Feishu document blocks, the blocks were not in the correct order because the API returns blocks separately from the first_level_block_ids array.

## Solution
Add sortBlocksByFirstLevel helper function to reorder blocks according to the first_level_block_ids array returned by the convertMarkdown API.

## Changes
- Add sortBlocksByFirstLevel helper function
- Apply sorting in appendDoc and writeDoc functions

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a helper (`sortBlocksByFirstLevel`) to reorder Feishu Docx blocks returned by `client.docx.document.convert()` so that block insertion follows `first_level_block_ids`. The helper is then applied in both `writeDoc` and `appendDoc` before calling `insertBlocks`, preserving the intended top-level content order when the API returns `blocks` out of sequence.

The update is localized to `extensions/feishu/src/docx.ts` and fits the existing flow: Markdown → `convertMarkdown` → `insertBlocks` → `processImages`, with the only behavioral change being the ordering of inserted blocks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and self-contained: it introduces deterministic sorting based on API-provided `first_level_block_ids` and uses it in the two call sites that insert converted blocks. No other behavior or external interfaces are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->