### PR TITLE
fix(cli): guard process.noDeprecation assignment for Node.js v23+

### DIFF
--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -672,7 +672,12 @@ function printResult(result: UpdateRunResult, opts: PrintResultOptions) {
 }
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
-  process.noDeprecation = true;
+  // Wrap in try/catch: property is read-only on Node.js v23+ (#14107)
+  try {
+    process.noDeprecation = true;
+  } catch {
+    // Read-only in newer Node.js versions; use env var fallback below.
+  }
   process.env.NODE_NO_WARNINGS = "1";
   const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
   const shouldRestart = opts.restart !== false;


### PR DESCRIPTION
## Problem

`openclaw update` crashes on Node.js v23+ with:
```
TypeError: Cannot assign to read only property 'noDeprecation' of object '#<process>'
```

Reported in #14107.

## Root Cause

Starting from Node.js v23, `process.noDeprecation` is read-only and cannot be directly assigned.

## Solution

Wrap the assignment in try/catch. The existing `NODE_NO_WARNINGS=1` env var (set on the next line) serves as a fallback.

Closes #14107

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `openclaw update` command to avoid crashing on Node.js v23+ by wrapping the `process.noDeprecation = true` assignment in a `try/catch`. The existing `process.env.NODE_NO_WARNINGS = "1"` line remains as the suppression mechanism when the assignment is rejected due to the property becoming read-only.

Change is localized to `src/cli/update-cli.ts` and does not alter the update flow beyond preventing an early runtime exception on newer Node versions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (a guarded assignment) and preserves the existing `NODE_NO_WARNINGS` behavior, eliminating a known crash on Node.js v23+ without affecting the rest of the update logic.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->