### PR TITLE
fix(linux): add trash command fallbacks for moveToTrash

### DIFF
--- a/src/browser/trash.test.ts
+++ b/src/browser/trash.test.ts
@@ -105,7 +105,7 @@ describe("movePathToTrash", () => {
       const trashFilesDir = path.join(xdgDataHome, "Trash", "files");
       const trashedEntries = fs.readdirSync(trashFilesDir);
       expect(trashedEntries.length).toBe(1);
-      expect(fs.existsSync(path.join(trashFilesDir, trashedEntries[0]!))).toBe(true);
+      expect(fs.existsSync(path.join(trashFilesDir, trashedEntries[0]))).toBe(true);
 
       // A .trashinfo file should exist in the info directory.
       const infoFile = path.join(xdgDataHome, "Trash", "info", `${trashedEntries[0]}.trashinfo`);

--- a/src/browser/trash.test.ts
+++ b/src/browser/trash.test.ts
@@ -95,17 +95,20 @@ describe("movePathToTrash", () => {
 
       const result = await movePathToTrash(targetFile);
 
+      // Return value should be the original path (consistent with CLI commands).
+      expect(result).toBe(targetFile);
+
       // File should no longer exist at original location.
       expect(fs.existsSync(targetFile)).toBe(false);
 
       // File should be in XDG trash.
       const trashFilesDir = path.join(xdgDataHome, "Trash", "files");
-      expect(result.startsWith(trashFilesDir)).toBe(true);
-      expect(fs.existsSync(result)).toBe(true);
+      const trashedEntries = fs.readdirSync(trashFilesDir);
+      expect(trashedEntries.length).toBe(1);
+      expect(fs.existsSync(path.join(trashFilesDir, trashedEntries[0]!))).toBe(true);
 
       // A .trashinfo file should exist in the info directory.
-      const destName = path.basename(result);
-      const infoFile = path.join(xdgDataHome, "Trash", "info", `${destName}.trashinfo`);
+      const infoFile = path.join(xdgDataHome, "Trash", "info", `${trashedEntries[0]}.trashinfo`);
       expect(fs.existsSync(infoFile)).toBe(true);
       const infoContent = fs.readFileSync(infoFile, "utf8");
       expect(infoContent).toContain("[Trash Info]");
@@ -130,9 +133,9 @@ describe("movePathToTrash", () => {
 
       const result = await movePathToTrash(targetFile);
 
+      // Return value should be the original path (consistent with CLI commands).
+      expect(result).toBe(targetFile);
       expect(fs.existsSync(targetFile)).toBe(false);
-      expect(result).toContain(".Trash");
-      expect(fs.existsSync(result)).toBe(true);
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
     }

--- a/src/browser/trash.test.ts
+++ b/src/browser/trash.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock runExec before importing the module under test.
+const runExecMock = vi.fn();
+vi.mock("../process/exec.js", () => ({
+  runExec: (...args: unknown[]) => runExecMock(...args),
+}));
+
+import { movePathToTrash } from "./trash.js";
+
+describe("movePathToTrash", () => {
+  let tmpDir: string;
+  let targetFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trash-test-"));
+    targetFile = path.join(tmpDir, "test-file.txt");
+    fs.writeFileSync(targetFile, "hello");
+    runExecMock.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns early when the first trash command succeeds", async () => {
+    runExecMock.mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+    const result = await movePathToTrash(targetFile);
+
+    expect(result).toBe(targetFile);
+    expect(runExecMock).toHaveBeenCalledTimes(1);
+    expect(runExecMock).toHaveBeenCalledWith("trash", [targetFile], { timeoutMs: 10_000 });
+  });
+
+  it("tries subsequent commands when earlier ones fail (Linux)", async () => {
+    // Simulate Linux platform for this test.
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+
+    try {
+      // trash fails, gio trash succeeds
+      runExecMock.mockRejectedValueOnce(new Error("trash not found"));
+      runExecMock.mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+      const result = await movePathToTrash(targetFile);
+
+      expect(result).toBe(targetFile);
+      expect(runExecMock).toHaveBeenCalledTimes(2);
+      expect(runExecMock).toHaveBeenNthCalledWith(1, "trash", [targetFile], { timeoutMs: 10_000 });
+      expect(runExecMock).toHaveBeenNthCalledWith(2, "gio", ["trash", targetFile], {
+        timeoutMs: 10_000,
+      });
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    }
+  });
+
+  it("tries trash-put when trash and gio both fail (Linux)", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+
+    try {
+      runExecMock.mockRejectedValueOnce(new Error("trash not found"));
+      runExecMock.mockRejectedValueOnce(new Error("gio not found"));
+      runExecMock.mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+      const result = await movePathToTrash(targetFile);
+
+      expect(result).toBe(targetFile);
+      expect(runExecMock).toHaveBeenCalledTimes(3);
+      expect(runExecMock).toHaveBeenNthCalledWith(3, "trash-put", [targetFile], {
+        timeoutMs: 10_000,
+      });
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    }
+  });
+
+  it("falls back to manual XDG move on Linux when all commands fail", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+
+    // Use a custom XDG_DATA_HOME inside tmpDir so the test stays hermetic.
+    const originalXdg = process.env["XDG_DATA_HOME"];
+    const xdgDataHome = path.join(tmpDir, ".local", "share");
+    process.env["XDG_DATA_HOME"] = xdgDataHome;
+
+    try {
+      // All commands fail.
+      runExecMock.mockRejectedValue(new Error("not found"));
+
+      const result = await movePathToTrash(targetFile);
+
+      // File should no longer exist at original location.
+      expect(fs.existsSync(targetFile)).toBe(false);
+
+      // File should be in XDG trash.
+      const trashFilesDir = path.join(xdgDataHome, "Trash", "files");
+      expect(result.startsWith(trashFilesDir)).toBe(true);
+      expect(fs.existsSync(result)).toBe(true);
+
+      // A .trashinfo file should exist in the info directory.
+      const destName = path.basename(result);
+      const infoFile = path.join(xdgDataHome, "Trash", "info", `${destName}.trashinfo`);
+      expect(fs.existsSync(infoFile)).toBe(true);
+      const infoContent = fs.readFileSync(infoFile, "utf8");
+      expect(infoContent).toContain("[Trash Info]");
+      expect(infoContent).toContain(`Path=${path.resolve(targetFile)}`);
+      expect(infoContent).toContain("DeletionDate=");
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+      if (originalXdg === undefined) {
+        delete process.env["XDG_DATA_HOME"];
+      } else {
+        process.env["XDG_DATA_HOME"] = originalXdg;
+      }
+    }
+  });
+
+  it("falls back to ~/.Trash on macOS when trash command fails", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+
+    try {
+      runExecMock.mockRejectedValue(new Error("not found"));
+
+      const result = await movePathToTrash(targetFile);
+
+      expect(fs.existsSync(targetFile)).toBe(false);
+      expect(result).toContain(".Trash");
+      expect(fs.existsSync(result)).toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    }
+  });
+
+  it("only tries trash command on macOS (no gio/trash-put)", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+
+    try {
+      runExecMock.mockRejectedValue(new Error("not found"));
+
+      await movePathToTrash(targetFile);
+
+      // On macOS only the `trash` command should be tried before manual fallback.
+      expect(runExecMock).toHaveBeenCalledTimes(1);
+      expect(runExecMock).toHaveBeenCalledWith("trash", [targetFile], { timeoutMs: 10_000 });
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    }
+  });
+});

