### PR TITLE
fix(agents): strip image content from history when switching to text-only models

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.strip.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.strip.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { stripImageContentForTextModel } from "./images.js";
+
+describe("stripImageContentForTextModel", () => {
+  it("returns messages unchanged when there are no image blocks", () => {
+    const messages = [
+      { role: "user" as const, content: [{ type: "text" as const, text: "Hello" }] },
+      { role: "assistant" as const, content: [{ type: "text" as const, text: "Hi there" }] },
+    ];
+    const { messages: result, strippedCount } = stripImageContentForTextModel(messages);
+    expect(strippedCount).toBe(0);
+    expect(result).toEqual(messages);
+  });
+
+  it("strips image blocks from user messages", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "What is in this image?" },
+          { type: "image" as const, data: "base64data", mediaType: "image/png" },
+        ],
+      },
+    ];
+    const { messages: result, strippedCount } = stripImageContentForTextModel(messages);
+    expect(strippedCount).toBe(1);
+    expect(result).toHaveLength(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ type: "text", text: "What is in this image?" });
+    expect(content[1]).toEqual({
+      type: "text",
+      text: "[An image was shared but is not available to this model]",
+    });
+  });
+
+  it("strips multiple image blocks from a single user message", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "Compare these" },
+          { type: "image" as const, data: "img1", mediaType: "image/png" },
+          { type: "image" as const, data: "img2", mediaType: "image/jpeg" },
+        ],
+      },
+    ];
+    const { messages: result, strippedCount } = stripImageContentForTextModel(messages);
+    expect(strippedCount).toBe(2);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(2);
+    expect(content[1]).toEqual({
+      type: "text",
+      text: "[2 images were shared but are not available to this model]",
+    });
+  });
+
+  it("strips image blocks from toolResult messages", () => {
+    const messages = [
+      {
+        role: "toolResult" as const,
+        toolCallId: "call_123",
+        content: [
+          { type: "text" as const, text: "Screenshot taken" },
+          { type: "image" as const, data: "screenshot", mediaType: "image/png" },
+        ],
+      },
+    ];
+    const { messages: result, strippedCount } = stripImageContentForTextModel(messages);
+    expect(strippedCount).toBe(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ type: "text", text: "Screenshot taken" });
+    expect(content[1]).toEqual({
+      type: "text",
+      text: "[image content stripped for text model]",
+    });
+  });
+
+  it("does not modify assistant messages", () => {
+    const messages = [
+      {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: "I can see the image" }],
+      },
+    ];
+    const { messages: result, strippedCount } = stripImageContentForTextModel(messages);
+    expect(strippedCount).toBe(0);
+    expect(result).toEqual(messages);
+  });
+
+  it("handles user messages with string content", () => {
+    const messages = [{ role: "user" as const, content: "Hello" }];
+    const { messages: result, strippedCount } = stripImageContentForTextModel(messages);
+    expect(strippedCount).toBe(0);
+    expect(result).toEqual(messages);
+  });
+
+  it("handles empty messages array", () => {
+    const { messages: result, strippedCount } = stripImageContentForTextModel([]);
+    expect(strippedCount).toBe(0);
+    expect(result).toEqual([]);
+  });
+
+  it("strips images across multiple messages", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "Image 1" },
+          { type: "image" as const, data: "img1", mediaType: "image/png" },
+        ],
+      },
+      {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: "I see a cat" }],
+      },
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "Image 2" },
+          { type: "image" as const, data: "img2", mediaType: "image/jpeg" },
+        ],
+      },
+    ];
+    const { messages: result, strippedCount } = stripImageContentForTextModel(messages);
+    expect(strippedCount).toBe(2);
+    expect(result).toHaveLength(3);
+    // First user message stripped
+    const content1 = (result[0] as { content: unknown[] }).content;
+    expect(content1.some((b: { type?: string }) => b.type === "image")).toBe(false);
+    // Assistant message unchanged
+    expect(result[1]).toEqual(messages[1]);
+    // Second user message stripped
+    const content2 = (result[2] as { content: unknown[] }).content;
+    expect(content2.some((b: { type?: string }) => b.type === "image")).toBe(false);
+  });
+
+  it("preserves message properties other than content", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "test" },
+          { type: "image" as const, data: "img", mediaType: "image/png" },
+        ],
+      },
+    ];
+    const { messages: result } = stripImageContentForTextModel(messages);
+    expect((result[0] as { role: string }).role).toBe("user");
+  });
+});


### PR DESCRIPTION
## Problem

When a conversation contains images (sent by the user or returned by tools like `image`/`screenshot`), switching to a text-only model (e.g., `qwen3-coder`) causes API errors because image content blocks are sent to a model that doesn't support them. This effectively blocks model switching for any session with images.

Closes #14129

## Solution

Added `stripImageContentForTextModel()` to strip image content blocks from session messages before sending them to models that lack vision support.

**Key design decisions:**
- Image blocks are replaced with text placeholders (e.g., `[An image was shared but is not available to this model]`) to preserve conversational context
- Stripping only applies when the target model's `input` array doesn't include `"image"`
- Only user and toolResult messages are affected (assistant messages don't contain image blocks)
- The stripping happens in the message preparation pipeline (after `limitHistoryTurns`), so original session data is untouched — switching back to a vision model restores full image context

## Testing

- 9 unit tests covering: no images, single image, multiple images, toolResult images, string content, empty messages, multi-message stripping, property preservation
- All existing image tests pass (24 tests)

cc @juehv

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `stripImageContentForTextModel()` step to the embedded runner’s session-history preparation pipeline so that, when switching to a text-only model, any `image` content blocks in prior user/toolResult messages are replaced with text placeholders. The intent is to prevent provider API errors from sending image blocks to non-vision models while preserving conversational context and leaving the on-disk session transcript unmodified.

Changes are primarily in `src/agents/pi-embedded-runner/run/attempt.ts` (apply stripping after `limitHistoryTurns` when `modelHasVision` is false) and `src/agents/pi-embedded-runner/run/images.ts` (new helper), with a new vitest suite for the helper.

Issue found: the new unit tests model image blocks with a `mediaType` field, but the repository’s `ImageContent` shape uses `mimeType`; this mismatch risks the tests not reflecting real transcripts and missing regressions.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the new test fixtures match real image block shapes.
- The runtime change is localized (only strips history blocks when the target model lacks vision input) and preserves original session data. The main problem identified is in the added unit tests: they use `mediaType` instead of the codebase’s `mimeType` for image blocks, which undermines test validity and could allow regressions to slip through.
- src/agents/pi-embedded-runner/run/images.strip.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->