### PR TITLE
fix(matrix): pass asVoice to audioAsVoice for native voice messages

### DIFF
--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -21,7 +21,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId }) => {
+  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId, asVoice }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
@@ -29,6 +29,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       replyToId: replyToId ?? undefined,
       threadId: resolvedThreadId,
+      audioAsVoice: asVoice,
     });
     return {
       channel: "matrix",


### PR DESCRIPTION
## Description

Fixes voice messages being sent as audio file attachments instead of native voice message bubbles in Matrix clients.

## Root Cause

The `sendMedia` adapter in `outbound.ts` was not passing the `asVoice` parameter to `sendMessageMatrix`, preventing the `org.matrix.msc3245.voice` flag from being set in the message content.

## Changes

- Added `asVoice` extraction from sendMedia parameters
- Passed `audioAsVoice: asVoice` to the send function

## Testing

1. Configure TTS with ElevenLabs and `auto: inbound`
2. Send a voice message or use `message` tool with `asVoice: true`
3. Voice messages should now display as native voice bubbles in Element/FluffyChat

## Related Issues

- Fixes #14226
- Related to #11654 (similar issue for Telegram)

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Single file change
- [x] No breaking changes

---

**Disclaimer:** This pull request was created by an AI assistant (Neo/Kimi) on behalf of a human user. The code changes were authored by AI based on human direction.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes the Matrix outbound adapter to forward the `asVoice` parameter as `audioAsVoice` to `sendMessageMatrix`, enabling native voice message bubbles (via `org.matrix.msc3245.voice`) instead of plain audio file attachments.

- Extracted `asVoice` from `sendMedia` destructured params and passed it as `audioAsVoice: asVoice` to the send function
- The inbound reply path (`deliverMatrixReplies` in `replies.ts`) already passed `audioAsVoice` correctly; this fix addresses the outbound adapter path used by the generic delivery pipeline and message tool
- Note: `ChannelOutboundContext` type does not include `asVoice`, so the value is only available at runtime when callers pass extra properties — this is a pre-existing type gap shared with other channels

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — minimal, well-scoped bug fix with no behavioral risk to non-voice code paths.
- Single-file, two-line change that correctly wires up an existing parameter (`audioAsVoice`) that was already supported by `sendMessageMatrix`. The `asVoice` value defaults to `undefined` when not provided, preserving backward compatibility. The only minor concern is that `ChannelOutboundContext` doesn't include `asVoice` in its type definition, but this is a pre-existing gap and doesn't affect runtime correctness.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->