### PR TITLE
fix(mattermost): respect chatmode setting for channel messages

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -427,7 +427,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const rawText = post.message?.trim() || "";
     const dmPolicy = account.config.dmPolicy ?? "pairing";
     const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-    const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+    const defaultGroupPolicyForMode = account.chatmode === "onmessage" ? "open" : "allowlist";
+    const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? defaultGroupPolicyForMode;
     const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
     const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
     const storeAllowFrom = normalizeAllowList(
@@ -605,6 +606,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         channel: "mattermost",
         accountId: account.accountId,
         groupId: channelId,
+        requireMentionOverride: account.requireMention,
       });
     const shouldBypassMention =
       isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;


### PR DESCRIPTION
Fixes #11797

When `chatmode: "onmessage"` is configured on a Mattermost account, channel messages are silently dropped due to two independent bugs:

### Bug 1: groupPolicy defaults to "allowlist"
The `groupPolicy` falls back to `"allowlist"` which drops all channel messages when `groupAllowFrom` is empty. Now defaults to `"open"` when chatmode is `"onmessage"`.

### Bug 2: requireMention ignores chatmode
`resolveRequireMention()` was called without the account-level `requireMention` override (derived from chatmode), so it defaulted to requiring @mentions. Now passes `account.requireMention` so the chatmode setting is respected.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Mattermost monitor’s inbound handling to respect account `chatmode` when deciding (1) the default `groupPolicy` fallback and (2) whether group/channel messages require an @mention.

Concretely:
- If `account.chatmode === "onmessage"`, the fallback `groupPolicy` now defaults to `"open"` (instead of `"allowlist"`) when neither the account-level nor global default policy is set.
- The call to `core.channel.groups.resolveRequireMention(...)` now passes `requireMentionOverride: account.requireMention`, allowing the chatmode-derived setting (from `resolveMattermostAccount`) to take effect during mention gating.

The changes are localized to `extensions/mattermost/src/mattermost/monitor.ts` and follow the existing config precedence patterns (account overrides > global defaults > hardcoded fallback).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, targeted, and consistent with existing config precedence patterns. The new `requireMentionOverride` wiring matches the underlying resolver behavior, and the groupPolicy fallback adjustment only applies when no explicit policy is configured.
- extensions/mattermost/src/mattermost/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->