### PR TITLE
[wip]support OpenViking Memory Plugin

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -981,7 +981,7 @@
               },
               {
                 "group": "Extensions",
-                "pages": ["plugins/voice-call", "plugins/zalouser"]
+                "pages": ["plugins/memory-openviking", "plugins/voice-call", "plugins/zalouser"]
               },
               {
                 "group": "Automation",

--- a/docs/plugins/memory-openviking.md
+++ b/docs/plugins/memory-openviking.md
@@ -1,0 +1,239 @@
+---
+summary: "Memory OpenViking plugin: production setup, configuration, validation, and troubleshooting (English + Chinese)"
+read_when:
+  - You are deploying OpenViking-backed memory in production
+  - You need a customer-facing runbook for memory-openviking
+title: "Memory OpenViking Plugin"
+---
+
+# Memory OpenViking Plugin
+
+This page is a release runbook for deploying and operating the `memory-openviking` plugin in production.
+
+## English
+
+### Scope
+
+Use this guide when you want OpenClaw to:
+
+- Automatically capture user memory from conversations (`autoCapture`)
+- Automatically inject relevant memory before answering (`autoRecall`)
+- Expose memory tools (`memory_store`, `memory_recall`, `memory_forget`)
+
+### Prerequisites
+
+- OpenClaw installed and reachable from your runtime host
+- OpenViking service running and reachable from OpenClaw
+- A model provider key for your agent runtime
+- OpenViking API key (if OpenViking auth is enabled)
+
+### One-time setup
+
+1. Install and enable the plugin.
+
+```bash
+openclaw plugins install @openclaw/memory-openviking
+openclaw plugins enable memory-openviking
+openclaw config set plugins.slots.memory memory-openviking
+```
+
+2. Configure the plugin (recommended: secret via env var).
+
+```bash
+openclaw config set plugins.entries.memory-openviking.config.baseUrl "http://127.0.0.1:1933"
+openclaw config set plugins.entries.memory-openviking.config.apiKey '${OPENVIKING_API_KEY}'
+openclaw config set plugins.entries.memory-openviking.config.targetUri "viking://user/memories"
+openclaw config set plugins.entries.memory-openviking.config.autoCapture true --json
+openclaw config set plugins.entries.memory-openviking.config.autoRecall true --json
+openclaw config set plugins.entries.memory-openviking.config.recallLimit 6 --json
+openclaw config set plugins.entries.memory-openviking.config.recallScoreThreshold 0.01 --json
+```
+
+3. Validate effective config.
+
+```bash
+openclaw config get plugins.slots.memory
+openclaw config get plugins.entries.memory-openviking.config --json
+```
+
+4. Restart the OpenClaw runtime/gateway process after config edits.
+
+### Recommended production values
+
+- `baseUrl`: internal service URL for OpenViking (stable DNS/port)
+- `apiKey`: `${OPENVIKING_API_KEY}` (avoid plaintext secrets)
+- `targetUri`: `viking://user/memories`
+- `autoCapture`: `true`
+- `autoRecall`: `true`
+- `recallLimit`: `6` (raise only if prompt budget allows)
+- `recallScoreThreshold`: `0.01` (tune higher if recall is noisy)
+- `timeoutMs`: `15000` (raise if network is slow)
+
+### Runtime verification (smoke test)
+
+1. Store a memory through OpenClaw.
+
+```bash
+OPENVIKING_API_KEY="<your-openviking-key>" \
+openclaw agent --local --json --session-id e2e-openviking \
+  --message 'Please call only memory_store and save: I like red flowers and prioritize red when buying flowers.'
+```
+
+2. Search directly in OpenViking to confirm persistence.
+
+```bash
+curl -sS -X POST http://127.0.0.1:1933/api/v1/search/search \
+  -H "X-API-Key: <your-openviking-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"red flowers prioritize buying","target_uri":"viking://user/memories","limit":20,"score_threshold":0}'
+```
+
+3. Validate recall injection on the next turn.
+
+```bash
+OPENVIKING_API_KEY="<your-openviking-key>" \
+openclaw agent --local --json --session-id e2e-openviking \
+  --message 'When buying flowers, which color should I prioritize?'
+```
+
+Expected behavior:
+
+- The plugin logs auto-recall/auto-capture events
+- OpenViking search returns leaf memories under `viking://user/memories/preferences/...`
+
+### Daily operations (minimal)
+
+- Check OpenViking health (`/health`)
+- Keep OpenClaw and OpenViking running as managed services
+- Monitor logs for:
+  - `Invalid API Key`
+  - `fetch failed`
+  - plugin load errors
+
+### Troubleshooting
+
+- `plugin not found: memory-openviking`
+  - Re-run install/enable and confirm `plugins.slots.memory`.
+- `OpenViking request failed [UNAUTHENTICATED]: Invalid API Key`
+  - OpenClaw plugin key and OpenViking server key do not match.
+- `fetch failed`
+  - OpenViking is down, wrong `baseUrl`, wrong port, or blocked network path.
+- Search returns empty
+  - Confirm `autoCapture=true`, run a message with capture triggers, then query with `score_threshold: 0`.
+- JSON request validation error in curl
+  - Ensure JSON uses standard double quotes (`"`), not smart quotes.
+
+---
+
+## 中文版
+
+### 适用范围
+
+当你希望 OpenClaw 具备以下能力时使用本指南：
+
+- 会话中自动抽取用户长期记忆（`autoCapture`）
+- 回答前自动召回相关记忆注入上下文（`autoRecall`）
+- 使用记忆工具（`memory_store`、`memory_recall`、`memory_forget`）
+
+### 前置条件
+
+- OpenClaw 已安装并可运行
+- OpenViking 服务已启动，且 OpenClaw 可访问
+- Agent 模型可用的 API Key
+- OpenViking API Key（如果服务开启鉴权）
+
+### 一次性初始化配置
+
+1. 安装并启用插件。
+
+```bash
+openclaw plugins install @openclaw/memory-openviking
+openclaw plugins enable memory-openviking
+openclaw config set plugins.slots.memory memory-openviking
+```
+
+2. 配置插件（建议密钥走环境变量）。
+
+```bash
+openclaw config set plugins.entries.memory-openviking.config.baseUrl "http://127.0.0.1:1933"
+openclaw config set plugins.entries.memory-openviking.config.apiKey '${OPENVIKING_API_KEY}'
+openclaw config set plugins.entries.memory-openviking.config.targetUri "viking://user/memories"
+openclaw config set plugins.entries.memory-openviking.config.autoCapture true --json
+openclaw config set plugins.entries.memory-openviking.config.autoRecall true --json
+openclaw config set plugins.entries.memory-openviking.config.recallLimit 6 --json
+openclaw config set plugins.entries.memory-openviking.config.recallScoreThreshold 0.01 --json
+```
+
+3. 校验生效配置。
+
+```bash
+openclaw config get plugins.slots.memory
+openclaw config get plugins.entries.memory-openviking.config --json
+```
+
+4. 配置变更后，重启 OpenClaw 运行进程（Gateway 或等价进程）。
+
+### 生产推荐参数
+
+- `baseUrl`: OpenViking 内网地址（稳定域名/端口）
+- `apiKey`: `${OPENVIKING_API_KEY}`（避免明文）
+- `targetUri`: `viking://user/memories`
+- `autoCapture`: `true`
+- `autoRecall`: `true`
+- `recallLimit`: `6`（提示词预算紧张时不要设置过大）
+- `recallScoreThreshold`: `0.01`（召回噪声大时可调高）
+- `timeoutMs`: `15000`（网络慢可适当增大）
+
+### 运行验收（冒烟）
+
+1. 通过 OpenClaw 写入记忆。
+
+```bash
+OPENVIKING_API_KEY="<your-openviking-key>" \
+openclaw agent --local --json --session-id e2e-openviking \
+  --message '请只调用 memory_store 保存：我喜欢红色花朵，买花时优先红色。'
+```
+
+2. 直接查询 OpenViking 验证入库。
+
+```bash
+curl -sS -X POST http://127.0.0.1:1933/api/v1/search/search \
+  -H "X-API-Key: <your-openviking-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"红色 花朵 买花 优先","target_uri":"viking://user/memories","limit":20,"score_threshold":0}'
+```
+
+3. 下一轮会话验证召回。
+
+```bash
+OPENVIKING_API_KEY="<your-openviking-key>" \
+openclaw agent --local --json --session-id e2e-openviking \
+  --message '我买花时该优先选什么颜色？'
+```
+
+预期结果：
+
+- 日志中能看到 auto-recall/auto-capture 相关输出
+- OpenViking 查询能返回 `viking://user/memories/preferences/...` 下的叶子记忆
+
+### 日常运维最小流程
+
+- 健康检查：`/health`
+- OpenClaw/OpenViking 均由进程托管方式常驻
+- 重点关注日志：
+  - `Invalid API Key`
+  - `fetch failed`
+  - 插件加载失败
+
+### 常见问题
+
+- `plugin not found: memory-openviking`
+  - 重新执行 install/enable，并确认 `plugins.slots.memory`。
+- `OpenViking request failed [UNAUTHENTICATED]: Invalid API Key`
+  - OpenClaw 插件配置的 key 与 OpenViking 启动 key 不一致。
+- `fetch failed`
+  - OpenViking 未启动，或 `baseUrl`/端口错误，或网络不可达。
+- 查不到数据
+  - 确认 `autoCapture=true`，发送包含触发词的用户消息，再用 `score_threshold: 0` 查询。
+- curl 参数校验报错
+  - 检查 JSON 引号是否为标准英文双引号 `"`，不要使用中文引号。

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -40,6 +40,7 @@ See [Voice Call](/plugins/voice-call) for a concrete example plugin.
 - Microsoft Teams is plugin-only as of 2026.1.15; install `@openclaw/msteams` if you use Teams.
 - Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
+- [Memory OpenViking](/plugins/memory-openviking) — `@openclaw/memory-openviking`
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
 - [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`

--- a/extensions/memory-openviking/config.ts
+++ b/extensions/memory-openviking/config.ts
@@ -1,0 +1,146 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type MemoryOpenVikingConfig = {
+  baseUrl?: string;
+  apiKey?: string;
+  targetUri?: string;
+  timeoutMs?: number;
+  autoCapture?: boolean;
+  autoRecall?: boolean;
+  recallLimit?: number;
+  recallScoreThreshold?: number;
+};
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:1933";
+const DEFAULT_TARGET_URI = "viking://";
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_RECALL_LIMIT = 6;
+const DEFAULT_RECALL_SCORE_THRESHOLD = 0.01;
+
+function resolveEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+    const envValue = process.env[envVar];
+    if (!envValue) {
+      throw new Error(`Environment variable ${envVar} is not set`);
+    }
+    return envValue;
+  });
+}
+
+function toNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length === 0) {
+    return;
+  }
+  throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
+}
+
+function resolveDefaultBaseUrl(): string {
+  const fromEnv = process.env.OPENVIKING_BASE_URL || process.env.OPENVIKING_URL;
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return DEFAULT_BASE_URL;
+}
+
+export const memoryOpenVikingConfigSchema = {
+  parse(value: unknown): Required<MemoryOpenVikingConfig> {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      value = {};
+    }
+    const cfg = value as Record<string, unknown>;
+    assertAllowedKeys(
+      cfg,
+      [
+        "baseUrl",
+        "apiKey",
+        "targetUri",
+        "timeoutMs",
+        "autoCapture",
+        "autoRecall",
+        "recallLimit",
+        "recallScoreThreshold",
+      ],
+      "memory-openviking config",
+    );
+
+    const rawBaseUrl = typeof cfg.baseUrl === "string" ? cfg.baseUrl : resolveDefaultBaseUrl();
+    const rawApiKey = typeof cfg.apiKey === "string" ? cfg.apiKey : process.env.OPENVIKING_API_KEY;
+
+    return {
+      baseUrl: resolveEnvVars(rawBaseUrl).replace(/\/+$/, ""),
+      apiKey: rawApiKey ? resolveEnvVars(rawApiKey) : "",
+      targetUri: typeof cfg.targetUri === "string" ? cfg.targetUri : DEFAULT_TARGET_URI,
+      timeoutMs: Math.max(1000, Math.floor(toNumber(cfg.timeoutMs, DEFAULT_TIMEOUT_MS))),
+      autoCapture: cfg.autoCapture !== false,
+      autoRecall: cfg.autoRecall !== false,
+      recallLimit: Math.max(1, Math.floor(toNumber(cfg.recallLimit, DEFAULT_RECALL_LIMIT))),
+      recallScoreThreshold: Math.min(
+        1,
+        Math.max(0, toNumber(cfg.recallScoreThreshold, DEFAULT_RECALL_SCORE_THRESHOLD)),
+      ),
+    };
+  },
+  uiHints: {
+    baseUrl: {
+      label: "OpenViking Base URL",
+      placeholder: DEFAULT_BASE_URL,
+      help: "HTTP URL of OpenViking server (or use ${OPENVIKING_BASE_URL})",
+    },
+    apiKey: {
+      label: "OpenViking API Key",
+      sensitive: true,
+      placeholder: "${OPENVIKING_API_KEY}",
+      help: "Optional API key for OpenViking server",
+    },
+    targetUri: {
+      label: "Search Target URI",
+      placeholder: DEFAULT_TARGET_URI,
+      help: "Default OpenViking target URI for memory search",
+    },
+    timeoutMs: {
+      label: "Request Timeout (ms)",
+      placeholder: String(DEFAULT_TIMEOUT_MS),
+      advanced: true,
+    },
+    autoCapture: {
+      label: "Auto-Capture",
+      help: "Extract memories from recent conversation messages via OpenViking sessions",
+    },
+    autoRecall: {
+      label: "Auto-Recall",
+      help: "Inject relevant OpenViking memories into agent context",
+    },
+    recallLimit: {
+      label: "Recall Limit",
+      placeholder: String(DEFAULT_RECALL_LIMIT),
+      advanced: true,
+    },
+    recallScoreThreshold: {
+      label: "Recall Score Threshold",
+      placeholder: String(DEFAULT_RECALL_SCORE_THRESHOLD),
+      advanced: true,
+    },
+  },
+};
+
+export const DEFAULT_MEMORY_OPENVIKING_DATA_DIR = join(
+  homedir(),
+  ".openclaw",
+  "memory",
+  "openviking",
+);

--- a/extensions/memory-openviking/index.test.ts
+++ b/extensions/memory-openviking/index.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { memoryOpenVikingConfigSchema } from "./config.js";
+
+describe("memory-openviking config", () => {
+  beforeEach(() => {
+    delete process.env.OPENVIKING_BASE_URL;
+    delete process.env.OPENVIKING_URL;
+    delete process.env.OPENVIKING_API_KEY;
+    delete process.env.MEMORY_OPENVIKING_API_KEY;
+  });
+
+  it("parses defaults", () => {
+    const cfg = memoryOpenVikingConfigSchema.parse({});
+    expect(cfg.baseUrl).toBe("http://127.0.0.1:1933");
+    expect(cfg.targetUri).toBe("viking://");
+    expect(cfg.recallLimit).toBe(6);
+    expect(cfg.autoCapture).toBe(true);
+    expect(cfg.autoRecall).toBe(true);
+  });
+
+  it("supports env variable interpolation", () => {
+    process.env.MEMORY_OPENVIKING_API_KEY = "secret-token";
+    const cfg = memoryOpenVikingConfigSchema.parse({
+      apiKey: "${MEMORY_OPENVIKING_API_KEY}",
+      baseUrl: "http://localhost:2933/",
+      recallLimit: "7",
+      recallScoreThreshold: "0.6",
+    });
+    expect(cfg.apiKey).toBe("secret-token");
+    expect(cfg.baseUrl).toBe("http://localhost:2933");
+    expect(cfg.recallLimit).toBe(7);
+    expect(cfg.recallScoreThreshold).toBe(0.6);
+  });
+});
+
+describe("memory-openviking plugin search behavior", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses hybrid search endpoint defaults and plugin-side postprocess for recall", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    const requests: Array<{ url: string; body?: Record<string, unknown> }> = [];
+    globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const body =
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : undefined;
+      requests.push({ url, body });
+
+      if (url.endsWith("/api/v1/search/search")) {
+        return new Response(
+          JSON.stringify({
+            status: "ok",
+            result: {
+              total: 4,
+              memories: [
+                {
+                  uri: "viking://user/memories/preferences/mem_black_1.md",
+                  category: "preferences",
+                  is_leaf: true,
+                  abstract: "Color preference: Black",
+                  score: 0.02,
+                },
+                {
+                  uri: "viking://user/memories/preferences/mem_black_2.md",
+                  category: "preferences",
+                  is_leaf: true,
+                  abstract: "Color preference: Black",
+                  score: 0.019,
+                },
+                {
+                  uri: "viking://user/memories/preferences/mem_red_1.md",
+                  category: "preferences",
+                  is_leaf: true,
+                  abstract: "Flower preference: Likes red flowers",
+                  score: 0.015,
+                },
+                {
+                  uri: "viking://user/memories/preferences/mem_low_score.md",
+                  category: "preferences",
+                  is_leaf: true,
+                  abstract: "Flower preference: Likes red flowers",
+                  score: 0.001,
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(JSON.stringify({ status: "ok", result: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const registeredTools: any[] = [];
+    const mockApi = {
+      id: "memory-openviking",
+      name: "Memory (OpenViking)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        baseUrl: "http://127.0.0.1:1933",
+        apiKey: "test-key",
+        targetUri: "viking://user/memories",
+        autoCapture: false,
+        autoRecall: false,
+      },
+      runtime: {},
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerTool: (tool: any, opts: any) => {
+        registeredTools.push({ tool, opts });
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerService: () => {},
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerCli: () => {},
+      // oxlint-disable-next-line typescript/no-explicit-any
+      on: () => {},
+      resolvePath: (p: string) => p,
+    };
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+    expect(recallTool).toBeDefined();
+
+    const recallResult = await recallTool.execute("recall-test", {
+      query: "我买花时偏好什么颜色",
+      limit: 3,
+      scoreThreshold: 0.01,
+    });
+
+    expect(recallResult.details?.count).toBe(2);
+    expect(recallResult.details?.memories?.map((m: { uri: string }) => m.uri)).toEqual([
+      "viking://user/memories/preferences/mem_black_1.md",
+      "viking://user/memories/preferences/mem_red_1.md",
+    ]);
+
+    const searchRequest = requests.find((req) => req.url.endsWith("/api/v1/search/search"));
+    expect(searchRequest).toBeTruthy();
+    expect(searchRequest?.body?.search_mode).toBeUndefined();
+    expect(searchRequest?.body?.score_threshold).toBe(0);
+    expect(searchRequest?.body?.limit).toBe(12);
+  });
+
+  it("auto-capture stores only user messages", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    const requests: Array<{ url: string; method: string; body?: Record<string, unknown> }> = [];
+    globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      const body =
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : undefined;
+      requests.push({ url, method, body });
+
+      if (url.endsWith("/api/v1/sessions") && method === "POST") {
+        return new Response(
+          JSON.stringify({ status: "ok", result: { session_id: "session-test" } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (url.endsWith("/extract") && method === "POST") {
+        return new Response(JSON.stringify({ status: "ok", result: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response(JSON.stringify({ status: "ok", result: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const listeners = new Map<string, any>();
+    const mockApi = {
+      id: "memory-openviking",
+      name: "Memory (OpenViking)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        baseUrl: "http://127.0.0.1:1933",
+        apiKey: "test-key",
+        targetUri: "viking://user/memories",
+        autoCapture: true,
+        autoRecall: false,
+      },
+      runtime: {},
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerTool: () => {},
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerService: () => {},
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerCli: () => {},
+      // oxlint-disable-next-line typescript/no-explicit-any
+      on: (eventName: string, handler: any) => {
+        listeners.set(eventName, handler);
+      },
+      resolvePath: (p: string) => p,
+    };
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    const agentEnd = listeners.get("agent_end");
+    expect(agentEnd).toBeDefined();
+
+    await agentEnd({
+      success: true,
+      messages: [
+        { role: "assistant", content: "记住：助手消息不应入库" },
+        { role: "user", content: "记住：我喜欢红色花朵，买花时优先红色。" },
+        { role: "assistant", content: [{ type: "text", text: "偏好黑色" }] },
+      ],
+    });
+
+    const messageCalls = requests.filter(
+      (req) => req.url.endsWith("/api/v1/sessions/session-test/messages") && req.method === "POST",
+    );
+    expect(messageCalls).toHaveLength(1);
+    expect(messageCalls[0]?.body?.content).toBe("记住：我喜欢红色花朵，买花时优先红色。");
+  });
+});
+
+const liveEnabled =
+  process.env.OPENCLAW_LIVE_TEST === "1" &&
+  Boolean(process.env.OPENVIKING_LIVE_BASE_URL) &&
+  Boolean(process.env.OPENVIKING_LIVE_API_KEY);
+const describeLive = liveEnabled ? describe : describe.skip;
+
+describeLive("memory-openviking live integration", () => {
+  it("executes store/recall/forget tools against live OpenViking", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const registeredTools: any[] = [];
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const registeredServices: any[] = [];
+
+    const mockApi = {
+      id: "memory-openviking",
+      name: "Memory (OpenViking)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        baseUrl: process.env.OPENVIKING_LIVE_BASE_URL,
+        apiKey: process.env.OPENVIKING_LIVE_API_KEY,
+        targetUri: "viking://user/memories",
+        timeoutMs: 30000,
+        autoCapture: false,
+        autoRecall: false,
+      },
+      runtime: {},
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerTool: (tool: any, opts: any) => {
+        registeredTools.push({ tool, opts });
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerService: (service: any) => {
+        registeredServices.push(service);
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerCli: () => {},
+      // oxlint-disable-next-line typescript/no-explicit-any
+      on: () => {},
+      resolvePath: (p: string) => p,
+    };
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    expect(registeredTools.length).toBe(3);
+    expect(registeredServices.length).toBe(1);
+    await registeredServices[0].start?.();
+
+    const storeTool = registeredTools.find((t) => t.opts?.name === "memory_store")?.tool;
+    const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+    const forgetTool = registeredTools.find((t) => t.opts?.name === "memory_forget")?.tool;
+
+    expect(storeTool).toBeDefined();
+    expect(recallTool).toBeDefined();
+    expect(forgetTool).toBeDefined();
+
+    const storeResult = await storeTool.execute("live-store", {
+      text: "请记住：我偏好中文且简洁的技术回答。",
+      role: "user",
+    });
+    expect(storeResult.details?.action).toBe("stored");
+    expect(typeof storeResult.details?.extractedCount).toBe("number");
+
+    const recallResult = await recallTool.execute("live-recall", {
+      query: "用户偏好 中文 简洁",
+      limit: 5,
+      targetUri: "viking://user/memories",
+    });
+    expect(typeof recallResult.details?.count).toBe("number");
+
+    const forgetResult = await forgetTool.execute("live-forget", {
+      query: "用户偏好 中文 简洁",
+      targetUri: "viking://user/memories",
+      limit: 5,
+    });
+    expect(["none", "candidates", "deleted"]).toContain(forgetResult.details?.action);
+  }, 120000);
+});

--- a/extensions/memory-openviking/index.ts
+++ b/extensions/memory-openviking/index.ts
@@ -1,0 +1,640 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { Type } from "@sinclair/typebox";
+import { memoryOpenVikingConfigSchema } from "./config.js";
+
+type FindResultItem = {
+  uri: string;
+  is_leaf?: boolean;
+  abstract?: string;
+  overview?: string;
+  category?: string;
+  score?: number;
+  match_reason?: string;
+};
+
+type FindResult = {
+  memories?: FindResultItem[];
+  resources?: FindResultItem[];
+  skills?: FindResultItem[];
+  total?: number;
+};
+
+const MEMORY_URI_PREFIXES = ["viking://user/memories", "viking://agent/memories"];
+
+const MEMORY_TRIGGERS = [
+  /remember|preference|prefer|important|decision|decided|always|never/i,
+  /记住|偏好|喜欢|重要|决定|总是|永远|优先/i,
+  /[\w.-]+@[\w.-]+\.\w+/,
+  /\+\d{10,}/,
+];
+
+function getCaptureDecision(text: string): { shouldCapture: boolean; reason: string } {
+  if (text.length < 10 || text.length > 1000) {
+    return { shouldCapture: false, reason: "length_out_of_range" };
+  }
+  if (text.includes("<relevant-memories>")) {
+    return { shouldCapture: false, reason: "injected_memory_context" };
+  }
+  for (const trigger of MEMORY_TRIGGERS) {
+    if (trigger.test(text)) {
+      return { shouldCapture: true, reason: `matched_trigger:${trigger.toString()}` };
+    }
+  }
+  return { shouldCapture: false, reason: "no_trigger_matched" };
+}
+
+function clampScore(value: number | undefined): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function isMemoryUri(uri: string): boolean {
+  return MEMORY_URI_PREFIXES.some((prefix) => uri.startsWith(prefix));
+}
+
+function normalizeDedupeText(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function isEventOrCaseMemory(item: FindResultItem): boolean {
+  const category = (item.category ?? "").toLowerCase();
+  const uri = item.uri.toLowerCase();
+  return (
+    category === "events" ||
+    category === "cases" ||
+    uri.includes("/events/") ||
+    uri.includes("/cases/")
+  );
+}
+
+function getMemoryDedupeKey(item: FindResultItem): string {
+  const abstract = normalizeDedupeText(item.abstract ?? item.overview ?? "");
+  const category = (item.category ?? "").toLowerCase() || "unknown";
+  if (abstract && !isEventOrCaseMemory(item)) {
+    return `abstract:${category}:${abstract}`;
+  }
+  return `uri:${item.uri}`;
+}
+
+function postProcessMemories(
+  items: FindResultItem[],
+  options: {
+    limit: number;
+    scoreThreshold: number;
+    leafOnly?: boolean;
+  },
+): FindResultItem[] {
+  const deduped: FindResultItem[] = [];
+  const seen = new Set<string>();
+  const sorted = [...items].sort((a, b) => clampScore(b.score) - clampScore(a.score));
+  for (const item of sorted) {
+    if (options.leafOnly && item.is_leaf !== true) {
+      continue;
+    }
+    if (clampScore(item.score) < options.scoreThreshold) {
+      continue;
+    }
+    const key = getMemoryDedupeKey(item);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(item);
+    if (deduped.length >= options.limit) {
+      break;
+    }
+  }
+  return deduped;
+}
+
+function formatMemoryLines(items: FindResultItem[]): string {
+  return items
+    .map((item, index) => {
+      const score = clampScore(item.score);
+      const abstract = item.abstract?.trim() || item.overview?.trim() || item.uri;
+      const category = item.category ?? "memory";
+      return `${index + 1}. [${category}] ${abstract} (${(score * 100).toFixed(0)}%)`;
+    })
+    .join("\n");
+}
+
+function isPreferencesMemory(item: FindResultItem): boolean {
+  return (
+    item.category === "preferences" ||
+    item.uri.includes("/preferences/") ||
+    item.uri.endsWith("/preferences")
+  );
+}
+
+function rankForInjection(item: FindResultItem): number {
+  // Prefer concrete memory leaves; prefer user preferences when scores are close.
+  const baseScore = clampScore(item.score);
+  const leafBoost = item.is_leaf ? 1 : 0;
+  const preferenceBoost = isPreferencesMemory(item) ? 0.05 : 0;
+  return baseScore + leafBoost + preferenceBoost;
+}
+
+function pickMemoriesForInjection(items: FindResultItem[], limit: number): FindResultItem[] {
+  if (items.length === 0 || limit <= 0) {
+    return [];
+  }
+
+  const sorted = [...items].sort((a, b) => rankForInjection(b) - rankForInjection(a));
+  const deduped: FindResultItem[] = [];
+  const seen = new Set<string>();
+  for (const item of sorted) {
+    const abstractKey = (item.abstract ?? item.overview ?? "").trim().toLowerCase();
+    const key = abstractKey || item.uri;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(item);
+  }
+  const leaves = deduped.filter((item) => item.is_leaf);
+  if (leaves.length >= limit) {
+    return leaves.slice(0, limit);
+  }
+
+  const picked = [...leaves];
+  const used = new Set(leaves.map((item) => item.uri));
+  for (const item of deduped) {
+    if (picked.length >= limit) {
+      break;
+    }
+    if (used.has(item.uri)) {
+      continue;
+    }
+    picked.push(item);
+  }
+  return picked;
+}
+
+class OpenVikingClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+    private readonly timeoutMs: number,
+  ) {}
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const headers = new Headers(init.headers ?? {});
+      if (this.apiKey) {
+        headers.set("X-API-Key", this.apiKey);
+      }
+      if (init.body && !headers.has("Content-Type")) {
+        headers.set("Content-Type", "application/json");
+      }
+
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        ...init,
+        headers,
+        signal: controller.signal,
+      });
+
+      const payload = (await response.json().catch(() => ({}))) as {
+        status?: string;
+        result?: T;
+        error?: { code?: string; message?: string };
+      };
+
+      if (!response.ok || payload.status === "error") {
+        const code = payload.error?.code ? ` [${payload.error.code}]` : "";
+        const message = payload.error?.message ?? `HTTP ${response.status}`;
+        throw new Error(`OpenViking request failed${code}: ${message}`);
+      }
+
+      return (payload.result ?? payload) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async healthCheck(): Promise<void> {
+    await this.request<{ status: string }>("/health");
+  }
+
+  async find(
+    query: string,
+    options: {
+      targetUri: string;
+      limit: number;
+      scoreThreshold?: number;
+      sessionId?: string;
+    },
+  ): Promise<FindResult> {
+    const body = {
+      query,
+      target_uri: options.targetUri,
+      limit: options.limit,
+      score_threshold: options.scoreThreshold,
+      session_id: options.sessionId,
+    };
+    return this.request<FindResult>("/api/v1/search/search", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  async createSession(): Promise<string> {
+    const result = await this.request<{ session_id: string }>("/api/v1/sessions", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    return result.session_id;
+  }
+
+  async addSessionMessage(sessionId: string, role: string, content: string): Promise<void> {
+    await this.request<{ session_id: string }>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
+      {
+        method: "POST",
+        body: JSON.stringify({ role, content }),
+      },
+    );
+  }
+
+  async extractSessionMemories(sessionId: string): Promise<Array<Record<string, unknown>>> {
+    return this.request<Array<Record<string, unknown>>>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/extract`,
+      { method: "POST", body: JSON.stringify({}) },
+    );
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, { method: "DELETE" });
+  }
+
+  async deleteUri(uri: string): Promise<void> {
+    await this.request(`/api/v1/fs?uri=${encodeURIComponent(uri)}&recursive=false`, {
+      method: "DELETE",
+    });
+  }
+}
+
+function extractTextsFromUserMessages(messages: unknown[]): string[] {
+  const texts: string[] = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const msgObj = msg as Record<string, unknown>;
+    if (msgObj.role !== "user") {
+      continue;
+    }
+    const content = msgObj.content;
+    if (typeof content === "string") {
+      texts.push(content);
+      continue;
+    }
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (!block || typeof block !== "object") {
+          continue;
+        }
+        const blockObj = block as Record<string, unknown>;
+        if (blockObj.type === "text" && typeof blockObj.text === "string") {
+          texts.push(blockObj.text);
+        }
+      }
+    }
+  }
+  return texts;
+}
+
+const memoryPlugin = {
+  id: "memory-openviking",
+  name: "Memory (OpenViking)",
+  description: "OpenViking-backed long-term memory with auto-recall/capture",
+  kind: "memory" as const,
+  configSchema: memoryOpenVikingConfigSchema,
+
+  register(api: OpenClawPluginApi) {
+    const cfg = memoryOpenVikingConfigSchema.parse(api.pluginConfig);
+    const client = new OpenVikingClient(cfg.baseUrl, cfg.apiKey, cfg.timeoutMs);
+
+    api.registerTool(
+      {
+        name: "memory_recall",
+        label: "Memory Recall (OpenViking)",
+        description:
+          "Search long-term memories from OpenViking. Use when you need past user preferences, facts, or decisions.",
+        parameters: Type.Object({
+          query: Type.String({ description: "Search query" }),
+          limit: Type.Optional(
+            Type.Number({ description: "Max results (default: plugin config)" }),
+          ),
+          scoreThreshold: Type.Optional(
+            Type.Number({ description: "Minimum score (0-1, default: plugin config)" }),
+          ),
+          targetUri: Type.Optional(
+            Type.String({ description: "Search scope URI (default: plugin config)" }),
+          ),
+        }),
+        async execute(_toolCallId, params) {
+          const { query } = params as { query: string };
+          const limit =
+            typeof (params as { limit?: number }).limit === "number"
+              ? Math.max(1, Math.floor((params as { limit: number }).limit))
+              : cfg.recallLimit;
+          const scoreThreshold =
+            typeof (params as { scoreThreshold?: number }).scoreThreshold === "number"
+              ? Math.max(0, Math.min(1, (params as { scoreThreshold: number }).scoreThreshold))
+              : cfg.recallScoreThreshold;
+          const targetUri =
+            typeof (params as { targetUri?: string }).targetUri === "string"
+              ? (params as { targetUri: string }).targetUri
+              : cfg.targetUri;
+          const requestLimit = Math.max(limit * 4, limit);
+          const result = await client.find(query, {
+            targetUri,
+            limit: requestLimit,
+            scoreThreshold: 0,
+          });
+          const memories = postProcessMemories(result.memories ?? [], {
+            limit,
+            scoreThreshold,
+          });
+          if (memories.length === 0) {
+            return {
+              content: [{ type: "text", text: "No relevant OpenViking memories found." }],
+              details: { count: 0, total: result.total ?? 0, scoreThreshold },
+            };
+          }
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Found ${memories.length} memories:\n\n${formatMemoryLines(memories)}`,
+              },
+            ],
+            details: {
+              count: memories.length,
+              memories,
+              total: result.total ?? memories.length,
+              scoreThreshold,
+              requestLimit,
+            },
+          };
+        },
+      },
+      { name: "memory_recall" },
+    );
+
+    api.registerTool(
+      {
+        name: "memory_store",
+        label: "Memory Store (OpenViking)",
+        description:
+          "Store text in OpenViking memory pipeline by writing to a session and running memory extraction.",
+        parameters: Type.Object({
+          text: Type.String({ description: "Information to store as memory source text" }),
+          role: Type.Optional(Type.String({ description: "Session role, default user" })),
+          sessionId: Type.Optional(Type.String({ description: "Existing OpenViking session ID" })),
+        }),
+        async execute(_toolCallId, params) {
+          const { text } = params as { text: string };
+          const role =
+            typeof (params as { role?: string }).role === "string"
+              ? (params as { role: string }).role
+              : "user";
+          const sessionIdIn = (params as { sessionId?: string }).sessionId;
+
+          let sessionId = sessionIdIn;
+          let createdTempSession = false;
+          try {
+            if (!sessionId) {
+              sessionId = await client.createSession();
+              createdTempSession = true;
+            }
+            await client.addSessionMessage(sessionId, role, text);
+            const extracted = await client.extractSessionMemories(sessionId);
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Stored in OpenViking session ${sessionId} and extracted ${extracted.length} memories.`,
+                },
+              ],
+              details: { action: "stored", sessionId, extractedCount: extracted.length, extracted },
+            };
+          } finally {
+            if (createdTempSession && sessionId) {
+              await client.deleteSession(sessionId).catch(() => {});
+            }
+          }
+        },
+      },
+      { name: "memory_store" },
+    );
+
+    api.registerTool(
+      {
+        name: "memory_forget",
+        label: "Memory Forget (OpenViking)",
+        description:
+          "Forget memory by URI, or search then delete when a strong single match is found.",
+        parameters: Type.Object({
+          uri: Type.Optional(Type.String({ description: "Exact memory URI to delete" })),
+          query: Type.Optional(Type.String({ description: "Search query to find memory URI" })),
+          targetUri: Type.Optional(
+            Type.String({ description: "Search scope URI (default: plugin config)" }),
+          ),
+          limit: Type.Optional(Type.Number({ description: "Search limit (default: 5)" })),
+          scoreThreshold: Type.Optional(
+            Type.Number({ description: "Minimum score (0-1, default: plugin config)" }),
+          ),
+        }),
+        async execute(_toolCallId, params) {
+          const uri = (params as { uri?: string }).uri;
+          if (uri) {
+            if (!isMemoryUri(uri)) {
+              return {
+                content: [{ type: "text", text: `Refusing to delete non-memory URI: ${uri}` }],
+                details: { action: "rejected", uri },
+              };
+            }
+            await client.deleteUri(uri);
+            return {
+              content: [{ type: "text", text: `Forgotten: ${uri}` }],
+              details: { action: "deleted", uri },
+            };
+          }
+
+          const query = (params as { query?: string }).query;
+          if (!query) {
+            return {
+              content: [{ type: "text", text: "Provide uri or query." }],
+              details: { error: "missing_param" },
+            };
+          }
+
+          const limit =
+            typeof (params as { limit?: number }).limit === "number"
+              ? Math.max(1, Math.floor((params as { limit: number }).limit))
+              : 5;
+          const scoreThreshold =
+            typeof (params as { scoreThreshold?: number }).scoreThreshold === "number"
+              ? Math.max(0, Math.min(1, (params as { scoreThreshold: number }).scoreThreshold))
+              : cfg.recallScoreThreshold;
+          const targetUri =
+            typeof (params as { targetUri?: string }).targetUri === "string"
+              ? (params as { targetUri: string }).targetUri
+              : cfg.targetUri;
+          const requestLimit = Math.max(limit * 4, 20);
+
+          const result = await client.find(query, {
+            targetUri,
+            limit: requestLimit,
+            scoreThreshold: 0,
+          });
+          const candidates = postProcessMemories(result.memories ?? [], {
+            limit: requestLimit,
+            scoreThreshold,
+            leafOnly: true,
+          }).filter((item) => isMemoryUri(item.uri));
+          if (candidates.length === 0) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "No matching leaf memory candidates found. Try a more specific query.",
+                },
+              ],
+              details: { action: "none", scoreThreshold },
+            };
+          }
+          const top = candidates[0];
+          if (candidates.length === 1 && clampScore(top.score) >= 0.85) {
+            await client.deleteUri(top.uri);
+            return {
+              content: [{ type: "text", text: `Forgotten: ${top.uri}` }],
+              details: { action: "deleted", uri: top.uri, score: top.score ?? 0 },
+            };
+          }
+
+          const list = candidates
+            .map((item) => `- ${item.uri} (${(clampScore(item.score) * 100).toFixed(0)}%)`)
+            .join("\n");
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Found ${candidates.length} candidates. Specify uri:\n${list}`,
+              },
+            ],
+            details: { action: "candidates", candidates, scoreThreshold, requestLimit },
+          };
+        },
+      },
+      { name: "memory_forget" },
+    );
+
+    if (cfg.autoRecall) {
+      api.on("before_agent_start", async (event) => {
+        if (!event.prompt || event.prompt.length < 5) {
+          return;
+        }
+        try {
+          const candidateLimit = Math.max(cfg.recallLimit * 4, cfg.recallLimit);
+          const result = await client.find(event.prompt, {
+            targetUri: cfg.targetUri,
+            limit: candidateLimit,
+            scoreThreshold: 0,
+          });
+          const processed = postProcessMemories(result.memories ?? [], {
+            limit: candidateLimit,
+            scoreThreshold: cfg.recallScoreThreshold,
+          });
+          const memories = pickMemoriesForInjection(processed, cfg.recallLimit);
+          if (memories.length === 0) {
+            return;
+          }
+          const memoryContext = memories
+            .map((item) => `- [${item.category ?? "memory"}] ${item.abstract ?? item.uri}`)
+            .join("\n");
+          api.logger.info?.(
+            `memory-openviking: injecting ${memories.length} memories into context`,
+          );
+          return {
+            prependContext:
+              "<relevant-memories>\nThe following OpenViking memories may be relevant:\n" +
+              `${memoryContext}\n` +
+              "</relevant-memories>",
+          };
+        } catch (err) {
+          api.logger.warn(`memory-openviking: auto-recall failed: ${String(err)}`);
+        }
+      });
+    }
+
+    if (cfg.autoCapture) {
+      api.on("agent_end", async (event) => {
+        if (!event.success || !event.messages || event.messages.length === 0) {
+          api.logger.info(
+            `memory-openviking: auto-capture skipped (success=${String(event.success)}, messages=${event.messages?.length ?? 0})`,
+          );
+          return;
+        }
+        try {
+          const texts = extractTextsFromUserMessages(event.messages);
+          api.logger.info(
+            `memory-openviking: auto-capture evaluating ${texts.length} text candidates`,
+          );
+          const decisions = texts
+            .map((text) => ({ text, decision: getCaptureDecision(text) }))
+            .filter((item) => item.text);
+          for (const item of decisions.slice(0, 5)) {
+            const preview = item.text.length > 80 ? `${item.text.slice(0, 80)}...` : item.text;
+            api.logger.info(
+              `memory-openviking: capture-check shouldCapture=${String(item.decision.shouldCapture)} reason=${item.decision.reason} text="${preview}"`,
+            );
+          }
+          const toCapture = decisions
+            .filter((item) => item.decision.shouldCapture)
+            .map((item) => item.text)
+            .slice(0, 3);
+          if (toCapture.length === 0) {
+            api.logger.info("memory-openviking: auto-capture skipped (no matched texts)");
+            return;
+          }
+          const sessionId = await client.createSession();
+          try {
+            for (const text of toCapture) {
+              await client.addSessionMessage(sessionId, "user", text);
+            }
+            const extracted = await client.extractSessionMemories(sessionId);
+            api.logger.info(
+              `memory-openviking: auto-captured ${toCapture.length} messages, extracted ${extracted.length} memories`,
+            );
+          } finally {
+            await client.deleteSession(sessionId).catch(() => {});
+          }
+        } catch (err) {
+          api.logger.warn(`memory-openviking: auto-capture failed: ${String(err)}`);
+        }
+      });
+    }
+
+    api.registerService({
+      id: "memory-openviking",
+      start: async () => {
+        await client.healthCheck().catch(() => {});
+        api.logger.info(
+          `memory-openviking: initialized (url: ${cfg.baseUrl}, targetUri: ${cfg.targetUri}, search: hybrid endpoint)`,
+        );
+      },
+      stop: () => {
+        api.logger.info("memory-openviking: stopped");
+      },
+    });
+  },
+};
+
+export default memoryPlugin;

--- a/extensions/memory-openviking/openclaw.plugin.json
+++ b/extensions/memory-openviking/openclaw.plugin.json
@@ -1,0 +1,75 @@
+{
+  "id": "memory-openviking",
+  "kind": "memory",
+  "uiHints": {
+    "baseUrl": {
+      "label": "OpenViking Base URL",
+      "placeholder": "http://127.0.0.1:1933",
+      "help": "HTTP URL of OpenViking server (or use ${OPENVIKING_BASE_URL})"
+    },
+    "apiKey": {
+      "label": "OpenViking API Key",
+      "sensitive": true,
+      "placeholder": "${OPENVIKING_API_KEY}",
+      "help": "Optional API key for OpenViking server"
+    },
+    "targetUri": {
+      "label": "Search Target URI",
+      "placeholder": "viking://",
+      "help": "Default OpenViking target URI for memory search"
+    },
+    "timeoutMs": {
+      "label": "Request Timeout (ms)",
+      "placeholder": "15000",
+      "advanced": true
+    },
+    "autoCapture": {
+      "label": "Auto-Capture",
+      "help": "Extract memories from recent conversation messages via OpenViking sessions"
+    },
+    "autoRecall": {
+      "label": "Auto-Recall",
+      "help": "Inject relevant OpenViking memories into agent context"
+    },
+    "recallLimit": {
+      "label": "Recall Limit",
+      "placeholder": "6",
+      "advanced": true
+    },
+    "recallScoreThreshold": {
+      "label": "Recall Score Threshold",
+      "placeholder": "0.01",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "baseUrl": {
+        "type": "string"
+      },
+      "apiKey": {
+        "type": "string"
+      },
+      "targetUri": {
+        "type": "string"
+      },
+      "timeoutMs": {
+        "type": "number"
+      },
+      "autoCapture": {
+        "type": "boolean"
+      },
+      "autoRecall": {
+        "type": "boolean"
+      },
+      "recallLimit": {
+        "type": "number"
+      },
+      "recallScoreThreshold": {
+        "type": "number"
+      }
+    }
+  }
+}

--- a/extensions/memory-openviking/package.json
+++ b/extensions/memory-openviking/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/memory-openviking",
+  "version": "2026.2.6-3",
+  "description": "OpenClaw OpenViking-backed long-term memory plugin with auto-recall/capture",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,16 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/memory-openviking:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/minimax-portal-auth:
     devDependencies:
       openclaw:

--- a/scripts/openviking-e2e.sh
+++ b/scripts/openviking-e2e.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+OPENVIKING_DIR="${OPENVIKING_DIR:-$(cd "$REPO_DIR/.." && pwd)/OpenViking}"
+OPENVIKING_CONF_SOURCE="${OPENVIKING_CONF_SOURCE:-$OPENVIKING_DIR/ov.conf}"
+OPENVIKING_CONF_TMP="${OPENVIKING_CONF_TMP:-/tmp/ov-live-e2e.conf}"
+OPENVIKING_LOG="${OPENVIKING_LOG:-/tmp/openviking-e2e.log}"
+OPENVIKING_DATA_PATH="${OPENVIKING_DATA_PATH:-/tmp/openviking-data}"
+OPENVIKING_HOST="${OPENVIKING_HOST:-127.0.0.1}"
+OPENVIKING_PORT="${OPENVIKING_PORT:-1933}"
+OPENVIKING_API_KEY="${OPENVIKING_API_KEY:-${OPENVIKING_APIKEY:-${APIKEY:-}}}"
+OPENVIKING_AGFS_PORT="${OPENVIKING_AGFS_PORT:-4833}"
+OPENVIKING_SPARSE_WEIGHT="${OPENVIKING_SPARSE_WEIGHT:-0.35}"
+OPENVIKING_ENABLE_HYBRID="${OPENVIKING_ENABLE_HYBRID:-1}"
+OPENVIKING_HEALTH_URL="http://${OPENVIKING_HOST}:${OPENVIKING_PORT}/health"
+OPENVIKING_VENV="${OPENVIKING_VENV:-/tmp/openviking-venv/bin/activate}"
+ZAI_API_KEY="${ZAI_API_KEY:-${APIKEY:-}}"
+SESSION_ID="${SESSION_ID:-e2e-openviking}"
+
+E2E_MESSAGE="${E2E_MESSAGE:-请严格按顺序调用 memory_store、memory_recall、memory_forget。先用 memory_store 保存：用户偏好中文简洁并先给结论后给步骤；再用 memory_recall 查询；最后仅当拿到 is_leaf=true 的 URI 时调用 memory_forget 删除。输出每步工具结果。}"
+
+cd "$REPO_DIR"
+
+if [ -z "$OPENVIKING_API_KEY" ]; then
+  echo "Missing API key: set OPENVIKING_API_KEY (or OPENVIKING_APIKEY/APIKEY)." >&2
+  exit 1
+fi
+
+if [ -z "$ZAI_API_KEY" ]; then
+  echo "Missing API key: set ZAI_API_KEY (or APIKEY)." >&2
+  exit 1
+fi
+
+pkill -f openviking-server || true
+pkill -f agfs || true
+
+if [ "$OPENVIKING_ENABLE_HYBRID" = "1" ]; then
+  jq \
+    '. + {
+      storage: ((.storage // {}) + {
+        agfs: ((.storage.agfs // {}) + {port: '"${OPENVIKING_AGFS_PORT}"'}),
+        vectordb: ((.storage.vectordb // {}) + {sparse_weight: '"${OPENVIKING_SPARSE_WEIGHT}"'})
+      }),
+      server: ((.server // {}) + {api_key: "'"${OPENVIKING_API_KEY}"'"}),
+      embedding: ((.embedding // {}) + {
+        hybrid: ((.embedding.hybrid // .embedding.dense) + {
+          provider: ((.embedding.hybrid.provider // .embedding.dense.provider) // "volcengine"),
+          backend: ((.embedding.hybrid.backend // .embedding.dense.backend) // "volcengine"),
+          input: ((.embedding.hybrid.input // .embedding.dense.input) // "multimodal")
+        })
+      })
+    }' \
+    "$OPENVIKING_CONF_SOURCE" >"$OPENVIKING_CONF_TMP"
+else
+  jq \
+    '. + {
+      storage: ((.storage // {}) + {agfs: ((.storage.agfs // {}) + {port: '"${OPENVIKING_AGFS_PORT}"'})}),
+      server: ((.server // {}) + {api_key: "'"${OPENVIKING_API_KEY}"'"})
+    }' \
+    "$OPENVIKING_CONF_SOURCE" >"$OPENVIKING_CONF_TMP"
+fi
+
+source "$OPENVIKING_VENV"
+
+export OPENVIKING_CONFIG_FILE="$OPENVIKING_CONF_TMP"
+export OPENVIKING_API_KEY
+
+openviking-server \
+  --host "$OPENVIKING_HOST" \
+  --port "$OPENVIKING_PORT" \
+  --path "$OPENVIKING_DATA_PATH" \
+  --api-key "$OPENVIKING_API_KEY" >"$OPENVIKING_LOG" 2>&1 &
+OV_PID=$!
+
+cleanup() {
+  kill "$OV_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+i=0
+while [ "$i" -lt 40 ]; do
+  if curl -fsS "$OPENVIKING_HEALTH_URL" >/dev/null; then
+    echo "OpenViking ready at $OPENVIKING_HEALTH_URL"
+    break
+  fi
+  sleep 1
+  i=$((i + 1))
+done
+
+if [ "$i" -eq 40 ]; then
+  echo "OpenViking failed to become healthy"
+  tail -n 120 "$OPENVIKING_LOG" || true
+  exit 1
+fi
+
+ZAI_API_KEY="$ZAI_API_KEY" OPENVIKING_API_KEY="$OPENVIKING_API_KEY" pnpm openclaw --dev agent --local --json \
+  --session-id "$SESSION_ID" \
+  --message "$E2E_MESSAGE"


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `memory-openviking` extension plugin implementing long-term memory via an OpenViking HTTP service, including tools (`memory_store`, `memory_recall`, `memory_forget`), optional auto-recall/auto-capture hooks, docs/runbook entries, and a helper E2E script.

Key integration points are via the plugin SDK hook system (`before_agent_start` for recall context injection and `agent_end` for capture), matching the existing `memory-lancedb` pattern, plus a new package under `extensions/memory-openviking` and corresponding lockfile/docs updates.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of concrete issues that can break usage and safety of the provided E2E script.
- Core plugin wiring and hook usage aligns with existing patterns, but (1) the E2E script uses unscoped `pkill -f` which can terminate unrelated processes, and (2) the config env fallback for the API key is inconsistent with the tests/examples, leading to auth failures when users rely on `MEMORY_OPENVIKING_API_KEY` alone.
- scripts/openviking-e2e.sh, extensions/memory-openviking/config.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->