### PR TITLE
fix(sessions): preserve label across /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -276,6 +276,7 @@ export async function initSessionState(params: {
     queueDebounceMs: baseEntry?.queueDebounceMs,
     queueCap: baseEntry?.queueCap,
     queueDrop: baseEntry?.queueDrop,
+    label: baseEntry?.label ?? entry?.label,
     displayName: baseEntry?.displayName,
     chatType: baseEntry?.chatType,
     channel: baseEntry?.channel,


### PR DESCRIPTION
## Problem

Session labels are cleared when a user runs `/new` or `/reset`. The label assigned to a session key should persist across resets since it identifies the session, not the conversation.

Fixes #14048

## Root Cause

In `initSessionState()`, when a reset is triggered, `baseEntry` is set to `undefined`. The session entry construction explicitly preserves fields like `displayName`, `chatType`, `channel`, etc. from `baseEntry`, but `label` was missing from this list.

## Fix

Add `label: baseEntry?.label ?? entry?.label` to the session entry construction. This falls back to the previous entry's label when `baseEntry` is undefined (reset case).

**1 line change** + test.

## Test

Added a test in `session-resets.test.ts` that seeds a session with a label, triggers `/new`, and verifies the label is retained on the new session entry.

All 12 tests in `session-resets.test.ts` pass.

---
*This PR was authored with AI assistance.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed session labels being cleared on `/new` and `/reset` commands by adding `label` field preservation in `initSessionState()`.

- Added `label: baseEntry?.label ?? entry?.label` to session entry construction in `src/auto-reply/reply/session.ts:279`
- When reset is triggered, `baseEntry` is `undefined`, so the fallback to `entry?.label` preserves the label from the previous session entry
- Added test in `session-resets.test.ts` that seeds a session with label "my-project", triggers `/new`, and verifies the label persists across the reset
- Follows the same pattern as other metadata fields like `displayName`, `chatType`, `channel`, etc.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal, well-tested fix that correctly preserves session labels across resets
- Single line fix with proper test coverage that follows existing codebase patterns. The change adds label preservation using the same fallback pattern (`baseEntry?.label ?? entry?.label`) used throughout the session entry construction. Test validates the expected behavior and all existing tests pass.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->