### PR TITLE
Sanitize JSON tool-call payload text

### DIFF
--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -12,13 +12,25 @@ import {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
+<<<<<<< HEAD
 import type {
   EmbeddedPiSubscribeContext,
   EmbeddedPiSubscribeState,
 } from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
-import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
+import {
+  formatReasoningMessage,
+  stripDowngradedToolCallText,
+  stripJsonToolCallText,
+} from "./pi-embedded-utils.js";
+=======
+import {
+  formatReasoningMessage,
+  stripDowngradedToolCallText,
+  stripJsonToolCallText,
+} from "./pi-embedded-utils.js";
+>>>>>>> 58b9a7c8a (fix: strip JSON tool-call text from assistant replies)
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
@@ -477,7 +489,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
-    const chunk = stripDowngradedToolCallText(stripBlockTags(text, state.blockState)).trimEnd();
+    const chunk = stripDowngradedToolCallText(
+      stripJsonToolCallText(stripBlockTags(text, state.blockState)),
+    ).trimEnd();
     if (!chunk) {
       return;
     }

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -28,6 +28,7 @@ import { extractTextFromChatContent } from "../../shared/chat-content.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
+  stripJsonToolCallText,
   stripMinimaxToolCallXml,
   stripThinkingTagsFromText,
 } from "../pi-embedded-utils.js";
@@ -139,7 +140,9 @@ export function sanitizeTextContent(text: string): string {
   if (!text) {
     return text;
   }
-  return stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text)));
+  return stripThinkingTagsFromText(
+    stripDowngradedToolCallText(stripJsonToolCallText(stripMinimaxToolCallXml(text))),
+  );
 }
 
 export function extractAssistantText(message: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- add stripJsonToolCallText helper to remove raw tool-call JSON payloads before they reach user surfaces
- call the helper from extractAssistantText, sanitizeTextContent, and the streaming pipeline so Ollama/local providers can no longer leak  blobs when tool downgrades happen
- add regression tests covering the helper and ensuring extractAssistantText drops JSON payloads but retains normal JSON blobs

## Testing
- corepack pnpm vitest run src/agents/pi-embedded-utils.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds defense against raw JSON tool-call payload leakage in text content. When local/Ollama providers downgrade tool calls to text (due to incompatibility or errors), the raw JSON can leak into user-facing surfaces. This PR introduces `stripJsonToolCallText()` helper that detects and removes JSON objects/arrays matching tool-call structure (having `name` + one of: `arguments`, `args`, `input`, `tool_input`, `parameters`, `payload`). The helper is integrated into the streaming pipeline (`pi-embedded-subscribe.ts`), text extraction (`extractAssistantText`), and message sanitization (`sanitizeTextContent`). Test coverage includes both removal of tool payloads and preservation of legitimate JSON blobs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is defensive and well-tested. The helper function includes both strict JSON parsing validation and a fallback regex pattern. All integration points (streaming, extraction, sanitization) are covered. Test cases verify both positive (removing tool payloads) and negative (preserving legitimate JSON) scenarios. The change only affects text sanitization paths and cannot break tool call functionality.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->