### PR TITLE
fix: resolve Render deploy timeout by fixing port and bind config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,6 @@ RUN chown -R node:node /app
 USER node
 
 # Start gateway server with default config.
-# Binds to loopback (127.0.0.1) by default for security.
-#
-# For container platforms requiring external health checks:
-#   1. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD env var
-#   2. Override CMD: ["node","openclaw.mjs","gateway","--allow-unconfigured","--bind","lan"]
-CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]
+# Binds to 0.0.0.0 (all interfaces) for container platforms (Render, etc.).
+# OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD should be set for auth.
+CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured", "--bind", "lan"]

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     plan: starter
     healthCheckPath: /health
     envVars:
-      - key: PORT
+      - key: OPENCLAW_GATEWAY_PORT
         value: "8080"
       - key: SETUP_PASSWORD
         sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,8 @@ services:
     plan: starter
     healthCheckPath: /health
     envVars:
+      - key: PORT
+        value: "8080"
       - key: OPENCLAW_GATEWAY_PORT
         value: "8080"
       - key: SETUP_PASSWORD


### PR DESCRIPTION
Two issues prevented Render from detecting the open port:
1. render.yaml set PORT env var, but the app reads OPENCLAW_GATEWAY_PORT
2. Dockerfile defaulted to --bind loopback (127.0.0.1), unreachable by Render's external health checks — now uses --bind lan (0.0.0.0)

https://claude.ai/code/session_01MMWWXLnNcAyQM9D5XaYDH3

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes two Render deployment issues: renames the `PORT` env var in `render.yaml` to `OPENCLAW_GATEWAY_PORT` (which the app actually reads), and changes the Dockerfile default bind from `loopback` (127.0.0.1) to `lan` (0.0.0.0) so Render's external health checks can reach the gateway.

- **`render.yaml`**: `PORT` → `OPENCLAW_GATEWAY_PORT` to match the env var the gateway code reads via `resolveGatewayPort()`.
- **`Dockerfile`**: Default CMD now includes `--bind lan` instead of defaulting to loopback, making the gateway reachable from outside the container.
- **Potential concern**: Render Docker services route traffic to the `PORT` env var (default 10000). Removing the `PORT` key may cause a routing mismatch if Render falls back to its default while the app listens on 8080. Verify that Render correctly routes to the app's actual listen port.

<h3>Confidence Score: 3/5</h3>

- The bind mode change is correct, but the port env var rename may introduce a routing mismatch on Render
- The `--bind lan` change is clearly correct for container deployments. However, removing the `PORT` env var from render.yaml could cause Render to route traffic to its default port (10000) while the app listens on 8080, potentially recreating the health-check timeout issue. The security implications are addressed — `OPENCLAW_GATEWAY_TOKEN` is already configured with `generateValue: true`, satisfying the non-loopback auth requirement.
- `render.yaml` — verify that Render correctly routes traffic to the app's listen port without an explicit `PORT` env var

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->