### PR TITLE
fix: use configured base URL for Ollama model discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Docs: https://docs.openclaw.ai
 - CLI: add `openclaw logs --local-time` to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
 - Config: avoid redacting `maxTokens`-like fields during config snapshot redaction, preventing round-trip validation failures in `/config`. (#14006) Thanks @constansino.
 
+### Fixes
+
+- Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
+
 ## 2026.2.9
 
 ### Added

--- a/src/agents/models-config.providers.ollama.test.ts
+++ b/src/agents/models-config.providers.ollama.test.ts
@@ -2,7 +2,27 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveImplicitProviders } from "./models-config.providers.js";
+import { resolveImplicitProviders, resolveOllamaApiBase } from "./models-config.providers.js";
+
+describe("resolveOllamaApiBase", () => {
+  it("returns default localhost base when no configured URL is provided", () => {
+    expect(resolveOllamaApiBase()).toBe("http://127.0.0.1:11434");
+  });
+
+  it("strips /v1 suffix from OpenAI-compatible URLs", () => {
+    expect(resolveOllamaApiBase("http://ollama-host:11434/v1")).toBe("http://ollama-host:11434");
+    expect(resolveOllamaApiBase("http://ollama-host:11434/V1")).toBe("http://ollama-host:11434");
+  });
+
+  it("keeps URLs without /v1 unchanged", () => {
+    expect(resolveOllamaApiBase("http://ollama-host:11434")).toBe("http://ollama-host:11434");
+  });
+
+  it("handles trailing slash before canonicalizing", () => {
+    expect(resolveOllamaApiBase("http://ollama-host:11434/v1/")).toBe("http://ollama-host:11434");
+    expect(resolveOllamaApiBase("http://ollama-host:11434/")).toBe("http://ollama-host:11434");
+  });
+});
 
 describe("Ollama provider", () => {
   it("should not include ollama when no API key is configured", async () => {
@@ -28,6 +48,28 @@ describe("Ollama provider", () => {
       // so we can't test the actual model discovery here. The streaming: false setting
       // is applied in the model mapping within discoverOllamaModels().
       // The configuration structure itself is validated by TypeScript and the Zod schema.
+    } finally {
+      delete process.env.OLLAMA_API_KEY;
+    }
+  });
+
+  it("should preserve explicit ollama baseUrl on implicit provider injection", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    process.env.OLLAMA_API_KEY = "test-key";
+
+    try {
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          ollama: {
+            baseUrl: "http://192.168.20.14:11434/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      });
+
+      expect(providers?.ollama?.baseUrl).toBe("http://192.168.20.14:11434/v1");
     } finally {
       delete process.env.OLLAMA_API_KEY;
     }

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -119,7 +119,7 @@ interface OllamaTagsResponse {
  * The native Ollama API lives at the root (e.g. `/api/tags`), so we
  * strip the `/v1` suffix when present.
  */
-function resolveOllamaApiBase(configuredBaseUrl?: string): string {
+export function resolveOllamaApiBase(configuredBaseUrl?: string): string {
   if (!configuredBaseUrl) {
     return OLLAMA_API_BASE_URL;
   }

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -111,13 +111,31 @@ interface OllamaTagsResponse {
   models: OllamaModel[];
 }
 
-async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
+/**
+ * Derive the Ollama native API base URL from a configured base URL.
+ *
+ * Users typically configure `baseUrl` with a `/v1` suffix (e.g.
+ * `http://192.168.20.14:11434/v1`) for the OpenAI-compatible endpoint.
+ * The native Ollama API lives at the root (e.g. `/api/tags`), so we
+ * strip the `/v1` suffix when present.
+ */
+function resolveOllamaApiBase(configuredBaseUrl?: string): string {
+  if (!configuredBaseUrl) {
+    return OLLAMA_API_BASE_URL;
+  }
+  // Strip trailing slash, then strip /v1 suffix if present
+  const trimmed = configuredBaseUrl.replace(/\/+$/, "");
+  return trimmed.replace(/\/v1$/i, "");
+}
+
+async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionConfig[]> {
   // Skip Ollama discovery in test environments
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return [];
   }
   try {
-    const response = await fetch(`${OLLAMA_API_BASE_URL}/api/tags`, {
+    const apiBase = resolveOllamaApiBase(baseUrl);
+    const response = await fetch(`${apiBase}/api/tags`, {
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) {
@@ -410,10 +428,10 @@ async function buildVeniceProvider(): Promise<ProviderConfig> {
   };
 }
 
-async function buildOllamaProvider(): Promise<ProviderConfig> {
-  const models = await discoverOllamaModels();
+async function buildOllamaProvider(configuredBaseUrl?: string): Promise<ProviderConfig> {
+  const models = await discoverOllamaModels(configuredBaseUrl);
   return {
-    baseUrl: OLLAMA_BASE_URL,
+    baseUrl: configuredBaseUrl ?? OLLAMA_BASE_URL,
     api: "openai-completions",
     models,
   };
@@ -456,6 +474,7 @@ export function buildQianfanProvider(): ProviderConfig {
 
 export async function resolveImplicitProviders(params: {
   agentDir: string;
+  explicitProviders?: Record<string, ProviderConfig> | null;
 }): Promise<ModelsConfig["providers"]> {
   const providers: Record<string, ProviderConfig> = {};
   const authStore = ensureAuthProfileStore(params.agentDir, {
@@ -541,12 +560,15 @@ export async function resolveImplicitProviders(params: {
     break;
   }
 
-  // Ollama provider - only add if explicitly configured
+  // Ollama provider - only add if explicitly configured.
+  // Use the user's configured baseUrl (from explicit providers) for model
+  // discovery so that remote / non-default Ollama instances are reachable.
   const ollamaKey =
     resolveEnvApiKeyVarName("ollama") ??
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
   if (ollamaKey) {
-    providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
+    const ollamaBaseUrl = params.explicitProviders?.ollama?.baseUrl;
+    providers.ollama = { ...(await buildOllamaProvider(ollamaBaseUrl)), apiKey: ollamaKey };
   }
 
   const togetherKey =

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -86,7 +86,7 @@ export async function ensureOpenClawModelsJson(
   const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveOpenClawAgentDir();
 
   const explicitProviders = cfg.models?.providers ?? {};
-  const implicitProviders = await resolveImplicitProviders({ agentDir });
+  const implicitProviders = await resolveImplicitProviders({ agentDir, explicitProviders });
   const providers: Record<string, ProviderConfig> = mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,


### PR DESCRIPTION
## Summary
- Fixes #14053
- Uses the user's configured Ollama base URL for model discovery instead of the hardcoded `http://127.0.0.1:11434`
- Falls back to the default URL when no custom URL is configured
- Enables model discovery for users running Ollama on remote servers or custom ports

## Test plan
- [x] `pnpm check` passes (format, lint, type-check)
- [x] Existing Ollama provider tests pass (`models-config.providers.ollama.test.ts`)
- [x] Existing Qianfan provider tests pass (also calls `resolveImplicitProviders`)

> [!NOTE]
> This PR was authored with assistance from Sylphx AI.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Ollama model discovery for users running Ollama on remote servers or custom ports by using the configured `baseUrl` instead of the hardcoded default. The changes enable the `resolveImplicitProviders` function to accept explicit provider configurations and extract the Ollama `baseUrl` for model discovery via the `/api/tags` endpoint. The implementation correctly strips the `/v1` suffix from OpenAI-compatible URLs to access the native Ollama API and maintains backward compatibility with optional parameters.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, backward compatible, and solve a clear bug. The new `resolveOllamaApiBase` function correctly handles URL transformations, the optional parameter ensures existing callers continue to work, and the logic properly threads the configured baseUrl through to model discovery. Tests pass and the implementation follows existing patterns in the codebase.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->