### PR TITLE
fix(docker): skip health check and UI prompts during docker-setup onboard

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -192,7 +192,11 @@ echo "  - Gateway token: $OPENCLAW_GATEWAY_TOKEN"
 echo "  - Tailscale exposure: Off"
 echo "  - Install Gateway daemon: No"
 echo ""
-docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard --no-install-daemon
+if ! docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard --no-install-daemon --skip-health --skip-ui; then
+  echo ""
+  echo "Onboarding cancelled or failed. Exiting."
+  exit 1
+fi
 
 echo ""
 echo "==> Provider setup (optional)"


### PR DESCRIPTION
## Problem

`docker-setup.sh` runs `openclaw onboard` before starting the gateway container. This causes two issues:

1. **Health check always fails** — the gateway isn't running yet, so the WS health check fails with `1006 abnormal closure`, printing confusing error messages (#14012)
2. **TUI/Web UI prompt is useless** — since the gateway isn't reachable, the hatch choice is never offered, and the script hangs or shows irrelevant SSH hints
3. **No error handling for onboard failure** — if the user cancels or onboard fails, `docker compose run` may not propagate the exit code cleanly in all Docker versions, so the script continues to start the gateway anyway (#14070)

## Solution

- Add `--skip-health` and `--skip-ui` flags to the onboard command in `docker-setup.sh` — these steps are meaningless before the gateway is running
- Add explicit `if !` error handling around the onboard command so cancellation/failure is caught regardless of `set -e` behavior with `docker compose run`

## Testing

- Verified the shell script syntax is correct
- The `--skip-health` and `--skip-ui` flags are already supported by the onboard command (see `register.onboard.ts`)
- One-line change to the onboard command + 4-line error guard

Closes #14012
Related: #14070

cc @Takhoffman

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `--skip-health` and `--skip-ui` flags to the `onboard` command in `docker-setup.sh` and wrapped it with error handling to catch failures. This prevents confusing error messages from health checks that fail because the gateway isn't running yet, and avoids hanging on UI prompts that can't be satisfied before the gateway starts. The error handling ensures the script exits cleanly if onboarding is cancelled or fails, rather than continuing to start the gateway anyway.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and directly address the stated issues. The `--skip-health` and `--skip-ui` flags are already supported in the codebase (verified in register.onboard.ts:108-109 and onboard-types.ts:123-124), and are used correctly in existing E2E tests. The shell script syntax is valid, and the error handling pattern follows bash best practices with the `if !` construct. The change prevents the script from attempting operations that cannot succeed before the gateway is running, which is the correct behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->