### PR TITLE
fix(infra): fall back to ss for port diagnostics when lsof is missing on Linux

### DIFF
--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -102,6 +102,34 @@ async function readUnixListeners(
     );
     return { listeners, detail: res.stdout.trim() || undefined, errors };
   }
+  // Fallback: try `ss` (iproute2) on Linux when lsof is unavailable or fails.
+  if (process.platform === "linux") {
+    const ssRes = await runCommandSafe(["ss", "-tlnp", `sport = :${port}`]);
+    if (ssRes.code === 0) {
+      const listeners = parseSsOutput(ssRes.stdout, port);
+      if (listeners.length > 0) {
+        await Promise.all(
+          listeners.map(async (listener) => {
+            if (!listener.pid) {
+              return;
+            }
+            const [commandLine, user] = await Promise.all([
+              resolveUnixCommandLine(listener.pid),
+              resolveUnixUser(listener.pid),
+            ]);
+            if (commandLine) {
+              listener.commandLine = commandLine;
+            }
+            if (user) {
+              listener.user = user;
+            }
+          }),
+        );
+        return { listeners, detail: ssRes.stdout.trim() || undefined, errors };
+      }
+    }
+  }
+
   const stderr = res.stderr.trim();
   if (res.code === 1 && !res.error && !stderr) {
     return { listeners: [], detail: undefined, errors };
@@ -114,6 +142,44 @@ async function readUnixListeners(
     errors.push(detail);
   }
   return { listeners: [], detail: undefined, errors };
+}
+
+/**
+ * Parse `ss -tlnp sport = :PORT` output.
+ * Typical line:
+ *   LISTEN  0  4096  0.0.0.0:18789  0.0.0.0:*  users:(("node",pid=1234,fd=19))
+ */
+function parseSsOutput(output: string, port: number): PortListener[] {
+  const listeners: PortListener[] = [];
+  const portToken = `:${port}`;
+  for (const rawLine of output.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || !line.startsWith("LISTEN")) {
+      continue;
+    }
+    if (!line.includes(portToken)) {
+      continue;
+    }
+    const listener: PortListener = {};
+
+    // Extract address (4th column: local address:port)
+    const parts = line.split(/\s+/);
+    if (parts.length >= 4 && parts[3]?.includes(portToken)) {
+      listener.address = parts[3];
+    }
+
+    // Extract PID and command from users:(("cmd",pid=N,...))
+    const usersMatch = line.match(/users:\(\("([^"]*)",pid=(\d+)/);
+    if (usersMatch) {
+      listener.command = usersMatch[1];
+      const pid = Number.parseInt(usersMatch[2], 10);
+      if (Number.isFinite(pid)) {
+        listener.pid = pid;
+      }
+    }
+    listeners.push(listener);
+  }
+  return listeners;
 }
 
 function parseNetstatListeners(output: string, port: number): PortListener[] {


### PR DESCRIPTION
## Problem

Port conflict diagnostics rely on `lsof` to identify which process owns a port. On minimal Linux installs (containers, cloud VMs, WSL), `lsof` is often not installed. Users get:

> Port is in use but process details are unavailable (install lsof or run as an admin user).

Not helpful when you're debugging why the gateway won't start.

Fixes #14083

## Fix

After `lsof` fails, try `ss -tlnp` (from `iproute2`, installed on virtually every Linux system):

```
LISTEN  0  4096  0.0.0.0:18789  0.0.0.0:*  users:(("node",pid=1234,fd=19))
```

The `parseSsOutput()` function extracts:
- Listen address (`0.0.0.0:18789`)
- Command name (`node`)
- PID (`1234`)

Then enriches with `ps` for full command line and user, same as the `lsof` path.

## Scope

- Only activates on `process.platform === "linux""
- Only runs when `lsof` fails or returns no results
- Zero impact on macOS/Windows paths
- All 457 infra tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `ss` fallback for port diagnostics on Linux when `lsof` is unavailable. The implementation correctly parses `ss -tlnp` output to extract process details (PID, command, address) and enriches with `ps` for full command line and user info, matching the existing `lsof` path.

Key changes:
- New `parseSsOutput()` function to parse `ss` command output format
- Fallback only activates on Linux when `lsof` fails (zero impact on macOS/Windows)
- Preserves same enrichment flow (uses `ps` for command line and user details)
- Maintains consistent error handling and return structure

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-isolated to Linux platform only, properly handles edge cases, follows existing patterns for process info enrichment, and has clear fallback behavior. The regex parsing is straightforward and the logic correctly validates data before use. PR author confirms all 457 infra tests pass.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->