### PR TITLE
fix(model): hardcoded fallback for claude-opus-4-6 when no template exists

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -26,7 +26,7 @@ import { discoverVeniceModels, VENICE_BASE_URL } from "./venice-models.js";
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
-const MINIMAX_API_BASE_URL = "https://api.minimax.chat/v1";
+const MINIMAX_API_BASE_URL = "https://api.minimaxi.chat/v1";
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
 const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.1";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -167,7 +167,7 @@ describe("models-config", () => {
             }
           >;
         };
-        expect(parsed.providers.minimax?.baseUrl).toBe("https://api.minimax.chat/v1");
+        expect(parsed.providers.minimax?.baseUrl).toBe("https://api.minimaxi.chat/v1");
         expect(parsed.providers.minimax?.apiKey).toBe("MINIMAX_API_KEY");
         const ids = parsed.providers.minimax?.models?.map((model) => model.id);
         expect(ids).toContain("MiniMax-M2.1");

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -207,6 +207,25 @@ describe("resolveModel", () => {
     });
   });
 
+  it("builds a hardcoded anthropic fallback for claude-opus-4-6 when no template exists", () => {
+    // When the pi-ai registry has no claude-opus-4-5 template at all,
+    // the fallback should still produce a valid model definition.
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn(() => null),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("anthropic", "claude-opus-4-6", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "anthropic",
+      id: "claude-opus-4-6",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: true,
+    });
+  });
+
   it("keeps unknown-model errors for non-gpt-5 openai-codex ids", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -111,7 +111,19 @@ function resolveAnthropicOpus46ForwardCompatModel(
     } as Model<Api>);
   }
 
-  return undefined;
+  // Hardcoded fallback when no template model exists in the registry (mirrors Codex fallback).
+  return normalizeModelCompat({
+    id: trimmedModelId,
+    name: trimmedModelId,
+    api: "anthropic-messages",
+    provider: normalizedProvider,
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    contextWindow: DEFAULT_CONTEXT_TOKENS,
+    maxTokens: DEFAULT_CONTEXT_TOKENS,
+  } as Model<Api>);
 }
 
 export function buildInlineProviderModels(

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -296,7 +296,7 @@ describe("image tool MiniMax VLM routing", () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const [url, init] = fetch.mock.calls[0];
-    expect(String(url)).toBe("https://api.minimax.chat/v1/coding_plan/vlm");
+    expect(String(url)).toBe("https://api.minimaxi.chat/v1/coding_plan/vlm");
     expect(init?.method).toBe("POST");
     expect(String((init?.headers as Record<string, string>)?.Authorization)).toBe(
       "Bearer minimax-test",


### PR DESCRIPTION
## Summary

- Add hardcoded fallback for `anthropic/claude-opus-4-6` in `resolveAnthropicOpus46ForwardCompatModel()` when no template model exists in the registry, preventing "Unknown model" errors
- Fix MiniMax OpenAI-compatible base URL from `api.minimax.chat` to `api.minimaxi.chat` (the correct domain with an 'i'), which caused all MiniMax completions to fail with HTTP 401

## Test plan

- [x] Existing model resolution tests pass (11/11)
- [x] MiniMax models-config test updated and passes
- [x] Image tool test updated and passes
- [x] Verified MiniMax fallback works end-to-end (Anthropic rate limit → MiniMax responds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)