### PR TITLE
Add gh cli

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -198,6 +198,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/google-antigravity-auth/**"
+"extensions: google-drive":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/google-drive/**"
 "extensions: google-gemini-cli-auth":
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -1,10 +1,12 @@
 name: Auto response
 
+# CI disabled – restore issues/pull_request_target to re-enable
 on:
-  issues:
-    types: [opened, edited, labeled]
-  pull_request_target:
-    types: [labeled]
+  workflow_dispatch:
+  # issues:
+  #   types: [opened, edited, labeled]
+  # pull_request_target:
+  #   types: [labeled]
 
 permissions: {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: CI
 
+# CI disabled – restore push/pull_request below to re-enable
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
+  # pull_request:
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,11 +1,13 @@
 name: Docker Release
 
+# CI disabled – restore push/tags to re-enable
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
+  #   tags:
+  #     - "v*"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -1,7 +1,9 @@
 name: Formal models (informational conformance)
 
+# CI disabled – restore pull_request to re-enable
 on:
-  pull_request:
+  workflow_dispatch:
+  # pull_request:
 
 concurrency:
   group: formal-conformance-${{ github.event.pull_request.number || github.ref_name }}

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,10 +1,11 @@
 name: Install Smoke
 
+# CI disabled – restore push/pull_request to re-enable
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
+  # push:
+  #   branches: [main]
+  # pull_request:
 
 concurrency:
   group: install-smoke-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,15 +1,18 @@
 name: Labeler
 
+# Disabled: no automatic labeling (enable by uncommenting triggers below)
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-  issues:
-    types: [opened]
+  workflow_dispatch: {}
+  # pull_request_target:
+  #   types: [opened, synchronize, reopened]
+  # issues:
+  #   types: [opened]
 
 permissions: {}
 
 jobs:
   label:
+    if: secrets.GH_APP_PRIVATE_KEY != ''
     permissions:
       contents: read
       pull-requests: write
@@ -48,6 +51,7 @@ jobs:
             });
 
   label-issues:
+    if: secrets.GH_APP_PRIVATE_KEY != ''
     permissions:
       issues: write
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -1,9 +1,11 @@
 name: Workflow Sanity
 
+# CI disabled – restore pull_request/push to re-enable
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_dispatch:
+  # pull_request:
+  # push:
+  #   branches: [main]
 
 concurrency:
   group: workflow-sanity-${{ github.event.pull_request.number || github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,42 @@ RUN corepack enable
 
 WORKDIR /app
 
+# Install Tailscale, gosu, and Brave browser with headless dependencies
+RUN curl -fsSL https://tailscale.com/install.sh | sh && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    gosu \
+    curl \
+    nano \
+    apt-transport-https \
+    ca-certificates \
+    gnupg && \
+    curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | tee /etc/apt/sources.list.d/brave-browser-release.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    brave-browser \
+    fonts-liberation \
+    fonts-noto-color-emoji \
+    # Additional libraries for headless browser operation
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    libatspi2.0-0 \
+    libxss1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Install summarize via npm (much simpler than Homebrew)
+RUN npm install -g @steipete/summarize
+
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
 RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       apt-get update && \
@@ -31,13 +67,27 @@ RUN pnpm ui:build
 
 ENV NODE_ENV=production
 
+# Install openclaw CLI globally so it's available as a command
+# Use npm instead of pnpm for global install (pnpm requires setup, npm works out of the box)
+RUN npm install -g .
+
+# Copy Tailscale startup script
+COPY scripts/fly-tailscale-start.sh /usr/local/bin/fly-tailscale-start.sh
+RUN chmod +x /usr/local/bin/fly-tailscale-start.sh
+
 # Allow non-root user to write temp files during runtime/tests.
 RUN chown -R node:node /app
 
-# Security hardening: Run as non-root user
-# The node:22-bookworm image includes a 'node' user (uid 1000)
-# This reduces the attack surface by preventing container escape via root privileges
-USER node
+# Create directory for Tailscale state (will be mounted at /data)
+RUN mkdir -p /var/run/tailscale && chmod 755 /var/run/tailscale
+
+# Note: We don't set USER node here because Tailscale needs root privileges.
+# The entrypoint script will handle Tailscale setup as root, then switch to node user
+# for running the gateway process.
+
+# Use entrypoint script that handles Tailscale setup, then runs the gateway
+# The script will run tailscale up as root, then exec the gateway as node user
+ENTRYPOINT ["/usr/local/bin/fly-tailscale-start.sh"]
 
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN curl -fsSL https://tailscale.com/install.sh | sh && \
     gosu \
     curl \
     nano \
+    gh \
     apt-transport-https \
     ca-certificates \
     gnupg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
 COPY scripts ./scripts
+COPY config ./config
+# Copy extensions before pnpm install so workspace dependencies are installed
+COPY extensions ./extensions
 
 RUN pnpm install --frozen-lockfile
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,49 @@
+# Fly.io Deployment Config
+
+This directory contains default configuration templates for Fly.io deployments.
+
+## `fly.default.json`
+
+Default OpenClaw configuration template for Fly.io deployments. Use it as a reference or copy it to `/data/.openclaw/openclaw.json` yourself (e.g. via a mounted volume, CI, or manually after first boot). The Fly Tailscale startup script does **not** copy this file automatically; you must ensure config exists at `$OPENCLAW_STATE_DIR/openclaw.json` (default `/data/.openclaw/openclaw.json`) before or after the first start.
+
+### Customization
+
+To customize the default config for your deployment:
+
+1. **Edit `fly.default.json`** with your desired settings
+2. **Provide config** at `/data/.openclaw/openclaw.json` (e.g. copy from this template, mount a volume, or create via SSH after first boot)
+3. Rebuild and deploy if you changed the image; otherwise update config on the machine and restart
+
+### Environment Variable Substitution
+
+Loaded config supports environment variable substitution at read time:
+
+- `${OPENCLAW_GATEWAY_TOKEN}` - Replaced with the value from Fly.io secrets (if set)
+
+### Important Notes
+
+- API keys and gateway token should be set as Fly.io secrets or in the config you provide
+- After deploy, you can modify the config via SSH or `openclaw config set`
+
+### Example: Adding Channels
+
+To add Discord to the default config:
+
+```json
+{
+  "channels": {
+    "discord": {
+      "enabled": true,
+      "groupPolicy": "allowlist"
+    }
+  },
+  "bindings": [
+    {
+      "agentId": "main",
+      "match": { "channel": "discord" }
+    }
+  ]
+}
+```
+
+Remember: Channel tokens (like `DISCORD_BOT_TOKEN`) should be set as Fly.io secrets, not in the config file.

--- a/config/fly.default.json
+++ b/config/fly.default.json
@@ -3,8 +3,9 @@
     "defaults": {
       "model": {
         "primary": "openai/gpt-5.2",
-        "fallbacks": ["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]
+        "fallbacks": ["anthropic/claude-sonnet-4-5", "openai/gpt-4o", "google/gemini-2.0-flash"]
       },
+      "workspace": "/data/.openclaw/workspace",
       "maxConcurrent": 4
     },
     "list": [{ "id": "main", "default": true }]
@@ -12,7 +13,8 @@
   "auth": {
     "profiles": {
       "anthropic:default": { "mode": "token", "provider": "anthropic" },
-      "openai:default": { "mode": "token", "provider": "openai" }
+      "openai:default": { "mode": "token", "provider": "openai" },
+      "google:default": { "mode": "token", "provider": "google" }
     }
   },
   "gateway": {
@@ -27,6 +29,16 @@
     "tailscale": {
       "mode": "serve",
       "resetOnExit": true
+    },
+    "nodes": {
+      "denyCommands": [
+        "camera.snap",
+        "camera.clip",
+        "screen.record",
+        "calendar.add",
+        "contacts.add",
+        "reminders.add"
+      ]
     },
     "controlUi": {
       "allowInsecureAuth": true

--- a/config/fly.default.json
+++ b/config/fly.default.json
@@ -1,0 +1,35 @@
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "openai/gpt-5.2",
+        "fallbacks": ["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]
+      },
+      "maxConcurrent": 4
+    },
+    "list": [{ "id": "main", "default": true }]
+  },
+  "auth": {
+    "profiles": {
+      "anthropic:default": { "mode": "token", "provider": "anthropic" },
+      "openai:default": { "mode": "token", "provider": "openai" }
+    }
+  },
+  "gateway": {
+    "mode": "local",
+    "bind": "loopback",
+    "port": 17568,
+    "trustedProxies": ["127.0.0.1"],
+    "auth": {
+      "mode": "token",
+      "allowTailscale": true
+    },
+    "tailscale": {
+      "mode": "serve",
+      "resetOnExit": true
+    },
+    "controlUi": {
+      "allowInsecureAuth": true
+    }
+  }
+}

--- a/docs/fly-io-device-pairing.md
+++ b/docs/fly-io-device-pairing.md
@@ -1,0 +1,133 @@
+# Device Pairing on Fly.io with Tailscale Serve
+
+This guide explains how to approve device pairing requests when running OpenClaw on Fly.io with Tailscale Serve.
+
+## Overview
+
+When the Control UI (or any device) connects to the gateway for the first time, it creates a device pairing request that must be approved before the connection can proceed.
+
+## Method 1: Approve via CLI (Recommended)
+
+### Step 1: SSH into your Fly.io machine
+
+```bash
+fly ssh console -a openclaw-lisan-al-gaib
+```
+
+### Step 2: List pending device pairing requests
+
+```bash
+cd /app
+node dist/index.js devices list --url ws://127.0.0.1:17568 --token $OPENCLAW_GATEWAY_TOKEN
+```
+
+
+
+This will show pending requests with their `requestId`, device ID, role, IP address, and age.
+
+### Step 3: Approve the pairing request
+
+```bash
+node dist/index.js devices approve <requestId> --url ws://127.0.0.1:17568 --token $OPENCLAW_GATEWAY_TOKEN
+```
+
+Replace:
+- `<requestId>` with the actual request ID from step 2
+- `OPENCLAW_GATEWAY_TOKEN` with your gateway token
+
+### Step 4: Verify the device is paired
+
+```bash
+node dist/index.js devices list --url ws://127.0.0.1:17568 --token $OPENCLAW_GATEWAY_TOKEN
+```
+
+The device should now appear in the "Paired" section instead of "Pending".
+
+## Method 2: Approve via Control UI
+
+### Prerequisites
+
+First, enable insecure auth to allow token-based access without device pairing:
+
+```bash
+fly ssh console -a openclaw-lisan-al-gaib
+cd /app
+node dist/index.js config set gateway.controlUi.allowInsecureAuth true
+exit
+fly apps restart openclaw-lisan-al-gaib
+```
+
+### Steps
+
+1. Open the Control UI at your Tailscale Serve URL:
+   ```
+   https://48e659eb767ee8-1.tail180196.ts.net/
+   ```
+
+2. In the "Gateway Access" card:
+   - Set **WebSocket URL** to: `wss://48e659eb767ee8-1.tail180196.ts.net`
+   - Set **Gateway Token** to your token
+   - Click **Connect**
+
+3. Once connected, go to the **"Nodes"** tab
+
+4. Find your device in the "Pending" section
+
+5. Click **"Approve"** next to the device
+
+
+## Troubleshooting
+
+### No pending requests shown
+
+If `devices list` shows no pending requests, the request may have expired (they expire after some time). Try connecting from the Control UI again to create a new pairing request.
+
+### Device ID from logs
+
+From the gateway logs, you can see the device ID attempting to connect:
+```
+"deviceId":"5be7c2aeeea118e0ab38261a84db43c686ac74af2d3446a29ee3d8eee996d5f9"
+```
+
+Use this to identify the correct pairing request in the list.
+
+### Connection still fails after approval
+
+1. Verify the device is paired: `devices list` should show it in "Paired"
+2. Check gateway logs for errors: `tail -50 /tmp/openclaw/openclaw-*.log`
+3. Ensure `gateway.trustedProxies` includes `127.0.0.1` for Tailscale Serve
+4. Ensure `gateway.auth.allowTailscale` is `true` if using Tailscale identity auth
+
+## Configuration Reference
+
+Your current gateway configuration should include:
+
+```json
+{
+  "gateway": {
+    "port": 17568,
+    "mode": "local",
+    "bind": "loopback",
+    "auth": {
+      "mode": "token",
+      "token": "YOUR_TOKEN",
+      "allowTailscale": true
+    },
+    "trustedProxies": ["127.0.0.1"],
+    "tailscale": {
+      "mode": "serve",
+      "resetOnExit": true
+    },
+    "controlUi": {
+      "allowInsecureAuth": true
+    }
+  }
+}
+```
+
+## Related Documentation
+
+- [Device Pairing Overview](/start/pairing)
+- [Gateway Security](/gateway/security)
+- [Tailscale Integration](/gateway/tailscale)
+- [Control UI](/web/control-ui)

--- a/extensions/google-drive/README.md
+++ b/extensions/google-drive/README.md
@@ -1,6 +1,6 @@
 # Google Drive Plugin
 
-OpenClaw plugin for browsing Google Drive, downloading files, and reading Google Docs.
+OpenClaw plugin for browsing Google Drive, downloading files, reading Google Docs, and reading Google Sheets.
 
 ## Features
 
@@ -8,6 +8,7 @@ OpenClaw plugin for browsing Google Drive, downloading files, and reading Google
 - **Get file metadata**: Retrieve detailed information about files
 - **Download files**: Download regular files or export Google Workspace files (Docs, Sheets, Slides) to PDF, DOCX, etc.
 - **Read Google Docs**: Extract content from Google Docs as markdown or plain text
+- **Read Google Sheets**: Read cell ranges from spreadsheets via the Sheets API (A1 notation)
 
 ## Setup
 
@@ -78,7 +79,7 @@ openclaw models auth login --provider google-drive
 **Local environment:**
 
 1. Browser will open automatically for Google authentication
-2. Request access to Google Drive (read-only) and Google Docs (read-only)
+2. Request access to Google Drive (read-only), Google Docs (read-only), and Google Sheets (read-only)
 3. Store the credentials in `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
 
 **Fly.io / Remote environment:**
@@ -122,15 +123,22 @@ Or enable for all agents:
 
 ### List Files
 
+Listing works for **My Drive** and **Shared Drives**. Use `driveId` when listing a Shared Drive (or a folder inside one).
+
 ```json
 {
   "action": "list",
-  "folderId": "root", // Optional: folder ID or "root" for root folder
-  "query": "name contains 'report'", // Optional: search query
-  "maxResults": 100, // Optional: max results (default: 100)
-  "pageToken": "..." // Optional: for pagination
+  "folderId": "root",
+  "driveId": "0ABC...",
+  "query": "name contains 'report'",
+  "maxResults": 100,
+  "pageToken": "..."
 }
 ```
+
+- **folderId**: Folder ID to list, or `"root"` for the root of My Drive (or the Shared Drive when `driveId` is set).
+- **driveId**: Optional. Shared Drive ID. When set, listing is scoped to that drive; use with `folderId` to list a folder inside it, or omit `folderId`/use `"root"` to list the Shared Drive root.
+- **query**, **maxResults**, **pageToken**: Optional (search, limit, pagination).
 
 ### Get File Metadata
 
@@ -165,9 +173,21 @@ Supported export formats for Google Workspace files:
 {
   "action": "read_docs",
   "fileId": "1abc123...",
-  "format": "markdown" // Optional: "markdown" (default) or "text"
+  "format": "markdown"
 }
 ```
+
+### Read Google Sheets
+
+```json
+{
+  "action": "read_sheets",
+  "spreadsheetId": "1abc123...",
+  "range": "Sheet1!A1:D10"
+}
+```
+
+Use A1 notation for `range` (e.g. `Sheet1!A1:Z`, `A1:D10`). Returns `values` (array of rows) and `range`.
 
 ## Examples
 
@@ -209,12 +229,23 @@ Supported export formats for Google Workspace files:
 }
 ```
 
+### Read a Google Sheets range
+
+```json
+{
+  "action": "read_sheets",
+  "spreadsheetId": "1abc123...",
+  "range": "Sheet1!A1:D10"
+}
+```
+
 ## Scopes
 
 The plugin requests the following OAuth scopes:
 
 - `https://www.googleapis.com/auth/drive.readonly` - Read-only access to Google Drive
 - `https://www.googleapis.com/auth/documents.readonly` - Read-only access to Google Docs
+- `https://www.googleapis.com/auth/spreadsheets.readonly` - Read-only access to Google Sheets
 
 ## Troubleshooting
 

--- a/extensions/google-drive/README.md
+++ b/extensions/google-drive/README.md
@@ -1,0 +1,253 @@
+# Google Drive Plugin
+
+OpenClaw plugin for browsing Google Drive, downloading files, and reading Google Docs.
+
+## Features
+
+- **Browse files and folders**: List files in Google Drive with search and pagination
+- **Get file metadata**: Retrieve detailed information about files
+- **Download files**: Download regular files or export Google Workspace files (Docs, Sheets, Slides) to PDF, DOCX, etc.
+- **Read Google Docs**: Extract content from Google Docs as markdown or plain text
+
+## Setup
+
+### 1. OAuth Authentication
+
+The plugin uses OAuth 2.0 with PKCE for authentication. Environment variables must be set:
+
+- `GOOGLE_CLIENT_ID`: Your Google OAuth client ID
+- `GOOGLE_CLIENT_SECRET`: Your Google OAuth client secret
+- `GOOGLE_OAUTH_REDIRECT_URL`: OAuth redirect URI (defaults to `http://localhost:8086/oauth2callback`)
+- `GOOGLE_TOKEN_ENCRYPTION_KEY`: Token encryption key (optional, for token storage)
+
+#### For Fly.io Deployments
+
+When deploying to Fly.io (especially private deployments without public IP), set these as Fly secrets:
+
+```bash
+fly secrets set GOOGLE_CLIENT_ID=your-client-id
+fly secrets set GOOGLE_CLIENT_SECRET=your-client-secret
+fly secrets set GOOGLE_OAUTH_REDIRECT_URL=http://localhost:8086/oauth2callback
+```
+
+**Important:** In Google Cloud Console, add `http://localhost:8086/oauth2callback` as an authorized redirect URI for your OAuth client, even though it won't actually receive the callback in manual mode.
+
+**Note:** In Fly.io containers, the OAuth flow will automatically use manual mode (you'll paste the redirect URL). This works because:
+
+- The plugin detects Fly.io environment via `FLY_APP_NAME` or `FLY_MACHINE_ID`
+- It also detects SSH/remote environments automatically
+- You'll open the OAuth URL in your local browser and paste the callback URL back
+
+#### Using Tailscale for Automatic OAuth (Advanced)
+
+If you're using Tailscale VPN (as configured in `fly-tailscale-start.sh`), you can optionally use Tailscale Funnel for automatic OAuth callbacks:
+
+1. **Set up Tailscale Funnel** (makes the callback publicly accessible):
+
+   ```bash
+   # In your Fly.io container, expose the OAuth callback endpoint
+   tailscale funnel --set-path /oauth2callback --yes 8086
+   ```
+
+2. **Get your Tailscale DNS name:**
+
+   ```bash
+   tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//'
+   # Example output: your-app.tailnet-xxxx.ts.net
+   ```
+
+3. **Update redirect URI:**
+
+   ```bash
+   # Use your Tailscale Funnel URL
+   fly secrets set GOOGLE_OAUTH_REDIRECT_URL=https://your-app.tailnet-xxxx.ts.net/oauth2callback
+   ```
+
+4. **Add to Google Cloud Console:** Add the Tailscale Funnel URL as an authorized redirect URI.
+
+**Note:** Manual mode (pasting the redirect URL) is simpler and recommended for most users. Tailscale Funnel is only needed if you want fully automatic OAuth callbacks.
+
+### 2. Authenticate
+
+Run the authentication command:
+
+```bash
+openclaw models auth login --provider google-drive
+```
+
+**Local environment:**
+
+1. Browser will open automatically for Google authentication
+2. Request access to Google Drive (read-only) and Google Docs (read-only)
+3. Store the credentials in `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
+
+**Fly.io / Remote environment:**
+
+1. A URL will be displayed - open it in your **local browser** (not in the container)
+2. Complete Google authentication in your browser
+3. Copy the redirect URL from your browser's address bar
+4. Paste it back into the terminal/SSH session
+5. Credentials will be stored in `/data/.openclaw/agents/<agentId>/agent/auth-profiles.json` (on the Fly.io volume)
+
+### 3. Enable the Tool
+
+Add `google_drive` to your agent's tool allowlist:
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "main",
+        tools: {
+          allow: ["google_drive"],
+        },
+      },
+    ],
+  },
+}
+```
+
+Or enable for all agents:
+
+```json5
+{
+  tools: {
+    allow: ["google_drive"],
+  },
+}
+```
+
+## Usage
+
+### List Files
+
+```json
+{
+  "action": "list",
+  "folderId": "root", // Optional: folder ID or "root" for root folder
+  "query": "name contains 'report'", // Optional: search query
+  "maxResults": 100, // Optional: max results (default: 100)
+  "pageToken": "..." // Optional: for pagination
+}
+```
+
+### Get File Metadata
+
+```json
+{
+  "action": "get",
+  "fileId": "1abc123..."
+}
+```
+
+### Download File
+
+```json
+{
+  "action": "download",
+  "fileId": "1abc123...",
+  "exportFormat": "pdf", // Optional: for Google Workspace files (pdf, docx, txt, etc.)
+  "outputPath": "downloads/file.pdf" // Optional: output path (relative to workspace)
+}
+```
+
+Supported export formats for Google Workspace files:
+
+- **Docs**: `pdf`, `docx`, `txt`, `html`, `rtf`, `odt`
+- **Sheets**: `pdf`, `xlsx`, `csv`, `tsv`
+- **Slides**: `pdf`, `pptx`, `png`, `jpg`, `svg`
+- **Drawings**: `pdf`, `png`, `jpg`, `svg`
+
+### Read Google Docs
+
+```json
+{
+  "action": "read_docs",
+  "fileId": "1abc123...",
+  "format": "markdown" // Optional: "markdown" (default) or "text"
+}
+```
+
+## Examples
+
+### Browse root folder
+
+```json
+{
+  "action": "list",
+  "folderId": "root"
+}
+```
+
+### Search for PDF files
+
+```json
+{
+  "action": "list",
+  "query": "mimeType = 'application/pdf'"
+}
+```
+
+### Download Google Doc as PDF
+
+```json
+{
+  "action": "download",
+  "fileId": "1abc123...",
+  "exportFormat": "pdf"
+}
+```
+
+### Read a Google Doc
+
+```json
+{
+  "action": "read_docs",
+  "fileId": "1abc123...",
+  "format": "markdown"
+}
+```
+
+## Scopes
+
+The plugin requests the following OAuth scopes:
+
+- `https://www.googleapis.com/auth/drive.readonly` - Read-only access to Google Drive
+- `https://www.googleapis.com/auth/documents.readonly` - Read-only access to Google Docs
+
+## Troubleshooting
+
+### "No Google Drive credentials found"
+
+Run `openclaw models auth login --provider google-drive` to authenticate.
+
+### "Export format not available"
+
+Not all export formats are available for all file types. Use the `get` action first to see available `exportFormats` for a specific file.
+
+### Permission errors
+
+Ensure your Google account has access to the files you're trying to access. Shared files may require explicit permission grants.
+
+### OAuth issues on Fly.io
+
+If OAuth fails in a Fly.io container:
+
+1. **Verify secrets are set:**
+
+   ```bash
+   fly secrets list
+   ```
+
+2. **Check redirect URL:** Ensure `GOOGLE_OAUTH_REDIRECT_URL` matches what's configured in Google Cloud Console. For Fly.io, you can use `http://localhost:8086/oauth2callback` (the plugin will use manual mode).
+
+3. **Use manual flow:** The plugin should automatically detect Fly.io and use manual OAuth flow. If not, ensure you're running via `fly ssh console` and the environment variables are set.
+
+4. **Check Google Cloud Console:** Ensure your OAuth client allows `http://localhost:8086/oauth2callback` as an authorized redirect URI (even though it won't actually be called in manual mode).
+
+## Security
+
+- Credentials are stored encrypted in `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
+- The plugin only requests read-only scopes
+- File downloads are saved to the workspace directory (respects sandboxing)

--- a/extensions/google-drive/index.ts
+++ b/extensions/google-drive/index.ts
@@ -1,0 +1,84 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { loginGoogleDriveOAuth } from "./src/auth.js";
+import { registerGoogleDriveTools } from "./src/tools.js";
+
+const PROVIDER_ID = "google-drive";
+const PROVIDER_LABEL = "Google Drive OAuth";
+const ENV_VARS = [
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
+  "GOOGLE_OAUTH_REDIRECT_URL",
+  "GOOGLE_TOKEN_ENCRYPTION_KEY",
+];
+
+const plugin = {
+  id: "google-drive",
+  name: "Google Drive",
+  description: "Google Drive plugin for browsing and downloading files",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    // Register provider for OAuth authentication
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: PROVIDER_LABEL,
+      docsPath: "/providers/models",
+      aliases: ["gdrive"],
+      envVars: ENV_VARS,
+      auth: [
+        {
+          id: "oauth",
+          label: "Google OAuth",
+          hint: "PKCE + localhost callback",
+          kind: "oauth",
+          run: async (ctx) => {
+            const spin = ctx.prompter.progress("Starting Google Drive OAuth…");
+            try {
+              const result = await loginGoogleDriveOAuth({
+                isRemote: ctx.isRemote,
+                openUrl: ctx.openUrl,
+                log: (msg) => ctx.runtime.log(msg),
+                note: ctx.prompter.note,
+                prompt: async (message) => String(await ctx.prompter.text({ message })),
+                progress: spin,
+              });
+
+              spin.stop("Google Drive OAuth complete");
+              const profileId = `google-drive:${result.email ?? "default"}`;
+              return {
+                profiles: [
+                  {
+                    profileId,
+                    credential: {
+                      type: "oauth",
+                      provider: PROVIDER_ID,
+                      access: result.access,
+                      refresh: result.refresh,
+                      expires: result.expires,
+                      email: result.email,
+                    },
+                  },
+                ],
+                notes: [
+                  "Google Drive tool is now available. Add 'google_drive' to your agent's tools.allow list to enable it.",
+                ],
+              };
+            } catch (err) {
+              spin.stop("Google Drive OAuth failed");
+              await ctx.prompter.note(
+                "Trouble with OAuth? Ensure your Google account has Drive API access enabled.",
+                "OAuth help",
+              );
+              throw err;
+            }
+          },
+        },
+      ],
+    });
+
+    // Register tools
+    registerGoogleDriveTools(api);
+  },
+};
+
+export default plugin;

--- a/extensions/google-drive/openclaw.plugin.json
+++ b/extensions/google-drive/openclaw.plugin.json
@@ -1,8 +1,6 @@
 {
   "id": "google-drive",
-  "configSchema": {
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {}
-  }
+  "name": "Google Drive",
+  "description": "Browse and download Google Drive files, read Google Docs, and read Google Sheets ranges.",
+  "configSchema": { "type": "object", "additionalProperties": false, "properties": {} }
 }

--- a/extensions/google-drive/openclaw.plugin.json
+++ b/extensions/google-drive/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "google-drive",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/google-drive/package.json
+++ b/extensions/google-drive/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openclaw/google-drive",
+  "version": "2026.2.6",
+  "description": "OpenClaw Google Drive plugin for browsing and downloading files",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "google-auth-library": "^10.5.0",
+    "googleapis": "^144.0.0"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "npmSpec": "@openclaw/google-drive",
+      "localPath": "extensions/google-drive",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/google-drive/src/auth.ts
+++ b/extensions/google-drive/src/auth.ts
@@ -3,7 +3,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
 // Dynamic type import for OAuthCredentials (not in plugin SDK)
-type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+type OAuthCredentials = import("../../../src/agents/auth-profiles/types.js").OAuthCredentials;
 
 const CLIENT_ID_KEY = "GOOGLE_CLIENT_ID";
 const CLIENT_SECRET_KEY = "GOOGLE_CLIENT_SECRET";
@@ -17,6 +17,7 @@ const USERINFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo?alt=json";
 const SCOPES = [
   "https://www.googleapis.com/auth/drive.readonly",
   "https://www.googleapis.com/auth/documents.readonly",
+  "https://www.googleapis.com/auth/spreadsheets.readonly",
 ];
 
 export type GoogleDriveOAuthCredentials = {

--- a/extensions/google-drive/src/auth.ts
+++ b/extensions/google-drive/src/auth.ts
@@ -1,0 +1,402 @@
+import { OAuth2Client } from "google-auth-library";
+import { createHash, randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+// Dynamic type import for OAuthCredentials (not in plugin SDK)
+type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+
+const CLIENT_ID_KEY = "GOOGLE_CLIENT_ID";
+const CLIENT_SECRET_KEY = "GOOGLE_CLIENT_SECRET";
+const REDIRECT_URI_KEY = "GOOGLE_OAUTH_REDIRECT_URL";
+const DEFAULT_REDIRECT_URI = "http://localhost:8086/oauth2callback";
+
+const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const USERINFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo?alt=json";
+
+const SCOPES = [
+  "https://www.googleapis.com/auth/drive.readonly",
+  "https://www.googleapis.com/auth/documents.readonly",
+];
+
+export type GoogleDriveOAuthCredentials = {
+  access: string;
+  refresh: string;
+  expires: number;
+  email?: string;
+};
+
+export type GoogleDriveOAuthContext = {
+  isRemote: boolean;
+  openUrl: (url: string) => Promise<void>;
+  log: (msg: string) => void;
+  note: (message: string, title?: string) => Promise<void>;
+  prompt: (message: string) => Promise<string>;
+  progress: { update: (msg: string) => void; stop: (msg?: string) => void };
+};
+
+function resolveEnv(key: string): string | undefined {
+  return process.env[key]?.trim();
+}
+
+function resolveOAuthClientConfig(): {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+} {
+  const clientId = resolveEnv(CLIENT_ID_KEY);
+  const clientSecret = resolveEnv(CLIENT_SECRET_KEY);
+  const redirectUri = resolveEnv(REDIRECT_URI_KEY) || DEFAULT_REDIRECT_URI;
+
+  if (!clientId) {
+    throw new Error(
+      `Missing ${CLIENT_ID_KEY} environment variable. Please set it to your Google OAuth client ID.`,
+    );
+  }
+  if (!clientSecret) {
+    throw new Error(
+      `Missing ${CLIENT_SECRET_KEY} environment variable. Please set it to your Google OAuth client secret.`,
+    );
+  }
+
+  return { clientId, clientSecret, redirectUri };
+}
+
+function isWSL(): boolean {
+  if (process.platform !== "linux") {
+    return false;
+  }
+  try {
+    const release = readFileSync("/proc/version", "utf8").toLowerCase();
+    return release.includes("microsoft") || release.includes("wsl");
+  } catch {
+    return false;
+  }
+}
+
+function isWSL2(): boolean {
+  if (!isWSL()) {
+    return false;
+  }
+  try {
+    const version = readFileSync("/proc/version", "utf8").toLowerCase();
+    return version.includes("wsl2") || version.includes("microsoft-standard");
+  } catch {
+    return false;
+  }
+}
+
+function shouldUseManualOAuthFlow(isRemote: boolean): boolean {
+  // Also check for Fly.io environment
+  const isFlyIo = Boolean(process.env.FLY_APP_NAME || process.env.FLY_MACHINE_ID);
+  return isRemote || isWSL2() || isFlyIo;
+}
+
+function generatePkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString("hex");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+function buildAuthUrl(
+  clientId: string,
+  redirectUri: string,
+  challenge: string,
+  verifier: string,
+): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    response_type: "code",
+    redirect_uri: redirectUri,
+    scope: SCOPES.join(" "),
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state: verifier,
+    access_type: "offline",
+    prompt: "consent",
+  });
+  return `${AUTH_URL}?${params.toString()}`;
+}
+
+function parseCallbackInput(
+  input: string,
+  expectedState: string,
+): { code: string; state: string } | { error: string } {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { error: "No input provided" };
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state") ?? expectedState;
+    if (!code) {
+      return { error: "Missing 'code' parameter in URL" };
+    }
+    if (!state) {
+      return { error: "Missing 'state' parameter. Paste the full URL." };
+    }
+    return { code, state };
+  } catch {
+    if (!expectedState) {
+      return { error: "Paste the full redirect URL, not just the code." };
+    }
+    return { code: trimmed, state: expectedState };
+  }
+}
+
+async function waitForLocalCallback(params: {
+  redirectUri: string;
+  expectedState: string;
+  timeoutMs: number;
+  onProgress?: (message: string) => void;
+}): Promise<{ code: string; state: string }> {
+  const url = new URL(params.redirectUri);
+  const port = url.port ? parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
+  const hostname = url.hostname || "localhost";
+  const expectedPath = url.pathname || "/oauth2callback";
+
+  return new Promise<{ code: string; state: string }>((resolve, reject) => {
+    let timeout: NodeJS.Timeout | null = null;
+    const server = createServer((req, res) => {
+      try {
+        const requestUrl = new URL(req.url ?? "/", `http://${hostname}:${port}`);
+        if (requestUrl.pathname !== expectedPath) {
+          res.statusCode = 404;
+          res.setHeader("Content-Type", "text/plain");
+          res.end("Not found");
+          return;
+        }
+
+        const error = requestUrl.searchParams.get("error");
+        const code = requestUrl.searchParams.get("code")?.trim();
+        const state = requestUrl.searchParams.get("state")?.trim();
+
+        if (error) {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "text/plain");
+          res.end(`Authentication failed: ${error}`);
+          finish(new Error(`OAuth error: ${error}`));
+          return;
+        }
+
+        if (!code || !state) {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "text/plain");
+          res.end("Missing code or state");
+          finish(new Error("Missing OAuth code or state"));
+          return;
+        }
+
+        if (state !== params.expectedState) {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "text/plain");
+          res.end("Invalid state");
+          finish(new Error("OAuth state mismatch"));
+          return;
+        }
+
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.end(
+          "<!doctype html><html><head><meta charset='utf-8'/></head>" +
+            "<body><h2>Google Drive OAuth complete</h2>" +
+            "<p>You can close this window and return to OpenClaw.</p></body></html>",
+        );
+
+        finish(undefined, { code, state });
+      } catch (err) {
+        finish(err instanceof Error ? err : new Error("OAuth callback failed"));
+      }
+    });
+
+    const finish = (err?: Error, result?: { code: string; state: string }) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      try {
+        server.close();
+      } catch {
+        // ignore close errors
+      }
+      if (err) {
+        reject(err);
+      } else if (result) {
+        resolve(result);
+      }
+    };
+
+    server.once("error", (err) => {
+      finish(err instanceof Error ? err : new Error("OAuth callback server error"));
+    });
+
+    server.listen(port, hostname, () => {
+      params.onProgress?.(`Waiting for OAuth callback on ${params.redirectUri}…`);
+    });
+
+    timeout = setTimeout(() => {
+      finish(new Error("OAuth callback timeout"));
+    }, params.timeoutMs);
+  });
+}
+
+async function exchangeCodeForTokens(
+  clientId: string,
+  clientSecret: string,
+  redirectUri: string,
+  code: string,
+  verifier: string,
+): Promise<GoogleDriveOAuthCredentials> {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    grant_type: "authorization_code",
+    redirect_uri: redirectUri,
+    code_verifier: verifier,
+  });
+
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Token exchange failed: ${errorText}`);
+  }
+
+  const data = (await response.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+  };
+
+  if (!data.refresh_token) {
+    throw new Error("No refresh token received. Please try again.");
+  }
+
+  const email = await getUserEmail(data.access_token);
+  const expiresAt = Date.now() + data.expires_in * 1000 - 5 * 60 * 1000;
+
+  return {
+    refresh: data.refresh_token,
+    access: data.access_token,
+    expires: expiresAt,
+    email,
+  };
+}
+
+async function getUserEmail(accessToken: string): Promise<string | undefined> {
+  try {
+    const response = await fetch(USERINFO_URL, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (response.ok) {
+      const data = (await response.json()) as { email?: string };
+      return data.email;
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+export async function loginGoogleDriveOAuth(
+  ctx: GoogleDriveOAuthContext,
+): Promise<GoogleDriveOAuthCredentials> {
+  const { clientId, clientSecret, redirectUri } = resolveOAuthClientConfig();
+  const needsManual = shouldUseManualOAuthFlow(ctx.isRemote);
+
+  await ctx.note(
+    needsManual
+      ? [
+          "You are running in a remote/VPS environment.",
+          "A URL will be shown for you to open in your LOCAL browser.",
+          "After signing in, copy the redirect URL and paste it back here.",
+        ].join("\n")
+      : [
+          "Browser will open for Google authentication.",
+          "Sign in with your Google account for Google Drive access.",
+          `The callback will be captured automatically on ${redirectUri}.`,
+        ].join("\n"),
+    "Google Drive OAuth",
+  );
+
+  const { verifier, challenge } = generatePkce();
+  const authUrl = buildAuthUrl(clientId, redirectUri, challenge, verifier);
+
+  if (needsManual) {
+    ctx.progress.update("OAuth URL ready");
+    ctx.log(`\nOpen this URL in your LOCAL browser:\n\n${authUrl}\n`);
+    ctx.progress.update("Waiting for you to paste the callback URL...");
+    const callbackInput = await ctx.prompt("Paste the redirect URL here: ");
+    const parsed = parseCallbackInput(callbackInput, verifier);
+    if ("error" in parsed) {
+      throw new Error(parsed.error);
+    }
+    if (parsed.state !== verifier) {
+      throw new Error("OAuth state mismatch - please try again");
+    }
+    ctx.progress.update("Exchanging authorization code for tokens...");
+    return exchangeCodeForTokens(clientId, clientSecret, redirectUri, parsed.code, verifier);
+  }
+
+  ctx.progress.update("Complete sign-in in browser...");
+  try {
+    await ctx.openUrl(authUrl);
+  } catch {
+    ctx.log(`\nOpen this URL in your browser:\n\n${authUrl}\n`);
+  }
+
+  try {
+    const { code } = await waitForLocalCallback({
+      redirectUri,
+      expectedState: verifier,
+      timeoutMs: 5 * 60 * 1000,
+      onProgress: (msg) => ctx.progress.update(msg),
+    });
+    ctx.progress.update("Exchanging authorization code for tokens...");
+    return await exchangeCodeForTokens(clientId, clientSecret, redirectUri, code, verifier);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.message.includes("EADDRINUSE") ||
+        err.message.includes("port") ||
+        err.message.includes("listen"))
+    ) {
+      ctx.progress.update("Local callback server failed. Switching to manual mode...");
+      ctx.log(`\nOpen this URL in your LOCAL browser:\n\n${authUrl}\n`);
+      const callbackInput = await ctx.prompt("Paste the redirect URL here: ");
+      const parsed = parseCallbackInput(callbackInput, verifier);
+      if ("error" in parsed) {
+        throw new Error(parsed.error, { cause: err });
+      }
+      if (parsed.state !== verifier) {
+        throw new Error("OAuth state mismatch - please try again", { cause: err });
+      }
+      ctx.progress.update("Exchanging authorization code for tokens...");
+      return exchangeCodeForTokens(clientId, clientSecret, redirectUri, parsed.code, verifier);
+    }
+    throw err;
+  }
+}
+
+export function createOAuth2ClientFromCredentials(credentials: OAuthCredentials): OAuth2Client {
+  const { clientId, clientSecret, redirectUri } = resolveOAuthClientConfig();
+  const client = new OAuth2Client({
+    clientId,
+    clientSecret,
+    redirectUri,
+  });
+
+  client.setCredentials({
+    access_token: credentials.access,
+    refresh_token: credentials.refresh,
+    expiry_date: credentials.expires,
+  });
+
+  return client;
+}

--- a/extensions/google-drive/src/client.ts
+++ b/extensions/google-drive/src/client.ts
@@ -1,0 +1,56 @@
+import { OAuth2Client } from "google-auth-library";
+import { google } from "googleapis";
+// Dynamic type import for OAuthCredentials (not in plugin SDK)
+type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+import { createOAuth2ClientFromCredentials } from "./auth.js";
+
+let cachedDriveClient: {
+  key: string;
+  client: ReturnType<typeof google.drive>;
+} | null = null;
+
+let cachedDocsClient: {
+  key: string;
+  client: ReturnType<typeof google.docs>;
+} | null = null;
+
+function buildCredentialsKey(credentials: OAuthCredentials): string {
+  return `${credentials.access}:${credentials.refresh}:${credentials.expires}`;
+}
+
+export function createGoogleDriveClient(
+  credentials: OAuthCredentials,
+): ReturnType<typeof google.drive> {
+  const key = buildCredentialsKey(credentials);
+  if (cachedDriveClient && cachedDriveClient.key === key) {
+    return cachedDriveClient.client;
+  }
+
+  const oauth2Client = createOAuth2ClientFromCredentials(credentials);
+  const drive = google.drive({ version: "v3", auth: oauth2Client });
+
+  cachedDriveClient = { key, client: drive };
+  return drive;
+}
+
+export function createGoogleDocsClient(
+  credentials: OAuthCredentials,
+): ReturnType<typeof google.docs> {
+  const key = buildCredentialsKey(credentials);
+  if (cachedDocsClient && cachedDocsClient.key === key) {
+    return cachedDocsClient.client;
+  }
+
+  const oauth2Client = createOAuth2ClientFromCredentials(credentials);
+  const docs = google.docs({ version: "v1", auth: oauth2Client });
+
+  cachedDocsClient = { key, client: docs };
+  return docs;
+}
+
+export async function refreshAccessTokenIfNeeded(oauth2Client: OAuth2Client): Promise<void> {
+  const token = await oauth2Client.getAccessToken();
+  if (!token.token) {
+    await oauth2Client.refreshAccessToken();
+  }
+}

--- a/extensions/google-drive/src/credentials.ts
+++ b/extensions/google-drive/src/credentials.ts
@@ -1,27 +1,43 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-// Dynamic imports for auth-profiles (not in plugin SDK, need src/dist fallback)
-let resolveApiKeyForProfile: typeof import("../../src/agents/auth-profiles/oauth.js").resolveApiKeyForProfile;
-let ensureAuthProfileStore: typeof import("../../src/agents/auth-profiles/store.js").ensureAuthProfileStore;
-type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+import path from "node:path";
+import { createOAuth2ClientFromCredentials } from "./auth.js";
+// Dynamic imports for auth-profiles (not in plugin SDK). Paths are relative to repo root (three levels up from src/).
+let resolveApiKeyForProfile: typeof import("../../../src/agents/auth-profiles/oauth.js").resolveApiKeyForProfile;
+let ensureAuthProfileStore: typeof import("../../../src/agents/auth-profiles/store.js").ensureAuthProfileStore;
+let saveAuthProfileStore: typeof import("../../../src/agents/auth-profiles/store.js").saveAuthProfileStore;
+type OAuthCredentials = import("../../../src/agents/auth-profiles/types.js").OAuthCredentials;
+
+/** When gateway doesn't pass agentDir (e.g. /tools/invoke), use state dir + default agent so we find credentials. */
+function resolveEffectiveAgentDir(agentDir?: string): string | undefined {
+  if (agentDir?.trim()) {
+    return agentDir.trim();
+  }
+  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (stateDir) {
+    return path.join(stateDir, "agents", "main", "agent");
+  }
+  return undefined;
+}
 
 // Load auth-profiles modules with src/dist fallback
 async function loadAuthProfileModules() {
   if (resolveApiKeyForProfile && ensureAuthProfileStore) {
     return;
   }
-  // Try src first (dev/test)
+  // Try dist first (production/Docker); then src (dev/test)
   try {
-    const oauthMod = await import("../../src/agents/auth-profiles/oauth.js");
-    const storeMod = await import("../../src/agents/auth-profiles/store.js");
+    const oauthMod = await import("../../../dist/agents/auth-profiles/oauth.js");
+    const storeMod = await import("../../../dist/agents/auth-profiles/store.js");
     resolveApiKeyForProfile = oauthMod.resolveApiKeyForProfile;
     ensureAuthProfileStore = storeMod.ensureAuthProfileStore;
+    saveAuthProfileStore = storeMod.saveAuthProfileStore;
     return;
   } catch {
-    // Fallback to dist (production)
-    const oauthMod = await import("../../dist/agents/auth-profiles/oauth.js");
-    const storeMod = await import("../../dist/agents/auth-profiles/store.js");
+    const oauthMod = await import("../../../src/agents/auth-profiles/oauth.js");
+    const storeMod = await import("../../../src/agents/auth-profiles/store.js");
     resolveApiKeyForProfile = oauthMod.resolveApiKeyForProfile;
     ensureAuthProfileStore = storeMod.ensureAuthProfileStore;
+    saveAuthProfileStore = storeMod.saveAuthProfileStore;
   }
 }
 
