### PR TITLE
docs: improved permission configuration instructions

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -26,6 +26,14 @@ Local checkout (when running from a git repo):
 openclaw plugins install ./extensions/feishu
 ```
 
+Makesure plugin is enabled:
+
+```
+openclaw plugins list
+# If plugin is disabled
+openclaw plugins enable feishu
+```
+
 ---
 
 ## Quickstart
@@ -98,8 +106,8 @@ From **Credentials & Basic Info**, copy:
 
 ### 4. Configure permissions
 
-On **Permissions**, click **Batch import** and paste:
-
+On **Permissions**, click **Batch import** and paste:  
+Feishu (China)
 ```json
 {
   "scopes": {
@@ -126,6 +134,27 @@ On **Permissions**, click **Batch import** and paste:
 }
 ```
 
+Lark (international)
+```json
+{
+  "scopes": {
+    "tenant": [
+      "application:application:self_manage",
+      "application:bot.menu:write",
+      "contact:user.employee_id:readonly",
+      "event:ip_list",
+      "im:chat.members:bot_access",
+      "im:message",
+      "im:message.group_at_msg:readonly",
+      "im:message.p2p_msg:readonly",
+      "im:message:readonly",
+      "im:message:send_as_bot",
+      "im:resource"
+    ]
+  }
+}
+```
+
 ![Configure permissions](../images/feishu-step4-permissions.png)
 
 ### 5. Enable bot capability
@@ -141,7 +170,7 @@ In **App Capability** > **Bot**:
 
 ⚠️ **Important:** before setting event subscription, make sure:
 
-1. You already ran `openclaw channels add` for Feishu
+1. You already ran `openclaw channels add` for Feishu (Please refer to Step 2: Configure OpenClaw)
 2. The gateway is running (`openclaw gateway status`)
 
 In **Event Subscription**:

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -109,6 +109,7 @@ From **Credentials & Basic Info**, copy:
 On **Permissions**, click **Batch import** and paste:
 
 Feishu (China)
+
 ```json
 {
   "scopes": {
@@ -136,6 +137,7 @@ Feishu (China)
 ```
 
 Lark (international)
+
 ```json
 {
   "scopes": {

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -26,7 +26,7 @@ Local checkout (when running from a git repo):
 openclaw plugins install ./extensions/feishu
 ```
 
-Makesure plugin is enabled:
+Make sure plugin is enabled:
 
 ```
 openclaw plugins list
@@ -106,7 +106,8 @@ From **Credentials & Basic Info**, copy:
 
 ### 4. Configure permissions
 
-On **Permissions**, click **Batch import** and paste:  
+On **Permissions**, click **Batch import** and paste:
+
 Feishu (China)
 ```json
 {

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -26,7 +26,7 @@ Local checkout (when running from a git repo):
 openclaw plugins install ./extensions/feishu
 ```
 
-Make sure plugin is enabled:
+Make sure feishu plugin is enabled:
 
 ```
 openclaw plugins list

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -26,6 +26,14 @@ openclaw plugins install @openclaw/feishu
 openclaw plugins install ./extensions/feishu
 ```
 
+确保飞书插件已启用：
+
+```
+openclaw plugins list
+# 如果插件未启用
+openclaw plugins enable feishu
+```
+
 ---
 
 ## 快速开始
@@ -100,6 +108,7 @@ Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设
 
 在 **权限管理** 页面，点击 **批量导入** 按钮，粘贴以下 JSON 配置一键导入所需权限：
 
+飞书（国内版）
 ```json
 {
   "scopes": {
@@ -132,6 +141,27 @@ Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设
 }
 ```
 
+Lark（国际版）
+```json
+{
+  "scopes": {
+    "tenant": [
+      "application:application:self_manage",
+      "application:bot.menu:write",
+      "contact:user.employee_id:readonly",
+      "event:ip_list",
+      "im:chat.members:bot_access",
+      "im:message",
+      "im:message.group_at_msg:readonly",
+      "im:message.p2p_msg:readonly",
+      "im:message:readonly",
+      "im:message:send_as_bot",
+      "im:resource"
+    ]
+  }
+}
+```
+
 ![配置应用权限](/images/feishu-step4-permissions.png)
 
 ### 5. 启用机器人能力
@@ -147,7 +177,7 @@ Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设
 
 ⚠️ **重要提醒**：在配置事件订阅前，请务必确保已完成以下步骤：
 
-1. 运行 `openclaw channels add` 添加了 Feishu 渠道
+1. 运行 `openclaw channels add` 添加了 Feishu 渠道（请参考第二步：配置 OpenClaw）
 2. 网关处于启动状态（可通过 `openclaw gateway status` 检查状态）
 
 在 **事件订阅** 页面：

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -109,6 +109,7 @@ Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设
 在 **权限管理** 页面，点击 **批量导入** 按钮，粘贴以下 JSON 配置一键导入所需权限：
 
 飞书（国内版）
+
 ```json
 {
   "scopes": {
@@ -142,6 +143,7 @@ Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设
 ```
 
 Lark（国际版）
+
 ```json
 {
   "scopes": {


### PR DESCRIPTION
- Remind users to ensure the Feishu plugin is enabled so that the configured event callback steps can execute correctly.
- Some permissions are not supported by Lark; the permission import section has been improved, and Feishu and Lark use different JSON formats.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Feishu/Lark channel setup docs (English + zh-CN) by adding a reminder to ensure the Feishu plugin is enabled before configuring callbacks, and by splitting the permission “batch import” JSON into separate examples for Feishu (China) vs Lark (international), since they use different formats / supported scopes.

Changes are limited to documentation under `docs/channels/` and its zh-CN counterpart, and do not affect runtime code paths.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, but has a couple of doc-quality issues that should be cleaned up.
- Only documentation changed; the main concerns are a visible typo and slightly broken/fragile markdown formatting in the permissions section that can render poorly on the docs site.
- docs/channels/feishu.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->