### PR TITLE
zulip: fix event queue registration for multiple monitored streams

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -99,6 +99,11 @@
       - any-glob-to-any-file:
           - "extensions/zalouser/**"
           - "docs/channels/zalouser.md"
+"channel: zulip":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/zulip/**"
+          - "docs/channels/zulip.md"
 
 "app: android":
   - changed-files:

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -30,6 +30,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Nostr](/channels/nostr) — Decentralized DMs via NIP-04 (plugin, installed separately).
 - [Tlon](/channels/tlon) — Urbit-based messenger (plugin, installed separately).
 - [Twitch](/channels/twitch) — Twitch chat via IRC connection (plugin, installed separately).
+- [Zulip](/channels/zulip) — Streams/topics with reaction indicators (plugin, installed separately).
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (plugin, installed separately).
 - [Zalo Personal](/channels/zalouser) — Zalo personal account via QR login (plugin, installed separately).
 - [WebChat](/web/webchat) — Gateway WebChat UI over WebSocket.

--- a/docs/channels/zulip.md
+++ b/docs/channels/zulip.md
@@ -76,11 +76,11 @@ To require an `@mention`, set:
 
 While OpenClaw generates a reply, it reacts to the triggering message:
 
-| Phase | Default emoji | Meaning |
-|-------|--------------|---------|
-| Start | 👀 `eyes` | Processing |
-| Success | ✅ `check_mark` | Done |
-| Failure | ⚠️ `warning` | Error |
+| Phase   | Default emoji   | Meaning    |
+| ------- | --------------- | ---------- |
+| Start   | 👀 `eyes`       | Processing |
+| Success | ✅ `check_mark` | Done       |
+| Failure | ⚠️ `warning`    | Error      |
 
 The start reaction is removed when the final reaction is added.
 
@@ -91,11 +91,11 @@ Customize or disable:
   channels: {
     zulip: {
       reactions: {
-        enabled: true,          // set false to disable
+        enabled: true, // set false to disable
         onStart: "eyes",
         onSuccess: "check_mark",
         onError: "warning",
-        clearOnFinish: true,    // remove onStart when done
+        clearOnFinish: true, // remove onStart when done
       },
     },
   },
@@ -139,7 +139,7 @@ Optional size limit:
 {
   channels: {
     zulip: {
-      mediaMaxMb: 5,  // default: 5MB
+      mediaMaxMb: 5, // default: 5MB
     },
   },
 }

--- a/docs/channels/zulip.md
+++ b/docs/channels/zulip.md
@@ -1,0 +1,207 @@
+---
+summary: "Zulip bot setup and OpenClaw config"
+read_when:
+  - Setting up Zulip
+  - Debugging Zulip routing
+title: "Zulip"
+---
+
+# Zulip (plugin)
+
+Status: supported via plugin (bot email + API key + event queue). Streams and topics are supported.
+File uploads (inbound and outbound) are supported via Zulip `user_uploads`.
+
+## Plugin required
+
+Zulip ships as a plugin and is not bundled with the core install.
+
+Install via CLI (npm registry):
+
+```bash
+openclaw plugins install @openclaw/zulip
+```
+
+Local checkout (when running from a git repo):
+
+```bash
+openclaw plugins install ./extensions/zulip
+```
+
+Details: [Plugins](/plugin)
+
+## Quick setup
+
+1. Create a **Generic bot** in your Zulip organization (Settings → Your bots).
+2. Copy the bot's email and API key.
+3. Subscribe the bot to the stream(s) you want it to monitor.
+4. Configure OpenClaw and start the gateway.
+
+Minimal config:
+
+```json5
+{
+  channels: {
+    zulip: {
+      enabled: true,
+      url: "https://zulip.example.com",
+      email: "your-bot@zulip.example.com",
+      apiKey: "zulip-bot-api-key",
+
+      // Streams to monitor. Use ["*"] for all public streams.
+      streams: ["my-stream"],
+
+      // Users allowed to interact with the bot.
+      allowFrom: ["user@zulip.example.com"],
+    },
+  },
+}
+```
+
+## Mention behavior
+
+By default, the bot replies to **every** message in monitored streams (no mention required).
+To require an `@mention`, set:
+
+```json5
+{
+  channels: {
+    zulip: {
+      requireMention: true,
+    },
+  },
+}
+```
+
+## Reaction indicators
+
+While OpenClaw generates a reply, it reacts to the triggering message:
+
+| Phase | Default emoji | Meaning |
+|-------|--------------|---------|
+| Start | 👀 `eyes` | Processing |
+| Success | ✅ `check_mark` | Done |
+| Failure | ⚠️ `warning` | Error |
+
+The start reaction is removed when the final reaction is added.
+
+Customize or disable:
+
+```json5
+{
+  channels: {
+    zulip: {
+      reactions: {
+        enabled: true,          // set false to disable
+        onStart: "eyes",
+        onSuccess: "check_mark",
+        onError: "warning",
+        clearOnFinish: true,    // remove onStart when done
+      },
+    },
+  },
+}
+```
+
+> **Note:** Emoji names are server-specific. Use names from your Zulip instance.
+> Both `eyes` and `:eyes:` formats are accepted (colons are stripped automatically).
+
+## Sessions (topics → sessions)
+
+Zulip topics map to OpenClaw sessions:
+
+- Same stream + same topic → same session
+- Different topic → different session
+
+This keeps conversations separated per topic.
+
+## Switching topics
+
+An agent can create or switch topics by prefixing a reply with:
+
+```
+[[zulip_topic: <topic>]]
+```
+
+OpenClaw strips this directive before posting and sends the reply into the requested topic.
+Topics are truncated to 60 characters.
+
+## Media (uploads)
+
+**Inbound:** When a message contains `/user_uploads/` links, OpenClaw downloads the files
+(with bot authentication) and attaches them to the agent context.
+
+**Outbound:** OpenClaw uploads local files to Zulip via `/api/v1/user_uploads` and posts
+the resulting link into the stream/topic.
+
+Optional size limit:
+
+```json5
+{
+  channels: {
+    zulip: {
+      mediaMaxMb: 5,  // default: 5MB
+    },
+  },
+}
+```
+
+## Outbound targets
+
+Use these target formats with `message send`:
+
+- `stream:<streamName>#<topic>` — stream with specific topic
+- `stream:<streamName>` — stream with default topic ("general chat")
+
+Examples:
+
+```bash
+openclaw message send --channel zulip --target "stream:my-stream" --message "hello"
+openclaw message send --channel zulip --target "stream:my-stream#deploy-notes" --message "shipped"
+```
+
+## Channel actions
+
+The Zulip plugin supports the following message tool actions:
+
+- `send` — Send a message to a stream/topic
+- `read` — Read recent messages
+- `search` — Search messages
+- `react` / `unreact` — Add/remove emoji reactions
+- `pin` / `unpin` — Pin/unpin messages
+- `edit` / `delete` — Edit or delete messages
+- `channel-list` — List streams
+- `channel-create` / `channel-edit` / `channel-delete` — Manage streams
+- `member-info` — Get user info
+
+## HTTP retry / rate limiting
+
+All API calls use exponential backoff with jitter:
+
+- **429 rate limits:** starts at 10s, respects `Retry-After` header, max 120s
+- **502/503/504 errors:** starts at 500ms, max 30s
+- **Event polling:** automatic reconnection with backoff on errors
+
+## Access control
+
+```json5
+{
+  channels: {
+    zulip: {
+      // Who can talk to the bot
+      allowFrom: ["user@zulip.example.com"],
+
+      // Or use group policy
+      groupPolicy: "allowlist",
+      allowlist: ["user@zulip.example.com"],
+    },
+  },
+}
+```
+
+## Troubleshooting
+
+- **No replies:** Confirm the bot is subscribed to the stream and `channels.zulip.streams` includes the stream name (or `"*"`).
+- **Auth errors:** Verify `url`, `email`, and `apiKey`. Use the bot's API key, not your personal key.
+- **Reactions not appearing:** Verify the emoji name exists on your Zulip server. Custom emoji names vary by instance.
+- **Uploads not downloading:** Check `mediaMaxMb` — files larger than the limit are skipped silently.
+- **After code changes:** Must compile TypeScript (`npx tsc`) AND do a full process restart (`systemctl --user restart openclaw-gateway`). SIGUSR1 restarts cache old modules.

--- a/extensions/zulip/index.ts
+++ b/extensions/zulip/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { zulipPlugin } from "./src/channel.js";
+import { setZulipRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "zulip",
+  name: "Zulip",
+  description: "Zulip channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setZulipRuntime(api.runtime);
+    api.registerChannel({ plugin: zulipPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/zulip/openclaw.plugin.json
+++ b/extensions/zulip/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "zulip",
+  "channels": ["zulip"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/zulip/package.json
+++ b/extensions/zulip/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@openclaw/zulip",
+  "version": "2026.2.4",
+  "description": "OpenClaw Zulip channel plugin",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "zulip",
+      "label": "Zulip",
+      "selectionLabel": "Zulip (plugin)",
+      "docsPath": "/channels/zulip",
+      "docsLabel": "zulip",
+      "blurb": "Zulip streams/topics with reaction-based reply indicators (plugin, installed separately).",
+      "order": 70
+    },
+    "install": {
+      "npmSpec": "@openclaw/zulip",
+      "localPath": "extensions/zulip",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/zulip/src/actions.ts
+++ b/extensions/zulip/src/actions.ts
@@ -270,7 +270,10 @@ function readBooleanParam(params: Record<string, unknown>, ...keys: string[]): b
   return undefined;
 }
 
-function readStringArrayParam(params: Record<string, unknown>, key: string): Array<string | number> | undefined {
+function readStringArrayParam(
+  params: Record<string, unknown>,
+  key: string,
+): Array<string | number> | undefined {
   if (!Object.prototype.hasOwnProperty.call(params, key)) {
     return undefined;
   }
@@ -351,12 +354,10 @@ function readUserIdOrEmailParam(params: Record<string, unknown>): string {
   throw new Error("userId or email is required for Zulip presence.");
 }
 
-function readRealmUpdateParams(params: Record<string, unknown>): Record<string, string | number | boolean> {
-  const raw =
-    params.settings ??
-    params.realm ??
-    params.updates ??
-    params.update;
+function readRealmUpdateParams(
+  params: Record<string, unknown>,
+): Record<string, string | number | boolean> {
+  const raw = params.settings ?? params.realm ?? params.updates ?? params.update;
   if (raw === undefined) {
     throw new Error("settings are required to update Zulip organization settings.");
   }
@@ -473,9 +474,7 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       const subscriptions = await fetchZulipSubscriptions(client, {
         includeAllPublic,
       });
-      const publicStreams = includeAllPublic
-        ? await fetchZulipStreams(client)
-        : undefined;
+      const publicStreams = includeAllPublic ? await fetchZulipStreams(client) : undefined;
       return jsonResult({
         ok: true,
         subscriptions,
@@ -656,7 +655,10 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
         readStringArrayParam(params, "users");
       // Support comma-separated string for userId param (message tool compat)
       if ((!principals || principals.length === 0) && typeof params.userId === "string") {
-        principals = params.userId.split(",").map((s: string) => s.trim()).filter(Boolean);
+        principals = params.userId
+          .split(",")
+          .map((s: string) => s.trim())
+          .filter(Boolean);
       }
       if (!principals || principals.length === 0) {
         throw new Error("principals are required to invite Zulip users to a stream.");
@@ -701,11 +703,9 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
         readStringParam(params, "emojiName") ??
         readStringParam(params, "emoji_name");
       const emojiCode =
-        readStringParam(params, "emojiCode") ??
-        readStringParam(params, "emoji_code");
+        readStringParam(params, "emojiCode") ?? readStringParam(params, "emoji_code");
       const reactionType =
-        readStringParam(params, "reactionType") ??
-        readStringParam(params, "reaction_type");
+        readStringParam(params, "reactionType") ?? readStringParam(params, "reaction_type");
       const remove = params.remove === true;
 
       if (!emojiName && !remove) {
@@ -793,7 +793,9 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       let targetMessageId = messageId;
       if (!targetMessageId) {
         if (!target?.stream) {
-          throw new Error("stream is required to resolve a Zulip topic when messageId is not provided.");
+          throw new Error(
+            "stream is required to resolve a Zulip topic when messageId is not provided.",
+          );
         }
         const messages = await fetchZulipMessages(client, {
           stream: target.stream,

--- a/extensions/zulip/src/actions.ts
+++ b/extensions/zulip/src/actions.ts
@@ -1,0 +1,855 @@
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionName,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk";
+import { jsonResult, readNumberParam, readStringParam } from "openclaw/plugin-sdk";
+import { resolveZulipAccount } from "./zulip/accounts.js";
+import {
+  addZulipReaction,
+  createZulipClient,
+  createZulipStream,
+  deactivateZulipUser,
+  deleteZulipMessage,
+  deleteZulipStream,
+  editZulipMessage,
+  fetchZulipMemberInfo,
+  fetchZulipMessages,
+  fetchZulipServerSettings,
+  fetchZulipStreams,
+  fetchZulipSubscriptions,
+  fetchZulipUserPresence,
+  inviteZulipUsersToStream,
+  normalizeZulipBaseUrl,
+  reactivateZulipUser,
+  removeZulipReaction,
+  resolveZulipStreamId,
+  searchZulipMessages,
+  sendZulipPrivateMessage,
+  sendZulipStreamMessage,
+  subscribeZulipStream,
+  updateZulipMessageFlag,
+  updateZulipMessageTopic,
+  updateZulipRealm,
+  updateZulipStream,
+} from "./zulip/client.js";
+
+const providerId = "zulip";
+const MAX_STRING_LENGTH = 10000;
+const SAFE_REALM_SETTINGS = [
+  "name",
+  "description",
+  "default_language",
+  "notifications_stream_id",
+  "signup_notifications_stream_id",
+  "message_retention_days",
+];
+
+type StreamTarget = {
+  stream: string;
+  topic?: string;
+};
+
+type SendTarget =
+  | { kind: "stream"; stream: string; topic: string }
+  | { kind: "user"; email: string };
+
+function resolveZulipClient(cfg: OpenClawConfig, accountId?: string | null) {
+  const account = resolveZulipAccount({ cfg, accountId });
+  const apiKey = account.apiKey?.trim();
+  const email = account.email?.trim();
+  if (!apiKey || !email) {
+    throw new Error(
+      `Zulip apiKey/email missing for account "${account.accountId}" (set channels.zulip.accounts.${account.accountId}.apiKey/email or ZULIP_API_KEY/ZULIP_EMAIL for default).`,
+    );
+  }
+  const baseUrl = normalizeZulipBaseUrl(account.baseUrl);
+  if (!baseUrl) {
+    throw new Error(
+      `Zulip url missing for account "${account.accountId}" (set channels.zulip.accounts.${account.accountId}.url or ZULIP_URL for default).`,
+    );
+  }
+  return {
+    account,
+    client: createZulipClient({ baseUrl, apiKey, email }),
+  };
+}
+
+function requireAdminActionsEnabled(account: ReturnType<typeof resolveZulipAccount>): void {
+  if (!account.enableAdminActions) {
+    throw new Error("Admin actions require enableAdminActions: true in Zulip config");
+  }
+}
+
+async function requireZulipAdmin(client: ReturnType<typeof createZulipClient>): Promise<void> {
+  const me = await fetchZulipMemberInfo(client, "me");
+  if (!me.is_admin) {
+    throw new Error("Zulip admin privileges are required for this action.");
+  }
+}
+
+function splitStreamTarget(raw: string): StreamTarget {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Stream is required for Zulip channel actions.");
+  }
+
+  const lower = trimmed.toLowerCase();
+  let candidate = trimmed;
+  if (lower.startsWith("stream:")) {
+    candidate = trimmed.slice("stream:".length).trim();
+  } else if (trimmed.startsWith("#")) {
+    candidate = trimmed.slice(1).trim();
+  }
+
+  if (!candidate) {
+    throw new Error("Stream name is required for Zulip channel actions.");
+  }
+
+  let stream = candidate;
+  let topic: string | undefined;
+  const topicMatch = /(?:^|\s)topic:\s*(.+)$/i.exec(candidate);
+  if (topicMatch) {
+    stream = candidate.slice(0, topicMatch.index).trim();
+    topic = topicMatch[1].trim();
+  } else {
+    const sepIndex = candidate.search(/[\/#]/);
+    if (sepIndex > -1) {
+      stream = candidate.slice(0, sepIndex).trim();
+      topic = candidate.slice(sepIndex + 1).trim();
+    }
+  }
+
+  if (!stream) {
+    throw new Error("Stream name is required for Zulip channel actions.");
+  }
+
+  assertStringLength(stream, "stream", MAX_STRING_LENGTH);
+  if (topic) {
+    assertStringLength(topic, "topic", MAX_STRING_LENGTH);
+  }
+
+  return { stream, topic: topic || undefined };
+}
+
+function parseSendTarget(raw: string): SendTarget {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Recipient is required for Zulip sends.");
+  }
+
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("stream:")) {
+    const rest = trimmed.slice("stream:".length).trim();
+    if (!rest) {
+      throw new Error("Stream name is required for Zulip sends.");
+    }
+    const sepIndex = rest.indexOf(":");
+    if (sepIndex === -1) {
+      throw new Error("Topic is required for Zulip stream sends.");
+    }
+    const stream = rest.slice(0, sepIndex).trim();
+    const topic = rest.slice(sepIndex + 1).trim();
+    if (!stream) {
+      throw new Error("Stream name is required for Zulip sends.");
+    }
+    if (!topic) {
+      throw new Error("Topic is required for Zulip stream sends.");
+    }
+    assertStringLength(stream, "stream", MAX_STRING_LENGTH);
+    assertStringLength(topic, "topic", MAX_STRING_LENGTH);
+    return { kind: "stream", stream, topic };
+  }
+
+  if (lower.startsWith("user:")) {
+    const email = trimmed.slice("user:".length).trim();
+    if (!email) {
+      throw new Error("Email is required for Zulip direct messages.");
+    }
+    assertStringLength(email, "email", MAX_STRING_LENGTH);
+    return { kind: "user", email };
+  }
+
+  throw new Error("Invalid Zulip send target; use stream:{stream}:{topic} or user:{email}.");
+}
+
+function assertStringLength(value: string, field: string, max = MAX_STRING_LENGTH): void {
+  if (value.length > max) {
+    throw new Error(`${field} must be ${max} characters or fewer.`);
+  }
+}
+
+function readMessageId(params: Record<string, unknown>): string {
+  const messageId = readStringParam(params, "messageId") ?? readStringParam(params, "id");
+  if (messageId) {
+    return messageId;
+  }
+  const numericId =
+    readNumberParam(params, "messageId", { integer: true }) ??
+    readNumberParam(params, "id", { integer: true });
+  if (typeof numericId === "number") {
+    return String(numericId);
+  }
+  throw new Error("messageId is required for Zulip message actions.");
+}
+
+function readMessageContent(params: Record<string, unknown>): string {
+  const content =
+    readStringParam(params, "message", { allowEmpty: true }) ??
+    readStringParam(params, "text", { allowEmpty: true }) ??
+    readStringParam(params, "content", { allowEmpty: true }) ??
+    readStringParam(params, "newText", { allowEmpty: true });
+  if (content === undefined) {
+    throw new Error("message content is required for Zulip edit actions.");
+  }
+  assertStringLength(content, "message", MAX_STRING_LENGTH);
+  return content;
+}
+
+function readSendMessageContent(params: Record<string, unknown>): string {
+  const content =
+    readStringParam(params, "message", { allowEmpty: true }) ??
+    readStringParam(params, "text", { allowEmpty: true }) ??
+    readStringParam(params, "content", { allowEmpty: true }) ??
+    readStringParam(params, "newText", { allowEmpty: true });
+  if (content === undefined) {
+    throw new Error("message content is required for Zulip sends.");
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    throw new Error("Zulip message is empty.");
+  }
+  assertStringLength(trimmed, "message", MAX_STRING_LENGTH);
+  return trimmed;
+}
+
+const resolvedTopicPrefixes = ["✔", "✅"];
+
+function resolveTopicName(topic: string): { topic: string; alreadyResolved: boolean } {
+  const trimmed = topic.trim();
+  if (!trimmed) {
+    return { topic: trimmed, alreadyResolved: false };
+  }
+  const alreadyResolved = resolvedTopicPrefixes.some((prefix) => trimmed.startsWith(prefix));
+  if (alreadyResolved) {
+    return { topic: trimmed, alreadyResolved: true };
+  }
+  return { topic: `✔ ${trimmed}`, alreadyResolved: false };
+}
+
+function parseBooleanValue(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return undefined;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "y", "on"].includes(normalized)) {
+      return true;
+    }
+    if (["false", "0", "no", "n", "off"].includes(normalized)) {
+      return false;
+    }
+  }
+  return undefined;
+}
+
+function readBooleanParam(params: Record<string, unknown>, ...keys: string[]): boolean | undefined {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      const parsed = parseBooleanValue(params[key]);
+      if (parsed !== undefined) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function readStringArrayParam(params: Record<string, unknown>, key: string): Array<string | number> | undefined {
+  if (!Object.prototype.hasOwnProperty.call(params, key)) {
+    return undefined;
+  }
+  const raw = params[key];
+  if (Array.isArray(raw)) {
+    return raw as Array<string | number>;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return [];
+    }
+    return trimmed
+      .split(/[\n,]/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  if (typeof raw === "number") {
+    return [raw];
+  }
+  return undefined;
+}
+
+function readStreamId(params: Record<string, unknown>): string {
+  const streamId =
+    readStringParam(params, "streamId") ??
+    readStringParam(params, "channelId") ??
+    readStringParam(params, "id");
+  if (streamId) {
+    return streamId;
+  }
+  const numericId =
+    readNumberParam(params, "streamId", { integer: true }) ??
+    readNumberParam(params, "channelId", { integer: true }) ??
+    readNumberParam(params, "id", { integer: true });
+  if (typeof numericId === "number") {
+    return String(numericId);
+  }
+  throw new Error("streamId is required for Zulip channel actions.");
+}
+
+function readUserIdParam(params: Record<string, unknown>): string {
+  const userId =
+    readStringParam(params, "userId") ??
+    readStringParam(params, "memberId") ??
+    readStringParam(params, "id") ??
+    readStringParam(params, "user");
+  if (userId) {
+    return userId;
+  }
+  const numericId =
+    readNumberParam(params, "userId", { integer: true }) ??
+    readNumberParam(params, "memberId", { integer: true }) ??
+    readNumberParam(params, "id", { integer: true });
+  if (typeof numericId === "number") {
+    return String(numericId);
+  }
+  throw new Error("userId is required for Zulip user actions.");
+}
+
+function readUserIdOrEmailParam(params: Record<string, unknown>): string {
+  const userIdOrEmail =
+    readStringParam(params, "userId") ??
+    readStringParam(params, "memberId") ??
+    readStringParam(params, "id") ??
+    readStringParam(params, "user") ??
+    readStringParam(params, "email");
+  if (userIdOrEmail) {
+    return userIdOrEmail;
+  }
+  const numericId =
+    readNumberParam(params, "userId", { integer: true }) ??
+    readNumberParam(params, "memberId", { integer: true }) ??
+    readNumberParam(params, "id", { integer: true });
+  if (typeof numericId === "number") {
+    return String(numericId);
+  }
+  throw new Error("userId or email is required for Zulip presence.");
+}
+
+function readRealmUpdateParams(params: Record<string, unknown>): Record<string, string | number | boolean> {
+  const raw =
+    params.settings ??
+    params.realm ??
+    params.updates ??
+    params.update;
+  if (raw === undefined) {
+    throw new Error("settings are required to update Zulip organization settings.");
+  }
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error("settings must be a JSON object or key/value map.");
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("settings must be a key/value object to update Zulip organization settings.");
+  }
+  const entries = Object.entries(parsed as Record<string, unknown>);
+  if (entries.length === 0) {
+    throw new Error("settings must include at least one field to update.");
+  }
+  const updates: Record<string, string | number | boolean> = {};
+  for (const [key, value] of entries) {
+    if (!SAFE_REALM_SETTINGS.includes(key)) {
+      throw new Error(`Unsupported organization setting: ${key}.`);
+    }
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      if (typeof value === "string") {
+        assertStringLength(value, key, MAX_STRING_LENGTH);
+      }
+      updates[key] = value;
+      continue;
+    }
+    throw new Error(`Unsupported setting value for ${key}; expected string, number, or boolean.`);
+  }
+  return updates;
+}
+
+export const zulipMessageActions: ChannelMessageActionAdapter = {
+  listActions: ({ cfg }) => {
+    const accounts = [resolveZulipAccount({ cfg })].filter((account) =>
+      Boolean(account.apiKey && account.email && account.baseUrl),
+    );
+    if (accounts.length === 0) {
+      return [];
+    }
+    const actions = new Set<ChannelMessageActionName>([
+      "send",
+      "read",
+      "channel-list",
+      "channel-create",
+      "channel-edit",
+      "channel-delete",
+      "react",
+      "edit",
+      "delete",
+      "search",
+      "member-info",
+      "pin",
+      "unpin",
+    ]);
+    // TODO: These actions require core SDK changes to MESSAGE_ACTION_TARGET_MODE.
+    // Re-enable once the SDK supports plugin-registered action target modes.
+    // See: https://github.com/openclaw/openclaw/issues/TBD
+    // actions.add("channel-subscribe" as ChannelMessageActionName);
+    // actions.add("invite" as ChannelMessageActionName);
+    // actions.add("resolve-topic" as ChannelMessageActionName);
+    // actions.add("user-presence" as ChannelMessageActionName);
+    // actions.add("user-deactivate" as ChannelMessageActionName);
+    // actions.add("user-reactivate" as ChannelMessageActionName);
+    // actions.add("org-settings" as ChannelMessageActionName);
+    // actions.add("org-settings-edit" as ChannelMessageActionName);
+    return Array.from(actions);
+  },
+  extractToolSend: ({ args }) => {
+    const action = typeof args.action === "string" ? args.action.trim() : "";
+    if (action !== "send") {
+      return null;
+    }
+    const to = typeof args.to === "string" ? args.to : undefined;
+    if (!to) {
+      return null;
+    }
+    const accountId = typeof args.accountId === "string" ? args.accountId.trim() : undefined;
+    return { to, accountId };
+  },
+  handleAction: async ({ action, params, cfg, accountId }) => {
+    const { client, account } = resolveZulipClient(cfg, accountId ?? undefined);
+
+    if (action === "send") {
+      const to = readStringParam(params, "to", { required: true });
+      const content = readSendMessageContent(params);
+      const target = parseSendTarget(to);
+
+      if (target.kind === "stream") {
+        const result = await sendZulipStreamMessage(client, {
+          stream: target.stream,
+          topic: target.topic,
+          content,
+        });
+        return jsonResult({ success: true, messageId: result.id });
+      }
+
+      const result = await sendZulipPrivateMessage(client, {
+        to: [target.email],
+        content,
+      });
+      return jsonResult({ success: true, messageId: result.id });
+    }
+
+    if (action === "channel-list") {
+      const includeAllPublic =
+        params.includeAllPublic === true ||
+        params.includePublic === true ||
+        params.allPublic === true ||
+        params.all === true;
+      const subscriptions = await fetchZulipSubscriptions(client, {
+        includeAllPublic,
+      });
+      const publicStreams = includeAllPublic
+        ? await fetchZulipStreams(client)
+        : undefined;
+      return jsonResult({
+        ok: true,
+        subscriptions,
+        ...(publicStreams ? { publicStreams } : {}),
+      });
+    }
+
+    if ((action as string) === "channel-subscribe") {
+      const raw =
+        readStringParam(params, "stream") ??
+        readStringParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      const target = splitStreamTarget(raw);
+      const result = await subscribeZulipStream(client, target.stream);
+      return jsonResult({ ok: true, stream: target.stream, result });
+    }
+
+    if (action === "channel-create") {
+      const raw =
+        readStringParam(params, "stream") ??
+        readStringParam(params, "name") ??
+        readStringParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      const target = splitStreamTarget(raw);
+      const description = readStringParam(params, "description", { allowEmpty: true });
+      if (description !== undefined) {
+        assertStringLength(description, "description", MAX_STRING_LENGTH);
+      }
+      const principals =
+        readStringArrayParam(params, "principals") ?? readStringArrayParam(params, "principal");
+      const announce = readBooleanParam(params, "announce");
+      const inviteOnly = readBooleanParam(
+        params,
+        "inviteOnly",
+        "invite_only",
+        "isPrivate",
+        "is_private",
+      );
+      const isWebPublic = readBooleanParam(params, "isWebPublic", "is_web_public");
+      const isDefaultStream = readBooleanParam(
+        params,
+        "isDefaultStream",
+        "is_default_stream",
+        "defaultStream",
+      );
+      const historyPublicToSubscribers = readBooleanParam(
+        params,
+        "historyPublicToSubscribers",
+        "history_public_to_subscribers",
+      );
+      await createZulipStream(client, {
+        name: target.stream,
+        description: description ?? undefined,
+        principals: principals && principals.length > 0 ? principals : undefined,
+        announce,
+        inviteOnly,
+        isWebPublic,
+        isDefaultStream,
+        historyPublicToSubscribers,
+      });
+      return jsonResult({ ok: true, stream: target.stream });
+    }
+
+    if (action === "channel-edit") {
+      const streamIdOrName = readStreamId(params);
+      const description = readStringParam(params, "description", { allowEmpty: true });
+      const newName = readStringParam(params, "newName") ?? readStringParam(params, "name");
+      if (description !== undefined) {
+        assertStringLength(description, "description", MAX_STRING_LENGTH);
+      }
+      if (newName !== undefined) {
+        assertStringLength(newName, "name", MAX_STRING_LENGTH);
+      }
+      const isPrivate = readBooleanParam(
+        params,
+        "isPrivate",
+        "inviteOnly",
+        "invite_only",
+        "is_private",
+      );
+      const isWebPublic = readBooleanParam(params, "isWebPublic", "is_web_public");
+      const historyPublicToSubscribers = readBooleanParam(
+        params,
+        "historyPublicToSubscribers",
+        "history_public_to_subscribers",
+      );
+      const isDefaultStream = readBooleanParam(params, "isDefaultStream", "is_default_stream");
+
+      if (
+        description === undefined &&
+        newName === undefined &&
+        isPrivate === undefined &&
+        isWebPublic === undefined &&
+        historyPublicToSubscribers === undefined &&
+        isDefaultStream === undefined
+      ) {
+        throw new Error("At least one field is required to update a Zulip channel.");
+      }
+
+      // Resolve stream name to ID if necessary
+      const streamId = await resolveZulipStreamId(client, streamIdOrName);
+
+      await updateZulipStream(client, {
+        streamId,
+        description: description ?? undefined,
+        newName: newName ?? undefined,
+        isPrivate,
+        isWebPublic,
+        historyPublicToSubscribers,
+        isDefaultStream,
+      });
+      return jsonResult({ ok: true, streamId, ...(newName ? { name: newName } : {}) });
+    }
+
+    if (action === "channel-delete") {
+      const streamIdOrName = readStreamId(params);
+      // Resolve stream name to ID if necessary
+      const streamId = await resolveZulipStreamId(client, streamIdOrName);
+      await deleteZulipStream(client, streamId);
+      return jsonResult({ ok: true, streamId });
+    }
+
+    if (action === "member-info") {
+      const userId =
+        readStringParam(params, "userId") ??
+        readStringParam(params, "memberId") ??
+        readStringParam(params, "id") ??
+        readStringParam(params, "user");
+      const user = await fetchZulipMemberInfo(client, userId ?? undefined);
+      return jsonResult({ ok: true, user });
+    }
+
+    if ((action as string) === "user-presence") {
+      const userIdOrEmail = readUserIdOrEmailParam(params);
+      const presence = await fetchZulipUserPresence(client, userIdOrEmail);
+      return jsonResult({ ok: true, user: userIdOrEmail, presence });
+    }
+
+    if ((action as string) === "user-deactivate") {
+      requireAdminActionsEnabled(account);
+      await requireZulipAdmin(client);
+      const userId = readUserIdParam(params);
+      await deactivateZulipUser(client, userId);
+      return jsonResult({ ok: true, userId, deactivated: true });
+    }
+
+    if ((action as string) === "user-reactivate") {
+      requireAdminActionsEnabled(account);
+      await requireZulipAdmin(client);
+      const userId = readUserIdParam(params);
+      await reactivateZulipUser(client, userId);
+      return jsonResult({ ok: true, userId, reactivated: true });
+    }
+
+    if ((action as string) === "org-settings") {
+      const settings = await fetchZulipServerSettings(client);
+      return jsonResult({ ok: true, settings });
+    }
+
+    if ((action as string) === "org-settings-edit") {
+      requireAdminActionsEnabled(account);
+      await requireZulipAdmin(client);
+      const updates = readRealmUpdateParams(params);
+      await updateZulipRealm(client, updates);
+      return jsonResult({ ok: true, updated: Object.keys(updates) });
+    }
+
+    if ((action as string) === "invite") {
+      const raw =
+        readStringParam(params, "stream") ??
+        readStringParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      const target = splitStreamTarget(raw);
+      let principals =
+        readStringArrayParam(params, "principals") ??
+        readStringArrayParam(params, "principal") ??
+        readStringArrayParam(params, "userIds") ??
+        readStringArrayParam(params, "users");
+      // Support comma-separated string for userId param (message tool compat)
+      if ((!principals || principals.length === 0) && typeof params.userId === "string") {
+        principals = params.userId.split(",").map((s: string) => s.trim()).filter(Boolean);
+      }
+      if (!principals || principals.length === 0) {
+        throw new Error("principals are required to invite Zulip users to a stream.");
+      }
+      for (const principal of principals) {
+        if (typeof principal === "string") {
+          assertStringLength(principal, "principal", MAX_STRING_LENGTH);
+        }
+      }
+      await inviteZulipUsersToStream(client, {
+        stream: target.stream,
+        principals,
+      });
+      return jsonResult({ ok: true, stream: target.stream, principals });
+    }
+
+    if (action === "read") {
+      const raw =
+        readStringParam(params, "stream") ??
+        readStringParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      const target = splitStreamTarget(raw);
+      const limit = readNumberParam(params, "limit", { integer: true });
+      const explicitTopic = readStringParam(params, "topic");
+      const messages = await fetchZulipMessages(client, {
+        stream: target.stream,
+        topic: explicitTopic ?? target.topic,
+        limit: limit ?? undefined,
+      });
+      return jsonResult({
+        ok: true,
+        stream: target.stream,
+        ...(explicitTopic || target.topic ? { topic: explicitTopic ?? target.topic } : {}),
+        messages,
+      });
+    }
+
+    if (action === "react") {
+      const messageId = readMessageId(params);
+      const emojiName =
+        readStringParam(params, "emoji") ??
+        readStringParam(params, "emojiName") ??
+        readStringParam(params, "emoji_name");
+      const emojiCode =
+        readStringParam(params, "emojiCode") ??
+        readStringParam(params, "emoji_code");
+      const reactionType =
+        readStringParam(params, "reactionType") ??
+        readStringParam(params, "reaction_type");
+      const remove = params.remove === true;
+
+      if (!emojiName && !remove) {
+        throw new Error("Zulip react requires emoji name unless removing reactions.");
+      }
+
+      if (remove) {
+        await removeZulipReaction(client, {
+          messageId,
+          emojiName: emojiName ?? undefined,
+          emojiCode: emojiCode ?? undefined,
+          reactionType: reactionType ?? undefined,
+        });
+        return jsonResult({ ok: true, removed: true, messageId, emoji: emojiName ?? null });
+      }
+
+      await addZulipReaction(client, {
+        messageId,
+        emojiName: emojiName ?? "",
+        emojiCode: emojiCode ?? undefined,
+        reactionType: reactionType ?? undefined,
+      });
+      return jsonResult({ ok: true, added: emojiName, messageId });
+    }
+
+    if (action === "edit") {
+      const messageId = readMessageId(params);
+      const content = readMessageContent(params);
+      await editZulipMessage(client, { messageId, content });
+      return jsonResult({ ok: true, edited: messageId });
+    }
+
+    if (action === "delete") {
+      const messageId = readMessageId(params);
+      await deleteZulipMessage(client, { messageId });
+      return jsonResult({ ok: true, deleted: messageId });
+    }
+
+    if (action === "pin" || action === "unpin") {
+      const messageId = readMessageId(params);
+      // Convert messageId to integer for API call
+      const messageIdInt = parseInt(messageId, 10);
+      if (isNaN(messageIdInt)) {
+        throw new Error(`Invalid messageId: ${messageId}`);
+      }
+      await updateZulipMessageFlag(client, {
+        messageId: messageIdInt,
+        flag: "starred",
+        op: action === "pin" ? "add" : "remove",
+      });
+      return jsonResult({
+        ok: true,
+        messageId,
+        starred: action === "pin",
+      });
+    }
+
+    if ((action as string) === "resolve-topic") {
+      const explicitTopic = readStringParam(params, "topic") ?? readStringParam(params, "subject");
+      const rawStream =
+        readStringParam(params, "stream") ??
+        readStringParam(params, "channelId") ??
+        readStringParam(params, "to");
+      const target = rawStream ? splitStreamTarget(rawStream) : undefined;
+      const topic = explicitTopic ?? target?.topic;
+
+      if (!topic) {
+        throw new Error("topic is required to resolve a Zulip topic.");
+      }
+
+      assertStringLength(topic, "topic", MAX_STRING_LENGTH);
+      const { topic: resolvedTopic, alreadyResolved } = resolveTopicName(topic);
+      if (alreadyResolved) {
+        return jsonResult({ ok: true, topic, resolvedTopic, alreadyResolved: true });
+      }
+
+      const messageId = (() => {
+        try {
+          return readMessageId(params);
+        } catch {
+          return undefined;
+        }
+      })();
+
+      let targetMessageId = messageId;
+      if (!targetMessageId) {
+        if (!target?.stream) {
+          throw new Error("stream is required to resolve a Zulip topic when messageId is not provided.");
+        }
+        const messages = await fetchZulipMessages(client, {
+          stream: target.stream,
+          topic,
+          limit: 1,
+        });
+        const latest = messages[0];
+        if (!latest?.id) {
+          throw new Error("No messages found for the specified stream/topic.");
+        }
+        targetMessageId = String(latest.id);
+      }
+
+      await updateZulipMessageTopic(client, {
+        messageId: targetMessageId,
+        topic: resolvedTopic,
+        propagateMode: "change_all",
+      });
+
+      return jsonResult({
+        ok: true,
+        stream: target?.stream,
+        topic,
+        resolvedTopic,
+        messageId: targetMessageId,
+      });
+    }
+
+    if (action === "search") {
+      const query =
+        readStringParam(params, "query") ??
+        readStringParam(params, "text") ??
+        readStringParam(params, "q", { required: true });
+      assertStringLength(query, "query", MAX_STRING_LENGTH);
+      const rawStream =
+        readStringParam(params, "stream") ??
+        readStringParam(params, "channelId") ??
+        readStringParam(params, "to");
+      const explicitTopic = readStringParam(params, "topic");
+      const limit = readNumberParam(params, "limit", { integer: true });
+      const target = rawStream ? splitStreamTarget(rawStream) : undefined;
+      const messages = await searchZulipMessages(client, {
+        query,
+        stream: target?.stream,
+        topic: explicitTopic ?? target?.topic,
+        limit: limit ?? undefined,
+      });
+      return jsonResult({
+        ok: true,
+        query,
+        ...(target?.stream ? { stream: target.stream } : {}),
+        ...(explicitTopic || target?.topic ? { topic: explicitTopic ?? target?.topic } : {}),
+        messages,
+      });
+    }
+
+    throw new Error(`Action ${action} is not supported for provider ${providerId}.`);
+  },
+};

--- a/extensions/zulip/src/channel.test.ts
+++ b/extensions/zulip/src/channel.test.ts
@@ -1,0 +1,72 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { createReplyPrefixOptions } from "openclaw/plugin-sdk";
+import { describe, expect, it } from "vitest";
+import { zulipPlugin } from "./channel.js";
+
+describe("zulipPlugin", () => {
+  describe("messaging", () => {
+    it("normalizes @username targets", () => {
+      const normalize = zulipPlugin.messaging?.normalizeTarget;
+      if (!normalize) {
+        return;
+      }
+
+      expect(normalize("@Alice")).toBe("user:Alice");
+      expect(normalize("@alice")).toBe("user:alice");
+    });
+
+    it("normalizes zulip: prefix to user:", () => {
+      const normalize = zulipPlugin.messaging?.normalizeTarget;
+      if (!normalize) {
+        return;
+      }
+
+      expect(normalize("zulip:USER123")).toBe("user:USER123");
+    });
+  });
+
+  describe("pairing", () => {
+    it("normalizes allowlist entries", () => {
+      const normalize = zulipPlugin.pairing?.normalizeAllowEntry;
+      if (!normalize) {
+        return;
+      }
+
+      expect(normalize("@Alice")).toBe("alice");
+      expect(normalize("user:USER123")).toBe("user123");
+    });
+  });
+
+  describe("config", () => {
+    it("formats allowFrom entries", () => {
+      const formatAllowFrom = zulipPlugin.config.formatAllowFrom;
+
+      const formatted = formatAllowFrom({
+        allowFrom: ["@Alice", "user:USER123", "zulip:BOT999"],
+      });
+      expect(formatted).toEqual(["@alice", "user123", "bot999"]);
+    });
+
+    it("uses account responsePrefix overrides", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          zulip: {
+            responsePrefix: "[Channel]",
+            accounts: {
+              default: { responsePrefix: "[Account]" },
+            },
+          },
+        },
+      };
+
+      const prefixContext = createReplyPrefixOptions({
+        cfg,
+        agentId: "main",
+        channel: "zulip",
+        accountId: "default",
+      });
+
+      expect(prefixContext.responsePrefix).toBe("[Account]");
+    });
+  });
+});

--- a/extensions/zulip/src/channel.ts
+++ b/extensions/zulip/src/channel.ts
@@ -10,9 +10,13 @@ import {
   type ChannelAccountSnapshot,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk";
+import type { ZulipAccountConfig, ZulipConfig } from "./types.js";
+import { zulipMessageActions } from "./actions.js";
 import { ZulipConfigSchema } from "./config-schema.js";
 import { resolveZulipGroupRequireMention } from "./group-mentions.js";
-import type { ZulipAccountConfig, ZulipConfig } from "./types.js";
+import { looksLikeZulipTargetId, normalizeZulipMessagingTarget } from "./normalize.js";
+import { zulipOnboardingAdapter } from "./onboarding.js";
+import { getZulipRuntime } from "./runtime.js";
 import {
   listZulipAccountIds,
   resolveDefaultZulipAccountId,
@@ -23,10 +27,6 @@ import { normalizeZulipBaseUrl } from "./zulip/client.js";
 import { monitorZulipProvider } from "./zulip/monitor.js";
 import { probeZulip } from "./zulip/probe.js";
 import { sendMessageZulip } from "./zulip/send.js";
-import { looksLikeZulipTargetId, normalizeZulipMessagingTarget } from "./normalize.js";
-import { zulipOnboardingAdapter } from "./onboarding.js";
-import { getZulipRuntime } from "./runtime.js";
-import { zulipMessageActions } from "./actions.js";
 
 const meta = {
   id: "zulip",
@@ -345,14 +345,12 @@ export const zulipPlugin: ChannelPlugin<ResolvedZulipAccount> = {
   gateway: {
     startAccount: async (ctx) => {
       const account = ctx.account;
-      ctx.setStatus(
-        {
-          accountId: account.accountId,
-          baseUrl: account.baseUrl,
-          apiKeySource: account.apiKeySource,
-          emailSource: account.emailSource,
-        } as ChannelAccountSnapshot,
-      );
+      ctx.setStatus({
+        accountId: account.accountId,
+        baseUrl: account.baseUrl,
+        apiKeySource: account.apiKeySource,
+        emailSource: account.emailSource,
+      } as ChannelAccountSnapshot);
       ctx.log?.info(`[${account.accountId}] starting channel`);
       return monitorZulipProvider({
         apiKey: account.apiKey ?? undefined,

--- a/extensions/zulip/src/channel.ts
+++ b/extensions/zulip/src/channel.ts
@@ -1,0 +1,369 @@
+import {
+  applyAccountNameToChannelSection,
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  migrateBaseNameToDefaultAccount,
+  normalizeAccountId,
+  setAccountEnabledInConfigSection,
+  type ChannelAccountSnapshot,
+  type ChannelPlugin,
+} from "openclaw/plugin-sdk";
+import { ZulipConfigSchema } from "./config-schema.js";
+import { resolveZulipGroupRequireMention } from "./group-mentions.js";
+import type { ZulipAccountConfig, ZulipConfig } from "./types.js";
+import {
+  listZulipAccountIds,
+  resolveDefaultZulipAccountId,
+  resolveZulipAccount,
+  type ResolvedZulipAccount,
+} from "./zulip/accounts.js";
+import { normalizeZulipBaseUrl } from "./zulip/client.js";
+import { monitorZulipProvider } from "./zulip/monitor.js";
+import { probeZulip } from "./zulip/probe.js";
+import { sendMessageZulip } from "./zulip/send.js";
+import { looksLikeZulipTargetId, normalizeZulipMessagingTarget } from "./normalize.js";
+import { zulipOnboardingAdapter } from "./onboarding.js";
+import { getZulipRuntime } from "./runtime.js";
+import { zulipMessageActions } from "./actions.js";
+
+const meta = {
+  id: "zulip",
+  label: "Zulip",
+  selectionLabel: "Zulip (plugin)",
+  detailLabel: "Zulip Bot",
+  docsPath: "/channels/zulip",
+  docsLabel: "zulip",
+  blurb: "self-hosted Slack-style chat; install the plugin to enable.",
+  systemImage: "bubble.left.and.bubble.right",
+  order: 65,
+  quickstartAllowFrom: true,
+} as const;
+
+function normalizeAllowEntry(entry: string): string {
+  return entry
+    .trim()
+    .replace(/^(zulip|user):/i, "")
+    .replace(/^@/, "")
+    .toLowerCase();
+}
+
+function formatAllowEntry(entry: string): string {
+  const trimmed = entry.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed.startsWith("@")) {
+    const username = trimmed.slice(1).trim();
+    return username ? `@${username.toLowerCase()}` : "";
+  }
+  return trimmed.replace(/^(zulip|user):/i, "").toLowerCase();
+}
+
+export const zulipPlugin: ChannelPlugin<ResolvedZulipAccount> = {
+  id: "zulip",
+  meta: {
+    ...meta,
+  },
+  onboarding: zulipOnboardingAdapter,
+  pairing: {
+    idLabel: "zulipUserId",
+    normalizeAllowEntry: (entry) => normalizeAllowEntry(entry),
+    notifyApproval: async ({ id }) => {
+      console.log(`[zulip] User ${id} approved for pairing`);
+    },
+  },
+  capabilities: {
+    chatTypes: ["direct", "channel", "group", "thread"],
+    threads: true,
+    media: true,
+  },
+  streaming: {
+    blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+  },
+  reload: { configPrefixes: ["channels.zulip"] },
+  configSchema: buildChannelConfigSchema(ZulipConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listZulipAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveZulipAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultZulipAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "zulip",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "zulip",
+        accountId,
+        clearBaseFields: ["apiKey", "email", "url", "name"] as const,
+      }),
+    isConfigured: (account) => Boolean(account.apiKey && account.email && account.baseUrl),
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: Boolean(account.apiKey && account.email && account.baseUrl),
+      // tokenSource for OpenClaw status display (maps apiKey → token)
+      tokenSource: account.apiKeySource,
+      apiKeySource: account.apiKeySource,
+      emailSource: account.emailSource,
+      baseUrl: account.baseUrl,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveZulipAccount({ cfg, accountId }).config.allowFrom ?? []).map((entry) =>
+        String(entry),
+      ),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom.map((entry) => formatAllowEntry(String(entry))).filter(Boolean),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const zulipSection = cfg.channels?.zulip as ZulipConfig | undefined;
+      const useAccountPath = Boolean(zulipSection?.accounts?.[resolvedAccountId]);
+      const basePath = useAccountPath
+        ? `channels.zulip.accounts.${resolvedAccountId}.`
+        : "channels.zulip.";
+      return {
+        policy: account.config.dmPolicy ?? "pairing",
+        allowFrom: account.config.allowFrom ?? [],
+        policyPath: `${basePath}dmPolicy`,
+        allowFromPath: basePath,
+        approveHint: formatPairingApproveHint("zulip"),
+        normalizeEntry: (raw) => normalizeAllowEntry(raw),
+      };
+    },
+    collectWarnings: ({ account, cfg }) => {
+      const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
+      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      if (groupPolicy !== "open") {
+        return [];
+      }
+      return [
+        `- Zulip streams: groupPolicy="open" allows any member to trigger (mention-gated). Set channels.zulip.groupPolicy="allowlist" + channels.zulip.groupAllowFrom to restrict senders.`,
+      ];
+    },
+  },
+  groups: {
+    resolveRequireMention: resolveZulipGroupRequireMention,
+  },
+  actions: zulipMessageActions,
+  messaging: {
+    normalizeTarget: normalizeZulipMessagingTarget,
+    targetResolver: {
+      looksLikeId: looksLikeZulipTargetId,
+      hint: "<stream:NAME[:topic]|user:email|#stream[:topic]|@email>",
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunker: (text, limit) => getZulipRuntime().channel.text.chunkMarkdownText(text, limit),
+    chunkerMode: "markdown",
+    textChunkLimit: 4000,
+    resolveTarget: ({ to }) => {
+      const trimmed = to?.trim();
+      if (!trimmed) {
+        return {
+          ok: false,
+          error: new Error(
+            "Delivering to Zulip requires --to <stream:NAME[:topic]|user:email|#stream[:topic]|@email>",
+          ),
+        };
+      }
+      return { ok: true, to: trimmed };
+    },
+    sendText: async ({ to, text, accountId }) => {
+      const result = await sendMessageZulip(to, text, {
+        accountId: accountId ?? undefined,
+      });
+      return { channel: "zulip", ...result };
+    },
+    sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+      const result = await sendMessageZulip(to, text, {
+        accountId: accountId ?? undefined,
+        mediaUrl,
+      });
+      return { channel: "zulip", ...result };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      connected: false,
+      lastConnectedAt: null,
+      lastDisconnect: null,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    buildChannelSummary: ({ snapshot }) => {
+      const zulipSnapshot = snapshot as ChannelAccountSnapshot & {
+        apiKeySource?: string;
+        emailSource?: string;
+        baseUrl?: string | null;
+      };
+      return {
+        configured: zulipSnapshot.configured ?? false,
+        apiKeySource: zulipSnapshot.apiKeySource ?? "none",
+        emailSource: zulipSnapshot.emailSource ?? "none",
+        running: zulipSnapshot.running ?? false,
+        connected: zulipSnapshot.connected ?? false,
+        lastStartAt: zulipSnapshot.lastStartAt ?? null,
+        lastStopAt: zulipSnapshot.lastStopAt ?? null,
+        lastError: zulipSnapshot.lastError ?? null,
+        baseUrl: zulipSnapshot.baseUrl ?? null,
+        probe: zulipSnapshot.probe,
+        lastProbeAt: zulipSnapshot.lastProbeAt ?? null,
+      };
+    },
+    probeAccount: async ({ account, timeoutMs }) => {
+      const apiKey = account.apiKey?.trim();
+      const email = account.email?.trim();
+      const baseUrl = account.baseUrl?.trim();
+      if (!apiKey || !email || !baseUrl) {
+        return { ok: false, error: "apiKey, email, or url missing" };
+      }
+      return await probeZulip(baseUrl, email, apiKey, timeoutMs);
+    },
+    buildAccountSnapshot: ({ account, runtime, probe }) =>
+      ({
+        accountId: account.accountId,
+        name: account.name,
+        enabled: account.enabled,
+        configured: Boolean(account.apiKey && account.email && account.baseUrl),
+        // Expose token/tokenSource for status display (maps to apiKey)
+        token: account.apiKey,
+        tokenSource: account.apiKeySource,
+        apiKeySource: account.apiKeySource,
+        emailSource: account.emailSource,
+        baseUrl: account.baseUrl,
+        running: runtime?.running ?? false,
+        connected: runtime?.connected ?? false,
+        lastConnectedAt: runtime?.lastConnectedAt ?? null,
+        lastDisconnect: runtime?.lastDisconnect ?? null,
+        lastStartAt: runtime?.lastStartAt ?? null,
+        lastStopAt: runtime?.lastStopAt ?? null,
+        lastError: runtime?.lastError ?? null,
+        probe,
+        lastInboundAt: runtime?.lastInboundAt ?? null,
+        lastOutboundAt: runtime?.lastOutboundAt ?? null,
+      }) as ChannelAccountSnapshot,
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "zulip",
+        accountId,
+        name,
+      }),
+    validateInput: ({ accountId, input }) => {
+      const inputAny = input as Record<string, string | boolean | undefined>;
+      if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+        return "Zulip env vars can only be used for the default account.";
+      }
+      const apiKey = (inputAny.apiKey as string | undefined) ?? input.botToken ?? input.token;
+      const email = inputAny.email as string | undefined;
+      const baseUrl = input.httpUrl;
+      if (!input.useEnv && (!apiKey || !email || !baseUrl)) {
+        return "Zulip requires --api-key, --email, and --http-url (or --use-env).";
+      }
+      if (baseUrl && !normalizeZulipBaseUrl(baseUrl)) {
+        return "Zulip --http-url must include a valid base URL.";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const inputAny = input as Record<string, string | boolean | undefined>;
+      const apiKey = (inputAny.apiKey as string | undefined) ?? input.botToken ?? input.token;
+      const email = inputAny.email as string | undefined;
+      const baseUrl = input.httpUrl?.trim();
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "zulip",
+        accountId,
+        name: input.name,
+      });
+      const next =
+        accountId !== DEFAULT_ACCOUNT_ID
+          ? migrateBaseNameToDefaultAccount({
+              cfg: namedConfig,
+              channelKey: "zulip",
+            })
+          : namedConfig;
+      const zulipSection = (next.channels?.zulip ?? {}) as ZulipConfig;
+      const zulipAccounts = (zulipSection.accounts ?? {}) as Record<string, ZulipAccountConfig>;
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            zulip: {
+              ...zulipSection,
+              enabled: true,
+              ...(input.useEnv
+                ? {}
+                : {
+                    ...(apiKey ? { apiKey } : {}),
+                    ...(email ? { email } : {}),
+                    ...(baseUrl ? { url: baseUrl } : {}),
+                  }),
+            },
+          },
+        };
+      }
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          zulip: {
+            ...zulipSection,
+            enabled: true,
+            accounts: {
+              ...zulipAccounts,
+              [accountId]: {
+                ...zulipAccounts[accountId],
+                enabled: true,
+                ...(apiKey ? { apiKey } : {}),
+                ...(email ? { email } : {}),
+                ...(baseUrl ? { url: baseUrl } : {}),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.setStatus(
+        {
+          accountId: account.accountId,
+          baseUrl: account.baseUrl,
+          apiKeySource: account.apiKeySource,
+          emailSource: account.emailSource,
+        } as ChannelAccountSnapshot,
+      );
+      ctx.log?.info(`[${account.accountId}] starting channel`);
+      return monitorZulipProvider({
+        apiKey: account.apiKey ?? undefined,
+        email: account.email ?? undefined,
+        baseUrl: account.baseUrl ?? undefined,
+        accountId: account.accountId,
+        config: ctx.cfg,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        statusSink: (patch) => ctx.setStatus({ accountId: ctx.accountId, ...patch }),
+      });
+    },
+  },
+};

--- a/extensions/zulip/src/config-schema.ts
+++ b/extensions/zulip/src/config-schema.ts
@@ -1,0 +1,67 @@
+import {
+  BlockStreamingCoalesceSchema,
+  DmPolicySchema,
+  GroupPolicySchema,
+  MarkdownConfigSchema,
+  requireOpenAllowFrom,
+} from "openclaw/plugin-sdk";
+import { z } from "zod";
+
+const ZulipAccountSchemaBase = z
+  .object({
+    name: z.string().optional(),
+    capabilities: z.array(z.string()).optional(),
+    markdown: MarkdownConfigSchema.optional(),
+    enabled: z.boolean().optional(),
+    configWrites: z.boolean().optional(),
+    url: z.string().optional(),
+    email: z.string().optional(),
+    apiKey: z.string().optional(),
+    streams: z.array(z.string()).optional(),
+    chatmode: z.enum(["oncall", "onmessage", "onchar"]).optional(),
+    oncharPrefixes: z.array(z.string()).optional(),
+    requireMention: z.boolean().optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupPolicy: GroupPolicySchema.optional(),
+    mediaMaxMb: z.number().int().positive().optional(),
+    reactions: z
+      .object({
+        enabled: z.boolean().optional(),
+        clearOnFinish: z.boolean().optional(),
+        onStart: z.string().optional(),
+        onSuccess: z.string().optional(),
+        onError: z.string().optional(),
+      })
+      .optional(),
+    textChunkLimit: z.number().int().positive().optional(),
+    chunkMode: z.enum(["length", "newline"]).optional(),
+    blockStreaming: z.boolean().optional(),
+    blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    responsePrefix: z.string().optional(),
+    enableAdminActions: z.boolean().optional(),
+  })
+  .strict();
+
+const ZulipAccountSchema = ZulipAccountSchemaBase.superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message: 'channels.zulip.dmPolicy="open" requires channels.zulip.allowFrom to include "*"',
+  });
+});
+
+export const ZulipConfigSchema = ZulipAccountSchemaBase.extend({
+  accounts: z.record(z.string(), ZulipAccountSchema.optional()).optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message: 'channels.zulip.dmPolicy="open" requires channels.zulip.allowFrom to include "*"',
+  });
+});

--- a/extensions/zulip/src/config-schema.ts
+++ b/extensions/zulip/src/config-schema.ts
@@ -15,6 +15,9 @@ const ZulipAccountSchemaBase = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     url: z.string().optional(),
+    // Backwards-compatible aliases for url.
+    site: z.string().optional(),
+    realm: z.string().optional(),
     email: z.string().optional(),
     apiKey: z.string().optional(),
     streams: z.array(z.string()).optional(),

--- a/extensions/zulip/src/group-mentions.ts
+++ b/extensions/zulip/src/group-mentions.ts
@@ -1,9 +1,7 @@
 import type { ChannelGroupContext } from "openclaw/plugin-sdk";
 import { resolveZulipAccount } from "./zulip/accounts.js";
 
-export function resolveZulipGroupRequireMention(
-  params: ChannelGroupContext,
-): boolean | undefined {
+export function resolveZulipGroupRequireMention(params: ChannelGroupContext): boolean | undefined {
   const account = resolveZulipAccount({
     cfg: params.cfg,
     accountId: params.accountId,

--- a/extensions/zulip/src/group-mentions.ts
+++ b/extensions/zulip/src/group-mentions.ts
@@ -1,0 +1,15 @@
+import type { ChannelGroupContext } from "openclaw/plugin-sdk";
+import { resolveZulipAccount } from "./zulip/accounts.js";
+
+export function resolveZulipGroupRequireMention(
+  params: ChannelGroupContext,
+): boolean | undefined {
+  const account = resolveZulipAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  if (typeof account.requireMention === "boolean") {
+    return account.requireMention;
+  }
+  return true;
+}

--- a/extensions/zulip/src/normalize.ts
+++ b/extensions/zulip/src/normalize.ts
@@ -1,0 +1,45 @@
+export function normalizeZulipMessagingTarget(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("stream:")) {
+    const rest = trimmed.slice("stream:".length).trim();
+    return rest ? `stream:${rest}` : undefined;
+  }
+  if (lower.startsWith("user:") || lower.startsWith("dm:")) {
+    const rest = trimmed.slice(trimmed.indexOf(":") + 1).trim();
+    return rest ? `user:${rest}` : undefined;
+  }
+  if (lower.startsWith("zulip:")) {
+    const rest = trimmed.slice("zulip:".length).trim();
+    return rest ? `user:${rest}` : undefined;
+  }
+  if (trimmed.startsWith("@")) {
+    const id = trimmed.slice(1).trim();
+    return id ? `user:${id}` : undefined;
+  }
+  if (trimmed.startsWith("#")) {
+    const id = trimmed.slice(1).trim();
+    return id ? `stream:${id}` : undefined;
+  }
+  if (trimmed.includes("@")) {
+    return `user:${trimmed}`;
+  }
+  return `stream:${trimmed}`;
+}
+
+export function looksLikeZulipTargetId(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (/^(user|dm|stream|zulip):/i.test(trimmed)) {
+    return true;
+  }
+  if (/^[@#]/.test(trimmed)) {
+    return true;
+  }
+  return trimmed.includes("@") || /^[a-z0-9][a-z0-9._-]{1,}$/i.test(trimmed);
+}

--- a/extensions/zulip/src/onboarding-helpers.ts
+++ b/extensions/zulip/src/onboarding-helpers.ts
@@ -1,0 +1,44 @@
+import type { OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+
+type PromptAccountIdParams = {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  label: string;
+  currentId?: string;
+  listAccountIds: (cfg: OpenClawConfig) => string[];
+  defaultAccountId: string;
+};
+
+export async function promptAccountId(params: PromptAccountIdParams): Promise<string> {
+  const existingIds = params.listAccountIds(params.cfg);
+  const initial = params.currentId?.trim() || params.defaultAccountId || DEFAULT_ACCOUNT_ID;
+  const choice = await params.prompter.select({
+    message: `${params.label} account`,
+    options: [
+      ...existingIds.map((id) => ({
+        value: id,
+        label: id === DEFAULT_ACCOUNT_ID ? "default (primary)" : id,
+      })),
+      { value: "__new__", label: "Add a new account" },
+    ],
+    initialValue: initial,
+  });
+
+  if (choice !== "__new__") {
+    return normalizeAccountId(choice);
+  }
+
+  const entered = await params.prompter.text({
+    message: `New ${params.label} account id`,
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  const normalized = normalizeAccountId(String(entered));
+  if (String(entered).trim() !== normalized) {
+    await params.prompter.note(
+      `Normalized account id to "${normalized}".`,
+      `${params.label} account`,
+    );
+  }
+  return normalized;
+}

--- a/extensions/zulip/src/onboarding.ts
+++ b/extensions/zulip/src/onboarding.ts
@@ -1,12 +1,12 @@
 import type { ChannelOnboardingAdapter, OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk";
-import type { ZulipAccountConfig, ZulipConfig } from "./types.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import type { ZulipAccountConfig, ZulipConfig } from "./types.js";
+import { promptAccountId } from "./onboarding-helpers.js";
 import {
   listZulipAccountIds,
   resolveDefaultZulipAccountId,
   resolveZulipAccount,
 } from "./zulip/accounts.js";
-import { promptAccountId } from "./onboarding-helpers.js";
 
 const channel = "zulip" as const;
 

--- a/extensions/zulip/src/onboarding.ts
+++ b/extensions/zulip/src/onboarding.ts
@@ -1,0 +1,219 @@
+import type { ChannelOnboardingAdapter, OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk";
+import type { ZulipAccountConfig, ZulipConfig } from "./types.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import {
+  listZulipAccountIds,
+  resolveDefaultZulipAccountId,
+  resolveZulipAccount,
+} from "./zulip/accounts.js";
+import { promptAccountId } from "./onboarding-helpers.js";
+
+const channel = "zulip" as const;
+
+async function noteZulipSetup(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "1) Zulip settings -> Bots -> Create a bot",
+      "2) Copy the bot email + API key",
+      "3) Use your server base URL (e.g., https://chat.example.com)",
+      "Tip: the bot must be a member of any stream you want it to monitor.",
+      "Docs: https://docs.openclaw.ai/channels/zulip",
+    ].join("\n"),
+    "Zulip credentials",
+  );
+}
+
+export const zulipOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  getStatus: async ({ cfg }) => {
+    const configured = listZulipAccountIds(cfg).some((accountId) => {
+      const account = resolveZulipAccount({ cfg, accountId });
+      return Boolean(account.apiKey && account.email && account.baseUrl);
+    });
+    return {
+      channel,
+      configured,
+      statusLines: [`Zulip: ${configured ? "configured" : "needs api key + email + url"}`],
+      selectionHint: configured ? "configured" : "needs setup",
+      quickstartScore: configured ? 2 : 1,
+    };
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const override = accountOverrides.zulip?.trim();
+    const defaultAccountId = resolveDefaultZulipAccountId(cfg);
+    let accountId = override ? normalizeAccountId(override) : defaultAccountId;
+    if (shouldPromptAccountIds && !override) {
+      accountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "Zulip",
+        currentId: accountId,
+        listAccountIds: listZulipAccountIds,
+        defaultAccountId,
+      });
+    }
+
+    let next = cfg;
+    const resolvedAccount = resolveZulipAccount({
+      cfg: next,
+      accountId,
+    });
+    const accountConfigured = Boolean(
+      resolvedAccount.apiKey && resolvedAccount.email && resolvedAccount.baseUrl,
+    );
+    const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
+    const canUseEnv =
+      allowEnv &&
+      Boolean(process.env.ZULIP_API_KEY?.trim()) &&
+      Boolean(process.env.ZULIP_EMAIL?.trim()) &&
+      Boolean(process.env.ZULIP_URL?.trim());
+    const hasConfigValues =
+      Boolean(resolvedAccount.config.apiKey) ||
+      Boolean(resolvedAccount.config.email) ||
+      Boolean(resolvedAccount.config.url);
+
+    let apiKey: string | null = null;
+    let email: string | null = null;
+    let baseUrl: string | null = null;
+
+    if (!accountConfigured) {
+      await noteZulipSetup(prompter);
+    }
+
+    if (canUseEnv && !hasConfigValues) {
+      const keepEnv = await prompter.confirm({
+        message: "ZULIP_API_KEY + ZULIP_EMAIL + ZULIP_URL detected. Use env vars?",
+        initialValue: true,
+      });
+      if (keepEnv) {
+        const zulipSection = (next.channels?.zulip ?? {}) as ZulipConfig;
+        next = {
+          ...next,
+          channels: {
+            ...next.channels,
+            zulip: {
+              ...zulipSection,
+              enabled: true,
+            },
+          },
+        };
+      } else {
+        apiKey = String(
+          await prompter.text({
+            message: "Enter Zulip API key",
+            validate: (value) => (value?.trim() ? undefined : "Required"),
+          }),
+        ).trim();
+        email = String(
+          await prompter.text({
+            message: "Enter Zulip bot email",
+            validate: (value) => (value?.trim() ? undefined : "Required"),
+          }),
+        ).trim();
+        baseUrl = String(
+          await prompter.text({
+            message: "Enter Zulip base URL",
+            validate: (value) => (value?.trim() ? undefined : "Required"),
+          }),
+        ).trim();
+      }
+    } else if (accountConfigured) {
+      const keep = await prompter.confirm({
+        message: "Zulip credentials already configured. Keep them?",
+        initialValue: true,
+      });
+      if (!keep) {
+        apiKey = String(
+          await prompter.text({
+            message: "Enter Zulip API key",
+            validate: (value) => (value?.trim() ? undefined : "Required"),
+          }),
+        ).trim();
+        email = String(
+          await prompter.text({
+            message: "Enter Zulip bot email",
+            validate: (value) => (value?.trim() ? undefined : "Required"),
+          }),
+        ).trim();
+        baseUrl = String(
+          await prompter.text({
+            message: "Enter Zulip base URL",
+            validate: (value) => (value?.trim() ? undefined : "Required"),
+          }),
+        ).trim();
+      }
+    } else {
+      apiKey = String(
+        await prompter.text({
+          message: "Enter Zulip API key",
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        }),
+      ).trim();
+      email = String(
+        await prompter.text({
+          message: "Enter Zulip bot email",
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        }),
+      ).trim();
+      baseUrl = String(
+        await prompter.text({
+          message: "Enter Zulip base URL",
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        }),
+      ).trim();
+    }
+
+    if (apiKey || email || baseUrl) {
+      const zulipSection = (next.channels?.zulip ?? {}) as ZulipConfig;
+      const zulipAccounts = (zulipSection.accounts ?? {}) as Record<string, ZulipAccountConfig>;
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        next = {
+          ...next,
+          channels: {
+            ...next.channels,
+            zulip: {
+              ...zulipSection,
+              enabled: true,
+              ...(apiKey ? { apiKey } : {}),
+              ...(email ? { email } : {}),
+              ...(baseUrl ? { url: baseUrl } : {}),
+            },
+          },
+        };
+      } else {
+        next = {
+          ...next,
+          channels: {
+            ...next.channels,
+            zulip: {
+              ...zulipSection,
+              enabled: true,
+              accounts: {
+                ...zulipAccounts,
+                [accountId]: {
+                  ...zulipAccounts[accountId],
+                  enabled: zulipAccounts[accountId]?.enabled ?? true,
+                  ...(apiKey ? { apiKey } : {}),
+                  ...(email ? { email } : {}),
+                  ...(baseUrl ? { url: baseUrl } : {}),
+                },
+              },
+            },
+          },
+        };
+      }
+    }
+
+    return { cfg: next, accountId };
+  },
+  disable: (cfg: OpenClawConfig) => {
+    const zulipSection = (cfg.channels?.zulip ?? {}) as ZulipConfig;
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        zulip: { ...zulipSection, enabled: false },
+      },
+    };
+  },
+};

--- a/extensions/zulip/src/runtime.ts
+++ b/extensions/zulip/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setZulipRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getZulipRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Zulip runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/zulip/src/types.ts
+++ b/extensions/zulip/src/types.ts
@@ -1,0 +1,68 @@
+import type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "openclaw/plugin-sdk";
+
+export type ZulipChatMode = "oncall" | "onmessage" | "onchar";
+
+export type ZulipAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** Allow channel-initiated config writes (default: true). */
+  configWrites?: boolean;
+  /** Require explicit opt-in for admin-only actions (default: false). */
+  enableAdminActions?: boolean;
+  /** If false, do not start this Zulip account. Default: true. */
+  enabled?: boolean;
+  /** Base URL for the Zulip server (e.g., https://chat.example.com). */
+  url?: string;
+  /** Zulip bot email address. */
+  email?: string;
+  /** Zulip API key for the bot. */
+  apiKey?: string;
+  /** Restrict monitored streams ("*" = all streams). */
+  streams?: string[];
+  /**
+   * Controls when channel messages trigger replies.
+   * - "oncall": only respond when mentioned
+   * - "onmessage": respond to every channel message
+   * - "onchar": respond when a trigger character prefixes the message
+   */
+  chatmode?: ZulipChatMode;
+  /** Prefix characters that trigger onchar mode (default: [">", "!"]). */
+  oncharPrefixes?: string[];
+  /** Require @mention to respond in channels. Default: true. */
+  requireMention?: boolean;
+  /** Direct message policy (pairing/allowlist/open/disabled). */
+  dmPolicy?: DmPolicy;
+  /** Allowlist for direct messages (user ids or @usernames). */
+  allowFrom?: Array<string | number>;
+  /** Allowlist for group messages (user ids or @usernames). */
+  groupAllowFrom?: Array<string | number>;
+  /** Group message policy (allowlist/open/disabled). */
+  groupPolicy?: GroupPolicy;
+  /** Inbound media max size (MB). Default: 5. */
+  mediaMaxMb?: number;
+  /** Reaction indicators. */
+  reactions?: {
+    enabled?: boolean;
+    clearOnFinish?: boolean;
+    onStart?: string;
+    onSuccess?: string;
+    onError?: string;
+  };
+  /** Outbound text chunk size (chars). Default: 4000. */
+  textChunkLimit?: number;
+  /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
+  chunkMode?: "length" | "newline";
+  /** Disable block streaming for this account. */
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /** Outbound response prefix override for this channel/account. */
+  responsePrefix?: string;
+};
+
+export type ZulipConfig = {
+  /** Optional per-account Zulip configuration (multi-account). */
+  accounts?: Record<string, ZulipAccountConfig>;
+} & ZulipAccountConfig;

