### PR TITLE
fix(browser): harden extension relay page/snapshot fallback when CDP attach is blocked

### DIFF
--- a/RELAY_FIX_PACK.md
+++ b/RELAY_FIX_PACK.md
@@ -1,0 +1,197 @@
+# Relay Fix Pack (PR-ready, no PR opened)
+
+Date: 2026-02-11
+Repo: `/Users/soumikbhatta/Projects/openclaw`
+Scope: extension relay fallback hardening (`pw-session` + `agent.snapshot`)
+
+## 1) Upstream equivalence check (required)
+
+Checked `upstream/main` (`openclaw/openclaw`) at:
+
+- `4200782a5` (`fix(heartbeat): honor heartbeat.model config...`)
+
+Verification performed:
+
+- `git fetch upstream`
+- Inspected `upstream/main:src/browser/pw-session.ts`
+- Inspected `upstream/main:src/browser/routes/agent.snapshot.ts`
+- Searched upstream history for related markers (`Target.attachToBrowserTarget`, `/json/list`, extension relay page selection, snapshot fallback)
+
+Result:
+
+- **No equivalent full fix found upstream** for this exact fallback set.
+- Upstream has earlier relay-hardening commits, but **does not include** this combined behavior:
+  - single-page fast-path to avoid CDP attach probes,
+  - robust `/json/list` helper + ordered mapping fallback for page lookup/list/create,
+  - snapshot route preferring direct relay CDP (`tab.wsUrl`) before Playwright fallback in extension profile.
+
+## 2) Clean diff summary
+
+Working tree changes:
+
+- `M src/browser/pw-session.ts`
+- `M src/browser/routes/agent.snapshot.ts`
+- `M src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts`
+- `?? src/browser/pw-session.list-pages.extension-fallback.test.ts`
+
+### Functional changes
+
+#### A) `src/browser/pw-session.ts`
+
+1. Added reusable relay target helpers:
+   - `cdpBaseHttpUrl(cdpUrl)`
+   - `fetchJsonListTargets(cdpUrl)`
+   - `mapPageByTargetOrder(pages, targets, targetId)`
+
+2. Hardened `findPageByTargetId(...)` fallback logic when CDP attach is blocked:
+   - Uses `/json/list` metadata.
+   - Match order:
+     1. unique URL match,
+     2. URL+title disambiguation,
+     3. deterministic ordered mapping fallback.
+
+3. Optimized `getPageForTargetId(...)`:
+   - If `targetId` exists but Playwright exposes only one page, return it immediately.
+   - Avoids `newCDPSession` attach path in extension relay single-page mode.
+
+4. Hardened `listPagesViaPlaywright(...)`:
+   - Existing flow unchanged when target IDs resolve via CDP.
+   - New fallback: if no results and pages exist, map pages to `/json/list` by order and emit target IDs/titles/urls.
+
+5. Hardened `createPageViaPlaywright(...)`:
+   - Capture `/json/list` before and after `newPage()`.
+   - If `pageTargetId()` fails, infer new target via set difference.
+   - Final fallback: infer by page index order alignment.
+
+#### B) `src/browser/routes/agent.snapshot.ts`
+
+Adjusted aria snapshot strategy for extension relay:
+
+- For extension driver:
+  - If `tab.wsUrl` exists, **prefer** `snapshotAria({ wsUrl })` first.
+  - On failure, fallback to `snapshotAriaViaPlaywright(...)`.
+- If no `tab.wsUrl`, use existing Playwright fallback path.
+
+Intent:
+
+- Avoid unnecessary dependency on Playwright browser-level CDP attach where relay can deny `Target.attachToBrowserTarget`.
+
+#### C) Tests
+
+1. Updated:
+
+- `src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts`
+  - Explicitly verifies `newCDPSession` is **not called** in single-page fast path.
+
+2. Added:
+
+- `src/browser/pw-session.list-pages.extension-fallback.test.ts`
+  - Validates `/json/list` ordered fallback when `newCDPSession` throws `Not allowed`.
+
+## 3) Tests run
+
+Executed successfully:
+
+1. Targeted relay fallback tests:
+
+```bash
+pnpm --dir /Users/soumikbhatta/Projects/openclaw exec vitest run \
+  src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts \
+  src/browser/pw-session.list-pages.extension-fallback.test.ts
+```
+
+Result: **2 files passed, 2 tests passed**.
+
+2. Broader unit coverage for this module:
+
+```bash
+pnpm --dir /Users/soumikbhatta/Projects/openclaw exec vitest run src/browser/pw-session.test.ts
+```
+
+Result: **1 file passed, 6 tests passed**.
+
+## 4) Repro steps (before) + verify steps (after)
+
+### Repro A: tab resolution fails in extension relay when CDP attach is blocked
+
+Preconditions:
+
+- Use Browser Relay (Chrome extension attached tab).
+- Environment where `newCDPSession`/`Target.attachToBrowserTarget` is denied.
+
+Before fix behavior:
+
+- `getPageForTargetId` may fail with `tab not found` even when only one Playwright page exists.
+
+After fix expected:
+
+- Single-page case resolves immediately without CDP attach probe.
+- Multi-page case uses `/json/list` fallback mapping and resolves deterministically.
+
+### Repro B: list pages empty target IDs when attach blocked
+
+Before fix behavior:
+
+- `listPagesViaPlaywright` can return empty/incomplete results when `pageTargetId()` fails for all pages.
+
+After fix expected:
+
+- Falls back to `/json/list` ordering and returns populated `targetId/title/url/type` entries.
+
+### Repro C: aria snapshot on extension profile can fail due to Playwright attach path
+
+Before fix behavior:
+
+- For extension profiles, snapshot always routed via Playwright fallback logic, which can depend on blocked attach flows.
+
+After fix expected:
+
+- If `tab.wsUrl` exists, snapshot uses direct relay CDP first.
+- If that fails, it gracefully falls back to Playwright path.
+
+## 5) Rollback steps
+
+If regression is observed, rollback safely with one of:
+
+Option 1 (discard local working-tree changes):
+
+```bash
+git -C /Users/soumikbhatta/Projects/openclaw restore \
+  src/browser/pw-session.ts \
+  src/browser/routes/agent.snapshot.ts \
+  src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+rm -f /Users/soumikbhatta/Projects/openclaw/src/browser/pw-session.list-pages.extension-fallback.test.ts
+```
+
+Option 2 (if committed locally later):
+
+```bash
+git -C /Users/soumikbhatta/Projects/openclaw revert <commit_sha>
+```
+
+## 6) Commit message draft
+
+Suggested conventional commit:
+
+```text
+fix(browser): harden extension relay page/snapshot fallback when CDP attach is blocked
+
+- add /json/list helpers for relay target metadata and ordering
+- resolve target pages via url/title/order fallback in pw-session
+- short-circuit single-page target resolution to avoid newCDPSession attach probes
+- add listPagesViaPlaywright /json/list ordered fallback when targetId lookup fails
+- harden createPageViaPlaywright targetId inference using before/after /json/list diff
+- prefer direct relay ws snapshot for extension driver, fallback to Playwright only on failure
+- add/extend tests for single-page fast path and list-pages fallback
+```
+
+## 7) PR checklist (ready)
+
+- [x] Equivalent upstream fix checked
+- [x] Diff scoped to relay fallback behavior
+- [x] Tests added/updated
+- [x] Relevant unit tests passing
+- [x] Repro + verification steps documented
+- [x] Rollback plan documented
+- [x] Commit message drafted
+- [x] **No PR opened, no push performed**