@@ -33,28 +49,65 @@ export async function resolveGoogleDriveCredentials(params: {
   profileId?: string;
 }): Promise<OAuthCredentials | null> {
   await loadAuthProfileModules();
-  const store = ensureAuthProfileStore(params.agentDir);
-  const profileId = params.profileId || `google-drive:default`;
+  const effectiveAgentDir = resolveEffectiveAgentDir(params.agentDir);
 
-  // Try to resolve the profile (this will refresh if needed)
-  const resolved = await resolveApiKeyForProfile({
-    cfg: params.config,
-    store,
-    profileId,
-    agentDir: params.agentDir,
-  });
+  const store = ensureAuthProfileStore(effectiveAgentDir);
 
-  if (!resolved) {
-    return null;
+  const candidateIds = params.profileId
+    ? [params.profileId]
+    : [
+        `google-drive:default`,
+        ...listGoogleDriveProfileIdsSync(store).filter((id) => id !== "google-drive:default"),
+      ];
+
+  for (const profileId of candidateIds) {
+    const cred = store.profiles[profileId];
+    const resolved = await resolveApiKeyForProfile({
+      cfg: params.config,
+      store,
+      profileId,
+      agentDir: effectiveAgentDir,
+    });
+    const credMatch = !!(cred?.type === "oauth" && cred.provider === PROVIDER_ID);
+    if (!resolved && cred?.type === "oauth") {
+      const now = Date.now();
+      const expires = typeof cred.expires === "number" ? cred.expires : 0;
+      const tokenExpired = expires > 0 && now >= expires;
+      // Core only refreshes providers from pi-ai (e.g. "google"); "google-drive" is not included, so refresh in extension.
+      if (
+        credMatch &&
+        tokenExpired &&
+        process.env.GOOGLE_CLIENT_ID &&
+        process.env.GOOGLE_CLIENT_SECRET
+      ) {
+        try {
+          const client = createOAuth2ClientFromCredentials(cred);
+          const { credentials: newCreds } = await client.refreshAccessToken();
+          const newAccess = newCreds.access_token ?? cred.access;
+          const newExpires = typeof newCreds.expiry_date === "number" ? newCreds.expiry_date : 0;
+          const updated = { ...cred, access: newAccess, expires: newExpires };
+          store.profiles[profileId] = updated;
+          saveAuthProfileStore(store, effectiveAgentDir);
+          return updated;
+        } catch {
+          // Refresh failed (e.g. revoked token); caller will get no credential.
+        }
+      }
+    }
+    if (!resolved) {
+      continue;
+    }
+    if (credMatch) {
+      return cred;
+    }
   }
+  return null;
+}
 
-  // Get the actual OAuth credentials from the store
-  const cred = store.profiles[profileId];
-  if (!cred || cred.type !== "oauth" || cred.provider !== PROVIDER_ID) {
-    return null;
-  }
-
-  return cred;
+function listGoogleDriveProfileIdsSync(store: ReturnType<typeof ensureAuthProfileStore>): string[] {
+  return Object.keys(store.profiles).filter(
+    (profileId) => store.profiles[profileId]?.provider === PROVIDER_ID,
+  );
 }
 
 export async function listGoogleDriveProfileIds(agentDir?: string): Promise<string[]> {

--- a/extensions/google-drive/src/credentials.ts
+++ b/extensions/google-drive/src/credentials.ts
@@ -1,0 +1,66 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+// Dynamic imports for auth-profiles (not in plugin SDK, need src/dist fallback)
+let resolveApiKeyForProfile: typeof import("../../src/agents/auth-profiles/oauth.js").resolveApiKeyForProfile;
+let ensureAuthProfileStore: typeof import("../../src/agents/auth-profiles/store.js").ensureAuthProfileStore;
+type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+
+// Load auth-profiles modules with src/dist fallback
+async function loadAuthProfileModules() {
+  if (resolveApiKeyForProfile && ensureAuthProfileStore) {
+    return;
+  }
+  // Try src first (dev/test)
+  try {
+    const oauthMod = await import("../../src/agents/auth-profiles/oauth.js");
+    const storeMod = await import("../../src/agents/auth-profiles/store.js");
+    resolveApiKeyForProfile = oauthMod.resolveApiKeyForProfile;
+    ensureAuthProfileStore = storeMod.ensureAuthProfileStore;
+    return;
+  } catch {
+    // Fallback to dist (production)
+    const oauthMod = await import("../../dist/agents/auth-profiles/oauth.js");
+    const storeMod = await import("../../dist/agents/auth-profiles/store.js");
+    resolveApiKeyForProfile = oauthMod.resolveApiKeyForProfile;
+    ensureAuthProfileStore = storeMod.ensureAuthProfileStore;
+  }
+}
+
+const PROVIDER_ID = "google-drive";
+
+export async function resolveGoogleDriveCredentials(params: {
+  config?: OpenClawConfig;
+  agentDir?: string;
+  profileId?: string;
+}): Promise<OAuthCredentials | null> {
+  await loadAuthProfileModules();
+  const store = ensureAuthProfileStore(params.agentDir);
+  const profileId = params.profileId || `google-drive:default`;
+
+  // Try to resolve the profile (this will refresh if needed)
+  const resolved = await resolveApiKeyForProfile({
+    cfg: params.config,
+    store,
+    profileId,
+    agentDir: params.agentDir,
+  });
+
+  if (!resolved) {
+    return null;
+  }
+
+  // Get the actual OAuth credentials from the store
+  const cred = store.profiles[profileId];
+  if (!cred || cred.type !== "oauth" || cred.provider !== PROVIDER_ID) {
+    return null;
+  }
+
+  return cred;
+}
+
+export async function listGoogleDriveProfileIds(agentDir?: string): Promise<string[]> {
+  await loadAuthProfileModules();
+  const store = ensureAuthProfileStore(agentDir);
+  return Object.keys(store.profiles).filter(
+    (profileId) => store.profiles[profileId]?.provider === PROVIDER_ID,
+  );
+}

--- a/extensions/google-drive/src/docs-read.test.ts
+++ b/extensions/google-drive/src/docs-read.test.ts
@@ -1,0 +1,101 @@
+import type { docs_v1 } from "googleapis";
+import { describe, it, expect } from "vitest";
+import { convertDocumentToText } from "./docs-read.js";
+
+function minimalDocument(
+  overrides: Partial<docs_v1.Schema$Document> = {},
+): docs_v1.Schema$Document {
+  return {
+    title: "Test",
+    body: { content: [] },
+    ...overrides,
+  };
+}
+
+describe("convertDocumentToText", () => {
+  it("returns empty string for empty body content", () => {
+    expect(convertDocumentToText(minimalDocument(), "markdown")).toBe("");
+    expect(convertDocumentToText(minimalDocument({ body: { content: [] } }), "text")).toBe("");
+  });
+
+  it("extracts paragraph text", () => {
+    const doc = minimalDocument({
+      body: {
+        content: [
+          {
+            paragraph: {
+              elements: [{ textRun: { content: "Hello world" } }],
+            },
+          },
+        ],
+      },
+    });
+    expect(convertDocumentToText(doc, "text")).toBe("Hello world");
+    expect(convertDocumentToText(doc, "markdown")).toBe("Hello world");
+  });
+
+  it("formats bold and italic in markdown", () => {
+    const doc = minimalDocument({
+      body: {
+        content: [
+          {
+            paragraph: {
+              elements: [
+                { textRun: { content: "bold ", textStyle: { bold: true } } },
+                { textRun: { content: "italic", textStyle: { italic: true } } },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(convertDocumentToText(doc, "markdown")).toBe("**bold ***italic*");
+    expect(convertDocumentToText(doc, "text")).toBe("bold italic");
+  });
+
+  it("outputs heading level in markdown", () => {
+    const doc = minimalDocument({
+      body: {
+        content: [
+          {
+            paragraph: {
+              elements: [{ textRun: { content: "Heading 2" } }],
+              paragraphStyle: { namedStyleType: "HEADING_2" },
+            },
+          },
+        ],
+      },
+    });
+    expect(convertDocumentToText(doc, "markdown")).toBe("## Heading 2");
+    expect(convertDocumentToText(doc, "text")).toBe("Heading 2");
+  });
+
+  it("converts table to markdown", () => {
+    const doc = minimalDocument({
+      body: {
+        content: [
+          {
+            table: {
+              tableRows: [
+                {
+                  tableCells: [
+                    { content: [{ paragraph: { elements: [{ textRun: { content: "A" } }] } }] },
+                    { content: [{ paragraph: { elements: [{ textRun: { content: "B" } }] } }] },
+                  ],
+                },
+                {
+                  tableCells: [
+                    { content: [{ paragraph: { elements: [{ textRun: { content: "1" } }] } }] },
+                    { content: [{ paragraph: { elements: [{ textRun: { content: "2" } }] } }] },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(convertDocumentToText(doc, "markdown")).toBe("| A | B |\n| --- | --- |\n| 1 | 2 |");
+    expect(convertDocumentToText(doc, "text")).toBe("A\tB\n1\t2");
+  });
+});

--- a/extensions/google-drive/src/docs-read.ts
+++ b/extensions/google-drive/src/docs-read.ts
@@ -1,7 +1,7 @@
 import type { docs_v1 } from "googleapis";
 import { createGoogleDocsClient } from "./client.js";
 // Dynamic type import for OAuthCredentials (not in plugin SDK)
-type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+type OAuthCredentials = import("../../../src/agents/auth-profiles/types.js").OAuthCredentials;
 
 export async function readGoogleDocs(params: {
   credentials: OAuthCredentials;
@@ -31,7 +31,8 @@ export async function readGoogleDocs(params: {
   };
 }
 
-function convertDocumentToText(
+/** Convert Docs API document to markdown or text. Exported for unit tests. */
+export function convertDocumentToText(
   document: docs_v1.Schema$Document,
   format: "markdown" | "text",
 ): string {

--- a/extensions/google-drive/src/docs-read.ts
+++ b/extensions/google-drive/src/docs-read.ts
@@ -1,0 +1,175 @@
+import type { docs_v1 } from "googleapis";
+import { createGoogleDocsClient } from "./client.js";
+// Dynamic type import for OAuthCredentials (not in plugin SDK)
+type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+
+export async function readGoogleDocs(params: {
+  credentials: OAuthCredentials;
+  fileId: string;
+  format?: "markdown" | "text";
+}): Promise<{
+  content: string;
+  title: string;
+}> {
+  const docs = createGoogleDocsClient(params.credentials);
+
+  const response = await docs.documents.get({
+    documentId: params.fileId,
+  });
+
+  const document = response.data;
+  if (!document.body?.content) {
+    throw new Error("Empty document or invalid response from Google Docs API");
+  }
+
+  const title = document.title || "Untitled Document";
+  const content = convertDocumentToText(document, params.format || "markdown");
+
+  return {
+    content,
+    title,
+  };
+}
+
+function convertDocumentToText(
+  document: docs_v1.Schema$Document,
+  format: "markdown" | "text",
+): string {
+  if (!document.body?.content) {
+    return "";
+  }
+
+  const parts: string[] = [];
+
+  for (const element of document.body.content) {
+    if (element.paragraph) {
+      const text = extractParagraphText(element.paragraph, format);
+      if (text) {
+        parts.push(text);
+      }
+    } else if (element.table) {
+      const text = extractTableText(element.table, format);
+      if (text) {
+        parts.push(text);
+      }
+    }
+  }
+
+  return parts.join(format === "markdown" ? "\n\n" : "\n");
+}
+
+function extractParagraphText(
+  paragraph: docs_v1.Schema$Paragraph,
+  format: "markdown" | "text",
+): string {
+  if (!paragraph.elements) {
+    return "";
+  }
+
+  const parts: string[] = [];
+
+  for (const element of paragraph.elements) {
+    if (element.textRun) {
+      const text = element.textRun.content || "";
+      const style = element.textRun.textStyle;
+
+      if (format === "markdown") {
+        let formatted = text;
+        if (style?.bold) {
+          formatted = `**${formatted}**`;
+        }
+        if (style?.italic) {
+          formatted = `*${formatted}*`;
+        }
+        if (style?.underline) {
+          formatted = `<u>${formatted}</u>`;
+        }
+        if (style?.link?.url) {
+          formatted = `[${formatted}](${style.link.url})`;
+        }
+        parts.push(formatted);
+      } else {
+        parts.push(text);
+      }
+    } else if (element.inlineObjectElement) {
+      // Skip inline objects for now
+      continue;
+    }
+  }
+
+  const text = parts.join("").trim();
+
+  // Add heading prefix if this is a heading
+  if (paragraph.paragraphStyle?.namedStyleType) {
+    const style = paragraph.paragraphStyle.namedStyleType;
+    if (format === "markdown" && text) {
+      const level = getHeadingLevel(style);
+      if (level > 0) {
+        return `${"#".repeat(level)} ${text}`;
+      }
+    }
+  }
+
+  return text;
+}
+
+function extractTableText(table: docs_v1.Schema$Table, format: "markdown" | "text"): string {
+  if (!table.tableRows) {
+    return "";
+  }
+
+  const rows: string[][] = [];
+
+  for (const row of table.tableRows) {
+    if (!row.tableCells) {
+      continue;
+    }
+    const cells: string[] = [];
+    for (const cell of row.tableCells) {
+      if (cell.content) {
+        const cellText = cell.content
+          .map((element) => {
+            if (element.paragraph) {
+              return extractParagraphText(element.paragraph, "text");
+            }
+            return "";
+          })
+          .join(" ")
+          .trim();
+        cells.push(cellText);
+      } else {
+        cells.push("");
+      }
+    }
+    if (cells.length > 0) {
+      rows.push(cells);
+    }
+  }
+
+  if (rows.length === 0) {
+    return "";
+  }
+
+  if (format === "markdown") {
+    // Build markdown table
+    const header = rows[0];
+    const body = rows.slice(1);
+
+    const headerRow = `| ${header.join(" | ")} |`;
+    const separatorRow = `| ${header.map(() => "---").join(" | ")} |`;
+    const bodyRows = body.map((row) => `| ${row.join(" | ")} |`).join("\n");
+
+    return `${headerRow}\n${separatorRow}\n${bodyRows}`;
+  } else {
+    // Plain text table
+    return rows.map((row) => row.join("\t")).join("\n");
+  }
+}
+
+function getHeadingLevel(style: string): number {
+  const match = style.match(/^HEADING_(\d+)$/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+  return 0;
+}

--- a/extensions/google-drive/src/drive-download.ts
+++ b/extensions/google-drive/src/drive-download.ts
@@ -3,7 +3,7 @@ import { promises as fs } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { createGoogleDriveClient } from "./client.js";
 // Dynamic type import for OAuthCredentials (not in plugin SDK)
-type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+type OAuthCredentials = import("../../../src/agents/auth-profiles/types.js").OAuthCredentials;
 import { getGoogleDriveFile } from "./drive-get.js";
 
 const GOOGLE_WORKSPACE_MIME_TYPES = {
@@ -93,6 +93,7 @@ export async function downloadGoogleDriveFile(params: {
       {
         fileId: params.fileId,
         mimeType: exportMimeType,
+        supportsAllDrives: true,
       },
       { responseType: "stream" },
     );
@@ -102,6 +103,7 @@ export async function downloadGoogleDriveFile(params: {
       {
         fileId: params.fileId,
         alt: "media",
+        supportsAllDrives: true,
       },
       { responseType: "stream" },
     );

--- a/extensions/google-drive/src/drive-download.ts
+++ b/extensions/google-drive/src/drive-download.ts
@@ -1,0 +1,152 @@
+import type { drive_v3 } from "googleapis";
+import { promises as fs } from "node:fs";
+import { join, dirname, basename } from "node:path";
+import { createGoogleDriveClient } from "./client.js";
+// Dynamic type import for OAuthCredentials (not in plugin SDK)
+type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+import { getGoogleDriveFile } from "./drive-get.js";
+
+const GOOGLE_WORKSPACE_MIME_TYPES = {
+  document: "application/vnd.google-apps.document",
+  spreadsheet: "application/vnd.google-apps.spreadsheet",
+  presentation: "application/vnd.google-apps.presentation",
+  drawing: "application/vnd.google-apps.drawing",
+  form: "application/vnd.google-apps.form",
+};
+
+const EXPORT_MIME_TYPES: Record<string, string> = {
+  pdf: "application/pdf",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  txt: "text/plain",
+  html: "text/html",
+  rtf: "application/rtf",
+  odt: "application/vnd.oasis.opendocument.text",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  csv: "text/csv",
+  tsv: "text/tab-separated-values",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  png: "image/png",
+  jpg: "image/jpeg",
+  svg: "image/svg+xml",
+};
+
+export async function downloadGoogleDriveFile(params: {
+  credentials: OAuthCredentials;
+  fileId: string;
+  exportFormat?: string;
+  outputPath?: string;
+  workspaceDir?: string;
+}): Promise<{
+  path: string;
+  size: number;
+  mimeType: string;
+  filename: string;
+}> {
+  const drive = createGoogleDriveClient(params.credentials);
+
+  // Get file metadata first
+  const fileInfo = await getGoogleDriveFile({
+    credentials: params.credentials,
+    fileId: params.fileId,
+  });
+
+  const isGoogleWorkspaceFile = fileInfo.isGoogleWorkspaceFile;
+  const shouldExport = isGoogleWorkspaceFile && params.exportFormat;
+
+  // Determine output path
+  let outputPath: string;
+  if (params.outputPath) {
+    outputPath = params.workspaceDir
+      ? join(params.workspaceDir, params.outputPath)
+      : params.outputPath;
+  } else {
+    const baseName = fileInfo.name;
+    const extension = shouldExport
+      ? params.exportFormat
+      : getFileExtension(fileInfo.mimeType, baseName);
+    const filename = extension ? `${baseName}.${extension}` : baseName;
+    outputPath = params.workspaceDir ? join(params.workspaceDir, filename) : filename;
+  }
+
+  // Ensure directory exists
+  await fs.mkdir(dirname(outputPath), { recursive: true });
+
+  // Download or export the file
+  let response: { data: unknown };
+  let mimeType: string;
+
+  if (shouldExport) {
+    const exportMimeType = EXPORT_MIME_TYPES[params.exportFormat.toLowerCase()];
+    if (!exportMimeType) {
+      throw new Error(
+        `Unsupported export format: ${params.exportFormat}. Supported formats: ${Object.keys(EXPORT_MIME_TYPES).join(", ")}`,
+      );
+    }
+
+    if (!fileInfo.exportFormats?.includes(exportMimeType)) {
+      throw new Error(
+        `Export format ${params.exportFormat} (${exportMimeType}) is not available for this file type (${fileInfo.mimeType}). Available formats: ${fileInfo.exportFormats?.join(", ") || "none"}`,
+      );
+    }
+
+    response = await drive.files.export(
+      {
+        fileId: params.fileId,
+        mimeType: exportMimeType,
+      },
+      { responseType: "stream" },
+    );
+    mimeType = exportMimeType;
+  } else {
+    response = await drive.files.get(
+      {
+        fileId: params.fileId,
+        alt: "media",
+      },
+      { responseType: "stream" },
+    );
+    mimeType = fileInfo.mimeType;
+  }
+
+  // Write file to disk
+  const stream = response.data as NodeJS.ReadableStream;
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  const buffer = Buffer.concat(chunks);
+  await fs.writeFile(outputPath, buffer);
+
+  return {
+    path: outputPath,
+    size: buffer.length,
+    mimeType,
+    filename: basename(outputPath),
+  };
+}
+
+function getFileExtension(mimeType: string, filename: string): string {
+  // Try to get extension from filename first
+  const match = filename.match(/\.([^.]+)$/);
+  if (match) {
+    return match[1];
+  }
+
+  // Fallback to mime type mapping
+  const mimeToExt: Record<string, string> = {
+    "application/pdf": "pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/msword": "doc",
+    "text/plain": "txt",
+    "text/html": "html",
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif",
+    "application/json": "json",
+    "application/zip": "zip",
+  };
+
+  return mimeToExt[mimeType] || "bin";
+}

--- a/extensions/google-drive/src/drive-get.ts
+++ b/extensions/google-drive/src/drive-get.ts
@@ -1,7 +1,7 @@
 import type { drive_v3 } from "googleapis";
 import { createGoogleDriveClient } from "./client.js";
 // Dynamic type import for OAuthCredentials (not in plugin SDK)
-type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+type OAuthCredentials = import("../../../src/agents/auth-profiles/types.js").OAuthCredentials;
 
 export async function getGoogleDriveFile(params: {
   credentials: OAuthCredentials;
@@ -26,6 +26,7 @@ export async function getGoogleDriveFile(params: {
     fileId: params.fileId,
     fields:
       "id, name, mimeType, size, modifiedTime, createdTime, webViewLink, webContentLink, parents, capabilities",
+    supportsAllDrives: true,
   });
 
   const file = response.data;

--- a/extensions/google-drive/src/drive-get.ts
+++ b/extensions/google-drive/src/drive-get.ts
@@ -1,0 +1,62 @@
+import type { drive_v3 } from "googleapis";
+import { createGoogleDriveClient } from "./client.js";
+// Dynamic type import for OAuthCredentials (not in plugin SDK)
+type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+
+export async function getGoogleDriveFile(params: {
+  credentials: OAuthCredentials;
+  fileId: string;
+}): Promise<{
+  id: string;
+  name: string;
+  mimeType: string;
+  size?: string;
+  modifiedTime?: string;
+  createdTime?: string;
+  webViewLink?: string;
+  webContentLink?: string;
+  parents?: string[];
+  isFolder: boolean;
+  isGoogleWorkspaceFile: boolean;
+  exportFormats?: string[];
+}> {
+  const drive = createGoogleDriveClient(params.credentials);
+
+  const response = await drive.files.get({
+    fileId: params.fileId,
+    fields:
+      "id, name, mimeType, size, modifiedTime, createdTime, webViewLink, webContentLink, parents, capabilities",
+  });
+
+  const file = response.data;
+  if (!file.id || !file.name) {
+    throw new Error("Invalid file response from Google Drive API");
+  }
+
+  const isGoogleWorkspaceFile = file.mimeType?.startsWith("application/vnd.google-apps.") ?? false;
+
+  // Get export formats for Google Workspace files
+  let exportFormats: string[] | undefined;
+  if (isGoogleWorkspaceFile) {
+    const aboutResponse = await drive.about.get({ fields: "exportFormats" });
+    const allExportFormats = aboutResponse.data.exportFormats;
+    if (allExportFormats && file.mimeType) {
+      exportFormats = allExportFormats[file.mimeType] || [];
+    }
+  }
+
+  return {
+    id: file.id,
+    name: file.name,
+    mimeType: file.mimeType || "application/octet-stream",
+    size: file.size,
+    modifiedTime: file.modifiedTime || undefined,
+    createdTime: file.createdTime || undefined,
+    webViewLink: file.webViewLink || undefined,
+    webContentLink: file.webContentLink || undefined,
+    parents: file.parents || undefined,
+    isFolder: file.mimeType === "application/vnd.google-apps.folder",
+    isGoogleWorkspaceFile,
+    exportFormats,
+  };
+}

--- a/extensions/google-drive/src/drive-list.test.ts
+++ b/extensions/google-drive/src/drive-list.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { buildQuery } from "./drive-list.js";
+
+describe("buildQuery", () => {
+  it("defaults to root folder and excludes trashed", () => {
+    expect(buildQuery()).toBe("'root' in parents and trashed = false");
+    expect(buildQuery(undefined, undefined)).toBe("'root' in parents and trashed = false");
+  });
+
+  it("uses 'root' when folderId is 'root'", () => {
+    expect(buildQuery("root")).toBe("'root' in parents and trashed = false");
+  });
+
+  it("uses folder id when provided and not 'root'", () => {
+    expect(buildQuery("abc123")).toBe("'abc123' in parents and trashed = false");
+  });
+
+  it("appends search query when provided", () => {
+    expect(buildQuery("root", "name contains 'report'")).toBe(
+      "'root' in parents and trashed = false and (name contains 'report')",
+    );
+  });
+
+  it("combines custom folder and query", () => {
+    expect(buildQuery("folderId1", "mimeType = 'application/pdf'")).toBe(
+      "'folderId1' in parents and trashed = false and (mimeType = 'application/pdf')",
+    );
+  });
+
+  it("uses parent clause from query when folderId is root/empty (avoids root AND folder)", () => {
+    expect(buildQuery(undefined, "'1MeTF_c' in parents")).toBe(
+      "'1MeTF_c' in parents and trashed = false",
+    );
+    expect(buildQuery("root", "'sharedFolderId' in parents and trashed = false")).toBe(
+      "'sharedFolderId' in parents and trashed = false",
+    );
+  });
+});

--- a/extensions/google-drive/src/drive-list.ts
+++ b/extensions/google-drive/src/drive-list.ts
@@ -1,15 +1,21 @@
 import type { drive_v3 } from "googleapis";
 import { createGoogleDriveClient } from "./client.js";
 // Dynamic type import for OAuthCredentials (not in plugin SDK)
-type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+type OAuthCredentials = import("../../../src/agents/auth-profiles/types.js").OAuthCredentials;
 
-export async function listGoogleDriveFiles(params: {
+export type ListGoogleDriveFilesOptions = {
   credentials: OAuthCredentials;
   folderId?: string;
+  /** When set, list is scoped to this Shared Drive (uses corpora=drive). Use with folderId for a folder inside the drive. */
+  driveId?: string;
   query?: string;
   maxResults?: number;
   pageToken?: string;
-}): Promise<{
+  /** When true, include debug info in the result (request params, raw counts) for troubleshooting. */
+  debug?: boolean;
+};
+
+export async function listGoogleDriveFiles(params: ListGoogleDriveFilesOptions): Promise<{
   files: Array<{
     id: string;
     name: string;
@@ -23,25 +29,74 @@ export async function listGoogleDriveFiles(params: {
     isFolder: boolean;
   }>;
   nextPageToken?: string;
+  /** Present when debug=true or when 0 files returned (to help troubleshoot Shared Drive listing). */
+  _debug?: {
+    request: {
+      q: string;
+      corpora?: string;
+      driveId?: string;
+      supportsAllDrives: boolean;
+      includeItemsFromAllDrives: boolean;
+    };
+    fileCount: number;
+    hint?: string;
+  };
 }> {
   const drive = createGoogleDriveClient(params.credentials);
 
+  // When listing a Shared Drive root, use driveId as the "folder" (Shared Drive root folder ID = drive ID).
+  const effectiveFolderId =
+    params.driveId && (!params.folderId || params.folderId === "root")
+      ? params.driveId
+      : params.folderId;
+
+  const q = buildQuery(effectiveFolderId, params.query);
   const request: drive_v3.Params$Resource$Files$List = {
-    q: buildQuery(params.folderId, params.query),
+    q,
     pageSize: params.maxResults || 100,
     fields:
       "nextPageToken, files(id, name, mimeType, size, modifiedTime, createdTime, webViewLink, webContentLink, parents)",
     orderBy: "modifiedTime desc",
+    supportsAllDrives: true,
+    includeItemsFromAllDrives: true,
   };
 
   if (params.pageToken) {
     request.pageToken = params.pageToken;
   }
 
+  // Scope to a single Shared Drive when driveId is provided; otherwise search all drives (My Drive + Shared Drives).
+  // Without corpora=allDrives, the default is "user" (My Drive only), so Shared Drive folders return 0 files.
+  if (params.driveId) {
+    request.corpora = "drive";
+    request.driveId = params.driveId;
+  } else {
+    request.corpora = "allDrives";
+  }
+
   const response = await drive.files.list(request);
+  const fileCount = response.data.files?.length ?? 0;
+  const wantDebug = params.debug === true || fileCount === 0;
+
+  const debugInfo = wantDebug
+    ? {
+        request: {
+          q,
+          corpora: request.corpora,
+          driveId: request.driveId,
+          supportsAllDrives: request.supportsAllDrives,
+          includeItemsFromAllDrives: request.includeItemsFromAllDrives,
+        },
+        fileCount,
+        hint:
+          fileCount === 0 && effectiveFolderId && effectiveFolderId !== "root"
+            ? "If this folder is in a Shared Drive and not empty in the Drive UI, try passing driveId (the Shared Drive ID) along with folderId."
+            : undefined,
+      }
+    : undefined;
 
   if (!response.data.files) {
-    return { files: [] };
+    return { files: [], _debug: debugInfo };
   }
 
   return {
@@ -58,25 +113,37 @@ export async function listGoogleDriveFiles(params: {
       isFolder: file.mimeType === "application/vnd.google-apps.folder",
     })),
     nextPageToken: response.data.nextPageToken || undefined,
+    ...(debugInfo && { _debug: debugInfo }),
   };
 }
 
-function buildQuery(folderId?: string, searchQuery?: string): string {
+/** Matches a single parent clause (with optional "and trashed = false") so we use it as folderId and avoid adding 'root' in parents. */
+const PARENT_CLAUSE_REGEX = /^\s*'([^']+)'\s+in\s+parents(\s+and\s+trashed\s*=\s*false)?\s*$/i;
+
+/** Build Drive API q parameter. Exported for unit tests. */
+export function buildQuery(folderId?: string, searchQuery?: string): string {
   const parts: string[] = [];
 
-  // Folder filter
-  if (folderId && folderId !== "root") {
-    parts.push(`'${folderId}' in parents`);
-  } else if (!folderId || folderId === "root") {
+  // If the caller put a parent clause in searchQuery (e.g. "'<id>' in parents"), use that as the folder filter
+  // and do not add 'root' — no file can have both root and another folder as parent.
+  const parentFromQuery = searchQuery?.trim();
+  const parentMatch = parentFromQuery ? PARENT_CLAUSE_REGEX.exec(parentFromQuery) : null;
+  const effectiveFolderId = parentMatch ? parentMatch[1]! : folderId;
+  const queryWithoutParent = parentMatch ? undefined : searchQuery;
+
+  // Folder filter: exactly one of root or effectiveFolderId
+  if (effectiveFolderId && effectiveFolderId !== "root") {
+    parts.push(`'${effectiveFolderId}' in parents`);
+  } else {
     parts.push(`'root' in parents`);
   }
 
   // Trash filter (exclude trashed files)
   parts.push("trashed = false");
 
-  // Search query
-  if (searchQuery) {
-    parts.push(`(${searchQuery})`);
+  // Any additional search query (name, mimeType, etc.) — not a bare parent clause
+  if (queryWithoutParent) {
+    parts.push(`(${queryWithoutParent})`);
   }
 
   return parts.join(" and ");

--- a/extensions/google-drive/src/drive-list.ts
+++ b/extensions/google-drive/src/drive-list.ts
@@ -1,0 +1,83 @@
+import type { drive_v3 } from "googleapis";
+import { createGoogleDriveClient } from "./client.js";
+// Dynamic type import for OAuthCredentials (not in plugin SDK)
+type OAuthCredentials = import("../../src/agents/auth-profiles/types.js").OAuthCredentials;
+
+export async function listGoogleDriveFiles(params: {
+  credentials: OAuthCredentials;
+  folderId?: string;
+  query?: string;
+  maxResults?: number;
+  pageToken?: string;
+}): Promise<{
+  files: Array<{
+    id: string;
+    name: string;
+    mimeType: string;
+    size?: string;
+    modifiedTime?: string;
+    createdTime?: string;
+    webViewLink?: string;
+    webContentLink?: string;
+    parents?: string[];
+    isFolder: boolean;
+  }>;
+  nextPageToken?: string;
+}> {
+  const drive = createGoogleDriveClient(params.credentials);
+
+  const request: drive_v3.Params$Resource$Files$List = {
+    q: buildQuery(params.folderId, params.query),
+    pageSize: params.maxResults || 100,
+    fields:
+      "nextPageToken, files(id, name, mimeType, size, modifiedTime, createdTime, webViewLink, webContentLink, parents)",
+    orderBy: "modifiedTime desc",
+  };
+
+  if (params.pageToken) {
+    request.pageToken = params.pageToken;
+  }
+
+  const response = await drive.files.list(request);
+
+  if (!response.data.files) {
+    return { files: [] };
+  }
+
+  return {
+    files: response.data.files.map((file) => ({
+      id: file.id!,
+      name: file.name!,
+      mimeType: file.mimeType || "application/octet-stream",
+      size: file.size,
+      modifiedTime: file.modifiedTime || undefined,
+      createdTime: file.createdTime || undefined,
+      webViewLink: file.webViewLink || undefined,
+      webContentLink: file.webContentLink || undefined,
+      parents: file.parents || undefined,
+      isFolder: file.mimeType === "application/vnd.google-apps.folder",
+    })),
+    nextPageToken: response.data.nextPageToken || undefined,
+  };
+}
+
+function buildQuery(folderId?: string, searchQuery?: string): string {
+  const parts: string[] = [];
+
+  // Folder filter
+  if (folderId && folderId !== "root") {
+    parts.push(`'${folderId}' in parents`);
+  } else if (!folderId || folderId === "root") {
+    parts.push(`'root' in parents`);
+  }
+
+  // Trash filter (exclude trashed files)
+  parts.push("trashed = false");
+
+  // Search query
+  if (searchQuery) {
+    parts.push(`(${searchQuery})`);
+  }
+
+  return parts.join(" and ");
+}

--- a/extensions/google-drive/src/schema.test.ts
+++ b/extensions/google-drive/src/schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { GoogleDriveSchema } from "./schema.js";
+
+describe("GoogleDriveSchema", () => {
+  it("is a single object schema (no anyOf/oneOf) for provider compatibility", () => {
+    expect(GoogleDriveSchema).toBeDefined();
+    expect(GoogleDriveSchema.anyOf).toBeUndefined();
+    expect(GoogleDriveSchema.oneOf).toBeUndefined();
+    expect(GoogleDriveSchema.properties).toBeDefined();
+  });
+
+  it("has action as string enum with list, get, download, read_docs, read_sheets", () => {
+    const action = (GoogleDriveSchema.properties as Record<string, { enum?: string[] }>).action;
+    expect(action).toBeDefined();
+    expect(action.enum).toEqual(["list", "get", "download", "read_docs", "read_sheets"]);
+  });
+
+  it("has optional fields for all actions", () => {
+    const props = GoogleDriveSchema.properties as Record<string, unknown>;
+    expect(props.folderId).toBeDefined();
+    expect(props.query).toBeDefined();
+    expect(props.fileId).toBeDefined();
+    expect(props.spreadsheetId).toBeDefined();
+    expect(props.range).toBeDefined();
+    expect(props.exportFormat).toBeDefined();
+    expect(props.format).toBeDefined();
+  });
+});

--- a/extensions/google-drive/src/schema.ts
+++ b/extensions/google-drive/src/schema.ts
@@ -1,0 +1,76 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+export const GoogleDriveListSchema = Type.Object({
+  action: Type.Literal("list"),
+  folderId: Type.Optional(
+    Type.String({
+      description: "Folder ID to list (omit for root directory). Use 'root' for root folder.",
+    }),
+  ),
+  query: Type.Optional(
+    Type.String({
+      description: "Search query to filter files (e.g., 'name contains \"report\"').",
+    }),
+  ),
+  maxResults: Type.Optional(
+    Type.Number({
+      description: "Maximum number of results to return (default: 100, max: 1000).",
+      minimum: 1,
+      maximum: 1000,
+      default: 100,
+    }),
+  ),
+  pageToken: Type.Optional(
+    Type.String({
+      description: "Page token for pagination (from previous list response).",
+    }),
+  ),
+});
+
+export const GoogleDriveGetSchema = Type.Object({
+  action: Type.Literal("get"),
+  fileId: Type.String({
+    description: "File ID to get metadata for.",
+  }),
+});
+
+export const GoogleDriveDownloadSchema = Type.Object({
+  action: Type.Literal("download"),
+  fileId: Type.String({
+    description: "File ID to download.",
+  }),
+  exportFormat: Type.Optional(
+    Type.String({
+      description:
+        "Export format for Google Workspace files. Options: 'pdf', 'docx', 'txt', 'html', 'rtf', 'odt', 'xlsx', 'csv', 'tsv', 'pptx', 'png', 'jpg', 'svg'. Omit for original format.",
+    }),
+  ),
+  outputPath: Type.Optional(
+    Type.String({
+      description:
+        "Optional output path (relative to workspace). If omitted, file will be saved with original name.",
+    }),
+  ),
+});
+
+export const GoogleDocsReadSchema = Type.Object({
+  action: Type.Literal("read_docs"),
+  fileId: Type.String({
+    description: "Google Docs file ID to read.",
+  }),
+  format: Type.Optional(
+    Type.String({
+      description: "Output format: 'markdown' (default) or 'text'.",
+      default: "markdown",
+    }),
+  ),
+});
+
+export const GoogleDriveSchema = Type.Union([
+  GoogleDriveListSchema,
+  GoogleDriveGetSchema,
+  GoogleDriveDownloadSchema,
+  GoogleDocsReadSchema,
+]);
+
+export type GoogleDriveParams = Static<typeof GoogleDriveSchema>;

--- a/extensions/google-drive/src/sheets-read.ts
+++ b/extensions/google-drive/src/sheets-read.ts
@@ -1,0 +1,31 @@
+import { createGoogleSheetsClient } from "./client.js";
+// Dynamic type import for OAuthCredentials (not in plugin SDK)
+type OAuthCredentials = import("../../../src/agents/auth-profiles/types.js").OAuthCredentials;
+
+export async function readGoogleSheetsRange(params: {
+  credentials: OAuthCredentials;
+  spreadsheetId: string;
+  range: string;
+}): Promise<{
+  range: string;
+  values: unknown[][];
+  majorDimension: string;
+}> {
+  const sheets = createGoogleSheetsClient(params.credentials);
+
+  const response = await sheets.spreadsheets.values.get({
+    spreadsheetId: params.spreadsheetId,
+    range: params.range,
+    majorDimension: "ROWS",
+  });
+
+  const values = (response.data.values ?? []) as unknown[][];
+  const range = response.data.range ?? params.range;
+  const majorDimension = response.data.majorDimension ?? "ROWS";
+
+  return {
+    range,
+    values,
+    majorDimension,
+  };
+}

--- a/extensions/google-drive/src/tools.ts
+++ b/extensions/google-drive/src/tools.ts
@@ -6,6 +6,25 @@ import { downloadGoogleDriveFile } from "./drive-download.js";
 import { getGoogleDriveFile } from "./drive-get.js";
 import { listGoogleDriveFiles } from "./drive-list.js";
 import { GoogleDriveSchema, type GoogleDriveParams } from "./schema.js";
+import { readGoogleSheetsRange } from "./sheets-read.js";
+
+function validateParams(p: GoogleDriveParams): string | null {
+  switch (p.action) {
+    case "list":
+      return null;
+    case "get":
+    case "download":
+      return p.fileId ? null : "fileId is required for this action";
+    case "read_docs":
+      return p.fileId ? null : "fileId is required for read_docs";
+    case "read_sheets":
+      if (!p.spreadsheetId) return "spreadsheetId is required for read_sheets";
+      if (!p.range?.trim()) return "range is required for read_sheets (e.g. 'Sheet1!A1:D10')";
+      return null;
+    default:
+      return `Unknown action: ${(p as { action: string }).action}`;
+  }
+}
 
 export function registerGoogleDriveTools(api: OpenClawPluginApi) {
   if (!api.config) {
@@ -19,12 +38,16 @@ export function registerGoogleDriveTools(api: OpenClawPluginApi) {
       name: "google_drive",
       label: "Google Drive",
       description:
-        "Browse Google Drive, get file metadata, download files, and read Google Docs. Actions: list, get, download, read_docs",
+        "Browse Google Drive, get file metadata, download files, read Google Docs, and read Google Sheets. Actions: list, get, download, read_docs, read_sheets",
       parameters: GoogleDriveSchema,
       async execute(_toolCallId, params) {
         const p = params as GoogleDriveParams;
 
-        // Resolve credentials using context values
+        const validationError = validateParams(p);
+        if (validationError) {
+          return jsonResult({ error: validationError });
+        }
+
         const credentials = await resolveGoogleDriveCredentials({
           config: ctx.config,
           agentDir: ctx.agentDir,
@@ -43,9 +66,11 @@ export function registerGoogleDriveTools(api: OpenClawPluginApi) {
               const result = await listGoogleDriveFiles({
                 credentials,
                 folderId: p.folderId,
+                driveId: p.driveId,
                 query: p.query,
                 maxResults: p.maxResults,
                 pageToken: p.pageToken,
+                debug: p.debug === true,
               });
               return jsonResult(result);
             }
@@ -53,17 +78,16 @@ export function registerGoogleDriveTools(api: OpenClawPluginApi) {
             case "get": {
               const result = await getGoogleDriveFile({
                 credentials,
-                fileId: p.fileId,
+                fileId: p.fileId!,
               });
               return jsonResult(result);
             }
 
             case "download": {
-              // Use workspaceDir from context if available, otherwise use current working directory
               const workspaceDir = ctx.workspaceDir || process.cwd();
               const result = await downloadGoogleDriveFile({
                 credentials,
-                fileId: p.fileId,
+                fileId: p.fileId!,
                 exportFormat: p.exportFormat,
                 outputPath: p.outputPath,
                 workspaceDir,
@@ -78,7 +102,7 @@ export function registerGoogleDriveTools(api: OpenClawPluginApi) {
             case "read_docs": {
               const result = await readGoogleDocs({
                 credentials,
-                fileId: p.fileId,
+                fileId: p.fileId!,
                 format: p.format === "text" ? "text" : "markdown",
               });
               return jsonResult({
@@ -88,9 +112,17 @@ export function registerGoogleDriveTools(api: OpenClawPluginApi) {
               });
             }
 
+            case "read_sheets": {
+              const result = await readGoogleSheetsRange({
+                credentials,
+                spreadsheetId: p.spreadsheetId!,
+                range: p.range!.trim(),
+              });
+              return jsonResult(result);
+            }
+
             default: {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-              return jsonResult({ error: `Unknown action: ${(p as any).action}` });
+              return jsonResult({ error: `Unknown action: ${(p as { action: string }).action}` });
             }
           }
         } catch (err) {

--- a/extensions/google-drive/src/tools.ts
+++ b/extensions/google-drive/src/tools.ts
@@ -1,0 +1,107 @@
+import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
+import { jsonResult } from "openclaw/plugin-sdk";
+import { resolveGoogleDriveCredentials } from "./credentials.js";
+import { readGoogleDocs } from "./docs-read.js";
+import { downloadGoogleDriveFile } from "./drive-download.js";
+import { getGoogleDriveFile } from "./drive-get.js";
+import { listGoogleDriveFiles } from "./drive-list.js";
+import { GoogleDriveSchema, type GoogleDriveParams } from "./schema.js";
+
+export function registerGoogleDriveTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("google_drive: No config available, skipping drive tools");
+    return;
+  }
+
+  // Use a factory function to capture context values
+  api.registerTool(
+    (ctx: OpenClawPluginToolContext) => ({
+      name: "google_drive",
+      label: "Google Drive",
+      description:
+        "Browse Google Drive, get file metadata, download files, and read Google Docs. Actions: list, get, download, read_docs",
+      parameters: GoogleDriveSchema,
+      async execute(_toolCallId, params) {
+        const p = params as GoogleDriveParams;
+
+        // Resolve credentials using context values
+        const credentials = await resolveGoogleDriveCredentials({
+          config: ctx.config,
+          agentDir: ctx.agentDir,
+        });
+
+        if (!credentials) {
+          return jsonResult({
+            error:
+              "No Google Drive credentials found. Please authenticate using 'openclaw models auth login --provider google-drive'",
+          });
+        }
+
+        try {
+          switch (p.action) {
+            case "list": {
+              const result = await listGoogleDriveFiles({
+                credentials,
+                folderId: p.folderId,
+                query: p.query,
+                maxResults: p.maxResults,
+                pageToken: p.pageToken,
+              });
+              return jsonResult(result);
+            }
+
+            case "get": {
+              const result = await getGoogleDriveFile({
+                credentials,
+                fileId: p.fileId,
+              });
+              return jsonResult(result);
+            }
+
+            case "download": {
+              // Use workspaceDir from context if available, otherwise use current working directory
+              const workspaceDir = ctx.workspaceDir || process.cwd();
+              const result = await downloadGoogleDriveFile({
+                credentials,
+                fileId: p.fileId,
+                exportFormat: p.exportFormat,
+                outputPath: p.outputPath,
+                workspaceDir,
+              });
+              return jsonResult({
+                success: true,
+                ...result,
+                message: `Downloaded to ${result.path}`,
+              });
+            }
+
+            case "read_docs": {
+              const result = await readGoogleDocs({
+                credentials,
+                fileId: p.fileId,
+                format: p.format === "text" ? "text" : "markdown",
+              });
+              return jsonResult({
+                title: result.title,
+                content: result.content,
+                format: p.format || "markdown",
+              });
+            }
+
+            default: {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+              return jsonResult({ error: `Unknown action: ${(p as any).action}` });
+            }
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          api.logger.error?.(`google_drive tool error: ${message}`);
+          return jsonResult({ error: message });
+        }
+      },
+    }),
+    { optional: true },
+  );
+
+  api.logger.info?.("google_drive: Registered google_drive tool");
+}

--- a/fly.private.toml
+++ b/fly.private.toml
@@ -9,8 +9,8 @@
 #
 # See https://fly.io/docs/reference/configuration/
 
-app = "my-openclaw" # change to your app name
-primary_region = "iad" # change to your closest region
+app = "openclaw-lisan-al-gaib" # change to your app name
+primary_region = "fra" # change to your closest region
 
 [build]
 dockerfile = "Dockerfile"
@@ -18,15 +18,17 @@ dockerfile = "Dockerfile"
 [env]
 NODE_ENV = "production"
 OPENCLAW_PREFER_PNPM = "1"
-OPENCLAW_STATE_DIR = "/data"
+OPENCLAW_STATE_DIR = "/data/.openclaw"
 NODE_OPTIONS = "--max-old-space-size=1536"
+OPENCLAW_DISABLE_BONJOUR = "1"
 
 [processes]
-app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
+app = "node dist/index.js gateway --allow-unconfigured --port 17568 --bind loopback"
 
 # NOTE: No [http_service] block = no public ingress allocated.
 # The gateway will only be accessible via:
-#   - fly proxy 3000:3000 -a <app-name>
+#   - Tailscale Serve: https://<machine-name>.tailnet-xxxx.ts.net/
+#   - fly proxy 17568:17568 -a <app-name>
 #   - fly wireguard (then access via internal IPv6)
 #   - fly ssh console
 
@@ -37,3 +39,14 @@ memory = "2048mb"
 [mounts]
 source = "openclaw_data"
 destination = "/data"
+
+# NOTE: Restart policy must be set via CLI, not in fly.toml:
+#   fly m update <machine-id> --restart always
+# 
+# Options:
+#   - "always": Restart even on clean exit (code 0) - ensures gateway restarts work
+#   - "on-fail": Only restart on non-zero exit codes (default) - works with our code fix
+#   - "no": Never restart automatically
+#
+# With our code fix, gateway exits with code 1 when restart is needed in containers,
+# so "on-fail" policy will work. Use "always" if you want restarts even on code 0.

--- a/fly.toml
+++ b/fly.toml
@@ -1,34 +1,36 @@
-# OpenClaw Fly.io deployment configuration
-# See https://fly.io/docs/reference/configuration/
+# fly.toml app configuration file generated for openclaw-lisan-al-gaib on 2026-02-04T12:54:00+01:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
-app = "openclaw"
-primary_region = "iad" # change to your closest region
+app = 'openclaw-lisan-al-gaib'
+primary_region = 'fra'
 
 [build]
-dockerfile = "Dockerfile"
+  dockerfile = 'Dockerfile'
 
 [env]
-NODE_ENV = "production"
-# Fly uses x86, but keep this for consistency
-OPENCLAW_PREFER_PNPM = "1"
-OPENCLAW_STATE_DIR = "/data"
-NODE_OPTIONS = "--max-old-space-size=1536"
+  NODE_ENV = 'production'
+  NODE_OPTIONS = '--max-old-space-size=1536'
+  OPENCLAW_PREFER_PNPM = '1'
+  OPENCLAW_STATE_DIR = '/data'
 
 [processes]
-app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
+  app = 'node dist/index.js gateway --allow-unconfigured --port 17568 --bind loopback'
 
-[http_service]
-internal_port = 3000
-force_https = true
-auto_stop_machines = false # Keep running for persistent connections
-auto_start_machines = true
-min_machines_running = 1
-processes = ["app"]
+[[mounts]]
+  source = 'openclaw_data'
+  destination = '/data'
+
+# NOTE: No [http_service] block = no public ingress allocated.
+# The gateway will only be accessible via:
+#   - Tailscale Serve: https://<machine-name>.tailnet-xxxx.ts.net/
+#   - fly proxy 17568:17568 -a <app-name>
+#   - fly wireguard (then access via internal IPv6)
+#   - fly ssh console
 
 [[vm]]
-size = "shared-cpu-2x"
-memory = "2048mb"
-
-[mounts]
-source = "openclaw_data"
-destination = "/data"
+  size = 'shared-cpu-2x'
+  memory = '2gb'
+  cpus = 2
+  memory_mb = 2048

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,22 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/google-drive:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+      google-auth-library:
+        specifier: ^10.5.0
+        version: 10.5.0
+      googleapis:
+        specifier: ^144.0.0
+        version: 144.0.0
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/google-gemini-cli-auth:
     devDependencies:
       openclaw:
@@ -3635,9 +3651,17 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
   gaxios@7.1.3:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
     engines: {node: '>=18'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
 
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
@@ -3685,9 +3709,25 @@ packages:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
     engines: {node: '>=18'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
+
+  googleapis-common@7.2.0:
+    resolution: {integrity: sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==}
+    engines: {node: '>=14.0.0'}
+
+  googleapis@144.0.0:
+    resolution: {integrity: sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==}
+    engines: {node: '>=14.0.0'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3699,6 +3739,10 @@ packages:
   grammy@1.39.3:
     resolution: {integrity: sha512-7arRRoOtOh9UwMwANZ475kJrWV6P3/EGNooeHlY0/SwZv4t3ZZ3Uiz9cAXK8Zg9xSdgmm8T21kx6n7SZaWvOcw==}
     engines: {node: ^12.20.0 || >=14.13.1}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   gtoken@8.0.0:
     resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
@@ -5308,6 +5352,9 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -5326,6 +5373,10 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   validate-npm-package-name@6.0.2:
@@ -9092,6 +9143,17 @@ snapshots:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
 
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gaxios@7.1.3:
     dependencies:
       extend: 3.0.2
@@ -9099,6 +9161,15 @@ snapshots:
       node-fetch: 3.3.2
       rimraf: 5.0.10
     transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
       - supports-color
 
   gcp-metadata@8.1.2:
@@ -9176,7 +9247,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   google-logging-utils@1.1.3: {}
+
+  googleapis-common@7.2.0:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 6.7.1
+      google-auth-library: 9.15.1
+      qs: 6.14.1
+      url-template: 2.0.8
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  googleapis@144.0.0:
+    dependencies:
+      google-auth-library: 9.15.1
+      googleapis-common: 7.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -9188,6 +9293,14 @@ snapshots:
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10964,6 +11077,8 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  url-template@2.0.8: {}
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -10973,6 +11088,8 @@ snapshots:
   uuid@3.4.0: {}
 
   uuid@8.3.2: {}
+
+  uuid@9.0.1: {}
 
   validate-npm-package-name@6.0.2: {}
 

--- a/scripts/check-gateway-access.sh
+++ b/scripts/check-gateway-access.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Quick script to check gateway access on fly.io
+
+APP_NAME="${1:-openclaw-lisan-al-gaib}"
+
+echo "Checking gateway status for app: $APP_NAME"
+echo ""
+
+echo "1. Checking if gateway is running..."
+fly logs --no-tail -a "$APP_NAME" | grep -i "gateway\|listening" | tail -5
+echo ""
+
+echo "2. Testing health endpoint (via proxy)..."
+echo "   Starting proxy in background..."
+fly proxy 3000:3000 -a "$APP_NAME" > /dev/null 2>&1 &
+PROXY_PID=$!
+sleep 3
+
+if curl -s http://localhost:3000/health > /dev/null 2>&1; then
+    echo "   ✓ Gateway is accessible at http://localhost:3000"
+    echo "   ✓ Control UI: http://localhost:3000/"
+    echo "   ✓ Health endpoint: http://localhost:3000/health"
+else
+    echo "   ✗ Gateway not accessible (may need authentication or gateway not started)"
+fi
+
+kill $PROXY_PID 2>/dev/null
+echo ""
+
+echo "3. To access the gateway:"
+echo "   - Start proxy: fly proxy 3000:3000 -a $APP_NAME"
+echo "   - Open browser: http://localhost:3000/"
+echo "   - Or use Tailscale if configured"

--- a/scripts/fly-tailscale-start.sh
+++ b/scripts/fly-tailscale-start.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+set -euo pipefail
+
+# Tailscale startup script for fly.io
+# This script authenticates Tailscale and then starts the OpenClaw gateway
+
+# Ensure node user exists and has a home directory
+# This prevents workspace resolution from defaulting to /root/.openclaw
+if ! id -u node >/dev/null 2>&1; then
+  echo "Creating node user..."
+  useradd -m -u 1000 node || true
+fi
+if [ ! -d /home/node ]; then
+  mkdir -p /home/node
+  chown node:node /home/node || true
+fi
+
+# Fix permissions for /data directory (mounted volume)
+# Ensure node user can read/write to /data
+echo "Setting up /data directory permissions..."
+mkdir -p /data
+chown -R node:node /data || true
+chmod -R 755 /data || true
+
+# Create necessary subdirectories with correct ownership
+# Create workspace directory explicitly - this is where agents store their files
+mkdir -p /data/.openclaw /data/.openclaw/workspace /data/workspace /var/run/tailscale
+chown -R node:node /data/.openclaw /data/workspace || true
+chmod -R 755 /data/.openclaw /data/workspace || true
+# Ensure workspace directory is writable
+chmod 755 /data/.openclaw/workspace || true
+
+# Ensure OPENCLAW_STATE_DIR is set and exported before any commands run
+# This prevents code from defaulting to /root/.openclaw when running as root
+export OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-/data}"
+
+# Create symlinks from both root and node user's home .openclaw to /data/.openclaw
+# This ensures workspace resolution (which uses homedir()) works correctly
+# even if OPENCLAW_STATE_DIR isn't checked by all code paths or if something runs as root
+if [ -d /home/node ] && [ ! -e /home/node/.openclaw ]; then
+  ln -s /data/.openclaw /home/node/.openclaw || true
+  chown -h node:node /home/node/.openclaw || true
+fi
+# Also create symlink for root user as fallback (in case any code runs as root)
+if [ ! -e /root/.openclaw ]; then
+  ln -s /data/.openclaw /root/.openclaw || true
+fi
+
+# Ensure config file has correct permissions (read/write for node user only)
+# The config file may have been created with root ownership or restrictive permissions
+# Use 600 (rw-------) for security since config contains sensitive tokens/passwords
+if [ -f /data/openclaw.json ]; then
+  chown node:node /data/openclaw.json || true
+  chmod 600 /data/openclaw.json || true
+  
+  # Set browser defaults for containerized environment (headless + noSandbox)
+  # Only set if not already configured to avoid overwriting user preferences
+  if [ -f /app/dist/index.js ] && command -v node >/dev/null 2>&1 && command -v gosu >/dev/null 2>&1; then
+    # Set browser.headless if not already set (run as node user to ensure proper permissions)
+    if ! gosu node node -e "const fs=require('fs'); try { const cfg=JSON.parse(fs.readFileSync('/data/openclaw.json','utf8')); process.exit(cfg.browser?.headless !== undefined ? 0 : 1); } catch { process.exit(1); }" 2>/dev/null; then
+      echo "Setting browser.headless=true for containerized environment..."
+      cd /app && gosu node node dist/index.js config set browser.headless true 2>/dev/null || true
+      chown node:node /data/openclaw.json || true
+      chmod 600 /data/openclaw.json || true
+    fi
+    # Set browser.noSandbox if not already set
+    if ! gosu node node -e "const fs=require('fs'); try { const cfg=JSON.parse(fs.readFileSync('/data/openclaw.json','utf8')); process.exit(cfg.browser?.noSandbox !== undefined ? 0 : 1); } catch { process.exit(1); }" 2>/dev/null; then
+      echo "Setting browser.noSandbox=true for containerized environment..."
+      cd /app && gosu node node dist/index.js config set browser.noSandbox true 2>/dev/null || true
+      chown node:node /data/openclaw.json || true
+      chmod 600 /data/openclaw.json || true
+    fi
+  fi
+  
+  # Try to auto-fix config issues before starting gateway (non-interactive, safe repairs only)
+  # This helps prevent crashes from invalid config
+  if command -v openclaw >/dev/null 2>&1; then
+    echo "Checking config health and attempting auto-repair..."
+    cd /app && gosu node openclaw doctor --non-interactive --repair 2>&1 || {
+      echo "Warning: Config auto-repair had issues (this may be normal if config is already valid)"
+    }
+    
+  fi
+fi
+
+# Function to start gateway with config error handling
+# If config is invalid, keeps container alive and exits with code 0 to prevent Fly.io restart
+start_gateway_safe() {
+  local cmd=("$@")
+  echo "Starting OpenClaw gateway: ${cmd[*]}"
+  
+  # Start gateway in background to monitor for immediate failures
+  gosu node env HOME=/home/node OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-/data}" "${cmd[@]}" &
+  local gateway_pid=$!
+  
+  # Wait a few seconds to see if gateway starts successfully or fails immediately
+  sleep 8
+  
+  # Check if gateway process is still running
+  if ! kill -0 "$gateway_pid" 2>/dev/null; then
+    # Gateway process died quickly - likely a config error
+    wait "$gateway_pid" 2>/dev/null || true
+    local exit_code=$?
+    
+    echo ""
+    echo "=========================================="
+    echo "ERROR: Gateway failed to start (exit code: $exit_code)"
+    echo "=========================================="
+    echo ""
+    echo "This is likely due to an invalid config file."
+    echo "The container will remain running so you can fix the issue."
+    echo ""
+    echo "To fix:"
+    echo "  1. SSH into the container: fly ssh console -a <app-name>"
+    echo "  2. Check config: cat /data/openclaw.json"
+    echo "  3. Edit config: nano /data/openclaw.json (or use: openclaw config set <path> <value>)"
+    echo "  4. Run doctor: openclaw doctor --repair"
+    echo "  5. Restart the machine: fly machines restart <machine-id> -a <app-name>"
+    echo ""
+    echo "Container is waiting. Fix the config and restart the machine."
+    echo "Exiting with code 0 to prevent Fly.io from restarting this container."
+    echo ""
+    # Keep container alive for a while so user can see the error and SSH in
+    sleep 300  # Wait 5 minutes
+    exit 0
+  else
+    # Gateway started successfully, wait for it
+    echo "Gateway started successfully (PID: $gateway_pid)"
+    wait "$gateway_pid"
+  fi
+}
+
+# Check if Tailscale auth key is provided
+if [ -z "${TAILSCALE_AUTHKEY:-}" ]; then
+  echo "Warning: TAILSCALE_AUTHKEY not set, skipping Tailscale setup"
+  # Set HOME for node user to prevent defaulting to /root
+  export HOME=/home/node
+  # No Tailscale, start gateway with error handling
+  start_gateway_safe env HOME=/home/node OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-/data}" "$@"
+else
+  echo "Starting Tailscale..."
+  
+  # Create Tailscale directories
+  # --statedir is required for TailscaleVarRoot (needed for Serve/TLS)
+  mkdir -p /data/tailscale-state
+  mkdir -p /var/lib/tailscale
+  chmod 755 /data/tailscale-state /var/lib/tailscale
+  
+  # Set Tailscale environment variables for containerized environments
+  export TS_STATE_DIR=/data/tailscale-state
+  export TS_SOCKET=/var/run/tailscale/tailscaled.sock
+  
+  # Start tailscaled in the background (runs as root)
+  # --statedir is required for TailscaleVarRoot (fixes "no TailscaleVarRoot" error)
+  # This sets the var root directory where Tailscale stores runtime files
+  tailscaled --statedir=/data/tailscale-state --socket=/var/run/tailscale/tailscaled.sock &
+  TAILSCALED_PID=$!
+  
+  # Wait for tailscaled to be ready
+  for i in {1..30}; do
+    if [ -S /var/run/tailscale/tailscaled.sock ]; then
+      break
+    fi
+    sleep 1
+  done
+  
+  # Authenticate with the auth key
+  # Check if already authenticated to avoid "requires mentioning all" error
+  if tailscale status &>/dev/null && ! tailscale status 2>/dev/null | grep -q "Logged out\|not running"; then
+    echo "Tailscale already authenticated"
+  else
+    # Not authenticated - authenticate with auth key
+    # Use --reset to clear any existing non-default settings and avoid "requires mentioning all" error
+    tailscale up --reset --authkey="${TAILSCALE_AUTHKEY}" --accept-routes=false --accept-dns=false || {
+      echo "Warning: tailscale up failed, trying without --reset..."
+      # Fallback: try without reset if reset fails (e.g., if already authenticated)
+      tailscale up --authkey="${TAILSCALE_AUTHKEY}" --accept-routes=false --accept-dns=false || true
+    }
+  fi
+  
+  # Set operator separately (this doesn't trigger "requires mentioning all" error)
+  tailscale set --operator=node || echo "Warning: Failed to set operator (may already be set)"
+  
+  echo "Tailscale connected. Status:"
+  tailscale status
+  
+  # Ensure node user can access the Tailscale socket
+  chmod 666 /var/run/tailscale/tailscaled.sock || chmod 755 /var/run/tailscale && chmod 666 /var/run/tailscale/tailscaled.sock || true
+  
+  # Set HOME for node user to prevent defaulting to /root
+  # This ensures workspace resolution uses OPENCLAW_STATE_DIR instead of /root/.openclaw
+  export HOME=/home/node
+  
+  # Start gateway with error handling
+  # If config is invalid, keeps container alive and exits with code 0 to prevent Fly.io restart
+  start_gateway_safe env HOME=/home/node OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-/data}" "$@"
+fi

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -6,15 +6,15 @@ const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const runs = [
   {
     name: "unit",
-    args: ["vitest", "run", "--config", "vitest.unit.config.ts"],
+    args: ["exec", "vitest", "run", "--config", "vitest.unit.config.ts"],
   },
   {
     name: "extensions",
-    args: ["vitest", "run", "--config", "vitest.extensions.config.ts"],
+    args: ["exec", "vitest", "run", "--config", "vitest.extensions.config.ts"],
   },
   {
     name: "gateway",
-    args: ["vitest", "run", "--config", "vitest.gateway.config.ts"],
+    args: ["exec", "vitest", "run", "--config", "vitest.gateway.config.ts"],
   },
 ];
 
@@ -99,8 +99,16 @@ process.on("SIGTERM", () => shutdown("SIGTERM"));
 
 if (passthroughArgs.length > 0) {
   const args = maxWorkers
-    ? ["vitest", "run", "--maxWorkers", String(maxWorkers), ...windowsCiArgs, ...passthroughArgs]
-    : ["vitest", "run", ...windowsCiArgs, ...passthroughArgs];
+    ? [
+        "exec",
+        "vitest",
+        "run",
+        "--maxWorkers",
+        String(maxWorkers),
+        ...windowsCiArgs,
+        ...passthroughArgs,
+      ]
+    : ["exec", "vitest", "run", ...windowsCiArgs, ...passthroughArgs];
   const nodeOptions = process.env.NODE_OPTIONS ?? "";
   const nextNodeOptions = WARNING_SUPPRESSION_FLAGS.reduce(
     (acc, flag) => (acc.includes(flag) ? acc : `${acc} ${flag}`.trim()),


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds GitHub CLI (`gh`) and a substantially expanded Fly.io/Tailscale-based Docker deployment setup, plus a new `extensions/google-drive` plugin (OAuth + Drive/Docs/Sheets tools) and various Fly config/docs/scripts updates.

Key things to fix before merge:
- Multiple GitHub Actions workflows have had their triggers changed to `workflow_dispatch` only, effectively disabling CI/labeling/auto-response/release workflows on PRs and pushes.
- Fly/Tailscale helper scripts and docs contain deployment-specific values and at least one port mismatch (script still assumes `3000` while configs use `17568`).
- The Fly entrypoint script’s gateway failure handling captures the wrong exit code and intentionally exits `0` on startup failure, which can leave deployments down depending on Fly restart policy.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to CI being effectively disabled and deployment scripts/docs containing incorrect or environment-specific settings.
- Score lowered because workflow triggers were changed to manual-only (so regressions won’t be caught), and the Fly/Tailscale startup and access scripts have concrete correctness issues (wrong exit code capture, intentional exit 0 on failure, and port mismatch) that can break production deploys.
- .github/workflows/*.yml, scripts/fly-tailscale-start.sh, scripts/check-gateway-access.sh, docs/fly-io-device-pairing.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->