### PR TITLE
fix: fire session-memory hook on auto-resets + topic-aware memory paths

### DIFF
--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -7,7 +7,7 @@ metadata:
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new"],
+        "events": ["command:new", "session:auto-reset"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -85,7 +85,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
   }
 
   try {
-    log.debug("Hook triggered for /new command");
+    log.debug("Hook triggered", { type: event.type, action: event.action });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;
@@ -142,7 +142,8 @@ const saveSessionToMemory: HookHandler = async (event) => {
       // Topic session: save to memory/topics/topic-{id}/YYYY-MM-DD.md
       const topicDir = path.join(memoryDir, "topics", `topic-${topicId}`);
       await fs.mkdir(topicDir, { recursive: true });
-      memoryFilePath = path.join(topicDir, `${dateStr}.md`);
+      const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "").slice(0, 4);
+      memoryFilePath = path.join(topicDir, `${dateStr}-${timeSlug}.md`);
       log.debug("Topic memory path resolved", {
         topicId,
         path: memoryFilePath.replace(os.homedir(), "~"),

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -67,8 +67,10 @@ async function getRecentSessionContent(
  * Save session context to memory when /new command is triggered
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on 'new' command
-  if (event.type !== "command" || event.action !== "new") {
+  // Trigger on /new command OR automatic session resets (SESSION-001)
+  const isNewCommand = event.type === "command" && event.action === "new";
+  const isAutoReset = event.type === "session" && event.action === "auto-reset";
+  if (!isNewCommand && !isAutoReset) {
     return;
   }
 

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -20,6 +20,16 @@ import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 const log = createSubsystemLogger("hooks/session-memory");
 
 /**
+ * Extract topic/thread ID from session key if present.
+ * Session keys look like: agent:main:telegram:group:-100...:topic:11
+ * or: agent:main:...:thread:123
+ */
+function extractTopicId(sessionKey: string): string | null {
+  const match = sessionKey.match(/:(?:topic|thread):([^:]+)$/);
+  return match ? match[1] : null;
+}
+
+/**
  * Read recent messages from session file for slug generation
  */
 async function getRecentSessionContent(
@@ -113,7 +123,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
         ? hookConfig.messages
         : 15;
 
-    let slug: string | null = null;
     let sessionContent: string | null = null;
 
     if (sessionFile) {
@@ -123,30 +132,41 @@ const saveSessionToMemory: HookHandler = async (event) => {
         length: sessionContent?.length ?? 0,
         messageCount,
       });
+    }
 
-      // Avoid calling the model provider in unit tests, keep hooks fast and deterministic.
+    // Determine save path: topic-specific or slug-based fallback
+    const topicId = extractTopicId(event.sessionKey);
+    let memoryFilePath: string;
+
+    if (topicId) {
+      // Topic session: save to memory/topics/topic-{id}/YYYY-MM-DD.md
+      const topicDir = path.join(memoryDir, "topics", `topic-${topicId}`);
+      await fs.mkdir(topicDir, { recursive: true });
+      memoryFilePath = path.join(topicDir, `${dateStr}.md`);
+      log.debug("Topic memory path resolved", {
+        topicId,
+        path: memoryFilePath.replace(os.homedir(), "~"),
+      });
+    } else {
+      // Non-topic session: generate LLM slug (original behavior)
+      let slug: string | null = null;
       if (sessionContent && cfg && !process.env.VITEST && process.env.NODE_ENV !== "test") {
         log.debug("Calling generateSlugViaLLM...");
-        // Use LLM to generate a descriptive slug
         slug = await generateSlugViaLLM({ sessionContent, cfg });
         log.debug("Generated slug", { slug });
       }
+      if (!slug) {
+        const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
+        slug = timeSlug.slice(0, 4); // HHMM
+        log.debug("Using fallback timestamp slug", { slug });
+      }
+      const filename = `${dateStr}-${slug}.md`;
+      memoryFilePath = path.join(memoryDir, filename);
+      log.debug("Memory file path resolved", {
+        filename,
+        path: memoryFilePath.replace(os.homedir(), "~"),
+      });
     }
-
-    // If no slug, use timestamp
-    if (!slug) {
-      const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
-      slug = timeSlug.slice(0, 4); // HHMM
-      log.debug("Using fallback timestamp slug", { slug });
-    }
-
-    // Create filename with date and slug
-    const filename = `${dateStr}-${slug}.md`;
-    const memoryFilePath = path.join(memoryDir, filename);
-    log.debug("Memory file path resolved", {
-      filename,
-      path: memoryFilePath.replace(os.homedir(), "~"),
-    });
 
     // Format time as HH:MM:SS UTC
     const timeStr = now.toISOString().split("T")[1].split(".")[0];


### PR DESCRIPTION
## Summary

The `session-memory` hook only fires on explicit `/new` commands, **not** on automatic session resets triggered by `evaluateSessionFreshness` (daily at 4 AM or after idle timeout). This means conversations silently lose all context overnight — no memory files are saved, and the bot wakes up with amnesia.

Additionally, for Telegram group topics (forum mode), saved memory files use LLM-generated slugs (`memory/2026-02-11-session-history.md`) that are impossible for the bot to locate later, since semantic search returns stale project files instead of the actual conversation transcripts.

### Changes

**Commit 1 — Fix auto-reset memory loss**
- `session.ts`: Capture `previousSessionEntry` before all reset types (not just explicit resets)
- `get-reply.ts`: Detect auto-resets and emit a new `session:auto-reset` hook event
- `handler.ts`: Accept `session:auto-reset` events in addition to `command:new`
- `HOOK.md`: Declare `session:auto-reset` in event list

**Commit 2 — Topic-aware memory file paths**
- `handler.ts`: When the session key contains a topic/thread ID (e.g., `topic:11`), save to `memory/topics/topic-{id}/YYYY-MM-DD.md` instead of a random slug
- Non-topic sessions (DMs, regular groups) continue using slug-based naming

### Why topic-aware paths matter

Each Telegram forum topic runs as a separate session. With deterministic paths:
- The recursive `walkDir` in the memory system auto-indexes them
- Workspace instructions (`AGENTS.md`) can direct the bot to read `memory/topics/topic-{id}/` on session start
- Conversation history accumulates in date-ordered files per topic

### Testing

| Scenario | Result |
|----------|--------|
| `/new` in topic — memory file created | PASS |
| Idle auto-reset in topic — file saved to `memory/topics/topic-{id}/` | PASS |
| Daily auto-reset in topic — file saved | PASS |
| Bot reads topic memory on new session | PASS |
| Bot recalls correct conversation context | PASS |
| Non-topic sessions still use slug naming | PASS |
| Cross-session memory search still works globally | PASS |

### Related

This issue has been reported by multiple users in community discussions — topic-based sessions losing context after overnight resets, with no way to recover conversation history.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes session memory loss during automatic session resets (daily 4 AM / idle timeout) by emitting a new `session:auto-reset` internal hook event from `get-reply.ts`, and adds topic-aware memory paths (`memory/topics/topic-{id}/`) for Telegram forum sessions so memory files are deterministically locatable.

- `session.ts`: Broadens `previousSessionEntry` capture to include stale-entry auto-resets (not just explicit `/new`), and adds `autoResetTriggered` flag
- `get-reply.ts`: Fires `session:auto-reset` internal hook when auto-reset is detected
- `handler.ts`: Accepts `session:auto-reset` events and routes topic sessions to deterministic paths
- `HOOK.md`: Declares the new `session:auto-reset` event
- **Issue**: Topic memory files use only the date (`YYYY-MM-DD.md`), so multiple resets in the same day will silently overwrite earlier saves — consider adding a time component to avoid data loss
- No tests were added for the new `session:auto-reset` event or topic-aware path logic

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge — addresses a real user-facing bug, but has a data-loss edge case with same-day topic overwrites that should be resolved first.
- The session logic changes (`previousSessionEntry`, `autoResetTriggered`) are well-reasoned and correctly handle the edge cases I checked. The hook plumbing follows existing patterns. However, topic memory files using only the date in the filename means `fs.writeFile` will silently overwrite earlier saves on the same day — this is a correctness issue that could cause unexpected data loss. Additionally, no tests cover the new auto-reset path or topic-aware file routing.
- `src/hooks/bundled/session-memory/handler.ts` — the topic memory file path uses only date, risking overwrites on same-day resets

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->