### PR TITLE
fix(tests): update thread ID handling in Slack message collection tests

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -44,13 +44,13 @@ export function scheduleFollowupDrain(
             const to = item.originatingTo;
             const accountId = item.originatingAccountId;
             const threadId = item.originatingThreadId;
-            if (!channel && !to && !accountId && typeof threadId !== "number") {
+            if (!channel && !to && !accountId && threadId == null) {
               return {};
             }
             if (!isRoutableChannel(channel) || !to) {
               return { cross: true };
             }
-            const threadKey = typeof threadId === "number" ? String(threadId) : "";
+            const threadKey = threadId != null ? String(threadId) : "";
             return {
               key: [channel, to, accountId || "", threadKey].join("|"),
             };
@@ -80,7 +80,7 @@ export function scheduleFollowupDrain(
             (i) => i.originatingAccountId,
           )?.originatingAccountId;
           const originatingThreadId = items.find(
-            (i) => typeof i.originatingThreadId === "number",
+            (i) => i.originatingThreadId != null,
           )?.originatingThreadId;
 
           const prompt = buildCollectPrompt({


### PR DESCRIPTION
- Changed `originatingThreadId` type to accept both string and number.
- Added tests to ensure messages are collected correctly when thread IDs match and not collected when they differ.
- Updated `scheduleFollowupDrain` to handle null thread IDs appropriately.


---
name: Fix Slack thread_ts loss
overview: "Fix GitHub issue #4424 where Slack thread replies escape to the main channel when multiple messages arrive before the bot replies. The root cause is in the followup queue drain logic which only handles numeric thread IDs (Telegram), dropping Slack's string-based thread_ts values."
todos:
  - id: fix-drain
    content: Fix the three typeof checks in drain.ts (lines 47, 53, 82-84) to handle string thread IDs
    status: completed
  - id: add-tests
    content: Add test cases for Slack string thread IDs in queue.collect-routing.test.ts
    status: completed
  - id: verify
    content: Run existing + new tests to confirm fix
    status: completed
isProject: false
---

# Fix Slack thread reply escaping to main channel (#4424)

## Root Cause

The bug is in `[src/auto-reply/reply/queue/drain.ts](src/auto-reply/reply/queue/drain.ts)` -- the followup queue's **collect** mode drops Slack thread context because it only recognizes **numeric** thread IDs (Telegram topic IDs), not **string** thread IDs (Slack `thread_ts`).

The `FollowupRun.originatingThreadId` field is typed as `string | number | undefined`, but two places in the drain logic only check for `number`:

### Bug site 1: Cross-channel detection key (line 47 + 53)

```typescript
// line 47: early-return treats string threadId as "no routing info"
if (!channel && !to && !accountId && typeof threadId !== "number") {
  return {};
}
// line 53: string threadId becomes empty string in the routing key
const threadKey = typeof threadId === "number" ? String(threadId) : "";
```

Messages in **different** Slack threads (same channel) get identical routing keys, so they are incorrectly collected together instead of being processed individually. Messages in the **same** thread get an empty thread key, which means after collection the thread context is lost.

### Bug site 2: Thread ID preservation during collect (lines 82-84)

```typescript
const originatingThreadId = items.find(
  (i) => typeof i.originatingThreadId === "number",
)?.originatingThreadId;
```

This **never** finds a Slack thread ID (which is a string like `"1706000000.000000"`), so the collected batch gets `originatingThreadId: undefined`. When `followup-runner.ts` then calls `routeReply()` with `threadId: undefined`, the reply goes to the main channel.

## Flow diagram

```mermaid
flowchart LR
    A["Two messages arrive in Slack thread"] --> B["Debounced and dispatched"]
    B --> C["First message: agent run starts"]
    B --> D["Second message: enqueued in followup queue"]
    D --> E["Queue drain: collect mode"]
    E --> F{"threadId type check"}
    F -->|"number (Telegram)"| G["threadKey preserved"]
    F -->|"string (Slack)"| H["threadKey = empty string BUG"]
    H --> I["originatingThreadId = undefined"]
    I --> J["routeReply with no threadId"]
    J --> K["Reply goes to main channel"]
```



## Fix

### 1. `[src/auto-reply/reply/queue/drain.ts](src/auto-reply/reply/queue/drain.ts)` -- two changes

**Line 47**: Include string thread IDs in the "has routing info" check:

```typescript
if (!channel && !to && !accountId && threadId == null) {
```

**Line 53**: Include string thread IDs in the routing key:

```typescript
const threadKey = threadId != null ? String(threadId) : "";
```

**Lines 82-84**: Preserve any non-nullish thread ID (string or number):

```typescript
const originatingThreadId = items.find(
  (i) => i.originatingThreadId != null,
)?.originatingThreadId;
```

### 2. `[src/auto-reply/reply/queue.collect-routing.test.ts](src/auto-reply/reply/queue.collect-routing.test.ts)` -- add test coverage

- Update the `createRun` helper to accept `string | number` for `originatingThreadId`
- Add test: two Slack messages in the **same** thread get collected and preserve `originatingThreadId`
- Add test: two Slack messages in **different** threads (same channel) are processed individually, not collected

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed bug where Slack thread replies escaped to main channel when multiple messages arrived before bot reply. The root cause was in the followup queue drain logic (`drain.ts:47,53,82-84`) which only handled numeric thread IDs (Telegram), dropping Slack's string-based `thread_ts` values.

**Key changes:**
- Updated three `typeof threadId === "number"` checks to `threadId != null` to handle both string and number thread IDs
- Added comprehensive test coverage for Slack string thread IDs (same thread collection, different thread separation)
- Updated `createRun` helper type signature to accept `string | number` for `originatingThreadId`

The fix ensures that when messages arrive in the same Slack thread during collection, the `originatingThreadId` is preserved and messages are properly routed back to the thread instead of the main channel.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are surgical, well-tested, and directly address the reported bug. The fix changes three `typeof` checks from strict number-only validation to null checks that accept both strings and numbers, matching the existing type signature. Two comprehensive test cases verify correct behavior for both same-thread collection and different-thread separation with Slack string thread IDs.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->