### PR TITLE
feat(telegram): add ignoreMediaTypes config to skip specific inbound media

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -121,6 +121,10 @@ export type TelegramAccountConfig = {
   /** @deprecated Legacy key; migrated automatically to `streaming`. */
   streamMode?: "off" | "partial" | "block";
   mediaMaxMb?: number;
+  /** Inbound media types to silently skip. Supported: "photo", "video", "video_note", "document", "audio", "voice", "sticker". */
+  ignoreMediaTypes?: Array<
+    "photo" | "video" | "video_note" | "document" | "audio" | "voice" | "sticker"
+  >;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
   /** Retry policy for outbound Telegram API calls. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -155,6 +155,9 @@ export const TelegramAccountSchemaBase = z
     // Legacy key kept for automatic migration to `streaming`.
     streamMode: z.enum(["off", "partial", "block"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
+    ignoreMediaTypes: z
+      .array(z.enum(["photo", "video", "video_note", "document", "audio", "voice", "sticker"]))
+      .optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -343,7 +343,7 @@ export const registerTelegramHandlers = ({
         const groupMsg = ctx.message;
         if (groupMsg && !albumHasMention && groupIgnoreList.length) {
           const mediaType = resolveTelegramMediaType(groupMsg);
-          if (mediaType && groupIgnoreList.includes(mediaType as any)) {
+          if (mediaType && (groupIgnoreList as readonly string[]).includes(mediaType)) {
             continue;
           }
         }
@@ -1237,7 +1237,7 @@ export const registerTelegramHandlers = ({
       const isIgnoredMediaType =
         detectedMediaType != null &&
         !mentionedInGroup &&
-        effectiveIgnoreList.includes(detectedMediaType as any);
+        (effectiveIgnoreList as readonly string[]).includes(detectedMediaType);
 
       if (isIgnoredMediaType) {
         const hasTextContent = Boolean((msg.text ?? msg.caption ?? "").trim());

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -52,6 +52,7 @@ import {
 } from "./group-access.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
+import { resolveIgnoreMediaTypes, resolveTelegramMediaType } from "./media-type-filter.js";
 import {
   buildModelsKeyboard,
   buildProviderKeyboard,
@@ -70,35 +71,6 @@ function isMediaSizeLimitError(err: unknown): boolean {
 
 function isRecoverableMediaGroupError(err: unknown): boolean {
   return err instanceof MediaFetchError || isMediaSizeLimitError(err);
-}
-
-/** Media types silently skipped in group chats when ignoreMediaTypes is not explicitly configured. */
-const GROUP_DEFAULT_IGNORE_MEDIA_TYPES: readonly string[] = ["video_note", "video"];
-
-/** Resolve the Telegram media type string from a message, or null if no media. */
-function resolveTelegramMediaType(msg: Message): string | null {
-  if (msg.video_note) {
-    return "video_note";
-  }
-  if (msg.voice) {
-    return "voice";
-  }
-  if (msg.audio) {
-    return "audio";
-  }
-  if (msg.video) {
-    return "video";
-  }
-  if (msg.document) {
-    return "document";
-  }
-  if (msg.photo) {
-    return "photo";
-  }
-  if (msg.sticker) {
-    return "sticker";
-  }
-  return null;
 }
 
 export const registerTelegramHandlers = ({
@@ -339,8 +311,7 @@ export const registerTelegramHandlers = ({
         isGroupAlbum && groupBotUsername
           ? entry.messages.some(({ msg: m }) => hasBotMention(m, groupBotUsername))
           : false;
-      const albumIgnoreList =
-        telegramCfg.ignoreMediaTypes ?? (isGroupAlbum ? GROUP_DEFAULT_IGNORE_MEDIA_TYPES : []);
+      const albumIgnoreList = resolveIgnoreMediaTypes(telegramCfg.ignoreMediaTypes, isGroupAlbum);
 
       const allMedia: TelegramMediaRef[] = [];
       for (const { ctx } of entry.messages) {
@@ -1236,8 +1207,7 @@ export const registerTelegramHandlers = ({
       const detectedMediaType = resolveTelegramMediaType(msg);
       const botUsername = ctx.me?.username?.toLowerCase();
       const mentionedInGroup = isGroup && botUsername ? hasBotMention(msg, botUsername) : false;
-      const effectiveIgnoreList =
-        telegramCfg.ignoreMediaTypes ?? (isGroup ? GROUP_DEFAULT_IGNORE_MEDIA_TYPES : []);
+      const effectiveIgnoreList = resolveIgnoreMediaTypes(telegramCfg.ignoreMediaTypes, isGroup);
       const isIgnoredMediaType =
         detectedMediaType != null &&
         !mentionedInGroup &&

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -41,6 +41,7 @@ import { resolveMedia } from "./bot/delivery.js";
 import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
+  hasBotMention,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
@@ -69,6 +70,35 @@ function isMediaSizeLimitError(err: unknown): boolean {
 
 function isRecoverableMediaGroupError(err: unknown): boolean {
   return err instanceof MediaFetchError || isMediaSizeLimitError(err);
+}
+
+/** Media types silently skipped in group chats when ignoreMediaTypes is not explicitly configured. */
+const GROUP_DEFAULT_IGNORE_MEDIA_TYPES: readonly string[] = ["video_note", "video"];
+
+/** Resolve the Telegram media type string from a message, or null if no media. */
+function resolveTelegramMediaType(msg: Message): string | null {
+  if (msg.video_note) {
+    return "video_note";
+  }
+  if (msg.voice) {
+    return "voice";
+  }
+  if (msg.audio) {
+    return "audio";
+  }
+  if (msg.video) {
+    return "video";
+  }
+  if (msg.document) {
+    return "document";
+  }
+  if (msg.photo) {
+    return "photo";
+  }
+  if (msg.sticker) {
+    return "sticker";
+  }
+  return null;
 }
 
 export const registerTelegramHandlers = ({
@@ -301,8 +331,22 @@ export const registerTelegramHandlers = ({
       const captionMsg = entry.messages.find((m) => m.msg.caption || m.msg.text);
       const primaryEntry = captionMsg ?? entry.messages[0];
 
+      // Media groups only occur in groups. Check if any message in the album mentions the bot.
+      const groupBotUsername = primaryEntry?.ctx.me?.username?.toLowerCase();
+      const albumHasMention = groupBotUsername
+        ? entry.messages.some(({ msg: m }) => hasBotMention(m, groupBotUsername))
+        : false;
+      const groupIgnoreList = telegramCfg.ignoreMediaTypes ?? GROUP_DEFAULT_IGNORE_MEDIA_TYPES;
+
       const allMedia: TelegramMediaRef[] = [];
       for (const { ctx } of entry.messages) {
+        const groupMsg = ctx.message;
+        if (groupMsg && !albumHasMention && groupIgnoreList.length) {
+          const mediaType = resolveTelegramMediaType(groupMsg);
+          if (mediaType && groupIgnoreList.includes(mediaType as any)) {
+            continue;
+          }
+        }
         let media;
         try {
           media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
@@ -1179,6 +1223,59 @@ export const registerTelegramHandlers = ({
           topicConfig,
         })
       ) {
+        return;
+      }
+
+      // Check ignoreMediaTypes — skip download for ignored types.
+      // In groups: default to skipping video_note + video (unless bot is @mentioned).
+      // In DMs: no default filtering. Explicit config always takes precedence.
+      const detectedMediaType = resolveTelegramMediaType(msg);
+      const botUsername = ctx.me?.username?.toLowerCase();
+      const mentionedInGroup = isGroup && botUsername ? hasBotMention(msg, botUsername) : false;
+      const effectiveIgnoreList =
+        telegramCfg.ignoreMediaTypes ?? (isGroup ? GROUP_DEFAULT_IGNORE_MEDIA_TYPES : []);
+      const isIgnoredMediaType =
+        detectedMediaType != null &&
+        !mentionedInGroup &&
+        effectiveIgnoreList.includes(detectedMediaType as any);
+
+      if (isIgnoredMediaType) {
+        const hasTextContent = Boolean((msg.text ?? msg.caption ?? "").trim());
+        if (!hasTextContent) {
+          logVerbose(`telegram: skipping ${detectedMediaType} message (ignoreMediaTypes)`);
+          return;
+        }
+        // Has caption text — fall through but skip media download
+      }
+
+      let media: Awaited<ReturnType<typeof resolveMedia>> = null;
+      if (!isIgnoredMediaType) {
+        try {
+          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+        } catch (mediaErr) {
+          const errMsg = String(mediaErr);
+          if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {
+            const limitMb = Math.round(mediaMaxBytes / (1024 * 1024));
+            await withTelegramApiErrorLogging({
+              operation: "sendMessage",
+              runtime,
+              fn: () =>
+                bot.api.sendMessage(chatId, `⚠️ File too large. Maximum size is ${limitMb}MB.`, {
+                  reply_to_message_id: msg.message_id,
+                }),
+            }).catch(() => {});
+            logger.warn({ chatId, error: errMsg }, "media exceeds size limit");
+            return;
+          }
+          throw mediaErr;
+        }
+      }
+
+      // Skip sticker-only messages where the sticker was skipped (animated/video)
+      // These have no media and no text content to process.
+      const hasText = Boolean((msg.text ?? msg.caption ?? "").trim());
+      if (msg.sticker && !media && !hasText) {
+        logVerbose("telegram: skipping sticker-only message (unsupported sticker type)");
         return;
       }
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,7 +1,4 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
-import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
-import type { TelegramMediaRef } from "./bot-message-context.js";
-import type { TelegramContext } from "./bot/types.js";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
@@ -20,6 +17,7 @@ import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js
 import { loadConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/io.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
+import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { MediaFetchError } from "../media/fetch.js";
@@ -32,6 +30,7 @@ import {
   normalizeAllowFromWithStore,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
+import type { TelegramMediaRef } from "./bot-message-context.js";
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
   MEDIA_GROUP_TIMEOUT_MS,
@@ -46,6 +45,7 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
+import type { TelegramContext } from "./bot/types.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,

--- a/src/telegram/media-type-filter.ts
+++ b/src/telegram/media-type-filter.ts
@@ -1,0 +1,41 @@
+import type { Message } from "@grammyjs/types";
+
+/** Media types silently skipped in group chats when ignoreMediaTypes is not explicitly configured. */
+export const GROUP_DEFAULT_IGNORE_MEDIA_TYPES: readonly string[] = ["video_note", "video"];
+
+/** Resolve the Telegram media type string from a message, or null if no media. */
+export function resolveTelegramMediaType(msg: Message): string | null {
+  if (msg.video_note) {
+    return "video_note";
+  }
+  if (msg.voice) {
+    return "voice";
+  }
+  if (msg.audio) {
+    return "audio";
+  }
+  if (msg.video) {
+    return "video";
+  }
+  if (msg.document) {
+    return "document";
+  }
+  if (msg.photo) {
+    return "photo";
+  }
+  if (msg.sticker) {
+    return "sticker";
+  }
+  return null;
+}
+
+/**
+ * Return the effective ignore list for a given context.
+ * Uses explicit config when set; otherwise falls back to group defaults in group chats.
+ */
+export function resolveIgnoreMediaTypes(
+  configuredTypes: readonly string[] | undefined,
+  isGroup: boolean,
+): readonly string[] {
+  return configuredTypes ?? (isGroup ? GROUP_DEFAULT_IGNORE_MEDIA_TYPES : []);
+}


### PR DESCRIPTION
## Problem

In group chats, the bot processes **every** incoming media message — including video notes (circles) and videos — even when it wasn't mentioned. This leads to:
- "File too large" errors on video notes
- Meaningless LLM responses to casual media the bot wasn't asked about
- Noise in active group chats where people share circles/videos frequently

![Screenshot 2026-02-23 at 19 23 56](https://github.com/user-attachments/assets/fe9a2630-2d06-4fc6-bc72-ac0734d21884)


The only existing media controls are `mediaMaxMb` (size limit) and sticker-type filtering — there's no way to skip specific media types at the config level.

## Solution

Add `channels.telegram.ignoreMediaTypes` — an optional array of media type strings to silently skip during inbound processing.

### Behavior matrix

#### Before (current behavior)

| Context                 | All media types        |
|-------------------------|------------------------|
| DM                      | ✅ Processed            |
| Group, no @mention      | ✅ Processed            |
| Group, bot @mentioned   | ✅ Processed            |

#### After (with this PR)

| Context                 | `ignoreMediaTypes` not set          | `ignoreMediaTypes` explicitly set |
|-------------------------|-------------------------------------|-----------------------------------|
| DM                      | ✅ All media processed               | 🚫 Skips types from list          |
| Group, no @mention      | 🚫 Skips `video_note` + `video`     | 🚫 Skips types from list          |
| Group, bot @mentioned   | ✅ All media processed               | ✅ All media processed             |

### Key design decisions

- **Context-aware defaults**: In groups, `video_note` and `video` are skipped by default (the most common source of noise). In DMs, nothing is filtered.
- **Mention override**: When the bot is `@mentioned` in a group, all media is processed regardless of the ignore list — the user deliberately asked.
- **Caption preservation**: If an ignored media message has caption text, the text is still processed (only the media download is skipped).
- **Explicit config overrides defaults**: Setting `ignoreMediaTypes: []` restores full media processing in groups.
- **Gateway auto-discovery**: The field uses `z.enum()` validation, so it automatically appears in the OpenClaw Gateway admin panel with proper controls.

### Supported media types

`"photo"` | `"video"` | `"video_note"` | `"document"` | `"audio"` | `"voice"` | `"sticker"`

### Config example

```json
{
  "channels": {
    "telegram": {
      "ignoreMediaTypes": ["video_note", "voice"]
    }
  }
}
```

## Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.providers-core.ts` | Add `ignoreMediaTypes` field with `z.enum()` validation |
| `src/config/types.telegram.ts` | Add TypeScript type + JSDoc |
| `src/telegram/bot-handlers.ts` | Add `resolveTelegramMediaType()` helper, context-aware filtering in single-message handler and `processMediaGroup` |

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `pnpm build` — passes
- [x] All 49 telegram test files pass (414 tests)
- [x] ESLint clean (0 errors)

## Notes

- Open PRs #6516 and #8479 also modify `bot-handlers.ts` around the `resolveMedia` call path — may need rebase coordination if they merge first.
- The `resolveTelegramMediaType()` helper checks `video_note` before `video` because grammY may set both fields on a video note message.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new Telegram config option `channels.telegram.ignoreMediaTypes` (validated via Zod) and applies it in the Telegram inbound handlers to skip downloading/processing selected media types. It also adds a small helper module (`src/telegram/media-type-filter.ts`) to resolve a message’s media type and compute the effective ignore list (including group-only defaults). The single-message handler now avoids calling `resolveMedia` for ignored types unless there is caption/text content to process; media groups apply similar filtering across album items, with `@mention` in groups overriding filtering.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are additive and localized: config schema/type additions plus straightforward handler gating that skips media downloads based on an explicit allowlist and existing mention detection. No behavior changes outside Telegram inbound media handling and the new helper module; logic paths still fall back to existing processing when captions/text are present or when mentioned in groups.
- src/telegram/bot-handlers.ts (ensure behavior matches the intended mention/DM/group matrix in real Telegram environments)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->