### PR TITLE
fix(daemon): catch EPIPE errors when writing to stdout during service lifecycle

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -16,24 +16,10 @@ import {
 } from "./launchd-plist.js";
 import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
+import { safeWrite } from "./safe-write.js";
 
 const execFileAsync = promisify(execFile);
 const toPosixPath = (value: string) => value.replace(/\\/g, "/");
-
-/**
- * Write to a stream, silently ignoring EPIPE/EIO errors that occur when the
- * receiving end of the pipe has already closed (e.g. during gateway restart).
- */
-function safeWrite(stream: NodeJS.WritableStream, data: string): void {
-  try {
-    stream.write(data);
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException | undefined)?.code;
-    if (code !== "EPIPE" && code !== "EIO") {
-      throw err;
-    }
-  }
-}
 
 const formatLine = (label: string, value: string) => {
   const rich = isRich();

--- a/src/daemon/safe-write.ts
+++ b/src/daemon/safe-write.ts
@@ -1,0 +1,14 @@
+/**
+ * Write to a stream, silently ignoring EPIPE/EIO errors that occur when the
+ * receiving end of the pipe has already closed (e.g. during service lifecycle).
+ */
+export function safeWrite(stream: NodeJS.WritableStream, data: string): void {
+  try {
+    stream.write(data);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code !== "EPIPE" && code !== "EIO") {
+      throw err;
+    }
+  }
+}

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -7,24 +7,9 @@ import { colorize, isRich, theme } from "../terminal/theme.js";
 import { formatGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
+import { safeWrite } from "./safe-write.js";
 
 const execFileAsync = promisify(execFile);
-
-
-/**
- * Write to a stream, silently ignoring EPIPE/EIO errors that occur when the
- * receiving end of the pipe has already closed (e.g. during task restart).
- */
-function safeWrite(stream: NodeJS.WritableStream, data: string): void {
-  try {
-    stream.write(data);
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException | undefined)?.code;
-    if (code !== "EPIPE" && code !== "EIO") {
-      throw err;
-    }
-  }
-}
 const formatLine = (label: string, value: string) => {
   const rich = isRich();
   return `${colorize(rich, theme.muted, `${label}:`)} ${colorize(rich, theme.command, value)}`;

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -25,6 +25,21 @@ import {
 const execFileAsync = promisify(execFile);
 const toPosixPath = (value: string) => value.replace(/\\/g, "/");
 
+/**
+ * Write to a stream, silently ignoring EPIPE/EIO errors that occur when the
+ * receiving end of the pipe has already closed (e.g. during service restart).
+ */
+function safeWrite(stream: NodeJS.WritableStream, data: string): void {
+  try {
+    stream.write(data);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code !== "EPIPE" && code !== "EIO") {
+      throw err;
+    }
+  }
+}
+
 const formatLine = (label: string, value: string) => {
   const rich = isRich();
   return `${colorize(rich, theme.muted, `${label}:`)} ${colorize(rich, theme.command, value)}`;
@@ -263,8 +278,8 @@ export async function installSystemdService({
   }
 
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
-  stdout.write("\n");
-  stdout.write(`${formatLine("Installed systemd service", unitPath)}\n`);
+  safeWrite(stdout, "\n");
+  safeWrite(stdout, `${formatLine("Installed systemd service", unitPath)}\n`);
   return { unitPath };
 }
 
@@ -283,9 +298,9 @@ export async function uninstallSystemdService({
   const unitPath = resolveSystemdUnitPath(env);
   try {
     await fs.unlink(unitPath);
-    stdout.write(`${formatLine("Removed systemd service", unitPath)}\n`);
+    safeWrite(stdout, `${formatLine("Removed systemd service", unitPath)}\n`);
   } catch {
-    stdout.write(`Systemd service not found at ${unitPath}\n`);
+    safeWrite(stdout, `Systemd service not found at ${unitPath}\n`);
   }
 }
 
@@ -303,7 +318,7 @@ export async function stopSystemdService({
   if (res.code !== 0) {
     throw new Error(`systemctl stop failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Stopped systemd service", unitName)}\n`);
+  safeWrite(stdout, `${formatLine("Stopped systemd service", unitName)}\n`);
 }
 
 export async function restartSystemdService({
@@ -320,7 +335,7 @@ export async function restartSystemdService({
   if (res.code !== 0) {
     throw new Error(`systemctl restart failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Restarted systemd service", unitName)}\n`);
+  safeWrite(stdout, `${formatLine("Restarted systemd service", unitName)}\n`);
 }
 
 export async function isSystemdServiceEnabled(args: {
@@ -434,14 +449,14 @@ export async function uninstallLegacySystemdUnits({
     if (systemctlAvailable) {
       await execSystemctl(["--user", "disable", "--now", `${unit.name}.service`]);
     } else {
-      stdout.write(`systemctl unavailable; removed legacy unit file only: ${unit.name}.service\n`);
+      safeWrite(stdout, `systemctl unavailable; removed legacy unit file only: ${unit.name}.service\n`);
     }
 
     try {
       await fs.unlink(unit.unitPath);
-      stdout.write(`${formatLine("Removed legacy systemd service", unit.unitPath)}\n`);
+      safeWrite(stdout, `${formatLine("Removed legacy systemd service", unit.unitPath)}\n`);
     } catch {
-      stdout.write(`Legacy systemd unit not found at ${unit.unitPath}\n`);
+      safeWrite(stdout, `Legacy systemd unit not found at ${unit.unitPath}\n`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Wraps all `stdout.write()` calls in `launchd.ts`, `systemd.ts`, and `schtasks.ts` with a `safeWrite()` helper that silently ignores `EPIPE` and `EIO` errors
- These errors occur when the receiving end of the pipe has already closed, which commonly happens during `openclaw gateway restart` on macOS
- Non-EPIPE/EIO errors are still re-thrown so genuine write failures are not suppressed

Fixes #14234

## Test plan
- [x] Existing `launchd.test.ts` tests pass (14 tests)
- [x] Existing `systemd.test.ts` tests pass (10 tests)
- [x] Existing `schtasks.test.ts` tests pass (17 tests)
- [x] `pnpm check` passes (format, typecheck, lint)
- [ ] Manual: run `openclaw gateway restart` on macOS and verify no EPIPE error in logs

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Wraps all `stdout.write()` calls in the three daemon service modules (`launchd.ts`, `systemd.ts`, `schtasks.ts`) with a `safeWrite()` helper that silently ignores EPIPE/EIO errors during service lifecycle operations. The fix is correct and targeted — these errors legitimately occur when the pipe closes during `openclaw gateway restart`.

- The error-handling logic is sound: only EPIPE and EIO are suppressed; other errors are re-thrown
- The synchronous try/catch pattern matches how Node.js `process.stdout.write()` raises EPIPE
- There is an existing `createSafeStreamWriter` utility in `src/terminal/stream-writer.ts` that handles the same error codes with additional state tracking; consider consolidating rather than maintaining three identical local copies
- Minor formatting inconsistency in `schtasks.ts` (extra blank line before JSDoc, missing blank line after `safeWrite`)

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the change only adds defensive error handling around existing stdout writes with no behavioral changes to the service lifecycle logic.
- The fix is correct and addresses a real EPIPE crash during gateway restart. The only concern is code duplication: the codebase already has a shared `createSafeStreamWriter` utility, and maintaining three identical local copies adds maintenance burden. No functional issues or risks.
- No files require special attention from a correctness standpoint. The duplication across all three files is a style/maintenance concern only.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->