### PR TITLE
fix: make '/model default' reset to configured default model

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.lists-allowlisted-models-model-list.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.lists-allowlisted-models-model-list.e2e.test.ts
@@ -299,4 +299,58 @@ describe("directive behavior", () => {
       expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
     });
   });
+
+  it("resets model override on /model default", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockReset();
+      const storePath = path.join(home, "sessions.json");
+
+      await getReplyFromConfig(
+        { Body: "/model openai/gpt-4.1-mini", From: "+1222", To: "+1222", CommandAuthorized: true },
+        {},
+        {
+          agents: {
+            defaults: {
+              model: { primary: "anthropic/claude-opus-4-5" },
+              workspace: path.join(home, "openclaw"),
+              models: {
+                "anthropic/claude-opus-4-5": {},
+                "openai/gpt-4.1-mini": {},
+              },
+            },
+          },
+          session: { store: storePath },
+        },
+      );
+
+      assertModelSelection(storePath, {
+        model: "gpt-4.1-mini",
+        provider: "openai",
+      });
+
+      await getReplyFromConfig(
+        { Body: "/model default", From: "+1222", To: "+1222", CommandAuthorized: true },
+        {},
+        {
+          agents: {
+            defaults: {
+              model: { primary: "anthropic/claude-opus-4-5" },
+              workspace: path.join(home, "openclaw"),
+              models: {
+                "anthropic/claude-opus-4-5": {},
+                "openai/gpt-4.1-mini": {},
+              },
+            },
+          },
+          session: { store: storePath },
+        },
+      );
+
+      assertModelSelection(storePath, {
+        model: undefined,
+        provider: undefined,
+      });
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -523,6 +523,16 @@ export function resolveModelDirectiveSelection(params: {
     return { selection: buildSelection(best.provider, best.model) };
   };
 
+  if (!rawTrimmed.includes("/") && rawLower === "default") {
+    return {
+      selection: {
+        provider: defaultProvider,
+        model: defaultModel,
+        isDefault: true,
+      },
+    };
+  }
+
   const resolved = resolveModelRefFromString({
     raw: rawTrimmed,
     defaultProvider,


### PR DESCRIPTION
Fixes #13982

`/model default` should reset the current session override back to the configured default model.

Before this change, `default` was treated like a literal model name, which could resolve to invalid IDs like `anthropic/default`.

### What changed
- Added explicit handling for `default` (without a provider prefix) in model directive resolution.
- It now maps to configured `defaultProvider/defaultModel` and clears the session override.
- Added an e2e test for:
  1) `/model openai/gpt-4.1-mini`
  2) `/model default`
  3) verify override is cleared.

### Validation
- Ran targeted e2e test for the new flow and it passes.