### PR TITLE
fix(config): avoid redacting maxTokens-like fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Version alignment: bump manifests and package versions to `2026.2.10`; keep `appcast.xml` unchanged until the next macOS release cut.
 - CLI: add `openclaw logs --local-time` (plus `--localTime` compatibility alias) to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
+- Config: avoid redacting `maxTokens`-like fields during config snapshot redaction, preventing round-trip validation failures in `/config`. (#14006) Thanks @constansino.
 
 ## 2026.2.9
 

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -123,6 +123,7 @@ describe("redactConfigSnapshot", () => {
               },
             ],
             apiKey: "sk-proj-abcdef1234567890ghij",
+            accessToken: "access-token-value-1234567890",
           },
         },
       },
@@ -130,14 +131,16 @@ describe("redactConfigSnapshot", () => {
 
     const result = redactConfigSnapshot(snapshot);
     const models = result.config.models as Record<string, unknown>;
-    const providerList = (((models.providers as Record<string, unknown>).openai as Record<string, unknown>)
-      .models ?? []) as Array<Record<string, unknown>>;
+    const providerList = ((
+      (models.providers as Record<string, unknown>).openai as Record<string, unknown>
+    ).models ?? []) as Array<Record<string, unknown>>;
     expect(providerList[0]?.maxTokens).toBe(65536);
     expect(providerList[0]?.contextTokens).toBe(200000);
     expect(providerList[0]?.maxTokensField).toBe("max_completion_tokens");
 
     const providers = (models.providers as Record<string, Record<string, string>>) ?? {};
     expect(providers.openai.apiKey).toBe(REDACTED_SENTINEL);
+    expect(providers.openai.accessToken).toBe(REDACTED_SENTINEL);
   });
 
   it("preserves hash unchanged", () => {

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -12,7 +12,7 @@ export const REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
  * Patterns that identify sensitive config field names.
  * Aligned with the UI-hint logic in schema.ts.
  */
-const SENSITIVE_KEY_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+const SENSITIVE_KEY_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));

--- a/src/config/schema.field-metadata.ts
+++ b/src/config/schema.field-metadata.ts
@@ -731,7 +731,7 @@ export const FIELD_PLACEHOLDERS: Record<string, string> = {
   "agents.list[].identity.avatar": "avatars/openclaw.png",
 };
 
-export const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+export const SENSITIVE_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 export function isSensitivePath(path: string): boolean {
   return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -745,7 +745,7 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "agents.list[].identity.avatar": "avatars/openclaw.png",
 };
 
-const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+const SENSITIVE_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 function isSensitiveConfigPath(path: string): boolean {
   return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));


### PR DESCRIPTION
## Summary
This PR fixes a root-cause config redaction bug where keys containing `token` were matched too broadly (`/token/i`).

That broad match accidentally included non-secret fields such as:
- `maxTokens`
- `contextTokens`
- `maxTokensField`

When these values were redacted as `__OPENCLAW_REDACTED__` and then round-tripped through `/config`, subsequent validation could fail with errors like:

- `models.providers.*.models[].maxTokens: expected number, received string/NaN`

## Root Cause
Sensitive-key detection currently uses:
- `/token/i`

This matches any key containing `token`, including `maxTokens`-style model config fields, which are not secrets.

## Fix
Narrow token matching from:
- `/token/i`

to:
- `/token$/i`

Applied consistently in:
- `src/config/redact-snapshot.ts`
- `src/config/schema.field-metadata.ts`
- `src/config/schema.hints.ts`

This keeps true secrets redacted (`token`, `botToken`, `appToken`, etc.) while avoiding redaction of `maxTokens`-like numeric fields.

## Tests
Added regression coverage in:
- `src/config/redact-snapshot.test.ts`

New test verifies:
- `maxTokens`, `contextTokens`, `maxTokensField` are preserved
- `apiKey` is still redacted

## Validation
Ran:
- `npx vitest run src/config/redact-snapshot.test.ts`

## Related issues
- #12078
- #12734
- #13058
- #13210
- #13236
- #13959

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Narrowed token pattern matching from `/token/i` to `/token$/i` to prevent over-redaction of non-secret fields like `maxTokens`, `contextTokens`, and `maxTokensField` during config serialization.

**Changes:**
- Updated `SENSITIVE_KEY_PATTERNS` regex in `redact-snapshot.ts:15`, `schema.field-metadata.ts:734`, and `schema.hints.ts:748`
- Pattern now matches keys ending in "token" (e.g., `apiKey`, `botToken`, `appToken`) while excluding compound words like `maxTokens`
- Added comprehensive test coverage in `redact-snapshot.test.ts:112-141` verifying both preservation of numeric token fields and continued redaction of actual secrets

**Impact:**
- Fixes validation errors when config is round-tripped through the Web UI (numeric fields no longer become `__OPENCLAW_REDACTED__`)
- Maintains security posture for actual credentials (`token`, `botToken`, `apiKey`, etc. still redacted)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted regex fix with comprehensive test coverage
- The change is a minimal, well-tested fix to a specific pattern-matching bug. The regex change from `/token/i` to `/token$/i` is applied consistently across all three locations where sensitive patterns are defined. The new test explicitly validates both the fix (maxTokens-style fields are preserved) and the security invariant (actual tokens remain redacted). The change addresses multiple related issues and has been validated via unit tests.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->