### PR TITLE
fix: prevent cron jobs from skipping execution when nextRunAtMs advances

### DIFF
--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { CronServiceState } from "./service/state.js";
+import { recomputeNextRunsForMaintenance } from "./service/jobs.js";
+import type { CronJob } from "./types.js";
+
+describe("issue #13992 regression - cron jobs skip execution", () => {
+  function createMockState(jobs: CronJob[]): CronServiceState {
+    return {
+      store: { version: 1, jobs },
+      running: false,
+      timer: null,
+      storeLoadedAtMs: Date.now(),
+      deps: {
+        storePath: "/mock/path",
+        cronEnabled: true,
+        nowMs: () => Date.now(),
+        log: {
+          debug: () => {},
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        } as never,
+      },
+    };
+  }
+
+  it("should NOT recompute nextRunAtMs for past-due jobs during maintenance", () => {
+    const now = Date.now();
+    const pastDue = now - 60_000; // 1 minute ago
+
+    const job: CronJob = {
+      id: "test-job",
+      name: "test job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "test" },
+      sessionTarget: "main",
+      createdAtMs: now - 3600_000,
+      updatedAtMs: now - 3600_000,
+      state: {
+        nextRunAtMs: pastDue, // This is in the past and should NOT be recomputed
+      },
+    };
+
+    const state = createMockState([job]);
+    recomputeNextRunsForMaintenance(state);
+
+    // Should not have changed the past-due nextRunAtMs
+    expect(job.state.nextRunAtMs).toBe(pastDue);
+  });
+
+  it("should compute missing nextRunAtMs during maintenance", () => {
+    const now = Date.now();
+
+    const job: CronJob = {
+      id: "test-job",
+      name: "test job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "test" },
+      sessionTarget: "main",
+      createdAtMs: now,
+      updatedAtMs: now,
+      state: {
+        // nextRunAtMs is missing
+      },
+    };
+
+    const state = createMockState([job]);
+    recomputeNextRunsForMaintenance(state);
+
+    // Should have computed a nextRunAtMs
+    expect(typeof job.state.nextRunAtMs).toBe("number");
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
+  it("should clear nextRunAtMs for disabled jobs during maintenance", () => {
+    const now = Date.now();
+    const futureTime = now + 3600_000;
+
+    const job: CronJob = {
+      id: "test-job",
+      name: "test job",
+      enabled: false, // Disabled
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "test" },
+      sessionTarget: "main",
+      createdAtMs: now,
+      updatedAtMs: now,
+      state: {
+        nextRunAtMs: futureTime,
+      },
+    };
+
+    const state = createMockState([job]);
+    recomputeNextRunsForMaintenance(state);
+
+    // Should have cleared nextRunAtMs for disabled job
+    expect(job.state.nextRunAtMs).toBeUndefined();
+  });
+
+  it("should clear stuck running markers during maintenance", () => {
+    const now = Date.now();
+    const stuckTime = now - 20 * 60_000; // 20 minutes ago (> 10 min threshold)
+    const futureTime = now + 3600_000;
+
+    const job: CronJob = {
+      id: "test-job",
+      name: "test job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "test" },
+      sessionTarget: "main",
+      createdAtMs: now,
+      updatedAtMs: now,
+      state: {
+        nextRunAtMs: futureTime,
+        runningAtMs: stuckTime, // Stuck running marker
+      },
+    };
+
+    const state = createMockState([job]);
+    recomputeNextRunsForMaintenance(state);
+
+    // Should have cleared stuck running marker
+    expect(job.state.runningAtMs).toBeUndefined();
+    // But should NOT have changed nextRunAtMs (it's still future)
+    expect(job.state.nextRunAtMs).toBe(futureTime);
+  });
+});


### PR DESCRIPTION
Fixes #13992

**Problem:**
Cron jobs were having their `nextRunAtMs` advanced to future times without executing. The scheduler would wake up, mark the time as processed, but never run the job - causing silent skips.

**Root Cause:**
When `runDueJobs()` found no due jobs (due to timing issues, race conditions, or bugs in job filtering), `onTimer()` would still call `recomputeNextRuns()` which unconditionally recomputed `nextRunAtMs` for all enabled jobs. This advanced past-due `nextRunAtMs` values to their next scheduled times WITHOUT executing the jobs first.

**Fix:**
1. Modified `runDueJobs()` to return the count of executed jobs
2. Created `recomputeNextRunsForMaintenance()` that only performs maintenance tasks (clearing disabled jobs, stuck markers) but does NOT recompute `nextRunAtMs` for enabled jobs with existing values
3. In `onTimer()`, use maintenance-only recompute when no jobs were executed to prevent silently advancing past-due `nextRunAtMs` values

**Testing:**
- Added comprehensive regression tests for #13992
- Tests verify past-due `nextRunAtMs` are NOT advanced during maintenance
- Tests verify missing `nextRunAtMs` ARE still computed
- Tests verify disabled jobs and stuck markers are still cleaned up

**Changes:**
- `src/cron/service/timer.ts` - Modified onTimer and runDueJobs
- `src/cron/service/jobs.ts` - Added recomputeNextRunsForMaintenance function
- `src/cron/service.issue-13992-regression.test.ts` - Complete regression test suite

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the cron scheduler tick behavior to avoid advancing `nextRunAtMs` for enabled jobs when a timer tick finds no due jobs, by introducing a maintenance-only recompute path and making `runDueJobs()` return an executed count.

Key additions:
- `recomputeNextRunsForMaintenance()` in `src/cron/service/jobs.ts` to only clear disabled jobs / stuck markers and fill missing `nextRunAtMs` without recalculating existing values.
- `src/cron/service/timer.ts` uses maintenance-only recompute when `runDueJobs()` executes zero jobs.
- A new regression test suite for issue #13992.

However, the current `timer.ts` in this commit appears to replace a much more feature-complete implementation from `main` (timeouts/backoff, drift handling, logging, session reaper, defensive `job.state` init). If unintentional, this is a merge-blocking regression.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge due to likely functional regressions in cron scheduler behavior.
- The fix idea is reasonable, but the `src/cron/service/timer.ts` in this commit appears to drop substantial existing scheduler logic from `main` (timeouts/backoff, drift recovery, session reaping, and defensive state handling). Additionally, the new `runDueJobs()` reads `job.state` without initialization and the regression test expectations don’t match the production stuck-run threshold constant.
- src/cron/service/timer.ts, src/cron/service/jobs.ts, src/cron/service.issue-13992-regression.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->