--- a/extensions/zulip/src/types.ts
+++ b/extensions/zulip/src/types.ts
@@ -15,6 +15,9 @@ export type ZulipAccountConfig = {
   enabled?: boolean;
   /** Base URL for the Zulip server (e.g., https://chat.example.com). */
   url?: string;
+  /** Backwards-compatible aliases for url (treated the same as url). */
+  site?: string;
+  realm?: string;
   /** Zulip bot email address. */
   email?: string;
   /** Zulip API key for the bot. */

--- a/extensions/zulip/src/zulip/accounts.ts
+++ b/extensions/zulip/src/zulip/accounts.ts
@@ -1,0 +1,148 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import type { ZulipAccountConfig, ZulipChatMode, ZulipConfig } from "../types.js";
+import { normalizeZulipBaseUrl } from "./client.js";
+
+export type ZulipTokenSource = "env" | "config" | "none";
+export type ZulipEmailSource = "env" | "config" | "none";
+export type ZulipBaseUrlSource = "env" | "config" | "none";
+
+export type ResolvedZulipAccount = {
+  accountId: string;
+  enabled: boolean;
+  name?: string;
+  apiKey?: string;
+  email?: string;
+  baseUrl?: string;
+  apiKeySource: ZulipTokenSource;
+  emailSource: ZulipEmailSource;
+  baseUrlSource: ZulipBaseUrlSource;
+  // Aliases for OpenClaw status display (maps apiKey → token)
+  token?: string;
+  tokenSource: ZulipTokenSource;
+  config: ZulipAccountConfig;
+  enableAdminActions?: boolean;
+  chatmode?: ZulipChatMode;
+  oncharPrefixes?: string[];
+  requireMention?: boolean;
+  textChunkLimit?: number;
+  blockStreaming?: boolean;
+  blockStreamingCoalesce?: ZulipAccountConfig["blockStreamingCoalesce"];
+  streams?: string[];
+};
+
+function resolveZulipSection(cfg: OpenClawConfig): ZulipConfig | undefined {
+  return cfg.channels?.zulip as ZulipConfig | undefined;
+}
+
+function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = resolveZulipSection(cfg)?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return [];
+  }
+  return Object.keys(accounts).filter(Boolean);
+}
+
+export function listZulipAccountIds(cfg: OpenClawConfig): string[] {
+  const ids = listConfiguredAccountIds(cfg);
+  if (ids.length === 0) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  return ids.toSorted((a, b) => a.localeCompare(b));
+}
+
+export function resolveDefaultZulipAccountId(cfg: OpenClawConfig): string {
+  const ids = listZulipAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): ZulipAccountConfig | undefined {
+  const accounts = resolveZulipSection(cfg)?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return undefined;
+  }
+  return accounts[accountId] as ZulipAccountConfig | undefined;
+}
+
+function mergeZulipAccountConfig(cfg: OpenClawConfig, accountId: string): ZulipAccountConfig {
+  const { accounts: _ignored, ...base } = (resolveZulipSection(cfg) ?? {}) as ZulipConfig;
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account };
+}
+
+function resolveZulipRequireMention(config: ZulipAccountConfig): boolean | undefined {
+  if (config.chatmode === "oncall") {
+    return true;
+  }
+  if (config.chatmode === "onmessage") {
+    return false;
+  }
+  if (config.chatmode === "onchar") {
+    return true;
+  }
+  return config.requireMention;
+}
+
+export function resolveZulipAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedZulipAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const zulipSection = resolveZulipSection(params.cfg);
+  const baseEnabled = zulipSection?.enabled !== false;
+  const merged = mergeZulipAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+
+  const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
+  const envApiKey = allowEnv ? process.env.ZULIP_API_KEY?.trim() : undefined;
+  const envEmail = allowEnv ? process.env.ZULIP_EMAIL?.trim() : undefined;
+  const envUrl = allowEnv ? process.env.ZULIP_URL?.trim() : undefined;
+  const configApiKey = merged.apiKey?.trim();
+  const configEmail = merged.email?.trim();
+  const configUrl = merged.url?.trim();
+  const apiKey = configApiKey || envApiKey;
+  const email = configEmail || envEmail;
+  const baseUrl = normalizeZulipBaseUrl(configUrl || envUrl);
+  const requireMention = resolveZulipRequireMention(merged);
+
+  const apiKeySource: ZulipTokenSource = configApiKey ? "config" : envApiKey ? "env" : "none";
+  const emailSource: ZulipEmailSource = configEmail ? "config" : envEmail ? "env" : "none";
+  const baseUrlSource: ZulipBaseUrlSource = configUrl ? "config" : envUrl ? "env" : "none";
+
+  return {
+    accountId,
+    enabled,
+    name: merged.name?.trim() || undefined,
+    apiKey,
+    email,
+    baseUrl,
+    apiKeySource,
+    emailSource,
+    baseUrlSource,
+    // Expose token/tokenSource aliases for OpenClaw status display
+    token: apiKey,
+    tokenSource: apiKeySource,
+    config: merged,
+    enableAdminActions: merged.enableAdminActions,
+    chatmode: merged.chatmode,
+    oncharPrefixes: merged.oncharPrefixes,
+    requireMention,
+    textChunkLimit: merged.textChunkLimit,
+    blockStreaming: merged.blockStreaming,
+    blockStreamingCoalesce: merged.blockStreamingCoalesce,
+    streams: merged.streams,
+  };
+}
+
+export function listEnabledZulipAccounts(cfg: OpenClawConfig): ResolvedZulipAccount[] {
+  return listZulipAccountIds(cfg)
+    .map((accountId) => resolveZulipAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}

--- a/extensions/zulip/src/zulip/accounts.ts
+++ b/extensions/zulip/src/zulip/accounts.ts
@@ -104,17 +104,23 @@ export function resolveZulipAccount(params: {
   const envApiKey = allowEnv ? process.env.ZULIP_API_KEY?.trim() : undefined;
   const envEmail = allowEnv ? process.env.ZULIP_EMAIL?.trim() : undefined;
   const envUrl = allowEnv ? process.env.ZULIP_URL?.trim() : undefined;
+  const envSite = allowEnv ? process.env.ZULIP_SITE?.trim() : undefined;
+  const envRealm = allowEnv ? process.env.ZULIP_REALM?.trim() : undefined;
   const configApiKey = merged.apiKey?.trim();
   const configEmail = merged.email?.trim();
-  const configUrl = merged.url?.trim();
+  const configUrl = (merged.url ?? merged.site ?? merged.realm)?.trim();
   const apiKey = configApiKey || envApiKey;
   const email = configEmail || envEmail;
-  const baseUrl = normalizeZulipBaseUrl(configUrl || envUrl);
+  const baseUrl = normalizeZulipBaseUrl(configUrl || envUrl || envSite || envRealm);
   const requireMention = resolveZulipRequireMention(merged);
 
   const apiKeySource: ZulipTokenSource = configApiKey ? "config" : envApiKey ? "env" : "none";
   const emailSource: ZulipEmailSource = configEmail ? "config" : envEmail ? "env" : "none";
-  const baseUrlSource: ZulipBaseUrlSource = configUrl ? "config" : envUrl ? "env" : "none";
+  const baseUrlSource: ZulipBaseUrlSource = configUrl
+    ? "config"
+    : envUrl || envSite || envRealm
+      ? "env"
+      : "none";
 
   return {
     accountId,

--- a/extensions/zulip/src/zulip/client.register-queue.test.ts
+++ b/extensions/zulip/src/zulip/client.register-queue.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { ZulipClient } from "./client.js";
+import { registerZulipQueue } from "./client.js";
+
+describe("registerZulipQueue", () => {
+  function makeClient(assertions: (path: string, init?: RequestInit) => void): ZulipClient {
+    return {
+      baseUrl: "https://zulip.example.com",
+      authHeader: "xxx",
+      fetchImpl: fetch,
+      request: async (path: string, init?: RequestInit) => {
+        assertions(path, init);
+        return {
+          result: "success",
+          msg: "",
+          queue_id: "q",
+          last_event_id: 0,
+        } as any;
+      },
+    };
+  }
+
+  it("uses all_public_streams=true when streams includes '*'", async () => {
+    const client = makeClient((path, init) => {
+      expect(path).toBe("/register");
+      expect(init?.method).toBe("POST");
+      const body = new URLSearchParams(String(init?.body ?? ""));
+      expect(body.get("all_public_streams")).toBe("true");
+      expect(body.has("narrow")).toBe(false);
+    });
+
+    await registerZulipQueue(client, { streams: ["*"] });
+  });
+
+  it("uses a stream narrow when exactly one stream is requested", async () => {
+    const client = makeClient((path, init) => {
+      expect(path).toBe("/register");
+      const body = new URLSearchParams(String(init?.body ?? ""));
+      expect(body.get("narrow")).toBe(JSON.stringify([["stream", "openclaw"]]));
+      expect(body.has("all_public_streams")).toBe(false);
+    });
+
+    await registerZulipQueue(client, { streams: ["openclaw"] });
+  });
+
+  it("omits narrow when multiple streams are requested (Zulip narrows are ANDed)", async () => {
+    const client = makeClient((path, init) => {
+      expect(path).toBe("/register");
+      const body = new URLSearchParams(String(init?.body ?? ""));
+      expect(body.has("narrow")).toBe(false);
+      expect(body.has("all_public_streams")).toBe(false);
+    });
+
+    await registerZulipQueue(client, { streams: ["build", "general", "openclaw", "research"] });
+  });
+});

--- a/extensions/zulip/src/zulip/client.ts
+++ b/extensions/zulip/src/zulip/client.ts
@@ -279,7 +279,11 @@ export async function registerZulipQueue(
   body.set("event_types", JSON.stringify(eventTypes));
   body.set("event_queue_longpoll_timeout_seconds", "90");
   if (params.streams && params.streams.length > 0 && !params.streams.includes("*")) {
-    const narrow = params.streams.map((stream) => ({ operator: "stream", operand: stream }));
+    // Zulip /register expects the "narrow" parameter in the legacy format:
+    //   [["stream", "general"], ["topic", "foo"], ...]
+    // Some deployments reject the newer object format ({operator, operand}) with:
+    //   "narrow[0] is not a list".
+    const narrow = params.streams.map((stream) => ["stream", stream]);
     body.set("narrow", JSON.stringify(narrow));
   }
   if (params.streams?.includes("*")) {

--- a/extensions/zulip/src/zulip/client.ts
+++ b/extensions/zulip/src/zulip/client.ts
@@ -1,0 +1,895 @@
+export type ZulipClient = {
+  baseUrl: string;
+  authHeader: string;
+  fetchImpl: typeof fetch;
+  request: <T>(path: string, init?: RequestInit) => Promise<T>;
+};
+
+export type ZulipApiResponse = {
+  result: "success" | "error";
+  msg: string;
+  code?: string;
+  [key: string]: unknown;
+};
+
+export type ZulipUser = {
+  id: string;
+  email?: string | null;
+  full_name?: string | null;
+  is_admin?: boolean | null;
+};
+
+export type ZulipPresenceEntry = {
+  status?: "active" | "idle" | string;
+  timestamp?: number;
+  client?: string | null;
+  [key: string]: unknown;
+};
+
+export type ZulipPresenceMap = Record<string, ZulipPresenceEntry>;
+
+export type ZulipServerSettings = ZulipApiResponse & Record<string, unknown>;
+
+export type ZulipRealmUpdate = Record<string, string | number | boolean>;
+
+export type ZulipStream = {
+  id: string;
+  name?: string | null;
+  description?: string | null;
+};
+
+export type ZulipSubscription = {
+  stream_id?: number;
+  name?: string;
+  description?: string | null;
+  email_address?: string | null;
+  invite_only?: boolean;
+  is_web_public?: boolean;
+};
+
+export type ZulipMessage = {
+  id: string;
+  sender_id?: string | null;
+  sender_email?: string | null;
+  sender_full_name?: string | null;
+  content?: string | null;
+  timestamp?: number | null;
+  type?: "stream" | "private" | string | null;
+  stream_id?: string | null;
+  display_recipient?: string | Array<{ id: number; email: string; full_name: string }> | null;
+  subject?: string | null;
+  recipient_id?: string | null;
+};
+
+export function normalizeZulipBaseUrl(raw?: string | null): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+function buildZulipApiUrl(baseUrl: string, path: string): string {
+  const normalized = normalizeZulipBaseUrl(baseUrl);
+  if (!normalized) {
+    throw new Error("Zulip baseUrl is required");
+  }
+  const suffix = path.startsWith("/") ? path : `/${path}`;
+  return `${normalized}/api/v1${suffix}`;
+}
+
+function resolveRetryAfterMs(res: Response): number | undefined {
+  const retryAfter = res.headers.get("retry-after");
+  if (!retryAfter) {
+    return undefined;
+  }
+  const seconds = Number(retryAfter);
+  if (!Number.isNaN(seconds)) {
+    return Math.max(0, seconds) * 1000;
+  }
+  const dateMs = Date.parse(retryAfter);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function readZulipError(res: Response): Promise<string> {
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const data = (await res.json()) as ZulipApiResponse | undefined;
+    if (data?.msg) {
+      return data.msg;
+    }
+    return JSON.stringify(data);
+  }
+  return await res.text();
+}
+
+export function createZulipClient(params: {
+  baseUrl: string;
+  email: string;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+}): ZulipClient {
+  const baseUrl = normalizeZulipBaseUrl(params.baseUrl);
+  if (!baseUrl) {
+    throw new Error("Zulip baseUrl is required");
+  }
+  const email = params.email?.trim();
+  const apiKey = params.apiKey?.trim();
+  if (!email || !apiKey) {
+    throw new Error("Zulip email + apiKey are required");
+  }
+  const authHeader = Buffer.from(`${email}:${apiKey}`).toString("base64");
+  const fetchImpl = params.fetchImpl ?? fetch;
+
+  const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
+    const url = buildZulipApiUrl(baseUrl, path);
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Basic ${authHeader}`);
+    if (init?.body && !headers.has("Content-Type") && typeof init.body === "string") {
+      headers.set("Content-Type", "application/x-www-form-urlencoded");
+    }
+    const res = await fetchImpl(url, { ...init, headers });
+    if (!res.ok) {
+      const detail = await readZulipError(res);
+      const error = new Error(
+        `Zulip API ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
+      ) as Error & { status?: number };
+      error.status = res.status;
+      throw error;
+    }
+    return (await res.json()) as T;
+  };
+
+  return { baseUrl, authHeader, fetchImpl, request };
+}
+
+function assertSuccess(payload: ZulipApiResponse, context: string): void {
+  if (payload.result === "success") {
+    return;
+  }
+  throw new Error(`${context}: ${payload.msg || "unknown error"}`);
+}
+
+export async function zulipRequestWithRetry<T>(
+  client: ZulipClient,
+  path: string,
+  init?: RequestInit,
+  options?: {
+    maxRetries?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+    retryStatuses?: number[];
+    rateLimitDelayMs?: number;
+  },
+): Promise<T> {
+  const maxRetries = options?.maxRetries ?? 3;
+  const baseDelayMs = options?.baseDelayMs ?? 1000;
+  const maxDelayMs = options?.maxDelayMs ?? 30000;
+  const retryStatuses = new Set(options?.retryStatuses ?? [429, 502, 503, 504]);
+  const rateLimitDelayMs = options?.rateLimitDelayMs ?? baseDelayMs;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    const url = buildZulipApiUrl(client.baseUrl, path);
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Basic ${client.authHeader}`);
+    if (init?.body && !headers.has("Content-Type") && typeof init.body === "string") {
+      headers.set("Content-Type", "application/x-www-form-urlencoded");
+    }
+    const res = await client.fetchImpl(url, { ...init, headers });
+    if (res.ok) {
+      return (await res.json()) as T;
+    }
+
+    const status = res.status;
+    const retryAfterMs = resolveRetryAfterMs(res);
+    const detail = await readZulipError(res);
+    const error = new Error(
+      `Zulip API ${status} ${res.statusText}: ${detail || "unknown error"}`,
+    ) as Error & { status?: number; retryAfterMs?: number };
+    error.status = status;
+    error.retryAfterMs = retryAfterMs;
+
+    if (!retryStatuses.has(status) || attempt >= maxRetries) {
+      throw error;
+    }
+
+    const base = status === 429 ? rateLimitDelayMs : baseDelayMs;
+    const backoff = Math.min(maxDelayMs, base * 2 ** attempt);
+    const waitMs = retryAfterMs && retryAfterMs > 0 ? Math.min(maxDelayMs, retryAfterMs) : backoff;
+    await sleep(waitMs);
+  }
+
+  throw new Error("Zulip API request failed after retries");
+}
+
+export async function fetchZulipMe(client: ZulipClient): Promise<ZulipUser> {
+  const payload = await client.request<
+    ZulipApiResponse & {
+      user_id?: number;
+      email?: string;
+      full_name?: string;
+      is_admin?: boolean;
+    }
+  >("/users/me");
+  assertSuccess(payload, "Zulip /users/me failed");
+  return {
+    id: String(payload.user_id ?? ""),
+    email: payload.email ?? null,
+    full_name: payload.full_name ?? null,
+    is_admin: payload.is_admin ?? null,
+  };
+}
+
+export async function fetchZulipUser(client: ZulipClient, userId: string): Promise<ZulipUser> {
+  const payload = await client.request<
+    ZulipApiResponse & { user?: { user_id: number; email?: string; full_name?: string } }
+  >(`/users/${userId}`);
+  assertSuccess(payload, "Zulip /users/{id} failed");
+  const user = payload.user;
+  return {
+    id: String(user?.user_id ?? userId),
+    email: user?.email ?? null,
+    full_name: user?.full_name ?? null,
+  };
+}
+
+export async function fetchZulipMemberInfo(
+  client: ZulipClient,
+  userId?: string | null,
+): Promise<ZulipUser> {
+  const trimmed = userId?.trim();
+  if (!trimmed || trimmed.toLowerCase() === "me") {
+    return await fetchZulipMe(client);
+  }
+  return await fetchZulipUser(client, trimmed);
+}
+
+export async function fetchZulipStream(client: ZulipClient, streamId: string): Promise<ZulipStream> {
+  const payload = await client.request<
+    ZulipApiResponse & { stream?: { stream_id: number; name?: string; description?: string } }
+  >(`/streams/${streamId}`);
+  assertSuccess(payload, "Zulip /streams/{id} failed");
+  const stream = payload.stream;
+  return {
+    id: String(stream?.stream_id ?? streamId),
+    name: stream?.name ?? null,
+    description: stream?.description ?? null,
+  };
+}
+
+export async function registerZulipQueue(
+  client: ZulipClient,
+  params: {
+    eventTypes?: string[];
+    streams?: string[];
+  },
+): Promise<{ queueId: string; lastEventId: number }> {
+  const body = new URLSearchParams();
+  const eventTypes = params.eventTypes ?? ["message"];
+  body.set("event_types", JSON.stringify(eventTypes));
+  body.set("event_queue_longpoll_timeout_seconds", "90");
+  if (params.streams && params.streams.length > 0 && !params.streams.includes("*")) {
+    const narrow = params.streams.map((stream) => ({ operator: "stream", operand: stream }));
+    body.set("narrow", JSON.stringify(narrow));
+  }
+  if (params.streams?.includes("*")) {
+    body.set("all_public_streams", "true");
+  }
+
+  const payload = await client.request<ZulipApiResponse & { queue_id?: string; last_event_id?: number }>(
+    "/register",
+    { method: "POST", body: body.toString() },
+  );
+  assertSuccess(payload, "Zulip /register failed");
+  if (!payload.queue_id) {
+    throw new Error("Zulip /register missing queue_id");
+  }
+  return {
+    queueId: payload.queue_id,
+    lastEventId: payload.last_event_id ?? -1,
+  };
+}
+
+export async function getZulipEvents(
+  client: ZulipClient,
+  params: {
+    queueId: string;
+    lastEventId: number;
+    timeoutMs?: number;
+  },
+): Promise<ZulipApiResponse & { events?: Array<{ id: number; type: string; message?: ZulipMessage }> }> {
+  const qs = new URLSearchParams({
+    queue_id: params.queueId,
+    last_event_id: String(params.lastEventId),
+    dont_block: "false",
+  });
+  const controller = new AbortController();
+  const timeoutMs = params.timeoutMs ?? 90000;
+  const timeout = setTimeout(() => controller.abort(), timeoutMs + 15000);
+  try {
+    return await client.request<
+      ZulipApiResponse & { events?: Array<{ id: number; type: string; message?: ZulipMessage }> }
+    >(`/events?${qs.toString()}`, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function getZulipEventsWithRetry(
+  client: ZulipClient,
+  params: {
+    queueId: string;
+    lastEventId: number;
+    timeoutMs?: number;
+    retryBaseDelayMs?: number;
+  },
+): Promise<ZulipApiResponse & { events?: Array<{ id: number; type: string; message?: ZulipMessage }> }> {
+  const qs = new URLSearchParams({
+    queue_id: params.queueId,
+    last_event_id: String(params.lastEventId),
+    dont_block: "false",
+  });
+  const controller = new AbortController();
+  const timeoutMs = params.timeoutMs ?? 90000;
+  const timeout = setTimeout(() => controller.abort(), timeoutMs + 15000);
+  try {
+    return await zulipRequestWithRetry<
+      ZulipApiResponse & { events?: Array<{ id: number; type: string; message?: ZulipMessage }> }
+    >(
+      client,
+      `/events?${qs.toString()}`,
+      { signal: controller.signal },
+      { baseDelayMs: params.retryBaseDelayMs },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function deleteZulipQueue(client: ZulipClient, queueId: string): Promise<void> {
+  if (!queueId) {
+    return;
+  }
+  try {
+    const payload = await client.request<ZulipApiResponse>(`/events?queue_id=${queueId}`, {
+      method: "DELETE",
+    });
+    assertSuccess(payload, "Zulip delete event queue failed");
+  } catch {
+    // ignore cleanup errors
+  }
+}
+
+export async function sendZulipStreamMessage(
+  client: ZulipClient,
+  params: {
+    stream: string;
+    topic: string;
+    content: string;
+  },
+): Promise<{ id?: number }> {
+  const body = new URLSearchParams({
+    type: "stream",
+    to: params.stream,
+    topic: params.topic,
+    content: params.content,
+  });
+  const payload = await zulipRequestWithRetry<ZulipApiResponse & { id?: number }>(client, "/messages", {
+    method: "POST",
+    body: body.toString(),
+  });
+  assertSuccess(payload, "Zulip stream send failed");
+  return { id: payload.id };
+}
+
+export async function sendZulipPrivateMessage(
+  client: ZulipClient,
+  params: {
+    to: string | string[];
+    content: string;
+  },
+): Promise<{ id?: number }> {
+  const recipients = Array.isArray(params.to) ? params.to : [params.to];
+  const body = new URLSearchParams({
+    type: "private",
+    to: JSON.stringify(recipients),
+    content: params.content,
+  });
+  const payload = await zulipRequestWithRetry<ZulipApiResponse & { id?: number }>(client, "/messages", {
+    method: "POST",
+    body: body.toString(),
+  });
+  assertSuccess(payload, "Zulip private send failed");
+  return { id: payload.id };
+}
+
+export async function uploadZulipFile(
+  client: ZulipClient,
+  filePath: string,
+): Promise<{ url: string }> {
+  const filename = filePath.split("/").pop() || "upload.bin";
+  const buffer = await (await import("node:fs/promises")).readFile(filePath);
+  const form = new FormData();
+  form.append("file", new Blob([buffer]), filename);
+  const payload = await zulipRequestWithRetry<ZulipApiResponse & { uri?: string }>(
+    client,
+    "/user_uploads",
+    {
+      method: "POST",
+      body: form,
+    },
+  );
+  assertSuccess(payload, "Zulip file upload failed");
+  if (!payload.uri) {
+    throw new Error("Zulip file upload missing uri");
+  }
+  const url = payload.uri.startsWith("/") ? `${client.baseUrl}${payload.uri}` : payload.uri;
+  return { url };
+}
+
+export async function sendZulipTyping(
+  client: ZulipClient,
+  params: {
+    op: "start" | "stop";
+  } & (
+    | { type: "stream"; streamId: number | string; topic: string }
+    | { type: "direct"; to: number[] }
+  ),
+): Promise<void> {
+  const body = new URLSearchParams();
+  body.set("op", params.op);
+  body.set("type", params.type);
+  if (params.type === "stream") {
+    body.set("stream_id", String(params.streamId));
+    body.set("topic", params.topic);
+  } else {
+    body.set("to", JSON.stringify(params.to));
+  }
+  await client.request("/typing", {
+    method: "POST",
+    body: body.toString(),
+  });
+}
+
+export async function fetchZulipSubscriptions(
+  client: ZulipClient,
+  params: { includeAllPublic?: boolean } = {},
+): Promise<ZulipSubscription[]> {
+  const qs = new URLSearchParams();
+  if (params.includeAllPublic) {
+    qs.set("include_all_public_streams", "true");
+  }
+  const suffix = qs.toString();
+  const payload = await client.request<ZulipApiResponse & { subscriptions?: ZulipSubscription[] }>(
+    `/users/me/subscriptions${suffix ? `?${suffix}` : ""}`,
+  );
+  assertSuccess(payload, "Zulip /users/me/subscriptions failed");
+  return payload.subscriptions ?? [];
+}
+
+export async function fetchZulipStreams(client: ZulipClient): Promise<ZulipStream[]> {
+  const payload = await client.request<
+    ZulipApiResponse & { streams?: Array<{ stream_id: number; name?: string; description?: string }> }
+  >("/streams");
+  assertSuccess(payload, "Zulip /streams failed");
+  return (payload.streams ?? []).map((stream) => ({
+    id: String(stream.stream_id),
+    name: stream.name ?? null,
+    description: stream.description ?? null,
+  }));
+}
+
+export async function resolveZulipStreamId(
+  client: ZulipClient,
+  streamIdOrName: string,
+): Promise<string> {
+  // The SDK normalizes channelId params to "stream:NAME" format (via normalizeZulipMessagingTarget)
+  // before passing to the plugin. Strip the prefix so we can match against actual stream names.
+  const raw = streamIdOrName.trim().replace(/^stream:/i, "").trim();
+  const trimmed = raw;
+  // If it's already a numeric ID, return it
+  if (/^\d+$/.test(trimmed)) {
+    return trimmed;
+  }
+  // Otherwise, look up the stream by name
+  const subscriptions = await fetchZulipSubscriptions(client, { includeAllPublic: true });
+  const found = subscriptions.find(
+    (sub) => sub.name?.toLowerCase() === trimmed.toLowerCase(),
+  );
+  if (found?.stream_id) {
+    return String(found.stream_id);
+  }
+  // Fall back to fetching all streams
+  const streams = await fetchZulipStreams(client);
+  const foundStream = streams.find((stream) => stream.name?.toLowerCase() === trimmed.toLowerCase());
+  if (foundStream) {
+    return foundStream.id;
+  }
+  throw new Error(`Zulip stream not found: ${streamIdOrName}`);
+}
+
+export async function subscribeZulipStream(client: ZulipClient, stream: string): Promise<void> {
+  const body = new URLSearchParams({
+    subscriptions: JSON.stringify([{ name: stream }]),
+  });
+  const payload = await client.request<ZulipApiResponse>("/users/me/subscriptions", {
+    method: "POST",
+    body: body.toString(),
+  });
+  assertSuccess(payload, "Zulip stream subscribe failed");
+}
+
+export async function inviteZulipUsersToStream(
+  client: ZulipClient,
+  params: {
+    stream: string;
+    principals: Array<string | number>;
+  },
+): Promise<void> {
+  const body = new URLSearchParams({
+    subscriptions: JSON.stringify([{ name: params.stream }]),
+    principals: JSON.stringify(params.principals),
+  });
+  const payload = await client.request<ZulipApiResponse>("/users/me/subscriptions", {
+    method: "POST",
+    body: body.toString(),
+  });
+  assertSuccess(payload, "Zulip stream invite failed");
+}
+
+export async function createZulipStream(
+  client: ZulipClient,
+  params: {
+    name: string;
+    description?: string;
+    principals?: Array<string | number>;
+    announce?: boolean;
+    inviteOnly?: boolean;
+    isWebPublic?: boolean;
+    isDefaultStream?: boolean;
+    historyPublicToSubscribers?: boolean;
+  },
+): Promise<void> {
+  const subscriptions: Array<{ name: string; description?: string }> = [
+    {
+      name: params.name,
+      ...(params.description ? { description: params.description } : {}),
+    },
+  ];
+  const body = new URLSearchParams({
+    subscriptions: JSON.stringify(subscriptions),
+  });
+  if (params.principals && params.principals.length > 0) {
+    body.set("principals", JSON.stringify(params.principals));
+  }
+  if (params.announce !== undefined) {
+    body.set("announce", String(params.announce));
+  }
+  if (params.inviteOnly !== undefined) {
+    body.set("invite_only", String(params.inviteOnly));
+  }
+  if (params.isWebPublic !== undefined) {
+    body.set("is_web_public", String(params.isWebPublic));
+  }
+  if (params.isDefaultStream !== undefined) {
+    body.set("is_default_stream", String(params.isDefaultStream));
+  }
+  if (params.historyPublicToSubscribers !== undefined) {
+    body.set("history_public_to_subscribers", String(params.historyPublicToSubscribers));
+  }
+  const payload = await client.request<ZulipApiResponse>("/users/me/subscriptions", {
+    method: "POST",
+    body: body.toString(),
+  });
+  assertSuccess(payload, "Zulip stream create failed");
+}
+
+export async function updateZulipStream(
+  client: ZulipClient,
+  params: {
+    streamId: string;
+    description?: string;
+    newName?: string;
+    isPrivate?: boolean;
+    isWebPublic?: boolean;
+    historyPublicToSubscribers?: boolean;
+    isDefaultStream?: boolean;
+  },
+): Promise<void> {
+  const body = new URLSearchParams();
+  if (params.description !== undefined) {
+    body.set("description", params.description);
+  }
+  if (params.newName !== undefined) {
+    body.set("new_name", params.newName);
+  }
+  if (params.isPrivate !== undefined) {
+    body.set("is_private", String(params.isPrivate));
+  }
+  if (params.isWebPublic !== undefined) {
+    body.set("is_web_public", String(params.isWebPublic));
+  }
+  if (params.historyPublicToSubscribers !== undefined) {
+    body.set("history_public_to_subscribers", String(params.historyPublicToSubscribers));
+  }
+  if (params.isDefaultStream !== undefined) {
+    body.set("is_default_stream", String(params.isDefaultStream));
+  }
+  const payload = await client.request<ZulipApiResponse>(`/streams/${params.streamId}` as const, {
+    method: "PATCH",
+    body: body.toString(),
+  });
+  assertSuccess(payload, "Zulip stream update failed");
+}
+
+export async function deleteZulipStream(client: ZulipClient, streamId: string): Promise<void> {
+  const payload = await client.request<ZulipApiResponse>(`/streams/${streamId}` as const, {
+    method: "DELETE",
+  });
+  assertSuccess(payload, "Zulip stream delete failed");
+}
+
+export async function addZulipReaction(
+  client: ZulipClient,
+  params: {
+    messageId: string;
+    emojiName: string;
+    emojiCode?: string;
+    reactionType?: string;
+  },
+): Promise<void> {
+  const body = new URLSearchParams({
+    emoji_name: params.emojiName,
+  });
+  if (params.emojiCode) {
+    body.set("emoji_code", params.emojiCode);
+  }
+  if (params.reactionType) {
+    body.set("reaction_type", params.reactionType);
+  }
+  const payload = await zulipRequestWithRetry<ZulipApiResponse>(
+    client,
+    `/messages/${params.messageId}/reactions`,
+    { method: "POST", body: body.toString() },
+  );
+  assertSuccess(payload, "Zulip add reaction failed");
+}
+
+export async function removeZulipReaction(
+  client: ZulipClient,
+  params: {
+    messageId: string;
+    emojiName?: string;
+    emojiCode?: string;
+    reactionType?: string;
+  },
+): Promise<void> {
+  const qs = new URLSearchParams();
+  if (params.emojiName) {
+    qs.set("emoji_name", params.emojiName);
+  }
+  if (params.emojiCode) {
+    qs.set("emoji_code", params.emojiCode);
+  }
+  if (params.reactionType) {
+    qs.set("reaction_type", params.reactionType);
+  }
+  const suffix = qs.toString();
+  const payload = await zulipRequestWithRetry<ZulipApiResponse>(
+    client,
+    `/messages/${params.messageId}/reactions${suffix ? `?${suffix}` : ""}`,
+    { method: "DELETE" },
+  );
+  assertSuccess(payload, "Zulip remove reaction failed");
+}
+
+export async function editZulipMessage(
+  client: ZulipClient,
+  params: {
+    messageId: string;
+    content: string;
+  },
+): Promise<void> {
+  const body = new URLSearchParams({
+    content: params.content,
+  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/messages/${params.messageId}`,
+    { method: "PATCH", body: body.toString() },
+  );
+  assertSuccess(payload, "Zulip edit message failed");
+}
+
+export async function deleteZulipMessage(
+  client: ZulipClient,
+  params: {
+    messageId: string;
+  },
+): Promise<void> {
+  const payload = await client.request<ZulipApiResponse>(
+    `/messages/${params.messageId}`,
+    { method: "DELETE" },
+  );
+  assertSuccess(payload, "Zulip delete message failed");
+}
+
+export async function updateZulipMessageFlag(
+  client: ZulipClient,
+  params: {
+    messageId: string | number;
+    flag: "starred";
+    op: "add" | "remove";
+  },
+): Promise<void> {
+  // Convert messageId to integer
+  const messageIdInt = typeof params.messageId === "number" 
+    ? params.messageId 
+    : parseInt(params.messageId, 10);
+  if (isNaN(messageIdInt)) {
+    throw new Error(`Invalid messageId: ${params.messageId}`);
+  }
+  const body = new URLSearchParams({
+    messages: JSON.stringify([messageIdInt]),
+    flag: params.flag,
+    op: params.op,
+  });
+  const payload = await client.request<ZulipApiResponse>("/messages/flags", {
+    method: "POST",
+    body: body.toString(),
+  });
+  assertSuccess(payload, "Zulip update message flags failed");
+}
+
+export async function updateZulipMessageTopic(
+  client: ZulipClient,
+  params: {
+    messageId: string;
+    topic: string;
+    propagateMode?: "change_one" | "change_all";
+  },
+): Promise<void> {
+  const body = new URLSearchParams({
+    topic: params.topic,
+    propagate_mode: params.propagateMode ?? "change_all",
+  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/messages/${params.messageId}`,
+    { method: "PATCH", body: body.toString() },
+  );
+  assertSuccess(payload, "Zulip update message topic failed");
+}
+
+export async function fetchZulipMessages(
+  client: ZulipClient,
+  params: {
+    stream: string;
+    topic?: string;
+    limit?: number;
+  },
+): Promise<ZulipMessage[]> {
+  const limit = Math.min(Math.max(1, params.limit ?? 50), 1000);
+  const narrow = [{ operator: "stream", operand: params.stream } as Record<string, unknown>];
+  if (params.topic) {
+    narrow.push({ operator: "topic", operand: params.topic });
+  }
+  const qs = new URLSearchParams({
+    anchor: "newest",
+    num_before: String(limit),
+    num_after: "0",
+    narrow: JSON.stringify(narrow),
+  });
+  const payload = await client.request<ZulipApiResponse & { messages?: ZulipMessage[] }>(
+    `/messages?${qs.toString()}`,
+  );
+  assertSuccess(payload, "Zulip /messages failed");
+  return payload.messages ?? [];
+}
+
+export async function searchZulipMessages(
+  client: ZulipClient,
+  params: {
+    query: string;
+    stream?: string;
+    topic?: string;
+    limit?: number;
+  },
+): Promise<ZulipMessage[]> {
+  const limit = Math.min(Math.max(1, params.limit ?? 50), 1000);
+  const narrow: Array<Record<string, unknown>> = [
+    { operator: "search", operand: params.query },
+  ];
+  if (params.stream) {
+    narrow.push({ operator: "stream", operand: params.stream });
+  }
+  if (params.topic) {
+    narrow.push({ operator: "topic", operand: params.topic });
+  }
+  const qs = new URLSearchParams({
+    anchor: "newest",
+    num_before: String(limit),
+    num_after: "0",
+    narrow: JSON.stringify(narrow),
+  });
+  const payload = await client.request<ZulipApiResponse & { messages?: ZulipMessage[] }>(
+    `/messages?${qs.toString()}`,
+  );
+  assertSuccess(payload, "Zulip search failed");
+  return payload.messages ?? [];
+}
+
+export async function fetchZulipUserPresence(
+  client: ZulipClient,
+  userIdOrEmail: string,
+): Promise<ZulipPresenceMap> {
+  const trimmed = userIdOrEmail?.trim();
+  if (!trimmed) {
+    throw new Error("userId or email is required to fetch Zulip presence.");
+  }
+  const encoded = encodeURIComponent(trimmed);
+  const payload = await client.request<ZulipApiResponse & { presence?: ZulipPresenceMap }>(
+    `/users/${encoded}/presence`,
+  );
+  assertSuccess(payload, "Zulip user presence failed");
+  return payload.presence ?? {};
+}
+
+export async function deactivateZulipUser(
+  client: ZulipClient,
+  userId: string,
+): Promise<void> {
+  const trimmed = userId?.trim();
+  if (!trimmed) {
+    throw new Error("userId is required to deactivate a Zulip user.");
+  }
+  const payload = await client.request<ZulipApiResponse>(`/users/${trimmed}` as const, {
+    method: "DELETE",
+  });
+  assertSuccess(payload, "Zulip deactivate user failed");
+}
+
+export async function reactivateZulipUser(
+  client: ZulipClient,
+  userId: string,
+): Promise<void> {
+  const trimmed = userId?.trim();
+  if (!trimmed) {
+    throw new Error("userId is required to reactivate a Zulip user.");
+  }
+  const payload = await client.request<ZulipApiResponse>(`/users/${trimmed}/reactivate` as const, {
+    method: "POST",
+  });
+  assertSuccess(payload, "Zulip reactivate user failed");
+}
+
+export async function fetchZulipServerSettings(
+  client: ZulipClient,
+): Promise<ZulipServerSettings> {
+  const payload = await client.request<ZulipServerSettings>("/server_settings");
+  assertSuccess(payload, "Zulip server settings failed");
+  return payload;
+}
+
+export async function updateZulipRealm(
+  client: ZulipClient,
+  params: ZulipRealmUpdate,
+): Promise<void> {
+  const body = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    body.set(key, String(value));
+  }
+  if (Array.from(body.keys()).length === 0) {
+    throw new Error("No realm settings provided to update.");
+  }
+  const payload = await client.request<ZulipApiResponse>("/realm", {
+    method: "PATCH",
+    body: body.toString(),
+  });
+  assertSuccess(payload, "Zulip realm update failed");
+}

--- a/extensions/zulip/src/zulip/index.ts
+++ b/extensions/zulip/src/zulip/index.ts
@@ -1,0 +1,9 @@
+export {
+  listEnabledZulipAccounts,
+  listZulipAccountIds,
+  resolveDefaultZulipAccountId,
+  resolveZulipAccount,
+} from "./accounts.js";
+export { monitorZulipProvider } from "./monitor.js";
+export { probeZulip } from "./probe.js";
+export { sendMessageZulip } from "./send.js";

--- a/extensions/zulip/src/zulip/monitor-helpers.streams.test.ts
+++ b/extensions/zulip/src/zulip/monitor-helpers.streams.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { isMonitoredStream } from "./monitor-helpers.js";
+
+describe("isMonitoredStream", () => {
+  it("allows when monitoredStreams is empty", () => {
+    expect(isMonitoredStream({ monitoredStreams: [], streamName: "general", streamId: "3" })).toBe(
+      true,
+    );
+  });
+
+  it("allows when monitoredStreams includes '*'", () => {
+    expect(
+      isMonitoredStream({ monitoredStreams: ["*"], streamName: "general", streamId: "3" }),
+    ).toBe(true);
+  });
+
+  it("matches by stream name (case-insensitive)", () => {
+    expect(
+      isMonitoredStream({ monitoredStreams: ["General"], streamName: "general", streamId: "3" }),
+    ).toBe(true);
+    expect(
+      isMonitoredStream({ monitoredStreams: ["general"], streamName: "GENERAL", streamId: "3" }),
+    ).toBe(true);
+  });
+
+  it("matches by stream id when name is unavailable", () => {
+    expect(isMonitoredStream({ monitoredStreams: ["5"], streamName: "", streamId: "5" })).toBe(
+      true,
+    );
+  });
+
+  it("rejects when stream is not monitored", () => {
+    expect(
+      isMonitoredStream({
+        monitoredStreams: ["build", "openclaw"],
+        streamName: "research",
+        streamId: "6",
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/zulip/src/zulip/monitor-helpers.ts
+++ b/extensions/zulip/src/zulip/monitor-helpers.ts
@@ -148,6 +148,38 @@ export function resolveIdentityName(cfg: OpenClawConfig, agentId: string): strin
   return entry?.identity?.name?.trim() || undefined;
 }
 
+export function normalizeStreamKey(value: string | undefined | null): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+export function isMonitoredStream(params: {
+  monitoredStreams?: string[] | null;
+  streamName?: string | null;
+  streamId?: string | null;
+}): boolean {
+  const monitored = params.monitoredStreams ?? [];
+  if (monitored.length === 0) {
+    return true;
+  }
+
+  const normalized = new Set(monitored.map((entry) => normalizeStreamKey(entry)).filter(Boolean));
+  if (normalized.has("*")) {
+    return true;
+  }
+
+  const streamName = normalizeStreamKey(params.streamName);
+  if (streamName && normalized.has(streamName)) {
+    return true;
+  }
+
+  const streamId = (params.streamId ?? "").trim();
+  if (streamId && monitored.includes(streamId)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function resolveThreadSessionKeys(params: {
   baseSessionKey: string;
   threadId?: string | null;

--- a/extensions/zulip/src/zulip/monitor-helpers.ts
+++ b/extensions/zulip/src/zulip/monitor-helpers.ts
@@ -1,0 +1,166 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type WebSocket from "ws";
+import { Buffer } from "node:buffer";
+
+export type ResponsePrefixContext = {
+  model?: string;
+  modelFull?: string;
+  provider?: string;
+  thinkingLevel?: string;
+  identityName?: string;
+};
+
+export function extractShortModelName(fullModel: string): string {
+  const slash = fullModel.lastIndexOf("/");
+  const modelPart = slash >= 0 ? fullModel.slice(slash + 1) : fullModel;
+  return modelPart.replace(/-\d{8}$/, "").replace(/-latest$/, "");
+}
+
+export function formatInboundFromLabel(params: {
+  isGroup: boolean;
+  groupLabel?: string;
+  groupId?: string;
+  directLabel: string;
+  directId?: string;
+  groupFallback?: string;
+}): string {
+  if (params.isGroup) {
+    const label = params.groupLabel?.trim() || params.groupFallback || "Group";
+    const id = params.groupId?.trim();
+    return id ? `${label} id:${id}` : label;
+  }
+
+  const directLabel = params.directLabel.trim();
+  const directId = params.directId?.trim();
+  if (!directId || directId === directLabel) {
+    return directLabel;
+  }
+  return `${directLabel} id:${directId}`;
+}
+
+type DedupeCache = {
+  check: (key: string | undefined | null, now?: number) => boolean;
+};
+
+export function createDedupeCache(options: { ttlMs: number; maxSize: number }): DedupeCache {
+  const ttlMs = Math.max(0, options.ttlMs);
+  const maxSize = Math.max(0, Math.floor(options.maxSize));
+  const cache = new Map<string, number>();
+
+  const touch = (key: string, now: number) => {
+    cache.delete(key);
+    cache.set(key, now);
+  };
+
+  const prune = (now: number) => {
+    const cutoff = ttlMs > 0 ? now - ttlMs : undefined;
+    if (cutoff !== undefined) {
+      for (const [entryKey, entryTs] of cache) {
+        if (entryTs < cutoff) {
+          cache.delete(entryKey);
+        }
+      }
+    }
+    if (maxSize <= 0) {
+      cache.clear();
+      return;
+    }
+    while (cache.size > maxSize) {
+      const oldestKey = cache.keys().next().value as string | undefined;
+      if (!oldestKey) {
+        break;
+      }
+      cache.delete(oldestKey);
+    }
+  };
+
+  return {
+    check: (key, now = Date.now()) => {
+      if (!key) {
+        return false;
+      }
+      const existing = cache.get(key);
+      if (existing !== undefined && (ttlMs <= 0 || now - existing < ttlMs)) {
+        touch(key, now);
+        return true;
+      }
+      touch(key, now);
+      prune(now);
+      return false;
+    },
+  };
+}
+
+export function rawDataToString(
+  data: WebSocket.RawData,
+  encoding: BufferEncoding = "utf8",
+): string {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString(encoding);
+  }
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString(encoding);
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString(encoding);
+  }
+  return Buffer.from(String(data)).toString(encoding);
+}
+
+function normalizeAgentId(value: string | undefined | null): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) {
+    return "main";
+  }
+  if (/^[a-z0-9][a-z0-9_-]{0,63}$/i.test(trimmed)) {
+    return trimmed;
+  }
+  return (
+    trimmed
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "-")
+      .replace(/^-+/, "")
+      .replace(/-+$/, "")
+      .slice(0, 64) || "main"
+  );
+}
+
+type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
+
+function listAgents(cfg: OpenClawConfig): AgentEntry[] {
+  const list = cfg.agents?.list;
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  return list.filter((entry): entry is AgentEntry => Boolean(entry && typeof entry === "object"));
+}
+
+function resolveAgentEntry(cfg: OpenClawConfig, agentId: string): AgentEntry | undefined {
+  const id = normalizeAgentId(agentId);
+  return listAgents(cfg).find((entry) => normalizeAgentId(entry.id) === id);
+}
+
+export function resolveIdentityName(cfg: OpenClawConfig, agentId: string): string | undefined {
+  const entry = resolveAgentEntry(cfg, agentId);
+  return entry?.identity?.name?.trim() || undefined;
+}
+
+export function resolveThreadSessionKeys(params: {
+  baseSessionKey: string;
+  threadId?: string | null;
+  parentSessionKey?: string;
+  useSuffix?: boolean;
+}): { sessionKey: string; parentSessionKey?: string } {
+  const threadId = (params.threadId ?? "").trim();
+  if (!threadId) {
+    return { sessionKey: params.baseSessionKey, parentSessionKey: undefined };
+  }
+  const useSuffix = params.useSuffix ?? true;
+  const sessionKey = useSuffix
+    ? `${params.baseSessionKey}:thread:${threadId}`
+    : params.baseSessionKey;
+  return { sessionKey, parentSessionKey: params.parentSessionKey };
+}

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -791,7 +791,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
       const events = response.events ?? [];
       if (events.length > 0) {
-        lastEventId = events[events.length - 1].id;
+        lastEventId = Number(events[events.length - 1].id);
         opts.statusSink?.({
           connected: true,
           lastConnectedAt: Date.now(),

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -307,17 +307,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     const rawText = stripHtmlToText(message.content ?? "");
 
-    // Temporary: log inbound messages for debugging (helps confirm whether /events polling is receiving anything).
-    try {
-      if (kind === "dm") {
-        runtime.log?.(`zulip inbound dm id=${messageId} from=${senderName} <${senderId}>`);
-      } else {
-        const roomLabel = streamName ? `#${streamName}` : `stream:${streamId}`;
-        runtime.log?.(
-          `zulip inbound stream id=${messageId} room=${roomLabel} topic=${topic} from=${senderName} <${senderId}>`,
-        );
-      }
-    } catch {}
     const oncharResult = stripOncharPrefix(rawText, oncharPrefixes);
 
     const uploadUrls = extractZulipUploadUrls(message.content ?? "", baseUrl);

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -251,11 +251,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       cfg,
       accountId: account.accountId,
       resolveChannelLimitMb: ({ cfg, accountId }) =>
-        (cfg.channels?.zulip as { mediaMaxMb?: number; accounts?: Record<string, { mediaMaxMb?: number }> })
-          ?.accounts?.[accountId]?.mediaMaxMb ??
+        (
+          cfg.channels?.zulip as {
+            mediaMaxMb?: number;
+            accounts?: Record<string, { mediaMaxMb?: number }>;
+          }
+        )?.accounts?.[accountId]?.mediaMaxMb ??
         (cfg.channels?.zulip as { mediaMaxMb?: number })?.mediaMaxMb,
-    }) ??
-    5 * 1024 * 1024;
+    }) ?? 5 * 1024 * 1024;
 
   const reactionConfig = account.config.reactions ?? {};
   const reactionsEnabled = reactionConfig.enabled !== false;
