### PR TITLE
feat(agents/ui): keep main responsive via per-agent sub-agent tool policy

### DIFF
--- a/src/agents/subagent-tool-deny.ts
+++ b/src/agents/subagent-tool-deny.ts
@@ -1,0 +1,22 @@
+/**
+ * Default tools denied for sub-agent sessions.
+ * Keep this list as the single source of truth for runtime policy and UI behavior.
+ */
+export const SUBAGENT_DEFAULT_TOOL_DENY = [
+  // Session management - main agent orchestrates
+  "sessions_list",
+  "sessions_history",
+  "sessions_send",
+  "sessions_spawn",
+  // System admin - dangerous from subagent
+  "gateway",
+  "agents_list",
+  // Interactive setup - not a task
+  "whatsapp_login",
+  // Status/scheduling - main agent coordinates
+  "session_status",
+  "cron",
+  // Memory - pass relevant info in spawn prompt instead
+  "memory_search",
+  "memory_get",
+] as const;

--- a/src/config/config.tools-alsoAllow.test.ts
+++ b/src/config/config.tools-alsoAllow.test.ts
@@ -39,6 +39,68 @@ describe("config: tools.alsoAllow", () => {
     }
   });
 
+  it("rejects agents.list[].subagents.tools.allow + alsoAllow together", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: {
+              tools: {
+                allow: ["group:fs"],
+                alsoAllow: ["lobster"],
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((i) => i.path.includes("agents.list"))).toBe(true);
+    }
+  });
+
+  it("accepts agents.list[].subagents.tools policy", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            tools: {
+              deny: ["read"],
+            },
+            subagents: {
+              tools: {
+                allow: ["*"],
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts agents.list[].subagents without tools override", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: {
+              model: "gpt-5-mini",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("allows profile + alsoAllow", () => {
     const res = validateConfigObject({
       tools: {

--- a/src/config/schema.field-metadata.ts
+++ b/src/config/schema.field-metadata.ts
@@ -122,6 +122,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.alsoAllow": "Tool Allowlist Additions",
   "agents.list[].tools.profile": "Agent Tool Profile",
   "agents.list[].tools.alsoAllow": "Agent Tool Allowlist Additions",
+  "agents.list[].subagents.tools": "Sub-Agent Tool Policy",
   "tools.byProvider": "Tool Policy by Provider",
   "agents.list[].tools.byProvider": "Agent Tool Policy by Provider",
   "tools.exec.applyPatch.enabled": "Enable apply_patch",
@@ -428,6 +429,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
+  "agents.list[].subagents.tools":
+    "Sub-agent session tool policy. When set, spawned sub-agents use this instead of inheriting agents.list[].tools.",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -137,6 +137,7 @@ const FIELD_LABELS: Record<string, string> = {
   "tools.alsoAllow": "Tool Allowlist Additions",
   "agents.list[].tools.profile": "Agent Tool Profile",
   "agents.list[].tools.alsoAllow": "Agent Tool Allowlist Additions",
+  "agents.list[].subagents.tools": "Sub-Agent Tool Policy",
   "tools.byProvider": "Tool Policy by Provider",
   "agents.list[].tools.byProvider": "Agent Tool Policy by Provider",
   "tools.exec.applyPatch.enabled": "Enable apply_patch",
@@ -443,6 +444,8 @@ const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
+  "agents.list[].subagents.tools":
+    "Sub-agent session tool policy. When set, spawned sub-agents use this instead of inheriting agents.list[].tools.",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -7,7 +7,7 @@ import type {
   SandboxDockerSettings,
   SandboxPruneSettings,
 } from "./types.sandbox.js";
-import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
+import type { AgentToolsConfig, MemorySearchConfig, ToolPolicyConfig } from "./types.tools.js";
 
 export type AgentModelConfig =
   | string
@@ -39,6 +39,11 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
+    /**
+     * Sub-agent-specific tool policy for sessions spawned under this agent.
+     * When set, sub-agent sessions use this policy instead of inheriting `agents.list[].tools`.
+     */
+    tools?: ToolPolicyConfig;
   };
   sandbox?: {
     mode?: "off" | "non-main" | "all";

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -466,6 +466,7 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        tools: ToolPolicySchema.optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -466,7 +466,7 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
-        tools: ToolPolicySchema.optional(),
+        tools: ToolPolicySchema,
       })
       .strict()
       .optional(),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -775,6 +775,40 @@ export function renderApp(state: AppViewState) {
                     removeConfigFormValue(state, [...basePath, "deny"]);
                   }
                 },
+                onSubagentToolsPolicyChange: (agentId, policy) => {
+                  if (!configValue) {
+                    return;
+                  }
+                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  if (!Array.isArray(list)) {
+                    return;
+                  }
+                  const index = list.findIndex(
+                    (entry) =>
+                      entry &&
+                      typeof entry === "object" &&
+                      "id" in entry &&
+                      (entry as { id?: string }).id === agentId,
+                  );
+                  if (index < 0) {
+                    return;
+                  }
+                  const basePath = ["agents", "list", index, "subagents", "tools"];
+                  if (!policy) {
+                    removeConfigFormValue(state, basePath);
+                    return;
+                  }
+                  if (Array.isArray(policy.allow) && policy.allow.length > 0) {
+                    updateConfigFormValue(state, [...basePath, "allow"], policy.allow);
+                  } else {
+                    removeConfigFormValue(state, [...basePath, "allow"]);
+                  }
+                  if (Array.isArray(policy.deny) && policy.deny.length > 0) {
+                    updateConfigFormValue(state, [...basePath, "deny"], policy.deny);
+                  } else {
+                    removeConfigFormValue(state, [...basePath, "deny"]);
+                  }
+                },
                 onConfigReload: () => loadConfig(state),
                 onConfigSave: () => saveConfig(state),
                 onChannelsRefresh: () => loadChannels(state, false),

--- a/ui/src/ui/controllers/agent-config-path.ts
+++ b/ui/src/ui/controllers/agent-config-path.ts
@@ -1,0 +1,125 @@
+type ConfigValue = Record<string, unknown> | null;
+export type ConfigPath = (string | number)[];
+type ApplyValue = (path: ConfigPath, value: unknown) => void;
+type RemoveValue = (path: ConfigPath) => void;
+
+export function resolveAgentConfigPath(
+  configValue: ConfigValue,
+  agentId: string,
+  scope: "tools" | "subagents.tools",
+): ConfigPath | null {
+  const list = (configValue as { agents?: { list?: unknown[] } } | null)?.agents?.list;
+  if (!Array.isArray(list)) {
+    return null;
+  }
+  const index = list.findIndex(
+    (entry) =>
+      entry &&
+      typeof entry === "object" &&
+      "id" in entry &&
+      (entry as { id?: string }).id === agentId,
+  );
+  if (index < 0) {
+    return null;
+  }
+  return scope === "tools"
+    ? ["agents", "list", index, "tools"]
+    : ["agents", "list", index, "subagents", "tools"];
+}
+
+export function updateOrRemoveConfigValue(
+  path: ConfigPath,
+  value: unknown,
+  shouldSet: boolean,
+  update: (path: ConfigPath, value: unknown) => void,
+  remove: (path: ConfigPath) => void,
+) {
+  if (shouldSet) {
+    update(path, value);
+    return;
+  }
+  remove(path);
+}
+
+export function applyAgentToolsProfileChange(params: {
+  configValue: ConfigValue;
+  agentId: string;
+  profile: string | null;
+  clearAllow: boolean;
+  update: ApplyValue;
+  remove: RemoveValue;
+}) {
+  const basePath = resolveAgentConfigPath(params.configValue, params.agentId, "tools");
+  if (!basePath) {
+    return;
+  }
+  updateOrRemoveConfigValue(
+    [...basePath, "profile"],
+    params.profile,
+    Boolean(params.profile),
+    params.update,
+    params.remove,
+  );
+  if (params.clearAllow) {
+    params.remove([...basePath, "allow"]);
+  }
+}
+
+export function applyAgentToolsOverridesChange(params: {
+  configValue: ConfigValue;
+  agentId: string;
+  alsoAllow: string[];
+  deny: string[];
+  update: ApplyValue;
+  remove: RemoveValue;
+}) {
+  const basePath = resolveAgentConfigPath(params.configValue, params.agentId, "tools");
+  if (!basePath) {
+    return;
+  }
+  updateOrRemoveConfigValue(
+    [...basePath, "alsoAllow"],
+    params.alsoAllow,
+    params.alsoAllow.length > 0,
+    params.update,
+    params.remove,
+  );
+  updateOrRemoveConfigValue(
+    [...basePath, "deny"],
+    params.deny,
+    params.deny.length > 0,
+    params.update,
+    params.remove,
+  );
+}
+
+export function applySubagentToolsPolicyChange(params: {
+  configValue: ConfigValue;
+  agentId: string;
+  policy: { allow?: string[]; deny?: string[] } | null;
+  update: ApplyValue;
+  remove: RemoveValue;
+}) {
+  const basePath = resolveAgentConfigPath(params.configValue, params.agentId, "subagents.tools");
+  if (!basePath) {
+    return;
+  }
+  if (!params.policy) {
+    params.remove(basePath);
+    return;
+  }
+  updateOrRemoveConfigValue(
+    [...basePath, "allow"],
+    params.policy.allow,
+    Array.isArray(params.policy.allow) && params.policy.allow.length > 0,
+    params.update,
+    params.remove,
+  );
+  updateOrRemoveConfigValue(
+    [...basePath, "deny"],
+    params.policy.deny,
+    Array.isArray(params.policy.deny) && params.policy.deny.length > 0,
+    params.update,
+    params.remove,
+  );
+}

--- a/ui/src/ui/views/agents-tool-policy.ts
+++ b/ui/src/ui/views/agents-tool-policy.ts
@@ -1,0 +1,229 @@
+import { SUBAGENT_DEFAULT_TOOL_DENY } from "../../../../src/agents/subagent-tool-deny.js";
+import { expandToolGroups, normalizeToolName } from "../../../../src/agents/tool-policy.js";
+
+type CompiledPattern =
+  | { kind: "all" }
+  | { kind: "exact"; value: string }
+  | { kind: "regex"; value: RegExp };
+
+export type ToolPolicy = {
+  allow?: string[];
+  deny?: string[];
+};
+
+type AgentConfigEntry = {
+  id: string;
+  name?: string;
+  workspace?: string;
+  agentDir?: string;
+  model?: unknown;
+  skills?: string[];
+  tools?: {
+    profile?: string;
+    allow?: string[];
+    alsoAllow?: string[];
+    deny?: string[];
+  };
+  subagents?: {
+    tools?: {
+      allow?: string[];
+      alsoAllow?: string[];
+      deny?: string[];
+    };
+  };
+};
+
+export type ConfigSnapshot = {
+  agents?: {
+    defaults?: { workspace?: string; model?: unknown; models?: Record<string, { alias?: string }> };
+    list?: AgentConfigEntry[];
+  };
+  tools?: {
+    profile?: string;
+    allow?: string[];
+    alsoAllow?: string[];
+    deny?: string[];
+  };
+};
+
+export const TOOL_SECTIONS = [
+  {
+    id: "fs",
+    label: "Files",
+    tools: [
+      { id: "read", label: "read", description: "Read file contents" },
+      { id: "write", label: "write", description: "Create or overwrite files" },
+      { id: "edit", label: "edit", description: "Make precise edits" },
+      { id: "apply_patch", label: "apply_patch", description: "Patch files (OpenAI)" },
+    ],
+  },
+  {
+    id: "runtime",
+    label: "Runtime",
+    tools: [
+      { id: "exec", label: "exec", description: "Run shell commands" },
+      { id: "process", label: "process", description: "Manage background processes" },
+    ],
+  },
+  {
+    id: "web",
+    label: "Web",
+    tools: [
+      { id: "web_search", label: "web_search", description: "Search the web" },
+      { id: "web_fetch", label: "web_fetch", description: "Fetch web content" },
+    ],
+  },
+  {
+    id: "memory",
+    label: "Memory",
+    tools: [
+      { id: "memory_search", label: "memory_search", description: "Semantic search" },
+      { id: "memory_get", label: "memory_get", description: "Read memory files" },
+    ],
+  },
+  {
+    id: "sessions",
+    label: "Sessions",
+    tools: [
+      { id: "sessions_list", label: "sessions_list", description: "List sessions" },
+      { id: "sessions_history", label: "sessions_history", description: "Session history" },
+      { id: "sessions_send", label: "sessions_send", description: "Send to session" },
+      { id: "sessions_spawn", label: "sessions_spawn", description: "Spawn sub-agent" },
+      { id: "session_status", label: "session_status", description: "Session status" },
+    ],
+  },
+  {
+    id: "ui",
+    label: "UI",
+    tools: [
+      { id: "browser", label: "browser", description: "Control web browser" },
+      { id: "canvas", label: "canvas", description: "Control canvases" },
+    ],
+  },
+  {
+    id: "messaging",
+    label: "Messaging",
+    tools: [{ id: "message", label: "message", description: "Send messages" }],
+  },
+  {
+    id: "automation",
+    label: "Automation",
+    tools: [
+      { id: "cron", label: "cron", description: "Schedule tasks" },
+      { id: "gateway", label: "gateway", description: "Gateway control" },
+    ],
+  },
+  {
+    id: "nodes",
+    label: "Nodes",
+    tools: [{ id: "nodes", label: "nodes", description: "Nodes + devices" }],
+  },
+  {
+    id: "agents",
+    label: "Agents",
+    tools: [{ id: "agents_list", label: "agents_list", description: "List agents" }],
+  },
+  {
+    id: "media",
+    label: "Media",
+    tools: [{ id: "image", label: "image", description: "Image understanding" }],
+  },
+] as const;
+
+export const PROFILE_OPTIONS = [
+  { id: "minimal", label: "Minimal" },
+  { id: "coding", label: "Coding" },
+  { id: "messaging", label: "Messaging" },
+  { id: "full", label: "Full" },
+] as const;
+
+export const SUBAGENT_LOCKED_TOOL_IDS = new Set(
+  SUBAGENT_DEFAULT_TOOL_DENY.map((entry) => normalizeToolName(entry)),
+);
+
+function compilePattern(pattern: string): CompiledPattern {
+  const normalized = normalizeToolName(pattern);
+  if (!normalized) {
+    return { kind: "exact", value: "" };
+  }
+  if (normalized === "*") {
+    return { kind: "all" };
+  }
+  if (!normalized.includes("*")) {
+    return { kind: "exact", value: normalized };
+  }
+  const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
+  return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
+}
+
+function compilePatterns(patterns?: string[]): CompiledPattern[] {
+  if (!Array.isArray(patterns)) {
+    return [];
+  }
+  return expandToolGroups(patterns)
+    .map(compilePattern)
+    .filter((pattern) => pattern.kind !== "exact" || pattern.value.length > 0);
+}
+
+function matchesAny(name: string, patterns: CompiledPattern[]) {
+  for (const pattern of patterns) {
+    if (pattern.kind === "all") {
+      return true;
+    }
+    if (pattern.kind === "exact" && name === pattern.value) {
+      return true;
+    }
+    if (pattern.kind === "regex" && pattern.value.test(name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resolveAgentConfig(config: Record<string, unknown> | null, agentId: string) {
+  const cfg = config as ConfigSnapshot | null;
+  const list = cfg?.agents?.list ?? [];
+  const entry = list.find((agent) => agent?.id === agentId);
+  return {
+    entry,
+    defaults: cfg?.agents?.defaults,
+    globalTools: cfg?.tools,
+  };
+}
+
+export function isAllowedByPolicy(name: string, policy?: ToolPolicy) {
+  if (!policy) {
+    return true;
+  }
+  const normalized = normalizeToolName(name);
+  const deny = compilePatterns(policy.deny);
+  if (matchesAny(normalized, deny)) {
+    return false;
+  }
+  const allow = compilePatterns(policy.allow);
+  if (allow.length === 0) {
+    return true;
+  }
+  if (matchesAny(normalized, allow)) {
+    return true;
+  }
+  if (normalized === "apply_patch" && matchesAny("exec", allow)) {
+    return true;
+  }
+  return false;
+}
+
+export function matchesList(name: string, list?: string[]) {
+  if (!Array.isArray(list) || list.length === 0) {
+    return false;
+  }
+  const normalized = normalizeToolName(name);
+  const patterns = compilePatterns(list);
+  if (matchesAny(normalized, patterns)) {
+    return true;
+  }
+  if (normalized === "apply_patch" && matchesAny("exec", patterns)) {
+    return true;
+  }
+  return false;
+}

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -1323,8 +1323,10 @@ function renderAgentTools(params: {
     params.onOverridesChange(params.agentId, [...nextAllow], [...nextDeny]);
   };
 
-  const subagentToolIds = toolIds.filter((toolId) => !SUBAGENT_LOCKED_TOOL_IDS.has(toolId));
-  const subagentToolIdSet = new Set(subagentToolIds);
+  const subagentToolIds: string[] = toolIds.filter(
+    (toolId) => !SUBAGENT_LOCKED_TOOL_IDS.has(toolId),
+  );
+  const subagentToolIdSet = new Set<string>(subagentToolIds);
   const subagentSections = TOOL_SECTIONS.map((section) => ({
     ...section,
     tools: section.tools.filter((tool) => subagentToolIdSet.has(tool.id)),

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -11,12 +11,8 @@ import type {
   SkillStatusEntry,
   SkillStatusReport,
 } from "../types.ts";
-import { SUBAGENT_DEFAULT_TOOL_DENY } from "../../../../src/agents/subagent-tool-deny.js";
-import {
-  expandToolGroups,
-  normalizeToolName,
-  resolveToolProfilePolicy,
-} from "../../../../src/agents/tool-policy.js";
+import type { ConfigSnapshot, ToolPolicy } from "./agents-tool-policy.ts";
+import { normalizeToolName, resolveToolProfilePolicy } from "../../../../src/agents/tool-policy.js";
 import { formatRelativeTimestamp } from "../format.ts";
 import {
   formatCronPayload,
@@ -24,6 +20,14 @@ import {
   formatCronState,
   formatNextRun,
 } from "../presenter.ts";
+import {
+  PROFILE_OPTIONS,
+  SUBAGENT_LOCKED_TOOL_IDS,
+  TOOL_SECTIONS,
+  isAllowedByPolicy,
+  matchesList,
+  resolveAgentConfig,
+} from "./agents-tool-policy.ts";
 
 export type AgentsPanel = "overview" | "files" | "tools" | "skills" | "channels" | "cron";
 
@@ -85,141 +89,6 @@ export type AgentsProps = {
   onAgentSkillToggle: (agentId: string, skillName: string, enabled: boolean) => void;
   onAgentSkillsClear: (agentId: string) => void;
   onAgentSkillsDisableAll: (agentId: string) => void;
-};
-
-const TOOL_SECTIONS = [
-  {
-    id: "fs",
-    label: "Files",
-    tools: [
-      { id: "read", label: "read", description: "Read file contents" },
-      { id: "write", label: "write", description: "Create or overwrite files" },
-      { id: "edit", label: "edit", description: "Make precise edits" },
-      { id: "apply_patch", label: "apply_patch", description: "Patch files (OpenAI)" },
-    ],
-  },
-  {
-    id: "runtime",
-    label: "Runtime",
-    tools: [
-      { id: "exec", label: "exec", description: "Run shell commands" },
-      { id: "process", label: "process", description: "Manage background processes" },
-    ],
-  },
-  {
-    id: "web",
-    label: "Web",
-    tools: [
-      { id: "web_search", label: "web_search", description: "Search the web" },
-      { id: "web_fetch", label: "web_fetch", description: "Fetch web content" },
-    ],
-  },
-  {
-    id: "memory",
-    label: "Memory",
-    tools: [
-      { id: "memory_search", label: "memory_search", description: "Semantic search" },
-      { id: "memory_get", label: "memory_get", description: "Read memory files" },
-    ],
-  },
-  {
-    id: "sessions",
-    label: "Sessions",
-    tools: [
-      { id: "sessions_list", label: "sessions_list", description: "List sessions" },
-      { id: "sessions_history", label: "sessions_history", description: "Session history" },
-      { id: "sessions_send", label: "sessions_send", description: "Send to session" },
-      { id: "sessions_spawn", label: "sessions_spawn", description: "Spawn sub-agent" },
-      { id: "session_status", label: "session_status", description: "Session status" },
-    ],
-  },
-  {
-    id: "ui",
-    label: "UI",
-    tools: [
-      { id: "browser", label: "browser", description: "Control web browser" },
-      { id: "canvas", label: "canvas", description: "Control canvases" },
-    ],
-  },
-  {
-    id: "messaging",
-    label: "Messaging",
-    tools: [{ id: "message", label: "message", description: "Send messages" }],
-  },
-  {
-    id: "automation",
-    label: "Automation",
-    tools: [
-      { id: "cron", label: "cron", description: "Schedule tasks" },
-      { id: "gateway", label: "gateway", description: "Gateway control" },
-    ],
-  },
-  {
-    id: "nodes",
-    label: "Nodes",
-    tools: [{ id: "nodes", label: "nodes", description: "Nodes + devices" }],
-  },
-  {
-    id: "agents",
-    label: "Agents",
-    tools: [{ id: "agents_list", label: "agents_list", description: "List agents" }],
-  },
-  {
-    id: "media",
-    label: "Media",
-    tools: [{ id: "image", label: "image", description: "Image understanding" }],
-  },
-];
-
-const PROFILE_OPTIONS = [
-  { id: "minimal", label: "Minimal" },
-  { id: "coding", label: "Coding" },
-  { id: "messaging", label: "Messaging" },
-  { id: "full", label: "Full" },
-] as const;
-
-const SUBAGENT_LOCKED_TOOL_IDS = new Set(
-  SUBAGENT_DEFAULT_TOOL_DENY.map((entry) => normalizeToolName(entry)),
-);
-
-type ToolPolicy = {
-  allow?: string[];
-  deny?: string[];
-};
-
-type AgentConfigEntry = {
-  id: string;
-  name?: string;
-  workspace?: string;
-  agentDir?: string;
-  model?: unknown;
-  skills?: string[];
-  tools?: {
-    profile?: string;
-    allow?: string[];
-    alsoAllow?: string[];
-    deny?: string[];
-  };
-  subagents?: {
-    tools?: {
-      allow?: string[];
-      alsoAllow?: string[];
-      deny?: string[];
-    };
-  };
-};
-
-type ConfigSnapshot = {
-  agents?: {
-    defaults?: { workspace?: string; model?: unknown; models?: Record<string, { alias?: string }> };
-    list?: AgentConfigEntry[];
-  };
-  tools?: {
-    profile?: string;
-    allow?: string[];
-    alsoAllow?: string[];
-    deny?: string[];
-  };
 };
 
 function normalizeAgentLabel(agent: { id: string; name?: string; identity?: { name?: string } }) {
@@ -292,17 +161,6 @@ function formatBytes(bytes?: number) {
     unitIndex += 1;
   }
   return `${size.toFixed(size < 10 ? 1 : 0)} ${units[unitIndex]}`;
-}
-
-function resolveAgentConfig(config: Record<string, unknown> | null, agentId: string) {
-  const cfg = config as ConfigSnapshot | null;
-  const list = cfg?.agents?.list ?? [];
-  const entry = list.find((agent) => agent?.id === agentId);
-  return {
-    entry,
-    defaults: cfg?.agents?.defaults,
-    globalTools: cfg?.tools,
-  };
 }
 
 type AgentContext = {
@@ -465,89 +323,6 @@ function buildModelOptions(configForm: Record<string, unknown> | null, current?:
     `;
   }
   return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
-}
-
-type CompiledPattern =
-  | { kind: "all" }
-  | { kind: "exact"; value: string }
-  | { kind: "regex"; value: RegExp };
-
-function compilePattern(pattern: string): CompiledPattern {
-  const normalized = normalizeToolName(pattern);
-  if (!normalized) {
-    return { kind: "exact", value: "" };
-  }
-  if (normalized === "*") {
-    return { kind: "all" };
-  }
-  if (!normalized.includes("*")) {
-    return { kind: "exact", value: normalized };
-  }
-  const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
-  return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
-}
-
-function compilePatterns(patterns?: string[]): CompiledPattern[] {
-  if (!Array.isArray(patterns)) {
-    return [];
-  }
-  return expandToolGroups(patterns)
-    .map(compilePattern)
-    .filter((pattern) => {
-      return pattern.kind !== "exact" || pattern.value.length > 0;
-    });
-}
-
-function matchesAny(name: string, patterns: CompiledPattern[]) {
-  for (const pattern of patterns) {
-    if (pattern.kind === "all") {
-      return true;
-    }
-    if (pattern.kind === "exact" && name === pattern.value) {
-      return true;
-    }
-    if (pattern.kind === "regex" && pattern.value.test(name)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function isAllowedByPolicy(name: string, policy?: ToolPolicy) {
-  if (!policy) {
-    return true;
-  }
-  const normalized = normalizeToolName(name);
-  const deny = compilePatterns(policy.deny);
-  if (matchesAny(normalized, deny)) {
-    return false;
-  }
-  const allow = compilePatterns(policy.allow);
-  if (allow.length === 0) {
-    return true;
-  }
-  if (matchesAny(normalized, allow)) {
-    return true;
-  }
-  if (normalized === "apply_patch" && matchesAny("exec", allow)) {
-    return true;
-  }
-  return false;
-}
-
-function matchesList(name: string, list?: string[]) {
-  if (!Array.isArray(list) || list.length === 0) {
-    return false;
-  }
-  const normalized = normalizeToolName(name);
-  const patterns = compilePatterns(list);
-  if (matchesAny(normalized, patterns)) {
-    return true;
-  }
-  if (normalized === "apply_patch" && matchesAny("exec", patterns)) {
-    return true;
-  }
-  return false;
 }
 
 export function renderAgents(props: AgentsProps) {


### PR DESCRIPTION
## Problem
Main sessions can become unresponsive when long-running or blocking tools are enabled (for example heavy runtime/web/browser actions).
In practice, user messages get queued behind tool work, so the main conversation stops responding in time.

## Goal
Separate tool permissions between main and sub-agent sessions so:
- main can stay interactive and lightweight
- sub-agents can still run task-focused capabilities

## Summary
- runtime: add per-agent sub-agent tool policy via `agents.list[].subagents.tools`
- runtime: when sub-agent policy exists, use it instead of inheriting parent `agents.list[].tools`
- runtime: do not inherit parent `tools.byProvider` for sub-agent sessions when sub-agent override is present
- policy: keep sub-agent system-level deny list as one shared source for runtime + Control UI
- control UI: add “Sub-Agent Tool Access” editor
- control UI: hide system-level always-denied sub-agent tools from the sub-agent toggle list
- control UI: show `Custom` state in quick presets for non-preset agent tool configs
- refactor: extract UI helpers/modules so large files do not grow (`app-render.ts`, `views/agents.ts`)

## Validation
- `pnpm vitest run src/agents/pi-tools.policy.test.ts src/config/config.tools-alsoAllow.test.ts`
- `pnpm vitest run src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts`
- `pnpm ui:build`
- size check intent validated: compared to `upstream/main`, these large files are now smaller:
  - `ui/src/ui/app-render.ts`: `1222 -> 1201`
  - `ui/src/ui/views/agents.ts`: `1963 -> 1950`

## Notes
- AI-assisted PR
- `pnpm --dir ui test` still reports unrelated pre-existing failures in this environment:
  - `ui/src/ui/format.test.ts`
  - `ui/src/ui/navigation.browser.test.ts`
