### PR TITLE
fix(linux): add gio and trash-put fallbacks for moveToTrash

### DIFF
--- a/src/browser/trash.ts
+++ b/src/browser/trash.ts
@@ -4,18 +4,28 @@ import path from "node:path";
 import { runExec } from "../process/exec.js";
 
 export async function movePathToTrash(targetPath: string): Promise<string> {
-  try {
-    await runExec("trash", [targetPath], { timeoutMs: 10_000 });
-    return targetPath;
-  } catch {
-    const trashDir = path.join(os.homedir(), ".Trash");
-    fs.mkdirSync(trashDir, { recursive: true });
-    const base = path.basename(targetPath);
-    let dest = path.join(trashDir, `${base}-${Date.now()}`);
-    if (fs.existsSync(dest)) {
-      dest = path.join(trashDir, `${base}-${Date.now()}-${Math.random()}`);
+  // Try multiple trash commands — trash-cli may not be installed on minimal Linux.
+  const commands: [string, string[]][] = [
+    ["trash", [targetPath]],
+    ["gio", ["trash", targetPath]],
+    ["trash-put", [targetPath]],
+  ];
+  for (const [cmd, args] of commands) {
+    try {
+      await runExec(cmd, args, { timeoutMs: 10_000 });
+      return targetPath;
+    } catch {
+      // Try next command.
     }
-    fs.renameSync(targetPath, dest);
-    return dest;
   }
+  // Last resort: move to ~/.Trash manually.
+  const trashDir = path.join(os.homedir(), ".Trash");
+  fs.mkdirSync(trashDir, { recursive: true });
+  const base = path.basename(targetPath);
+  let dest = path.join(trashDir, `${base}-${Date.now()}`);
+  if (fs.existsSync(dest)) {
+    dest = path.join(trashDir, `${base}-${Date.now()}-${Math.random()}`);
+  }
+  fs.renameSync(targetPath, dest);
+  return dest;
 }


### PR DESCRIPTION
#### Summary

On minimal Linux installs, `trash-cli` is often not installed, causing `moveToTrash()` to silently fail. This leaves files in place with only a log message during `openclaw reset` and agent deletion.

Fixes #14081

#### Root Cause

Both trash implementations only try the `trash` command. If it fails:
- `onboard-helpers.ts:moveToTrash` — logs failure and continues (files left in place)
- `browser/trash.ts:movePathToTrash` — falls back to `~/.Trash` rename (better, but still only tries `trash`)

However, `gio trash` (from GLib, available on most desktop Linux) and `trash-put` (alternative trash-cli name) are commonly available alternatives.

#### Changes

**`src/commands/onboard-helpers.ts`**
- `moveToTrash()` now tries three commands in order: `trash` → `gio trash` → `trash-put`
- Returns on first success; only logs failure if all three fail

**`src/browser/trash.ts`**
- `movePathToTrash()` now tries the same three commands before falling back to `~/.Trash` rename

#### Tests

5 new tests in `onboard-helpers.test.ts`:

```
✓ src/commands/onboard-helpers.test.ts (14 tests) 10ms
```

- First command succeeds
- Fallback to `gio trash`
- Fallback to `trash-put`
- All commands fail → logs failure
- Skips non-existent paths

lobster-biscuit

**Sign-Off**

- Models used: Claude Opus 4
- Submitter effort: AI-assisted, verified both trash code paths
- Agent notes: Simple but impactful — fixes silent failures on minimal Linux installs

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added fallback support for `gio trash` and `trash-put` commands when `trash` is unavailable on minimal Linux installations.

- Both `moveToTrash()` and `movePathToTrash()` now try three commands sequentially: `trash` → `gio trash` → `trash-put`
- Prevents silent failures during `openclaw reset` and agent deletion when trash-cli is not installed
- Comprehensive test coverage with 5 new tests covering all fallback scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-implemented with proper fallback logic, comprehensive test coverage (5 new tests covering all code paths), and follow existing code patterns. The implementation is defensive, maintains backward compatibility, and solves a real issue on minimal Linux installations without introducing side effects
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->