### PR TITLE
fix(discord): default thread-create to public (type 11) when no messageId

### DIFF
--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -107,6 +107,22 @@ describe("sendMessageDiscord", () => {
     );
   });
 
+  it("defaults route-less text-channel threads to public", async () => {
+    const { rest, getMock, postMock } = makeRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildText });
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord("chan1", { name: "thread" }, { rest, token: "t" });
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.threads("chan1"),
+      expect.objectContaining({
+        body: {
+          name: "thread",
+          type: ChannelType.PublicThread,
+        },
+      }),
+    );
+  });
+
   it("falls back when channel lookup is unavailable", async () => {
     const { rest, getMock, postMock } = makeRest();
     getMock.mockRejectedValue(new Error("lookup failed"));
@@ -114,7 +130,12 @@ describe("sendMessageDiscord", () => {
     await createThreadDiscord("chan1", { name: "thread" }, { rest, token: "t" });
     expect(postMock).toHaveBeenCalledWith(
       Routes.threads("chan1"),
-      expect.objectContaining({ body: { name: "thread" } }),
+      expect.objectContaining({
+        body: {
+          name: "thread",
+          type: ChannelType.PublicThread,
+        },
+      }),
     );
   });
 

--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -123,19 +123,14 @@ describe("sendMessageDiscord", () => {
     );
   });
 
-  it("falls back when channel lookup is unavailable", async () => {
+  it("does not force type when channel lookup fails", async () => {
     const { rest, getMock, postMock } = makeRest();
     getMock.mockRejectedValue(new Error("lookup failed"));
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, { rest, token: "t" });
     expect(postMock).toHaveBeenCalledWith(
       Routes.threads("chan1"),
-      expect.objectContaining({
-        body: {
-          name: "thread",
-          type: ChannelType.PublicThread,
-        },
-      }),
+      expect.objectContaining({ body: { name: "thread" } }),
     );
   });
 

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -121,6 +121,8 @@ export async function createThreadDiscord(
   if (isForumLike) {
     const starterContent = payload.content?.trim() ? payload.content : payload.name;
     body.message = { content: starterContent };
+  } else if (!payload.messageId) {
+    body.type = ChannelType.PublicThread;
   }
   const route = payload.messageId
     ? Routes.threads(channelId, payload.messageId)


### PR DESCRIPTION
## Summary

Without a `messageId`, `createThreadDiscord()` doesn't set `type` in the request body. Discord API defaults to **type 12 (private thread)**, which is unexpected — users expect public threads.

## Changes

- **`src/discord/send.messages.ts`**: Add `body.type = ChannelType.PublicThread` for non-forum/media channels when no `messageId` is provided
- **`src/discord/send.creates-thread.test.ts`**: Add test for public thread default on text channels; update fallback test to expect public type

## Verified

Empirically tested on Discord — confirmed type 11 (public) vs type 12 (private) behavior.

Fixes #14147

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `createThreadDiscord()` to explicitly set `type: PublicThread` when creating a thread without a `messageId` on non-forum/media channels, and adds tests asserting the new default (including when channel lookup fails).

The change addresses Discord’s API defaulting to private threads when `type` is omitted. However, the new behavior currently also applies when the channel-type lookup fails/returns unknown, which can force `PublicThread` for channel IDs where that type is invalid (callers can pass arbitrary `channelId` values).

<h3>Confidence Score: 3/5</h3>

- Moderately safe, but has a real compatibility risk for unknown channel types.
- The change is small and well-tested for guild text/forum/media cases, but it also forces `type=PublicThread` when channel lookup fails, which can cause thread creation to fail for non-text channels (since callers accept arbitrary channel IDs).
- src/discord/send.messages.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->