### PR TITLE
fix(linux): fall back to ss for port diagnostics when lsof is missing

### DIFF
--- a/src/infra/ports-inspect.test.ts
+++ b/src/infra/ports-inspect.test.ts
@@ -1,5 +1,6 @@
 import net from "node:net";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseSsOutput } from "./ports-inspect.js";
 
 const runCommandWithTimeoutMock = vi.fn();
 
@@ -31,5 +32,161 @@ describeUnix("inspectPortUsage", () => {
     } finally {
       server.close();
     }
+  });
+});
+
+describe("parseSsOutput", () => {
+  it("parses a single IPv4 listener with process info", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:18789       0.0.0.0:*        users:(("node",pid=12345,fd=3))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 18789);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]).toEqual({
+      address: "0.0.0.0:18789",
+      pid: 12345,
+      command: "node",
+    });
+  });
+
+  it("parses a single IPv6 listener with process info", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    [::]:18789          [::]:*           users:(("node",pid=12345,fd=3))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 18789);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]).toEqual({
+      address: "[::]:18789",
+      pid: 12345,
+      command: "node",
+    });
+  });
+
+  it("parses both IPv4 and IPv6 listeners", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:3000        0.0.0.0:*        users:(("node",pid=999,fd=10))',
+      'LISTEN 0      128    [::]:3000           [::]:*           users:(("node",pid=999,fd=10))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 3000);
+    expect(listeners).toHaveLength(2);
+    expect(listeners[0]?.pid).toBe(999);
+    expect(listeners[0]?.address).toBe("0.0.0.0:3000");
+    expect(listeners[1]?.pid).toBe(999);
+    expect(listeners[1]?.address).toBe("[::]:3000");
+  });
+
+  it("filters out lines for other ports", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:8080        0.0.0.0:*        users:(("nginx",pid=100,fd=6))',
+      'LISTEN 0      128    0.0.0.0:3000        0.0.0.0:*        users:(("node",pid=200,fd=3))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 3000);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]?.pid).toBe(200);
+    expect(listeners[0]?.command).toBe("node");
+  });
+
+  it("handles output with no process info (insufficient permissions)", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      "LISTEN 0      128    0.0.0.0:18789       0.0.0.0:*       ",
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 18789);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]).toEqual({
+      address: "0.0.0.0:18789",
+    });
+    expect(listeners[0]?.pid).toBeUndefined();
+    expect(listeners[0]?.command).toBeUndefined();
+  });
+
+  it("handles 127.0.0.1 local address", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      511    127.0.0.1:6379      0.0.0.0:*        users:(("redis-server",pid=555,fd=6))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 6379);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]).toEqual({
+      address: "127.0.0.1:6379",
+      pid: 555,
+      command: "redis-server",
+    });
+  });
+
+  it("returns empty array for empty output", () => {
+    expect(parseSsOutput("", 18789)).toEqual([]);
+  });
+
+  it("returns empty array when no matching port", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:8080        0.0.0.0:*        users:(("nginx",pid=100,fd=6))',
+    ].join("\n");
+
+    expect(parseSsOutput(output, 3000)).toEqual([]);
+  });
+
+  it("returns empty array when only header is present", () => {
+    const output = "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process\n";
+    expect(parseSsOutput(output, 18789)).toEqual([]);
+  });
+
+  it("does not match port as substring of another port", () => {
+    // Port 80 should not match :8080
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:8080        0.0.0.0:*        users:(("nginx",pid=100,fd=6))',
+    ].join("\n");
+
+    expect(parseSsOutput(output, 80)).toEqual([]);
+  });
+
+  it("handles multiple processes on the same port", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:443         0.0.0.0:*        users:(("nginx",pid=100,fd=6))',
+      'LISTEN 0      128    0.0.0.0:443         0.0.0.0:*        users:(("haproxy",pid=200,fd=4))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 443);
+    expect(listeners).toHaveLength(2);
+    expect(listeners[0]?.command).toBe("nginx");
+    expect(listeners[1]?.command).toBe("haproxy");
+  });
+
+  it("handles process names with special characters", () => {
+    const output = [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN 0      128    0.0.0.0:5432        0.0.0.0:*        users:(("postgres: main",pid=777,fd=3))',
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 5432);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]?.command).toBe("postgres: main");
+    expect(listeners[0]?.pid).toBe(777);
+  });
+
+  it("ignores non-LISTEN state lines", () => {
+    const output = [
+      "State      Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      'LISTEN     0      128    0.0.0.0:3000        0.0.0.0:*        users:(("node",pid=100,fd=3))',
+      "ESTAB      0      0      192.168.1.1:3000    10.0.0.1:54321",
+      "TIME-WAIT  0      0      192.168.1.1:3000    10.0.0.1:54322",
+    ].join("\n");
+
+    const listeners = parseSsOutput(output, 3000);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]?.pid).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary

