### PR TITLE
fix(plugin-sdk): add .js extension to generated d.ts re-export path

### DIFF
--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -6,4 +6,4 @@ import path from "node:path";
 // Keep a stable `dist/plugin-sdk/index.d.ts` alongside `index.js` for TS users.
 const out = path.join(process.cwd(), "dist/plugin-sdk/index.d.ts");
 fs.mkdirSync(path.dirname(out), { recursive: true });
-fs.writeFileSync(out, 'export * from "./plugin-sdk/index";\n', "utf8");
+fs.writeFileSync(out, 'export * from "./plugin-sdk/index.js";\n', "utf8");


### PR DESCRIPTION
## Summary
- The build script `scripts/write-plugin-sdk-entry-dts.ts` generates `dist/plugin-sdk/index.d.ts` with a re-export path that lacks a `.js` extension (`export * from "./plugin-sdk/index"`)
- Under TypeScript's `moduleResolution: NodeNext`, bare specifiers without explicit file extensions fail to resolve, breaking plugin SDK imports for consumers using that setting
- This PR appends `.js` to the re-export path so the emitted declaration reads `export * from "./plugin-sdk/index.js"`

Closes #14291

## Test plan
- [x] Existing `src/plugin-sdk/index.test.ts` continues to pass
- [x] `npx oxfmt --check` passes on the changed file
- [ ] Verify a downstream plugin project with `moduleResolution: NodeNext` can resolve `openclaw/plugin-sdk` imports after this fix

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Appends `.js` extension to the generated `dist/plugin-sdk/index.d.ts` re-export path, changing `export * from "./plugin-sdk/index"` to `export * from "./plugin-sdk/index.js"`. This fixes TypeScript `moduleResolution: NodeNext` consumers that require explicit file extensions in import specifiers to resolve declarations correctly.

- Single-line fix in `scripts/write-plugin-sdk-entry-dts.ts` — adds `.js` to the re-export specifier
- No logic, test, or configuration changes beyond the extension addition

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, correct one-line fix to a build script string literal.
- The change appends `.js` to a single string literal in a build helper script. The resulting re-export path (`./plugin-sdk/index.js`) correctly maps to the tsc-emitted `dist/plugin-sdk/plugin-sdk/index.d.ts` under NodeNext resolution. No logic, runtime behavior, or test changes are involved. Risk of regression is negligible.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->