### PR TITLE
Feature: Implement EU compliant gateway Cortecs

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -226,6 +226,27 @@ Synthetic provides Anthropic-compatible models behind the `synthetic` provider:
 }
 ```
 
+### Cortecs Gateway
+
+Cortecs is an LLM Router compliant with Europe's data privacy laws. It supports most European providers offering GDPR compliance and data privacy.
+
+- Provider: `cortecs`
+- Auth: `CORTECS_API_KEY`
+- Example model: `cortecs/gpt-oss-120b`
+- CLI: `clawdbot onboard --auth-choice cortecs-api-key`
+
+Models are auto-discovered from the Cortecs catalog. The recommended model is `gpt-oss-120b`, a 120 billion parameter model.
+
+```json5
+{
+  agents: {
+    defaults: { model: { primary: "cortecs/gpt-oss-120b" } },
+  },
+}
+```
+
+The provider is automatically configured when `CORTECS_API_KEY` is set. See [/providers/cortecs](/providers/cortecs) for setup and configuration details.
+
 ### MiniMax
 
 MiniMax is configured via `models.providers` because it uses custom endpoints:

--- a/docs/providers/cortecs.md
+++ b/docs/providers/cortecs.md
@@ -1,0 +1,53 @@
+---
+summary: "Use Cortecs's unified API to access various EU compliant models in OpenClaw"
+read_when:
+  - You want an EU compliant infrastructure for your LLMs
+  - You want to run models via a single API key in OpenClaw
+---
+
+# Cortecs Gateway
+
+Cortecs is an AI inference platform designed for strict European data compliance. It provides a gateway to run large language models across a sovereign, scalable, and privacy-first network.
+
+Source: [Cortecs Gateway](https://docs.cortecs.ai/)
+
+## Model overview
+
+Built on the principles of Sky Computing, Cortecs provides access to multiple models across various cloud providers.
+
+On our website you can find all our available [models](https://cortecs.ai/serverlessModels).
+
+The recommended model is **gpt-oss-120b**, a powerful 120 billion parameter model made by OpenAI. Which is provided by various European cloud providers such as Scaleway, OVHcloud, and Nebius.
+
+## Setup
+
+### Quick start
+
+Configure via CLI:
+
+```bash
+clawdbot onboard --auth-choice cortecs-api-key
+```
+
+Or set the API key manually:
+
+```bash
+export CORTECS_API_KEY="your-api-key-here"
+```
+
+### Config snippet
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "cortecs/gpt-oss-120b" },
+    },
+  },
+}
+```
+
+## Notes
+
+- Model refs use `cortecs/<model>` format.
+- Your data is not reused or kept by Cortecs; data privacy is guaranteed.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -51,6 +51,7 @@ See [Venice AI](/providers/venice).
 - [Venice (Venice AI, privacy-focused)](/providers/venice)
 - [Ollama (local models)](/providers/ollama)
 - [Qianfan](/providers/qianfan)
+- [Cortecs](/providers/cortecs)
 
 ## Transcription providers
 

--- a/src/agents/cortecs-models.ts
+++ b/src/agents/cortecs-models.ts
@@ -7,7 +7,7 @@ import type { ModelDefinitionConfig } from "../config/types.js";
  */
 
 export const CORTECS_BASE_URL = "https://api.cortecs.ai/v1/";
-export const CORTECS_MODELS_URL = `${CORTECS_BASE_URL}models?tag=Instruct`;
+export const CORTECS_MODELS_URL = `${CORTECS_BASE_URL}models?tag=OpenClaw`;
 
 export const CORTECS_DEFAULT_MODEL_ID = "gpt-oss-120b";
 export const CORTECS_DEFAULT_MODEL_REF = `cortecs/${CORTECS_DEFAULT_MODEL_ID}`;

