### PR TITLE
fix: catch EPIPE when writing to stdout after restartLaunchAgent

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -460,5 +460,10 @@ export async function restartLaunchAgent({
   if (res.code !== 0) {
     throw new Error(`launchctl kickstart failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+  try {
+    stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+  } catch {
+    // EPIPE is expected: `launchctl kickstart -k` kills the current process,
+    // so stdout may already be closed by the time we try to write.
+  }
 }


### PR DESCRIPTION
launchctl kickstart -k kills the current process, so by the time the command returns stdout may already be closed. The resulting write EPIPE is harmless but pollutes error logs. Wrap the diagnostic write in a try/catch to suppress it.

Fixes #14234

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Wraps a diagnostic `stdout.write` in `restartLaunchAgent` with try/catch to suppress harmless EPIPE errors that occur when `launchctl kickstart -k` kills the current process before the write completes.

- The fix is correct and well-scoped for `restartLaunchAgent`.
- The sibling function `installLaunchAgent` has the same `kickstart -k` followed by unprotected `stdout.write` calls (lines 444-446) and may be susceptible to the same EPIPE.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds a try/catch around a non-critical diagnostic write.
- The change is minimal, correct, and well-commented. The catch block silences only a harmless EPIPE on a diagnostic message. One point deducted because the same pattern exists in `installLaunchAgent` and isn't addressed.
- `src/daemon/launchd.ts` — `installLaunchAgent` has the same unprotected stdout writes after `kickstart -k` (lines 444-446).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->