--- a/src/browser/trash.ts
+++ b/src/browser/trash.ts
@@ -58,6 +58,13 @@ function writeTrashInfo(trashDir: string, destName: string, originalPath: string
   }
 }
 
+/**
+ * Move a file or directory to the system Trash.
+ *
+ * Returns the original `targetPath` on success — CLI trash commands do not
+ * expose the destination path, so the return value is consistently the path
+ * that was trashed rather than where it ended up.
+ */
 export async function movePathToTrash(targetPath: string): Promise<string> {
   const commands = resolveTrashCommands();
 
@@ -89,5 +96,5 @@ export async function movePathToTrash(targetPath: string): Promise<string> {
     writeTrashInfo(trashDir, destName, path.resolve(targetPath));
   }
 
-  return dest;
+  return targetPath;
 }

--- a/src/browser/trash.ts
+++ b/src/browser/trash.ts
@@ -3,19 +3,91 @@ import os from "node:os";
 import path from "node:path";
 import { runExec } from "../process/exec.js";
 
-export async function movePathToTrash(targetPath: string): Promise<string> {
-  try {
-    await runExec("trash", [targetPath], { timeoutMs: 10_000 });
-    return targetPath;
-  } catch {
-    const trashDir = path.join(os.homedir(), ".Trash");
-    fs.mkdirSync(trashDir, { recursive: true });
-    const base = path.basename(targetPath);
-    let dest = path.join(trashDir, `${base}-${Date.now()}`);
-    if (fs.existsSync(dest)) {
-      dest = path.join(trashDir, `${base}-${Date.now()}-${Math.random()}`);
-    }
-    fs.renameSync(targetPath, dest);
-    return dest;
+type TrashCommand = { cmd: string; args: (targetPath: string) => string[] };
+
+/**
+ * Ordered list of trash CLI commands to attempt.
+ * On macOS, `trash` is typically the only option (via Homebrew trash-cli or
+ * the built-in `trash` wrapper). On Linux, `gio trash` is the most
+ * universally available (ships with GLib/GNOME), followed by `trash-put`
+ * and `trash` from trash-cli.
+ */
+function resolveTrashCommands(): TrashCommand[] {
+  if (process.platform === "darwin") {
+    return [{ cmd: "trash", args: (p) => [p] }];
   }
+  // Linux (and other Unix-like)
+  return [
+    { cmd: "trash", args: (p) => [p] },
+    { cmd: "gio", args: (p) => ["trash", p] },
+    { cmd: "trash-put", args: (p) => [p] },
+  ];
+}
+
+/**
+ * Resolve the platform-appropriate fallback trash directory.
+ *
+ * - macOS: `~/.Trash`
+ * - Linux: `$XDG_DATA_HOME/Trash/files` (defaults to `~/.local/share/Trash/files`)
+ *
+ * On Linux the XDG Trash specification requires an `info/` sibling directory
+ * with `.trashinfo` metadata files. We create both directories but only write
+ * the mandatory info entry so that file managers can display the trashed item.
+ */
+function resolveTrashDir(): string {
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), ".Trash");
+  }
+  const xdgDataHome = process.env["XDG_DATA_HOME"] || path.join(os.homedir(), ".local", "share");
+  return path.join(xdgDataHome, "Trash", "files");
+}
+
+/**
+ * Write a minimal `.trashinfo` file so that XDG-compliant file managers
+ * (Nautilus, Dolphin, Thunar, etc.) can show and restore the trashed item.
+ */
+function writeTrashInfo(trashDir: string, destName: string, originalPath: string): void {
+  try {
+    const infoDir = path.join(path.dirname(trashDir), "info");
+    fs.mkdirSync(infoDir, { recursive: true });
+    const now = new Date().toISOString().replace(/\.\d{3}Z$/, "");
+    const content = `[Trash Info]\nPath=${originalPath}\nDeletionDate=${now}\n`;
+    fs.writeFileSync(path.join(infoDir, `${destName}.trashinfo`), content, "utf8");
+  } catch {
+    // Best-effort: the file itself is already in Trash/files.
+  }
+}
+
+export async function movePathToTrash(targetPath: string): Promise<string> {
+  const commands = resolveTrashCommands();
+
+  for (const { cmd, args } of commands) {
+    try {
+      await runExec(cmd, args(targetPath), { timeoutMs: 10_000 });
+      return targetPath;
+    } catch {
+      // Try the next command.
+    }
+  }
+
+  // Manual fallback: move the file/directory into the trash directory.
+  const trashDir = resolveTrashDir();
+  fs.mkdirSync(trashDir, { recursive: true });
+
+  const base = path.basename(targetPath);
+  let destName = `${base}-${Date.now()}`;
+  let dest = path.join(trashDir, destName);
+  if (fs.existsSync(dest)) {
+    destName = `${base}-${Date.now()}-${Math.random()}`;
+    dest = path.join(trashDir, destName);
+  }
+
+  fs.renameSync(targetPath, dest);
+
+  // On Linux, write a .trashinfo entry for XDG compliance.
+  if (process.platform !== "darwin") {
+    writeTrashInfo(trashDir, destName, path.resolve(targetPath));
+  }
+
+  return dest;
 }

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { NodeManagerChoice, OnboardMode, ResetScope } from "./onboard-types.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
+import { movePathToTrash } from "../browser/trash.js";
 import { CONFIG_PATH } from "../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
