### PR TITLE
Add MindsDB federated query plugin tool

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -216,6 +216,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/llm-task/**"
+"extensions: mindsdb":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/mindsdb/**"
 "extensions: lobster":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -948,6 +948,7 @@
                 "pages": [
                   "tools/lobster",
                   "tools/llm-task",
+                  "tools/mindsdb",
                   "tools/exec",
                   "tools/web",
                   "tools/apply-patch",

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -174,6 +174,7 @@ Optional plugin tools:
 
 - [Lobster](/tools/lobster): typed workflow runtime with resumable approvals (requires the Lobster CLI on the gateway host).
 - [LLM Task](/tools/llm-task): JSON-only LLM step for structured workflow output (optional schema validation).
+- [MindsDB](/tools/mindsdb): federated SQL access across any databases connected to a MindsDB instance.
 
 ## Tool inventory
 

--- a/docs/tools/mindsdb.md
+++ b/docs/tools/mindsdb.md
@@ -62,6 +62,11 @@ openclaw plugins enable mindsdb
 
 Restart the Gateway after config changes.
 
+## Agent discovery
+
+This plugin ships a bundled `mindsdb` skill (loaded when the plugin is enabled)
+so agents can recognize when MindsDB is the right path for cross-database SQL.
+
 ## Auth modes
 
 Use one of:

--- a/docs/tools/mindsdb.md
+++ b/docs/tools/mindsdb.md
@@ -1,0 +1,135 @@
+---
+summary: "Query any MindsDB-connected database from OpenClaw agents"
+read_when:
+  - You want OpenClaw agents to query databases through MindsDB
+  - You are configuring the MindsDB plugin tool
+title: "MindsDB"
+---
+
+# MindsDB
+
+`mindsdb` is an optional plugin tool that lets OpenClaw agents run SQL through
+MindsDB's Federated Query Engine.
+
+Use it when you want one OpenClaw tool to query many backends (Postgres,
+Snowflake, BigQuery, MySQL, and more) through a single MindsDB endpoint.
+
+## Enable plugin + tool
+
+1. Install/enable plugin:
+
+```bash
+openclaw plugins install @openclaw/mindsdb
+openclaw plugins enable mindsdb
+```
+
+2. Allowlist the optional tool:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "tools": { "allow": ["mindsdb"] }
+      }
+    ]
+  }
+}
+```
+
+3. Configure plugin:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "mindsdb": {
+        "enabled": true,
+        "config": {
+          "baseUrl": "http://127.0.0.1:47334",
+          "token": "<mindsdb-token>",
+          "allowMutatingQueries": false,
+          "requestTimeoutMs": 30000,
+          "maxRows": 100,
+          "maxChars": 30000
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the Gateway after config changes.
+
+## Auth modes
+
+Use one of:
+
+- `token`: static bearer token (recommended)
+- `username` + `password`: tool logs in via `/api/login` and caches returned token
+- No auth: for local MindsDB with HTTP auth disabled
+
+Environment fallbacks are supported:
+
+- `MINDSDB_URL` / `MINDSDB_API_URL`
+- `MINDSDB_TOKEN`
+- `MINDSDB_USERNAME`
+- `MINDSDB_PASSWORD`
+
+## Tool API
+
+`action` values:
+
+- `query`
+- `list_databases`
+- `parametrize_constants`
+
+Parameters:
+
+- `action` (required)
+- `query` (required for `query` and `parametrize_constants`)
+- `params` (optional object; named SQL params for `query`)
+- `context` (optional object; forwarded to `/api/sql/query`)
+
+## Safety defaults
+
+By default, `allowMutatingQueries` is `false`.
+
+That blocks statements that do not start with a read-style prefix (`SELECT`,
+`SHOW`, `DESCRIBE`, `EXPLAIN`, `WITH`, `USE`).
+
+Enable mutating queries only when you intentionally want agents to run DDL/DML
+(creating databases, inserting rows, dropping objects, etc).
+
+## Example invocations
+
+Read query:
+
+```json
+{
+  "action": "query",
+  "query": "SELECT * FROM information_schema.databases"
+}
+```
+
+Parameterized query:
+
+```json
+{
+  "action": "query",
+  "query": "SELECT NAME FROM information_schema.databases WHERE NAME = :db_name",
+  "params": {
+    "db_name": "mindsdb"
+  }
+}
+```
+
+Utility endpoint:
+
+```json
+{
+  "action": "parametrize_constants",
+  "query": "INSERT INTO postgres.employees (employee_id, first_name) VALUES (101, 'John')"
+}
+```

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -40,6 +40,7 @@ See [Voice Call](/plugins/voice-call) for a concrete example plugin.
 - Microsoft Teams is plugin-only as of 2026.1.15; install `@openclaw/msteams` if you use Teams.
 - Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
+- [MindsDB](/tools/mindsdb) — `@openclaw/mindsdb`
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
 - [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`

--- a/extensions/mindsdb/README.md
+++ b/extensions/mindsdb/README.md
@@ -1,0 +1,52 @@
+# @openclaw/mindsdb
+
+OpenClaw plugin that adds an optional `mindsdb` agent tool for MindsDB's Federated Query Engine.
+
+## What it does
+
+- Executes SQL through `POST /api/sql/query`
+- Supports named query params (`params`) and context (`context`)
+- Exposes `list_databases` and `parametrize_constants` utility actions
+- Supports auth via static bearer token or username/password login (`/api/login`)
+
+## Enable
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "mindsdb": {
+        "enabled": true,
+        "config": {
+          "baseUrl": "http://127.0.0.1:47334",
+          "token": "<mindsdb-token>",
+          "allowMutatingQueries": false,
+          "maxRows": 100,
+          "maxChars": 30000
+        }
+      }
+    }
+  },
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "tools": { "allow": ["mindsdb"] }
+      }
+    ]
+  }
+}
+```
+
+The tool is registered with `optional: true`, so you must allowlist it.
+
+## Tool actions
+
+- `query`: execute SQL (`query` required)
+- `list_databases`: call `GET /api/sql/list_databases`
+- `parametrize_constants`: call `POST /api/sql/query/utils/parametrize_constants` (`query` required)
+
+## Security defaults
+
+- `allowMutatingQueries` defaults to `false` and blocks mutating SQL statements.
+- Enable mutations only when you intentionally want agents to run DDL/DML.

--- a/extensions/mindsdb/index.ts
+++ b/extensions/mindsdb/index.ts
@@ -1,0 +1,21 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { createMindsdbTool, resolveMindsdbPluginConfig } from "./src/tool.js";
+
+const mindsdbPlugin = {
+  id: "mindsdb",
+  name: "MindsDB",
+  description: "MindsDB Federated Query Engine tool",
+  register(api: OpenClawPluginApi) {
+    const config = resolveMindsdbPluginConfig(api.pluginConfig);
+
+    if (!config.token && (!config.username || !config.password)) {
+      api.logger.info(
+        "[mindsdb] no token or username/password configured; assuming MindsDB auth is disabled or handled upstream",
+      );
+    }
+
+    api.registerTool(createMindsdbTool(api, config), { optional: true });
+  },
+};
+
+export default mindsdbPlugin;

--- a/extensions/mindsdb/openclaw.plugin.json
+++ b/extensions/mindsdb/openclaw.plugin.json
@@ -1,0 +1,76 @@
+{
+  "id": "mindsdb",
+  "name": "MindsDB",
+  "description": "MindsDB Federated Query Engine tool for querying connected databases.",
+  "uiHints": {
+    "baseUrl": {
+      "label": "Base URL",
+      "help": "MindsDB HTTP endpoint (default: http://127.0.0.1:47334)."
+    },
+    "token": {
+      "label": "API Token",
+      "sensitive": true,
+      "help": "Bearer token used for Authorization header."
+    },
+    "username": {
+      "label": "Username",
+      "help": "Used to fetch a token from /api/login when token is not set."
+    },
+    "password": {
+      "label": "Password",
+      "sensitive": true,
+      "help": "Used with username for /api/login token retrieval."
+    },
+    "allowMutatingQueries": {
+      "label": "Allow Mutating Queries",
+      "help": "When false, blocks CREATE/INSERT/UPDATE/DELETE/DROP/ALTER/TRUNCATE-style statements."
+    },
+    "requestTimeoutMs": {
+      "label": "Request Timeout (ms)",
+      "advanced": true
+    },
+    "maxRows": {
+      "label": "Max Rows",
+      "advanced": true
+    },
+    "maxChars": {
+      "label": "Max Output Characters",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "baseUrl": {
+        "type": "string"
+      },
+      "token": {
+        "type": "string"
+      },
+      "username": {
+        "type": "string"
+      },
+      "password": {
+        "type": "string"
+      },
+      "allowMutatingQueries": {
+        "type": "boolean"
+      },
+      "requestTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000
+      },
+      "maxRows": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 1000
+      },
+      "maxChars": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 300000
+      }
+    }
+  }
+}

--- a/extensions/mindsdb/openclaw.plugin.json
+++ b/extensions/mindsdb/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "mindsdb",
   "name": "MindsDB",
   "description": "MindsDB Federated Query Engine tool for querying connected databases.",
+  "skills": ["./skills"],
   "uiHints": {
     "baseUrl": {
       "label": "Base URL",

--- a/extensions/mindsdb/package.json
+++ b/extensions/mindsdb/package.json
@@ -3,6 +3,9 @@
   "version": "2026.2.10",
   "description": "OpenClaw MindsDB federated query plugin",
   "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
+  },
   "devDependencies": {
     "openclaw": "workspace:*"
   },

--- a/extensions/mindsdb/package.json
+++ b/extensions/mindsdb/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openclaw/mindsdb",
+  "version": "2026.2.10",
+  "description": "OpenClaw MindsDB federated query plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "npmSpec": "@openclaw/mindsdb",
+      "localPath": "extensions/mindsdb",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/mindsdb/skills/mindsdb/SKILL.md
+++ b/extensions/mindsdb/skills/mindsdb/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: mindsdb
+description: Use for cross-database querying through MindsDB's Federated Query Engine when users ask for SQL/data lookup across connected databases.
+metadata: { "openclaw": { "emoji": "🧠", "homepage": "https://mindsdb.com" } }
+---
+
+# MindsDB Federated Query
+
+Use the `mindsdb` tool when the user needs SQL access to data and MindsDB is available.
+
+## When to use
+
+- Querying one or more connected databases through MindsDB
+- Inspecting available databases/sources
+- Turning literal SQL constants into named parameters
+
+## Tool actions
+
+- `query`: Execute SQL via MindsDB
+- `list_databases`: List database sources visible to MindsDB
+- `parametrize_constants`: Convert constants in SQL to parameter placeholders
+
+## Guidance
+
+- Prefer `query` with read-only SQL unless the user explicitly requests writes.
+- Do not invent schema/table names. If unknown, inspect with `SHOW DATABASES` or metadata queries first.
+- For user input in filters, prefer named parameters (`params`) instead of string interpolation.
+- Keep responses concise and include key rows/columns rather than dumping huge outputs.
+
+## Examples
+
+Read query:
+
+```json
+{
+  "action": "query",
+  "query": "SELECT * FROM information_schema.databases"
+}
+```
+
+Parameterized query:
+
+```json
+{
+  "action": "query",
+  "query": "SELECT NAME FROM information_schema.databases WHERE NAME = :db_name",
+  "params": {
+    "db_name": "mindsdb"
+  }
+}
+```
+
+List sources:
+
+```json
+{
+  "action": "list_databases"
+}
+```

--- a/extensions/mindsdb/src/plugin.test.ts
+++ b/extensions/mindsdb/src/plugin.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import plugin from "../index.js";
+
+describe("mindsdb plugin", () => {
+  it("registers the mindsdb tool as optional", () => {
+    const registerTool = vi.fn();
+
+    plugin.register({
+      id: "mindsdb",
+      name: "MindsDB",
+      source: "test",
+      config: {},
+      pluginConfig: {},
+      runtime: {},
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+      registerTool,
+      registerHook() {},
+      registerHttpHandler() {},
+      registerHttpRoute() {},
+      registerChannel() {},
+      registerGatewayMethod() {},
+      registerCli() {},
+      registerService() {},
+      registerProvider() {},
+      registerCommand() {},
+      resolvePath: (input: string) => input,
+      on() {},
+    } as never);
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registerTool).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "mindsdb" }),
+      expect.objectContaining({ optional: true }),
+    );
+  });
+});

--- a/extensions/mindsdb/src/tool.test.ts
+++ b/extensions/mindsdb/src/tool.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMindsdbTool, looksMutatingQuery, resolveMindsdbPluginConfig } from "./tool.js";
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeApi(pluginConfig: Record<string, unknown>) {
+  return {
+    id: "mindsdb",
+    name: "MindsDB",
+    source: "test",
+    config: {},
+    pluginConfig,
+    runtime: {},
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    registerTool() {},
+    registerHook() {},
+    registerHttpHandler() {},
+    registerHttpRoute() {},
+    registerChannel() {},
+    registerGatewayMethod() {},
+    registerCli() {},
+    registerService() {},
+    registerProvider() {},
+    registerCommand() {},
+    resolvePath: (input: string) => input,
+    on() {},
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  globalThis.fetch = originalFetch;
+});
+
+describe("mindsdb tool", () => {
+  it("runs query action with bearer token and row preview truncation", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({
+        type: "table",
+        column_names: ["id"],
+        data: [[1], [2], [3]],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const tool = createMindsdbTool(
+      fakeApi({ token: "token-123" }) as never,
+      resolveMindsdbPluginConfig({ token: "token-123", maxRows: 2, maxChars: 10_000 }),
+    );
+
+    const result = (await tool.execute("call-1", {
+      action: "query",
+      query: "SELECT * FROM t",
+    })) as {
+      details: {
+        responseType: string;
+        totalRows: number;
+        shownRows: number;
+        outputTruncated: boolean;
+      };
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:47334/api/sql/query");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer token-123");
+
+    const requestBody = JSON.parse(String(init.body));
+    expect(requestBody.query).toBe("SELECT * FROM t");
+
+    expect(result.details.responseType).toBe("table");
+    expect(result.details.totalRows).toBe(3);
+    expect(result.details.shownRows).toBe(2);
+    expect(result.details.outputTruncated).toBe(false);
+    expect(result.content[0]?.text).toContain("truncated_rows");
+  });
+
+  it("logs in once and reuses cached login token", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ token: "session-token" }))
+      .mockResolvedValueOnce(jsonResponse({ type: "ok" }))
+      .mockResolvedValueOnce(jsonResponse({ type: "ok" }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const tool = createMindsdbTool(
+      fakeApi({ username: "mindsdb", password: "mindsdb" }) as never,
+      resolveMindsdbPluginConfig({ username: "mindsdb", password: "mindsdb" }),
+    );
+
+    await tool.execute("call-1", { action: "query", query: "SELECT 1" });
+    await tool.execute("call-2", { action: "query", query: "SELECT 2" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    const [loginUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(loginUrl).toBe("http://127.0.0.1:47334/api/login");
+
+    const [, firstQueryInit] = fetchSpy.mock.calls[1] as [string, RequestInit];
+    expect((firstQueryInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer session-token",
+    );
+
+    const [, secondQueryInit] = fetchSpy.mock.calls[2] as [string, RequestInit];
+    expect((secondQueryInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer session-token",
+    );
+  });
+
+  it("blocks mutating SQL by default", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const tool = createMindsdbTool(fakeApi({}) as never, resolveMindsdbPluginConfig({}));
+
+    await expect(
+      tool.execute("call-1", {
+        action: "query",
+        query: "CREATE DATABASE analytics WITH ENGINE = 'postgres'",
+      }),
+    ).rejects.toThrow(/Mutating queries are disabled/i);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("supports list_databases action", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ type: "table", data: [["mindsdb"]], column_names: ["name"] }),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const tool = createMindsdbTool(
+      fakeApi({ token: "abc" }) as never,
+      resolveMindsdbPluginConfig({ token: "abc" }),
+    );
+
+    await tool.execute("call-1", { action: "list_databases" });
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:47334/api/sql/list_databases");
+    expect(init.method).toBe("GET");
+  });
+
+  it("truncates very large outputs by maxChars", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({
+        type: "table",
+        column_names: ["payload"],
+        data: [["x".repeat(6_000)]],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const tool = createMindsdbTool(
+      fakeApi({ token: "abc" }) as never,
+      resolveMindsdbPluginConfig({ token: "abc", maxChars: 1_000 }),
+    );
+
+    const result = (await tool.execute("call-1", {
+      action: "query",
+      query: "SELECT 1",
+    })) as {
+      details: { outputTruncated: boolean };
+      content: Array<{ text: string }>;
+    };
+
+    expect(result.details.outputTruncated).toBe(true);
+    expect(result.content[0]?.text).toContain("[truncated");
+  });
+});
+
+describe("mindsdb query classifier", () => {
+  it("recognizes read-only and mutating SQL", () => {
+    expect(looksMutatingQuery("SELECT * FROM information_schema.databases")).toBe(false);
+    expect(looksMutatingQuery("-- comment\nSHOW DATABASES")).toBe(false);
+    expect(looksMutatingQuery("CREATE DATABASE demo WITH ENGINE='postgres'")).toBe(true);
+  });
+});

--- a/extensions/mindsdb/src/tool.ts
+++ b/extensions/mindsdb/src/tool.ts
@@ -340,7 +340,7 @@ export function resolveMindsdbPluginConfig(raw: unknown): MindsdbPluginConfig {
   };
 }
 
-function validateAction(action: string): MindsdbAction {
+function parseMindsdbAction(action: string): MindsdbAction {
   if ((MINDSDB_ACTIONS as readonly string[]).includes(action)) {
     return action as MindsdbAction;
   }
@@ -430,7 +430,7 @@ export function createMindsdbTool(
       "Query MindsDB's federated SQL engine to access connected databases with one tool.",
     parameters: MindsdbToolSchema,
     async execute(_toolCallId: string, rawParams: Record<string, unknown>) {
-      const action = validateAction(readStringParam(rawParams, "action", { required: true }));
+      const action = parseMindsdbAction(readStringParam(rawParams, "action", { required: true }));
       const query = readStringParam(rawParams, "query");
       const params = readRecordParam(rawParams, "params");
       const context = readRecordParam(rawParams, "context");

--- a/extensions/mindsdb/src/tool.ts
+++ b/extensions/mindsdb/src/tool.ts
@@ -1,0 +1,469 @@
+import { Type } from "@sinclair/typebox";
+import {
+  readStringParam,
+  stringEnum,
+  type AnyAgentTool,
+  type OpenClawPluginApi,
+} from "openclaw/plugin-sdk";
+
+const MINDSDB_ACTIONS = ["query", "list_databases", "parametrize_constants"] as const;
+const READ_ONLY_QUERY_PREFIXES = new Set([
+  "SELECT",
+  "SHOW",
+  "DESCRIBE",
+  "DESC",
+  "EXPLAIN",
+  "WITH",
+  "USE",
+]);
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:47334";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_ROWS = 100;
+const DEFAULT_MAX_CHARS = 30_000;
+
+const MIN_TIMEOUT_MS = 1_000;
+const MIN_ROWS = 1;
+const MAX_ROWS = 1_000;
+const MIN_CHARS = 1_000;
+const MAX_CHARS = 300_000;
+
+type MindsdbAction = (typeof MINDSDB_ACTIONS)[number];
+
+type JsonRecord = Record<string, unknown>;
+
+export type MindsdbPluginConfig = {
+  baseUrl: string;
+  token?: string;
+  username?: string;
+  password?: string;
+  allowMutatingQueries: boolean;
+  requestTimeoutMs: number;
+  maxRows: number;
+  maxChars: number;
+};
+
+export type MindsdbToolParams = {
+  action: MindsdbAction;
+  query?: string;
+  params?: JsonRecord;
+  context?: JsonRecord;
+};
+
+export const MindsdbToolSchema = Type.Object(
+  {
+    action: stringEnum(MINDSDB_ACTIONS, {
+      description: `Action to perform: ${MINDSDB_ACTIONS.join(", ")}`,
+    }),
+    query: Type.Optional(
+      Type.String({
+        description:
+          "SQL query string. Required for action=query and action=parametrize_constants.",
+      }),
+    ),
+    params: Type.Optional(
+      Type.Record(Type.String(), Type.Unknown(), {
+        description:
+          "Optional named query parameters for action=query (maps to MindsDB /api/sql/query params).",
+      }),
+    ),
+    context: Type.Optional(
+      Type.Record(Type.String(), Type.Unknown(), {
+        description: "Optional MindsDB SQL context object (for example: { profiling: true }).",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readBoundedInteger(
+  value: unknown,
+  fallback: number,
+  bounds: { min: number; max: number },
+): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.min(bounds.max, Math.max(bounds.min, Math.trunc(value)));
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return Math.min(bounds.max, Math.max(bounds.min, parsed));
+    }
+  }
+  return fallback;
+}
+
+function readRecordParam(params: Record<string, unknown>, key: string): JsonRecord | undefined {
+  const value = params[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new Error(`${key} must be an object`);
+  }
+  return value;
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function buildUrl(baseUrl: string, path: string): string {
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizeBaseUrl(baseUrl)}${cleanPath}`;
+}
+
+function stripLeadingSqlComments(query: string): string {
+  return query
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/--[^\n\r]*/g, " ")
+    .trimStart();
+}
+
+export function looksMutatingQuery(query: string): boolean {
+  const normalized = stripLeadingSqlComments(query);
+  if (!normalized) {
+    return false;
+  }
+
+  const keywordMatch = normalized.match(/^([A-Za-z_]+)/);
+  if (!keywordMatch) {
+    return true;
+  }
+
+  const prefix = keywordMatch[1]?.toUpperCase() ?? "";
+  return !READ_ONLY_QUERY_PREFIXES.has(prefix);
+}
+
+function tableRowCount(payload: unknown): number | undefined {
+  if (isRecord(payload) && Array.isArray(payload.data)) {
+    return payload.data.length;
+  }
+  return undefined;
+}
+
+function previewResponse(payload: unknown, maxRows: number): unknown {
+  if (!isRecord(payload) || payload.type !== "table" || !Array.isArray(payload.data)) {
+    return payload;
+  }
+
+  const rows = payload.data;
+  const previewRows = rows.slice(0, maxRows);
+  return {
+    ...payload,
+    data: previewRows,
+    total_rows: rows.length,
+    shown_rows: previewRows.length,
+    truncated_rows: Math.max(0, rows.length - previewRows.length),
+  };
+}
+
+function renderPayload(
+  payload: unknown,
+  maxChars: number,
+): {
+  text: string;
+  truncated: boolean;
+  originalChars: number;
+} {
+  let serialized = "";
+
+  try {
+    serialized = JSON.stringify(payload, null, 2);
+  } catch {
+    serialized = String(payload);
+  }
+
+  const originalChars = serialized.length;
+  if (originalChars <= maxChars) {
+    return { text: serialized, truncated: false, originalChars };
+  }
+
+  const keepChars = Math.max(0, maxChars - 96);
+  const remaining = originalChars - keepChars;
+  const truncatedText = `${serialized.slice(0, keepChars)}\n... [truncated ${remaining} chars]`;
+  return {
+    text: truncatedText,
+    truncated: true,
+    originalChars,
+  };
+}
+
+function responseType(payload: unknown): string {
+  if (isRecord(payload) && typeof payload.type === "string") {
+    return payload.type;
+  }
+  return "unknown";
+}
+
+function formatHttpError(status: number, payload: unknown): string {
+  if (isRecord(payload)) {
+    const errorMessage = readOptionalString(payload.error_message);
+    if (errorMessage) {
+      return `MindsDB request failed (${status}): ${errorMessage}`;
+    }
+
+    const message = readOptionalString(payload.message);
+    if (message) {
+      return `MindsDB request failed (${status}): ${message}`;
+    }
+  }
+
+  return `MindsDB request failed with HTTP ${status}`;
+}
+
+async function requestJson(params: {
+  baseUrl: string;
+  path: string;
+  method: "GET" | "POST";
+  body?: unknown;
+  authHeader?: string;
+  timeoutMs: number;
+}): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), params.timeoutMs);
+
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+
+    let body: string | undefined;
+    if (params.body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(params.body);
+    }
+
+    if (params.authHeader) {
+      headers.Authorization = params.authHeader;
+    }
+
+    const response = await fetch(buildUrl(params.baseUrl, params.path), {
+      method: params.method,
+      headers,
+      body,
+      signal: controller.signal,
+    });
+
+    const raw = await response.text();
+    let payload: unknown = {};
+    if (raw.trim()) {
+      try {
+        payload = JSON.parse(raw);
+      } catch {
+        payload = { message: raw };
+      }
+    }
+
+    if (!response.ok) {
+      throw new Error(formatHttpError(response.status, payload));
+    }
+
+    return payload;
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`MindsDB request timed out after ${params.timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchLoginToken(config: MindsdbPluginConfig): Promise<string> {
+  if (!config.username || !config.password) {
+    throw new Error("username/password required to request a MindsDB token");
+  }
+
+  const response = await requestJson({
+    baseUrl: config.baseUrl,
+    path: "/api/login",
+    method: "POST",
+    body: {
+      username: config.username,
+      password: config.password,
+    },
+    timeoutMs: config.requestTimeoutMs,
+  });
+
+  if (isRecord(response) && typeof response.token === "string" && response.token.trim()) {
+    return response.token.trim();
+  }
+
+  throw new Error(
+    "MindsDB login succeeded but no token was returned. Configure a token directly or enable token auth in MindsDB.",
+  );
+}
+
+export function resolveMindsdbPluginConfig(raw: unknown): MindsdbPluginConfig {
+  const input = isRecord(raw) ? raw : {};
+
+  const baseUrl = normalizeBaseUrl(
+    readOptionalString(input.baseUrl) ??
+      readOptionalString(process.env.MINDSDB_URL) ??
+      readOptionalString(process.env.MINDSDB_API_URL) ??
+      DEFAULT_BASE_URL,
+  );
+
+  const token = readOptionalString(input.token) ?? readOptionalString(process.env.MINDSDB_TOKEN);
+  const username =
+    readOptionalString(input.username) ?? readOptionalString(process.env.MINDSDB_USERNAME);
+  const password =
+    readOptionalString(input.password) ?? readOptionalString(process.env.MINDSDB_PASSWORD);
+
+  return {
+    baseUrl,
+    token,
+    username,
+    password,
+    allowMutatingQueries: input.allowMutatingQueries === true,
+    requestTimeoutMs: readBoundedInteger(input.requestTimeoutMs, DEFAULT_TIMEOUT_MS, {
+      min: MIN_TIMEOUT_MS,
+      max: Number.MAX_SAFE_INTEGER,
+    }),
+    maxRows: readBoundedInteger(input.maxRows, DEFAULT_MAX_ROWS, {
+      min: MIN_ROWS,
+      max: MAX_ROWS,
+    }),
+    maxChars: readBoundedInteger(input.maxChars, DEFAULT_MAX_CHARS, {
+      min: MIN_CHARS,
+      max: MAX_CHARS,
+    }),
+  };
+}
+
+function validateAction(action: string): MindsdbAction {
+  if ((MINDSDB_ACTIONS as readonly string[]).includes(action)) {
+    return action as MindsdbAction;
+  }
+  throw new Error(`Unknown action: ${action}. Valid actions: ${MINDSDB_ACTIONS.join(", ")}`);
+}
+
+export function createMindsdbTool(
+  api: OpenClawPluginApi,
+  pluginConfig: MindsdbPluginConfig = resolveMindsdbPluginConfig(api.pluginConfig),
+): AnyAgentTool {
+  let cachedToken: string | undefined;
+
+  const resolveAuthHeader = async (): Promise<string | undefined> => {
+    if (pluginConfig.token) {
+      return `Bearer ${pluginConfig.token}`;
+    }
+
+    if (pluginConfig.username && pluginConfig.password) {
+      if (!cachedToken) {
+        cachedToken = await fetchLoginToken(pluginConfig);
+      }
+      return `Bearer ${cachedToken}`;
+    }
+
+    return undefined;
+  };
+
+  const executeAction = async (action: MindsdbAction, params: MindsdbToolParams) => {
+    const authHeader = await resolveAuthHeader();
+
+    if (action === "list_databases") {
+      return requestJson({
+        baseUrl: pluginConfig.baseUrl,
+        path: "/api/sql/list_databases",
+        method: "GET",
+        authHeader,
+        timeoutMs: pluginConfig.requestTimeoutMs,
+      });
+    }
+
+    if (action === "parametrize_constants") {
+      if (!params.query) {
+        throw new Error("query required for parametrize_constants");
+      }
+      return requestJson({
+        baseUrl: pluginConfig.baseUrl,
+        path: "/api/sql/query/utils/parametrize_constants",
+        method: "POST",
+        body: { query: params.query },
+        authHeader,
+        timeoutMs: pluginConfig.requestTimeoutMs,
+      });
+    }
+
+    if (!params.query) {
+      throw new Error("query required for query action");
+    }
+
+    if (!pluginConfig.allowMutatingQueries && looksMutatingQuery(params.query)) {
+      throw new Error(
+        "Mutating queries are disabled by plugin config. Set plugins.entries.mindsdb.config.allowMutatingQueries=true to enable CREATE/INSERT/UPDATE/DELETE/ALTER operations.",
+      );
+    }
+
+    const body: JsonRecord = { query: params.query };
+    if (params.params) {
+      body.params = params.params;
+    }
+    if (params.context) {
+      body.context = params.context;
+    }
+
+    return requestJson({
+      baseUrl: pluginConfig.baseUrl,
+      path: "/api/sql/query",
+      method: "POST",
+      body,
+      authHeader,
+      timeoutMs: pluginConfig.requestTimeoutMs,
+    });
+  };
+
+  return {
+    name: "mindsdb",
+    label: "MindsDB",
+    description:
+      "Query MindsDB's federated SQL engine to access connected databases with one tool.",
+    parameters: MindsdbToolSchema,
+    async execute(_toolCallId: string, rawParams: Record<string, unknown>) {
+      const action = validateAction(readStringParam(rawParams, "action", { required: true }));
+      const query = readStringParam(rawParams, "query");
+      const params = readRecordParam(rawParams, "params");
+      const context = readRecordParam(rawParams, "context");
+
+      try {
+        const responsePayload = await executeAction(action, {
+          action,
+          query,
+          params,
+          context,
+        });
+
+        const totalRows = tableRowCount(responsePayload);
+        const previewPayload = previewResponse(responsePayload, pluginConfig.maxRows);
+        const shownRows = tableRowCount(previewPayload);
+        const rendered = renderPayload(previewPayload, pluginConfig.maxChars);
+
+        return {
+          content: [{ type: "text", text: rendered.text }],
+          details: {
+            action,
+            responseType: responseType(responsePayload),
+            totalRows,
+            shownRows,
+            outputTruncated: rendered.truncated,
+            outputChars: rendered.originalChars,
+            baseUrl: pluginConfig.baseUrl,
+          },
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`[mindsdb:${action}] ${message}`);
+      }
+    },
+  } satisfies AnyAgentTool;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/mindsdb:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/minimax-portal-auth:
     devDependencies:
       openclaw:
@@ -6672,7 +6678,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.58.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6688,7 +6694,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.12
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6891,7 +6897,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7726,7 +7732,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7772,7 +7778,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.2.2
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8666,14 +8672,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9248,8 +9246,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,10 @@ importers:
         version: link:../..
 
   extensions/mindsdb:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
     devDependencies:
       openclaw:
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- add a new bundled `mindsdb` extension (`extensions/mindsdb`) with an optional `mindsdb` agent tool
- implement MindsDB HTTP integration for:
  - `query` (`POST /api/sql/query`)
  - `list_databases` (`GET /api/sql/list_databases`)
  - `parametrize_constants` (`POST /api/sql/query/utils/parametrize_constants`)
- support auth via either:
  - static bearer token (`plugins.entries.mindsdb.config.token`), or
  - username/password login (`/api/login`, token cached per tool instance)
- add safety and output controls:
  - mutating SQL blocked by default (`allowMutatingQueries: false`)
  - bounded response preview (`maxRows`, `maxChars`) to keep agent context stable
- add docs + nav updates for setup/usage at `docs/tools/mindsdb.md`
- add labeler mapping for the new extension (`extensions: mindsdb`)

## Why
This gives OpenClaw agents a direct path to MindsDB’s federated SQL layer, so users can query many different databases through one tool endpoint from their existing OpenClaw workflows/channels.

## Testing
- `pnpm vitest run extensions/mindsdb/src/tool.test.ts extensions/mindsdb/src/plugin.test.ts`
- `pnpm exec oxfmt --check extensions/mindsdb/index.ts extensions/mindsdb/src/tool.ts extensions/mindsdb/src/tool.test.ts extensions/mindsdb/src/plugin.test.ts docs/tools/mindsdb.md docs/tools/index.md docs/tools/plugin.md docs/docs.json extensions/mindsdb/openclaw.plugin.json extensions/mindsdb/package.json`
- `pnpm dlx markdownlint-cli2 docs/tools/mindsdb.md docs/tools/index.md docs/tools/plugin.md`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new bundled `extensions/mindsdb` plugin that registers an optional `mindsdb` agent tool. The tool integrates with MindsDB’s HTTP API (`/api/sql/query`, `/api/sql/list_databases`, and `/api/sql/query/utils/parametrize_constants`), supports either a configured bearer token or username/password login, and includes guardrails for mutating SQL and response-size truncation.

One issue to address before merging: the PR also removes the `openclaw logs --local-time` / `--localTime` option and related documentation/changelog content, which is an unrelated, user-visible breaking change compared to the MindsDB scope described here.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is due to an unrelated user-visible CLI behavior change bundled into the PR.
- The MindsDB extension changes look internally consistent and covered by targeted tests, but the same commit range removes `openclaw logs --local-time` support and documentation/changelog entries without being mentioned in the PR scope, which is likely unintended and would be a breaking change for users.
- src/cli/logs-cli.ts (and corresponding docs/cli/logs.md, CHANGELOG.md)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->