### PR TITLE
fix(sessions): preserve label on /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -135,6 +135,7 @@ export async function initSessionState(params: {
   let persistedTtsAuto: TtsAutoMode | undefined;
   let persistedModelOverride: string | undefined;
   let persistedProviderOverride: string | undefined;
+  let persistedLabel: string | undefined;
 
   const normalizedChatType = normalizeChatType(ctx.ChatType);
   const isGroup =
@@ -232,6 +233,7 @@ export async function initSessionState(params: {
     persistedTtsAuto = entry.ttsAuto;
     persistedModelOverride = entry.modelOverride;
     persistedProviderOverride = entry.providerOverride;
+    persistedLabel = entry.label;
   } else {
     sessionId = crypto.randomUUID();
     isNewSession = true;
@@ -276,6 +278,7 @@ export async function initSessionState(params: {
     queueDebounceMs: baseEntry?.queueDebounceMs,
     queueCap: baseEntry?.queueCap,
     queueDrop: baseEntry?.queueDrop,
+    label: persistedLabel ?? baseEntry?.label,
     displayName: baseEntry?.displayName,
     chatType: baseEntry?.chatType,
     channel: baseEntry?.channel,


### PR DESCRIPTION
## Summary

- Session labels were silently dropped when a user issued `/new` or `/reset` because `initSessionState()` preserves other session metadata (thinkingLevel, verboseLevel, modelOverride, etc.) but omitted `label`
- Added `persistedLabel` following the identical pattern used by the 10+ other preserved settings
- Three one-line additions — no logic changes, purely additive

## Changes

- `src/auto-reply/reply/session.ts` — Declare `persistedLabel`, extract from previous entry, include in new `sessionEntry`

## Test plan

- [x] Existing session tests pass
- [x] Formatted with oxfmt

Closes #14048

### AI Disclosure

This PR was authored with assistance from Sylphx AI.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `initSessionState()` in `src/auto-reply/reply/session.ts` to preserve a session’s `label` when users run `/new` or `/reset`, matching how other session metadata (e.g., thinking/verbose levels and model overrides) are already carried forward. The change introduces a `persistedLabel` variable extracted from the previous session entry and includes it in the newly created `sessionEntry`, preventing silent loss of labels across session resets.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to preserving an existing session metadata field (`label`) across `/new` and `/reset`, following the established pattern used for other persisted session settings. No behavior is altered beyond preventing unintended label loss, and it does not introduce new control flow or external interactions.
- src/auto-reply/reply/session.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->