@@ -326,8 +329,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             mediaTypes.push(saved.contentType);
             mediaUrls.push(uploadUrl);
           }
-        } catch (err) {
-        }
+        } catch (err) {}
       }
     }
     const oncharTriggered = oncharEnabled && oncharResult.triggered;
@@ -517,7 +519,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     const preview = bodyText.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel =
-      kind === "dm" ? `Zulip DM from ${senderName}` : `Zulip message in ${roomLabel} from ${senderName}`;
+      kind === "dm"
+        ? `Zulip DM from ${senderName}`
+        : `Zulip message in ${roomLabel} from ${senderName}`;
     core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
       sessionKey,
       contextKey: `zulip:message:${messageId}`,
@@ -775,7 +779,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       });
 
       if (response.result === "error") {
-        if (response.code === "BAD_EVENT_QUEUE_ID" || response.msg?.includes("Bad event queue id")) {
+        if (
+          response.code === "BAD_EVENT_QUEUE_ID" ||
+          response.msg?.includes("Bad event queue id")
+        ) {
           runtime.log?.("zulip: queue expired, re-registering...");
           const newQueue = await registerZulipQueue(client, {
             eventTypes: ["message"],
@@ -829,7 +836,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       } else {
         pollBackoffMs = Math.min(30000, pollBackoffMs * 2);
       }
-      const delay = retryAfterMs && retryAfterMs > 0 ? Math.min(30000, retryAfterMs) : pollBackoffMs;
+      const delay =
+        retryAfterMs && retryAfterMs > 0 ? Math.min(30000, retryAfterMs) : pollBackoffMs;
       await sleep(delay);
     }
   }

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -820,6 +820,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           });
           queueId = newQueue.queueId;
           lastEventId = newQueue.lastEventId;
