### PR TITLE
Update docker-release.yml

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,7 +6,7 @@ on:
       - main
     tags:
       - "v*"
-
+  workflow_dispatch:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Docker release workflow with three main changes: removes the `paths-ignore` filter, switches from registry-based caching to GitHub Actions cache (`type=gha`), and adds `workflow_dispatch` for manual triggers.

**Critical issue found**: Both build jobs define identical metadata tags including both `-amd64` and `-arm64` suffixes (lines 43-49, 92-98). This creates tag conflicts since each architecture-specific job will attempt to push tags for both architectures. Each job should only generate tags with its own architecture suffix.

- Cache change to `type=gha` is reasonable and should improve performance
- Manual `workflow_dispatch` trigger is useful
- Removing `paths-ignore` will trigger builds on doc-only changes

<h3>Confidence Score: 1/5</h3>

- Not safe to merge due to critical Docker tagging logic errors
- The duplicate tag definitions across both architecture-specific build jobs will cause tag conflicts and incorrect image tagging. This breaks the multi-architecture Docker build workflow and needs to be fixed before merging.
- `.github/workflows/docker-release.yml` requires fixes to metadata tag definitions in both build jobs

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->