### PR TITLE
fix(voice-call): Telnyx inbound call support - missing direction/from/to and auto-answer

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -564,6 +564,17 @@ export class CallManager {
         event.to || this.config.fromNumber || "unknown",
       );
 
+      // Auto-answer inbound calls
+      if (this.provider && "answerCall" in this.provider) {
+        void (this.provider as { answerCall: (id: string) => Promise<void> })
+          .answerCall(event.providerCallId)
+          .catch((err: unknown) => {
+            console.warn(
+              `[voice-call] Failed to answer inbound call: ${err instanceof Error ? err.message : err}`,
+            );
+          });
+      }
+
       // Update the event's callId to use our internal ID
       event.callId = call.callId;
     }

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -188,6 +188,11 @@ export class TelnyxProvider implements VoiceCallProvider {
       callId,
       providerCallId: data.payload?.call_control_id,
       timestamp: Date.now(),
+      direction: (data.payload?.direction === "incoming" ? "inbound" : "outbound") as
+        | "inbound"
+        | "outbound",
+      from: data.payload?.from as string | undefined,
+      to: data.payload?.to as string | undefined,
     };
 
     switch (data.event_type) {
@@ -296,6 +301,15 @@ export class TelnyxProvider implements VoiceCallProvider {
   }
 
   /**
+   * Answer an inbound call via Telnyx API.
+   */
+  async answerCall(providerCallId: string): Promise<void> {
+    await this.apiRequest(`/calls/${providerCallId}/actions/answer`, {
+      command_id: crypto.randomUUID(),
+    });
+  }
+
+  /**
    * Hang up a call via Telnyx API.
    */
   async hangupCall(input: HangupCallInput): Promise<void> {
@@ -350,6 +364,9 @@ interface TelnyxEvent {
   payload?: {
     call_control_id?: string;
     client_state?: string;
+    direction?: string;
+    from?: string;
+    to?: string;
     text?: string;
     transcription?: string;
     is_final?: boolean;


### PR DESCRIPTION
## Problem

The Telnyx voice-call provider does not populate `direction`, `from`, or `to` fields on normalized webhook events. This causes inbound calls to be silently dropped in `CallManager.processEvent()` because the inbound direction check (`event.direction === "inbound"`) never matches.

Additionally, when an inbound call is accepted, there is no mechanism to answer it via the Telnyx Call Control API.

## Changes

### `extensions/voice-call/src/providers/telnyx.ts`
- Add `direction`, `from`, `to` to `baseEvent` in `normalizeEvent()` — maps Telnyx `incoming`/`outgoing` to normalized `inbound`/`outbound`
- Add `answerCall()` method that calls Telnyx `/actions/answer` endpoint
- Add `direction`, `from`, `to` fields to `TelnyxEvent` payload type

### `extensions/voice-call/src/manager.ts`
- Auto-answer accepted inbound calls by calling `answerCall()` on the provider (guarded by capability check)

## Testing

Tested with a live Telnyx Call Control v2 setup:
- Before fix: inbound calls created no call record, were never answered
- After fix: inbound calls are detected, call record is created, call is auto-answered, and greeting is spoken

Outbound calls are unaffected (they match by `callId` from `client_state`, bypassing the direction check).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Telnyx voice-call provider to include `direction`, `from`, and `to` on normalized webhook events, and adds a Telnyx-specific `answerCall()` implementation that hits the Call Control v2 `/actions/answer` endpoint. `CallManager.processEvent()` is also updated to auto-answer newly accepted inbound calls when the provider exposes an `answerCall` capability.

These changes integrate into the existing normalized event flow (`parseWebhookEvent()` → `CallManager.processEvent()`), where inbound calls are only materialized into a `CallRecord` when `event.direction === "inbound"` and `event.providerCallId` are present.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge once direction normalization and the auto-answer guard are corrected.
- Core changes are small and localized, but the current Telnyx direction mapping can still misclassify inbound events when `payload.direction` is absent/variant, and the `answerCall` capability check can throw at runtime if the property exists but isn’t callable.
- extensions/voice-call/src/providers/telnyx.ts, extensions/voice-call/src/manager.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->