### PR TITLE
fix(cron): re-arm timer when onTimer fires during active job execution

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -212,7 +212,7 @@ describe("Cron issue regressions", () => {
     await store.cleanup();
   });
 
-  it("does not hot-loop zero-delay timers while a run is already in progress", async () => {
+  it("re-arms timer without hot-looping when a run is already in progress", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const store = await makeStorePath();
     const now = Date.parse("2026-02-06T10:05:00.000Z");
@@ -233,8 +233,16 @@ describe("Cron issue regressions", () => {
 
     await onTimer(state);
 
-    expect(timeoutSpy).not.toHaveBeenCalled();
-    expect(state.timer).toBeNull();
+    // The timer should be re-armed (not null) so the scheduler stays alive,
+    // but the delay must be > 0 to avoid a hot-loop.  armTimer() clamps to
+    // MAX_TIMER_DELAY_MS (60s) when the job is past-due, preventing a
+    // zero-delay spin.  See #12025.
+    expect(timeoutSpy).toHaveBeenCalled();
+    expect(state.timer).not.toBeNull();
+    const delays = timeoutSpy.mock.calls
+      .map(([, delay]) => delay)
+      .filter((d): d is number => typeof d === "number");
+    expect(delays.every((d) => d > 0)).toBe(true);
     timeoutSpy.mockRestore();
     await store.cleanup();
   });

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -234,15 +234,14 @@ describe("Cron issue regressions", () => {
     await onTimer(state);
 
     // The timer should be re-armed (not null) so the scheduler stays alive,
-    // but the delay must be > 0 to avoid a hot-loop.  armTimer() clamps to
-    // MAX_TIMER_DELAY_MS (60s) when the job is past-due, preventing a
-    // zero-delay spin.  See #12025.
+    // with a fixed MAX_TIMER_DELAY_MS (60s) delay to avoid a hot-loop when
+    // past-due jobs are waiting.  See #12025.
     expect(timeoutSpy).toHaveBeenCalled();
     expect(state.timer).not.toBeNull();
     const delays = timeoutSpy.mock.calls
       .map(([, delay]) => delay)
       .filter((d): d is number => typeof d === "number");
-    expect(delays.every((d) => d > 0)).toBe(true);
+    expect(delays).toContain(60_000);
     timeoutSpy.mockRestore();
     await store.cleanup();
   });

--- a/src/cron/service.rearm-timer-when-running.test.ts
+++ b/src/cron/service.rearm-timer-when-running.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("CronService - timer re-arm when running (#12025)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-13T00:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-arms the timer when onTimer fires while a job is still running", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    // Simulate a slow isolated job that takes 90 seconds (longer than
+    // MAX_TIMER_DELAY_MS = 60s).  Before the fix, the clamped 60s timer
+    // would fire mid-execution, hit the `state.running` guard, return
+    // without re-arming, and silently kill the scheduler.
+    let resolveSlowJob: (v: { status: string }) => void;
+    const runIsolatedAgentJob = vi.fn(
+      () =>
+        new Promise<{ status: string }>((resolve) => {
+          resolveSlowJob = resolve;
+        }),
+    );
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+
+    // Add a recurring job that runs every 5 minutes.
+    await cron.add({
+      name: "slow recurring job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 5 * 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "do something slow" },
+    });
+
+    // Advance to when the job is due (5 minutes).
+    vi.setSystemTime(new Date("2025-12-13T00:05:00.000Z"));
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    // The job should have started.
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+
+    // Advance 60+ seconds while the job is still running.
+    // This triggers the clamped timer.  Before the fix, this would kill
+    // the scheduler.
+    vi.setSystemTime(new Date("2025-12-13T00:06:01.000Z"));
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    // Now complete the slow job.
+    resolveSlowJob!({ status: "ok" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The scheduler should still be alive.  Advance to the next occurrence
+    // (10 minutes from start) and verify the job fires again.
+    vi.setSystemTime(new Date("2025-12-13T00:10:00.000Z"));
+    await vi.advanceTimersByTimeAsync(4 * 60_000);
+
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service.rearm-timer-when-running.test.ts
+++ b/src/cron/service.rearm-timer-when-running.test.ts
@@ -88,9 +88,14 @@ describe("CronService - timer re-arm when running (#12025)", () => {
     // silently killing the scheduler.
     await onTimer(state);
 
-    // The timer must be re-armed so the scheduler continues ticking.
+    // The timer must be re-armed so the scheduler continues ticking,
+    // with a fixed 60s delay to avoid hot-looping.
     expect(state.timer).not.toBeNull();
     expect(timeoutSpy).toHaveBeenCalled();
+    const delays = timeoutSpy.mock.calls
+      .map(([, delay]) => delay)
+      .filter((d): d is number => typeof d === "number");
+    expect(delays).toContain(60_000);
 
     // state.running should still be true (onTimer bailed out, didn't
     // touch it — the original caller's finally block handles that).

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -168,7 +168,9 @@ export async function onTimer(state: CronServiceState) {
     // zero-delay hot-loop when past-due jobs are waiting for the current
     // execution to finish.
     // See: https://github.com/openclaw/openclaw/issues/12025
-    if (state.timer) clearTimeout(state.timer);
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
     state.timer = setTimeout(async () => {
       try {
         await onTimer(state);


### PR DESCRIPTION
## Problem

Recurring cron jobs (`kind: "cron"` and `kind: "every"`) silently stop firing after the first execution, while one-shot (`kind: "at"`) jobs work fine. Reported in #12025.

## Root Cause

In `src/cron/service/timer.ts`, `armTimer()` clamps the setTimeout delay to `MAX_TIMER_DELAY_MS` (60 seconds) to avoid schedule drift. When a job execution takes longer than 60 seconds (common for `agentTurn` jobs that run LLM calls), the clamped timer fires while `state.running` is still `true`.

The `onTimer()` function has a guard at the top:

```typescript
if (state.running) {
    return; // ← exits without re-arming the timer!
}
```

Since `armTimer()` clears the previous timer at entry (`clearTimeout`), and the early return skips the `finally { armTimer(state) }` block, **no new timer is ever set**. The scheduler goes silent permanently until the gateway restarts.

## Fix

Call `armTimer(state)` before the early return so the scheduler continues ticking:

```typescript
if (state.running) {
    armTimer(state);
    return;
}
```

This is safe because `armTimer()` always clears the existing timer before setting a new one, preventing duplicates.

## Why one-shot jobs were unaffected

One-shot `kind: "at"` jobs are typically `systemEvent` payloads that execute near-instantly (just enqueue text), completing well within the 60-second timer clamp. `agentTurn` jobs on recurring schedules are the ones that exceed the clamp and trigger this bug.

## Testing

Added `service.rearm-timer-when-running.test.ts` that:
1. Creates a recurring `every` job
2. Simulates a slow execution exceeding `MAX_TIMER_DELAY_MS`  
3. Verifies the job fires again on its next scheduled occurrence

## Environment

Reproduced across OpenClaw v2026.2.3-1, v2026.2.6-3, and v2026.2.9 on macOS arm64.

Closes #12025

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes recurring cron jobs (`kind: "every"` and `kind: "cron"`) silently stopping after the first execution when job duration exceeds the 60-second `MAX_TIMER_DELAY_MS` clamp. The root cause was the `onTimer()` early return when `state.running` is `true` — it exited without re-arming the timer, permanently killing the scheduler. The fix adds an `armTimer(state)` call before the early return, which is safe since `armTimer()` always clears the existing timer first.

- Added `armTimer(state)` call before the `state.running` early return in `onTimer()` to keep the scheduler alive during long-running job executions
- Added regression test that simulates a slow isolated agent job exceeding `MAX_TIMER_DELAY_MS` and verifies the scheduler continues to fire on subsequent occurrences

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-understood one-line fix with a comprehensive regression test.
- The fix is a single `armTimer(state)` call added to an early-return code path. `armTimer()` is idempotent (always clears the previous timer before setting a new one), so this cannot introduce duplicate timers. The change is backed by clear root cause analysis and a focused regression test. The existing `finally` block already calls `armTimer(state)` on the normal path, so this just brings the early-return path to parity.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->