### PR TITLE
config: add readable durable/off mode for pre-compaction memory flush

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1949,10 +1949,10 @@ auto-compaction, instructing the model to store durable memories on disk (e.g.
 `memory/YYYY-MM-DD.md`). It triggers when the session token estimate crosses a
 soft threshold below the compaction limit.
 
-Legacy defaults:
+Defaults:
 
 - `memoryFlush.mode`: `durable` (recommended) or `off`
-- `memoryFlush.enabled`: `true`
+- `memoryFlush.enabled` (legacy boolean): `true`
 - `memoryFlush.softThresholdTokens`: `4000`
 - `memoryFlush.prompt` / `memoryFlush.systemPrompt`: built-in defaults with `NO_REPLY`
 - Note: memory flush is skipped when the session workspace is read-only

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1951,11 +1951,20 @@ soft threshold below the compaction limit.
 
 Legacy defaults:
 
+- `memoryFlush.mode`: `durable` (recommended) or `off`
 - `memoryFlush.enabled`: `true`
 - `memoryFlush.softThresholdTokens`: `4000`
 - `memoryFlush.prompt` / `memoryFlush.systemPrompt`: built-in defaults with `NO_REPLY`
 - Note: memory flush is skipped when the session workspace is read-only
   (`agents.defaults.sandbox.workspaceAccess: "ro"` or `"none"`).
+
+`memoryFlush.mode` is the readable on/off switch for this behavior:
+
+- `durable`: run a silent durable-memory checkpoint before compaction
+- `off`: disable this checkpoint
+
+When `memoryFlush.mode` is set, it takes precedence over the legacy
+`memoryFlush.enabled` boolean.
 
 Example (tuned):
 
@@ -1967,7 +1976,7 @@ Example (tuned):
         mode: "safeguard",
         reserveTokensFloor: 24000,
         memoryFlush: {
-          enabled: true,
+          mode: "durable",
           softThresholdTokens: 6000,
           systemPrompt: "Session nearing compaction. Store durable memories now.",
           prompt: "Write any lasting notes to memory/YYYY-MM-DD.md; reply with NO_REPLY if nothing to store.",

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -256,10 +256,13 @@ OpenClaw uses the **pre-threshold flush** approach:
 
 Config (`agents.defaults.compaction.memoryFlush`):
 
+- `mode` (`durable` or `off`, recommended switch)
 - `enabled` (default: `true`)
 - `softThresholdTokens` (default: `4000`)
 - `prompt` (user message for the flush turn)
 - `systemPrompt` (extra system prompt appended for the flush turn)
+
+If `mode` is set, it takes precedence over `enabled`.
 
 Notes:
 

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -25,6 +25,23 @@ describe("memory flush settings", () => {
     ).toBeNull();
   });
 
+  it("supports named memory flush modes", () => {
+    const enabled = resolveMemoryFlushSettings({
+      agents: {
+        defaults: { compaction: { memoryFlush: { mode: "durable", enabled: false } } },
+      },
+    });
+    expect(enabled).not.toBeNull();
+    expect(enabled?.enabled).toBe(true);
+
+    const disabled = resolveMemoryFlushSettings({
+      agents: {
+        defaults: { compaction: { memoryFlush: { mode: "off", enabled: true } } },
+      },
+    });
+    expect(disabled).toBeNull();
+  });
+
   it("appends NO_REPLY hint when missing", () => {
     const settings = resolveMemoryFlushSettings({
       agents: {

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -37,7 +37,11 @@ const normalizeNonNegativeInt = (value: unknown): number | null => {
 
 export function resolveMemoryFlushSettings(cfg?: OpenClawConfig): MemoryFlushSettings | null {
   const defaults = cfg?.agents?.defaults?.compaction?.memoryFlush;
-  const enabled = defaults?.enabled ?? true;
+  const mode = defaults?.mode;
+  if (mode === "off") {
+    return null;
+  }
+  const enabled = mode === "durable" ? true : (defaults?.enabled ?? true);
   if (!enabled) {
     return null;
   }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -256,7 +256,16 @@ export type AgentCompactionConfig = {
   memoryFlush?: AgentCompactionMemoryFlushConfig;
 };
 
+export type AgentCompactionMemoryFlushMode = "durable" | "off";
+
 export type AgentCompactionMemoryFlushConfig = {
+  /**
+   * Named pre-compaction memory flush mode.
+   * - "durable": run the durable-memory checkpoint turn before compaction
+   * - "off": disable pre-compaction memory flush
+   * When set, this takes precedence over `enabled`.
+   */
+  mode?: AgentCompactionMemoryFlushMode;
   /** Enable the pre-compaction memory flush (default: true). */
   enabled?: boolean;
   /** Run the memory flush when context is within this many tokens of the compaction threshold. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -95,6 +95,7 @@ export const AgentDefaultsSchema = z
         maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
         memoryFlush: z
           .object({
+            mode: z.union([z.literal("durable"), z.literal("off")]).optional(),
             enabled: z.boolean().optional(),
             softThresholdTokens: z.number().int().nonnegative().optional(),
             prompt: z.string().optional(),


### PR DESCRIPTION
## Summary
- add a readable `agents.defaults.compaction.memoryFlush.mode` switch with `durable | off`
- keep legacy `memoryFlush.enabled` behavior for backward compatibility
- make `mode` take precedence over `enabled` when both are set
- document the new switch in compaction/configuration docs and update examples

## Why
`memoryFlush.enabled` works but is hard to read in configs and discussions. A named mode makes intent clearer while keeping old configs working.

## Testing
- `pnpm vitest run src/auto-reply/reply/memory-flush.test.ts src/config/config.compaction-settings.test.ts`
- `pnpm check`
- `pnpm build`
- local agent smoke run (`openclaw agent --local --agent main ...`) after rebase on latest `origin/main`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added a readable `mode` field (`durable` | `off`) to `agents.defaults.compaction.memoryFlush` configuration, replacing the less clear `enabled` boolean while maintaining full backward compatibility. When `mode` is set, it takes precedence over the legacy `enabled` field.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and maintains complete backward compatibility. The logic correctly prioritizes the new `mode` field over the legacy `enabled` field. Tests verify both the new behavior and backward compatibility. Documentation is comprehensive with only minor wording improvements suggested.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->