### PR TITLE
fix(infra): satisfy lint in ports-inspect

### DIFF
--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -172,7 +172,7 @@ function parseSsOutput(output: string, port: number): PortListener[] {
     const usersMatch = line.match(/users:\(\("([^"]*)",pid=(\d+)/);
     if (usersMatch) {
       listener.command = usersMatch[1];
-      const pid = Number.parseInt(usersMatch[2]!, 10);
+      const pid = Number.parseInt(usersMatch[2], 10);
       if (Number.isFinite(pid)) {
         listener.pid = pid;
       }


### PR DESCRIPTION
Fixes oxlint typescript-eslint(no-unnecessary-type-assertion) by removing an unnecessary non-null assertion.\n\nThis is intended as a CI-fix for #14167 (can't push to that branch from this account).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/infra/ports-inspect.ts` to satisfy an oxlint `typescript-eslint(no-unnecessary-type-assertion)` warning by removing an unnecessary non-null assertion, with no intended behavior change. The surrounding logic continues to determine port status via listener discovery first and falls back to socket bind probing when no listener details are available.

I didn’t find any definite correctness or safety issues introduced by the change that must be fixed before merge.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Change is a targeted lint fix (removal of an unnecessary non-null assertion) with no substantive behavioral impact observed in the relevant code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->