### PR TITLE
test(discord): fix createThreadDiscord expectation

### DIFF
--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -114,7 +114,7 @@ describe("sendMessageDiscord", () => {
     await createThreadDiscord("chan1", { name: "thread" }, { rest, token: "t" });
     expect(postMock).toHaveBeenCalledWith(
       Routes.threads("chan1"),
-      expect.objectContaining({ body: { name: "thread" } }),
+      expect.objectContaining({ body: { name: "thread", type: 11 } }),
     );
   });
 

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -122,6 +122,12 @@ export async function createThreadDiscord(
     const starterContent = payload.content?.trim() ? payload.content : payload.name;
     body.message = { content: starterContent };
   }
+  // When creating a standalone thread (no messageId) in a non-forum channel,
+  // default to public thread (type 11). Discord defaults to private (type 12)
+  // which is unexpected for most users. (#14147)
+  if (!payload.messageId && !isForumLike && body.type === undefined) {
+    body.type = ChannelType.PublicThread;
+  }
   const route = payload.messageId
     ? Routes.threads(channelId, payload.messageId)
     : Routes.threads(channelId);

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -72,6 +72,8 @@ export type DiscordThreadCreate = {
   name: string;
   autoArchiveMinutes?: number;
   content?: string;
+  /** Discord thread type (default: PublicThread for standalone threads). */
+  type?: number;
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
Fixes failing CI on #14162: updates  to expect default thread type=11 (public) when channel lookup fails.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Discord thread creation to default standalone (no `messageId`) thread creation in non-forum/non-media channels to `ChannelType.PublicThread` (type `11`) when `type` is not explicitly provided, including when the channel lookup fails.

It also updates the corresponding unit test expectation to include `type: 11` in the REST POST body for the “channel lookup unavailable” case, aligning CI expectations with the new defaulting behavior.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge and addresses the failing test by aligning expectations with the intended default thread type behavior.
- Changes are small, localized, and consistent: `createThreadDiscord` now sets `type` to `PublicThread` for standalone threads in non-forum channels, including the channel-lookup-failure path, and the unit test was updated to match. No other call sites or types appear to be broken by this addition.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->