### PR TITLE
fix(browser): add gio and trash-put fallbacks for Linux trash operations

### DIFF
--- a/src/browser/trash.ts
+++ b/src/browser/trash.ts
@@ -4,18 +4,34 @@ import path from "node:path";
 import { runExec } from "../process/exec.js";
 
 export async function movePathToTrash(targetPath: string): Promise<string> {
-  try {
-    await runExec("trash", [targetPath], { timeoutMs: 10_000 });
-    return targetPath;
-  } catch {
-    const trashDir = path.join(os.homedir(), ".Trash");
-    fs.mkdirSync(trashDir, { recursive: true });
-    const base = path.basename(targetPath);
-    let dest = path.join(trashDir, `${base}-${Date.now()}`);
-    if (fs.existsSync(dest)) {
-      dest = path.join(trashDir, `${base}-${Date.now()}-${Math.random()}`);
+  // Try platform-native trash commands in order of preference.
+  // macOS: `trash` (trash-cli or Homebrew formula)
+  // Linux: `trash` (trash-cli) → `gio trash` (GLib/GNOME) → `trash-put` (trash-cli alt)
+  const commands: Array<[string, string[]]> = [
+    ["trash", [targetPath]],
+    ["gio", ["trash", targetPath]],
+    ["trash-put", [targetPath]],
+  ];
+  for (const [cmd, args] of commands) {
+    try {
+      await runExec(cmd, args, { timeoutMs: 10_000 });
+      return targetPath;
+    } catch {
+      // Command not found or failed — try next
     }
-    fs.renameSync(targetPath, dest);
-    return dest;
   }
+
+  // Final fallback: move to ~/.Trash (macOS) or XDG trash (Linux)
+  const trashDir =
+    process.platform === "linux"
+      ? path.join(os.homedir(), ".local", "share", "Trash", "files")
+      : path.join(os.homedir(), ".Trash");
+  fs.mkdirSync(trashDir, { recursive: true });
+  const base = path.basename(targetPath);
+  let dest = path.join(trashDir, `${base}-${Date.now()}`);
+  if (fs.existsSync(dest)) {
+    dest = path.join(trashDir, `${base}-${Date.now()}-${Math.random()}`);
+  }
+  fs.renameSync(targetPath, dest);
+  return dest;
 }


### PR DESCRIPTION
## Problem

`moveToTrash()` only tries the `trash` command (from `trash-cli`). On most minimal Linux installs, `trash-cli` isn't installed, so trash operations silently fail — files stay in place with only a log message.

Most desktop Linux systems have `gio` (from GLib/GNOME) which provides `gio trash` and is more commonly available.

Fixes #14081

## Fix

1. **Try multiple commands** in order: `trash` → `gio trash` → `trash-put`
2. **XDG-compliant fallback** on Linux: use `~/.local/share/Trash/files` instead of `~/.Trash` (which is macOS-specific)

```ts
const commands: Array<[string, string[]]> = [
  ["trash", [targetPath]],
  ["gio", ["trash", targetPath]],
  ["trash-put", [targetPath]],
];
```

## Testing

All 172 browser tests pass. No behavior change on macOS (still tries `trash` first, falls back to `~/.Trash`).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improved Linux trash operations by adding fallback commands (`gio trash` and `trash-put`) and switching to XDG-compliant trash directory (`~/.local/share/Trash/files`). The implementation tries multiple platform-native commands in sequence before falling back to manual file movement, addressing silent failures on minimal Linux installs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, backwards-compatible, and improve existing functionality. The logic is straightforward with proper error handling via try-catch blocks. All 172 browser tests pass, and the implementation follows Linux XDG standards.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->