### PR TITLE
fix(exec): detect git SSH signing config and warn before execution

### DIFF
--- a/src/agents/git-signing-detect.test.ts
+++ b/src/agents/git-signing-detect.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGitSshSigningWarning,
+  detectGitSshSigning,
+  parseGitSigningCommand,
+} from "./git-signing-detect.js";
+
+describe("parseGitSigningCommand", () => {
+  it("detects plain git commit", () => {
+    expect(parseGitSigningCommand("git commit -m 'hello'")).toBe("commit");
+  });
+
+  it("detects git merge", () => {
+    expect(parseGitSigningCommand("git merge main")).toBe("merge");
+  });
+
+  it("detects git tag", () => {
+    expect(parseGitSigningCommand("git tag v1.0.0")).toBe("tag");
+  });
+
+  it("detects git rebase", () => {
+    expect(parseGitSigningCommand("git rebase main")).toBe("rebase");
+  });
+
+  it("detects git cherry-pick", () => {
+    expect(parseGitSigningCommand("git cherry-pick abc123")).toBe("cherry-pick");
+  });
+
+  it("detects git push", () => {
+    expect(parseGitSigningCommand("git push origin main")).toBe("push");
+  });
+
+  it("detects git commit with -C flag", () => {
+    expect(parseGitSigningCommand("git -C /some/path commit -m 'test'")).toBe("commit");
+  });
+
+  it("detects git commit with -c config flag", () => {
+    expect(parseGitSigningCommand("git -c user.name=test commit -m 'test'")).toBe("commit");
+  });
+
+  it("detects git commit after cd command", () => {
+    expect(parseGitSigningCommand("cd /project && git commit -m 'test'")).toBe("commit");
+  });
+
+  it("detects git commit with env prefix", () => {
+    expect(parseGitSigningCommand("GIT_AUTHOR_NAME=test git commit -m 'test'")).toBe("commit");
+  });
+
+  it("returns null for non-git commands", () => {
+    expect(parseGitSigningCommand("ls -la")).toBeNull();
+  });
+
+  it("returns null for git commands that dont trigger signing", () => {
+    expect(parseGitSigningCommand("git status")).toBeNull();
+    expect(parseGitSigningCommand("git log")).toBeNull();
+    expect(parseGitSigningCommand("git diff")).toBeNull();
+    expect(parseGitSigningCommand("git fetch origin")).toBeNull();
+    expect(parseGitSigningCommand("git pull")).toBeNull();
+    expect(parseGitSigningCommand("git clone repo")).toBeNull();
+    expect(parseGitSigningCommand("git add .")).toBeNull();
+  });
+
+  it("returns null when --no-gpg-sign is used", () => {
+    expect(parseGitSigningCommand("git commit --no-gpg-sign -m 'test'")).toBeNull();
+  });
+
+  it("returns null when commit.gpgsign=false is used", () => {
+    expect(parseGitSigningCommand("git -c commit.gpgsign=false commit -m 'test'")).toBeNull();
+  });
+
+  it("returns null for empty command", () => {
+    expect(parseGitSigningCommand("")).toBeNull();
+  });
+
+  it("handles piped git commands", () => {
+    expect(parseGitSigningCommand("echo test | git commit -m 'test'")).toBe("commit");
+  });
+
+  it("handles semicolon-separated git commands", () => {
+    expect(parseGitSigningCommand("git add . ; git commit -m 'test'")).toBe("commit");
+  });
+});
+
+describe("detectGitSshSigning", () => {
+  it("returns result without throwing for any directory", async () => {
+    const result = await detectGitSshSigning(process.cwd());
+    expect(result).toHaveProperty("sshSigning");
+    expect(result).toHaveProperty("gpgSignEnabled");
+    expect(result).toHaveProperty("gpgFormat");
+    expect(typeof result.sshSigning).toBe("boolean");
+    expect(typeof result.gpgSignEnabled).toBe("boolean");
+  });
+
+  it("does not throw for non-existent directory", async () => {
+    const result = await detectGitSshSigning("/nonexistent/path/abc123");
+    expect(result.sshSigning).toBe(false);
+    expect(result.gpgSignEnabled).toBe(false);
+  });
+});
+
+describe("buildGitSshSigningWarning", () => {
+  it("includes the subcommand in the warning", () => {
+    const warning = buildGitSshSigningWarning("commit");
+    expect(warning).toContain("git commit");
+    expect(warning).toContain("SSH-based commit signing");
+    expect(warning).toContain("pty=true");
+    expect(warning).toContain("--no-gpg-sign");
+  });
+
+  it("includes workaround with the correct subcommand", () => {
+    const warning = buildGitSshSigningWarning("merge");
+    expect(warning).toContain("git merge");
+    expect(warning).toContain("git -c commit.gpgsign=false merge");
+  });
+});

