### PR TITLE
fix(scripts): add js extension

### DIFF
--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -6,4 +6,4 @@ import path from "node:path";
 // Keep a stable `dist/plugin-sdk/index.d.ts` alongside `index.js` for TS users.
 const out = path.join(process.cwd(), "dist/plugin-sdk/index.d.ts");
 fs.mkdirSync(path.dirname(out), { recursive: true });
-fs.writeFileSync(out, 'export * from "./plugin-sdk/index";\n', "utf8");
+fs.writeFileSync(out, 'export * from "./plugin-sdk/index.js";\n', "utf8");


### PR DESCRIPTION
add a js extension to the import statement in the generated dist/plugin-sdk/index.d.ts file so it functions properly in projects that use moduleResolution: NodeNext. fix #14291

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds the `.js` file extension to the import specifier in the generated `dist/plugin-sdk/index.d.ts` re-export wrapper, fixing TypeScript resolution for consumers using `moduleResolution: NodeNext`.

- The `write-plugin-sdk-entry-dts.ts` script generates a re-export file at `dist/plugin-sdk/index.d.ts` that bridges the package.json export (`"./plugin-sdk"`) to the tsc-emitted types at `dist/plugin-sdk/plugin-sdk/index.d.ts`
- The import path lacked the `.js` extension, which is required under `NodeNext` module resolution (TypeScript enforces explicit extensions in ESM)
- This is a one-line fix with no risk to existing consumers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped one-line fix with no risk of regression.
- The change is a single character addition (`.js` extension) to a string literal in a build script. The project already uses `moduleResolution: NodeNext` in its tsconfig, making this fix both correct and necessary. No logic changes, no new dependencies, no behavioral changes for existing consumers.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->