### PR TITLE
fix(discord): default standalone threads to public type

### DIFF
--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -120,6 +120,24 @@ describe("sendMessageDiscord", () => {
     );
   });
 
+  it("respects explicit thread type for standalone threads", async () => {
+    const { rest, getMock, postMock } = makeRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildText });
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord(
+      "chan1",
+      { name: "thread", type: ChannelType.PrivateThread },
+      { rest, token: "t" },
+    );
+    expect(getMock).toHaveBeenCalledWith(Routes.channel("chan1"));
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.threads("chan1"),
+      expect.objectContaining({
+        body: expect.objectContaining({ name: "thread", type: ChannelType.PrivateThread }),
+      }),
+    );
+  });
+
   it("lists active threads by guild", async () => {
     const { rest, getMock } = makeRest();
     getMock.mockResolvedValue({ threads: [] });

--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -114,7 +114,9 @@ describe("sendMessageDiscord", () => {
     await createThreadDiscord("chan1", { name: "thread" }, { rest, token: "t" });
     expect(postMock).toHaveBeenCalledWith(
       Routes.threads("chan1"),
-      expect.objectContaining({ body: { name: "thread" } }),
+      expect.objectContaining({
+        body: expect.objectContaining({ name: "thread", type: ChannelType.PublicThread }),
+      }),
     );
   });
 

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -122,6 +122,12 @@ export async function createThreadDiscord(
     const starterContent = payload.content?.trim() ? payload.content : payload.name;
     body.message = { content: starterContent };
   }
+  // When creating a standalone thread (no messageId) in a non-forum channel,
+  // default to public thread (type 11). Discord defaults to private (type 12)
+  // which is unexpected for most users. (#14147)
+  if (!payload.messageId && !isForumLike && body.type === undefined) {
+    body.type = ChannelType.PublicThread;
+  }
   const route = payload.messageId
     ? Routes.threads(channelId, payload.messageId)
     : Routes.threads(channelId);

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -105,6 +105,9 @@ export async function createThreadDiscord(
   if (payload.autoArchiveMinutes) {
     body.auto_archive_duration = payload.autoArchiveMinutes;
   }
+  if (!payload.messageId && payload.type !== undefined) {
+    body.type = payload.type;
+  }
   let channelType: ChannelType | undefined;
   if (!payload.messageId) {
     // Only detect channel kind for route-less thread creation.

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -72,6 +72,8 @@ export type DiscordThreadCreate = {
   name: string;
   autoArchiveMinutes?: number;
   content?: string;
+  /** Discord thread type (default: PublicThread for standalone threads). */
+  type?: number;
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Problem

When creating a Discord thread via `thread-create` without a `messageId`, the thread is created as **private** (type 12) instead of **public** (type 11).

Reported in #14147.

## Root Cause

Discord's `POST /channels/{id}/threads` defaults to type 12 (private) when no `type` is specified.

## Solution

Set `type: ChannelType.PublicThread` (11) for standalone threads in non-forum channels.

Closes #14147

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Discord thread creation to default *standalone* threads (created via `POST /channels/{id}/threads` with no `messageId`) to `ChannelType.PublicThread` in non-forum-like channels, aligning behavior with user expectations and Discord’s API defaults.

Main functional concern is around `type` handling: `DiscordThreadCreate` gained a `type` field but `createThreadDiscord` doesn’t forward `payload.type` into the request body (and the current guard checks `body.type`, which is always unset). Additionally, when the channel-type lookup fails, the new defaulting logic now forces `PublicThread`, changing the prior “let Discord default/validate” behavior and breaking an existing unit test (`send.creates-thread.test.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close but has a couple behavior/regression issues to resolve before merging.
- The change is localized, but it currently (1) drops any caller-provided thread `type` despite adding it to the public API, and (2) changes behavior when channel lookup fails (and breaks an existing test), so it needs adjustment and test updates before being considered safe.
- src/discord/send.messages.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->