### PR TITLE
fix(providers): map developer role to system for Dashscope API compatibility

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -16,6 +16,20 @@ const baseModel = (): Model<Api> =>
     maxTokens: 1024,
   }) as Model<Api>;
 
+const dashscopeModel = (): Model<Api> =>
+  ({
+    id: "qwen3-coder-flash",
+    name: "Qwen3 Coder Flash",
+    api: "openai-completions",
+    provider: "dashscope",
+    baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 131072,
+    maxTokens: 8192,
+  }) as Model<Api>;
+
 describe("normalizeModelCompat", () => {
   it("forces supportsDeveloperRole off for z.ai models", () => {
     const model = baseModel();
@@ -40,5 +54,47 @@ describe("normalizeModelCompat", () => {
     model.compat = { supportsDeveloperRole: false };
     const normalized = normalizeModelCompat(model);
     expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for Dashscope models", () => {
+    const model = dashscopeModel();
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("sets thinkingFormat to qwen for Dashscope models", () => {
+    const model = dashscopeModel();
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.thinkingFormat).toBe("qwen");
+  });
+
+  it("handles Dashscope international endpoint", () => {
+    const model = {
+      ...dashscopeModel(),
+      baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+    expect(normalized.compat?.thinkingFormat).toBe("qwen");
+  });
+
+  it("preserves existing Dashscope compat fields", () => {
+    const model = dashscopeModel();
+    model.compat = { supportsStore: false };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+    expect(normalized.compat?.thinkingFormat).toBe("qwen");
+    expect(normalized.compat?.supportsStore).toBe(false);
+  });
+
+  it("does not override already-correct Dashscope compat", () => {
+    const model = dashscopeModel();
+    model.compat = { supportsDeveloperRole: false, thinkingFormat: "qwen" };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+    expect(normalized.compat?.thinkingFormat).toBe("qwen");
   });
 });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -4,21 +4,54 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
   return model.api === "openai-completions";
 }
 
+/**
+ * Detect whether a model targets the Dashscope API (Alibaba Cloud).
+ *
+ * Dashscope serves Qwen models via an OpenAI-compatible endpoint but rejects
+ * the "developer" role — only "system", "assistant", "user", "tool", and
+ * "function" are accepted.  It also uses `enable_thinking` instead of
+ * `reasoning_effort` for reasoning models.
+ */
+function isDashscope(model: Model<Api>): boolean {
+  const baseUrl = model.baseUrl ?? "";
+  return (
+    baseUrl.includes("dashscope.aliyuncs.com") || baseUrl.includes("dashscope-intl.aliyuncs.com")
+  );
+}
+
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
+  if (!isOpenAiCompletionsModel(model)) {
+    return model;
+  }
+
   const baseUrl = model.baseUrl ?? "";
   const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+
+  if (isZai) {
+    const compat = model.compat ?? undefined;
+    if (compat?.supportsDeveloperRole === false) {
+      return model;
+    }
+    model.compat = compat
+      ? { ...compat, supportsDeveloperRole: false }
+      : { supportsDeveloperRole: false };
     return model;
   }
 
-  const openaiModel = model;
-  const compat = openaiModel.compat ?? undefined;
-  if (compat?.supportsDeveloperRole === false) {
+  if (isDashscope(model)) {
+    const compat = model.compat ?? undefined;
+    const needsDeveloperFix = compat?.supportsDeveloperRole !== false;
+    const needsThinkingFix = compat?.thinkingFormat !== "qwen";
+    if (!needsDeveloperFix && !needsThinkingFix) {
+      return model;
+    }
+    model.compat = {
+      ...compat,
+      supportsDeveloperRole: false,
+      thinkingFormat: "qwen",
+    };
     return model;
   }
 
-  openaiModel.compat = compat
-    ? { ...compat, supportsDeveloperRole: false }
-    : { supportsDeveloperRole: false };
-  return openaiModel;
+  return model;
 }

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -11,6 +11,7 @@ export type ModelCompatConfig = {
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
+  thinkingFormat?: string;
 };
 
 export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -18,6 +18,7 @@ export const ModelCompatSchema = z
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),
+    thinkingFormat: z.string().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Dashscope API (Alibaba Cloud) rejects the `developer` role, causing all requests to Qwen reasoning models (e.g. `qwen3-coder-flash`) to fail with: `"developer is not one of ['system', 'assistant', 'user', 'tool', 'function']"`
- Extends `normalizeModelCompat` to detect Dashscope base URLs (`dashscope.aliyuncs.com` and `dashscope-intl.aliyuncs.com`) and set `supportsDeveloperRole: false` (maps `developer` to `system`) and `thinkingFormat: "qwen"` (uses `enable_thinking` instead of `reasoning_effort`)
- Follows the same pattern already established for Z.ai provider compatibility

Closes #14040

## AI Disclosure

This PR was authored with the assistance of Sylphx AI.

## Test plan

- [x] Existing Z.ai compat tests still pass (no regression)
- [x] New test: forces `supportsDeveloperRole` off for Dashscope models
- [x] New test: sets `thinkingFormat` to `"qwen"` for Dashscope models
- [x] New test: handles Dashscope international endpoint (`dashscope-intl.aliyuncs.com`)
- [x] New test: preserves existing compat fields when adding Dashscope overrides
- [x] New test: skips mutation when compat is already correct
- [ ] Manual: configure a Dashscope provider with `qwen3-coder-flash` (reasoning model) and verify requests no longer fail with role validation error

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends `normalizeModelCompat` to apply provider-specific compatibility overrides for Dashscope (Alibaba Cloud) OpenAI-compatible endpoints, mapping `developer` role support off and selecting a Qwen-specific thinking format. It also adds unit tests covering the Dashscope base and intl endpoints, preservation of existing compat fields, and idempotent normalization.

Main issue to address before merge: the new `compat.thinkingFormat` field is introduced in normalization/tests but is not present in the repo’s `ModelCompatConfig` type or the strict Zod schema for `compat`, creating an inconsistent/invalid config contract for this field.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but introduces a config/schema contract mismatch for a new compat field.
- Logic for Dashscope detection and compat normalization is straightforward and test-covered, but `compat.thinkingFormat` is not defined in the repo’s ModelCompat types or strict Zod schema, which can break config validation or make the field impossible to configure consistently.
- src/config/types.models.ts, src/config/zod-schema.core.ts (add/align compat.thinkingFormat)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->