### PR TITLE
fix(docker): exit setup.sh immediately when user declines

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -192,7 +192,11 @@ echo "  - Gateway token: $OPENCLAW_GATEWAY_TOKEN"
 echo "  - Tailscale exposure: Off"
 echo "  - Install Gateway daemon: No"
 echo ""
-docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard --no-install-daemon
+if ! docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard --no-install-daemon; then
+  echo ""
+  echo "Onboarding cancelled or failed. Exiting." >&2
+  exit 1
+fi
 
 echo ""
 echo "==> Provider setup (optional)"

--- a/src/commands/onboard-interactive.ts
+++ b/src/commands/onboard-interactive.ts
@@ -15,7 +15,7 @@ export async function runInteractiveOnboarding(
     await runOnboardingWizard(opts, runtime, prompter);
   } catch (err) {
     if (err instanceof WizardCancelledError) {
-      runtime.exit(0);
+      runtime.exit(1);
       return;
     }
     throw err;

--- a/src/infra/ports-inspect.test.ts
+++ b/src/infra/ports-inspect.test.ts
@@ -1,5 +1,6 @@
 import net from "node:net";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseSsOutput } from "./ports-inspect.js";
 
 const runCommandWithTimeoutMock = vi.fn();
 
@@ -31,5 +32,161 @@ describeUnix("inspectPortUsage", () => {
     } finally {
       server.close();
     }
+  });
+});
+
+describe("parseSsOutput", () => {
+  it("parses a single IPv4 listener with process info", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:18789       0.0.0.0:*        users:(("node",pid=12345,fd=3))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 18789);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]).toEqual({
+      address: "0.0.0.0:18789",
+      pid: 12345,
+      command: "node",
+    });
+  });
+
+  it("parses a single IPv6 listener with process info", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    [::]:18789          [::]:*           users:(("node",pid=12345,fd=3))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 18789);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]).toEqual({
+      address: "[::]:18789",
+      pid: 12345,
+      command: "node",
+    });
+  });
+
+  it("parses both IPv4 and IPv6 listeners", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:3000        0.0.0.0:*        users:(("node",pid=999,fd=10))',
+      'LISTEN 0      128    [::]:3000           [::]:*           users:(("node",pid=999,fd=10))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 3000);
+    expect(listeners).toHaveLength(2);
+    expect(listeners[0]?.pid).toBe(999);
+    expect(listeners[0]?.address).toBe("0.0.0.0:3000");
+    expect(listeners[1]?.pid).toBe(999);
+    expect(listeners[1]?.address).toBe("[::]:3000");
+  });
+
+  it("filters out lines for other ports", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:8080        0.0.0.0:*        users:(("nginx",pid=100,fd=6))',
+      'LISTEN 0      128    0.0.0.0:3000        0.0.0.0:*        users:(("node",pid=200,fd=3))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 3000);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]?.pid).toBe(200);
+    expect(listeners[0]?.command).toBe("node");
+  });
+
+  it("handles output with no process info (insufficient permissions)", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      "LISTEN 0      128    0.0.0.0:18789       0.0.0.0:*       ",
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 18789);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]).toEqual({
+      address: "0.0.0.0:18789",
+    });
+    expect(listeners[0]?.pid).toBeUndefined();
+    expect(listeners[0]?.command).toBeUndefined();
+  });
+
+  it("handles 127.0.0.1 local address", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      511    127.0.0.1:6379      0.0.0.0:*        users:(("redis-server",pid=555,fd=6))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 6379);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]).toEqual({
+      address: "127.0.0.1:6379",
+      pid: 555,
+      command: "redis-server",
+    });
+  });
+
+  it("returns empty array for empty output", () => {
+    expect(parseSsOutput("", 18789)).toEqual([]);
+  });
+
+  it("returns empty array when no matching port", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:8080        0.0.0.0:*        users:(("nginx",pid=100,fd=6))',
+    ].join("\n");
+
+    expect(parseSsOutput(output, 3000)).toEqual([]);
+  });
+
+  it("returns empty array when only header is present", () => {
+    const output = "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process\n";
+    expect(parseSsOutput(output, 18789)).toEqual([]);
+  });
+
+  it("does not match port as substring of another port", () => {
+    // Port 80 should not match :8080
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:8080        0.0.0.0:*        users:(("nginx",pid=100,fd=6))',
+    ].join("\n");
+
+    expect(parseSsOutput(output, 80)).toEqual([]);
+  });
+
+  it("handles multiple processes on the same port", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:443         0.0.0.0:*        users:(("nginx",pid=100,fd=6))',
+      'LISTEN 0      128    0.0.0.0:443         0.0.0.0:*        users:(("haproxy",pid=200,fd=4))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 443);
+    expect(listeners).toHaveLength(2);
+    expect(listeners[0]?.command).toBe("nginx");
+    expect(listeners[1]?.command).toBe("haproxy");
+  });
+
+  it("handles process names with special characters", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:5432        0.0.0.0:*        users:(("postgres: main",pid=777,fd=3))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 5432);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]?.command).toBe("postgres: main");
+    expect(listeners[0]?.pid).toBe(777);
+  });
+
+  it("ignores non-LISTEN state lines", () => {
+    const output = [
+      "State      Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN     0      128    0.0.0.0:3000        0.0.0.0:*        users:(("node",pid=100,fd=3))',
+      "ESTAB      0      0      192.168.1.1:3000    10.0.0.1:54321",
+      "TIME-WAIT  0      0      192.168.1.1:3000    10.0.0.1:54322",
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 3000);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]?.pid).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary

- When the user says "no" to the risk acknowledgement prompt during `docker-setup.sh` onboarding, the script now exits immediately instead of continuing to start the gateway.
- Root cause: `WizardCancelledError` was caught in `onboard-interactive.ts` and mapped to `process.exit(0)`, so `docker-setup.sh` (which relies on exit codes) treated cancellation as success and proceeded to launch the gateway.
- Changed the cancellation exit code from `0` to `1` in `onboard-interactive.ts` so callers can distinguish successful completion from user cancellation.
- Added an explicit guard in `docker-setup.sh` around the onboard command that prints a clear message and exits on failure.

Closes #14070

## AI Disclosure

This PR was authored with the assistance of Sylphx AI.

## Test plan

- [ ] Run `docker-setup.sh` and answer "no" to the risk acknowledgement prompt — verify the script exits immediately with "Onboarding cancelled or failed. Exiting." and does **not** start the gateway
- [ ] Run `docker-setup.sh` and complete onboarding normally — verify the gateway starts as expected
- [ ] Run `openclaw onboard` standalone (outside Docker) and cancel — verify it exits with code 1
- [ ] Run `openclaw onboard` standalone and complete — verify it exits with code 0
- [ ] Press Ctrl+C during any onboard prompt — verify `docker-setup.sh` exits cleanly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changed `WizardCancelledError` exit code from `0` to `1` in `onboard-interactive.ts` and added explicit error handling in `docker-setup.sh`. When users decline the risk acknowledgement during onboarding, the script now exits immediately instead of proceeding to start the gateway.

The PR also includes a separate commit that adds `ss` fallback for port diagnostics when `lsof` is unavailable on Linux systems.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and solve the specific issue. The exit code change is intentional and necessary for shell script error handling. The docker-setup.sh guard provides a clear user experience. The ports-inspect changes are well-tested with comprehensive test coverage.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->