### PR TITLE
fix(slack): detect control commands when message starts with @mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
+- Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
 
 ## 2026.2.9
 

--- a/src/slack/monitor/commands.ts
+++ b/src/slack/monitor/commands.ts
@@ -1,5 +1,16 @@
 import type { SlackSlashCommandConfig } from "../../config/config.js";
 
+/**
+ * Strip Slack mentions (<@U123>, <@U123|name>) so command detection works on
+ * normalized text. Use in both prepare and debounce gate for consistency.
+ */
+export function stripSlackMentionsForCommandDetection(text: string): string {
+  return (text ?? "")
+    .replace(/<@[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export function normalizeSlackSlashCommandName(raw: string) {
   return raw.replace(/^\/+/, "");
 }

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -6,6 +6,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
+import { stripSlackMentionsForCommandDetection } from "./commands.js";
 import { dispatchPreparedSlackMessage } from "./message-handler/dispatch.js";
 import { prepareSlackMessage } from "./message-handler/prepare.js";
 import { createSlackThreadTsResolver } from "./thread-resolution.js";
@@ -50,7 +51,8 @@ export function createSlackMessageHandler(params: {
       if (entry.message.files && entry.message.files.length > 0) {
         return false;
       }
-      return !hasControlCommand(text, ctx.cfg);
+      const textForCommandDetection = stripSlackMentionsForCommandDetection(text);
+      return !hasControlCommand(textForCommandDetection, ctx.cfg);
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/src/slack/monitor/message-handler/prepare.sender-prefix.test.ts
+++ b/src/slack/monitor/message-handler/prepare.sender-prefix.test.ts
@@ -76,4 +76,79 @@ describe("prepareSlackMessage sender prefix", () => {
     const body = result?.ctxPayload.Body ?? "";
     expect(body).toContain("Alice (U1): <@BOT> hello");
   });
+
+  it("detects /new as control command when prefixed with Slack mention", async () => {
+    const ctx = {
+      cfg: {
+        agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+        channels: { slack: { dm: { enabled: true, policy: "open", allowFrom: ["*"] } } },
+      },
+      accountId: "default",
+      botToken: "xoxb",
+      app: { client: {} },
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: (code: number): never => {
+          throw new Error(`exit ${code}`);
+        },
+      },
+      botUserId: "BOT",
+      teamId: "T1",
+      apiAppId: "A1",
+      historyLimit: 0,
+      channelHistories: new Map(),
+      sessionScope: "per-sender",
+      mainKey: "agent:main:main",
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: ["U1"],
+      groupDmEnabled: false,
+      groupDmChannels: [],
+      defaultRequireMention: true,
+      groupPolicy: "open",
+      useAccessGroups: true,
+      reactionMode: "off",
+      reactionAllowlist: [],
+      replyToMode: "off",
+      threadHistoryScope: "channel",
+      threadInheritParent: false,
+      slashCommand: {
+        enabled: false,
+        name: "openclaw",
+        sessionPrefix: "slack:slash",
+        ephemeral: true,
+      },
+      textLimit: 2000,
+      ackReactionScope: "off",
+      mediaMaxBytes: 1000,
+      removeAckAfterReply: false,
+      logger: { info: vi.fn() },
+      markMessageSeen: () => false,
+      shouldDropMismatchedSlackEvent: () => false,
+      resolveSlackSystemEventSessionKey: () => "agent:main:slack:channel:c1",
+      isChannelAllowed: () => true,
+      resolveChannelName: async () => ({ name: "general", type: "channel" }),
+      resolveUserName: async () => ({ name: "Alice" }),
+      setSlackThreadStatus: async () => undefined,
+    } satisfies SlackMonitorContext;
+
+    const result = await prepareSlackMessage({
+      ctx,
+      account: { accountId: "default", config: {} } as never,
+      message: {
+        type: "message",
+        channel: "C1",
+        channel_type: "channel",
+        text: "<@BOT> /new",
+        user: "U1",
+        ts: "1700000000.0002",
+        event_ts: "1700000000.0002",
+      } as never,
+      opts: { source: "message", wasMentioned: true },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.ctxPayload.CommandAuthorized).toBe(true);
+  });
 });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -42,6 +42,7 @@ import { resolveSlackThreadContext } from "../../threading.js";
 import { resolveSlackAllowListMatch, resolveSlackUserAllowed } from "../allow-list.js";
 import { resolveSlackEffectiveAllowFrom } from "../auth.js";
 import { resolveSlackChannelConfig } from "../channel-config.js";
+import { stripSlackMentionsForCommandDetection } from "../commands.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "../context.js";
 import { resolveSlackMedia, resolveSlackThreadStarter } from "../media.js";
 
@@ -250,10 +251,7 @@ export async function prepareSlackMessage(params: {
     surface: "slack",
   });
   // Strip Slack mentions (<@U123>) before command detection so "@Labrador /new" is recognized
-  const textForCommandDetection = (message.text ?? "")
-    .replace(/<@[^>]+>/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  const textForCommandDetection = stripSlackMentionsForCommandDetection(message.text ?? "");
   const hasControlCommandInMessage = hasControlCommand(textForCommandDetection, cfg);
 
   const ownerAuthorized = resolveSlackAllowListMatch({

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -249,7 +249,12 @@ export async function prepareSlackMessage(params: {
     cfg,
     surface: "slack",
   });
-  const hasControlCommandInMessage = hasControlCommand(message.text ?? "", cfg);
+  // Strip Slack mentions (<@U123>) before command detection so "@Labrador /new" is recognized
+  const textForCommandDetection = (message.text ?? "")
+    .replace(/<@[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const hasControlCommandInMessage = hasControlCommand(textForCommandDetection, cfg);
 
   const ownerAuthorized = resolveSlackAllowListMatch({
     allowList: allowFromLower,


### PR DESCRIPTION
#### Related

[#9971](https://github.com/openclaw/openclaw/pull/9971) did not resolve this issue for me.

#### Summary

Slack messages like `@Labrador /new` arrive as regular messages with the mention as `<@U123> /new`. Control-command detection was done on the raw text, so `<@U123> /new` was never matched as `/new`. This fix strips Slack mentions before detection so `@Bot /new` is recognized.

#### Repro Steps

1. Configure Slack channel with bot (e.g. @Labrador).
2. In a channel, send `@Labrador /new` or 

> `@BOT123 /new`.

3. **Before:** Message treated as normal chat; model may say the command doesn’t work.
4. **After:** Recognized as control command; `/new` runs.

#### Root Cause

`hasControlCommand` was called with raw `message.text` (e.g. `<@U123> /new`). `normalizeCommandBody` requires text to start with `/`, so it returned the raw string unchanged. No command alias matched `<@u123> /new`, so detection failed.

#### Behavior Changes

- **Before:** `@Bot /new` → not detected as control command → goes to model.
- **After:** `@Bot /new` → detected as control command → processed as `/new` (subject to authorization).

#### Tests

- `prepare.sender-prefix.test.ts`: New test for `<@BOT> /new` → `CommandAuthorized: true`.
- `prepare.inbound-contract.test.ts`: All pass.
- `command-control.test.ts`: All pass.
- `session-resets.test.ts`: All pass.

#### Manual Testing (omit if N/A)

### Prerequisites

- Slack app with bot in a channel.
- User in `channels.slack.dm.allowFrom` or channel `users` allowlist (if `commands.useAccessGroups: true`).

### Steps

1. Send `@Bot /new` in a channel.
2. Bot should start a new session (not reply as normal chat).
3. Send `@Bot /help` — should show help.
4. Send `hello @Bot /new` — should not be treated as command (unchanged).

#### Evidence (omit if N/A)

**Sign-Off**

- Models used:
- Submitter effort:
- Agent notes:

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes control command detection when Slack messages start with bot mentions. The core change strips Slack mention tags (`<@U123>`) before command detection so messages like `@Labrador /new` are correctly recognized as the `/new` command rather than being passed to the model as normal chat.

The implementation:
- Replaces all Slack mention patterns `<@[^>]+>` with spaces before command detection
- Collapses whitespace and trims the result
- Passes the cleaned text to `hasControlCommand()` for matching against command aliases

The test coverage validates the fix: `<@BOT> /new` now correctly sets `CommandAuthorized: true`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted and addresses a specific bug. The regex pattern is safe (no ReDoS risk with simple character class), the test coverage validates the expected behavior, and the change only affects command detection logic without altering other message handling paths. The PR description provides clear reproduction steps and explains the root cause.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->