### PR TITLE
fix(memory): bm25RankToScore returns constant 1.0 for all negative BM25 ranks

### DIFF
--- a/src/memory/hybrid.test.ts
+++ b/src/memory/hybrid.test.ts
@@ -12,7 +12,11 @@ describe("memory hybrid helpers", () => {
     expect(bm25RankToScore(0)).toBeCloseTo(1);
     expect(bm25RankToScore(1)).toBeCloseTo(0.5);
     expect(bm25RankToScore(10)).toBeLessThan(bm25RankToScore(1));
-    expect(bm25RankToScore(-100)).toBeCloseTo(1);
+    // FTS5 bm25() returns negative values (more negative = more relevant).
+    // Math.abs converts them so the scoring function works correctly.
+    expect(bm25RankToScore(-1)).toBeCloseTo(0.5);
+    expect(bm25RankToScore(-10)).toBeLessThan(bm25RankToScore(-1));
+    expect(bm25RankToScore(-100)).toBeLessThan(bm25RankToScore(-10));
   });
 
   it("mergeHybridResults unions by id and combines weighted scores", () => {

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -34,7 +34,7 @@ export function buildFtsQuery(raw: string): string | null {
 }
 
 export function bm25RankToScore(rank: number): number {
-  const normalized = Number.isFinite(rank) ? Math.max(0, rank) : 999;
+  const normalized = Number.isFinite(rank) ? Math.abs(rank) : 999;
   return 1 / (1 + normalized);
 }
 


### PR DESCRIPTION
FTS5 `bm25()` returns negative values (more negative = more relevant), but `bm25RankToScore` was doing `Math.max(0, rank)` which clamps all negative scores to 0. That means `1 / (1 + 0)` = 1.0 for every result, so BM25 relevance was completely thrown away in hybrid search.

Fixed by using `Math.abs(rank)` instead, which preserves the magnitude while keeping the normalization formula working.

Added test assertions for monotonic behavior with negative inputs.

Fixes #5767