### PR TITLE
fix(cli): guard process.noDeprecation assignment for Node.js v23+

### DIFF
--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -672,7 +672,11 @@ function printResult(result: UpdateRunResult, opts: PrintResultOptions) {
 }
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
-  process.noDeprecation = true;
+  try {
+    process.noDeprecation = true;
+  } catch {
+    // Read-only in Node.js v23+ (frozen process properties); suppress via env instead.
+  }
   process.env.NODE_NO_WARNINGS = "1";
   const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
   const shouldRestart = opts.restart !== false;


### PR DESCRIPTION
## Problem

`openclaw update` crashes on Node.js v23+ with:

```
TypeError: Cannot assign to read only property 'noDeprecation' of object '#<process>'
```

Node.js v23 froze several `process` properties that were previously writable.

Fixes #14107

## Fix

Wrap the assignment in a try/catch. The `NODE_NO_WARNINGS=1` env var on the very next line already provides equivalent deprecation suppression as a fallback, so functionality is preserved.

```diff
- process.noDeprecation = true;
+ try {
+   process.noDeprecation = true;
+ } catch {
+   // Read-only in Node.js v23+ (frozen process properties); suppress via env instead.
+ }
```

## Testing

- `pnpm build` passes
- Change is isolated to the update command entry point

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Wraps `process.noDeprecation = true` assignment in a try/catch block to prevent crashes on Node.js v23+, where this property was frozen and made read-only. The next line (`process.env.NODE_NO_WARNINGS = "1"`) already provides equivalent deprecation suppression as a fallback, ensuring functionality is preserved.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-isolated, and properly handles a known Node.js v23+ compatibility issue. The fallback mechanism (`NODE_NO_WARNINGS`) was already in place, and the try/catch simply prevents the crash without changing any logic or behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->