### PR TITLE
fix(discord): add timeout to restart to prevent duplicate responses

### DIFF
--- a/docs/install/systemd.service.example
+++ b/docs/install/systemd.service.example
@@ -1,0 +1,16 @@
+[Unit]
+Description=OpenClaw Gateway
+After=network.target
+
+[Service]
+Type=simple
+User=openclaw
+WorkingDirectory=/var/lib/openclaw
+ExecStart=/usr/local/bin/openclaw gateway --port 18789
+TimeoutStopSec=5
+KillMode=mixed
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Restarts by openclaw were too quick to restart, resulting in more than one bot per channel, and duplicate responses.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a systemd service example file (`docs/install/systemd.service.example`) to prevent duplicate Discord bot responses caused by overly fast gateway restarts. The key fix is `RestartSec=10`, which introduces a 10-second delay between restart attempts, giving the previous bot instance time to fully disconnect before a new one starts.

- Adds new systemd unit file at `docs/install/systemd.service.example` with `RestartSec=10` to throttle restarts
- Configures the gateway to run as a dedicated `openclaw` user under `/var/lib/openclaw`
- Note: existing docs reference `systemd --user` services, while this example uses a system-level unit — both are valid deployment models but this difference is worth documenting

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds a documentation example file with no code changes.
- The change is a single new example file in the docs directory with no runtime code impact. The systemd configuration follows standard conventions and the `RestartSec=10` value is reasonable for preventing duplicate bot instances. Minor note: the system-level service pattern differs from the existing user-level systemd references in the docs, but both are valid approaches.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->