### PR TITLE
fix(onboard): exit with non-zero code when wizard is cancelled

### DIFF
--- a/src/commands/onboard-interactive.test.ts
+++ b/src/commands/onboard-interactive.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+
+const wizardMock = vi.hoisted(() => ({
+  runOnboardingWizard: vi.fn(),
+}));
+
+vi.mock("../wizard/onboarding.js", () => wizardMock);
+
+vi.mock("../terminal/restore.js", () => ({
+  restoreTerminalState: vi.fn(),
+}));
+
+import { WizardCancelledError } from "../wizard/prompts.js";
+import { runInteractiveOnboarding } from "./onboard-interactive.js";
+
+const runtime: RuntimeEnv = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+describe("runInteractiveOnboarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exits with code 1 when the wizard is cancelled", async () => {
+    wizardMock.runOnboardingWizard.mockRejectedValue(new WizardCancelledError());
+
+    await runInteractiveOnboarding({} as never, runtime);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("re-throws non-cancellation errors", async () => {
+    const error = new Error("unexpected");
+    wizardMock.runOnboardingWizard.mockRejectedValue(error);
+
+    await expect(runInteractiveOnboarding({} as never, runtime)).rejects.toThrow("unexpected");
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/onboard-interactive.ts
+++ b/src/commands/onboard-interactive.ts
@@ -15,7 +15,7 @@ export async function runInteractiveOnboarding(
     await runOnboardingWizard(opts, runtime, prompter);
   } catch (err) {
     if (err instanceof WizardCancelledError) {
-      runtime.exit(0);
+      runtime.exit(1);
       return;
     }
     throw err;


### PR DESCRIPTION
## Problem

When users cancel the interactive onboarding wizard (e.g. answering "no" to the first question), `runInteractiveOnboarding` catches the `WizardCancelledError` and calls `runtime.exit(0)`. Since the exit code is 0, `docker-setup.sh` (which uses `set -euo pipefail`) doesn't detect the cancellation and proceeds to start the gateway anyway.

Reported in #14070.

## Solution

Change the exit code from `0` to `1` in the `WizardCancelledError` handler in `onboard-interactive.ts`. This way, any caller using `set -e` (like `docker-setup.sh`) will correctly stop when the user cancels.

## Testing

- Added `onboard-interactive.test.ts` with tests for:
  - Wizard cancellation exits with code 1
  - Non-cancellation errors are re-thrown (not swallowed)
- `npx vitest run src/commands/onboard-interactive.test.ts` — 2/2 passing

Closes #14070

cc @steipete

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changed exit code from 0 to 1 when the onboarding wizard is cancelled, ensuring `docker-setup.sh` (which uses `set -e`) correctly detects cancellation and stops instead of proceeding to start the gateway.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line fix with appropriate test coverage. The logic is simple and correct - exiting with code 1 on cancellation is the expected behavior for shell scripts using `set -e`. Tests verify both the cancellation path and that other errors are properly re-thrown.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->