### PR TITLE
fix: don't lowercase Slack channel IDs

### DIFF
--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -11,8 +11,7 @@ export function normalizeTargetForProvider(provider: string, raw?: string): stri
   }
   const providerId = normalizeChannelId(provider);
   const plugin = providerId ? getChannelPlugin(providerId) : undefined;
-  const normalized =
-    plugin?.messaging?.normalizeTarget?.(raw) ?? (raw.trim().toLowerCase() || undefined);
+  const normalized = plugin?.messaging?.normalizeTarget?.(raw) ?? (raw.trim() || undefined);
   return normalized || undefined;
 }
 


### PR DESCRIPTION
### Problem
Slack channel IDs are case-sensitive. Lowercasing them causes "Unknown channel" errors for DMs (`D0ADSDZ345P` → `d0adsdz345p`).

### Solution
Removed `.toLowerCase()` from target normalization. IDs now preserve original case.

### Changes
- `src/infra/outbound/target-normalization.ts`: removed `.toLowerCase()` call

fixes #14010

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removes `.toLowerCase()` from target normalization fallback to preserve case-sensitivity of Slack channel IDs. This fixes "Unknown channel" errors for DM channels where Slack requires exact case (e.g., `D0ADSDZ345P` must stay uppercase, not `d0adsdz345p`).

The change is minimal and correct:
- All 19 channel plugins provide custom `normalizeTarget` functions, so this fallback path is rarely used
- Slack's custom normalizer (`normalizeSlackMessagingTarget`) preserves the original case in the `id` field which is used for API calls
- The fallback now returns `raw.trim()` instead of `raw.trim().toLowerCase()`, preventing case mutation when no plugin normalizer is available

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted one-line change that removes case mutation from a rarely-used fallback path. All channel plugins provide custom normalizers, so the fallback only triggers when a plugin is missing or misconfigured. The change directly addresses the reported issue and doesn't introduce new logic or complexity.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->