### PR TITLE
fix(security): harden browser API auth, token comparisons, and hook tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,10 @@
 - Environment variables: see `~/.profile`.
 - Never commit or publish real phone numbers, videos, or live configuration values. Use obviously fake placeholders in docs, tests, and examples.
 - Release flow: always read `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md` before any release work; do not ask routine questions once those docs answer them.
+- **Token comparison**: always use `safeEqual()` from `src/security/safe-equal.ts` for secret/token comparisons. Never use `===`/`!==` for tokens — it leaks timing information. The shared utility uses Node's `timingSafeEqual` under the hood.
+- **Browser control API auth**: the browser control server (`src/browser/server.ts`) requires Bearer token auth by default. Config: `browser.auth.enabled` (default: `true`), `browser.auth.token` (auto-generated if omitted). When writing tests that use `startBrowserControlServerFromConfig()`, add `auth: { enabled: false }` to the mock browser config.
+- **Hook token security**: hook auth tokens should be passed via `Authorization: Bearer <token>` or `X-OpenClaw-Token` header, not query strings. Config: `hooks.allowQueryToken` (default: `true`, deprecated — will change to `false`).
+- **DNS rebinding protection**: the browser control server validates `Host` headers, rejecting non-loopback hosts. When adding new localhost HTTP servers, apply the same Host header validation pattern.
 
 ## Troubleshooting
 

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -63,6 +63,7 @@ function buildSandboxBrowserResolvedConfig(params: {
     noSandbox: false,
     attachOnly: true,
     defaultProfile: DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
+    auth: { enabled: false, token: null },
     profiles: {
       [DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]: {
         cdpPort: params.cdpPort,

--- a/src/browser/bridge-server.ts
+++ b/src/browser/bridge-server.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from "node:net";
 import express from "express";
 import type { ResolvedBrowserConfig } from "./config.js";
 import type { BrowserRouteRegistrar } from "./routes/types.js";
+import { safeEqual } from "../security/safe-equal.js";
 import { registerBrowserRoutes } from "./routes/index.js";
 import {
   type BrowserServerState,
@@ -34,7 +35,7 @@ export async function startBrowserBridgeServer(params: {
   if (authToken) {
     app.use((req, res, next) => {
       const auth = String(req.headers.authorization ?? "").trim();
-      if (auth === `Bearer ${authToken}`) {
+      if (safeEqual(auth, `Bearer ${authToken}`)) {
         return next();
       }
       res.status(401).send("Unauthorized");

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import type { BrowserConfig, BrowserProfileConfig, OpenClawConfig } from "../config/config.js";
 import { resolveGatewayPort } from "../config/paths.js";
 import {
@@ -30,6 +31,10 @@ export type ResolvedBrowserConfig = {
   attachOnly: boolean;
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
+  auth: {
+    enabled: boolean;
+    token: string | null;
+  };
 };
 
 export type ResolvedBrowserProfile = {
@@ -208,6 +213,11 @@ export function resolveBrowserConfig(
       ? DEFAULT_BROWSER_DEFAULT_PROFILE_NAME
       : DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME);
 
+  const authEnabled = cfg?.auth?.enabled !== false; // default: true
+  const authToken = authEnabled
+    ? cfg?.auth?.token?.trim() || randomBytes(32).toString("base64url")
+    : null;
+
   return {
     enabled,
     evaluateEnabled,
@@ -224,6 +234,10 @@ export function resolveBrowserConfig(
     attachOnly,
     defaultProfile,
     profiles,
+    auth: {
+      enabled: authEnabled,
+      token: authToken,
+    },
   };
 }
 

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -5,6 +5,7 @@ import { randomBytes } from "node:crypto";
 import { createServer } from "node:http";
 import WebSocket, { WebSocketServer } from "ws";
 import { rawDataToString } from "../infra/ws.js";
+import { safeEqual } from "../security/safe-equal.js";
 
 type CdpCommand = {
   id: number;
@@ -365,7 +366,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
     if (path.startsWith("/json")) {
       const token = getHeader(req, RELAY_AUTH_HEADER);
-      if (!token || token !== relayAuthToken) {
+      if (!token || !safeEqual(token, relayAuthToken)) {
         res.writeHead(401);
         res.end("Unauthorized");
         return;
@@ -511,7 +512,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
     if (pathname === "/cdp") {
       const token = getHeader(req, RELAY_AUTH_HEADER);
-      if (!token || token !== relayAuthToken) {
+      if (!token || !safeEqual(token, relayAuthToken)) {
         rejectUpgrade(socket, 401, "Unauthorized");
         return;
       }

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -96,6 +96,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
         attachOnly: cfgAttachOnly,
         headless: true,
         defaultProfile: "openclaw",
+        auth: { enabled: false },
         profiles: {
           openclaw: { cdpPort: testPort + 1, color: "#FF4500" },
         },

--- a/src/browser/server.agent-contract-snapshot-endpoints.test.ts
+++ b/src/browser/server.agent-contract-snapshot-endpoints.test.ts
@@ -98,6 +98,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
         profiles: {
           openclaw: { cdpPort: testPort + 1, color: "#FF4500" },
         },
+        auth: { enabled: false },
       },
     }),
     writeConfigFile: vi.fn(async () => {}),

--- a/src/browser/server.covers-additional-endpoint-branches.test.ts
+++ b/src/browser/server.covers-additional-endpoint-branches.test.ts
@@ -94,6 +94,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
         attachOnly: cfgAttachOnly,
         headless: true,
         defaultProfile: "openclaw",
+        auth: { enabled: false },
         profiles: {
           openclaw: { cdpPort: testPort + 1, color: "#FF4500" },
         },

--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -94,6 +94,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
         attachOnly: cfgAttachOnly,
         headless: true,
         defaultProfile: "openclaw",
+        auth: { enabled: false },
         profiles: {
           openclaw: { cdpPort: testPort + 1, color: "#FF4500" },
         },

--- a/src/browser/server.serves-status-starts-browser-requested.test.ts
+++ b/src/browser/server.serves-status-starts-browser-requested.test.ts
@@ -94,6 +94,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
         attachOnly: cfgAttachOnly,
         headless: true,
         defaultProfile: "openclaw",
+        auth: { enabled: false },
         profiles: {
           openclaw: { cdpPort: testPort + 1, color: "#FF4500" },
         },

--- a/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
+++ b/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
@@ -94,6 +94,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
         attachOnly: cfgAttachOnly,
         headless: true,
         defaultProfile: "openclaw",
+        auth: { enabled: false },
         profiles: {
           openclaw: { cdpPort: testPort + 1, color: "#FF4500" },
         },

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -38,4 +38,11 @@ export type BrowserConfig = {
   profiles?: Record<string, BrowserProfileConfig>;
   /** Default snapshot options (applied by the browser tool/CLI when unset). */
   snapshotDefaults?: BrowserSnapshotDefaults;
+  /** Browser control API auth. Default: enabled with auto-generated token. */
+  auth?: {
+    /** Enable Bearer token auth on the browser control server. Default: true */
+    enabled?: boolean;
+    /** Static auth token. If omitted, a random token is generated at startup. */
+    token?: string;
+  };
 };

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -114,6 +114,8 @@ export type HooksConfig = {
   enabled?: boolean;
   path?: string;
   token?: string;
+  /** Allow hook auth token in query string. Default: true (deprecated, will change to false). */
+  allowQueryToken?: boolean;
   maxBodyBytes?: number;
   presets?: string[];
   transformsDir?: string;

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from "node:http";
-import { timingSafeEqual } from "node:crypto";
 import type { GatewayAuthConfig, GatewayTailscaleMode } from "../config/config.js";
 import { readTailscaleWhoisIdentity, type TailscaleWhoisIdentity } from "../infra/tailscale.js";
+import { safeEqual } from "../security/safe-equal.js";
 import { isTrustedProxyAddress, parseForwardedForClientIp, resolveGatewayClientIp } from "./net.js";
 export type ResolvedGatewayAuthMode = "token" | "password";
 
@@ -31,13 +31,6 @@ type TailscaleUser = {
 };
 
 type TailscaleWhoisLookup = (ip: string) => Promise<TailscaleWhoisIdentity | null>;
-
-function safeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
-}
 
 function normalizeLogin(login: string): string {
   return login.trim().toLowerCase();

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -12,6 +12,7 @@ const DEFAULT_HOOKS_MAX_BODY_BYTES = 256 * 1024;
 export type HooksConfigResolved = {
   basePath: string;
   token: string;
+  allowQueryToken: boolean;
   maxBodyBytes: number;
   mappings: HookMappingResolved[];
 };
@@ -30,6 +31,7 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
   if (trimmed === "/") {
     throw new Error("hooks.path may not be '/'");
   }
+  const allowQueryToken = cfg.hooks?.allowQueryToken !== false; // default: true (backward compat)
   const maxBodyBytes =
     cfg.hooks?.maxBodyBytes && cfg.hooks.maxBodyBytes > 0
       ? cfg.hooks.maxBodyBytes
@@ -38,6 +40,7 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
   return {
     basePath: trimmed,
     token,
+    allowQueryToken,
     maxBodyBytes,
     mappings,
   };

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
+import { safeEqual } from "../security/safe-equal.js";
 
 export type DevicePairingPendingRequest = {
   requestId: string;
@@ -431,7 +432,7 @@ export async function verifyDeviceToken(params: {
     if (entry.revokedAtMs) {
       return { ok: false, reason: "token-revoked" };
     }
-    if (entry.token !== params.token) {
+    if (!safeEqual(entry.token, params.token)) {
       return { ok: false, reason: "token-mismatch" };
     }
     const requestedScopes = normalizeScopes(params.scopes);

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
+import { safeEqual } from "../security/safe-equal.js";
 
 export type NodePairingPendingRequest = {
   requestId: string;
@@ -274,7 +275,7 @@ export async function verifyNodeToken(
   if (!node) {
     return { ok: false };
   }
-  return node.token === token ? { ok: true, node } : { ok: false };
+  return safeEqual(node.token, token) ? { ok: true, node } : { ok: false };
 }
 
 export async function updatePairedNodeMetadata(

--- a/src/security/safe-equal.test.ts
+++ b/src/security/safe-equal.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { safeEqual } from "./safe-equal.js";
+
+describe("safeEqual", () => {
+  it("returns true for identical strings", () => {
+    expect(safeEqual("abc", "abc")).toBe(true);
+  });
+
+  it("returns false for different strings of same length", () => {
+    expect(safeEqual("abc", "def")).toBe(false);
+  });
+
+  it("returns false for different lengths", () => {
+    expect(safeEqual("abc", "abcd")).toBe(false);
+  });
+
+  it("returns true for empty strings", () => {
+    expect(safeEqual("", "")).toBe(true);
+  });
+
+  it("handles UUID-style tokens", () => {
+    const token = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4";
+    expect(safeEqual(token, token)).toBe(true);
+    expect(safeEqual(token, "x1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4")).toBe(false);
+  });
+});

--- a/src/security/safe-equal.ts
+++ b/src/security/safe-equal.ts
@@ -1,0 +1,15 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Constant-time string comparison for secret tokens.
+ *
+ * Note: the early return on length mismatch leaks length information.
+ * This is acceptable for fixed-length tokens (e.g. 32-char hex UUIDs)
+ * but callers should be aware of this tradeoff for variable-length secrets.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}


### PR DESCRIPTION
## Summary

- **Extract `safeEqual()` to shared utility** (`src/security/safe-equal.ts`) for constant-time string comparison, replacing the local copy in `gateway/auth.ts`
- **Fix 7 timing-unsafe token comparisons** across gateway hooks, device/node pairing, bridge server, and extension relay using the shared `safeEqual`
- **Add Bearer token auth + Host header validation to browser control API** — secure by default with auto-generated token; opt-out via `browser.auth.enabled: false`
- **Add `hooks.allowQueryToken` config flag** to control query-string token acceptance (default `true` for backward compat, with `Deprecation` header and migration path to `false`)
- **Add security guardrails to AGENTS.md** — document safeEqual usage, browser auth config, hook token security, and DNS rebinding protection patterns

Based on a Codex CLI security audit that identified three categories of vulnerability:
1. Unauthenticated browser control API with ~30+ mutation endpoints (Medium)
2. Hook auth token accepted via query string leaking in logs/referrers (Medium)
3. Non-constant-time token comparisons in 7 locations (Low)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (type-check + lint + format)
- [x] All 169 browser tests pass (28 test files)
- [x] All hooks tests pass (5/5)
- [x] All device/node pairing tests pass
- [x] New `safeEqual` unit tests pass (5/5)
- [x] Existing browser test mocks updated with `auth: { enabled: false }`
- [x] AGENTS.md guardrails added for future contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR strengthens several auth-related surfaces:

- Introduces a shared `safeEqual()` helper for timing-safe string comparisons and replaces direct `===` token checks across gateway hooks, pairing flows, browser bridge/relay, and gateway auth.
- Secures the browser control API by default with Bearer token auth (auto-generated token unless configured) and adds Host header validation to reduce DNS rebinding exposure.
- Adds `hooks.allowQueryToken` to control whether hook tokens are accepted via query string, with deprecation messaging to encourage moving to header-based auth.

Overall, the changes align with existing gateway auth patterns and tighten local control surfaces, but there is a correctness bug in the new browser Host validation (see comment).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but has a loopback Host validation bug that can break legitimate IPv6 local access to the browser control API.
- Most changes are localized and add security hardening with minimal behavioral impact, but the new Host header allowlist in the browser server will incorrectly reject standard bracketed IPv6 hosts with ports (e.g. `[::1]:<port>`), which can cause 403s for valid requests until fixed.
- src/browser/server.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->