### PR TITLE
fix(providers): fall back to reasoning_content when content is empty

### DIFF
--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -231,7 +231,7 @@ export function extractAssistantText(msg: AssistantMessage): string {
       (block) =>
         block != null &&
         typeof block === "object" &&
-        (block as Record<string, unknown>).type === "toolCall",
+        (block as unknown as Record<string, unknown>).type === "toolCall",
     );
     if (!hasToolCalls) {
       const thinkingText = msg.content
@@ -239,8 +239,8 @@ export function extractAssistantText(msg: AssistantMessage): string {
           (block): block is { type: "thinking"; thinking: string } =>
             block != null &&
             typeof block === "object" &&
-            (block as Record<string, unknown>).type === "thinking" &&
-            typeof (block as Record<string, unknown>).thinking === "string",
+            (block as unknown as Record<string, unknown>).type === "thinking" &&
+            typeof (block as unknown as Record<string, unknown>).thinking === "string",
         )
         .map((block) => block.thinking.trim())
         .filter(Boolean)

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -369,7 +369,7 @@ describe("image tool response validation", () => {
               total: 0,
             },
           },
-          content: [{ type: "thinking", thinking: "hmm" }],
+          content: [],
         },
       }),
     ).toThrow(/returned no text/i);

--- a/src/browser/chrome.executables.ts
+++ b/src/browser/chrome.executables.ts
@@ -312,6 +312,19 @@ function findDesktopFilePath(desktopId: string): string | null {
     path.join("/usr/local/share/applications", desktopId),
     path.join("/usr/share/applications", desktopId),
     path.join("/var/lib/snapd/desktop/applications", desktopId),
+    // Flatpak (system-wide)
+    path.join("/var/lib/flatpak/exports/share/applications", desktopId),
+    // Flatpak (user-local)
+    path.join(
+      os.homedir(),
+      ".local",
+      "share",
+      "flatpak",
+      "exports",
+      "share",
+      "applications",
+      desktopId,
+    ),
   ];
   for (const candidate of candidates) {
     if (exists(candidate)) {
@@ -507,6 +520,8 @@ export function findChromeExecutableMac(): BrowserExecutable | null {
 }
 
 export function findChromeExecutableLinux(): BrowserExecutable | null {
+  const home = os.homedir();
+
   const candidates: Array<BrowserExecutable> = [
     { kind: "chrome", path: "/usr/bin/google-chrome" },
     { kind: "chrome", path: "/usr/bin/google-chrome-stable" },
@@ -520,6 +535,34 @@ export function findChromeExecutableLinux(): BrowserExecutable | null {
     { kind: "chromium", path: "/usr/bin/chromium" },
     { kind: "chromium", path: "/usr/bin/chromium-browser" },
     { kind: "chromium", path: "/snap/bin/chromium" },
+
+    // Flatpak (system-wide)
+    { kind: "chrome", path: "/var/lib/flatpak/exports/bin/com.google.Chrome" },
+    { kind: "brave", path: "/var/lib/flatpak/exports/bin/com.brave.Browser" },
+    { kind: "chromium", path: "/var/lib/flatpak/exports/bin/org.chromium.Chromium" },
+    { kind: "edge", path: "/var/lib/flatpak/exports/bin/com.microsoft.Edge" },
+
+    // Flatpak (user-local)
+    {
+      kind: "chrome",
+      path: path.join(home, ".local", "share", "flatpak", "exports", "bin", "com.google.Chrome"),
+    },
+    {
+      kind: "brave",
+      path: path.join(home, ".local", "share", "flatpak", "exports", "bin", "com.brave.Browser"),
+    },
+    {
+      kind: "chromium",
+      path: path.join(
+        home,
+        ".local",
+        "share",
+        "flatpak",
+        "exports",
+        "bin",
+        "org.chromium.Chromium",
+      ),
+    },
   ];
 
   return findFirstExecutable(candidates);


### PR DESCRIPTION
## Summary

- When some OpenAI-compatible providers (e.g. Poe's `gemini-3-flash`) return the model's actual answer in `reasoning_content` instead of `content`, OpenClaw's `extractAssistantText` now falls back to thinking block content instead of returning an empty string
- The fallback is defensive: it only activates when there are **no text blocks** and **no tool calls** in the assistant message, avoiding interference with genuine reasoning content during tool-use flows
- Adds 5 new unit tests covering the fallback behavior, including edge cases (tool calls present, mixed content, empty thinking blocks)

## Technical Details

The OpenAI Chat Completions streaming layer (`openai-completions.js` in pi-ai) maps `choice.delta.reasoning_content` to `thinking` blocks. When a provider like Poe puts the actual answer there instead of in `choice.delta.content`, the response arrives as only thinking blocks with no text blocks. `extractAssistantText` previously only extracted `type: "text"` blocks, resulting in "no response."

The fix adds a fallback path in `extractAssistantText` (`src/agents/pi-embedded-utils.ts`) that promotes thinking content to assistant text when no text blocks or tool calls exist.

## Test Plan

- [x] `extractAssistantText` falls back to thinking content when no text blocks exist
- [x] Does not fall back when text blocks have content (normal reasoning models)
- [x] Does not fall back when tool calls are present (genuine reasoning during tool use)
- [x] Falls back to multiple thinking blocks joined with newlines
- [x] Does not fall back to whitespace-only thinking blocks
- [x] All 48 `pi-embedded-utils` tests pass
- [x] All 67 `pi-embedded-subscribe` tests pass

## AI Disclosure

This PR was authored with assistance from Sylphx AI.

Closes #14071

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a defensive fallback in `extractAssistantText` to handle OpenAI-compatible providers (like Poe's `gemini-3-flash`) that incorrectly return the assistant's actual response in `reasoning_content` instead of `content`. The fallback promotes thinking blocks to assistant text only when no text blocks and no tool calls exist, preventing empty responses. The implementation is well-tested with 5 new unit tests covering the fallback behavior and edge cases.

Key changes:
- Added fallback logic in `extractAssistantText` (src/agents/pi-embedded-utils.ts:225-253) that extracts thinking content when no text blocks or tool calls exist
- Added comprehensive test coverage for the fallback behavior including edge cases
- Included unrelated Flatpak browser detection paths in `chrome.executables.ts` (from commit 1a28307)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, defensive, and well-tested. The fallback logic only activates in a narrow scenario (no text blocks AND no tool calls), preventing interference with normal reasoning model behavior. The 5 new tests provide excellent coverage of edge cases. The Flatpak browser detection changes follow existing patterns and are additive-only.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->