### PR TITLE
slack: add DM policy matrix regressions (open/allowlist/pairing/disabled)

### DIFF
--- a/src/slack/monitor.tool-result.forces-thread-replies-replytoid-is-set.test.ts
+++ b/src/slack/monitor.tool-result.forces-thread-replies-replytoid-is-set.test.ts
@@ -21,6 +21,47 @@ beforeEach(() => {
 });
 
 describe("monitorSlackProvider tool results", () => {
+  async function runDmMessageWithPolicy(policy: "open" | "allowlist" | "pairing" | "disabled") {
+    slackTestState.config = {
+      ...slackTestState.config,
+      channels: {
+        ...slackTestState.config.channels,
+        slack: {
+          ...slackTestState.config.channels?.slack,
+          dm: { enabled: true, policy, allowFrom: [] },
+        },
+      },
+    };
+
+    const controller = new AbortController();
+    const run = monitorSlackProvider({
+      botToken: "bot-token",
+      appToken: "app-token",
+      abortSignal: controller.signal,
+    });
+
+    await waitForSlackEvent("message");
+    const handler = getSlackHandlers()?.get("message");
+    if (!handler) {
+      throw new Error("Slack message handler not registered");
+    }
+
+    await handler({
+      event: {
+        type: "message",
+        user: "U1",
+        text: "hello",
+        ts: "200",
+        channel: "D200",
+        channel_type: "im",
+      },
+    });
+
+    await flush();
+    controller.abort();
+    await run;
+  }
+
   it("forces thread replies when replyToId is set", async () => {
     replyMock.mockResolvedValue({ text: "forced reply", replyToId: "555" });
     slackTestState.config = {
@@ -209,5 +250,37 @@ describe("monitorSlackProvider tool results", () => {
     await run;
 
     expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows DM processing in open mode even with an empty allowlist", async () => {
+    replyMock.mockResolvedValue({ text: "ok" });
+    await runDmMessageWithPolicy("open");
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks unauthorized DM in allowlist mode without triggering pairing", async () => {
+    replyMock.mockResolvedValue({ text: "ok" });
+    await runDmMessageWithPolicy("allowlist");
+
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("triggers pairing in pairing mode for unauthorized DM", async () => {
+    replyMock.mockResolvedValue({ text: "ok" });
+    await runDmMessageWithPolicy("pairing");
+
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks DM in disabled mode", async () => {
+    replyMock.mockResolvedValue({ text: "ok" });
+    await runDmMessageWithPolicy("disabled");
+
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem
Fixes #13294. Slack DM policy behavior needs explicit regression coverage to prevent fail-open routing and incorrect pairing behavior across policy modes.

## What Changed
- Added a DM policy matrix helper in Slack monitor tests.
- Added policy-path tests for `open`, `allowlist`, `pairing`, and `disabled`.
- Asserts pairing is only triggered for `pairing` mode and blocked paths do not process replies.

## Validation
- `pnpm vitest run src/slack/monitor.tool-result.forces-thread-replies-replytoid-is-set.test.ts`
  - Passed (8 tests)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds regression test coverage for Slack DM policy matrix behavior across all four modes (`open`, `allowlist`, `pairing`, `disabled`). A shared `runDmMessageWithPolicy` helper consolidates DM event setup with an empty `allowFrom` list, and four new test cases verify that each policy mode produces the correct routing outcome — ensuring `open` processes messages regardless of allowlist, `allowlist` and `disabled` block without triggering pairing, and only `pairing` mode invokes the pairing flow.

- Added `runDmMessageWithPolicy` helper that configures DM policy and fires a simulated DM event
- Added 4 regression tests covering each `DmPolicy` variant with correct assertion boundaries
- All test assertions align with the existing enforcement logic in `prepare.ts`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds test code with no production changes.
- The PR adds only regression tests in a single test file. No production code is modified. The test assertions correctly match the existing DM policy enforcement logic in prepare.ts. The helper function is well-structured and the four policy paths are all covered with appropriate expectations.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->