When `lsof` is not installed (common on minimal Linux servers, containers, and cloud VMs), port conflict diagnostics now fall back to `ss -tlnp` (from iproute2, nearly universal on Linux) instead of reporting a generic "process details are unavailable" message.

- Add `parseSsOutput()` to parse `ss -tlnp` output into `PortListener` entries
- Add `readSsListeners()` to invoke `ss` with port-specific filtering (`sport = :PORT`)
- Modify `readUnixListeners()` to try `ss` when `lsof` fails on Linux (`process.platform === "linux"`)
- Extract shared `enrichListenersWithProcessInfo()` helper to deduplicate `ps` enrichment logic
- Update fallback hint to mention `iproute2` alongside `lsof`
- Add 13 unit tests covering `parseSsOutput()`: IPv4/IPv6, multiple listeners, missing process info, port substring safety, special characters, non-LISTEN state filtering

Closes #14083

## Test plan

- [x] `parseSsOutput` correctly parses IPv4 listener lines with pid and command
- [x] `parseSsOutput` correctly parses IPv6 (`[::]`) listener lines
- [x] `parseSsOutput` handles both IPv4 and IPv6 listeners in the same output
- [x] `parseSsOutput` filters out lines for non-matching ports
- [x] `parseSsOutput` handles missing process info (no permissions)
- [x] `parseSsOutput` handles `127.0.0.1` local addresses
- [x] `parseSsOutput` returns empty array for empty output
- [x] `parseSsOutput` returns empty array when no matching port exists
- [x] `parseSsOutput` returns empty array for header-only output
- [x] `parseSsOutput` does not match port as substring (`:80` vs `:8080`)
- [x] `parseSsOutput` handles multiple processes on the same port
- [x] `parseSsOutput` handles process names with special characters
- [x] `parseSsOutput` ignores non-LISTEN state lines (ESTAB, TIME-WAIT)
- [x] Existing `inspectPortUsage` test continues to pass
- [ ] Manual: verify on a Linux container without `lsof` that `ss` fallback provides process details

## AI Disclosure

This pull request was authored with the assistance of Sylphx AI.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `ss` (iproute2) fallback for port diagnostics on Linux when `lsof` is missing, improving diagnostics on minimal containers and cloud VMs.

- Implemented `parseSsOutput()` to parse `ss -tlnp` output with comprehensive test coverage (13 unit tests)
- Added `readSsListeners()` to invoke `ss` with port filtering
- Modified `readUnixListeners()` to fall back to `ss` on Linux when `lsof` fails
- Extracted `enrichListenersWithProcessInfo()` to deduplicate process enrichment logic between `lsof` and `ss` code paths
- Updated user-facing hint to mention iproute2 alongside lsof

The implementation correctly filters for LISTEN state lines, handles both IPv4/IPv6 addresses, parses process info from the `ss` output format, and validates port matches against the local address column to avoid false positives.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with 13 comprehensive unit tests covering edge cases (IPv4/IPv6, missing permissions, port substring matching, special characters, state filtering). The implementation follows defensive programming practices with proper validation, extracts shared logic to avoid duplication, and only activates the `ss` fallback on Linux when `lsof` fails. The existing test suite continues to pass, and the changes are isolated to the port inspection module.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->