### PR TITLE
fix(cli): guard against read-only process.noDeprecation on Node.js v23+

### DIFF
--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -672,7 +672,11 @@ function printResult(result: UpdateRunResult, opts: PrintResultOptions) {
 }
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
-  process.noDeprecation = true;
+  try {
+    process.noDeprecation = true;
+  } catch {
+    /* read-only on Node v23+ */
+  }
   process.env.NODE_NO_WARNINGS = "1";
   const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
   const shouldRestart = opts.restart !== false;

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -62,6 +62,7 @@ import { formatCliCommand } from "./command-format.js";
 import { installCompletion } from "./completion-cli.js";
 import { runDaemonRestart } from "./daemon-cli.js";
 import { formatHelpExamples } from "./help-format.js";
+import { suppressDeprecations } from "./update-cli/suppress-deprecations.js";
 
 export type UpdateCommandOptions = {
   json?: boolean;
@@ -672,12 +673,7 @@ function printResult(result: UpdateRunResult, opts: PrintResultOptions) {
 }
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
-  try {
-    process.noDeprecation = true;
-  } catch {
-    /* read-only on Node v23+ */
-  }
-  process.env.NODE_NO_WARNINGS = "1";
+  suppressDeprecations();
   const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
   const shouldRestart = opts.restart !== false;
 

--- a/src/cli/update-cli/suppress-deprecations.ts
+++ b/src/cli/update-cli/suppress-deprecations.ts
@@ -1,0 +1,16 @@
+/**
+ * Suppress Node.js deprecation warnings.
+ *
+ * On Node.js v23+ `process.noDeprecation` may be a read-only property
+ * (defined via a getter on the prototype with no setter), so the
+ * assignment can throw. We fall back to the environment variable which
+ * achieves the same effect.
+ */
+export function suppressDeprecations(): void {
+  try {
+    process.noDeprecation = true;
+  } catch {
+    // read-only on Node v23+; NODE_NO_WARNINGS below covers this case
+  }
+  process.env.NODE_NO_WARNINGS = "1";
+}


### PR DESCRIPTION
## Problem

`openclaw update` crashes on Node.js v23+ with:

```
TypeError: Cannot assign to read only property 'noDeprecation' of object '#<process>'
```

Node.js v23 freezes certain process properties, making direct assignment throw.

Fixes #14107

## Fix

Wrap the assignment in a try/catch:

```diff
- process.noDeprecation = true;
+ try {
+   process.noDeprecation = true;
+ } catch {
+   // Read-only in Node.js v23+ (frozen process properties)
+ }
```

The `NODE_NO_WARNINGS=1` env var on the next line already covers the same intent as a fallback.

## Testing

All 216 CLI tests pass. The fix is defensive — no behavior change on Node.js <23.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a crash in `openclaw update` on Node.js v23+ by moving the deprecation-warning suppression into a helper (`suppressDeprecations`) that wraps `process.noDeprecation = true` in a try/catch and always sets `NODE_NO_WARNINGS=1`. `updateCommand` now calls this helper at startup instead of assigning the process property directly.

This change is localized to the update CLI entrypoint and preserves prior behavior on older Node versions while avoiding the thrown `TypeError` when `process.noDeprecation` is read-only/frozen.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, isolated to the update CLI startup path, and directly address a runtime crash on Node.js v23+ by guarding a single assignment while keeping the existing env-var suppression behavior. No other behavior changes were found in the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->