### PR TITLE
fix(agents): stabilize overflow compaction retries and session context accounting

### DIFF
--- a/src/agents/pi-embedded-helpers.iscompactionfailureerror.test.ts
+++ b/src/agents/pi-embedded-helpers.iscompactionfailureerror.test.ts
@@ -6,6 +6,7 @@ describe("isCompactionFailureError", () => {
       'Context overflow: Summarization failed: 400 {"message":"prompt is too long"}',
       "auto-compaction failed due to context overflow",
       "Compaction failed: prompt is too long",
+      "Summarization failed: context window exceeded for this request",
     ];
     for (const sample of samples) {
       expect(isCompactionFailureError(sample)).toBe(true);

--- a/src/agents/pi-embedded-helpers.islikelycontextoverflowerror.test.ts
+++ b/src/agents/pi-embedded-helpers.islikelycontextoverflowerror.test.ts
@@ -30,6 +30,8 @@ describe("isLikelyContextOverflowError", () => {
       "too many requests",
       "429 Too Many Requests",
       "exceeded your current quota",
+      "This request would exceed your account's rate limit",
+      "429 Too Many Requests: request exceeds rate limit",
     ];
     for (const sample of samples) {
       expect(isLikelyContextOverflowError(sample)).toBe(false);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -72,9 +72,13 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
   if (!hasCompactionTerm) {
     return false;
   }
-  // For compaction failures, also accept "context overflow" without colon
-  // since the error message itself describes a compaction/summarization failure
-  return isContextOverflowError(errorMessage) || lower.includes("context overflow");
+  // Treat any likely overflow shape as a compaction failure when compaction terms are present.
+  // Providers often vary wording (e.g. "context window exceeded") across APIs.
+  if (isLikelyContextOverflowError(errorMessage)) {
+    return true;
+  }
+  // Keep explicit fallback for bare "context overflow" strings.
+  return lower.includes("context overflow");
 }
 
 const ERROR_PAYLOAD_PREFIX_RE =

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -38,7 +38,9 @@ export function isContextOverflowError(errorMessage?: string): boolean {
 
 const CONTEXT_WINDOW_TOO_SMALL_RE = /context window.*(too small|minimum is)/i;
 const CONTEXT_OVERFLOW_HINT_RE =
-  /context.*overflow|context window.*(too (?:large|long)|exceed|over|limit|max(?:imum)?|requested|sent|tokens)|(?:prompt|request|input).*(too (?:large|long)|exceed|over|limit|max(?:imum)?)/i;
+  /context.*overflow|context window.*(too (?:large|long)|exceed|over|limit|max(?:imum)?|requested|sent|tokens)|prompt.*(too (?:large|long)|exceed|over|limit|max(?:imum)?)|(?:request|input).*(?:context|window|length|token).*(too (?:large|long)|exceed|over|limit|max(?:imum)?)/i;
+const RATE_LIMIT_HINT_RE =
+  /rate limit|too many requests|requests per (?:minute|hour|day)|quota|throttl|429\b/i;
 
 export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
@@ -55,6 +57,9 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   }
   if (isContextOverflowError(errorMessage)) {
     return true;
+  }
+  if (RATE_LIMIT_HINT_RE.test(errorMessage)) {
+    return false;
   }
   return CONTEXT_OVERFLOW_HINT_RE.test(errorMessage);
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -34,7 +34,7 @@ import {
   isAuthAssistantError,
   isBillingAssistantError,
   isCompactionFailureError,
-  isContextOverflowError,
+  isLikelyContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
   parseImageSizeError,
@@ -44,7 +44,7 @@ import {
   pickFallbackThinkingLevel,
   type FailoverReason,
 } from "../pi-embedded-helpers.js";
-import { normalizeUsage, type UsageLike } from "../usage.js";
+import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { compactEmbeddedPiSessionDirect } from "./compact.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
@@ -408,6 +408,7 @@ export async function runEmbeddedPiAgent(
       let overflowCompactionAttempts = 0;
       let toolResultTruncationAttempted = false;
       const usageAccumulator = createUsageAccumulator();
+      let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
       try {
         while (true) {
@@ -475,10 +476,12 @@ export async function runEmbeddedPiAgent(
           });
 
           const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;
-          mergeUsageIntoAccumulator(
-            usageAccumulator,
-            attempt.attemptUsage ?? normalizeUsage(lastAssistant?.usage as UsageLike),
-          );
+          const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+          const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
+          mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
+          // Keep prompt size from the latest model call so session totalTokens
+          // reflects current context usage, not accumulated tool-loop usage.
+          lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
           autoCompactionCount += Math.max(0, attempt.compactionCount ?? 0);
           const formattedAssistantErrorText = lastAssistant
             ? formatAssistantErrorText(lastAssistant, {
@@ -496,14 +499,14 @@ export async function runEmbeddedPiAgent(
             ? (() => {
                 if (promptError) {
                   const errorText = describeUnknownError(promptError);
-                  if (isContextOverflowError(errorText)) {
+                  if (isLikelyContextOverflowError(errorText)) {
                     return { text: errorText, source: "promptError" as const };
                   }
                   // Prompt submission failed with a non-overflow error. Do not
                   // inspect prior assistant errors from history for this attempt.
                   return null;
                 }
-                if (assistantErrorText && isContextOverflowError(assistantErrorText)) {
+                if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
                   return { text: assistantErrorText, source: "assistantError" as const };
                 }
                 return null;
@@ -826,12 +829,14 @@ export async function runEmbeddedPiAgent(
           // overstates the actual context size. `lastCallUsage` reflects only
           // the final call, giving an accurate snapshot of current context.
           const lastCallUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+          const promptTokens = derivePromptTokens(lastRunPromptUsage);
           const agentMeta: EmbeddedPiAgentMeta = {
             sessionId: sessionIdUsed,
             provider: lastAssistant?.provider ?? provider,
             model: lastAssistant?.model ?? model.id,
             usage,
             lastCallUsage: lastCallUsage ?? undefined,
+            promptTokens,
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
           };
 

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -6,6 +6,7 @@ export type EmbeddedPiAgentMeta = {
   provider: string;
   model: string;
   compactionCount?: number;
+  promptTokens?: number;
   usage?: {
     input?: number;
     output?: number;

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -74,4 +74,19 @@ describe("normalizeUsage", () => {
       }),
     ).toBe(1_550);
   });
+
+  it("prefers explicit prompt token overrides", () => {
+    expect(
+      deriveSessionTotalTokens({
+        usage: {
+          input: 1_200,
+          cacheRead: 300,
+          cacheWrite: 50,
+          total: 9_999,
+        },
+        promptTokens: 65_000,
+        contextTokens: 200_000,
+      }),
+    ).toBe(65_000);
+  });
 });

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -112,18 +112,24 @@ export function deriveSessionTotalTokens(params: {
     cacheWrite?: number;
   };
   contextTokens?: number;
+  promptTokens?: number;
 }): number | undefined {
+  const promptOverride = params.promptTokens;
+  const hasPromptOverride =
+    typeof promptOverride === "number" && Number.isFinite(promptOverride) && promptOverride > 0;
   const usage = params.usage;
-  if (!usage) {
+  if (!usage && !hasPromptOverride) {
     return undefined;
   }
-  const input = usage.input ?? 0;
-  const promptTokens = derivePromptTokens({
-    input: usage.input,
-    cacheRead: usage.cacheRead,
-    cacheWrite: usage.cacheWrite,
-  });
-  let total = promptTokens ?? usage.total ?? input;
+  const input = usage?.input ?? 0;
+  const promptTokens = hasPromptOverride
+    ? promptOverride
+    : derivePromptTokens({
+        input: usage?.input,
+        cacheRead: usage?.cacheRead,
+        cacheWrite: usage?.cacheWrite,
+      });
+  let total = promptTokens ?? usage?.total ?? input;
   if (!(total > 0)) {
     return undefined;
   }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -371,6 +371,7 @@ export async function runReplyAgent(params: {
     }
 
     const usage = runResult.meta.agentMeta?.usage;
+    const promptTokens = runResult.meta.agentMeta?.promptTokens;
     const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
     const providerUsed =
       runResult.meta.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
@@ -388,6 +389,7 @@ export async function runReplyAgent(params: {
       sessionKey,
       usage,
       lastCallUsage: runResult.meta.agentMeta?.lastCallUsage,
+      promptTokens,
       modelUsed,
       providerUsed,
       contextTokensUsed,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -194,6 +194,7 @@ export function createFollowupRunner(params: {
       }
 
       const usage = runResult.meta.agentMeta?.usage;
+      const promptTokens = runResult.meta.agentMeta?.promptTokens;
       const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const contextTokensUsed =
         agentCfgContextTokens ??
@@ -207,6 +208,7 @@ export function createFollowupRunner(params: {
           sessionKey,
           usage,
           lastCallUsage: runResult.meta.agentMeta?.lastCallUsage,
+          promptTokens,
           modelUsed,
           providerUsed: fallbackProvider,
           contextTokensUsed,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -25,6 +25,7 @@ export async function persistSessionUsageUpdate(params: {
   modelUsed?: string;
   providerUsed?: string;
   contextTokensUsed?: number;
+  promptTokens?: number;
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;
   logLabel?: string;
@@ -56,6 +57,7 @@ export async function persistSessionUsageUpdate(params: {
               deriveSessionTotalTokens({
                 usage: usageForContext,
                 contextTokens: resolvedContextTokens,
+                promptTokens: params.promptTokens,
               }) ?? input,
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -37,6 +37,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   } = params;
 
   const usage = result.meta.agentMeta?.usage;
+  const promptTokens = result.meta.agentMeta?.promptTokens;
   const compactionsThisRun = Math.max(0, result.meta.agentMeta?.compactionCount ?? 0);
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
@@ -71,6 +72,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
       deriveSessionTotalTokens({
         usage,
         contextTokens,
+        promptTokens,
       }) ?? input;
   }
   if (compactionsThisRun > 0) {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -456,6 +456,7 @@ export async function runCronIsolatedAgentTurn(params: {
   // Update token+model fields in the session store.
   {
     const usage = runResult.meta.agentMeta?.usage;
+    const promptTokens = runResult.meta.agentMeta?.promptTokens;
     const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = runResult.meta.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
@@ -479,6 +480,7 @@ export async function runCronIsolatedAgentTurn(params: {
         deriveSessionTotalTokens({
           usage,
           contextTokens,
+          promptTokens,
         }) ?? input;
     }
     await persistSessionEntry();


### PR DESCRIPTION
## Summary

This PR fixes two related compaction/context-accounting issues observed in embedded Pi runs:

1. `totalTokens` persisted in session store could inflate to `contextTokens` (e.g. `200k/200k`) after tool-heavy turns because prompt-size accounting used accumulated usage across the turn.
2. Some real overflow errors were missed by auto-compaction retry because the run loop only matched strict `isContextOverflowError(...)` wording.

## Root Causes

- Session accounting used aggregated per-turn usage in `deriveSessionTotalTokens(...)`, which overstates current context size when multiple model calls happen in one run.
- Overflow handling in `run.ts` matched only strict overflow signatures, while providers can return variants like `context window exceeded`.

## Changes

- Track prompt-size for session context using the latest model call usage and persist it as `agentMeta.promptTokens`.
- Thread `promptTokens` through session-store persistence paths and let `deriveSessionTotalTokens(...)` prefer an explicit prompt-token override.
- Keep accumulated usage for overall run usage/cost metadata while using latest-call prompt size for context-window display/thresholding.
- Use `isLikelyContextOverflowError(...)` in overflow retry detection in the run loop.
- Harden `isCompactionFailureError(...)` to treat likely overflow variants as compaction failures when compaction terms are present.

## Tests

- Added/updated targeted coverage for:
  - likely-overflow promptError retry path,
  - `isCompactionFailureError` overflow variant handling,
  - prompt-token override behavior in `deriveSessionTotalTokens`,
  - `promptTokens` derived from latest model call usage rather than accumulated attempt usage.

Ran:

- `pnpm vitest run src/agents/usage.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts src/agents/pi-embedded-helpers.iscompactionfailureerror.test.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/agent-runner.response-usage-footer.test.ts src/auto-reply/reply/agent-runner.messaging-tools.test.ts`
- `pnpm lint -- src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers.iscompactionfailureerror.test.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/agents/pi-embedded-runner/types.ts src/agents/usage.ts src/agents/usage.test.ts src/auto-reply/reply/session-usage.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/followup-runner.ts src/commands/agent/session-store.ts src/cron/isolated-agent/run.ts`

## Related

- #13782
- #13698
- #13853

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes two related issues in embedded Pi agent context accounting and overflow detection that were causing incorrect session token counts and missed overflow retries:

**Context accounting fix:** The session store was inflating `totalTokens` to match `contextTokens` (e.g., 200k/200k) after tool-heavy turns because `deriveSessionTotalTokens` used accumulated usage across multiple model calls in a turn. The fix tracks the latest model call's prompt size separately as `agentMeta.promptTokens` and threads it through the persistence paths. This ensures session context displays current prompt size rather than accumulated tool-loop usage, while preserving total usage for cost metadata.

**Overflow detection fix:** The auto-compaction retry logic only matched strict `isContextOverflowError(...)` patterns, missing provider variants like "context window exceeded". The fix switches to `isLikelyContextOverflowError(...)` in the run loop retry detection and hardens `isCompactionFailureError(...)` to treat likely-overflow variants as compaction failures when compaction terms are present.

Both changes are well-tested with targeted unit tests covering the new behaviors and edge cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated to context accounting and overflow detection logic, with comprehensive test coverage validating the new behavior. The fixes address real production issues observed in Pi runs without modifying core run loop logic. All changes maintain backward compatibility by making `promptTokens` optional and preserving existing usage accumulation for cost tracking.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->