### PR TITLE
fix(cli): guard compdef in zsh completion when compinit is not loaded

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -374,7 +374,15 @@ _${rootCmd}_root_completion() {
 
 ${generateZshSubcommands(program, rootCmd)}
 
-compdef _${rootCmd}_root_completion ${rootCmd}
+if type compdef &>/dev/null; then
+  compdef _${rootCmd}_root_completion ${rootCmd}
+else
+  _${rootCmd}_completion_setup() {
+    compdef _${rootCmd}_root_completion ${rootCmd}
+    unfunction _${rootCmd}_completion_setup
+  }
+  precmd_functions+=(_${rootCmd}_completion_setup)
+fi
 `;
   return script;
 }


### PR DESCRIPTION
## Summary
- Fixes zsh completion failing with `command not found: compdef` when `compinit` has not been initialized before the completion script is sourced
- Wraps the `compdef` call in the generated zsh completion script with a guard that checks if `compdef` is available
- If `compdef` is not yet available, defers registration using `precmd_functions` so it runs automatically once `compinit` loads

## Test plan
- [x] `pnpm check` passes (format, typecheck, lint)
- [x] Smoke tests pass
- [ ] Manually verify: run `openclaw completion --shell zsh`, confirm the output includes the `if type compdef` guard
- [ ] Manually verify: source the generated completion script in a zsh session without `compinit` loaded -- should not error
- [ ] Manually verify: source the generated completion script in a zsh session with `compinit` loaded -- completions should work immediately

Fixes #14289

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Guards the `compdef` call in the generated zsh completion script so it no longer errors when `compinit` hasn't been loaded yet. If `compdef` is unavailable at source time, registration is deferred via `precmd_functions` and auto-cleans up after the first prompt.

- Wraps `compdef` in a `type compdef` availability check
- Defers registration using `precmd_functions` + self-removing hook when `compinit` is not yet loaded
- No changes to bash, fish, or PowerShell completion paths

<h3>Confidence Score: 5/5</h3>

- Safe to merge — small, well-scoped fix using a standard zsh pattern with no risk to other shells or code paths.
- The change is minimal (one code block in generated shell output), uses a widely adopted zsh idiom for deferred compdef registration, and doesn't touch any TypeScript logic or other completion generators. No new dependencies or architectural changes.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->