### PR TITLE
fix: report subagent timeout as 'timed out' instead of 'completed successfully'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: fix multi-agent sessions.usage discovery. (#11523) Thanks @Takhoffman.
 - Agents: recover from context overflow caused by oversized tool results (pre-emptive capping + fallback truncation). (#11579) Thanks @tyler6204.
 - Subagents/compaction: stabilize announce timing and preserve compaction metrics across retries. (#11664) Thanks @tyler6204.
+- Subagents: report timeout-aborted runs as timed out instead of completed successfully in parent-session announcements. (#13996) Thanks @dario-github.
 - Cron: share isolated announce flow and harden scheduling/delivery reliability. (#11641) Thanks @tyler6204.
 - Cron tool: recover flat params when LLM omits the `job` wrapper for add requests. (#12124) Thanks @tyler6204.
 - Gateway/CLI: when `gateway.bind=lan`, use a LAN IP for probe URLs and Control UI links. (#11448) Thanks @AnonO6.

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -338,7 +338,7 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       },
       timeoutMs: timeoutMs + 10_000,
     });
-    if (wait?.status !== "ok" && wait?.status !== "error") {
+    if (wait?.status !== "ok" && wait?.status !== "error" && wait?.status !== "timeout") {
       return;
     }
     const entry = subagentRuns.get(runId);
@@ -360,7 +360,11 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
     }
     const waitError = typeof wait.error === "string" ? wait.error : undefined;
     entry.outcome =
-      wait.status === "error" ? { status: "error", error: waitError } : { status: "ok" };
+      wait.status === "error"
+        ? { status: "error", error: waitError }
+        : wait.status === "timeout"
+          ? { status: "timeout" }
+          : { status: "ok" };
     mutated = true;
     if (mutated) {
       persistSubagentRuns();

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -214,6 +214,8 @@ function ensureListener() {
     if (phase === "error") {
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
       entry.outcome = { status: "error", error };
+    } else if (evt.data?.aborted) {
+      entry.outcome = { status: "timeout" };
     } else {
       entry.outcome = { status: "ok" };
     }

--- a/src/gateway/server-methods/agent-job.test.ts
+++ b/src/gateway/server-methods/agent-job.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { emitAgentEvent } from "../../infra/agent-events.js";
+import { waitForAgentJob } from "./agent-job.js";
+
+describe("waitForAgentJob", () => {
+  it("maps lifecycle end events with aborted=true to timeout", async () => {
+    const runId = `run-timeout-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const waitPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
+
+    emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "start", startedAt: 100 } });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 200, aborted: true },
+    });
+
+    const snapshot = await waitPromise;
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.status).toBe("timeout");
+    expect(snapshot?.startedAt).toBe(100);
+    expect(snapshot?.endedAt).toBe(200);
+  });
+
+  it("keeps non-aborted lifecycle end events as ok", async () => {
+    const runId = `run-ok-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const waitPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
+
+    emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "start", startedAt: 300 } });
+    emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end", endedAt: 400 } });
+
+    const snapshot = await waitPromise;
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.status).toBe("ok");
+    expect(snapshot?.startedAt).toBe(300);
+    expect(snapshot?.endedAt).toBe(400);
+  });
+});

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -7,7 +7,7 @@ let agentRunListenerStarted = false;
 
 type AgentRunSnapshot = {
   runId: string;
-  status: "ok" | "error";
+  status: "ok" | "error" | "timeout";
   startedAt?: number;
   endedAt?: number;
   error?: string;
@@ -55,7 +55,7 @@ function ensureAgentRunListener() {
     agentRunStarts.delete(evt.runId);
     recordAgentRunSnapshot({
       runId: evt.runId,
-      status: phase === "error" ? "error" : "ok",
+      status: phase === "error" ? "error" : evt.data?.aborted ? "timeout" : "ok",
       startedAt,
       endedAt,
       error,
@@ -118,7 +118,7 @@ export async function waitForAgentJob(params: {
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
       const snapshot: AgentRunSnapshot = {
         runId: evt.runId,
-        status: phase === "error" ? "error" : "ok",
+        status: phase === "error" ? "error" : evt.data?.aborted ? "timeout" : "ok",
         startedAt,
         endedAt,
         error,


### PR DESCRIPTION
## Problem

When a subagent times out (aborted due to timeout), it is incorrectly reported as `completed successfully` to the parent session. This causes confusion — the parent agent trusts the success status and doesn't retry or report the failure.

## Root Cause

In `src/agents/subagent-registry.ts`, the lifecycle event listener only checks for `phase === "error"`. When a subagent times out, `commands/agent.ts` emits `phase: "end"` with `aborted: true`, but the registry treats all non-error phases as `status: "ok"`.

## Fix

Check `evt.data?.aborted` in the lifecycle event handler and set `status: "timeout"` accordingly. The downstream `subagent-announce.ts` already supports the `"timeout"` status and formats it as `"timed out"` in the announce message.

**2 lines added. All 19 subagent tests pass.**

```diff
 if (phase === "error") {
   const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
   entry.outcome = { status: "error", error };
+} else if (evt.data?.aborted) {
+  entry.outcome = { status: "timeout" };
 } else {
   entry.outcome = { status: "ok" };
 }
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the subagent lifecycle event listener in `src/agents/subagent-registry.ts` to treat aborted lifecycle `end` events as a timeout outcome (instead of defaulting to `ok`), so the parent session can announce “timed out” rather than “completed successfully” for embedded runs.

The codebase also records subagent completion via a cross-process `agent.wait` RPC (in `waitForSubagentCompletion()`), and the announce flow already understands `status: "timeout"` and formats it as “timed out”.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but it likely doesn’t fully fix timeout reporting on the primary completion path.
- The lifecycle listener change correctly maps aborted lifecycle end events to `timeout`, but the main `agent.wait` (gateway) completion handler in `waitForSubagentCompletion()` still ignores `status === "timeout"`, so some timeouts may continue to be misreported or not recorded consistently.
- src/agents/subagent-registry.ts (gateway wait path)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->