### PR TITLE
fix(models): handle @ symbol in OpenRouter preset paths

### DIFF
--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -36,6 +36,27 @@ describe("extractModelDirective", () => {
       expect(result.rawProfile).toBe("myprofile");
     });
 
+    it("preserves @ in OpenRouter preset paths", () => {
+      const result = extractModelDirective("/model openrouter/@preset/kimi-2-5");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("openrouter/@preset/kimi-2-5");
+      expect(result.rawProfile).toBeUndefined();
+    });
+
+    it("preserves @ in OpenRouter preset paths with profile override", () => {
+      const result = extractModelDirective("/model openrouter/@preset/kimi-2-5@myprofile");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("openrouter/@preset/kimi-2-5");
+      expect(result.rawProfile).toBe("myprofile");
+    });
+
+    it("handles multiple @ in path correctly", () => {
+      const result = extractModelDirective("/model provider/@foo/@bar/model");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("provider/@foo/@bar/model");
+      expect(result.rawProfile).toBeUndefined();
+    });
+
     it("returns no directive for plain text", () => {
       const result = extractModelDirective("hello world");
       expect(result.hasDirective).toBe(false);

--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -57,6 +57,14 @@ describe("extractModelDirective", () => {
       expect(result.rawProfile).toBeUndefined();
     });
 
+    it("preserves @ in middle of path segment", () => {
+      // e.g. provider/foo@bar/baz should not split on @
+      const result = extractModelDirective("/model provider/foo@bar/baz");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("provider/foo@bar/baz");
+      expect(result.rawProfile).toBeUndefined();
+    });
+
     it("returns no directive for plain text", () => {
       const result = extractModelDirective("hello world");
       expect(result.hasDirective).toBe(false);

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -34,9 +34,16 @@ export function extractModelDirective(
   let rawModel = raw;
   let rawProfile: string | undefined;
   if (raw?.includes("@")) {
-    const parts = raw.split("@");
-    rawModel = parts[0]?.trim();
-    rawProfile = parts.slice(1).join("@").trim() || undefined;
+    // Find the last @ that could be an auth profile separator.
+    // Only treat @ as a separator if it's NOT preceded by a / (to support
+    // OpenRouter preset paths like "openrouter/@preset/model-name").
+    const atIndex = raw.lastIndexOf("@");
+    const charBefore = atIndex > 0 ? raw[atIndex - 1] : undefined;
+    if (charBefore !== "/") {
+      // Split only on the last @ to preserve any @ in the model path
+      rawModel = raw.slice(0, atIndex).trim();
+      rawProfile = raw.slice(atIndex + 1).trim() || undefined;
+    }
   }
 
   const cleaned = match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim();

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -35,14 +35,15 @@ export function extractModelDirective(
   let rawProfile: string | undefined;
   if (raw?.includes("@")) {
     // Find the last @ that could be an auth profile separator.
-    // Only treat @ as a separator if it's NOT preceded by a / (to support
-    // OpenRouter preset paths like "openrouter/@preset/model-name").
+    // Only treat @ as a separator when used as a trailing profile override
+    // (i.e., no '/' characters after the '@'). This preserves OpenRouter
+    // preset paths like "openrouter/@preset/model-name" and any model paths
+    // containing @ in path segments like "provider/foo@bar/baz".
     const atIndex = raw.lastIndexOf("@");
-    const charBefore = atIndex > 0 ? raw[atIndex - 1] : undefined;
-    if (charBefore !== "/") {
-      // Split only on the last @ to preserve any @ in the model path
+    const afterAt = raw.slice(atIndex + 1);
+    if (!afterAt.includes("/")) {
       rawModel = raw.slice(0, atIndex).trim();
-      rawProfile = raw.slice(atIndex + 1).trim() || undefined;
+      rawProfile = afterAt.trim() || undefined;
     }
   }
 


### PR DESCRIPTION
Fixes #14120

## What
Handle the @ symbol in OpenRouter custom preset paths like `openrouter/@preset/kimi-2-5`.

## Why
OpenRouter presets use `@preset/` in their paths, but OpenClaw was interpreting the `@` as an auth profile separator, breaking the model name.

## How
Only treat `@` as auth separator when it's NOT preceded by a `/` (i.e., it's the last `@` in the string and appears after a model identifier, not in the middle of a path segment like `/@preset/`).

## Testing
- [x] Added unit tests for @ in model paths
- [x] `pnpm check` passes
- [x] `pnpm vitest run src/auto-reply/` passes (569 tests)

## AI-Assisted
This PR was built with AI assistance (Claude via OpenClaw). The code has been reviewed, tested, and I understand what it does.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `extractModelDirective` to stop interpreting `@` as an auth-profile separator when it appears in OpenRouter preset paths like `openrouter/@preset/...`, and adds unit tests covering preset paths and multiple `@` segments.

The change is localized to auto-reply model directive parsing (`src/auto-reply/model.ts`) and should improve correctness for OpenRouter custom preset identifiers while keeping existing `/model ...@profile` overrides working.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but has a likely correctness issue in `@`-profile splitting for some valid model identifiers.
- The updated parsing logic fixes the reported OpenRouter `/@preset/` case and is covered by new tests, but it changes the semantics of `@` handling to depend only on the preceding character. Given the existing regex allows `@` anywhere in a model identifier, model names containing `@` not preceded by `/` (and not intended as a profile override) will now be mis-parsed. Tests and local execution couldn’t be fully verified here because `pnpm` is unavailable in the environment.
- src/auto-reply/model.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->