--- a/src/agents/cortecs-models.ts
+++ b/src/agents/cortecs-models.ts
@@ -1,0 +1,139 @@
+import type { ModelDefinitionConfig } from "../config/types.js";
+
+/**
+ * ---------------------------------------------------------------------------
+ * Cortecs constants
+ * ---------------------------------------------------------------------------
+ */
+
+//TODO FIX::::::
+export const CORTECS_BASE_URL = "https://api.cortecs.ai/v1/";
+export const CORTECS_MODELS_URL = `${CORTECS_BASE_URL}models`;
+
+export const CORTECS_DEFAULT_MODEL_ID = "gpt-oss-120b";
+export const CORTECS_DEFAULT_MODEL_REF = `cortecs/${CORTECS_DEFAULT_MODEL_ID}`;
+export const CORTECS_DEFAULT_CONTEXT_WINDOW = 128000;
+export const CORTECS_DEFAULT_MAX_TOKENS = 8192;
+export const CORTECS_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+/**
+ * ---------------------------------------------------------------------------
+ * Cortecs /v1/models response types
+ * ---------------------------------------------------------------------------
+ */
+interface CortecsPricing {
+  /** Cost per 1M input tokens (as returned by Cortecs). */
+  input_token: number;
+  /** Cost per 1M output tokens (as returned by Cortecs). */
+  output_token: number;
+  currency: string;
+}
+
+interface CortecsModel {
+  id: string;
+  object: "model";
+  created: number;
+  owned_by: string;
+  description?: string;
+  pricing?: CortecsPricing;
+  context_size?: number;
+  tags?: string[];
+}
+
+interface CortecsModelsResponse {
+  object: "list";
+  data: CortecsModel[];
+}
+
+/**
+ * ---------------------------------------------------------------------------
+ * Default Cortecs model definition (fallback)
+ * ---------------------------------------------------------------------------
+ */
+export function buildCortecsModelDefinition(): ModelDefinitionConfig {
+  return {
+    id: CORTECS_DEFAULT_MODEL_ID,
+    name: "GPT Oss 120b",
+    reasoning: true,
+    input: ["text"],
+    cost: CORTECS_DEFAULT_COST,
+    contextWindow: CORTECS_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: CORTECS_DEFAULT_MAX_TOKENS,
+  };
+}
+
+/**
+ * ---------------------------------------------------------------------------
+ * Discover models from Cortecs /v1/models (with fallback)
+ * ---------------------------------------------------------------------------
+ */
+export async function discoverCortecsModels(): Promise<ModelDefinitionConfig[]> {
+  // Skip API discovery in test environment
+  if (process.env.VITEST || process.env.NODE_ENV === "test") {
+    return [buildCortecsModelDefinition()];
+  }
+
+  try {
+    const res = await fetch(CORTECS_MODELS_URL, {
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!res.ok) {
+      console.warn(
+        `[cortecs-models] Failed to discover models: HTTP ${res.status}, using default model`,
+      );
+      return [buildCortecsModelDefinition()];
+    }
+
+    const payload = (await res.json()) as CortecsModelsResponse;
+
+    if (!Array.isArray(payload.data) || payload.data.length === 0) {
+      console.warn("[cortecs-models] No models found from catalog, using default model");
+      return [buildCortecsModelDefinition()];
+    }
+
+    const models: ModelDefinitionConfig[] = payload.data.map((m) => {
+      const tags = m.tags ?? [];
+      const tagsLower = new Set(tags.map((t) => t.toLowerCase()));
+
+      const reasoning = tagsLower.has("reasoning");
+      const hasVision = tagsLower.has("image");
+
+      return {
+        id: m.id,
+        name: m.id,
+        reasoning,
+        input: hasVision ? ["text", "image"] : ["text"],
+        cost: {
+          // Cortecs already returns per-1M-token pricing in numeric form.
+          input: Number.isFinite(m.pricing?.input_token as number)
+            ? (m.pricing!.input_token ?? 0)
+            : 0,
+          output: Number.isFinite(m.pricing?.output_token as number)
+            ? (m.pricing!.output_token ?? 0)
+            : 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        contextWindow: m.context_size ?? CORTECS_DEFAULT_CONTEXT_WINDOW,
+
+        /**
+         * Cortecs /v1/models does not provide a separate "max output tokens".
+         * Many systems cap maxTokens separately from contextWindow.
+         *
+         * We choose a conservative default unless you later add a field.
+         */
+        maxTokens: CORTECS_DEFAULT_MAX_TOKENS,
+      };
+    });
+    return models.length > 0 ? models : [buildCortecsModelDefinition()];
+  } catch (error) {
+    console.warn(`[cortecs-models] Discovery failed: ${String(error)}, using default model`);
+    return [buildCortecsModelDefinition()];
+  }
+}

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -304,6 +304,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     opencode: "OPENCODE_API_KEY",
     qianfan: "QIANFAN_API_KEY",
     ollama: "OLLAMA_API_KEY",
+    cortecs: "CORTECS_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -7,7 +7,8 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
   const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  const isCortecs = model.provider === "cortecs" || baseUrl.includes("api.cortecs.ai");
+  if ((!isZai && !isCortecs) || !isOpenAiCompletionsModel(model)) {
     return model;
   }
 

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -58,7 +58,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option(
       "--auth-choice <choice>",
-      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
+      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|cortecs-api-key|skip",
     )
     .option(
       "--token-provider <id>",
@@ -86,6 +86,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--synthetic-api-key <key>", "Synthetic API key")
     .option("--venice-api-key <key>", "Venice API key")
     .option("--opencode-zen-api-key <key>", "OpenCode Zen API key")
+    .option("--cortecs-api-key <key>", "Cortecs API key")
     .option("--xai-api-key <key>", "xAI API key")
     .option("--qianfan-api-key <key>", "QIANFAN API key")
     .option("--gateway-port <port>", "Gateway port")

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -24,7 +24,8 @@ export type AuthChoiceGroupId =
   | "venice"
   | "qwen"
   | "qianfan"
-  | "xai";
+  | "xai"
+  | "cortecs";
 
 export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
@@ -141,6 +142,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     hint: "Account ID + Gateway ID + API key",
     choices: ["cloudflare-ai-gateway-api-key"],
   },
+  {
+    value: "cortecs",
+    label: "Cortecs",
+    hint: "API key",
+    choices: ["cortecs-api-key"],
+  },
 ];
 
 export function buildAuthChoiceOptions(params: {
@@ -191,6 +198,11 @@ export function buildAuthChoiceOptions(params: {
     value: "venice-api-key",
     label: "Venice AI API key",
     hint: "Privacy-focused inference (uncensored models)",
+  });
+  options.push({
+    value: "cortecs-api-key",
+    label: "Cortecs API key",
+    hint: "Europe's LLMRouter with GDPR compliance",
   });
   options.push({
     value: "github-copilot",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -23,6 +23,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "xiaomi-api-key": "xiaomi",
   "synthetic-api-key": "synthetic",
   "venice-api-key": "venice",
+  "cortecs-api-key": "cortecs",
   "github-copilot": "github-copilot",
   "copilot-proxy": "copilot-proxy",
   "minimax-cloud": "minimax",

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -608,7 +608,6 @@ export function applyCortecsConfig(cfg: OpenClawConfig): OpenClawConfig {
  */
 export function applyVeniceProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
-  console.log("models", models);
   models[VENICE_DEFAULT_MODEL_REF] = {
     ...models[VENICE_DEFAULT_MODEL_REF],
     alias: models[VENICE_DEFAULT_MODEL_REF]?.alias ?? "Llama 3.3 70B",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -115,6 +115,19 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
   });
 }
 
+export async function setCortecsApiKey(key: string, agentDir?: string) {
+  // Write to resolved agent dir so gateway finds credentials on startup.
+  upsertAuthProfile({
+    profileId: "cortecs:default",
+    credential: {
+      type: "api_key",
+      provider: "cortecs",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -141,8 +141,8 @@ export function buildXaiModelDefinition(): ModelDefinitionConfig {
 export function buildCortecsModelDefinition(): ModelDefinitionConfig {
   return {
     id: CORTECS_DEFAULT_MODEL_ID,
-    name: "gpt-oss-120b",
-    reasoning: false,
+    name: "GPT Oss 120b",
+    reasoning: true,
     input: ["text"],
     cost: CORTECS_DEFAULT_COST,
     contextWindow: CORTECS_DEFAULT_CONTEXT_WINDOW,

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -1,4 +1,12 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
+import {
+  CORTECS_BASE_URL,
+  CORTECS_DEFAULT_CONTEXT_WINDOW,
+  CORTECS_DEFAULT_COST,
+  CORTECS_DEFAULT_MAX_TOKENS,
+  CORTECS_DEFAULT_MODEL_ID,
+  CORTECS_DEFAULT_MODEL_REF,
+} from "../agents/cortecs-models.ts";
 import { QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";
 
 export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
@@ -16,6 +24,15 @@ export const MOONSHOT_DEFAULT_CONTEXT_WINDOW = 256000;
 export const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
 export const KIMI_CODING_MODEL_ID = "k2p5";
 export const KIMI_CODING_MODEL_REF = `kimi-coding/${KIMI_CODING_MODEL_ID}`;
+
+export {
+  CORTECS_BASE_URL,
+  CORTECS_DEFAULT_CONTEXT_WINDOW,
+  CORTECS_DEFAULT_COST,
+  CORTECS_DEFAULT_MAX_TOKENS,
+  CORTECS_DEFAULT_MODEL_ID,
+  CORTECS_DEFAULT_MODEL_REF,
+};
 
 export { QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID };
 export const QIANFAN_DEFAULT_MODEL_REF = `qianfan/${QIANFAN_DEFAULT_MODEL_ID}`;
@@ -118,5 +135,17 @@ export function buildXaiModelDefinition(): ModelDefinitionConfig {
     cost: XAI_DEFAULT_COST,
     contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
     maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  };
+}
+
+export function buildCortecsModelDefinition(): ModelDefinitionConfig {
+  return {
+    id: CORTECS_DEFAULT_MODEL_ID,
+    name: "gpt-oss-120b",
+    reasoning: false,
+    input: ["text"],
+    cost: CORTECS_DEFAULT_COST,
+    contextWindow: CORTECS_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: CORTECS_DEFAULT_MAX_TOKENS,
   };
 }

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -21,6 +21,8 @@ export {
   applySyntheticProviderConfig,
   applyVeniceConfig,
   applyVeniceProviderConfig,
+  applyCortecsConfig,
+  applyCortecsProviderConfig,
   applyVercelAiGatewayConfig,
   applyVercelAiGatewayProviderConfig,
   applyXiaomiConfig,
@@ -56,6 +58,7 @@ export {
   setOpenrouterApiKey,
   setSyntheticApiKey,
   setVeniceApiKey,
+  setCortecsApiKey,
   setVercelAiGatewayApiKey,
   setXiaomiApiKey,
   setZaiApiKey,
@@ -83,4 +86,5 @@ export {
   MOONSHOT_BASE_URL,
   MOONSHOT_DEFAULT_MODEL_ID,
   MOONSHOT_DEFAULT_MODEL_REF,
+  CORTECS_DEFAULT_MODEL_REF,
 } from "./onboard-auth.models.js";

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -21,6 +21,7 @@ import {
   applyOpenrouterConfig,
   applySyntheticConfig,
   applyVeniceConfig,
+  applyCortecsConfig,
   applyVercelAiGatewayConfig,
   applyXaiConfig,
   applyXiaomiConfig,
@@ -37,6 +38,7 @@ import {
   setSyntheticApiKey,
   setXaiApiKey,
   setVeniceApiKey,
+  setCortecsApiKey,
   setVercelAiGatewayApiKey,
   setXiaomiApiKey,
   setZaiApiKey,
@@ -485,6 +487,29 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applyVeniceConfig(nextConfig);
+  }
+
+  if (authChoice === "cortecs-api-key") {
+    const resolved = await resolveNonInteractiveApiKey({
+      provider: "cortecs",
+      cfg: baseConfig,
+      flagValue: opts.cortecsApiKey,
+      flagName: "--cortecs-api-key",
+      envVar: "CORTECS_API_KEY",
+      runtime,
+    });
+    if (!resolved) {
+      return null;
+    }
+    if (resolved.source !== "profile") {
+      await setCortecsApiKey(resolved.key);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "cortecs:default",
+      provider: "cortecs",
+      mode: "api_key",
+    });
+    return applyCortecsConfig(nextConfig);
   }
 
   if (

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -19,6 +19,7 @@ export type AuthChoice =
   | "kimi-code-api-key"
   | "synthetic-api-key"
   | "venice-api-key"
+  | "cortecs-api-key"
   | "codex-cli"
   | "apiKey"
   | "gemini-api-key"
@@ -80,6 +81,7 @@ export type OnboardOptions = {
   minimaxApiKey?: string;
   syntheticApiKey?: string;
   veniceApiKey?: string;
+  cortecsApiKey?: string;
   opencodeZenApiKey?: string;
   xaiApiKey?: string;
   qianfanApiKey?: string;


### PR DESCRIPTION
### Integrating Cortecs Gateway

This pull request integrates the GDPR-compliant router  [cortecs](https://cortecs.ai/), which supports all major European providers, including OVHCloud, Scaleway, Ionos, Mistral, and more. 
As suggested in #10419, natively supporting EU-providers would be beneficial.

### Implementation

The implementation closely follows that of the other OpenAI-compatible providers. The tests ran without issues. In addition, the integration was tested with all models manually. Our API was configured to filter for OpenClaw-compatible models, so they can be fetched properly within the system. 

<img width="662" height="934" alt="image" src="https://github.com/user-attachments/assets/52949e87-f7b5-491c-848d-603ba8a66322" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds first-class support for the Cortecs EU/GDPR-compliant gateway as an OpenAI-compatible provider. It introduces Cortecs model discovery (`src/agents/cortecs-models.ts`), wires `CORTECS_API_KEY` into auth resolution and implicit provider detection, and extends the onboarding/auth-choice flows (interactive and non-interactive) to configure Cortecs and set a default `cortecs/gpt-oss-120b` model. Documentation is updated to list Cortecs and provide setup instructions.

Overall, the change follows existing provider patterns (Venice/Synthetic/etc.) and integrates at the expected seams: env var auth mapping, implicit providers, onboarding option plumbing, and model compatibility normalization for OpenAI-completions providers.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the remaining debug output is removed.
- Integration is localized and follows existing provider/onboarding patterns, with model discovery guarded in tests and auth wiring consistent with other providers. The main merge blocker spotted is a stray `console.log` added to the Venice config path, which will produce noisy output in normal CLI runs and may expose configuration details.
- src/commands/onboard-auth.config-core.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->