### PR TITLE
docs(channels): fix missing Telegram card icon

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -16,7 +16,7 @@ Status: production-ready for bot DMs + groups via grammY. Long polling is the de
   <Card title="Channel troubleshooting" icon="wrench" href="/channels/troubleshooting">
     Cross-channel diagnostics and repair playbooks.
   </Card>
-  <Card title="Gateway configuration" icon="sliders" href="/gateway/configuration">
+  <Card title="Gateway configuration" icon="settings" href="/gateway/configuration">
     Full channel config patterns and examples.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- fix missing icon on Telegram docs card by switching to a valid icon name
- update `docs/channels/telegram.md` card icon from `sliders` to `settings`

## Validation
- `pnpm lint:docs`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Telegram channel docs card icon from `sliders` to `settings` in `docs/channels/telegram.md` to use a valid icon name, restoring the missing icon on the docs card. No behavioral or structural doc changes beyond the icon token were introduced.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line documentation update to a Card icon token; it is isolated to a single markdown file and does not affect runtime code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->