### PR TITLE
fix(sandbox): pass docker.env config to container creation

### DIFF
--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -238,6 +238,64 @@ describe("buildSandboxCreateArgs", () => {
     expectBuildToThrow(containerName, cfg, expected);
   });
 
+  it("emits -e flags for configured docker env vars", () => {
+    const cfg: SandboxDockerConfig = {
+      image: "openclaw-sandbox:bookworm-slim",
+      containerPrefix: "openclaw-sbx-",
+      workdir: "/workspace",
+      readOnlyRoot: false,
+      tmpfs: [],
+      network: "none",
+      capDrop: [],
+      env: {
+        LANG: "C.UTF-8",
+        OPENCLAW_SANDBOX_TEST: "enabled",
+      },
+    };
+
+    const args = buildSandboxCreateArgs({
+      name: "openclaw-sbx-env",
+      cfg,
+      scopeKey: "main",
+      createdAtMs: 1700000000000,
+    });
+
+    const envFlags: string[] = [];
+    for (let i = 0; i < args.length; i += 1) {
+      if (args[i] === "-e") {
+        const value = args[i + 1];
+        if (value) {
+          envFlags.push(value);
+        }
+      }
+    }
+    expect(envFlags).toEqual(
+      expect.arrayContaining(["LANG=C.UTF-8", "OPENCLAW_SANDBOX_TEST=enabled"]),
+    );
+  });
+
+  it("omits -e flags when docker env is undefined", () => {
+    const cfg: SandboxDockerConfig = {
+      image: "openclaw-sandbox:bookworm-slim",
+      containerPrefix: "openclaw-sbx-",
+      workdir: "/workspace",
+      readOnlyRoot: false,
+      tmpfs: [],
+      network: "none",
+      capDrop: [],
+    };
+
+    const args = buildSandboxCreateArgs({
+      name: "openclaw-sbx-no-env",
+      cfg,
+      scopeKey: "main",
+      createdAtMs: 1700000000000,
+    });
+
+    const hasEnvFlag = args.includes("-e");
+    expect(hasEnvFlag).toBe(false);
+  });
+
   it("omits -v flags when binds is empty or undefined", () => {
     const cfg: SandboxDockerConfig = {
       image: "openclaw-sandbox:bookworm-slim",

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -423,6 +423,9 @@ export function buildSandboxCreateArgs(params: {
       args.push("-v", bind);
     }
   }
+  for (const [key, value] of Object.entries(params.cfg.env ?? {})) {
+    args.push("-e", `${key}=${value}`);
+  }
   return args;
 }
 


### PR DESCRIPTION
## Summary
- The `docker.env` configuration was being resolved correctly but never passed to `docker create`
- Added missing loop to pass environment variables as `-e` flags in `buildSandboxCreateArgs()`

## Problem
Users setting `agents.list[N].sandbox.docker.env` in config had no way to pass environment variables to sandboxed containers. The env object was correctly merged in `resolveSandboxDockerConfig()` but the resulting values were never added to the docker create command.

## Solution
Added a simple loop after the binds handling:
```typescript
for (const [key, value] of Object.entries(params.cfg.env ?? {})) {
  args.push("-e", `${key}=${value}`);
}
```

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm check` passes (format + lint)
- [x] `pnpm test` passes (267/267 tests)
- [x] Manually verified: env vars appear in `docker inspect .Config.Env`
- [x] Manually verified: env vars accessible inside container via `printenv`

## AI-assisted
Yes - Claude Code identified the bug and generated the fix. Human verified the fix works correctly in a real OpenClaw deployment.

🦞 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a bug where `docker.env` config values were resolved and merged correctly in `resolveSandboxDockerConfig()` but never actually passed as `-e` flags to `docker create`. The 3-line addition follows the same pattern used for other optional config fields (`binds`, `dns`, `extraHosts`) in `buildSandboxCreateArgs()`.

- Added loop to emit environment variable flags from `params.cfg.env` in `buildSandboxCreateArgs()`
- The `?? {}` fallback correctly handles the optional `env` field
- Values are passed as separate `spawn()` args (not shell-interpolated), so no injection concern

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — minimal, well-scoped bug fix following existing patterns.
- The change is 3 lines, follows the exact pattern of adjacent code for other config fields (binds, dns, extraHosts), the type system constrains env values to strings, and the nullish coalescing handles the optional field correctly. No new dependencies or architectural changes.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->