### PR TITLE
fix(heartbeat): propagate originating session key for exec event queue lookup

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -392,7 +392,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey });
 }
 
 function createApprovalSlug(id: string) {
@@ -415,7 +415,7 @@ function emitExecSystemEvent(text: string, opts: { sessionKey?: string; contextK
     return;
   }
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 async function runExecProcess(opts: {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -239,7 +239,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event" });
+      requestHeartbeatNow({ reason: "exec-event", sessionKey });
       return;
     }
     default:

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -3,10 +3,14 @@ export type HeartbeatRunResult =
   | { status: "skipped"; reason: string }
   | { status: "failed"; reason: string };
 
-export type HeartbeatWakeHandler = (opts: { reason?: string }) => Promise<HeartbeatRunResult>;
+export type HeartbeatWakeHandler = (opts: {
+  reason?: string;
+  sessionKey?: string;
+}) => Promise<HeartbeatRunResult>;
 
 let handler: HeartbeatWakeHandler | null = null;
 let pendingReason: string | null = null;
+let pendingSessionKey: string | null = null;
 let scheduled = false;
 let running = false;
 let timer: NodeJS.Timeout | null = null;
@@ -32,10 +36,15 @@ function schedule(coalesceMs: number) {
     }
 
     const reason = pendingReason;
+    const sessionKey = pendingSessionKey;
     pendingReason = null;
+    pendingSessionKey = null;
     running = true;
     try {
-      const res = await active({ reason: reason ?? undefined });
+      const res = await active({
+        reason: reason ?? undefined,
+        sessionKey: sessionKey ?? undefined,
+      });
       if (res.status === "skipped" && res.reason === "requests-in-flight") {
         // The main lane is busy; retry soon.
         pendingReason = reason ?? "retry";
@@ -62,8 +71,15 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null) {
   }
 }
 
-export function requestHeartbeatNow(opts?: { reason?: string; coalesceMs?: number }) {
+export function requestHeartbeatNow(opts?: {
+  reason?: string;
+  sessionKey?: string;
+  coalesceMs?: number;
+}) {
   pendingReason = opts?.reason ?? pendingReason ?? "requested";
+  if (opts?.sessionKey) {
+    pendingSessionKey = opts.sessionKey;
+  }
   schedule(opts?.coalesceMs ?? DEFAULT_COALESCE_MS);
 }
 


### PR DESCRIPTION
#### Summary

Fixes #14191. When an exec completes on a channel-specific session (Discord, WhatsApp, Slack, etc.), the heartbeat fires but fails to find the pending exec event because it peeks the main session queue instead of the originating session's queue.

lobster-biscuit

#### Root Cause

`requestHeartbeatNow()` discarded the originating session key. The system event was enqueued under the peer-specific session key (e.g. `agent:main:discord:channel:<id>`), but the heartbeat runner always checked `peekSystemEvents()` with the resolved heartbeat session key (`agent:main:main`).

#### Behavior Changes

- `requestHeartbeatNow()` now accepts an optional `sessionKey` parameter
- The wake handler propagates `sessionKey` through to `runHeartbeatOnce()`
- `runHeartbeatOnce()` uses the originating session key (when provided) for `peekSystemEvents()` instead of the resolved heartbeat session key
- No change to behavior when `sessionKey` is not provided (backward compatible)

#### Codebase and GitHub Search

- Searched all callers of `requestHeartbeatNow` — updated the three that enqueue exec events (`server-node-events.ts`, `bash-tools.exec.ts` x2)
- Confirmed `peekSystemEvents` is keyed per-session in `system-events.ts`
- Verified no other consumers depend on the previous signature shape

#### Tests

- All 67 existing heartbeat tests pass (`pnpm test -- --run src/infra/heartbeat`)
- `pnpm check` (format + typecheck + lint) passes clean

#### Files Changed

| File | Change |
|------|--------|
| `src/infra/heartbeat-wake.ts` | Add `sessionKey` to `HeartbeatWakeHandler` type, `requestHeartbeatNow()`, and propagation through scheduler |
| `src/infra/heartbeat-runner.ts` | Add `eventSessionKey` param to `runHeartbeatOnce()`, use it for `peekSystemEvents()` |
| `src/gateway/server-node-events.ts` | Pass `sessionKey` to `requestHeartbeatNow()` |
| `src/agents/bash-tools.exec.ts` | Pass `sessionKey` to `requestHeartbeatNow()` (2 call sites) |

**Sign-Off**

- Models used: Claude Opus 4
- Submitter effort: medium (traced full event flow across 4 files)
- Agent notes: Root cause was clearly documented in the issue; fix is minimal and backward-compatible

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Propagates the originating session key through the heartbeat wake/run pipeline so that `peekSystemEvents()` checks the correct per-session queue when an exec event completes on a channel-specific session (Discord, WhatsApp, etc.).

- Adds optional `sessionKey` param to `requestHeartbeatNow()`, `HeartbeatWakeHandler`, and `runHeartbeatOnce()` — backward compatible, falls back to the resolved heartbeat session key when not provided.
- All three call sites that enqueue exec events (`server-node-events.ts`, `bash-tools.exec.ts` x2) now pass through `sessionKey`.
- **Bug in retry path**: The coalescing scheduler in `heartbeat-wake.ts` does not restore `pendingSessionKey` on retry (when "requests-in-flight" or error), causing the session key to be lost on the next attempt.

<h3>Confidence Score: 3/5</h3>

- Fix is directionally correct but has a bug in the retry path that can reproduce the original issue under load.
- The core approach is sound and the changes are minimal and backward-compatible. However, the retry branches in heartbeat-wake.ts do not restore pendingSessionKey, meaning the session key is silently dropped whenever the main lane is busy — a likely scenario under real-world load. This undermines the fix for the exact scenario described in the issue.
- `src/infra/heartbeat-wake.ts` — retry branches at lines 48-56 need to restore `pendingSessionKey` alongside `pendingReason`.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->