### PR TITLE
fix(agents): honor heartbeat.model override instead of session model

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -391,6 +391,7 @@ export async function resolveReplyDirectives(params: {
     provider,
     model,
     hasModelDirective: directives.hasModelDirective,
+    isHeartbeat: opts?.isHeartbeat,
   });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -106,6 +106,7 @@ export async function resolveReplyDirectives(params: {
   aliasIndex: ModelAliasIndex;
   provider: string;
   model: string;
+  hasResolvedHeartbeatModelOverride: boolean;
   typing: TypingController;
   opts?: GetReplyOptions;
   skillFilter?: string[];
@@ -131,6 +132,7 @@ export async function resolveReplyDirectives(params: {
     defaultModel,
     provider: initialProvider,
     model: initialModel,
+    hasResolvedHeartbeatModelOverride,
     typing,
     opts,
     skillFilter,
@@ -391,7 +393,7 @@ export async function resolveReplyDirectives(params: {
     provider,
     model,
     hasModelDirective: directives.hasModelDirective,
-    isHeartbeat: opts?.isHeartbeat,
+    hasResolvedHeartbeatModelOverride,
   });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -78,6 +78,7 @@ export async function getReplyFromConfig(
   });
   let provider = defaultProvider;
   let model = defaultModel;
+  let hasResolvedHeartbeatModelOverride = false;
   if (opts?.isHeartbeat) {
     const heartbeatRaw = agentCfg?.heartbeat?.model?.trim() ?? "";
     const heartbeatRef = heartbeatRaw
@@ -90,6 +91,7 @@ export async function getReplyFromConfig(
     if (heartbeatRef) {
       provider = heartbeatRef.ref.provider;
       model = heartbeatRef.ref.model;
+      hasResolvedHeartbeatModelOverride = true;
     }
   }
 
@@ -196,6 +198,7 @@ export async function getReplyFromConfig(
     aliasIndex,
     provider,
     model,
+    hasResolvedHeartbeatModelOverride,
     typing,
     opts: resolvedOpts,
     skillFilter: mergedSkillFilter,

--- a/src/auto-reply/reply/model-selection.inherit-parent.test.ts
+++ b/src/auto-reply/reply/model-selection.inherit-parent.test.ts
@@ -153,4 +153,62 @@ describe("createModelSelectionState parent inheritance", () => {
     expect(state.provider).toBe(defaultProvider);
     expect(state.model).toBe(defaultModel);
   });
+
+  it("applies stored override when heartbeat override was not resolved", async () => {
+    const cfg = {} as OpenClawConfig;
+    const sessionKey = "agent:main:discord:channel:c1";
+    const sessionEntry = makeEntry({
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    });
+    const sessionStore = {
+      [sessionKey]: sessionEntry,
+    };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      hasModelDirective: false,
+      hasResolvedHeartbeatModelOverride: false,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o");
+  });
+
+  it("skips stored override when heartbeat override was resolved", async () => {
+    const cfg = {} as OpenClawConfig;
+    const sessionKey = "agent:main:discord:channel:c1";
+    const sessionEntry = makeEntry({
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    });
+    const sessionStore = {
+      [sessionKey]: sessionEntry,
+    };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      hasModelDirective: false,
+      hasResolvedHeartbeatModelOverride: true,
+    });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-opus-4-5");
+  });
 });


### PR DESCRIPTION
## Problem

Configuring `heartbeat.model` to route heartbeats to a cheap local model doesn't work. The session's stored `/model` override always takes precedence:

```json
{
  "agents": {
    "defaults": {
      "model": { "primary": "openai/gpt-5.1" },
      "heartbeat": {
        "every": "60s",
        "model": "ollama/llama3.2:1b"
      }
    }
  }
}
```

Expected: heartbeats hit ollama. Actual: heartbeats hit OpenAI (costs money on every tick).

Fixes #14087

## Root Cause

In `get-reply.ts`, the heartbeat model is correctly resolved from config and set as `provider`/`model`. But downstream in `createModelSelectionState()`, the session's stored model override (from `/model` command) unconditionally overwrites it:

```ts
// model-selection.ts:347
if (storedOverride?.model) {
  provider = candidateProvider;  // ← clobbers heartbeat model
  model = storedOverride.model;
}
```

## Fix

Pass `isHeartbeat` through the model selection chain. When the caller is a heartbeat run with an explicitly configured model, skip the session's stored override so the heartbeat model is honored.

## Testing

All 566 auto-reply tests pass. The change is conservative — only affects heartbeat runs, regular `/model` switching is unaffected.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes model selection precedence for heartbeat runs by threading a `hasResolvedHeartbeatModelOverride` signal from `get-reply.ts` through `resolveReplyDirectives()` into `createModelSelectionState()`. When `agents.defaults.heartbeat.model` is explicitly configured and successfully resolved, model selection now skips the session/parent stored `/model` override so heartbeats can be routed to a cheaper model as intended.

Coverage was expanded with targeted tests:
- An e2e test ensures heartbeat runs honor `heartbeat.model` even when `sessions.json` contains a stored model override, and that heartbeats still inherit the stored override when `heartbeat.model` is not configured.
- A unit test in `model-selection.inherit-parent.test.ts` validates the new gating behavior for stored overrides.

Overall, the change is localized to model selection and keeps non-heartbeat behavior unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to model selection precedence, add an explicit gating flag to avoid broad behavioral changes, and include focused unit/e2e tests covering both the new heartbeat override behavior and the fallback to stored overrides when no heartbeat model is configured. No additional call sites were impacted by the signature change.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->