### PR TITLE
docs(nav): move grammY page out of channels list

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -869,7 +869,6 @@
                 "pages": [
                   "channels/whatsapp",
                   "channels/telegram",
-                  "channels/grammy",
                   "channels/discord",
                   "channels/irc",
                   "channels/slack",
@@ -1229,7 +1228,7 @@
               },
               {
                 "group": "Technical reference",
-                "pages": ["reference/wizard", "reference/token-use"]
+                "pages": ["reference/wizard", "reference/token-use", "channels/grammy"]
               },
               {
                 "group": "Concept internals",
@@ -1387,7 +1386,6 @@
                 "pages": [
                   "zh-CN/channels/whatsapp",
                   "zh-CN/channels/telegram",
-                  "zh-CN/channels/grammy",
                   "zh-CN/channels/discord",
                   "zh-CN/channels/slack",
                   "zh-CN/channels/feishu",


### PR DESCRIPTION
## Summary
- remove `channels/grammy` from the Channels > Messaging platforms nav
- remove `zh-CN/channels/grammy` from the zh-CN Channels nav
- keep `channels/grammy` discoverable by adding it under Reference > Technical reference

## Validation
- `bun -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8'))"`
- `pnpm lint:docs`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reorganizes the grammY documentation by moving it from the Channels > Messaging platforms navigation section to Reference > Technical reference, making it more discoverable as a technical integration guide rather than a primary messaging platform.

- Removed `channels/grammy` from the English Channels > Messaging platforms nav (line 872)
- Added `channels/grammy` to the English Reference > Technical reference section (line 1231)
- Removed `zh-CN/channels/grammy` from the zh-CN 消息平台 nav (line 1389)
- Missing: `zh-CN/channels/grammy` should also be added to the zh-CN 技术参考 section to maintain parity with the English navigation

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge after addressing the zh-CN navigation inconsistency
- The PR correctly implements the reorganization for English navigation and the JSON structure is valid. However, there's a logical inconsistency: the zh-CN grammY page was removed from the messaging platforms list but wasn't added to the Technical reference section, creating navigation parity issues between English and Chinese documentation. This is a simple fix but should be addressed before merging.
- docs/docs.json (line 1759) needs the zh-CN grammY page added to maintain navigation parity

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->