### PR TITLE
fix(cron): pass agentId to runHeartbeatOnce for main-session jobs

### DIFF
--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -37,7 +37,7 @@ export type CronServiceDeps = {
   sessionStorePath?: string;
   enqueueSystemEvent: (text: string, opts?: { agentId?: string }) => void;
   requestHeartbeatNow: (opts?: { reason?: string }) => void;
-  runHeartbeatOnce?: (opts?: { reason?: string }) => Promise<HeartbeatRunResult>;
+  runHeartbeatOnce?: (opts?: { reason?: string; agentId?: string }) => Promise<HeartbeatRunResult>;
   runIsolatedAgentJob: (params: { job: CronJob; message: string }) => Promise<{
     status: "ok" | "error" | "skipped";
     summary?: string;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -440,7 +440,7 @@ async function executeJobCore(
 
       let heartbeatResult: HeartbeatRunResult;
       for (;;) {
-        heartbeatResult = await state.deps.runHeartbeatOnce({ reason });
+        heartbeatResult = await state.deps.runHeartbeatOnce({ reason, agentId: job.agentId });
         if (
           heartbeatResult.status !== "skipped" ||
           heartbeatResult.reason !== "requests-in-flight"

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -69,9 +69,11 @@ export function buildGatewayCronService(params: {
     requestHeartbeatNow,
     runHeartbeatOnce: async (opts) => {
       const runtimeConfig = loadConfig();
+      const agentId = opts?.agentId ? resolveCronAgent(opts.agentId).agentId : undefined;
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
         reason: opts?.reason,
+        agentId,
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },


### PR DESCRIPTION
## Summary

- Main-session cron jobs with `agentId` always ran the heartbeat under the default agent, ignoring the job's agent binding
- `enqueueSystemEvent` correctly routed the system event to the bound agent's session, but `runHeartbeatOnce` was called without `agentId`, so the heartbeat ran under the default agent and never picked up the event
- When per-agent heartbeat config disables the default agent's heartbeat, the job is immediately skipped with `disabled`, and the system event is never processed

## Root cause

In `server-cron.ts`, the `runHeartbeatOnce` wrapper only forwarded `reason` but not `agentId`:

```ts
// Before (broken)
runHeartbeatOnce: async (opts) => {
  return await runHeartbeatOnce({
    cfg: runtimeConfig,
    reason: opts?.reason,      // agentId missing
    deps: { ... },
  });
},
```

`heartbeat-runner.ts` then fell back to `resolveDefaultAgentId(cfg)`, running the heartbeat for the wrong agent.

## Fix

Thread `agentId` from `job.agentId` through `runHeartbeatOnce` → gateway wrapper → `heartbeat-runner`:

1. `src/cron/service/state.ts`: Add `agentId` to `runHeartbeatOnce` opts type
2. `src/cron/service/timer.ts`: Pass `job.agentId` when calling `runHeartbeatOnce`
3. `src/gateway/server-cron.ts`: Forward `agentId` via `resolveCronAgent`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (265 tests)
- [x] `pnpm check` passes (for modified files)
- [x] Manual: confirmed unpatched build returns `skipped (disabled)` for a main-session job with `agentId`
- [x] Manual: confirmed patched build returns `ok` and the bound agent correctly processes the system event

🤖 AI-assisted (Claude Code). Manually verified.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes main-session cron jobs with `agentId` to run heartbeats under the correct agent. Previously, the `agentId` parameter was not threaded through to `runHeartbeatOnce`, causing heartbeats to fall back to the default agent. When per-agent heartbeat config disabled the default agent's heartbeat, jobs were immediately skipped and system events were never processed.

**Changes made:**
- Updated `CronServiceDeps` type to include `agentId` in `runHeartbeatOnce` options (`src/cron/service/state.ts:40`)
- Modified job execution to pass `job.agentId` when calling `runHeartbeatOnce` (`src/cron/service/timer.ts:423`)
- Updated gateway wrapper to resolve and forward `agentId` via `resolveCronAgent` (`src/gateway/server-cron.ts:72-76`)

The fix ensures that `runHeartbeatOnce` receives the correct agent context, allowing it to check the right agent's heartbeat config and process system events in the bound agent's session.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and follow existing patterns in the codebase. Type signatures are properly updated, the fix correctly threads `agentId` through the call chain using the existing `resolveCronAgent` helper, and manual testing confirms the fix works. The change is backwards compatible (all new parameters are optional) and aligns with how `agentId` is already handled in adjacent code for `enqueueSystemEvent` and `runIsolatedAgentJob`.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->