@@ -15,7 +16,6 @@ import { pickPrimaryLanIPv4, isValidIPv4 } from "../gateway/net.js";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
-import { movePathToTrash } from "../browser/trash.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
 import {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -15,6 +15,7 @@ import { pickPrimaryLanIPv4, isValidIPv4 } from "../gateway/net.js";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
+import { movePathToTrash } from "../browser/trash.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
 import {
@@ -300,7 +301,7 @@ export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promis
     return;
   }
   try {
-    await runCommandWithTimeout(["trash", pathname], { timeoutMs: 5000 });
+    await movePathToTrash(pathname);
     runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
   } catch {
     runtime.log(`Failed to move to Trash (manual delete): ${shortenHomePath(pathname)}`);


### PR DESCRIPTION
## Summary

Fixes #14081 — `moveToTrash()` / `movePathToTrash()` only tries the `trash` command (from `trash-cli`). On most minimal Linux installs, `trash-cli` is not installed, causing `openclaw reset` and agent deletion to silently fail, leaving files in place.

### Changes

- **Multiple trash commands**: Try `trash` → `gio trash` (GLib/GNOME) → `trash-put` (trash-cli alt name) in order, stopping at the first success
- **XDG-compliant fallback**: When all commands fail, move files to `$XDG_DATA_HOME/Trash/files` (defaults to `~/.local/share/Trash/files`) on Linux, or `~/.Trash` on macOS (preserving existing behavior)
- **`.trashinfo` metadata**: Write XDG-compliant `.trashinfo` files so desktop file managers (Nautilus, Dolphin, Thunar, etc.) can display and restore trashed items
- **Code deduplication**: `moveToTrash()` in `onboard-helpers.ts` now delegates to the shared `movePathToTrash()` from `browser/trash.ts` instead of directly calling `trash`
- **Unit tests**: 6 new tests covering all fallback paths (first command success, sequential fallbacks, manual XDG move with trashinfo, macOS-only behavior)

### Files Changed

| File | Change |
|------|--------|
| `src/browser/trash.ts` | Add `gio trash`, `trash-put` fallbacks + XDG trash dir + `.trashinfo` |
| `src/commands/onboard-helpers.ts` | Use shared `movePathToTrash()` instead of direct `trash` call |
| `src/browser/trash.test.ts` | New: 6 unit tests for all fallback paths |

### Why this approach

1. **`gio trash`** is the most universally available trash command on Linux — it ships with GLib, which is installed with virtually every desktop environment (GNOME, KDE, XFCE, etc.)
2. **XDG Trash Specification** compliance ensures that manually-moved files appear correctly in desktop file managers, not just as orphaned files
3. **Delegating to `movePathToTrash()`** eliminates the duplicate trash implementation that existed between `onboard-helpers.ts` and `browser/trash.ts`

## Test Plan

- [x] All 6 new tests pass (`pnpm vitest run src/browser/trash.test.ts`)
- [x] Existing `profiles-service.test.ts` tests still pass (4/4)
- [x] Existing `agents-mutate.test.ts` tests still pass (16/16)
- [ ] Manual test on Linux without `trash-cli` installed
- [ ] Manual test on macOS (verify existing behavior preserved)

## AI Disclosure

- [x] AI-assisted (Sylphx AI)
- [x] Fully tested with vitest
- [x] I understand what the code does

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves `movePathToTrash()` behavior on Linux by attempting multiple trash CLI commands (`trash`, `gio trash`, `trash-put`) before falling back to a manual move into an XDG-compliant trash directory (and writing `.trashinfo` metadata). It also deduplicates the CLI onboarding helper by delegating to the shared `movePathToTrash()` and adds targeted unit tests for the fallback chain.

One issue to address before merge: `movePathToTrash()` currently returns inconsistent values depending on which path succeeds (original path vs destination path), and at least one caller (`resetProfile`) uses the return value as the destination (`to:`).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one behavioral inconsistency should be fixed first.
- Core change is additive (extra fallbacks + manual XDG move) and covered by tests, but the function’s return value is inconsistent across success paths and is already used by at least one caller as the destination path, which can lead to incorrect reporting/logic.
- src/browser/trash.ts (return-value semantics); src/browser/server-context.ts call site expectations

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->