### PR TITLE
fix(media): prevent PDF files from being misidentified as text/plain

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -390,9 +390,12 @@ async function extractFileBlocks(params: {
     // will be inlined as <file mime="text/plain">%PDF-1.7...</file> instead of being
     // properly extracted via pdfjs-dist.
     //
-    // Fix: Skip text-detection override when the original MIME is application/pdf.
-    const isPdfMime = normalizedRawMime === "application/pdf";
-    const textHint = isPdfMime
+    // Fix: Skip text-detection override when the content is a PDF (by MIME, magic, or extension).
+    const isPdf =
+      normalizedRawMime === "application/pdf" ||
+      bufferResult?.buffer?.subarray(0, 5).toString("latin1") === "%PDF-" ||
+      /\.pdf$/i.test(nameHint ?? "");
+    const textHint = isPdf
       ? undefined
       : (forcedTextMimeResolved ?? guessedDelimited ?? (textLike ? "text/plain" : undefined));
     const mimeType = sanitizeMimeType(textHint ?? normalizeMimeType(rawMime));


### PR DESCRIPTION
## Summary

  PDF files sent in group chats (e.g. WhatsApp with @mention) were being misclassified
  as `text/plain`, causing raw binary garbage to be output instead of properly extracted
  text content.

  ## Problem

  PDF files often contain highly printable ASCII in their first 4 KB — headers, metadata,
  font names like "Helvetica", and object definitions. This causes `looksLikeUtf8Text()`
  to return `true` (>95% printable, >30% word-like chars), which overrides the correct
  `application/pdf` MIME type with `text/plain`. As a result, `extractFileContentFromSource()`
  skips PDF extraction via `pdfjs-dist` and inlines the raw binary content.

  ## Fix

  Skip the text-detection MIME override when the content is a PDF, detected by:
  - Original MIME type (`application/pdf`)
  - Magic bytes (`%PDF-` header)
  - File extension (`.pdf`)

  ## How to reproduce

  Send a PDF resume via WhatsApp group chat with @mention. Before this fix, the PDF
  would be inlined as `<file mime="text/plain">%PDF-1.7...</file>` instead of being
  properly extracted.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `extractFileBlocks()` in `src/media-understanding/apply.ts` to detect PDFs (by MIME, `%PDF-` magic bytes, or `.pdf` name) and avoid applying the existing “looks like text” heuristic that can set `textHint` to `text/plain`.

The intent is to ensure PDFs are routed through the PDF extraction path (`extractFileContentFromSource()` → `extractPdfContent()` in `src/media/input-files.ts`) instead of being inlined as plain text.

<h3>Confidence Score: 3/5</h3>

- Moderate risk to merge because the fix may not address the reported misclassification path.
- The change prevents overriding an already-correct application/pdf MIME to text/plain, but PDF extraction is still gated on the MIME value; if the upstream MIME is already text/plain (as described), this code path will still treat the file as text and won’t invoke PDF extraction.
- src/media-understanding/apply.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->