--- a/src/agents/git-signing-detect.ts
+++ b/src/agents/git-signing-detect.ts
@@ -1,0 +1,113 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Git sub-commands that trigger commit signing when `commit.gpgsign=true`.
+ */
+const GIT_SIGNING_SUBCOMMANDS = new Set([
+  "commit",
+  "merge",
+  "tag",
+  "rebase",
+  "cherry-pick",
+  "revert",
+  "am",
+  "push", // push can trigger signing for signed pushes
+]);
+
+/**
+ * Check if a shell command is a git command that may trigger signing.
+ * Returns the detected git sub-command, or null if not a signing-eligible git command.
+ */
+export function parseGitSigningCommand(command: string): string | null {
+  const trimmed = command.trim();
+
+  // Check if the command already explicitly disables signing
+  if (
+    trimmed.includes("--no-gpg-sign") ||
+    trimmed.includes("commit.gpgsign=false") ||
+    trimmed.includes("gpgsign=false")
+  ) {
+    return null;
+  }
+
+  // Match patterns like: git commit, git -C /path commit, git -c key=val commit, etc.
+  // Also handles: cd foo && git commit, ENV=val git commit, etc.
+  // Use global flag to find all git invocations in compound commands.
+  const gitPattern = /(?:^|&&|\|\||;\s*|\|)\s*(?:\S+=\S+\s+)*git\s+(?:-[cC]\s+\S+\s+)*(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = gitPattern.exec(trimmed)) !== null) {
+    const subcommand = match[1];
+    if (subcommand && GIT_SIGNING_SUBCOMMANDS.has(subcommand)) {
+      return subcommand;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Result of SSH signing detection.
+ */
+export type GitSshSigningInfo = {
+  /** Whether SSH-based signing is active */
+  sshSigning: boolean;
+  /** Whether commit.gpgsign is enabled */
+  gpgSignEnabled: boolean;
+  /** The gpg.format value (e.g. "ssh", "openpgp", "x509") */
+  gpgFormat: string | null;
+};
+
+/**
+ * Detect if git is configured with SSH-based commit signing.
+ * Reads git config from the given working directory.
+ *
+ * This is intentionally fast — runs two `git config` lookups with a short timeout.
+ */
+export async function detectGitSshSigning(cwd: string): Promise<GitSshSigningInfo> {
+  const result: GitSshSigningInfo = {
+    sshSigning: false,
+    gpgSignEnabled: false,
+    gpgFormat: null,
+  };
+
+  try {
+    const [gpgSignResult, formatResult] = await Promise.all([
+      execFileAsync("git", ["config", "--get", "commit.gpgsign"], {
+        cwd,
+        timeout: 3000,
+        encoding: "utf8",
+      }).catch(() => ({ stdout: "" })),
+      execFileAsync("git", ["config", "--get", "gpg.format"], {
+        cwd,
+        timeout: 3000,
+        encoding: "utf8",
+      }).catch(() => ({ stdout: "" })),
+    ]);
+
+    const gpgSign = gpgSignResult.stdout.trim().toLowerCase();
+    const format = formatResult.stdout.trim().toLowerCase();
+
+    result.gpgSignEnabled = gpgSign === "true";
+    result.gpgFormat = format || null;
+    result.sshSigning = result.gpgSignEnabled && format === "ssh";
+  } catch {
+    // If we can't read git config, don't block execution
+  }
+
+  return result;
+}
+
+/**
+ * Build a warning message for git SSH signing issues.
+ */
+export function buildGitSshSigningWarning(subcommand: string): string {
+  return (
+    `Warning: git ${subcommand} may fail — SSH-based commit signing (gpg.format=ssh) ` +
+    `requires TTY access unavailable in non-interactive shells. ` +
+    `Workaround: use pty=true, or pass --no-gpg-sign, ` +
+    `or run: git -c commit.gpgsign=false ${subcommand}`
+  );
+}


### PR DESCRIPTION
## Problem

When `commit.gpgsign=true` is configured with SSH-based signing (`gpg.format=ssh`), any `git commit`, `git merge`, or similar command run via the exec tool receives **SIGKILL** immediately. This happens because SSH signing requires interactive TTY access unavailable in non-interactive shells.

Users hit this silently — the command just dies with no explanation.

Closes #14134

## Solution

Added **pre-execution detection** of git SSH signing configuration:

1. **`parseGitSigningCommand(command)`** — parses shell commands to detect git subcommands that trigger signing (`commit`, `merge`, `tag`, `rebase`, `cherry-pick`, `revert`, `am`, `push`). Skips commands that already disable signing (`--no-gpg-sign`, `commit.gpgsign=false`).

2. **`detectGitSshSigning(cwd)`** — reads `commit.gpgsign` and `gpg.format` from git config in the working directory. Fast (3s timeout), non-blocking on failure.

3. When SSH signing is detected, a **warning** is prepended to the exec output with actionable workarounds:
   - Use `pty=true`
   - Pass `--no-gpg-sign`
   - Use `git -c commit.gpgsign=false <subcommand>`

The detection runs **only** for non-sandbox git commands and never blocks execution — if config detection fails, the command proceeds normally.

## Testing

- 21 unit tests covering command parsing, edge cases (compound commands, env prefixes, `-C`/`-c` flags), signing detection, and warning format.
- All existing bash-tools tests pass.

cc @juehv

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a pre-execution warning path in `exec` that detects when a shell command appears to be a signing-eligible `git` subcommand and the repo has `commit.gpgsign=true` with `gpg.format=ssh`. It introduces a small parser (`parseGitSigningCommand`) to identify relevant `git <subcommand>` invocations and a config probe (`detectGitSshSigning`) that runs `git config --get …` with a short timeout, then prepends a warning with suggested workarounds.

The change integrates into the existing `createExecTool` flow by appending the warning to the `warnings` array before process spawn, so the message shows up in both streaming updates and final output.


<h3>Confidence Score: 3/5</h3>

- This PR is close, but the SSH-signing warning may not trigger in node-host executions and the parser can miss real cases due to over-broad substring matching.
- Core approach is reasonable and localized, but (1) `detectGitSshSigning` is executed locally even when the command will run on a remote node host, making the detection ineffective there, and (2) `parseGitSigningCommand` can incorrectly suppress warnings when `gpgsign=false` appears anywhere in the shell string. These issues reduce the reliability of the feature in real-world scenarios.
- src/agents/bash-tools.exec.ts, src/agents/git-signing-detect.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->