### PR TITLE
fix(cron): prevent duplicate fires when multiple jobs trigger simultaneously

### DIFF
--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -50,16 +50,18 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
     catch: false,
   });
   // Cron operates at second granularity, so floor nowMs to the start of the
-  // current second.  This prevents the lookback from landing inside a matching
-  // second — if nowMs is e.g. 12:00:00.500 and the pattern fires at second 0,
-  // a 1ms lookback (12:00:00.499) is still *within* that second, causing
-  // croner to skip ahead to the next occurrence (e.g. the following day).
-  // Flooring first ensures the lookback always falls in the *previous* second.
+  // current second.  We ask croner for the next occurrence strictly *after*
+  // nowSecondMs so that a job whose schedule matches the current second is
+  // never re-scheduled into the same (already-elapsed) second.
+  //
+  // Previous code used `nowSecondMs - 1` which caused croner to return the
+  // current second as a valid next-run, leading to rapid duplicate fires when
+  // multiple jobs triggered simultaneously (see #14164).
   const nowSecondMs = Math.floor(nowMs / 1000) * 1000;
-  const next = cron.nextRun(new Date(nowSecondMs - 1));
+  const next = cron.nextRun(new Date(nowSecondMs));
   if (!next) {
     return undefined;
   }
   const nextMs = next.getTime();
-  return Number.isFinite(nextMs) && nextMs >= nowSecondMs ? nextMs : undefined;
+  return Number.isFinite(nextMs) && nextMs > nowSecondMs ? nextMs : undefined;
 }


### PR DESCRIPTION
Fixes #14164

### Root Cause

`computeNextRunAtMs()` in `src/cron/schedule.ts` used `nowSecondMs - 1` as the reference time for croner's `nextRun()`. This caused it to return the **current second** as a valid next-run time.

When a cron job fired at e.g. 11:00:00.500, computing the next run yielded 11:00:00.000 (same second, already elapsed). The scheduler then saw `nextRunAtMs` in the past → immediately re-fired → computed same `nextRunAtMs` again → tight loop of 15-21 duplicate executions until the second boundary passed.

### Fix

Two changes in `computeNextRunAtMs()` (cron-expression branch):

1. **Remove the `-1` lookback**: `cron.nextRun(new Date(nowSecondMs))` instead of `new Date(nowSecondMs - 1)` — ensures croner returns the next occurrence **after** the current second, not the current one.

2. **Strict comparison**: `nextMs > nowSecondMs` instead of `>=` — guarantees the returned time is always strictly in the future.

### Testing

All 9 tests in `schedule.test.ts` pass. Updated 3 tests that previously encoded the buggy "return current second" behavior.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a cron scheduling bug (#14164) where `computeNextRunAtMs()` could return the **current second** as the next run time, causing 15-21 rapid duplicate fires in a tight loop until the second boundary passed.

- Removed the `-1` lookback in croner's `nextRun()` reference time so the current second is never returned as a valid next occurrence
- Changed the guard from `>=` to `>` to ensure the computed next run is always strictly in the future
- Updated 3 tests that previously encoded the buggy "return current second" behavior to expect advancement to the next day

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-targeted bug fix with updated tests.
- The fix is a two-line change with clear root cause analysis. Both changes (removing the -1 lookback and tightening >= to >) are logically correct and work together. All callers in timer.ts and jobs.ts use `now >= nextRunAtMs` which remains correct. The 3 updated tests now correctly encode the expected behavior, and the remaining tests confirm no regressions.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->