### PR TITLE
Whitewookie32 patch 1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  deploy:
+    name: Deploy nanobot
+    runs-on: ubuntu-latest
+    # Only deploy on push to main, not PRs
+    if: github.event_name == 'push'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+        
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy nanobot
+    name: Deploy oppenclaw-padilla
     runs-on: ubuntu-latest
     # Only deploy on push to main, not PRs
     if: github.event_name == 'push'

--- a/fly.toml
+++ b/fly.toml
@@ -1,23 +1,30 @@
-# fly.toml app configuration file generated for openclaw-gsalzq on 2026-02-11T17:59:58Z
-#
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
-
 app = "openclaw-npadilla"
-primary_region = "iad" # change to your closest region
+primary_region = "iad"
 
 [build]
+dockerfile = "Dockerfile"
+
+[env]
+NODE_ENV = "production"
+NODE_OPTIONS = "--max-old-space-size=1536"
+OPENCLAW_PREFER_PNPM = "1"
+OPENCLAW_STATE_DIR = "/data"
 
 [http_service]
-  internal_port = 8080
-  force_https = true
-  auto_stop_machines = 'stop'
-  auto_start_machines = true
-  min_machines_running = 0
-  processes = ['app']
+auto_start_machines = true
+auto_stop_machines = false
+force_https = true
+internal_port = 3000
+min_machines_running = 1
+processes = [ "app" ]
+
+[[mounts]]
+destination = "/data"
+source = "openclaw_data"
+
+[processes]
+app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind 0.0.0.0"
 
 [[vm]]
-  memory = '1gb'
-  cpu_kind = 'shared'
-  cpus = 1
-  memory_mb = 256
+memory = "2048mb"
+size = "shared-cpu-2x"

--- a/fly.toml
+++ b/fly.toml
@@ -1,34 +1,23 @@
-# OpenClaw Fly.io deployment configuration
-# See https://fly.io/docs/reference/configuration/
+# fly.toml app configuration file generated for openclaw-gsalzq on 2026-02-11T17:59:58Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
-app = "openclaw"
-primary_region = "iad" # change to your closest region
+app = 'openclaw-gsalzq'
+primary_region = 'iad'
 
 [build]
-dockerfile = "Dockerfile"
-
-[env]
-NODE_ENV = "production"
-# Fly uses x86, but keep this for consistency
-OPENCLAW_PREFER_PNPM = "1"
-OPENCLAW_STATE_DIR = "/data"
-NODE_OPTIONS = "--max-old-space-size=1536"
-
-[processes]
-app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
 
 [http_service]
-internal_port = 3000
-force_https = true
-auto_stop_machines = false # Keep running for persistent connections
-auto_start_machines = true
-min_machines_running = 1
-processes = ["app"]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
 
 [[vm]]
-size = "shared-cpu-2x"
-memory = "2048mb"
-
-[mounts]
-source = "openclaw_data"
-destination = "/data"
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 256

--- a/fly.toml
+++ b/fly.toml
@@ -1,7 +1,7 @@
 # OpenClaw Fly.io deployment configuration
 # See https://fly.io/docs/reference/configuration/
 
-app = "openclaw"
+app = "openclaw-npadilla"
 primary_region = "iad" # change to your closest region
 
 [build]


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a GitHub Actions CI/CD workflow for deploying to Fly.io and modifies the shared `fly.toml` for a personal deployment (`openclaw-npadilla`).

- **Personal config pushed to shared repo**: `fly.toml` app name changed from `openclaw` to `openclaw-npadilla`, which overwrites the shared deployment configuration with a personal one. This should use a separate file or be kept out of the shared config.
- **Typo in workflow**: Job name says "oppenclaw-padilla" instead of "openclaw".
- **CI action pinned to branch**: `superfly/flyctl-actions/setup-flyctl@master` should be pinned to a specific version or commit SHA for supply-chain safety.
- **Bind address changed**: `--bind lan` (documented convention) replaced with raw `--bind 0.0.0.0`.

<h3>Confidence Score: 2/5</h3>

- This PR overwrites shared deployment config with personal settings and has a typo in the CI workflow.
- The `fly.toml` change replaces the shared/generic app name with a personal deployment name, which would break anyone else deploying from this config. The CI workflow has a typo and uses an unpinned action reference. These aren't catastrophic, but the shared config overwrite is a significant concern for a shared repository.
- `fly.toml` needs attention — the app name change from `openclaw` to `openclaw-npadilla` overwrites the shared deployment configuration.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->