+          runtime.log?.(`zulip event queue re-registered: ${queueId}`);
           resetPollBackoff();
           continue;
         }
@@ -865,6 +866,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         });
         queueId = newQueue.queueId;
         lastEventId = newQueue.lastEventId;
+        runtime.log?.(`zulip event queue re-registered: ${queueId}`);
         resetPollBackoff();
         continue;
       }

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -1,0 +1,840 @@
+import type {
+  ChannelAccountSnapshot,
+  OpenClawConfig,
+  ReplyPayload,
+  RuntimeEnv,
+} from "openclaw/plugin-sdk";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createReplyPrefixOptions,
+  createTypingCallbacks,
+  logInboundDrop,
+  logTypingFailure,
+  buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  recordPendingHistoryEntryIfEnabled,
+  resolveControlCommandGate,
+  resolveChannelMediaMaxBytes,
+  type HistoryEntry,
+} from "openclaw/plugin-sdk";
+import { getZulipRuntime } from "../runtime.js";
+import { resolveZulipAccount } from "./accounts.js";
+import {
+  createZulipClient,
+  fetchZulipMe,
+  fetchZulipStream,
+  normalizeZulipBaseUrl,
+  registerZulipQueue,
+  getZulipEventsWithRetry,
+  deleteZulipQueue,
+  sendZulipTyping,
+  addZulipReaction,
+  removeZulipReaction,
+  type ZulipMessage,
+  type ZulipStream,
+} from "./client.js";
+import {
+  createDedupeCache,
+  formatInboundFromLabel,
+  resolveThreadSessionKeys,
+} from "./monitor-helpers.js";
+import { sendMessageZulip } from "./send.js";
+import { downloadZulipUpload, extractZulipUploadUrls, normalizeEmojiName } from "./uploads.js";
+
+export type MonitorZulipOpts = {
+  apiKey?: string;
+  email?: string;
+  baseUrl?: string;
+  accountId?: string;
+  config?: OpenClawConfig;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  statusSink?: (patch: Partial<ChannelAccountSnapshot>) => void;
+};
+
+const RECENT_MESSAGE_TTL_MS = 5 * 60_000;
+const RECENT_MESSAGE_MAX = 2000;
+const DEFAULT_ONCHAR_PREFIXES = [">", "!"];
+const DEFAULT_TOPIC = "general";
+
+const recentInboundMessages = createDedupeCache({
+  ttlMs: RECENT_MESSAGE_TTL_MS,
+  maxSize: RECENT_MESSAGE_MAX,
+});
+
+function resolveRuntime(opts: MonitorZulipOpts): RuntimeEnv {
+  return (
+    opts.runtime ?? {
+      log: console.log,
+      error: console.error,
+      exit: (code: number): never => {
+        throw new Error(`exit ${code}`);
+      },
+    }
+  );
+}
+
+function stripHtmlToText(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/@\*\*([^*]+)\*\*/g, "@$1")
+    .trim();
+}
+
+function normalizeMention(text: string, mention: string | undefined): string {
+  if (!mention) {
+    return text.trim();
+  }
+  const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`@${escaped}\\b`, "gi");
+  return text.replace(re, " ").replace(/\s+/g, " ").trim();
+}
+
+function resolveOncharPrefixes(prefixes: string[] | undefined): string[] {
+  const cleaned = prefixes?.map((entry) => entry.trim()).filter(Boolean) ?? DEFAULT_ONCHAR_PREFIXES;
+  return cleaned.length > 0 ? cleaned : DEFAULT_ONCHAR_PREFIXES;
+}
+
+function stripOncharPrefix(
+  text: string,
+  prefixes: string[],
+): { triggered: boolean; stripped: string } {
+  const trimmed = text.trimStart();
+  for (const prefix of prefixes) {
+    if (!prefix) {
+      continue;
+    }
+    if (trimmed.startsWith(prefix)) {
+      return {
+        triggered: true,
+        stripped: trimmed.slice(prefix.length).trimStart(),
+      };
+    }
+  }
+  return { triggered: false, stripped: text };
+}
+
+function extractZulipTopicDirective(text: string): { text: string; topic?: string } {
+  const match = text.match(/^\s*\[\[zulip_topic:\s*([^\]]+?)\s*\]\]\s*/i);
+  if (!match) {
+    return { text };
+  }
+  const topic = match[1]?.trim();
+  if (!topic) {
+    return { text: text.slice(match[0].length).trimStart() };
+  }
+  return {
+    text: text.slice(match[0].length).trimStart(),
+    topic,
+  };
+}
+
+function normalizeAllowEntry(entry: string): string {
+  const trimmed = entry.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed === "*") {
+    return "*";
+  }
+  return trimmed
+    .replace(/^(zulip|user):/i, "")
+    .replace(/^@/, "")
+    .toLowerCase();
+}
+
+function normalizeAllowList(entries: Array<string | number>): string[] {
+  const normalized = entries.map((entry) => normalizeAllowEntry(String(entry))).filter(Boolean);
+  return Array.from(new Set(normalized));
+}
+
+function isSenderAllowed(params: {
+  senderId: string;
+  senderName?: string;
+  allowFrom: string[];
+}): boolean {
+  const allowFrom = params.allowFrom;
+  if (allowFrom.length === 0) {
+    return false;
+  }
+  if (allowFrom.includes("*")) {
+    return true;
+  }
+  const normalizedSenderId = normalizeAllowEntry(params.senderId);
+  const normalizedSenderName = params.senderName ? normalizeAllowEntry(params.senderName) : "";
+  return allowFrom.some(
+    (entry) =>
+      entry === normalizedSenderId || (normalizedSenderName && entry === normalizedSenderName),
+  );
+}
+
+async function saveZulipMediaBuffer(params: {
+  core: ReturnType<typeof getZulipRuntime>;
+  buffer: Buffer;
+  contentType: string;
+  filename: string;
+  maxBytes: number;
+}): Promise<{ path: string; contentType: string } | null> {
+  const { core, buffer, contentType, filename, maxBytes } = params;
+  if (core.channel.media?.saveMediaBuffer) {
+    const saved = await core.channel.media.saveMediaBuffer(
+      buffer,
+      contentType,
+      "inbound",
+      maxBytes,
+      filename,
+    );
+    return {
+      path: saved.path,
+      contentType: saved.contentType ?? contentType,
+    };
+  }
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "zulip-upload-"));
+  const filePath = path.join(dir, filename);
+  await fs.writeFile(filePath, buffer);
+  return { path: filePath, contentType };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise<void> {
+  const core = getZulipRuntime();
+  const cfg = opts.config ?? core.config.loadConfig();
+  const runtime = resolveRuntime(opts);
+  const account = resolveZulipAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+
+  const apiKey = opts.apiKey?.trim() || account.apiKey?.trim();
+  const email = opts.email?.trim() || account.email?.trim();
+  if (!apiKey || !email) {
+    throw new Error(
+      `Zulip apiKey/email missing for account "${account.accountId}" (set channels.zulip.accounts.${account.accountId}.apiKey/email or ZULIP_API_KEY/ZULIP_EMAIL for default).`,
+    );
+  }
+  const baseUrl = normalizeZulipBaseUrl(opts.baseUrl ?? account.baseUrl);
+  if (!baseUrl) {
+    throw new Error(
+      `Zulip url missing for account "${account.accountId}" (set channels.zulip.accounts.${account.accountId}.url or ZULIP_URL for default).`,
+    );
+  }
+
+  const client = createZulipClient({ baseUrl, email, apiKey });
+  const botUser = await fetchZulipMe(client);
+  const botUserId = botUser.id;
+  const botEmail = botUser.email ?? "";
+  const botUsername = botUser.full_name ?? "";
+
+  runtime.log?.(`zulip connected as ${botUsername ? botUsername : botUserId} (${botEmail})`);
+
+  const logger = core.logging.getChildLogger({ module: "zulip" });
+  const logVerboseMessage = core.logging.shouldLogVerbose()
+    ? (message: string) => logger.debug?.(message)
+    : () => {};
+
+  const oncharPrefixes = resolveOncharPrefixes(account.oncharPrefixes);
+  const oncharEnabled = account.chatmode === "onchar";
+  const channelHistories = new Map<string, HistoryEntry[]>();
+
+  const mediaMaxBytes =
+    resolveChannelMediaMaxBytes({
+      cfg,
+      accountId: account.accountId,
+      resolveChannelLimitMb: ({ cfg, accountId }) =>
+        (cfg.channels?.zulip as { mediaMaxMb?: number; accounts?: Record<string, { mediaMaxMb?: number }> })
+          ?.accounts?.[accountId]?.mediaMaxMb ??
+        (cfg.channels?.zulip as { mediaMaxMb?: number })?.mediaMaxMb,
+    }) ??
+    5 * 1024 * 1024;
+
+  const reactionConfig = account.config.reactions ?? {};
+  const reactionsEnabled = reactionConfig.enabled !== false;
+  const reactionClearOnFinish = reactionConfig.clearOnFinish !== false;
+  const reactionStart = normalizeEmojiName(reactionConfig.onStart ?? "eyes");
+  const reactionSuccess = normalizeEmojiName(reactionConfig.onSuccess ?? "check_mark");
+  const reactionError = normalizeEmojiName(reactionConfig.onError ?? "warning");
+
+  const handleMessage = async (message: ZulipMessage) => {
+    const messageId = String(message.id ?? "");
+    if (!messageId) {
+      return;
+    }
+    const dedupeKey = `${account.accountId}:${messageId}`;
+    if (recentInboundMessages.check(dedupeKey)) {
+      return;
+    }
+
+    const senderId = message.sender_email || String(message.sender_id ?? "");
+    if (!senderId) {
+      return;
+    }
+    if (senderId === botEmail || String(message.sender_id) === botUserId) {
+      return;
+    }
+
+    const senderName = message.sender_full_name?.trim() || senderId;
+    const isDM = message.type === "private";
+    const kind = isDM ? "dm" : "channel";
+    const chatType = isDM ? "direct" : "channel";
+
+    let streamName = "";
+    let streamId = "";
+    let topic = DEFAULT_TOPIC;
+    let channelId = "";
+
+    if (isDM) {
+      channelId = senderId;
+    } else {
+      streamId = String(message.stream_id ?? "");
+      channelId = streamId;
+      if (typeof message.display_recipient === "string") {
+        streamName = message.display_recipient;
+      }
+      topic = message.subject?.trim() || DEFAULT_TOPIC;
+    }
+
+    const rawText = stripHtmlToText(message.content ?? "");
+    const oncharResult = stripOncharPrefix(rawText, oncharPrefixes);
+
+    const uploadUrls = extractZulipUploadUrls(message.content ?? "", baseUrl);
+    const mediaPaths: string[] = [];
+    const mediaTypes: string[] = [];
+    const mediaUrls: string[] = [];
+    if (uploadUrls.length > 0) {
+      for (const uploadUrl of uploadUrls) {
+        try {
+          const downloaded = await downloadZulipUpload(uploadUrl, client.authHeader, mediaMaxBytes);
+          const saved = await saveZulipMediaBuffer({
+            core,
+            buffer: downloaded.buffer,
+            contentType: downloaded.contentType,
+            filename: downloaded.filename,
+            maxBytes: mediaMaxBytes,
+          });
+          if (saved) {
+            mediaPaths.push(saved.path);
+            mediaTypes.push(saved.contentType);
+            mediaUrls.push(uploadUrl);
+          }
+        } catch (err) {
+        }
+      }
+    }
+    const oncharTriggered = oncharEnabled && oncharResult.triggered;
+
+    const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, "main");
+    const wasMentioned =
+      !isDM &&
+      (rawText.toLowerCase().includes(`@${botUsername.toLowerCase()}`) ||
+        core.channel.mentions.matchesMentionPatterns(rawText, mentionRegexes));
+
+    const dmPolicy = account.config.dmPolicy ?? "pairing";
+    const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
+    const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+    const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
+    const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
+    const storeAllowFrom = normalizeAllowList(
+      await core.channel.pairing.readAllowFromStore("zulip").catch(() => []),
+    );
+    const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
+    const effectiveGroupAllowFrom = Array.from(
+      new Set([
+        ...(configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom),
+        ...storeAllowFrom,
+      ]),
+    );
+
+    const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
+      cfg,
+      surface: "zulip",
+    });
+    const hasControlCommand = core.channel.text.hasControlCommand(rawText, cfg);
+    const isControlCommand = allowTextCommands && hasControlCommand;
+    const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+    const senderAllowedForCommands = isSenderAllowed({
+      senderId,
+      senderName,
+      allowFrom: effectiveAllowFrom,
+    });
+    const groupAllowedForCommands = isSenderAllowed({
+      senderId,
+      senderName,
+      allowFrom: effectiveGroupAllowFrom,
+    });
+    const commandGate = resolveControlCommandGate({
+      useAccessGroups,
+      authorizers: [
+        { configured: effectiveAllowFrom.length > 0, allowed: senderAllowedForCommands },
+        {
+          configured: effectiveGroupAllowFrom.length > 0,
+          allowed: groupAllowedForCommands,
+        },
+      ],
+      allowTextCommands,
+      hasControlCommand,
+    });
+    const commandAuthorized =
+      kind === "dm"
+        ? dmPolicy === "open" || senderAllowedForCommands
+        : commandGate.commandAuthorized;
+
+    if (kind === "dm") {
+      if (dmPolicy === "disabled") {
+        logVerboseMessage(`zulip: drop dm (dmPolicy=disabled sender=${senderId})`);
+        return;
+      }
+      if (dmPolicy !== "open" && !senderAllowedForCommands) {
+        if (dmPolicy === "pairing") {
+          const { code, created } = await core.channel.pairing.upsertPairingRequest({
+            channel: "zulip",
+            id: senderId,
+            meta: { name: senderName },
+          });
+          logVerboseMessage(`zulip: pairing request sender=${senderId} created=${created}`);
+          if (created) {
+            try {
+              await sendMessageZulip(
+                `user:${senderId}`,
+                core.channel.pairing.buildPairingReply({
+                  channel: "zulip",
+                  idLine: `Your Zulip email: ${senderId}`,
+                  code,
+                }),
+                { accountId: account.accountId },
+              );
+              opts.statusSink?.({ lastOutboundAt: Date.now() });
+            } catch (err) {
+              logVerboseMessage(`zulip: pairing reply failed for ${senderId}: ${String(err)}`);
+            }
+          }
+        } else {
+          logVerboseMessage(`zulip: drop dm sender=${senderId} (dmPolicy=${dmPolicy})`);
+        }
+        return;
+      }
+    } else {
+      if (groupPolicy === "disabled") {
+        logVerboseMessage("zulip: drop group message (groupPolicy=disabled)");
+        return;
+      }
+      if (groupPolicy === "allowlist") {
+        if (effectiveGroupAllowFrom.length === 0) {
+          logVerboseMessage("zulip: drop group message (no group allowlist)");
+          return;
+        }
+        if (!groupAllowedForCommands) {
+          logVerboseMessage(`zulip: drop group sender=${senderId} (not in groupAllowFrom)`);
+          return;
+        }
+      }
+    }
+
+    if (kind !== "dm" && commandGate.shouldBlock) {
+      logInboundDrop({
+        log: logVerboseMessage,
+        channel: "zulip",
+        reason: "control command (unauthorized)",
+        target: senderId,
+      });
+      return;
+    }
+
+    const shouldRequireMention =
+      kind !== "dm" &&
+      core.channel.groups.resolveRequireMention({
+        cfg,
+        channel: "zulip",
+        accountId: account.accountId,
+        groupId: channelId,
+        requireMentionOverride: account.config.requireMention,
+      });
+    const shouldBypassMention =
+      isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;
+    const effectiveWasMentioned = wasMentioned || shouldBypassMention || oncharTriggered;
+    const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
+
+    if (oncharEnabled && !oncharTriggered && !wasMentioned && !isControlCommand) {
+      return;
+    }
+
+    if (kind !== "dm" && shouldRequireMention && canDetectMention) {
+      if (!effectiveWasMentioned) {
+        return;
+      }
+    }
+
+    const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
+    const bodyText = normalizeMention(bodySource, botUsername);
+    if (!bodyText) {
+      return;
+    }
+
+    core.channel.activity.record({
+      channel: "zulip",
+      accountId: account.accountId,
+      direction: "inbound",
+    });
+
+    const roomLabel = streamName ? `#${streamName}` : `stream:${streamId}`;
+    const fromLabel = formatInboundFromLabel({
+      isGroup: kind !== "dm",
+      groupLabel: roomLabel,
+      groupId: channelId,
+      groupFallback: "Stream",
+      directLabel: senderName,
+      directId: senderId,
+    });
+
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "zulip",
+      accountId: account.accountId,
+      teamId: undefined,
+      peer: {
+        kind,
+        id: kind === "dm" ? senderId : channelId,
+      },
+    });
+
+    // Use the SDK-provided session key (includes agent: prefix from routing)
+    const baseSessionKey = route.sessionKey ?? `zulip:${account.accountId}:${channelId}`;
+    const threadKeys = resolveThreadSessionKeys({
+      baseSessionKey,
+      threadId: topic !== DEFAULT_TOPIC ? topic : undefined,
+    });
+    const sessionKey = threadKeys.sessionKey;
+    const historyKey = kind === "dm" ? null : sessionKey;
+
+    const preview = bodyText.replace(/\s+/g, " ").slice(0, 160);
+    const inboundLabel =
+      kind === "dm" ? `Zulip DM from ${senderName}` : `Zulip message in ${roomLabel} from ${senderName}`;
+    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+      sessionKey,
+      contextKey: `zulip:message:${messageId}`,
+    });
+
+    const timestamp = message.timestamp ? message.timestamp * 1000 : undefined;
+    const textWithId = `${bodyText}\n[zulip message id: ${messageId}]`;
+    const body = core.channel.reply.formatInboundEnvelope({
+      channel: "Zulip",
+      from: fromLabel,
+      timestamp,
+      body: textWithId,
+      chatType,
+      sender: { name: senderName, id: senderId },
+    });
+
+    const to = kind === "dm" ? `user:${senderId}` : `stream:${streamName || streamId}:${topic}`;
+    const ctxPayload = core.channel.reply.finalizeInboundContext({
+      Body: body,
+      RawBody: bodyText,
+      CommandBody: bodyText,
+      From: kind === "dm" ? `zulip:${senderId}` : `zulip:channel:${channelId}`,
+      To: to,
+      SessionKey: sessionKey,
+      ParentSessionKey: threadKeys.parentSessionKey,
+      AccountId: route.accountId,
+      ChatType: chatType,
+      ConversationLabel: fromLabel,
+      GroupSubject: kind !== "dm" ? roomLabel : undefined,
+      GroupChannel: streamName ? `#${streamName}` : undefined,
+      SenderName: senderName,
+      SenderId: senderId,
+      Provider: "zulip" as const,
+      Surface: "zulip" as const,
+      MessageSid: messageId,
+      ReplyToId: topic !== DEFAULT_TOPIC ? topic : undefined,
+      MessageThreadId: topic !== DEFAULT_TOPIC ? topic : undefined,
+      Timestamp: timestamp,
+      WasMentioned: kind !== "dm" ? effectiveWasMentioned : undefined,
+      CommandAuthorized: commandAuthorized,
+      OriginatingChannel: "zulip" as const,
+      OriginatingTo: to,
+      MediaPath: mediaPaths[0],
+      MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
+      MediaUrl: mediaUrls[0],
+      MediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+      MediaType: mediaTypes[0],
+      MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+    });
+
+    if (kind === "dm") {
+      const sessionCfg = cfg.session;
+      const storePath = core.channel.session.resolveStorePath(sessionCfg?.store, {
+        agentId: route.agentId,
+      });
+      await core.channel.session.updateLastRoute({
+        storePath,
+        sessionKey: route.mainSessionKey,
+        deliveryContext: {
+          channel: "zulip",
+          to,
+          accountId: route.accountId,
+        },
+      });
+    }
+
+    const previewLine = bodyText.slice(0, 200).replace(/\n/g, "\\n");
+    logVerboseMessage(
+      `zulip inbound: from=${ctxPayload.From} len=${bodyText.length} preview="${previewLine}"`,
+    );
+
+    const addReactionSafe = async (emojiName: string) => {
+      if (!reactionsEnabled || !emojiName) {
+        return;
+      }
+      try {
+        await addZulipReaction(client, { messageId, emojiName });
+      } catch (err) {
+        logVerboseMessage(`zulip: failed to add reaction ${emojiName}: ${String(err)}`);
+      }
+    };
+    const removeReactionSafe = async (emojiName: string) => {
+      if (!reactionsEnabled || !emojiName) {
+        return;
+      }
+      try {
+        await removeZulipReaction(client, { messageId, emojiName });
+      } catch (err) {
+        logVerboseMessage(`zulip: failed to remove reaction ${emojiName}: ${String(err)}`);
+      }
+    };
+
+    if (reactionsEnabled) {
+      await addReactionSafe(reactionStart);
+    }
+
+    const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "zulip", account.accountId, {
+      fallbackLimit: account.textChunkLimit ?? 4000,
+    });
+    const tableMode = core.channel.text.resolveMarkdownTableMode({
+      cfg,
+      channel: "zulip",
+      accountId: account.accountId,
+    });
+
+    const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+      cfg,
+      agentId: route.agentId,
+      channel: "zulip",
+      accountId: account.accountId,
+    });
+
+    const typingParams = isDM
+      ? { op: "start" as const, type: "direct" as const, to: [Number(message.sender_id)] }
+      : streamId
+        ? { op: "start" as const, type: "stream" as const, streamId: Number(streamId), topic }
+        : null;
+
+    const typingCallbacks = createTypingCallbacks({
+      start: async () => {
+        if (typingParams) {
+          await sendZulipTyping(client, typingParams);
+        }
+      },
+      stop: async () => {
+        if (typingParams) {
+          await sendZulipTyping(client, { ...typingParams, op: "stop" });
+        }
+      },
+      onStartError: (err) => {
+        logTypingFailure({
+          log: logVerboseMessage,
+          channel: "zulip",
+          target: isDM ? senderId : `stream:${streamId}:${topic}`,
+          error: err,
+        });
+      },
+      onStopError: (err) => {
+        logTypingFailure({
+          log: logVerboseMessage,
+          channel: "zulip",
+          target: isDM ? senderId : `stream:${streamId}:${topic}`,
+          error: err,
+        });
+      },
+    });
+
+    const { dispatcher, replyOptions, markDispatchIdle } =
+      core.channel.reply.createReplyDispatcherWithTyping({
+        ...prefixOptions,
+        humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
+        onReplyStart: typingCallbacks.onReplyStart,
+        deliver: async (payload: ReplyPayload) => {
+          const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+          const rawText = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+          const { text, topic: topicOverride } = extractZulipTopicDirective(rawText);
+          const resolvedTopic = topicOverride ? topicOverride.slice(0, 60) : topic;
+          if (mediaUrls.length === 0) {
+            const chunkMode = core.channel.text.resolveChunkMode(cfg, "zulip", account.accountId);
+            const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
+            for (const chunk of chunks.length > 0 ? chunks : [text]) {
+              if (!chunk) {
+                continue;
+              }
+              await sendMessageZulip(to, chunk, {
+                accountId: account.accountId,
+                topic: resolvedTopic,
+              });
+            }
+          } else {
+            let first = true;
+            for (const mediaUrl of mediaUrls) {
+              const caption = first ? text : "";
+              first = false;
+              await sendMessageZulip(to, caption, {
+                accountId: account.accountId,
+                mediaUrl,
+                topic: resolvedTopic,
+              });
+            }
+          }
+          opts.statusSink?.({ lastOutboundAt: Date.now() });
+        },
+        onError: (err: unknown) => {
+          runtime.error?.(`zulip reply failed: ${String(err)}`);
+        },
+      });
+
+    let dispatchError: unknown;
+    try {
+      await core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          disableBlockStreaming:
+            typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+          onModelSelected,
+        },
+      });
+    } catch (err) {
+      dispatchError = err;
+      runtime.error?.(`zulip reply failed: ${String(err)}`);
+    } finally {
+      markDispatchIdle();
+    }
+
+    if (reactionsEnabled) {
+      if (reactionClearOnFinish) {
+        await removeReactionSafe(reactionStart);
+      }
+      if (dispatchError) {
+        await addReactionSafe(reactionError);
+      } else {
+        await addReactionSafe(reactionSuccess);
+      }
+    }
+
+    if (historyKey) {
+      clearHistoryEntriesIfEnabled({
+        historyMap: channelHistories,
+        historyKey,
+        limit: DEFAULT_GROUP_HISTORY_LIMIT,
+      });
+    }
+
+    opts.statusSink?.({ lastInboundAt: Date.now() });
+  };
+
+  // Register event queue
+  const streams = account.streams ?? ["*"];
+  const queue = await registerZulipQueue(client, {
+    eventTypes: ["message"],
+    streams, // Pass ["*"] to trigger all_public_streams=true in registerZulipQueue
+  });
+  let queueId = queue.queueId;
+  let lastEventId = queue.lastEventId;
+  let pollBackoffMs = 0;
+
+  runtime.log?.(`zulip event queue registered: ${queueId}`);
+
+  const resetPollBackoff = () => {
+    pollBackoffMs = 0;
+  };
+
+  // Long-polling loop
+  while (!opts.abortSignal?.aborted) {
+    try {
+      const response = await getZulipEventsWithRetry(client, {
+        queueId,
+        lastEventId,
+        timeoutMs: 90000,
+        retryBaseDelayMs: 1000,
+      });
+
+      if (response.result === "error") {
+        if (response.code === "BAD_EVENT_QUEUE_ID" || response.msg?.includes("Bad event queue id")) {
+          runtime.log?.("zulip: queue expired, re-registering...");
+          const newQueue = await registerZulipQueue(client, {
+            eventTypes: ["message"],
+            streams, // Pass ["*"] to trigger all_public_streams=true in registerZulipQueue
+          });
+          queueId = newQueue.queueId;
+          lastEventId = newQueue.lastEventId;
+          resetPollBackoff();
+          continue;
+        }
+        throw new Error(`Zulip events error: ${response.msg}`);
+      }
+
+      const events = response.events ?? [];
+      if (events.length > 0) {
+        lastEventId = events[events.length - 1].id;
+        opts.statusSink?.({
+          connected: true,
+          lastConnectedAt: Date.now(),
+        });
+      }
+
+      if (events.length === 0) {
+        await sleep(1000);
+      }
+
+      resetPollBackoff();
+
+      for (const event of events) {
+        if (event.type === "message" && event.message) {
+          // Fire-and-forget: don't block the poll loop while generating replies
+          handleMessage(event.message).catch((err) => {
+            runtime.error?.(`zulip message handler failed: ${String(err)}`);
+          });
+        }
+      }
+    } catch (err) {
+      if (opts.abortSignal?.aborted) {
+        break;
+      }
+      const status = (err as { status?: number })?.status;
+      const retryAfterMs = (err as { retryAfterMs?: number })?.retryAfterMs;
+      runtime.error?.(`zulip polling error: ${String(err)}`);
+      opts.statusSink?.({
+        connected: false,
+        lastError: String(err),
+      });
+      const baseDelay = status === 429 ? 10000 : 1000;
+      if (!pollBackoffMs) {
+        pollBackoffMs = baseDelay;
+      } else {
+        pollBackoffMs = Math.min(30000, pollBackoffMs * 2);
+      }
+      const delay = retryAfterMs && retryAfterMs > 0 ? Math.min(30000, retryAfterMs) : pollBackoffMs;
+      await sleep(delay);
+    }
+  }
+
+  // Cleanup
+  await deleteZulipQueue(client, queueId);
+  runtime.log?.("zulip monitor stopped");
+}

