### PR TITLE
fix(cli): exit with non-zero code when configure/agents-add wizards are cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
+- CLI/Wizard: exit with code 1 when `configure`, `agents add`, or interactive `onboard` wizards are canceled, so `set -e` automation stops correctly. (#14156) Thanks @0xRaini.
 
 ## 2026.2.9
 

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -6,6 +6,10 @@ const configMocks = vi.hoisted(() => ({
   writeConfigFile: vi.fn().mockResolvedValue(undefined),
 }));
 
+const wizardMocks = vi.hoisted(() => ({
+  createClackPrompter: vi.fn(),
+}));
+
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
   return {
@@ -15,6 +19,11 @@ vi.mock("../config/config.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../wizard/clack-prompter.js", () => ({
+  createClackPrompter: wizardMocks.createClackPrompter,
+}));
+
+import { WizardCancelledError } from "../wizard/prompts.js";
 import { agentsAddCommand } from "./agents.js";
 
 const runtime: RuntimeEnv = {
@@ -38,6 +47,7 @@ describe("agents add command", () => {
   beforeEach(() => {
     configMocks.readConfigFileSnapshot.mockReset();
     configMocks.writeConfigFile.mockClear();
+    wizardMocks.createClackPrompter.mockReset();
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
@@ -61,6 +71,22 @@ describe("agents add command", () => {
     });
 
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--workspace"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("exits with code 1 when the interactive wizard is cancelled", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseSnapshot });
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn().mockRejectedValue(new WizardCancelledError()),
+      text: vi.fn(),
+      confirm: vi.fn(),
+      note: vi.fn(),
+      outro: vi.fn(),
+    });
+
+    await agentsAddCommand({}, runtime);
+
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
   });

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -359,7 +359,7 @@ export async function agentsAddCommand(
     await prompter.outro(`Agent "${agentId}" ready.`);
   } catch (err) {
     if (err instanceof WizardCancelledError) {
-      runtime.exit(0);
+      runtime.exit(1);
       return;
     }
     throw err;

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -587,7 +587,7 @@ export async function runConfigureWizard(
     outro("Configure complete.");
   } catch (err) {
     if (err instanceof WizardCancelledError) {
-      runtime.exit(0);
+      runtime.exit(1);
       return;
     }
     throw err;

--- a/src/commands/onboard-interactive.test.ts
+++ b/src/commands/onboard-interactive.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  createClackPrompter: vi.fn(),
+  runOnboardingWizard: vi.fn(),
+  restoreTerminalState: vi.fn(),
+}));
+
+vi.mock("../wizard/clack-prompter.js", () => ({
+  createClackPrompter: mocks.createClackPrompter,
+}));
+
+vi.mock("../wizard/onboarding.js", () => ({
+  runOnboardingWizard: mocks.runOnboardingWizard,
+}));
+
+vi.mock("../terminal/restore.js", () => ({
+  restoreTerminalState: mocks.restoreTerminalState,
+}));
+
+import { WizardCancelledError } from "../wizard/prompts.js";
+import { runInteractiveOnboarding } from "./onboard-interactive.js";
+
+const runtime: RuntimeEnv = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+describe("runInteractiveOnboarding", () => {
+  beforeEach(() => {
+    mocks.createClackPrompter.mockReset();
+    mocks.runOnboardingWizard.mockReset();
+    mocks.restoreTerminalState.mockReset();
+    runtime.log.mockClear();
+    runtime.error.mockClear();
+    runtime.exit.mockClear();
+
+    mocks.createClackPrompter.mockReturnValue({});
+  });
+
+  it("exits with code 1 when the wizard is cancelled", async () => {
+    mocks.runOnboardingWizard.mockRejectedValue(new WizardCancelledError());
+
+    await runInteractiveOnboarding({} as never, runtime);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.restoreTerminalState).toHaveBeenCalledWith("onboarding finish");
+  });
+
+  it("rethrows non-cancel errors", async () => {
+    const err = new Error("boom");
+    mocks.runOnboardingWizard.mockRejectedValue(err);
+
+    await expect(runInteractiveOnboarding({} as never, runtime)).rejects.toThrow("boom");
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(mocks.restoreTerminalState).toHaveBeenCalledWith("onboarding finish");
+  });
+});

--- a/src/commands/onboard-interactive.ts
+++ b/src/commands/onboard-interactive.ts
@@ -15,7 +15,7 @@ export async function runInteractiveOnboarding(
     await runOnboardingWizard(opts, runtime, prompter);
   } catch (err) {
     if (err instanceof WizardCancelledError) {
-      runtime.exit(0);
+      runtime.exit(1);
       return;
     }
     throw err;


### PR DESCRIPTION
## Problem

`configure` and `agents add` wizard flows returned `runtime.exit(0)` on `WizardCancelledError`, which reports cancellation as success.

`runInteractiveOnboarding` had the same behavior. For scripts using `set -e`, cancellation should be treated as non-success so chained steps stop correctly.

## Solution

Change cancel handling from `runtime.exit(0)` to `runtime.exit(1)` in:

- `src/commands/configure.wizard.ts`
- `src/commands/agents.commands.add.ts`
- `src/commands/onboard-interactive.ts`

Add regression tests covering all three cancel paths.

## Testing

- `pnpm exec vitest run src/commands/configure.wizard.test.ts src/commands/agents.add.test.ts src/commands/onboard-interactive.test.ts` (7/7 passing)
- `pnpm build`
- `pnpm ui:build`
- `pnpm check`
- `pnpm test`

cc @gumadeiras