### PR TITLE
feat(hooks): add message:received and message:sent internal hook events

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -201,8 +201,8 @@ Each event includes:
 
 ```typescript
 {
-  type: 'command' | 'session' | 'agent' | 'gateway',
-  action: string,              // e.g., 'new', 'reset', 'stop'
+  type: 'command' | 'session' | 'agent' | 'gateway' | 'message',
+  action: string,              // e.g., 'new', 'reset', 'stop', 'received', 'sent'
   sessionKey: string,          // Session identifier
   timestamp: Date,             // When the event occurred
   messages: string[],          // Push messages here to send to user
@@ -240,6 +240,14 @@ Triggered when the gateway starts:
 
 - **`gateway:startup`**: After channels start and hooks are loaded
 
+### Message Events
+
+Triggered during the message lifecycle:
+
+- **`message:received`**: When an inbound message is received from any channel, before reply generation. Fires after the plugin `message_received` hook but is part of the internal hook system. Context includes `text`, `channel`, `chatType`, `from`, `to`, `senderId`, `senderName`, `senderUsername`, `messageId`, `threadId`, `timestamp`, `accountId`, `provider`, and `surface`.
+
+- **`message:sent`**: When an outbound reply is successfully delivered to a channel. Fires after each reply payload (block, tool, or final) is sent. Context includes `text`, `channel`, `chatType`, `kind` (the dispatch kind: `"tool"`, `"block"`, or `"final"`), `mediaUrl`, and `mediaUrls`.
+
 ### Tool Result Hooks (Plugin API)
 
 These hooks are not event-stream listeners; they let plugins synchronously adjust tool results before OpenClaw persists them.
@@ -253,8 +261,6 @@ Planned event types:
 - **`session:start`**: When a new session begins
 - **`session:end`**: When a session ends
 - **`agent:error`**: When an agent encounters an error
-- **`message:sent`**: When a message is sent
-- **`message:received`**: When a message is received
 
 ## Creating Custom Hooks
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -5,6 +5,7 @@ import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import {
   logMessageProcessed,
@@ -195,6 +196,37 @@ export async function dispatchReplyFromConfig(params: {
       .catch((err) => {
         logVerbose(`dispatch-from-config: message_received hook failed: ${String(err)}`);
       });
+  }
+
+  // Trigger internal message:received hook for extensions (e.g., memory systems)
+  {
+    const content =
+      typeof ctx.BodyForCommands === "string"
+        ? ctx.BodyForCommands
+        : typeof ctx.RawBody === "string"
+          ? ctx.RawBody
+          : typeof ctx.Body === "string"
+            ? ctx.Body
+            : "";
+    const hookEvent = createInternalHookEvent("message", "received", ctx.SessionKey ?? "", {
+      text: content,
+      channel: (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase(),
+      chatType: ctx.ChatType,
+      from: ctx.From,
+      to: ctx.To,
+      senderId: ctx.SenderId,
+      senderName: ctx.SenderName,
+      senderUsername: ctx.SenderUsername,
+      messageId: ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast,
+      threadId: ctx.MessageThreadId,
+      timestamp: ctx.Timestamp,
+      accountId: ctx.AccountId,
+      provider: ctx.Provider,
+      surface: ctx.Surface,
+    });
+    void triggerInternalHook(hookEvent).catch((err) => {
+      logVerbose(`dispatch-from-config: message:received hook failed: ${String(err)}`);
+    });
   }
 
   // Check if we should route replies to originating channel instead of dispatcher.

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -2,6 +2,8 @@ import type { HumanDelayConfig } from "../../config/types.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { ResponsePrefixContext } from "./response-prefix-template.js";
 import type { TypingController } from "./typing.js";
+import { logVerbose } from "../../globals.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { sleep } from "../../utils.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 
@@ -53,6 +55,12 @@ export type ReplyDispatcherOptions = {
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
+  /** Session key for message:sent hook events. */
+  sessionKey?: string;
+  /** Channel identifier for message:sent hook events. */
+  channel?: string;
+  /** Chat type (dm/group) for message:sent hook events. */
+  chatType?: string;
 };
 
 export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onIdle"> & {
@@ -141,6 +149,19 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           }
         }
         await options.deliver(normalized, { kind });
+
+        // Trigger message:sent hook after successful delivery
+        const hookEvent = createInternalHookEvent("message", "sent", options.sessionKey ?? "", {
+          text: normalized.text,
+          channel: options.channel,
+          chatType: options.chatType,
+          kind,
+          mediaUrl: normalized.mediaUrl,
+          mediaUrls: normalized.mediaUrls,
+        });
+        void triggerInternalHook(hookEvent).catch((err) => {
+          logVerbose(`reply-dispatcher: message:sent hook failed: ${String(err)}`);
+        });
       })
       .catch((err) => {
         options.onError?.(err, { kind });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,7 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;

--- a/src/hooks/message-hooks.test.ts
+++ b/src/hooks/message-hooks.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  registerInternalHook,
+  clearInternalHooks,
+  type InternalHookEvent,
+} from "./internal-hooks.js";
+
+describe("message hook events", () => {
+  beforeEach(() => {
+    clearInternalHooks();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+  });
+
+  describe("message:received", () => {
+    it("triggers handler registered for message:received", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:received", handler);
+
+      const { createInternalHookEvent, triggerInternalHook } = await import("./internal-hooks.js");
+
+      const event = createInternalHookEvent("message", "received", "agent:main:test", {
+        text: "Hello world",
+        channel: "telegram",
+        chatType: "dm",
+        from: "telegram:12345",
+        senderId: "12345",
+        senderName: "Test User",
+      });
+
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const fired = handler.mock.calls[0][0] as InternalHookEvent;
+      expect(fired.type).toBe("message");
+      expect(fired.action).toBe("received");
+      expect(fired.sessionKey).toBe("agent:main:test");
+      expect(fired.context.text).toBe("Hello world");
+      expect(fired.context.channel).toBe("telegram");
+      expect(fired.context.senderId).toBe("12345");
+    });
+
+    it("triggers both general message and specific message:received handlers", async () => {
+      const generalHandler = vi.fn();
+      const specificHandler = vi.fn();
+      registerInternalHook("message", generalHandler);
+      registerInternalHook("message:received", specificHandler);
+
+      const { createInternalHookEvent, triggerInternalHook } = await import("./internal-hooks.js");
+
+      const event = createInternalHookEvent("message", "received", "test-session", {
+        text: "Test",
+      });
+
+      await triggerInternalHook(event);
+
+      expect(generalHandler).toHaveBeenCalledTimes(1);
+      expect(specificHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("message:sent", () => {
+    it("triggers handler registered for message:sent", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:sent", handler);
+
+      const { createInternalHookEvent, triggerInternalHook } = await import("./internal-hooks.js");
+
+      const event = createInternalHookEvent("message", "sent", "agent:main:test", {
+        text: "Hello back!",
+        channel: "telegram",
+        chatType: "dm",
+        kind: "final",
+      });
+
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const fired = handler.mock.calls[0][0] as InternalHookEvent;
+      expect(fired.type).toBe("message");
+      expect(fired.action).toBe("sent");
+      expect(fired.context.text).toBe("Hello back!");
+      expect(fired.context.kind).toBe("final");
+    });
+
+    it("includes media fields when present", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:sent", handler);
+
+      const { createInternalHookEvent, triggerInternalHook } = await import("./internal-hooks.js");
+
+      const event = createInternalHookEvent("message", "sent", "test-session", {
+        text: "Check this out",
+        mediaUrl: "/tmp/image.png",
+        kind: "final",
+      });
+
+      await triggerInternalHook(event);
+
+      const fired = handler.mock.calls[0][0] as InternalHookEvent;
+      expect(fired.context.mediaUrl).toBe("/tmp/image.png");
+    });
+  });
+
+  describe("error isolation", () => {
+    it("does not throw when a handler errors", async () => {
+      registerInternalHook("message:received", () => {
+        throw new Error("handler boom");
+      });
+
+      const { createInternalHookEvent, triggerInternalHook } = await import("./internal-hooks.js");
+
+      const event = createInternalHookEvent("message", "received", "test", { text: "hi" });
+
+      // Should not throw — errors are caught internally
+      await expect(triggerInternalHook(event)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("message type is valid InternalHookEventType", () => {
+    it("accepts 'message' as a valid event type", async () => {
+      const { createInternalHookEvent } = await import("./internal-hooks.js");
+      const event = createInternalHookEvent("message", "received", "s", {});
+      expect(event.type).toBe("message");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `message:received` and `message:sent` internal hook events documented as "Future Events" in the hooks documentation. These events enable extensions to observe the complete message lifecycle for logging, analytics, memory systems, conversation archival, and search indexing.

## Changes

### New Events

**`message:received`** — Triggered when an inbound message is processed
- Context: `text`, `channel`, `chatType`, `from`, `to`, `senderId`, `senderName`, `senderUsername`, `messageId`, `threadId`, `timestamp`, `accountId`, `mediaUrls`, `mediaTypes`
- Triggered in `dispatchReplyFromConfig()` after duplicate check

**`message:sent`** — Triggered after an outbound message is successfully delivered
- Context: `text`, `channel`, `chatType`, `kind` (tool/block/final), `mediaUrl`, `mediaUrls`
- Triggered in the reply dispatcher after successful delivery

### Implementation

1. Added `"message"` to `InternalHookEventType` (`src/hooks/internal-hooks.ts`)
2. Trigger `message:received` in `dispatchReplyFromConfig()` for inbound messages (`src/auto-reply/reply/dispatch-from-config.ts`)
3. Trigger `message:sent` in the reply dispatcher after delivery success (`src/auto-reply/reply/reply-dispatcher.ts`)
4. Added `sessionKey`, `channel`, `chatType` to `ReplyDispatcherOptions` for hook context (`src/auto-reply/reply/reply-dispatcher.ts`)
5. Inject session context into dispatcher options in both dispatchers (`src/auto-reply/dispatch.ts`)
6. Updated docs to move these events from "Future Events" to documented (`docs/automation/hooks.md`)

### Tests

6 test cases in `src/hooks/message-hooks.test.ts`:
- Event triggering for `message:received` and `message:sent`
- General (`message`) and specific (`message:received`) handler routing
- Media field inclusion
- Error isolation (handler errors do not propagate)
- Type validation

## Use Cases

- **Conversation logging** — persist all messages to a database for analytics or fine-tuning
- **Memory systems** — feed messages into RAG/retrieval pipelines
- **Archival & search** — index conversations for full-text search
- **Output validation** — inspect outbound messages before/after delivery

## Prior Work

This PR combines approaches from the community PRs below. It takes the minimal footprint of #6384, adds tests inspired by #6797, and includes the docs update from #9859.

- #6384 by @heybeaux
- #6797 by @NOVA-Openclaw  
- #9859 by @Drickon

## Related Issues

Resolves #12775, #8807, #13004
Related: #5354, #12867, #12914

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds new internal hook event type `message` and emits two lifecycle events: `message:received` from the inbound message dispatcher and `message:sent` after successful outbound delivery. It also threads session/channel/chatType context into the auto-reply dispatch path and updates hooks documentation accordingly, with a small Vitest suite to validate handler routing and error isolation.

One issue to address before merge: `message:sent` is emitted inside `createReplyDispatcher()` for *all* dispatchers, but the hook context relies on optional `ReplyDispatcherOptions` fields (`sessionKey`, `channel`, `chatType`). Some existing call sites (e.g. gateway webchat) construct a dispatcher without these fields, so emitted events can have an empty `sessionKey` and undefined channel/chatType, which makes the new event unreliable for consumers and inconsistent with the documentation.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but needs a fix to ensure message hook events have consistent context across all dispatcher call sites.
- The core implementation and tests look sound, but `message:sent` is emitted from a shared dispatcher that is also used in paths that don't supply the new optional context fields, leading to incomplete hook events (empty sessionKey / undefined channel/chatType) in real usage.
- src/auto-reply/reply/reply-dispatcher.ts (hook emission relies on optional context); src/gateway/server-methods/chat.ts (dispatcher constructed without new context fields)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->