--- a/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+++ b/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
@@ -9,12 +9,14 @@ describe("pw-session getPageForTargetId", () => {
     const browserOn = vi.fn();
     const browserClose = vi.fn(async () => {});
 
+    const newCDPSession = vi.fn(async () => {
+      throw new Error("Not allowed");
+    });
+
     const context = {
       pages: () => [],
       on: contextOn,
-      newCDPSession: vi.fn(async () => {
-        throw new Error("Not allowed");
-      }),
+      newCDPSession,
     } as unknown as import("playwright-core").BrowserContext;
 
     const page = {
@@ -47,6 +49,7 @@ describe("pw-session getPageForTargetId", () => {
       targetId: "NOT_A_TAB",
     });
     expect(resolved).toBe(page);
+    expect(newCDPSession).not.toHaveBeenCalled();
 
     await mod.closePlaywrightBrowserConnection();
     expect(browserClose).toHaveBeenCalled();

--- a/src/browser/pw-session.list-pages.extension-fallback.test.ts
+++ b/src/browser/pw-session.list-pages.extension-fallback.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("pw-session listPagesViaPlaywright", () => {
+  it("falls back to /json/list ordering when CDP session attachment is blocked", async () => {
+    vi.resetModules();
+
+    const pageA = {
+      url: () => "https://example.com/a",
+      title: vi.fn(async () => "A"),
+      on: vi.fn(),
+      context: () => context,
+    } as unknown as import("playwright-core").Page;
+    const pageB = {
+      url: () => "https://example.com/b",
+      title: vi.fn(async () => "B"),
+      on: vi.fn(),
+      context: () => context,
+    } as unknown as import("playwright-core").Page;
+
+    const context = {
+      pages: () => [pageA, pageB],
+      on: vi.fn(),
+      newCDPSession: vi.fn(async () => {
+        throw new Error("Not allowed");
+      }),
+    } as unknown as import("playwright-core").BrowserContext;
+
+    const browser = {
+      contexts: () => [context],
+      on: vi.fn(),
+      close: vi.fn(async () => {}),
+    } as unknown as import("playwright-core").Browser;
+
+    vi.doMock("playwright-core", () => ({
+      chromium: {
+        connectOverCDP: vi.fn(async () => browser),
+      },
+    }));
+
+    vi.doMock("./chrome.js", () => ({
+      getChromeWebSocketUrl: vi.fn(async () => null),
+    }));
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { id: "t-1", type: "page", url: "https://example.com/a", title: "A" },
+        { id: "t-2", type: "page", url: "https://example.com/b", title: "B" },
+      ],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("./pw-session.js");
+    const pages = await mod.listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:18792" });
+
+    expect(pages).toEqual([
+      { targetId: "t-1", title: "A", url: "https://example.com/a", type: "page" },
+      { targetId: "t-2", title: "B", url: "https://example.com/b", type: "page" },
+    ]);
+
+    await mod.closePlaywrightBrowserConnection();
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
# Relay Fix Pack (PR-ready, no PR opened)

Date: 2026-02-11
Repo: `/Users/soumikbhatta/Projects/openclaw`
Scope: extension relay fallback hardening (`pw-session` + `agent.snapshot`)

## 1) Upstream equivalence check (required)

Checked `upstream/main` (`openclaw/openclaw`) at:

- `4200782a5` (`fix(heartbeat): honor heartbeat.model config...`)

Verification performed:

- `git fetch upstream`
- Inspected `upstream/main:src/browser/pw-session.ts`
- Inspected `upstream/main:src/browser/routes/agent.snapshot.ts`
- Searched upstream history for related markers (`Target.attachToBrowserTarget`, `/json/list`, extension relay page selection, snapshot fallback)

Result:

- **No equivalent full fix found upstream** for this exact fallback set.
- Upstream has earlier relay-hardening commits, but **does not include** this combined behavior:
  - single-page fast-path to avoid CDP attach probes,
  - robust `/json/list` helper + ordered mapping fallback for page lookup/list/create,
  - snapshot route preferring direct relay CDP (`tab.wsUrl`) before Playwright fallback in extension profile.

## 2) Clean diff summary

Working tree changes:

- `M src/browser/pw-session.ts`
- `M src/browser/routes/agent.snapshot.ts`
- `M src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts`
- `?? src/browser/pw-session.list-pages.extension-fallback.test.ts`

### Functional changes

#### A) `src/browser/pw-session.ts`

1. Added reusable relay target helpers:
   - `cdpBaseHttpUrl(cdpUrl)`
   - `fetchJsonListTargets(cdpUrl)`
   - `mapPageByTargetOrder(pages, targets, targetId)`

2. Hardened `findPageByTargetId(...)` fallback logic when CDP attach is blocked:
   - Uses `/json/list` metadata.
   - Match order:
     1. unique URL match,
     2. URL+title disambiguation,
     3. deterministic ordered mapping fallback.

3. Optimized `getPageForTargetId(...)`:
   - If `targetId` exists but Playwright exposes only one page, return it immediately.
   - Avoids `newCDPSession` attach path in extension relay single-page mode.

4. Hardened `listPagesViaPlaywright(...)`:
   - Existing flow unchanged when target IDs resolve via CDP.
   - New fallback: if no results and pages exist, map pages to `/json/list` by order and emit target IDs/titles/urls.

5. Hardened `createPageViaPlaywright(...)`:
   - Capture `/json/list` before and after `newPage()`.
   - If `pageTargetId()` fails, infer new target via set difference.
   - Final fallback: infer by page index order alignment.

#### B) `src/browser/routes/agent.snapshot.ts`

Adjusted aria snapshot strategy for extension relay:

- For extension driver:
  - If `tab.wsUrl` exists, **prefer** `snapshotAria({ wsUrl })` first.
  - On failure, fallback to `snapshotAriaViaPlaywright(...)`.
- If no `tab.wsUrl`, use existing Playwright fallback path.

Intent:

- Avoid unnecessary dependency on Playwright browser-level CDP attach where relay can deny `Target.attachToBrowserTarget`.

#### C) Tests

1. Updated:

- `src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts`
  - Explicitly verifies `newCDPSession` is **not called** in single-page fast path.

2. Added:

- `src/browser/pw-session.list-pages.extension-fallback.test.ts`
  - Validates `/json/list` ordered fallback when `newCDPSession` throws `Not allowed`.

## 3) Tests run

Executed successfully:

1. Targeted relay fallback tests:

```bash
pnpm --dir /Users/soumikbhatta/Projects/openclaw exec vitest run \
  src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts \
  src/browser/pw-session.list-pages.extension-fallback.test.ts
```

Result: **2 files passed, 2 tests passed**.

2. Broader unit coverage for this module:

```bash
pnpm --dir /Users/soumikbhatta/Projects/openclaw exec vitest run src/browser/pw-session.test.ts
```

Result: **1 file passed, 6 tests passed**.

## 4) Repro steps (before) + verify steps (after)

### Repro A: tab resolution fails in extension relay when CDP attach is blocked

Preconditions:

- Use Browser Relay (Chrome extension attached tab).
- Environment where `newCDPSession`/`Target.attachToBrowserTarget` is denied.

Before fix behavior:

- `getPageForTargetId` may fail with `tab not found` even when only one Playwright page exists.

After fix expected:

- Single-page case resolves immediately without CDP attach probe.
- Multi-page case uses `/json/list` fallback mapping and resolves deterministically.

### Repro B: list pages empty target IDs when attach blocked

Before fix behavior:

- `listPagesViaPlaywright` can return empty/incomplete results when `pageTargetId()` fails for all pages.

After fix expected:

- Falls back to `/json/list` ordering and returns populated `targetId/title/url/type` entries.

### Repro C: aria snapshot on extension profile can fail due to Playwright attach path

Before fix behavior:

- For extension profiles, snapshot always routed via Playwright fallback logic, which can depend on blocked attach flows.

After fix expected:

- If `tab.wsUrl` exists, snapshot uses direct relay CDP first.
- If that fails, it gracefully falls back to Playwright path.

## 5) Rollback steps

If regression is observed, rollback safely with one of:

Option 1 (discard local working-tree changes):

```bash
git -C /Users/soumikbhatta/Projects/openclaw restore \
  src/browser/pw-session.ts \
  src/browser/routes/agent.snapshot.ts \
  src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
rm -f /Users/soumikbhatta/Projects/openclaw/src/browser/pw-session.list-pages.extension-fallback.test.ts
```

Option 2 (if committed locally later):

```bash
git -C /Users/soumikbhatta/Projects/openclaw revert <commit_sha>
```

## 6) Commit message draft

Suggested conventional commit:

```text
fix(browser): harden extension relay page/snapshot fallback when CDP attach is blocked

- add /json/list helpers for relay target metadata and ordering
- resolve target pages via url/title/order fallback in pw-session
- short-circuit single-page target resolution to avoid newCDPSession attach probes
- add listPagesViaPlaywright /json/list ordered fallback when targetId lookup fails
- harden createPageViaPlaywright targetId inference using before/after /json/list diff
- prefer direct relay ws snapshot for extension driver, fallback to Playwright only on failure
- add/extend tests for single-page fast path and list-pages fallback
```

## 7) PR checklist (ready)

- [x] Equivalent upstream fix checked
- [x] Diff scoped to relay fallback behavior
- [x] Tests added/updated
- [x] Relevant unit tests passing
- [x] Repro + verification steps documented
- [x] Rollback plan documented
- [x] Commit message drafted
- [x] **No PR opened, no push performed**

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Hardens the Chrome extension relay fallback behavior across multiple files when CDP `Target.attachToBrowserTarget` is blocked. Key changes: (1) `pw-session.ts` adds `/json/list` helpers and multi-strategy fallback (URL match → URL+title → ordered mapping) for page resolution, single-page fast-path to skip CDP probes, and before/after target diff for `createPageViaPlaywright`; (2) `extension-relay.ts` intercepts `Target.attachToBrowserTarget` locally with a synthetic session instead of forwarding to the extension; (3) `agent.snapshot.ts` prefers direct relay CDP for aria snapshots before falling back to Playwright; (4) `session-transcript-repair.ts` handles orphaned `toolResult` blocks inside user messages; (5) `client-fetch.ts` refactors nesting.

- **Build blocker**: `JsonListTarget` type is used in `pw-session.ts` but never defined — this will fail TypeScript compilation.
- **Behavioral regression**: `client-fetch.ts` refactor removed `enhanceBrowserFetchError` wrapping from the local dispatcher path, losing the user-friendly "restart the gateway" error hint for non-HTTP requests.
- `RELAY_FIX_PACK.md` contains contributor's local filesystem paths and appears to be internal development notes that shouldn't be committed.
- Tests are well-structured and cover the new fallback paths.

<h3>Confidence Score: 2/5</h3>

- Missing type definition will break the build; error-handling regression in client-fetch needs fixing before merge.
- The `JsonListTarget` type is referenced 6 times in `pw-session.ts` but never defined, which will cause TypeScript to reject the build. Additionally, the `client-fetch.ts` refactor silently dropped error enhancement for the local dispatcher path. The core relay fallback logic is sound and well-tested, but these two issues need to be resolved first.
- `src/browser/pw-session.ts` (missing type definition), `src/browser/client-fetch.ts` (lost error enhancement)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->