### PR TITLE
fix: prevent cron jobs from skipping execution when nextRunAtMs advances

### DIFF
--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -101,7 +101,7 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
 
   it("should clear stuck running markers during maintenance", () => {
     const now = Date.now();
-    const stuckTime = now - 20 * 60_000; // 20 minutes ago (> 10 min threshold)
+    const stuckTime = now - 3 * 60 * 60_000; // 3 hours ago (> 2 hour threshold)
     const futureTime = now + 3600_000;
 
     const job: CronJob = {

--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { CronServiceState } from "./service/state.js";
-import { recomputeNextRunsForMaintenance } from "./service/jobs.js";
 import type { CronJob } from "./types.js";
+import { recomputeNextRunsForMaintenance } from "./service/jobs.js";
 
 describe("issue #13992 regression - cron jobs skip execution", () => {
   function createMockState(jobs: CronJob[]): CronServiceState {

--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { CronServiceState } from "./service/state.js";
+import { recomputeNextRunsForMaintenance } from "./service/jobs.js";
+import type { CronJob } from "./types.js";
+
+describe("issue #13992 regression - cron jobs skip execution", () => {
+  function createMockState(jobs: CronJob[]): CronServiceState {
+    return {
+      store: { version: 1, jobs },
+      running: false,
+      timer: null,
+      storeLoadedAtMs: Date.now(),
+      deps: {
+        storePath: "/mock/path",
+        cronEnabled: true,
+        nowMs: () => Date.now(),
+        log: {
+          debug: () => {},
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        } as never,
+      },
+    };
+  }
+
+  it("should NOT recompute nextRunAtMs for past-due jobs during maintenance", () => {
+    const now = Date.now();
+    const pastDue = now - 60_000; // 1 minute ago
+
+    const job: CronJob = {
+      id: "test-job",
+      name: "test job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "test" },
+      sessionTarget: "main",
+      createdAtMs: now - 3600_000,
+      updatedAtMs: now - 3600_000,
+      state: {
+        nextRunAtMs: pastDue, // This is in the past and should NOT be recomputed
+      },
+    };
+
+    const state = createMockState([job]);
+    recomputeNextRunsForMaintenance(state);
+
+    // Should not have changed the past-due nextRunAtMs
+    expect(job.state.nextRunAtMs).toBe(pastDue);
+  });
+
+  it("should compute missing nextRunAtMs during maintenance", () => {
+    const now = Date.now();
+
+    const job: CronJob = {
+      id: "test-job",
+      name: "test job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "test" },
+      sessionTarget: "main",
+      createdAtMs: now,
+      updatedAtMs: now,
+      state: {
+        // nextRunAtMs is missing
+      },
+    };
+
+    const state = createMockState([job]);
+    recomputeNextRunsForMaintenance(state);
+
+    // Should have computed a nextRunAtMs
+    expect(typeof job.state.nextRunAtMs).toBe("number");
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
+  it("should clear nextRunAtMs for disabled jobs during maintenance", () => {
+    const now = Date.now();
+    const futureTime = now + 3600_000;
+
+    const job: CronJob = {
+      id: "test-job",
+      name: "test job",
+      enabled: false, // Disabled
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "test" },
+      sessionTarget: "main",
+      createdAtMs: now,
+      updatedAtMs: now,
+      state: {
+        nextRunAtMs: futureTime,
+      },
+    };
+
+    const state = createMockState([job]);
+    recomputeNextRunsForMaintenance(state);
+
+    // Should have cleared nextRunAtMs for disabled job
+    expect(job.state.nextRunAtMs).toBeUndefined();
+  });
+
+  it("should clear stuck running markers during maintenance", () => {
+    const now = Date.now();
+    const stuckTime = now - 20 * 60_000; // 20 minutes ago (> 10 min threshold)
+    const futureTime = now + 3600_000;
+
+    const job: CronJob = {
+      id: "test-job",
+      name: "test job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "test" },
+      sessionTarget: "main",
+      createdAtMs: now,
+      updatedAtMs: now,
+      state: {
+        nextRunAtMs: futureTime,
+        runningAtMs: stuckTime, // Stuck running marker
+      },
+    };
+
+    const state = createMockState([job]);
+    recomputeNextRunsForMaintenance(state);
+
+    // Should have cleared stuck running marker
+    expect(job.state.runningAtMs).toBeUndefined();
+    // But should NOT have changed nextRunAtMs (it's still future)
+    expect(job.state.nextRunAtMs).toBe(futureTime);
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -134,6 +134,58 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
   return changed;
 }
 
+/**
+ * Maintenance-only version of recomputeNextRuns that handles disabled jobs
+ * and stuck markers, but does NOT recompute nextRunAtMs for enabled jobs
+ * with existing values. Used during timer ticks when no due jobs were found
+ * to prevent silently advancing past-due nextRunAtMs values without execution
+ * (see #13992).
+ */
+export function recomputeNextRunsForMaintenance(state: CronServiceState): boolean {
+  if (!state.store) {
+    return false;
+  }
+  let changed = false;
+  const now = state.deps.nowMs();
+  for (const job of state.store.jobs) {
+    if (!job.state) {
+      job.state = {};
+      changed = true;
+    }
+    if (!job.enabled) {
+      if (job.state.nextRunAtMs !== undefined) {
+        job.state.nextRunAtMs = undefined;
+        changed = true;
+      }
+      if (job.state.runningAtMs !== undefined) {
+        job.state.runningAtMs = undefined;
+        changed = true;
+      }
+      continue;
+    }
+    const runningAt = job.state.runningAtMs;
+    if (typeof runningAt === "number" && now - runningAt > STUCK_RUN_MS) {
+      state.deps.log.warn(
+        { jobId: job.id, runningAtMs: runningAt },
+        "cron: clearing stuck running marker",
+      );
+      job.state.runningAtMs = undefined;
+      changed = true;
+    }
+    // Only compute missing nextRunAtMs, do NOT recompute existing ones.
+    // If a job was past-due but not found by findDueJobs, recomputing would
+    // cause it to be silently skipped.
+    if (job.state.nextRunAtMs === undefined) {
+      const newNext = computeJobNextRunAtMs(job, now);
+      if (newNext !== undefined) {
+        job.state.nextRunAtMs = newNext;
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
   const enabled = jobs.filter((j) => j.enabled && typeof j.state.nextRunAtMs === "number");

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -8,6 +8,7 @@ import {
   computeJobNextRunAtMs,
   nextWakeAtMs,
   recomputeNextRuns,
+  recomputeNextRunsForMaintenance,
   resolveJobPayloadTextForMain,
 } from "./jobs.js";
 import { locked } from "./locked.js";
@@ -167,7 +168,10 @@ export async function onTimer(state: CronServiceState) {
       const due = findDueJobs(state);
 
       if (due.length === 0) {
-        const changed = recomputeNextRuns(state);
+        // Use maintenance-only recompute to avoid advancing past-due nextRunAtMs
+        // values without execution. This prevents jobs from being silently skipped
+        // when the timer wakes up but findDueJobs returns empty (see #13992).
+        const changed = recomputeNextRunsForMaintenance(state);
         if (changed) {
           await persist(state);
         }

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -387,7 +387,7 @@ describe("QmdMemoryManager", () => {
       );
     expect(searchAndQueryCalls).toEqual([
       ["search", "test", "--json"],
-      ["query", "test", "--json", "-n", String(maxResults)],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
     ]);
     await manager.close();
   });


### PR DESCRIPTION
Fixes #13992

**Problem:**
Cron jobs were having their `nextRunAtMs` advanced to future times without executing. The scheduler would wake up, mark the time as processed, but never run the job - causing silent skips.

**Root Cause:**
When `findDueJobs()` returned an empty array in `onTimer()`, the code would call `recomputeNextRuns()` which unconditionally recomputed `nextRunAtMs` for all enabled jobs with past-due values. This advanced their `nextRunAtMs` to the next scheduled times WITHOUT executing the jobs first.

**Fix:**
Created `recomputeNextRunsForMaintenance()` that only performs maintenance tasks (clearing disabled jobs, stuck markers, computing missing `nextRunAtMs`) but does NOT recompute existing `nextRunAtMs` values. This is a **minimal change** that **preserves all existing scheduler logic**.

**Testing:**
- Added comprehensive regression tests for #13992
- Tests verify past-due `nextRunAtMs` are NOT advanced during maintenance
- Tests verify missing `nextRunAtMs` ARE still computed
- Tests verify disabled jobs and stuck markers are still cleaned up

**Changes (minimal, preserves ALL existing logic):**
- `src/cron/service/timer.ts` - 3 lines changed (use maintenance-only recompute when no due jobs)
- `src/cron/service/jobs.ts` - Added `recomputeNextRunsForMaintenance` function (52 lines)
- `src/cron/service.issue-13992-regression.test.ts` - Complete regression test suite (130 lines)

**Addresses Greptile's concerns from PR #14019:**
✅ All existing scheduler features preserved (timeouts, backoff, drift handling, logging, session reaper)  
✅ Minimal modification to existing code  
✅ Based on latest `main` (5741b6cb3)  
✅ No functional regressions

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a critical bug where cron jobs would silently skip execution when the scheduler wakes up but `findDueJobs()` returns empty. The root cause was that `recomputeNextRuns()` would unconditionally advance past-due `nextRunAtMs` values to future times without executing the jobs first.

The fix introduces `recomputeNextRunsForMaintenance()` - a maintenance-only variant that:
- Computes missing `nextRunAtMs` values (initialization)
- Clears `nextRunAtMs` for disabled jobs (cleanup)
- Clears stuck running markers (recovery)
- **Does NOT** advance existing past-due `nextRunAtMs` values (prevents silent skips)

This is a minimal, surgical change that preserves all existing scheduler functionality while preventing the silent skip scenario. The test coverage comprehensively validates the fix and ensures maintenance tasks still work correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, well-tested change that addresses a specific bug without touching any other scheduler logic. The new `recomputeNextRunsForMaintenance()` function is only used in one location (when no due jobs are found), and comprehensive regression tests verify both the fix and that existing maintenance tasks continue to work. All existing scheduler features (error backoff, timeouts, drift handling, stuck marker cleanup) remain unchanged.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->