### PR TITLE
feat(compaction): optional memory flush before manual /compact

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -733,6 +733,7 @@ Periodic heartbeat runs.
         reserveTokensFloor: 24000,
         memoryFlush: {
           enabled: true,
+          onManualCompact: true,
           softThresholdTokens: 6000,
           systemPrompt: "Session nearing compaction. Store durable memories now.",
           prompt: "Write any lasting notes to memory/YYYY-MM-DD.md; reply with NO_REPLY if nothing to store.",
@@ -745,6 +746,7 @@ Periodic heartbeat runs.
 
 - `mode`: `default` or `safeguard` (chunked summarization for long histories). See [Compaction](/concepts/compaction).
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.
+- `memoryFlush.onManualCompact`: when true, run a flush turn before a manual `/compact` (default: false).
 
 ### `agents.defaults.contextPruning`
 

--- a/docs/zh-CN/gateway/configuration.md
+++ b/docs/zh-CN/gateway/configuration.md
@@ -1893,6 +1893,7 @@ MiniMax 认证：设置 `MINIMAX_API_KEY`（环境变量）或配置 `models.pro
 旧版默认值：
 
 - `memoryFlush.enabled`：`true`
+- `memoryFlush.onManualCompact`：`false`（为 true 时，在手动 `/compact` 前先运行一次记忆刷新）
 - `memoryFlush.softThresholdTokens`：`4000`
 - `memoryFlush.prompt` / `memoryFlush.systemPrompt`：带 `NO_REPLY` 的内置默认值
 - 注意：当会话工作区为只读时跳过记忆刷新（`agents.defaults.sandbox.workspaceAccess: "ro"` 或 `"none"`）。
@@ -1908,6 +1909,7 @@ MiniMax 认证：设置 `MINIMAX_API_KEY`（环境变量）或配置 `models.pro
         reserveTokensFloor: 24000,
         memoryFlush: {
           enabled: true,
+          onManualCompact: true,
           softThresholdTokens: 6000,
           systemPrompt: "Session nearing compaction. Store durable memories now.",
           prompt: "Write any lasting notes to memory/YYYY-MM-DD.md; reply with NO_REPLY if nothing to store.",

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -22,6 +22,8 @@ export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
 
 export type MemoryFlushSettings = {
   enabled: boolean;
+  /** When true, run a memory flush turn before executing a manual /compact command. Default: false. */
+  onManualCompact: boolean;
   softThresholdTokens: number;
   prompt: string;
   systemPrompt: string;
@@ -42,6 +44,7 @@ export function resolveMemoryFlushSettings(cfg?: OpenClawConfig): MemoryFlushSet
   if (!enabled) {
     return null;
   }
+  const onManualCompact = defaults?.onManualCompact ?? false;
   const softThresholdTokens =
     normalizeNonNegativeInt(defaults?.softThresholdTokens) ?? DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
   const prompt = defaults?.prompt?.trim() || DEFAULT_MEMORY_FLUSH_PROMPT;
@@ -52,6 +55,7 @@ export function resolveMemoryFlushSettings(cfg?: OpenClawConfig): MemoryFlushSet
 
   return {
     enabled,
+    onManualCompact,
     softThresholdTokens,
     prompt: ensureNoReplyHint(prompt),
     systemPrompt: ensureNoReplyHint(systemPrompt),

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -261,6 +261,8 @@ export type AgentCompactionConfig = {
 export type AgentCompactionMemoryFlushConfig = {
   /** Enable the pre-compaction memory flush (default: true). */
   enabled?: boolean;
+  /** When true, run a memory flush turn before executing a manual /compact command (default: false). */
+  onManualCompact?: boolean;
   /** Run the memory flush when context is within this many tokens of the compaction threshold. */
   softThresholdTokens?: number;
   /** User prompt used for the memory flush turn (NO_REPLY is enforced if missing). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -97,6 +97,7 @@ export const AgentDefaultsSchema = z
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),
+            onManualCompact: z.boolean().optional(),
             softThresholdTokens: z.number().int().nonnegative().optional(),
             prompt: z.string().optional(),
             systemPrompt: z.string().optional(),


### PR DESCRIPTION
Adds an optional pre-compaction memory flush turn before manual /compact.\n\n- New config: agents.defaults.compaction.memoryFlush.onManualCompact (default: false)\n- When enabled, /compact runs a memory flush agent turn first, then compacts\n- Skips flush when workspace is read-only (sandbox workspaceAccess != rw) or when using CLI providers\n- Fail-open: if the flush run throws, compaction still proceeds\n\nDocs: updated configuration reference (EN + zh-CN).\nTests: added e2e coverage to ensure flush runs before compact when enabled.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional pre-compaction memory flush feature for manual `/compact` commands. When `agents.defaults.compaction.memoryFlush.onManualCompact` is enabled (default: false), the system runs a memory flush agent turn before compacting the session, allowing the agent to store durable memories to disk. The feature intelligently skips the flush when the workspace is read-only or when using CLI providers (which don't support tool runs), and follows a fail-open pattern where compaction proceeds even if the flush fails.

Key changes:
- Added `onManualCompact` config field to `AgentCompactionMemoryFlushConfig` with proper TypeScript types and Zod validation
- Updated `commands-compact.ts` to conditionally run `runEmbeddedPiAgent` before compaction
- Implemented proper guard checks for workspace access (`rw` only) and CLI provider detection
- Added comprehensive e2e test coverage verifying flush runs before compact and ordering is correct
- Updated documentation in both English and Chinese (zh-CN)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper guard rails, fail-open error handling, comprehensive test coverage, and follows existing codebase patterns. All changes are backward-compatible (feature is opt-in with default: false), and the code includes proper checks for edge cases like read-only workspaces and CLI providers.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->