### PR TITLE
fix(voice-call): pass Twilio stream auth token via <Parameter> instead of query string

### DIFF
--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -429,10 +429,21 @@ export class TwilioProvider implements VoiceCallProvider {
    * @param streamUrl - WebSocket URL (wss://...) for the media stream
    */
   getStreamConnectXml(streamUrl: string): string {
+    // Extract token from URL and pass via <Parameter> instead of query string.
+    // Twilio strips query params from WebSocket URLs, but delivers <Parameter>
+    // values in the "start" message's customParameters field.
+    const parsed = new URL(streamUrl);
+    const token = parsed.searchParams.get("token");
+    parsed.searchParams.delete("token");
+    const cleanUrl = parsed.toString();
+
+    const paramXml = token ? `\n      <Parameter name="token" value="${escapeXml(token)}" />` : "";
+
     return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
-    <Stream url="${escapeXml(streamUrl)}" />
+    <Stream url="${escapeXml(cleanUrl)}">${paramXml}
+    </Stream>
   </Connect>
 </Response>`;
   }


### PR DESCRIPTION
## Problem

Twilio strips query parameters from WebSocket URLs in `<Stream>` TwiML, so the auth token set via `?token=xxx` on the stream URL never arrives on the WebSocket connection. This causes `isValidStreamToken()` to always reject the stream when token validation is enabled.

## Fix

- Pass the token as a `<Parameter>` element inside `<Stream>` TwiML, which Twilio reliably delivers in the `start` message's `customParameters` field
- Extract the token from `customParameters` in the media stream handler's `handleStart()`
- Falls back to query string token for backwards compatibility

## Changes

- `twilio.ts`: `getStreamConnectXml()` now strips the token from the URL and adds it as `<Parameter name="token">`
- `media-stream.ts`: `handleStart()` reads token from `message.start.customParameters.token`, added `customParameters` to the `TwilioMediaMessage` interface

## Testing

Tested end-to-end with Twilio outbound calls — stream connects, token validates, TTS plays successfully.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Twilio media stream authentication flow to avoid relying on query parameters in `<Stream>` URLs (which Twilio strips for WebSocket connections). `TwilioProvider.getStreamConnectXml()` now removes `token` from the stream URL and passes it via a `<Parameter name="token" .../>` child element, and `MediaStreamHandler.handleStart()` prefers `message.start.customParameters.token` (falling back to the query-string token for backwards compatibility).

Overall, the change is localized to the voice-call extension’s TwiML generation and the Twilio media stream start-message handling, and it aligns with how the provider already generates and validates per-call stream tokens.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are narrowly scoped to TwiML generation and token extraction on the Twilio media stream start message. URL/token handling is properly escaped for XML, internal call sites always pass absolute stream URLs, and the previous query-string token path remains as a fallback.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->