### PR TITLE
feat(telegram): add member-info action to get chat administrators

### DIFF
--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -60,6 +60,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       actions.add("sticker");
       actions.add("sticker-search");
     }
+    if (gate("memberInfo", false)) {
+      actions.add("member-info");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -193,6 +196,21 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "searchSticker",
           query,
           limit: limit ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "member-info") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringOrNumberParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      return await handleTelegramAction(
+        {
+          action: "memberInfo",
+          chatId,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -18,6 +18,8 @@ export type TelegramActionConfig = {
   editMessage?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
+  /** Enable member-info action to retrieve chat administrators. */
+  memberInfo?: boolean;
 };
 
 export type TelegramNetworkConfig = {


### PR DESCRIPTION
## Summary
Add support for `member-info` action in Telegram plugin to retrieve chat administrators.

## Changes
- Add `getChatMembersTelegram()` function in `src/telegram/send.ts` using Telegram Bot API `getChatAdministrators`
- Add `memberInfo` action handler in `src/agents/tools/telegram-actions.ts`
- Register `member-info` action in `src/channels/plugins/actions/telegram.ts`
- Add `memberInfo` option to `TelegramActionConfig` type in `src/config/types.telegram.ts`

## Usage
Enable in config:
```yaml
channels:
  telegram:
    actions:
      memberInfo: true
```

Call via message tool:
```
message(action='member-info', channel='telegram', chatId='-1003707749614')
```

## Returns
```json
{
  "ok": true,
  "chatId": "-1003707749614",
  "members": [
    {
      "id": 123456789,
      "username": "admin_user",
      "firstName": "Admin",
      "lastName": "User",
      "isBot": false,
      "status": "administrator"
    }
  ]
}
```

## Notes
- Telegram Bot API only provides `getChatAdministrators` (admins with elevated privileges), not a full member list
- Full member enumeration requires Telegram User API (MTProto), which is outside bot scope
- For most tagging use cases, administrators list is sufficient

## Testing
- TypeScript compiles without errors
- Existing Telegram action tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a `member-info` action to the Telegram plugin that calls `getChatAdministrators` via the Telegram Bot API and returns a list of admin members. The implementation follows the existing action pattern (config gate, action handler, send function) across four files.

- **Bug**: The action gate default in `handleTelegramAction` (`isActionEnabled("memberInfo")` → defaults to `true`) is inconsistent with `listActions` (`gate("memberInfo", false)` → defaults to `false`). Should pass `false` to match the `sticker` pattern and ensure the action is opt-in.
- The `getChatMembersTelegram` function in `send.ts` correctly reuses the existing retry/error-logging infrastructure.

<h3>Confidence Score: 3/5</h3>

- Low-risk feature addition with one action-gate inconsistency that should be fixed before merge.
- The PR follows existing patterns well and the new functionality is straightforward, but the mismatched default value for the memberInfo action gate means the handler could be invoked even when the feature isn't explicitly enabled in config, bypassing the intended opt-in behavior.
- `src/agents/tools/telegram-actions.ts` — action gate default mismatch

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->