### PR TITLE
fix(linux): add Flatpak browser detection paths

### DIFF
--- a/src/browser/chrome.executables.ts
+++ b/src/browser/chrome.executables.ts
@@ -312,6 +312,19 @@ function findDesktopFilePath(desktopId: string): string | null {
     path.join("/usr/local/share/applications", desktopId),
     path.join("/usr/share/applications", desktopId),
     path.join("/var/lib/snapd/desktop/applications", desktopId),
+    // Flatpak (system-wide)
+    path.join("/var/lib/flatpak/exports/share/applications", desktopId),
+    // Flatpak (user-local)
+    path.join(
+      os.homedir(),
+      ".local",
+      "share",
+      "flatpak",
+      "exports",
+      "share",
+      "applications",
+      desktopId,
+    ),
   ];
   for (const candidate of candidates) {
     if (exists(candidate)) {
@@ -507,6 +520,8 @@ export function findChromeExecutableMac(): BrowserExecutable | null {
 }
 
 export function findChromeExecutableLinux(): BrowserExecutable | null {
+  const home = os.homedir();
+
   const candidates: Array<BrowserExecutable> = [
     { kind: "chrome", path: "/usr/bin/google-chrome" },
     { kind: "chrome", path: "/usr/bin/google-chrome-stable" },
@@ -520,6 +535,34 @@ export function findChromeExecutableLinux(): BrowserExecutable | null {
     { kind: "chromium", path: "/usr/bin/chromium" },
     { kind: "chromium", path: "/usr/bin/chromium-browser" },
     { kind: "chromium", path: "/snap/bin/chromium" },
+
+    // Flatpak (system-wide)
+    { kind: "chrome", path: "/var/lib/flatpak/exports/bin/com.google.Chrome" },
+    { kind: "brave", path: "/var/lib/flatpak/exports/bin/com.brave.Browser" },
+    { kind: "chromium", path: "/var/lib/flatpak/exports/bin/org.chromium.Chromium" },
+    { kind: "edge", path: "/var/lib/flatpak/exports/bin/com.microsoft.Edge" },
+
+    // Flatpak (user-local)
+    {
+      kind: "chrome",
+      path: path.join(home, ".local", "share", "flatpak", "exports", "bin", "com.google.Chrome"),
+    },
+    {
+      kind: "brave",
+      path: path.join(home, ".local", "share", "flatpak", "exports", "bin", "com.brave.Browser"),
+    },
+    {
+      kind: "chromium",
+      path: path.join(
+        home,
+        ".local",
+        "share",
+        "flatpak",
+        "exports",
+        "bin",
+        "org.chromium.Chromium",
+      ),
+    },
   ];
 
   return findFirstExecutable(candidates);

--- a/src/browser/chrome.executables.ts
+++ b/src/browser/chrome.executables.ts
@@ -45,7 +45,11 @@ const CHROMIUM_DESKTOP_IDS = new Set([
   "opera.desktop",
   "opera-gx.desktop",
   "yandex-browser.desktop",
+  // Flatpak reverse-DNS desktop file IDs
+  "com.google.Chrome.desktop",
+  "com.brave.Browser.desktop",
   "org.chromium.Chromium.desktop",
+  "com.microsoft.Edge.desktop",
 ]);
 
 const CHROMIUM_EXE_NAMES = new Set([


### PR DESCRIPTION
## Summary

Adds Flatpak-installed browser detection for Linux systems. Flatpak is increasingly the default packaging format on Fedora, Ubuntu, and other major distributions, but `findChromeExecutableLinux()` and `findDesktopFilePath()` had no awareness of Flatpak paths, causing browser launch failures for users who install Chrome, Brave, Chromium, or Edge via Flatpak.

### Changes

**`findChromeExecutableLinux()`** -- added executable paths for:

- System-wide Flatpak (`/var/lib/flatpak/exports/bin/`):
  - `com.google.Chrome`
  - `com.brave.Browser`
  - `org.chromium.Chromium`
  - `com.microsoft.Edge`
- User-local Flatpak (`~/.local/share/flatpak/exports/bin/`):
  - `com.google.Chrome`
  - `com.brave.Browser`
  - `org.chromium.Chromium`

**`findDesktopFilePath()`** -- added desktop file directories for:

- `/var/lib/flatpak/exports/share/applications/`
- `~/.local/share/flatpak/exports/share/applications/`

This enables default-browser detection via `xdg-settings`/`xdg-mime` to correctly resolve Flatpak `.desktop` files.

### Design notes

- Flatpak paths are appended after existing candidates so native/Snap installs remain preferred when both exist
- User-local paths use `os.homedir()` to correctly resolve `~` at runtime
- No new dependencies introduced

Closes #14082

## Test plan

- [x] Existing browser detection tests pass (16/16)
- [ ] Verify on a Flatpak-based Linux system (Fedora Silverblue / Ubuntu with Flatpak Chrome) that openclaw auto-detects the browser
- [ ] Verify that systems without Flatpak are unaffected (paths simply don't exist, `findFirstExecutable` skips them)

## AI Disclosure

This contribution was authored with assistance from Sylphx AI.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added Flatpak browser detection paths for Linux to fix browser launch failures when browsers are installed via Flatpak. The PR correctly appends Flatpak paths after native/Snap paths to preserve existing install preferences.

**Critical issue found:**
- Missing Flatpak desktop IDs in `CHROMIUM_DESKTOP_IDS` set will prevent default browser detection via `xdg-settings`/`xdg-mime` from working for Flatpak installations

**What works:**
- Direct executable detection via `findChromeExecutableLinux()` will work as a fallback
- Path ordering is correct (native → Snap → Flatpak)
- Both system-wide and user-local Flatpak paths are covered
- Uses `os.homedir()` correctly for user paths

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logical error that prevents the main feature (default browser detection) from working for Flatpak installations
- The implementation is incomplete - while Flatpak paths are added to search locations, the missing desktop IDs in `CHROMIUM_DESKTOP_IDS` means default browser detection will fail for Flatpak browsers. Only the fallback path works, which doesn't fully solve the stated problem.
- src/browser/chrome.executables.ts requires the `CHROMIUM_DESKTOP_IDS` constant to be updated with Flatpak desktop file IDs

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->