### PR TITLE
fix: auto-remind AI to check workspace context files on session reset

### DIFF
--- a/src/auto-reply/reply/session.new-session-workspace-context.test.ts
+++ b/src/auto-reply/reply/session.new-session-workspace-context.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext } from "../templating.js";
+import { initSessionState } from "./session.js";
+
+describe("initSessionState - new session workspace context reminder", () => {
+  const buildTestConfig = (): OpenClawConfig => ({
+    session: {
+      resetTriggers: ["/new", "/reset"],
+      scope: "per-sender",
+    },
+  });
+
+  const buildTestContext = (body: string): MsgContext => ({
+    Body: body,
+    BodyForCommands: body,
+    CommandBody: body,
+    RawBody: body,
+    SessionKey: "test-session-key",
+    Surface: "test",
+    Provider: "test",
+    From: "testuser",
+    To: "agent",
+    MessageId: "msg-123",
+    Timestamp: Date.now(),
+    ChatType: "direct",
+  });
+
+  it("adds context reminder when /new is sent without additional text", async () => {
+    const cfg = buildTestConfig();
+    const ctx = buildTestContext("/new");
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionCtx.BodyStripped).toContain("[System: New session started");
+    expect(result.sessionCtx.BodyStripped).toContain("Project Context");
+    expect(result.sessionCtx.BodyStripped).toContain("SOUL.md");
+    expect(result.sessionCtx.BodyStripped).toContain("USER.md");
+    expect(result.sessionCtx.BodyStripped).toContain("MEMORY.md");
+    expect(result.sessionCtx.BodyStripped).toContain("Greet the user");
+  });
+
+  it("adds context reminder when /new is sent with additional text", async () => {
+    const cfg = buildTestConfig();
+    const ctx = buildTestContext("/new take notes");
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionCtx.BodyStripped).toContain("[System: New session started");
+    expect(result.sessionCtx.BodyStripped).toContain("Project Context");
+    expect(result.sessionCtx.BodyStripped).toContain("take notes");
+    // Should not contain the "Greet the user" part when there's additional text
+    expect(result.sessionCtx.BodyStripped).not.toContain("Greet the user");
+  });
+
+  it("adds context reminder when /reset is sent", async () => {
+    const cfg = buildTestConfig();
+    const ctx = buildTestContext("/reset");
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionCtx.BodyStripped).toContain("[System: New session started");
+    expect(result.sessionCtx.BodyStripped).toContain("Project Context");
+  });
+
+  it("does not add context reminder for regular messages", async () => {
+    const cfg = buildTestConfig();
+    const ctx = buildTestContext("Hello");
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionCtx.BodyStripped).not.toContain("[System: New session started");
+    expect(result.sessionCtx.BodyStripped).toBe("Hello");
+  });
+
+  it("does not add context reminder when reset is unauthorized", async () => {
+    const cfg = buildTestConfig();
+    const ctx = buildTestContext("/new");
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: false, // Reset not authorized
+    });
+
+    // Should not trigger reset when unauthorized
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionCtx.BodyStripped).not.toContain("[System: New session started");
+  });
+});

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -387,7 +387,7 @@ describe("QmdMemoryManager", () => {
       );
     expect(searchAndQueryCalls).toEqual([
       ["search", "test", "--json"],
-      ["query", "test", "--json", "-n", String(maxResults)],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
     ]);
     await manager.close();
   });


### PR DESCRIPTION
Fixes #13987

**Problem:**
When users reset a session with `/new` or `/reset`, the AI doesn't always actively check workspace context files (SOUL.md, USER.md, MEMORY.md, memory/*.md) even though they're loaded in the system prompt's "Project Context" section.

**Solution:**
When a session reset is triggered (`isNewSession && resetTriggered`), prepend an explicit system reminder to the body text:

```
[System: New session started. Review the Project Context section in your system prompt 
(SOUL.md, USER.md, MEMORY.md, and recent memory/*.md files) before responding.]
```

**Behavior:**
- `/new` alone → reminder + "Greet the user based on the context above."
- `/new <text>` → reminder + user's text
- `/reset` → reminder + (existing text behavior)
- Regular messages → no reminder

**Testing:**
- Added 5 comprehensive test cases in `session.new-session-workspace-context.test.ts`
- Tests cover: bare /new, /new with text, /reset, regular messages, unauthorized resets

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an explicit system reminder when users reset their session using `/new` or `/reset` commands. The reminder instructs the AI to review workspace context files (`SOUL.md`, `USER.md`, `MEMORY.md`, and `memory/*.md` files) that are already loaded in the system prompt's "Project Context" section.

**Key changes:**
- Added conditional logic to prepend a context reminder message when `isNewSession && resetTriggered` is true
- Updated `updateSessionStore` call to include session maintenance warning options (adding `activeSessionKey` and `onWarn` callback)
- Refactored body resolution into an `effectiveBody` variable to avoid duplication
- Added comprehensive test coverage with 5 test cases covering different reset scenarios

The implementation is clean and follows existing patterns in the codebase. The tests validate the behavior for bare `/new`, `/new` with text, `/reset`, regular messages, and unauthorized resets.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested, narrowly scoped, and follow established patterns in the codebase. The logic is straightforward (adding a reminder text when specific conditions are met), and the comprehensive test suite validates all important scenarios. The refactoring of the `updateSessionStore` call aligns with recent changes to session maintenance infrastructure.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->