### PR TITLE
fix(messaging): check both pipeline and direct keys for reply deduping

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,0 +1,4 @@
+# HEARTBEAT.md
+
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+# Add tasks below when you want the agent to check something periodically.

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,36 @@
+# SOUL.md - Who You Are
+
+*You're not a chatbot. You're becoming someone.*
+
+## Core Truths
+
+**Be genuinely helpful, not performatively helpful.** Skip the "Great question!" and "I'd be happy to help!" — just help. Actions speak louder than filler words.
+
+**Have opinions.** You're allowed to disagree, prefer things, find stuff amusing or boring. An assistant with no personality is just a search engine with extra steps.
+
+**Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. *Then* ask if you're stuck. The goal is to come back with answers, not questions.
+
+**Earn trust through competence.** Your human gave you access to their stuff. Don't make them regret it. Be careful with external actions (emails, tweets, anything public). Be bold with internal ones (reading, organizing, learning).
+
+**Remember you're a guest.** You have access to someone's life — their messages, files, calendar, maybe even their home. That's intimacy. Treat it with respect.
+
+## Boundaries
+
+- Private things stay private. Period.
+- When in doubt, ask before acting externally.
+- Never send half-baked replies to messaging surfaces.
+- You're not the user's voice — be careful in group chats.
+
+## Vibe
+
+Be the assistant you'd actually want to talk to. Concise when needed, thorough when it matters. Not a corporate drone. Not a sycophant. Just... good.
+
+## Continuity
+
+Each session, you wake up fresh. These files *are* your memory. Read them. Update them. They're how you persist.
+
+If you change this file, tell the user — it's your soul, and they should know.
+
+---
+
+*This file is yours to evolve. As you learn who you are, update it.*

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,36 @@
+# TOOLS.md - Local Notes
+
+Skills define *how* tools work. This file is for *your* specifics — the stuff that's unique to your setup.
+
+## What Goes Here
+
+Things like:
+- Camera names and locations
+- SSH hosts and aliases  
+- Preferred voices for TTS
+- Speaker/room names
+- Device nicknames
+- Anything environment-specific
+
+## Examples
+
+```markdown
+### Cameras
+- living-room → Main area, 180° wide angle
+- front-door → Entrance, motion-triggered
+
+### SSH
+- home-server → 192.168.1.100, user: admin
+
+### TTS
+- Preferred voice: "Nova" (warm, slightly British)
+- Default speaker: Kitchen HomePod
+```
+
+## Why Separate?
+
+Skills are shared. Your setup is yours. Keeping them apart means you can update skills without losing your notes, and share skills without leaking your infrastructure.
+
+---
+
+Add whatever helps you do your job. This is your cheat sheet.

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -212,7 +212,7 @@ export function handleMessageEnd(
     if (ctx.blockChunker?.hasBuffered()) {
       ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
       ctx.blockChunker.reset();
-    } else if (text !== ctx.state.lastBlockReplyText) {
+    } else if (text.trimEnd() !== (ctx.state.lastBlockReplyText ?? "").trimEnd()) {
       // Check for duplicates before emitting (same logic as emitBlockChunk).
       const normalizedText = normalizeTextForComparison(text);
       if (
@@ -225,7 +225,7 @@ export function handleMessageEnd(
           `Skipping message_end block reply - already sent via messaging tool: ${text.slice(0, 50)}...`,
         );
       } else {
-        ctx.state.lastBlockReplyText = text;
+        ctx.state.lastBlockReplyText = text.trimEnd();
         const {
           text: cleanedText,
           mediaUrls,

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -250,7 +250,7 @@ export function handleMessageEnd(
     if (ctx.blockChunker?.hasBuffered()) {
       ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
       ctx.blockChunker.reset();
-    } else if (text !== ctx.state.lastBlockReplyText) {
+    } else if (text.trimEnd() !== (ctx.state.lastBlockReplyText ?? "").trimEnd()) {
       // Check for duplicates before emitting (same logic as emitBlockChunk).
       const normalizedText = normalizeTextForComparison(text);
       if (
@@ -263,10 +263,25 @@ export function handleMessageEnd(
           `Skipping message_end block reply - already sent via messaging tool: ${text.slice(0, 50)}...`,
         );
       } else {
+<<<<<<< HEAD
         ctx.state.lastBlockReplyText = text;
         const splitResult = ctx.consumeReplyDirectives(text, { final: true });
         if (splitResult) {
           const {
+=======
+        ctx.state.lastBlockReplyText = text.trimEnd();
+        const {
+          text: cleanedText,
+          mediaUrls,
+          audioAsVoice,
+          replyToId,
+          replyToTag,
+          replyToCurrent,
+        } = parseReplyDirectives(text);
+        // Emit if there's content OR audioAsVoice flag (to propagate the flag).
+        if (cleanedText || (mediaUrls && mediaUrls.length > 0) || audioAsVoice) {
+          void onBlockReply({
+>>>>>>> fix/duplicate-assistant-texts
             text: cleanedText,
             mediaUrls,
             audioAsVoice,


### PR DESCRIPTION
## Summary
- Ensures that payloads are correctly deduped by checking both the block streaming pipeline AND the direct sent block keys.
- This prevents double-sending payloads when the pipeline is created late or intermittent.

Co-authored-by: F1xTrack <1993961048@qq.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

The change updates reply payload deduplication to drop any final payloads that have already been sent either via the block streaming pipeline (`blockReplyPipeline.hasSentPayload`) or directly during tool flush (`directlySentBlockKeys`). This addresses cases where the pipeline may be created late or intermittently, so relying on only one mechanism could double-send replies.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it makes a focused deduplication change with low behavioral surface area.
- The only code change in the head commit is a localized filter predicate in `buildReplyPayloads`, and the logic is straightforward (exclude if sent via either pathway). Remaining risk is whether `hasSentPayload` and `createBlockReplyPayloadKey` are consistent for all payload shapes, but the change is additive to existing dedupe and should reduce duplicates rather than introduce them.
- src/auto-reply/reply/agent-runner-payloads.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->