### PR TITLE
Implemented issue #14047: default setting for /reasoning flag

### DIFF
--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -95,7 +95,9 @@ export async function applyInlineDirectivesFastLane(params: {
     (sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (agentCfg?.verboseDefault as VerboseLevel | undefined);
   const currentReasoningLevel =
-    (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+    (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+    "off";
   const currentElevatedLevel =
     (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
     (agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -154,7 +154,9 @@ export async function applyInlineDirectiveOverrides(params: {
       (sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
       (agentCfg?.verboseDefault as VerboseLevel | undefined);
     const currentReasoningLevel =
-      (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+      (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+      (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+      "off";
     const currentElevatedLevel =
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -355,6 +355,7 @@ export async function resolveReplyDirectives(params: {
   const resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -356,7 +356,7 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
   const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const reasoningLevel = args.resolvedReasoning ?? args.agent?.reasoningDefault ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -138,6 +138,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Default reasoning level when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -116,6 +116,7 @@ export const AgentDefaultsSchema = z
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),


### PR DESCRIPTION
Added the possibility to set "reasoningDefault" in openclaw.json, so that new sessions start with the given value.

I implemented it AI assisted.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `reasoningDefault` configuration option to allow setting the default `/reasoning` flag state for new sessions, matching the existing pattern for `thinkingDefault`, `verboseDefault`, and `elevatedDefault`.

- Added `reasoningDefault` to TypeScript type definition in `src/config/types.agent-defaults.ts`
- Added Zod schema validation for `reasoningDefault` in `src/config/zod-schema.agent-defaults.ts`
- Updated all reasoning level resolution points to check for `agentCfg?.reasoningDefault` before falling back to "off"
- Updated status message builder to use `reasoningDefault` from agent config

The implementation follows the established pattern for other directive defaults. One minor inconsistency: `commands-status.ts` should explicitly include `reasoningDefault` alongside the other default directives for clarity and consistency.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor style improvement recommended
- The implementation correctly follows the existing pattern for directive defaults (`thinkingDefault`, `verboseDefault`, `elevatedDefault`). All the necessary files are updated consistently. The only issue is a minor style inconsistency in `commands-status.ts` where `reasoningDefault` should be explicitly listed alongside the other defaults for clarity, though it would work without this change due to the spread operator.
- Review the suggestion for `src/auto-reply/reply/commands-status.ts` to maintain consistency with other directive defaults

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->