### PR TITLE
fix(webchat): hide inbound untrusted metadata block in chat bubbles

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -43,3 +43,22 @@ describe("extractThinkingCached", () => {
     expect(extractThinkingCached(message)).toBe("Plan A");
   });
 });
+
+describe("extractText metadata stripping", () => {
+  it("strips inbound untrusted conversation metadata from user-visible text", () => {
+    const message = {
+      role: "user",
+      content:
+        "Conversation info (untrusted metadata):\n```json\n{\n  \"conversation_label\": \"Test\"\n}\n```\n\nHello world",
+    };
+    expect(extractText(message)).toBe("Hello world");
+  });
+
+  it("keeps normal user content untouched", () => {
+    const message = {
+      role: "user",
+      content: "Just a normal message",
+    };
+    expect(extractText(message)).toBe("Just a normal message");
+  });
+});


### PR DESCRIPTION
Fixes #13989

Webchat should not show injected inbound metadata blocks as if they were user-typed content.

This change keeps metadata available for agent processing, but removes it from chat bubble display.

### What changed
- Added display-layer stripping for inbound metadata blocks in `ui/src/ui/chat/message-extract.ts`.
- Added unit tests in `ui/src/ui/chat/message-extract.test.ts` to confirm:
  - metadata blocks are hidden from rendered user text
  - normal user messages stay unchanged.

### Notes
- Scope is intentionally UI-only (no behavior change in agent context ingestion).