--- a/extensions/zulip/src/zulip/probe.ts
+++ b/extensions/zulip/src/zulip/probe.ts
@@ -18,9 +18,7 @@ export async function probeZulip(
     return { ok: false, error: "invalid baseUrl" };
   }
   const controller = new AbortController();
-  const timeout = timeoutMs
-    ? setTimeout(() => controller.abort(), Math.max(timeoutMs, 500))
-    : null;
+  const timeout = timeoutMs ? setTimeout(() => controller.abort(), Math.max(timeoutMs, 500)) : null;
 
   try {
     const authHeader = Buffer.from(`${email}:${apiKey}`).toString("base64");

--- a/extensions/zulip/src/zulip/probe.ts
+++ b/extensions/zulip/src/zulip/probe.ts
@@ -1,0 +1,63 @@
+import { normalizeZulipBaseUrl, readZulipError, type ZulipUser } from "./client.js";
+
+export type ZulipProbe = {
+  ok: boolean;
+  baseUrl?: string;
+  bot?: ZulipUser;
+  error?: string;
+};
+
+export async function probeZulip(
+  baseUrl: string,
+  email: string,
+  apiKey: string,
+  timeoutMs?: number,
+): Promise<ZulipProbe> {
+  const normalized = normalizeZulipBaseUrl(baseUrl);
+  if (!normalized) {
+    return { ok: false, error: "invalid baseUrl" };
+  }
+  const controller = new AbortController();
+  const timeout = timeoutMs
+    ? setTimeout(() => controller.abort(), Math.max(timeoutMs, 500))
+    : null;
+
+  try {
+    const authHeader = Buffer.from(`${email}:${apiKey}`).toString("base64");
+    const res = await fetch(`${normalized}/api/v1/users/me`, {
+      headers: {
+        Authorization: `Basic ${authHeader}`,
+      },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const detail = await readZulipError(res);
+      return { ok: false, error: detail || res.statusText };
+    }
+    const data = (await res.json()) as {
+      result?: string;
+      msg?: string;
+      user_id?: number;
+      email?: string;
+      full_name?: string;
+    };
+    if (data.result && data.result !== "success") {
+      return { ok: false, error: data.msg || "Zulip API error" };
+    }
+    return {
+      ok: true,
+      baseUrl: normalized,
+      bot: {
+        id: String(data.user_id ?? ""),
+        email: data.email ?? null,
+        full_name: data.full_name ?? null,
+      },
+    };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/extensions/zulip/src/zulip/send.ts
+++ b/extensions/zulip/src/zulip/send.ts
@@ -1,0 +1,232 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { getZulipRuntime } from "../runtime.js";
+import { resolveZulipAccount } from "./accounts.js";
+import {
+  createZulipClient,
+  normalizeZulipBaseUrl,
+  sendZulipPrivateMessage,
+  sendZulipStreamMessage,
+  uploadZulipFile,
+} from "./client.js";
+
+export type ZulipSendOpts = {
+  apiKey?: string;
+  email?: string;
+  baseUrl?: string;
+  accountId?: string;
+  mediaUrl?: string;
+  topic?: string;
+};
+
+export type ZulipSendResult = {
+  messageId: string;
+  channelId: string;
+};
+
+type ZulipTarget =
+  | { kind: "stream"; stream: string; topic?: string }
+  | { kind: "user"; email: string };
+
+const DEFAULT_TOPIC = "general";
+
+const getCore = () => getZulipRuntime();
+
+function normalizeMessage(text: string, mediaUrl?: string): string {
+  const trimmed = text.trim();
+  const media = mediaUrl?.trim();
+  return [trimmed, media].filter(Boolean).join("\n");
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function resolveLocalPath(value: string): string | null {
+  if (value.startsWith("file://")) {
+    return fileURLToPath(value);
+  }
+  if (!isHttpUrl(value)) {
+    return value;
+  }
+  return null;
+}
+
+async function writeTempFile(buffer: Buffer, filename: string): Promise<string> {
+  const dir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "zulip-upload-"));
+  const filePath = path.join(dir, filename);
+  await fsPromises.writeFile(filePath, buffer);
+  return filePath;
+}
+
+function parseZulipTarget(raw: string): ZulipTarget {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Recipient is required for Zulip sends");
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("stream:")) {
+    const rest = trimmed.slice("stream:".length).trim();
+    if (!rest) {
+      throw new Error("Stream name is required for Zulip sends");
+    }
+    const [stream, topic] = rest.split(/[:#/]/);
+    return { kind: "stream", stream: stream.trim(), topic: topic?.trim() };
+  }
+  if (lower.startsWith("user:") || lower.startsWith("dm:")) {
+    const email = trimmed.slice(trimmed.indexOf(":") + 1).trim();
+    if (!email) {
+      throw new Error("Email is required for Zulip direct messages");
+    }
+    return { kind: "user", email };
+  }
+  if (lower.startsWith("zulip:")) {
+    const email = trimmed.slice("zulip:".length).trim();
+    if (!email) {
+      throw new Error("Email is required for Zulip direct messages");
+    }
+    return { kind: "user", email };
+  }
+  if (trimmed.startsWith("@")) {
+    const email = trimmed.slice(1).trim();
+    if (!email) {
+      throw new Error("Email is required for Zulip direct messages");
+    }
+    return { kind: "user", email };
+  }
+  if (trimmed.startsWith("#")) {
+    const rest = trimmed.slice(1).trim();
+    const [stream, topic] = rest.split(/[:#/]/);
+    if (!stream) {
+      throw new Error("Stream name is required for Zulip sends");
+    }
+    return { kind: "stream", stream: stream.trim(), topic: topic?.trim() };
+  }
+  if (trimmed.includes("@")) {
+    return { kind: "user", email: trimmed };
+  }
+  return { kind: "stream", stream: trimmed };
+}
+
+export async function sendMessageZulip(
+  to: string,
+  text: string,
+  opts: ZulipSendOpts = {},
+): Promise<ZulipSendResult> {
+  const core = getCore();
+  const logger = core.logging.getChildLogger({ module: "zulip" });
+  const cfg = core.config.loadConfig();
+  const account = resolveZulipAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+  const apiKey = opts.apiKey?.trim() || account.apiKey?.trim();
+  const email = opts.email?.trim() || account.email?.trim();
+  if (!apiKey || !email) {
+    throw new Error(
+      `Zulip apiKey/email missing for account "${account.accountId}" (set channels.zulip.accounts.${account.accountId}.apiKey/email or ZULIP_API_KEY/ZULIP_EMAIL for default).`,
+    );
+  }
+  const baseUrl = normalizeZulipBaseUrl(opts.baseUrl ?? account.baseUrl);
+  if (!baseUrl) {
+    throw new Error(
+      `Zulip url missing for account "${account.accountId}" (set channels.zulip.accounts.${account.accountId}.url or ZULIP_URL for default).`,
+    );
+  }
+
+  const client = createZulipClient({ baseUrl, email, apiKey });
+  const target = parseZulipTarget(to);
+  let message = text?.trim() ?? "";
+  const rawMediaUrl = opts.mediaUrl?.trim();
+  let mediaUrl = rawMediaUrl;
+  let tempFilePath: string | undefined;
+  let tempFileCleanup = false;
+
+  if (mediaUrl) {
+    const localPath = resolveLocalPath(mediaUrl);
+    const isZulipHosted = isHttpUrl(mediaUrl) && mediaUrl.startsWith(baseUrl);
+    if (localPath && fs.existsSync(localPath)) {
+      const upload = await uploadZulipFile(client, localPath);
+      mediaUrl = upload.url;
+    } else if (isHttpUrl(mediaUrl) && !isZulipHosted) {
+      const maxBytes = (cfg.agents?.defaults?.mediaMaxMb ?? 5) * 1024 * 1024;
+      const fetched = await core.channel.media.fetchRemoteMedia({
+        url: mediaUrl,
+        maxBytes,
+      });
+      const filename = (() => {
+        try {
+          return path.basename(new URL(mediaUrl).pathname) || "upload.bin";
+        } catch {
+          return "upload.bin";
+        }
+      })();
+      if (core.channel.media?.saveMediaBuffer) {
+        const saved = await core.channel.media.saveMediaBuffer(
+          fetched.buffer,
+          fetched.contentType ?? "application/octet-stream",
+          "outbound",
+          maxBytes,
+          filename,
+        );
+        tempFilePath = saved.path;
+      } else {
+        tempFilePath = await writeTempFile(fetched.buffer, filename);
+        tempFileCleanup = true;
+      }
+      const upload = await uploadZulipFile(client, tempFilePath);
+      mediaUrl = upload.url;
+      if (tempFileCleanup && tempFilePath) {
+        await fsPromises.unlink(tempFilePath).catch(() => undefined);
+      }
+    }
+    message = normalizeMessage(message, mediaUrl);
+  }
+
+  if (message) {
+    const tableMode = core.channel.text.resolveMarkdownTableMode({
+      cfg,
+      channel: "zulip",
+      accountId: account.accountId,
+    });
+    message = core.channel.text.convertMarkdownTables(message, tableMode);
+  }
+
+  if (!message) {
+    throw new Error("Zulip message is empty");
+  }
+
+  let messageId = "unknown";
+  if (target.kind === "user") {
+    const response = await sendZulipPrivateMessage(client, {
+      to: target.email,
+      content: message,
+    });
+    messageId = response.id ? String(response.id) : "unknown";
+  } else {
+    const topic = target.topic || opts.topic || DEFAULT_TOPIC;
+    if (!topic) {
+      logger.debug?.("zulip send: missing topic for stream message");
+    }
+    const response = await sendZulipStreamMessage(client, {
+      stream: target.stream,
+      topic: topic || DEFAULT_TOPIC,
+      content: message,
+    });
+    messageId = response.id ? String(response.id) : "unknown";
+  }
+
+  core.channel.activity.record({
+    channel: "zulip",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  return {
+    messageId,
+    channelId: target.kind === "stream" ? target.stream : target.email,
+  };
+}

--- a/extensions/zulip/src/zulip/uploads.test.ts
+++ b/extensions/zulip/src/zulip/uploads.test.ts
@@ -28,10 +28,7 @@ describe("extractZulipUploadUrls", () => {
   const baseUrl = "https://zulip.example.com";
 
   it("extracts relative /user_uploads links", () => {
-    const urls = extractZulipUploadUrls(
-      "[file](/user_uploads/abc123/photo.png)",
-      baseUrl,
-    );
+    const urls = extractZulipUploadUrls("[file](/user_uploads/abc123/photo.png)", baseUrl);
     expect(urls).toEqual(["https://zulip.example.com/user_uploads/abc123/photo.png"]);
   });
 

--- a/extensions/zulip/src/zulip/uploads.test.ts
+++ b/extensions/zulip/src/zulip/uploads.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { extractZulipUploadUrls, normalizeEmojiName } from "./uploads.js";
+
+describe("normalizeEmojiName", () => {
+  it("returns plain names unchanged", () => {
+    expect(normalizeEmojiName("eyes")).toBe("eyes");
+    expect(normalizeEmojiName("check_mark")).toBe("check_mark");
+  });
+
+  it("strips leading and trailing colons", () => {
+    expect(normalizeEmojiName(":eyes:")).toBe("eyes");
+    expect(normalizeEmojiName(":warning:")).toBe("warning");
+  });
+
+  it("handles double colons", () => {
+    expect(normalizeEmojiName("::eyes::")).toBe("eyes");
+  });
+
+  it("returns empty string for null/undefined/empty", () => {
+    expect(normalizeEmojiName(null)).toBe("");
+    expect(normalizeEmojiName(undefined)).toBe("");
+    expect(normalizeEmojiName("")).toBe("");
+    expect(normalizeEmojiName("  ")).toBe("");
+  });
+});
+
+describe("extractZulipUploadUrls", () => {
+  const baseUrl = "https://zulip.example.com";
+
+  it("extracts relative /user_uploads links", () => {
+    const urls = extractZulipUploadUrls(
+      "[file](/user_uploads/abc123/photo.png)",
+      baseUrl,
+    );
+    expect(urls).toEqual(["https://zulip.example.com/user_uploads/abc123/photo.png"]);
+  });
+
+  it("extracts absolute URLs", () => {
+    const urls = extractZulipUploadUrls(
+      "see https://zulip.example.com/user_uploads/xyz/cat.jpg here",
+      baseUrl,
+    );
+    expect(urls).toEqual(["https://zulip.example.com/user_uploads/xyz/cat.jpg"]);
+  });
+
+  it("deduplicates URLs", () => {
+    const urls = extractZulipUploadUrls(
+      "/user_uploads/a.png and /user_uploads/a.png again",
+      baseUrl,
+    );
+    expect(urls).toHaveLength(1);
+  });
+
+  it("returns empty for no uploads", () => {
+    expect(extractZulipUploadUrls("just text", baseUrl)).toEqual([]);
+    expect(extractZulipUploadUrls("", baseUrl)).toEqual([]);
+  });
+
+  it("handles multiple uploads", () => {
+    const urls = extractZulipUploadUrls(
+      "[a](/user_uploads/1/a.png) and [b](/user_uploads/2/b.pdf)",
+      baseUrl,
+    );
+    expect(urls).toHaveLength(2);
+  });
+});

--- a/extensions/zulip/src/zulip/uploads.ts
+++ b/extensions/zulip/src/zulip/uploads.ts
@@ -68,15 +68,13 @@ export async function downloadZulipUpload(
   url: string,
   authHeader: string,
   maxBytes: number,
-  baseUrl?: string,
+  baseUrl: string,
 ): Promise<{ buffer: Buffer; contentType: string; filename: string }> {
   // Never send Zulip Basic auth to a non-Zulip origin.
-  if (baseUrl) {
-    const baseOrigin = new URL(baseUrl).origin;
-    const target = new URL(url);
-    if (target.origin !== baseOrigin || !target.pathname.includes("/user_uploads/")) {
-      throw new Error("Refusing to download Zulip upload from non-Zulip origin");
-    }
+  const baseOrigin = new URL(baseUrl).origin;
+  const target = new URL(url);
+  if (target.origin !== baseOrigin || !target.pathname.includes("/user_uploads/")) {
+    throw new Error("Refusing to download Zulip upload from non-Zulip origin");
   }
 
   const res = await fetch(url, {

--- a/extensions/zulip/src/zulip/uploads.ts
+++ b/extensions/zulip/src/zulip/uploads.ts
@@ -1,0 +1,79 @@
+import path from "node:path";
+
+export function normalizeEmojiName(raw?: string | null): string {
+  const trimmed = raw?.trim() ?? "";
+  if (!trimmed) {
+    return "";
+  }
+  return trimmed.replace(/^:+|:+$/g, "");
+}
+
+export function extractZulipUploadUrls(html: string, baseUrl: string): string[] {
+  if (!html) {
+    return [];
+  }
+  const matches = html.matchAll(/(?:https?:\/\/[^\s"'<>)]+)?\/user_uploads\/[^\s"'<>)]+/g);
+  const urls = new Set<string>();
+  for (const match of matches) {
+    const raw = match[0];
+    try {
+      const absolute = new URL(raw, baseUrl).toString();
+      urls.add(absolute);
+    } catch {
+      // ignore malformed URLs
+    }
+  }
+  return Array.from(urls);
+}
+
+function resolveFilename(url: string, contentDisposition?: string | null): string {
+  if (contentDisposition) {
+    const encodedMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+    if (encodedMatch?.[1]) {
+      return decodeURIComponent(encodedMatch[1]);
+    }
+    const match = contentDisposition.match(/filename="?([^";]+)"?/i);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  try {
+    const parsed = new URL(url);
+    const base = path.basename(parsed.pathname);
+    if (base) {
+      return base;
+    }
+  } catch {
+    // ignore
+  }
+  return "upload.bin";
+}
+
+export async function downloadZulipUpload(
+  url: string,
+  authHeader: string,
+  maxBytes: number,
+): Promise<{ buffer: Buffer; contentType: string; filename: string }> {
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Basic ${authHeader}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Zulip upload download failed: ${res.status} ${res.statusText}`);
+  }
+  const contentLength = res.headers.get("content-length");
+  if (contentLength) {
+    const length = Number(contentLength);
+    if (!Number.isNaN(length) && length > maxBytes) {
+      throw new Error(`Zulip upload exceeds max size (${length} > ${maxBytes})`);
+    }
+  }
+  const buffer = Buffer.from(await res.arrayBuffer());
+  if (buffer.length > maxBytes) {
+    throw new Error(`Zulip upload exceeds max size (${buffer.length} > ${maxBytes})`);
+  }
+  const contentType = res.headers.get("content-type") ?? "application/octet-stream";
+  const filename = resolveFilename(url, res.headers.get("content-disposition"));
+  return { buffer, contentType, filename };
+}

--- a/extensions/zulip/tsconfig.json
+++ b/extensions/zulip/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts", "src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,16 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/zulip:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   packages/clawdbot:
     dependencies:
       openclaw:
@@ -6591,7 +6601,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.58.0':
     dependencies:
-      axios: 1.13.4
+      axios: 1.13.4(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6607,7 +6617,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.11
     optionalDependencies:
-      axios: 1.13.4
+      axios: 1.13.4(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6810,7 +6820,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.4
+      axios: 1.13.4(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7645,7 +7655,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.4
+      axios: 1.13.4(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7691,7 +7701,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.2.1
       '@types/retry': 0.12.0
-      axios: 1.13.4
+      axios: 1.13.4(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8585,14 +8595,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.4:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.4(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9167,8 +9169,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -23,6 +23,7 @@ const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([
   "signal",
   "discord",
   "googlechat",
+  "zulip",
   "tui",
   INTERNAL_MESSAGE_CHANNEL,
 ]);


### PR DESCRIPTION
## Problem
When `channels.zulip.streams` contains multiple stream names, the Zulip plugin was registering an event queue with a `narrow` like:

```json
[["stream","build"],["stream","general"],["stream","openclaw"],["stream","research"]]
```

Zulip narrows are ANDed, so this matches nothing (a message cannot be in multiple streams at once). This caused the default/Marvin account to stop receiving messages, while role accounts (1 stream each) continued to work.

## Fix
- If streams contains `"*"`: use `all_public_streams=true`
- If exactly 1 stream: use `narrow=[["stream","<name>"]]` (legacy list format)
- If multiple streams: omit `narrow` (broad queue) and rely on existing client-side filtering

## Tests
Adds a Vitest regression test covering the three cases above.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Zulip event queue registration when multiple monitored streams are configured: it uses `all_public_streams=true` for `"*"`, uses a single-stream `narrow` for exactly one stream (legacy list format), and omits `narrow` for multiple streams while enforcing the stream allowlist client-side. It also adds new Zulip plugin implementation files (client, monitor, send/probe, config schema, normalization) plus Vitest coverage for queue registration and stream filtering, and updates docs/labeler to include Zulip.

The change integrates into the channel plugin system by providing a `zulipPlugin` with config + pairing + outbound delivery, a monitor loop using Zulip event queues, and shared helpers for routing/session keys and stream monitoring.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of logic issues that can affect message routing and inbound gating.
- Core stream registration fix looks correct and is covered by targeted tests, but there are two verified logic bugs: outbound parsing can truncate topics, and inbound mention detection uses a hardcoded agentId which can drop messages for routed agents when requireMention is enabled.
- extensions/zulip/src/zulip/send.ts; extensions/zulip/src/zulip/monitor.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->