### PR TITLE
feat(subagents): opt-in nested sessions_spawn with depth caps

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -328,6 +328,27 @@ describe("createOpenClawCodingTools", () => {
     expect(names.has("process")).toBe(true);
     expect(names.has("apply_patch")).toBe(false);
   });
+
+  it("keeps sessions_spawn for sub-agent sessions when nested spawning is enabled", () => {
+    const tools = createOpenClawCodingTools({
+      sessionKey: "agent:main:subagent:test",
+      config: {
+        agents: {
+          defaults: {
+            subagents: {
+              allowNestedSpawns: true,
+            },
+          },
+        },
+      },
+    });
+    const names = new Set(tools.map((tool) => tool.name));
+    expect(names.has("sessions_spawn")).toBe(true);
+    expect(names.has("sessions_list")).toBe(false);
+    expect(names.has("sessions_history")).toBe(false);
+    expect(names.has("sessions_send")).toBe(false);
+  });
+
   it("supports allow-only sub-agent tool policy", () => {
     const tools = createOpenClawCodingTools({
       sessionKey: "agent:main:subagent:test",

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -349,6 +349,28 @@ describe("createOpenClawCodingTools", () => {
     expect(names.has("sessions_send")).toBe(false);
   });
 
+  it("keeps sessions_spawn for alias-like sub-agent sessions when nested spawning is enabled", () => {
+    const tools = createOpenClawCodingTools({
+      sessionKey: "main",
+      spawnedBy: "agent:jobs:main",
+      agentDir: "/tmp/.openclaw/agents/jobs/agent",
+      config: {
+        agents: {
+          list: [
+            {
+              id: "jobs",
+              subagents: {
+                allowNestedSpawns: true,
+              },
+            },
+          ],
+        },
+      },
+    });
+    const names = new Set(tools.map((tool) => tool.name));
+    expect(names.has("sessions_spawn")).toBe(true);
+  });
+
   it("supports allow-only sub-agent tool policy", () => {
     const tools = createOpenClawCodingTools({
       sessionKey: "agent:main:subagent:test",

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -3,7 +3,10 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxToolPolicy } from "./sandbox.js";
 import { getChannelDock } from "../channels/dock.js";
 import { resolveChannelGroupToolsPolicy } from "../config/group-policy.js";
-import { resolveThreadParentSessionKey } from "../sessions/session-key-utils.js";
+import {
+  isSubagentSessionKey,
+  resolveThreadParentSessionKey,
+} from "../sessions/session-key-utils.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentConfig, resolveAgentIdFromSessionKey } from "./agent-scope.js";
 import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
@@ -81,7 +84,6 @@ const DEFAULT_SUBAGENT_TOOL_DENY = [
   "sessions_list",
   "sessions_history",
   "sessions_send",
-  "sessions_spawn",
   // System admin - dangerous from subagent
   "gateway",
   "agents_list",
@@ -95,10 +97,28 @@ const DEFAULT_SUBAGENT_TOOL_DENY = [
   "memory_get",
 ];
 
-export function resolveSubagentToolPolicy(cfg?: OpenClawConfig): SandboxToolPolicy {
+function isNestedSpawnEnabledForSession(cfg?: OpenClawConfig, sessionKey?: string): boolean {
+  if (!cfg || !isSubagentSessionKey(sessionKey)) {
+    return false;
+  }
+  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  return (
+    agentConfig?.subagents?.allowNestedSpawns ??
+    cfg.agents?.defaults?.subagents?.allowNestedSpawns ??
+    false
+  );
+}
+
+export function resolveSubagentToolPolicy(
+  cfg?: OpenClawConfig,
+  opts?: { sessionKey?: string },
+): SandboxToolPolicy {
   const configured = cfg?.tools?.subagents?.tools;
+  const nestedSpawnEnabled = isNestedSpawnEnabledForSession(cfg, opts?.sessionKey);
   const deny = [
     ...DEFAULT_SUBAGENT_TOOL_DENY,
+    ...(nestedSpawnEnabled ? [] : ["sessions_spawn"]),
     ...(Array.isArray(configured?.deny) ? configured.deny : []),
   ];
   const allow = Array.isArray(configured?.allow) ? configured.allow : undefined;

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -97,11 +97,19 @@ const DEFAULT_SUBAGENT_TOOL_DENY = [
   "memory_get",
 ];
 
-function isNestedSpawnEnabledForSession(cfg?: OpenClawConfig, sessionKey?: string): boolean {
-  if (!cfg || !isSubagentSessionKey(sessionKey)) {
+function isNestedSpawnEnabledForSession(
+  cfg?: OpenClawConfig,
+  opts?: { sessionKey?: string; agentId?: string; forceSubagent?: boolean },
+): boolean {
+  if (!cfg) {
     return false;
   }
-  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+  const sessionKey = opts?.sessionKey;
+  const isSubagent = opts?.forceSubagent ?? isSubagentSessionKey(sessionKey);
+  if (!isSubagent) {
+    return false;
+  }
+  const agentId = opts?.agentId ? opts.agentId : resolveAgentIdFromSessionKey(sessionKey);
   const agentConfig = resolveAgentConfig(cfg, agentId);
   return (
     agentConfig?.subagents?.allowNestedSpawns ??
@@ -112,10 +120,10 @@ function isNestedSpawnEnabledForSession(cfg?: OpenClawConfig, sessionKey?: strin
 
 export function resolveSubagentToolPolicy(
   cfg?: OpenClawConfig,
-  opts?: { sessionKey?: string },
+  opts?: { sessionKey?: string; agentId?: string; forceSubagent?: boolean },
 ): SandboxToolPolicy {
   const configured = cfg?.tools?.subagents?.tools;
-  const nestedSpawnEnabled = isNestedSpawnEnabledForSession(cfg, opts?.sessionKey);
+  const nestedSpawnEnabled = isNestedSpawnEnabledForSession(cfg, opts);
   const deny = [
     ...DEFAULT_SUBAGENT_TOOL_DENY,
     ...(nestedSpawnEnabled ? [] : ["sessions_spawn"]),

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -215,7 +215,7 @@ export function createOpenClawCodingTools(options?: {
   const scopeKey = options?.exec?.scopeKey ?? (agentId ? `agent:${agentId}` : undefined);
   const subagentPolicy =
     isSubagentSessionKey(options?.sessionKey) && options?.sessionKey
-      ? resolveSubagentToolPolicy(options.config)
+      ? resolveSubagentToolPolicy(options.config, { sessionKey: options?.sessionKey })
       : undefined;
   const allowBackground = isToolAllowedByPolicies("process", [
     profilePolicyWithAlsoAllow,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -279,7 +279,7 @@ export function createOpenClawCodingTools(options?: {
     spawnedBy: options?.spawnedBy,
   });
   const subagentPolicy = subagentPolicyContext.forceSubagent
-    ? resolveSubagentToolPolicy(options.config, subagentPolicyContext)
+    ? resolveSubagentToolPolicy(options?.config, subagentPolicyContext)
     : undefined;
   const allowBackground = isToolAllowedByPolicies("process", [
     profilePolicyWithAlsoAllow,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -11,7 +11,7 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import { isSubagentSessionKey } from "../routing/session-key.js";
+import { isSubagentSessionKey, normalizeAgentId } from "../routing/session-key.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import {
@@ -56,6 +56,65 @@ import {
 function isOpenAIProvider(provider?: string) {
   const normalized = provider?.trim().toLowerCase();
   return normalized === "openai" || normalized === "openai-codex";
+}
+
+function deriveAgentIdFromAgentDir(agentDir?: string): string | undefined {
+  const raw = agentDir?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const match = raw.match(/[\\/]agents[\\/]([^\\/]+)[\\/]agent(?:[\\/]|$)/i);
+  const candidate = match?.[1]?.trim();
+  return candidate ? normalizeAgentId(candidate) : undefined;
+}
+
+function resolveSubagentSessionPolicyContext(params: {
+  sessionKey?: string;
+  agentId?: string;
+  agentDir?: string;
+  spawnedBy?: string | null;
+}): { sessionKey?: string; agentId?: string; forceSubagent: boolean } {
+  const raw = params.sessionKey?.trim();
+  const agentIdFromDir = deriveAgentIdFromAgentDir(params.agentDir);
+  const preferDirAgentId = !!params.spawnedBy && (!raw || !raw.startsWith("agent:"));
+  const fallbackAgentId = normalizeAgentId(
+    preferDirAgentId
+      ? (agentIdFromDir ?? params.agentId ?? "main")
+      : (params.agentId ?? agentIdFromDir ?? "main"),
+  );
+  if (!raw) {
+    return {
+      sessionKey: params.spawnedBy ? `agent:${fallbackAgentId}:subagent:derived` : undefined,
+      agentId: fallbackAgentId,
+      forceSubagent: !!params.spawnedBy,
+    };
+  }
+  if (raw.startsWith("agent:")) {
+    return {
+      sessionKey: raw,
+      agentId: fallbackAgentId,
+      forceSubagent: !!params.spawnedBy || isSubagentSessionKey(raw),
+    };
+  }
+  if (isSubagentSessionKey(raw)) {
+    return {
+      sessionKey: `agent:${fallbackAgentId}:${raw}`,
+      agentId: fallbackAgentId,
+      forceSubagent: true,
+    };
+  }
+  if (params.spawnedBy) {
+    return {
+      sessionKey: `agent:${fallbackAgentId}:subagent:derived`,
+      agentId: fallbackAgentId,
+      forceSubagent: true,
+    };
+  }
+  return {
+    sessionKey: raw,
+    agentId: fallbackAgentId,
+    forceSubagent: false,
+  };
 }
 
 function isApplyPatchAllowedForModel(params: {
@@ -213,10 +272,15 @@ export function createOpenClawCodingTools(options?: {
     providerProfileAlsoAllow,
   );
   const scopeKey = options?.exec?.scopeKey ?? (agentId ? `agent:${agentId}` : undefined);
-  const subagentPolicy =
-    isSubagentSessionKey(options?.sessionKey) && options?.sessionKey
-      ? resolveSubagentToolPolicy(options.config, { sessionKey: options?.sessionKey })
-      : undefined;
+  const subagentPolicyContext = resolveSubagentSessionPolicyContext({
+    sessionKey: options?.sessionKey,
+    agentId,
+    agentDir: options?.agentDir,
+    spawnedBy: options?.spawnedBy,
+  });
+  const subagentPolicy = subagentPolicyContext.forceSubagent
+    ? resolveSubagentToolPolicy(options.config, subagentPolicyContext)
+    : undefined;
   const allowBackground = isToolAllowedByPolicies("process", [
     profilePolicyWithAlsoAllow,
     providerProfilePolicyWithAlsoAllow,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -210,6 +210,10 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Allow sub-agent sessions to call sessions_spawn (nested spawning). Default: false. */
+    allowNestedSpawns?: boolean;
+    /** Max allowed sub-agent nesting depth when nested spawning is enabled (default: 2). */
+    maxDepth?: number;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -39,6 +39,12 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
+    /** Per-agent default thinking level for spawned sub-agents. */
+    thinking?: string;
+    /** Allow this agent's sub-agent sessions to call sessions_spawn (nested spawning). */
+    allowNestedSpawns?: boolean;
+    /** Max allowed sub-agent nesting depth when nested spawning is enabled. */
+    maxDepth?: number;
   };
   sandbox?: {
     mode?: "off" | "non-main" | "all";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -153,6 +153,8 @@ export const AgentDefaultsSchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        allowNestedSpawns: z.boolean().optional(),
+        maxDepth: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -466,6 +466,8 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        allowNestedSpawns: z.boolean().optional(),
+        maxDepth: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

This PR adds an **opt-in nested sub-agent spawning policy** so teams can allow controlled `sessions_spawn` fan-out from sub-agent sessions.

By default, behavior stays unchanged (nested spawning remains disabled).

## What changed

### Runtime behavior
- `sessions_spawn` no longer hard-blocks all sub-agent callers.
- Nested spawning is now gated by config:
  - `allowNestedSpawns` (default: `false`)
  - `maxDepth` (default: `2` when nested spawning is enabled)
- Enforced depth policy in `sessions_spawn`:
  - requester sub-agent depth is detected from session key
  - child spawn is rejected if it would exceed `maxDepth`
- Child session keys now encode depth for nested runs (depth > 1), e.g.:
  - `agent:<id>:subagent:2:<uuid>`

### Tool policy
- `sessions_spawn` remains denied for sub-agent sessions by default.
- If nested spawning is enabled for the current sub-agent's agent, `sessions_spawn` is exposed to that sub-agent session.

### Config/schema/types
Added fields under both:
- `agents.defaults.subagents`
- `agents.list[].subagents`

New fields:
- `allowNestedSpawns?: boolean`
- `maxDepth?: number`

### Docs
- Updated `docs/tools/subagents.md`:
  - default deny table wording
  - new “Enabling nested spawning (advanced)” section
  - updated full config example and limitations
- Updated `docs/gateway/configuration.md`:
  - documented new per-agent and default subagent fields

## Why

This keeps the current safe default, while supporting advanced orchestrator workflows that need one controlled nested hop (for example, planner → implementer/qa).

## Tests

Added/updated tests covering:
- nested spawning remains forbidden by default
- nested spawning allowed when enabled and within depth cap
- nested spawning rejected when depth cap would be exceeded
- sub-agent tool filtering keeps `sessions_spawn` hidden by default
- sub-agent tool filtering exposes `sessions_spawn` when nested spawning is enabled

## Validation run

- `pnpm vitest run src/agents/openclaw-tools.subagents.sessions-spawn-*.test.ts src/agents/sessions-spawn-threadid.test.ts src/agents/pi-tools-agent-config.test.ts`
- `pnpm vitest run src/agents/openclaw-tools.subagents.sessions-spawn-normalizes-allowlisted-agent-ids.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts`
- `pnpm lint`
- `pnpm format:docs:check`
- `pnpm lint:docs`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an opt-in policy for allowing sub-agent sessions to call `sessions_spawn` (nested spawning), with a configurable `maxDepth` cap. The change is implemented in `sessions-spawn-tool.ts` by parsing requester depth from the session key, checking `allowNestedSpawns` and enforcing `maxDepth`, and encoding depth into newly-created child sub-agent session keys. Tool filtering is updated so `sessions_spawn` is denied to sub-agents by default, but can be exposed when nested spawning is enabled for the requesting agent via config; config types/schemas and docs are updated accordingly.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe but has a policy-gating mismatch that can incorrectly hide `sessions_spawn` from sub-agent sessions even when enabled.
- Core depth enforcement logic in `sessions_spawn` is straightforward and covered by tests, but sub-agent tool filtering now derives nested-spawn enablement from the raw external session key, which may be an alias/non-`agent:` key and will cause incorrect denial. Fixing that alignment would reduce the risk of confusing/incorrect runtime behavior.
- src/agents/pi-tools.policy.ts, src/agents/pi-tools.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->