### PR TITLE
feat(context-decay): proactive graduated context management with lifecycle telemetry

### DIFF
--- a/scripts/context-lifecycle-report.ts
+++ b/scripts/context-lifecycle-report.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env tsx
+/**
+ * Context Lifecycle Report
+ *
+ * Reads a context-lifecycle JSONL file and outputs a human-readable summary.
+ *
+ * Usage:
+ *   tsx scripts/context-lifecycle-report.ts <file.jsonl> [--json]
+ */
+import fs from "node:fs";
+
+type ContextLifecycleRule =
+  | "decay:strip_thinking"
+  | "decay:summarize_tool_result"
+  | "decay:summarize_group"
+  | "decay:strip_tool_result"
+  | "decay:file_swap"
+  | "decay:max_messages"
+  | "decay:pass"
+  | "prune:soft_trim"
+  | "prune:hard_clear"
+  | "prune:pass"
+  | "compact:memory_flush"
+  | "compact:compaction";
+
+interface ContextLifecycleEvent {
+  timestamp: string;
+  sessionKey: string;
+  sessionId: string;
+  turn: number;
+  rule: ContextLifecycleRule;
+  beforeTokens: number;
+  beforePct: number;
+  freedTokens: number;
+  afterTokens: number;
+  afterPct: number;
+  contextWindow: number;
+  details?: Record<string, unknown>;
+}
+
+interface RuleStats {
+  count: number;
+  totalFreed: number;
+  maxFreed: number;
+  maxBeforePct: number;
+}
+
+interface SessionSummary {
+  sessionKey: string;
+  sessionId: string;
+  contextWindow: number;
+  eventCount: number;
+  firstEvent: string;
+  lastEvent: string;
+  peakBeforePct: number;
+  totalFreed: number;
+  rules: Record<string, RuleStats>;
+  compactions: number;
+}
+
+function parseEvents(filePath: string): ContextLifecycleEvent[] {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const events: ContextLifecycleEvent[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      events.push(JSON.parse(trimmed) as ContextLifecycleEvent);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+  return events;
+}
+
+function groupBySession(events: ContextLifecycleEvent[]): Map<string, ContextLifecycleEvent[]> {
+  const groups = new Map<string, ContextLifecycleEvent[]>();
+  for (const evt of events) {
+    const key = evt.sessionId;
+    const arr = groups.get(key);
+    if (arr) {
+      arr.push(evt);
+    } else {
+      groups.set(key, [evt]);
+    }
+  }
+  return groups;
+}
+
+function summarizeSession(events: ContextLifecycleEvent[]): SessionSummary {
+  const first = events[0];
+  const last = events[events.length - 1];
+  const rules: Record<string, RuleStats> = {};
+  let peakBeforePct = 0;
+  let totalFreed = 0;
+  let compactions = 0;
+
+  for (const evt of events) {
+    if (evt.beforePct > peakBeforePct) {
+      peakBeforePct = evt.beforePct;
+    }
+    totalFreed += evt.freedTokens;
+    if (evt.rule === "compact:compaction") {
+      compactions++;
+    }
+
+    const r = rules[evt.rule];
+    if (r) {
+      r.count++;
+      r.totalFreed += evt.freedTokens;
+      if (evt.freedTokens > r.maxFreed) {
+        r.maxFreed = evt.freedTokens;
+      }
+      if (evt.beforePct > r.maxBeforePct) {
+        r.maxBeforePct = evt.beforePct;
+      }
+    } else {
+      rules[evt.rule] = {
+        count: 1,
+        totalFreed: evt.freedTokens,
+        maxFreed: evt.freedTokens,
+        maxBeforePct: evt.beforePct,
+      };
+    }
+  }
+
+  return {
+    sessionKey: first.sessionKey,
+    sessionId: first.sessionId,
+    contextWindow: first.contextWindow,
+    eventCount: events.length,
+    firstEvent: first.timestamp,
+    lastEvent: last.timestamp,
+    peakBeforePct,
+    totalFreed,
+    rules,
+    compactions,
+  };
+}
+
+function formatTokens(n: number): string {
+  if (Math.abs(n) >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
+  }
+  if (Math.abs(n) >= 1_000) {
+    return `${(n / 1_000).toFixed(1)}k`;
+  }
+  return String(n);
+}
+
+function formatDuration(start: string, end: string): string {
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const sec = ms / 1000;
+  if (sec < 60) {
+    return `${sec.toFixed(0)}s`;
+  }
+  const min = sec / 60;
+  if (min < 60) {
+    return `${min.toFixed(1)}m`;
+  }
+  const hr = min / 60;
+  return `${hr.toFixed(1)}h`;
+}
+
+function printSummary(summary: SessionSummary): void {
+  const duration = formatDuration(summary.firstEvent, summary.lastEvent);
+  console.log(`\nSession: ${summary.sessionKey}`);
+  console.log(`  ID:             ${summary.sessionId}`);
+  console.log(`  Context window: ${formatTokens(summary.contextWindow)} tokens`);
+  console.log(`  Duration:       ${duration}`);
+  console.log(`  Events:         ${summary.eventCount}`);
+  console.log(`  Peak usage:     ${summary.peakBeforePct}%`);
+  console.log(`  Total freed:    ${formatTokens(summary.totalFreed)} tokens`);
+  console.log(`  Compactions:    ${summary.compactions}`);
+
+  const sortedRules = Object.entries(summary.rules).toSorted(
+    (a, b) => b[1].totalFreed - a[1].totalFreed,
+  );
+  if (sortedRules.length > 0) {
+    console.log(`  Rules:`);
+    for (const [rule, stats] of sortedRules) {
+      const freed = formatTokens(stats.totalFreed);
+      const maxFreed = formatTokens(stats.maxFreed);
+      console.log(
+        `    ${rule.padEnd(28)} ${String(stats.count).padStart(4)}x  freed ${freed.padStart(7)} total  max ${maxFreed.padStart(7)}  peak ${stats.maxBeforePct}%`,
+      );
+    }
+  }
+}
+
+function printOverview(summaries: SessionSummary[]): void {
+  const totalEvents = summaries.reduce((s, x) => s + x.eventCount, 0);
+  const totalFreed = summaries.reduce((s, x) => s + x.totalFreed, 0);
+  const totalCompactions = summaries.reduce((s, x) => s + x.compactions, 0);
+  const peakPct = Math.max(...summaries.map((s) => s.peakBeforePct));
+
+  console.log("=== Context Lifecycle Report ===");
+  console.log(`Sessions:     ${summaries.length}`);
+  console.log(`Total events: ${totalEvents}`);
+  console.log(`Total freed:  ${formatTokens(totalFreed)} tokens`);
+  console.log(`Compactions:  ${totalCompactions}`);
+  console.log(`Peak usage:   ${peakPct}%`);
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes("--json");
+  const filePath = args.find((a) => !a.startsWith("--"));
+
+  if (!filePath) {
+    console.error("Usage: tsx scripts/context-lifecycle-report.ts <file.jsonl> [--json]");
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`File not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const events = parseEvents(filePath);
+  if (events.length === 0) {
+    console.error("No events found in file.");
+    process.exit(1);
+  }
+
+  const groups = groupBySession(events);
+  const summaries = [...groups.values()].map(summarizeSession);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(summaries, null, 2));
+    return;
+  }
+
+  printOverview(summaries);
+  for (const summary of summaries) {
+    printSummary(summary);
+  }
+}
+
+main();

--- a/src/agents/context-decay/clear-stores.test.ts
+++ b/src/agents/context-decay/clear-stores.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./file-store.js", () => ({
+  clearSwappedFileStore: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("./summary-store.js", () => ({
+  clearSummaryStore: vi.fn().mockResolvedValue(undefined),
+  clearGroupSummaryStore: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { clearAllDecayStores } from "./clear-stores.js";
+import { clearSwappedFileStore } from "./file-store.js";
+import { clearGroupSummaryStore, clearSummaryStore } from "./summary-store.js";
+
+describe("clearAllDecayStores", () => {
+  it("calls all three clear functions with the session file path", async () => {
+    const sessionFile = "/tmp/test-session.jsonl";
+    await clearAllDecayStores(sessionFile);
+
+    expect(clearSummaryStore).toHaveBeenCalledWith(sessionFile);
+    expect(clearGroupSummaryStore).toHaveBeenCalledWith(sessionFile);
+    expect(clearSwappedFileStore).toHaveBeenCalledWith(sessionFile);
+  });
+
+  it("runs all clears in parallel (all called before any resolves)", async () => {
+    const order: string[] = [];
+    vi.mocked(clearSummaryStore).mockImplementation(async () => {
+      order.push("summary");
+    });
+    vi.mocked(clearGroupSummaryStore).mockImplementation(async () => {
+      order.push("group");
+    });
+    vi.mocked(clearSwappedFileStore).mockImplementation(async () => {
+      order.push("swap");
+    });
+
+    await clearAllDecayStores("/tmp/s.jsonl");
+    expect(order).toHaveLength(3);
+    expect(order).toContain("summary");
+    expect(order).toContain("group");
+    expect(order).toContain("swap");
+  });
+
+  it("propagates errors from any clear function", async () => {
+    vi.mocked(clearGroupSummaryStore).mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(clearAllDecayStores("/tmp/s.jsonl")).rejects.toThrow("disk full");
+  });
+});

--- a/src/agents/context-decay/clear-stores.ts
+++ b/src/agents/context-decay/clear-stores.ts
@@ -1,0 +1,14 @@
+import { clearSwappedFileStore } from "./file-store.js";
+import { clearGroupSummaryStore, clearSummaryStore } from "./summary-store.js";
+
+/**
+ * Clear all decay stores (summary, group-summary, swapped-file) for a session.
+ * Indices are positional and become invalid after compaction rewrites the session JSONL.
+ */
+export async function clearAllDecayStores(sessionFilePath: string): Promise<void> {
+  await Promise.all([
+    clearSummaryStore(sessionFilePath),
+    clearGroupSummaryStore(sessionFilePath),
+    clearSwappedFileStore(sessionFilePath),
+  ]);
+}

--- a/src/agents/context-decay/file-store.test.ts
+++ b/src/agents/context-decay/file-store.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SwappedFileStore } from "./file-store.js";
+import {
+  clearSwappedFileStore,
+  loadSwappedFileStore,
+  loadSwappedFileStoreSync,
+  resultsDir,
+  saveSwappedFileStore,
+} from "./file-store.js";
+
+let tmpDir: string;
+
+function sessionPath(): string {
+  return path.join(tmpDir, "session.jsonl");
+}
+
+function storePath(): string {
+  return path.join(tmpDir, "session.swapped-results.json");
+}
+
+function makeSampleStore(): SwappedFileStore {
+  return {
+    3: {
+      filePath: "/tmp/results/1700000000000-Read.txt",
+      toolName: "Read",
+      hint: "[136 lines, TypeScript] Contains resolveUserPath()",
+      originalChars: 4200,
+      swappedAt: "2026-01-15T10:00:00.000Z",
+    },
+    7: {
+      filePath: "/tmp/results/1700000001000-Bash.txt",
+      toolName: "Bash",
+      hint: "[exit 0, 12 lines] npm install completed",
+      originalChars: 800,
+      swappedAt: "2026-01-15T10:01:00.000Z",
+    },
+  };
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "file-store-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("file-store", () => {
+  describe("loadSwappedFileStore (async)", () => {
+    it("returns empty store when file does not exist", async () => {
+      const store = await loadSwappedFileStore(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("returns empty store when file contains invalid JSON", async () => {
+      await fs.writeFile(storePath(), "not json!", "utf-8");
+      const store = await loadSwappedFileStore(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("returns empty store when file contains a JSON array", async () => {
+      await fs.writeFile(storePath(), "[1,2,3]", "utf-8");
+      const store = await loadSwappedFileStore(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("loads a valid store", async () => {
+      const sample = makeSampleStore();
+      await fs.writeFile(storePath(), JSON.stringify(sample), "utf-8");
+      const store = await loadSwappedFileStore(sessionPath());
+      expect(store).toEqual(sample);
+    });
+  });
+
+  describe("loadSwappedFileStoreSync", () => {
+    it("returns empty store when file does not exist", () => {
+      const store = loadSwappedFileStoreSync(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("returns empty store when file contains invalid JSON", async () => {
+      await fs.writeFile(storePath(), "{broken", "utf-8");
+      const store = loadSwappedFileStoreSync(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("loads a valid store", async () => {
+      const sample = makeSampleStore();
+      await fs.writeFile(storePath(), JSON.stringify(sample), "utf-8");
+      const store = loadSwappedFileStoreSync(sessionPath());
+      expect(store).toEqual(sample);
+    });
+  });
+
+  describe("saveSwappedFileStore", () => {
+    it("creates directories and saves a round-trippable store", async () => {
+      const nestedSession = path.join(tmpDir, "a", "b", "session.jsonl");
+      const sample = makeSampleStore();
+
+      await saveSwappedFileStore(nestedSession, sample);
+
+      const loaded = await loadSwappedFileStore(nestedSession);
+      expect(loaded).toEqual(sample);
+    });
+
+    it("overwrites an existing store", async () => {
+      const sample1 = makeSampleStore();
+      await saveSwappedFileStore(sessionPath(), sample1);
+
+      const sample2: SwappedFileStore = {
+        10: {
+          filePath: "/tmp/results/new.txt",
+          toolName: "Grep",
+          hint: "[5 result lines]",
+          originalChars: 300,
+          swappedAt: "2026-02-01T00:00:00.000Z",
+        },
+      };
+      await saveSwappedFileStore(sessionPath(), sample2);
+
+      const loaded = await loadSwappedFileStore(sessionPath());
+      expect(loaded).toEqual(sample2);
+      expect(loaded[3]).toBeUndefined();
+    });
+
+    it("writes pretty-printed JSON", async () => {
+      await saveSwappedFileStore(sessionPath(), makeSampleStore());
+      const raw = await fs.readFile(storePath(), "utf-8");
+      expect(raw).toContain("\n");
+      expect(raw).toContain("  ");
+    });
+  });
+
+  describe("clearSwappedFileStore", () => {
+    it("removes an existing store file and results directory", async () => {
+      await saveSwappedFileStore(sessionPath(), makeSampleStore());
+      await expect(fs.access(storePath())).resolves.toBeUndefined();
+
+      // Create a results directory with a file
+      const resDir = resultsDir(sessionPath());
+      await fs.mkdir(resDir, { recursive: true });
+      await fs.writeFile(path.join(resDir, "test.txt"), "content", "utf-8");
+
+      await clearSwappedFileStore(sessionPath());
+
+      const store = await loadSwappedFileStore(sessionPath());
+      expect(store).toEqual({});
+
+      // Results directory should also be gone
+      await expect(fs.access(resDir)).rejects.toThrow();
+    });
+
+    it("is a no-op when the file does not exist", async () => {
+      await expect(clearSwappedFileStore(sessionPath())).resolves.toBeUndefined();
+    });
+  });
+
+  describe("resultsDir", () => {
+    it("returns path alongside session file", () => {
+      const result = resultsDir("/data/sessions/abc.jsonl");
+      expect(result).toBe("/data/sessions/abc.results");
+    });
+  });
+});

--- a/src/agents/context-decay/file-store.test.ts
+++ b/src/agents/context-decay/file-store.test.ts
@@ -161,7 +161,7 @@ describe("file-store", () => {
   describe("resultsDir", () => {
     it("returns path alongside session file", () => {
       const result = resultsDir("/data/sessions/abc.jsonl");
-      expect(result).toBe("/data/sessions/abc.results");
+      expect(result).toBe(path.join("/data/sessions", "abc.results"));
     });
   });
 });

--- a/src/agents/context-decay/file-store.ts
+++ b/src/agents/context-decay/file-store.ts
@@ -1,0 +1,101 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface SwappedFileEntry {
+  /** Absolute path to the file containing the original tool result. */
+  filePath: string;
+  /** Name of the tool that produced the result. */
+  toolName: string;
+  /** Heuristic hint summarizing the content (no LLM). */
+  hint: string;
+  /** Character count of the original content. */
+  originalChars: number;
+  /** ISO timestamp of when the swap occurred. */
+  swappedAt: string;
+}
+
+/** Maps message index (position in transcript) to its swapped file entry. */
+export type SwappedFileStore = Record<number, SwappedFileEntry>;
+
+function swappedFileStorePath(sessionFilePath: string): string {
+  const dir = path.dirname(sessionFilePath);
+  const base = path.basename(sessionFilePath, path.extname(sessionFilePath));
+  return path.join(dir, `${base}.swapped-results.json`);
+}
+
+/** Directory for individual tool result files, alongside the session file. */
+export function resultsDir(sessionFilePath: string): string {
+  const dir = path.dirname(sessionFilePath);
+  const base = path.basename(sessionFilePath, path.extname(sessionFilePath));
+  return path.join(dir, `${base}.results`);
+}
+
+/** Load the swapped file store for a session (async). Returns empty store on missing/invalid file. */
+export async function loadSwappedFileStore(sessionFilePath: string): Promise<SwappedFileStore> {
+  const filePath = swappedFileStorePath(sessionFilePath);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as SwappedFileStore;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Load the swapped file store for a session (synchronous). Returns empty store on missing/invalid file. */
+export function loadSwappedFileStoreSync(sessionFilePath: string): SwappedFileStore {
+  const filePath = swappedFileStorePath(sessionFilePath);
+  try {
+    const raw = fsSync.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as SwappedFileStore;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Atomically persist the swapped file store (tmp + rename). Creates directories as needed. */
+export async function saveSwappedFileStore(
+  sessionFilePath: string,
+  store: SwappedFileStore,
+): Promise<void> {
+  const filePath = swappedFileStorePath(sessionFilePath);
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  try {
+    await fs.writeFile(tmpPath, JSON.stringify(store, null, 2), "utf-8");
+    await fs.rename(tmpPath, filePath);
+  } catch (err) {
+    await fs.unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+}
+
+/** Remove the swapped file store and results directory for a session. No-op if they don't exist. */
+export async function clearSwappedFileStore(sessionFilePath: string): Promise<void> {
+  const storePath = swappedFileStorePath(sessionFilePath);
+  try {
+    await fs.unlink(storePath);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  const resDir = resultsDir(sessionFilePath);
+  try {
+    await fs.rm(resDir, { recursive: true, force: true });
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+}

--- a/src/agents/context-decay/file-swapper.test.ts
+++ b/src/agents/context-decay/file-swapper.test.ts
@@ -1,0 +1,233 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import { loadSwappedFileStore, resultsDir } from "./file-store.js";
+import { swapAgedToolResults } from "./file-swapper.js";
+
+let tmpDir: string;
+
+function sessionPath(): string {
+  return path.join(tmpDir, "session.jsonl");
+}
+
+/**
+ * Build a minimal message transcript for testing.
+ * Pattern: user → assistant (with tool_use) → toolResult → user → assistant → ...
+ * Each user message marks a new turn boundary.
+ */
+function buildMessages(turnCount: number, toolResultContent: string = "x".repeat(500)): AgentMessage[] {
+  const messages: AgentMessage[] = [];
+  for (let turn = 0; turn < turnCount; turn++) {
+    // User message
+    messages.push({
+      role: "user",
+      content: `User message turn ${turn}`,
+      timestamp: Date.now(),
+    } as AgentMessage);
+
+    // Assistant with tool_use
+    messages.push({
+      role: "assistant",
+      content: [
+        { type: "text", text: "Let me check that." },
+        { type: "tool_use", id: `tool-${turn}`, name: "Read", input: { path: `/src/file${turn}.ts` } },
+      ],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage);
+
+    // Tool result
+    messages.push({
+      role: "toolResult",
+      toolCallId: `tool-${turn}`,
+      content: [{ type: "text", text: toolResultContent }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage);
+  }
+
+  // Final user message (current turn)
+  messages.push({
+    role: "user",
+    content: "Current message",
+    timestamp: Date.now(),
+  } as AgentMessage);
+
+  return messages;
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "file-swapper-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("swapAgedToolResults", () => {
+  it("swaps tool results older than threshold", async () => {
+    const messages = buildMessages(5);
+    const config: ContextDecayConfig = {
+      swapToolResultsAfterTurns: 2,
+    };
+
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+    });
+
+    const store = await loadSwappedFileStore(sessionPath());
+    // Turns 0-2 have age >= 2 (5 turns total, last is current)
+    // Turn 0 = age 5, Turn 1 = age 4, Turn 2 = age 3, Turn 3 = age 2, Turn 4 = age 1
+    const swappedIndices = Object.keys(store).map(Number);
+    expect(swappedIndices.length).toBeGreaterThan(0);
+
+    // Verify files exist on disk
+    for (const entry of Object.values(store)) {
+      const content = await fs.readFile(entry.filePath, "utf-8");
+      expect(content.length).toBeGreaterThan(0);
+      expect(entry.hint).toBeTruthy();
+      expect(entry.toolName).toBe("Read");
+    }
+  });
+
+  it("skips tool results below swapMinChars", async () => {
+    const messages = buildMessages(3, "short");
+    const config: ContextDecayConfig = {
+      swapToolResultsAfterTurns: 1,
+      swapMinChars: 256,
+    };
+
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+    });
+
+    const store = await loadSwappedFileStore(sessionPath());
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it("skips tool results past summarize threshold", async () => {
+    const messages = buildMessages(5);
+    const config: ContextDecayConfig = {
+      swapToolResultsAfterTurns: 2,
+      summarizeToolResultsAfterTurns: 3,
+    };
+
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+    });
+
+    const store = await loadSwappedFileStore(sessionPath());
+    // Only results with age >= 2 AND age < 3 should be swapped
+    for (const [, entry] of Object.entries(store)) {
+      expect(entry).toBeDefined();
+    }
+    // Older results (age >= 3) should NOT be in the store
+    // since summarizer handles those
+  });
+
+  it("skips tool results past strip threshold", async () => {
+    const messages = buildMessages(5);
+    const config: ContextDecayConfig = {
+      swapToolResultsAfterTurns: 2,
+      stripToolResultsAfterTurns: 3,
+    };
+
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+    });
+
+    const store = await loadSwappedFileStore(sessionPath());
+    // Results with age >= 3 should be skipped (strip handles them)
+    for (const [, entry] of Object.entries(store)) {
+      expect(entry).toBeDefined();
+    }
+  });
+
+  it("does not re-swap already swapped results", async () => {
+    const messages = buildMessages(5);
+    const config: ContextDecayConfig = {
+      swapToolResultsAfterTurns: 2,
+    };
+
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+    });
+
+    const store1 = await loadSwappedFileStore(sessionPath());
+    const count1 = Object.keys(store1).length;
+
+    // Run again — should not change anything
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+    });
+
+    const store2 = await loadSwappedFileStore(sessionPath());
+    expect(Object.keys(store2).length).toBe(count1);
+  });
+
+  it("is a no-op when swapToolResultsAfterTurns is not set", async () => {
+    const messages = buildMessages(5);
+    const config: ContextDecayConfig = {
+      summarizeToolResultsAfterTurns: 5,
+    };
+
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+    });
+
+    const store = await loadSwappedFileStore(sessionPath());
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it("respects abort signal", async () => {
+    const messages = buildMessages(10);
+    const config: ContextDecayConfig = {
+      swapToolResultsAfterTurns: 1,
+    };
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+      abortSignal: controller.signal,
+    });
+
+    const store = await loadSwappedFileStore(sessionPath());
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it("creates results directory alongside session file", async () => {
+    const messages = buildMessages(3);
+    const config: ContextDecayConfig = {
+      swapToolResultsAfterTurns: 1,
+    };
+
+    await swapAgedToolResults({
+      sessionFilePath: sessionPath(),
+      messages,
+      config,
+    });
+
+    const resDir = resultsDir(sessionPath());
+    const stat = await fs.stat(resDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+});

--- a/src/agents/context-decay/file-swapper.test.ts
+++ b/src/agents/context-decay/file-swapper.test.ts
@@ -1,7 +1,7 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
 import { loadSwappedFileStore, resultsDir } from "./file-store.js";
@@ -18,7 +18,10 @@ function sessionPath(): string {
  * Pattern: user → assistant (with tool_use) → toolResult → user → assistant → ...
  * Each user message marks a new turn boundary.
  */
-function buildMessages(turnCount: number, toolResultContent: string = "x".repeat(500)): AgentMessage[] {
+function buildMessages(
+  turnCount: number,
+  toolResultContent: string = "x".repeat(500),
+): AgentMessage[] {
   const messages: AgentMessage[] = [];
   for (let turn = 0; turn < turnCount; turn++) {
     // User message
@@ -33,7 +36,12 @@ function buildMessages(turnCount: number, toolResultContent: string = "x".repeat
       role: "assistant",
       content: [
         { type: "text", text: "Let me check that." },
-        { type: "tool_use", id: `tool-${turn}`, name: "Read", input: { path: `/src/file${turn}.ts` } },
+        {
+          type: "tool_use",
+          id: `tool-${turn}`,
+          name: "Read",
+          input: { path: `/src/file${turn}.ts` },
+        },
       ],
       timestamp: Date.now(),
     } as unknown as AgentMessage);

--- a/src/agents/context-decay/file-swapper.ts
+++ b/src/agents/context-decay/file-swapper.ts
@@ -1,6 +1,6 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
 import { log } from "../pi-embedded-runner/logger.js";
 import { loadSwappedFileStore, resultsDir, saveSwappedFileStore } from "./file-store.js";
@@ -115,9 +115,7 @@ export async function swapAgedToolResults(params: {
   if (didUpdate) {
     try {
       await saveSwappedFileStore(sessionFilePath, updatedStore);
-      log.info(
-        `context-decay: swapped ${toSwap.length} tool result(s) to files in ${resDir}`,
-      );
+      log.info(`context-decay: swapped ${toSwap.length} tool result(s) to files in ${resDir}`);
     } catch (err) {
       log.warn(`context-decay: failed to save swapped file store: ${String(err)}`);
     }

--- a/src/agents/context-decay/file-swapper.ts
+++ b/src/agents/context-decay/file-swapper.ts
@@ -1,0 +1,125 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import { log } from "../pi-embedded-runner/logger.js";
+import { loadSwappedFileStore, resultsDir, saveSwappedFileStore } from "./file-store.js";
+import { generateHeuristicHint } from "./hint-generator.js";
+import { extractContentText, extractToolInfo } from "./message-utils.js";
+import { computeTurnAges } from "./turn-ages.js";
+
+const DEFAULT_SWAP_MIN_CHARS = 256;
+
+/**
+ * Swap aged tool results to files on disk.
+ * This is fire-and-forget — failures are logged but don't affect the agent run.
+ * No LLM calls. No API key needed. Pure I/O.
+ */
+export async function swapAgedToolResults(params: {
+  sessionFilePath: string;
+  messages: AgentMessage[];
+  config: ContextDecayConfig;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const { sessionFilePath, messages, config, abortSignal } = params;
+
+  const swapAfter = config.swapToolResultsAfterTurns;
+  if (!swapAfter || swapAfter < 1) {
+    return;
+  }
+
+  const minChars = config.swapMinChars ?? DEFAULT_SWAP_MIN_CHARS;
+  const existingStore = await loadSwappedFileStore(sessionFilePath);
+  const turnAges = computeTurnAges(messages);
+  const toSwap: Array<{ index: number; toolName: string; args: string; content: string }> = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    if (abortSignal?.aborted) {
+      return;
+    }
+
+    const msg = messages[i];
+    if (msg.role !== "toolResult") {
+      continue;
+    }
+
+    const age = turnAges.get(i) ?? 0;
+    if (age < swapAfter) {
+      continue;
+    }
+    // Skip if already swapped
+    if (existingStore[i]) {
+      continue;
+    }
+    // Skip if past summarize threshold — let the summarizer handle it
+    if (config.summarizeToolResultsAfterTurns && age >= config.summarizeToolResultsAfterTurns) {
+      continue;
+    }
+    // Skip if past strip threshold — will be stripped anyway
+    if (config.stripToolResultsAfterTurns && age >= config.stripToolResultsAfterTurns) {
+      continue;
+    }
+
+    const content = extractContentText(msg);
+    if (content.length < minChars) {
+      continue;
+    }
+
+    const { toolName, args } = extractToolInfo(messages, i);
+    toSwap.push({ index: i, toolName, args, content });
+  }
+
+  if (toSwap.length === 0) {
+    return;
+  }
+
+  // Ensure results directory exists
+  const resDir = resultsDir(sessionFilePath);
+  await fs.mkdir(resDir, { recursive: true });
+
+  const updatedStore = { ...existingStore };
+  let didUpdate = false;
+
+  for (const item of toSwap) {
+    if (abortSignal?.aborted) {
+      break;
+    }
+
+    try {
+      // Sanitize tool name for filename
+      const safeName = item.toolName.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 50);
+      const fileName = `${Date.now()}-${safeName}.txt`;
+      const filePath = path.join(resDir, fileName);
+
+      await fs.writeFile(filePath, item.content, "utf-8");
+
+      const hint = generateHeuristicHint({
+        toolName: item.toolName,
+        args: item.args,
+        content: item.content,
+      });
+
+      updatedStore[item.index] = {
+        filePath,
+        toolName: item.toolName,
+        hint,
+        originalChars: item.content.length,
+        swappedAt: new Date().toISOString(),
+      };
+      didUpdate = true;
+    } catch (err) {
+      log.warn(`context-decay: failed to swap tool result at index ${item.index}: ${String(err)}`);
+    }
+  }
+
+  if (didUpdate) {
+    try {
+      await saveSwappedFileStore(sessionFilePath, updatedStore);
+      log.info(
+        `context-decay: swapped ${toSwap.length} tool result(s) to files in ${resDir}`,
+      );
+    } catch (err) {
+      log.warn(`context-decay: failed to save swapped file store: ${String(err)}`);
+    }
+  }
+}

--- a/src/agents/context-decay/group-summarizer.test.ts
+++ b/src/agents/context-decay/group-summarizer.test.ts
@@ -1,0 +1,317 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import type { GroupSummaryStore, SummaryStore } from "./summary-store.js";
+import {
+  findEligibleWindows,
+  buildGroupSummarizationPrompt,
+  type TurnWindow,
+} from "./group-summarizer.js";
+import { computeTurnAges } from "./turn-ages.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(text: string): AgentMessage {
+  return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function makeAssistant(text: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "fake",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function makeAssistantWithToolUse(toolCallId: string, toolName: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Let me call a tool." },
+      { type: "tool_use", id: toolCallId, name: toolName, input: { path: "/src/foo.ts" } },
+    ],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "fake",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+    stopReason: "tool_use",
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function makeToolResult(toolCallId: string, toolName: string, text: string): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName,
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: Date.now(),
+  };
+}
+
+// Pad to ensure token estimates clear the MIN_WINDOW_TOKENS (500) threshold.
+const PAD = " ".repeat(400);
+
+/**
+ * Build a multi-turn conversation with N turns, each containing user + assistant + tool call.
+ * Returns messages array suitable for testing.
+ */
+function buildConversation(turnCount: number): AgentMessage[] {
+  const messages: AgentMessage[] = [];
+  for (let i = 0; i < turnCount; i++) {
+    messages.push(
+      makeUser(
+        `User message for turn ${i} with some context about what needs to be done in this step of the conversation.${PAD}`,
+      ),
+    );
+    messages.push(makeAssistantWithToolUse(`call_${i}`, `tool_${i}`));
+    messages.push(
+      makeToolResult(
+        `call_${i}`,
+        `tool_${i}`,
+        `Result for turn ${i}: found the file at /src/module-${i}.ts with function handle${i}() that processes the data correctly and returns the expected output.${PAD}`,
+      ),
+    );
+  }
+  // Final turn (current)
+  messages.push(makeUser("Latest user message"));
+  messages.push(makeAssistant("Latest assistant response"));
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: findEligibleWindows
+// ---------------------------------------------------------------------------
+
+describe("findEligibleWindows", () => {
+  it("returns empty when summarizeWindowAfterTurns is not set", () => {
+    const messages = buildConversation(8);
+    const config: ContextDecayConfig = {};
+    const result = findEligibleWindows({ messages, config, existingGroupSummaries: [] });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when no turns meet the age threshold", () => {
+    const messages = buildConversation(3);
+    const config: ContextDecayConfig = { summarizeWindowAfterTurns: 10 };
+    const result = findEligibleWindows({ messages, config, existingGroupSummaries: [] });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when fewer than 2 eligible turns exist", () => {
+    // 2 history turns + 1 current = turn ages 0, 1, 2
+    // With threshold 2, only turn age 2 qualifies → not enough for a window
+    const messages = buildConversation(2);
+    messages.push(makeUser("current"));
+    messages.push(makeAssistant("current response"));
+    const config: ContextDecayConfig = { summarizeWindowAfterTurns: 100 };
+    const result = findEligibleWindows({ messages, config, existingGroupSummaries: [] });
+    expect(result).toEqual([]);
+  });
+
+  it("finds windows when enough turns meet the age threshold", () => {
+    const messages = buildConversation(8);
+    // Turn ages: 8,8,8, 7,7,7, 6,6,6, 5,5,5, 4,4,4, 3,3,3, 2,2,2, 1,1,1, 0,0
+    // With threshold 3, turns 3-8 are eligible (6 turns)
+    // Default window size 4: should create 1 full window + leftover < 2 skipped
+    const config: ContextDecayConfig = { summarizeWindowAfterTurns: 3, summarizeWindowSize: 4 };
+    const result = findEligibleWindows({ messages, config, existingGroupSummaries: [] });
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    for (const win of result) {
+      expect(win.indices.length).toBeGreaterThan(0);
+      expect(win.anchorIndex).toBeDefined();
+      expect(win.turnRange).toHaveLength(2);
+    }
+  });
+
+  it("respects custom window size", () => {
+    const messages = buildConversation(10);
+    const config: ContextDecayConfig = { summarizeWindowAfterTurns: 2, summarizeWindowSize: 2 };
+    const result = findEligibleWindows({ messages, config, existingGroupSummaries: [] });
+    // With window size 2, we should get multiple windows
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("excludes turns already covered by existing group summaries", () => {
+    const messages = buildConversation(8);
+    const config: ContextDecayConfig = { summarizeWindowAfterTurns: 3, summarizeWindowSize: 4 };
+
+    // First call: get the windows
+    const firstResult = findEligibleWindows({ messages, config, existingGroupSummaries: [] });
+    expect(firstResult.length).toBeGreaterThanOrEqual(1);
+
+    // Simulate that the first window was already summarized
+    const existingGroupSummaries: GroupSummaryStore = [
+      {
+        summary: "Already summarized",
+        anchorIndex: firstResult[0].anchorIndex,
+        indices: firstResult[0].indices,
+        turnRange: firstResult[0].turnRange,
+        originalTokenEstimate: 500,
+        summaryTokenEstimate: 50,
+        summarizedAt: new Date().toISOString(),
+        model: "test",
+      },
+    ];
+
+    // Second call: those turns should be excluded
+    const secondResult = findEligibleWindows({
+      messages,
+      config,
+      existingGroupSummaries,
+    });
+
+    // The previously summarized indices should not appear in any new window
+    const coveredIndices = new Set(firstResult[0].indices);
+    for (const win of secondResult) {
+      for (const idx of win.indices) {
+        expect(coveredIndices.has(idx)).toBe(false);
+      }
+    }
+  });
+
+  it("excludes turns past stripToolResultsAfterTurns", () => {
+    const messages = buildConversation(10);
+    const config: ContextDecayConfig = {
+      summarizeWindowAfterTurns: 3,
+      stripToolResultsAfterTurns: 7,
+      summarizeWindowSize: 4,
+    };
+    const result = findEligibleWindows({ messages, config, existingGroupSummaries: [] });
+    // No window should include turns with age >= 7
+    for (const win of result) {
+      expect(win.turnRange[0]).toBeLessThan(7);
+    }
+  });
+
+  it("sets anchor to first user message in window", () => {
+    const messages = buildConversation(8);
+    const config: ContextDecayConfig = { summarizeWindowAfterTurns: 3, summarizeWindowSize: 4 };
+    const result = findEligibleWindows({ messages, config, existingGroupSummaries: [] });
+    for (const win of result) {
+      // The anchor should be in the window's indices
+      expect(win.indices).toContain(win.anchorIndex);
+      // The anchor should be a user message
+      expect(messages[win.anchorIndex].role).toBe("user");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildGroupSummarizationPrompt
+// ---------------------------------------------------------------------------
+
+describe("buildGroupSummarizationPrompt", () => {
+  it("includes header instruction", () => {
+    const messages = buildConversation(4);
+    const turnAges = computeTurnAges(messages);
+    const win: TurnWindow = {
+      turnRange: [3, 2],
+      indices: [0, 1, 2, 3, 4, 5],
+      anchorIndex: 0,
+    };
+    const prompt = buildGroupSummarizationPrompt({
+      messages,
+      window: win,
+      turnAges,
+      individualSummaries: {},
+    });
+    expect(prompt).toContain("Summarize this conversation window");
+    expect(prompt).toContain("causal chains");
+  });
+
+  it("includes user, assistant, and tool result content", () => {
+    const messages = buildConversation(4);
+    const turnAges = computeTurnAges(messages);
+    const win: TurnWindow = {
+      turnRange: [3, 2],
+      indices: [0, 1, 2, 3, 4, 5],
+      anchorIndex: 0,
+    };
+    const prompt = buildGroupSummarizationPrompt({
+      messages,
+      window: win,
+      turnAges,
+      individualSummaries: {},
+    });
+    expect(prompt).toContain("[User]:");
+    expect(prompt).toContain("[Assistant]:");
+    expect(prompt).toContain("[Tool:");
+  });
+
+  it("uses individual summaries when available instead of raw content", () => {
+    const messages = buildConversation(4);
+    const turnAges = computeTurnAges(messages);
+    const individualSummaries: SummaryStore = {
+      2: {
+        summary: "Individual summary of tool result 0",
+        originalTokenEstimate: 100,
+        summaryTokenEstimate: 10,
+        summarizedAt: new Date().toISOString(),
+        model: "haiku",
+      },
+    };
+    const win: TurnWindow = {
+      turnRange: [3, 2],
+      indices: [0, 1, 2, 3, 4, 5],
+      anchorIndex: 0,
+    };
+    const prompt = buildGroupSummarizationPrompt({
+      messages,
+      window: win,
+      turnAges,
+      individualSummaries,
+    });
+    expect(prompt).toContain("[Previously summarized]");
+    expect(prompt).toContain("Individual summary of tool result 0");
+  });
+
+  it("includes turn age markers", () => {
+    const messages = buildConversation(4);
+    const turnAges = computeTurnAges(messages);
+    const win: TurnWindow = {
+      turnRange: [3, 2],
+      indices: [0, 1, 2, 3, 4, 5],
+      anchorIndex: 0,
+    };
+    const prompt = buildGroupSummarizationPrompt({
+      messages,
+      window: win,
+      turnAges,
+      individualSummaries: {},
+    });
+    expect(prompt).toContain("--- Turn [age");
+  });
+
+  it("truncates very long prompts", () => {
+    // Build messages with very long content
+    const messages: AgentMessage[] = [];
+    const longContent = "x".repeat(60_000);
+    messages.push(makeUser(longContent));
+    messages.push(makeAssistant(longContent));
+    messages.push(makeUser("current"));
+    messages.push(makeAssistant("current"));
+    const turnAges = computeTurnAges(messages);
+    const win: TurnWindow = {
+      turnRange: [1, 1],
+      indices: [0, 1],
+      anchorIndex: 0,
+    };
+    const prompt = buildGroupSummarizationPrompt({
+      messages,
+      window: win,
+      turnAges,
+      individualSummaries: {},
+    });
+    expect(prompt.length).toBeLessThanOrEqual(100_020); // MAX_PROMPT_CHARS + "\n[truncated]"
+    expect(prompt).toContain("[truncated]");
+  });
+});

--- a/src/agents/context-decay/group-summarizer.test.ts
+++ b/src/agents/context-decay/group-summarizer.test.ts
@@ -1,12 +1,12 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
-import type { GroupSummaryStore, SummaryStore } from "./summary-store.js";
 import {
   findEligibleWindows,
   buildGroupSummarizationPrompt,
   type TurnWindow,
 } from "./group-summarizer.js";
+import type { GroupSummaryStore, SummaryStore } from "./summary-store.js";
 import { computeTurnAges } from "./turn-ages.js";
 
 // ---------------------------------------------------------------------------
@@ -27,7 +27,7 @@ function makeAssistant(text: string): AgentMessage {
     usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
     stopReason: "stop",
     timestamp: Date.now(),
-  } as AgentMessage;
+  } as unknown as AgentMessage;
 }
 
 function makeAssistantWithToolUse(toolCallId: string, toolName: string): AgentMessage {
@@ -40,10 +40,18 @@ function makeAssistantWithToolUse(toolCallId: string, toolName: string): AgentMe
     api: "anthropic-messages",
     provider: "anthropic",
     model: "fake",
-    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
-    stopReason: "tool_use",
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 2,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "toolUse",
     timestamp: Date.now(),
-  } as AgentMessage;
+  } as unknown as AgentMessage;
 }
 
 function makeToolResult(toolCallId: string, toolName: string, text: string): AgentMessage {

--- a/src/agents/context-decay/group-summarizer.ts
+++ b/src/agents/context-decay/group-summarizer.ts
@@ -1,0 +1,335 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { type AuthStorage, estimateTokens, generateSummary } from "@mariozechner/pi-coding-agent";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import type { GroupSummaryEntry, GroupSummaryStore, SummaryStore } from "./summary-store.js";
+import { log } from "../pi-embedded-runner/logger.js";
+import { extractContentText, extractToolInfo } from "./message-utils.js";
+import { loadGroupSummaryStore, loadSummaryStore, saveGroupSummaryStore } from "./summary-store.js";
+import { computeTurnAges, groupIndicesByTurn } from "./turn-ages.js";
+
+/** Reserve tokens for the group summarization model response. */
+const GROUP_SUMMARY_RESERVE_TOKENS = 1000;
+
+/** Minimum estimated tokens in a window to warrant summarization. */
+const MIN_WINDOW_TOKENS = 500;
+
+/** Maximum chars for the summarization prompt payload. */
+const MAX_PROMPT_CHARS = 100_000;
+
+/** Estimate total tokens for a set of message indices. */
+function estimateWindowTokens(messages: AgentMessage[], indices: number[]): number {
+  let total = 0;
+  for (const idx of indices) {
+    const tokenMsg = {
+      role: "user",
+      content: extractContentText(messages[idx]),
+      timestamp: Date.now(),
+    } as AgentMessage;
+    total += estimateTokens(tokenMsg);
+  }
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TurnWindow {
+  turnRange: [number, number]; // [oldest age, newest age]
+  indices: number[];
+  anchorIndex: number;
+}
+
+// ---------------------------------------------------------------------------
+// Window identification
+// ---------------------------------------------------------------------------
+
+/**
+ * Find eligible windows of turns ready for group summarization.
+ */
+export function findEligibleWindows(params: {
+  messages: AgentMessage[];
+  config: ContextDecayConfig;
+  existingGroupSummaries: GroupSummaryStore;
+}): TurnWindow[] {
+  const { messages, config, existingGroupSummaries } = params;
+  const windowAfter = config.summarizeWindowAfterTurns;
+  if (!windowAfter || windowAfter < 1) {
+    return [];
+  }
+
+  const windowSize = config.summarizeWindowSize ?? 4;
+  const turnAges = computeTurnAges(messages);
+  const turnGroups = groupIndicesByTurn(turnAges);
+
+  // Build set of indices already covered by existing group summaries
+  const coveredIndices = new Set<number>();
+  for (const entry of existingGroupSummaries) {
+    for (const idx of entry.indices) {
+      coveredIndices.add(idx);
+    }
+  }
+
+  // Collect eligible turn ages (sorted descending = oldest first by age number)
+  const eligibleTurnAges: number[] = [];
+  for (const [age] of turnGroups) {
+    if (age < windowAfter) {
+      continue;
+    }
+    // Skip turns past strip threshold (they'll be stripped anyway)
+    if (config.stripToolResultsAfterTurns && age >= config.stripToolResultsAfterTurns) {
+      continue;
+    }
+    // Check if any index in this turn is NOT already covered
+    const indices = turnGroups.get(age) ?? [];
+    const hasUncovered = indices.some((idx) => !coveredIndices.has(idx));
+    if (hasUncovered) {
+      eligibleTurnAges.push(age);
+    }
+  }
+
+  if (eligibleTurnAges.length < 2) {
+    return [];
+  }
+
+  // Sort by age descending (oldest first = highest age number)
+  eligibleTurnAges.sort((a, b) => b - a);
+
+  // Group consecutive eligible turns into windows
+  const windows: TurnWindow[] = [];
+  for (let i = 0; i < eligibleTurnAges.length; i += windowSize) {
+    const chunk = eligibleTurnAges.slice(i, i + windowSize);
+    if (chunk.length < 2) {
+      continue; // Skip windows with < 2 turns
+    }
+
+    // Collect all indices for this window
+    const windowIndices: number[] = [];
+    for (const age of chunk) {
+      const indices = turnGroups.get(age) ?? [];
+      windowIndices.push(...indices);
+    }
+    windowIndices.sort((a, b) => a - b);
+
+    // Estimate tokens — skip if too small
+    const estimatedTokens = estimateWindowTokens(messages, windowIndices);
+    if (estimatedTokens < MIN_WINDOW_TOKENS) {
+      continue;
+    }
+
+    // Find anchor: first user message index in this window
+    let anchorIndex = windowIndices[0];
+    for (const idx of windowIndices) {
+      if (messages[idx].role === "user") {
+        anchorIndex = idx;
+        break;
+      }
+    }
+
+    const oldestAge = Math.max(...chunk);
+    const newestAge = Math.min(...chunk);
+
+    windows.push({
+      turnRange: [oldestAge, newestAge],
+      indices: windowIndices,
+      anchorIndex,
+    });
+  }
+
+  return windows;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt building
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a multi-turn summarization prompt for a window of messages.
+ * Uses existing individual summaries where available for more concise input.
+ */
+export function buildGroupSummarizationPrompt(params: {
+  messages: AgentMessage[];
+  window: TurnWindow;
+  turnAges: Map<number, number>;
+  individualSummaries: SummaryStore;
+}): string {
+  const { messages, window: win, turnAges, individualSummaries } = params;
+
+  const lines: string[] = [
+    "Summarize this conversation window concisely. Preserve: user intent, decisions made, tool call outcomes, file paths, function names, error messages, key values. Maintain causal chains (what was requested → what was done → what resulted).",
+    "",
+  ];
+
+  let currentTurnAge: number | undefined;
+
+  for (const idx of win.indices) {
+    const msg = messages[idx];
+    const age = turnAges.get(idx) ?? 0;
+
+    if (age !== currentTurnAge) {
+      lines.push(`--- Turn [age ${age}] ---`);
+      currentTurnAge = age;
+    }
+
+    if (msg.role === "user") {
+      lines.push(`[User]: ${extractContentText(msg)}`);
+    } else if (msg.role === "assistant") {
+      const content = (msg as unknown as { content: unknown }).content;
+      if (Array.isArray(content)) {
+        const textParts: string[] = [];
+        for (const block of content as Array<Record<string, unknown>>) {
+          if (block.type === "text") {
+            textParts.push(block.text as string);
+          } else if (block.type === "tool_use") {
+            const argsStr = JSON.stringify(block.input ?? {});
+            const truncatedArgs = argsStr.length > 500 ? argsStr.slice(0, 500) + "..." : argsStr;
+            textParts.push(`[Called tool: ${String(block.name)}(${truncatedArgs})]`);
+          }
+          // Skip thinking blocks
+        }
+        if (textParts.length > 0) {
+          lines.push(`[Assistant]: ${textParts.join("\n")}`);
+        }
+      } else {
+        lines.push(`[Assistant]: ${extractContentText(msg)}`);
+      }
+    } else if (msg.role === "toolResult") {
+      // Use existing individual summary if available
+      const individualSummary = individualSummaries[idx];
+      if (individualSummary) {
+        const { toolName } = extractToolInfo(messages, idx);
+        lines.push(`[Tool: ${toolName}]: [Previously summarized] ${individualSummary.summary}`);
+      } else {
+        const { toolName } = extractToolInfo(messages, idx);
+        const content = extractContentText(msg);
+        lines.push(`[Tool: ${toolName}]: ${content}`);
+      }
+    }
+  }
+
+  let prompt = lines.join("\n");
+  if (prompt.length > MAX_PROMPT_CHARS) {
+    prompt = prompt.slice(0, MAX_PROMPT_CHARS) + "\n[truncated]";
+  }
+  return prompt;
+}
+
+// ---------------------------------------------------------------------------
+// Fire-and-forget entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Summarize aged turn windows. Fire-and-forget — failures are logged but don't affect the agent run.
+ */
+export async function summarizeAgedTurnWindows(params: {
+  sessionFilePath: string;
+  messages: AgentMessage[];
+  config: ContextDecayConfig;
+  model: NonNullable<ExtensionContext["model"]>;
+  authStorage: AuthStorage;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const { sessionFilePath, messages, config, model, authStorage, abortSignal } = params;
+
+  const windowAfter = config.summarizeWindowAfterTurns;
+  if (!windowAfter || windowAfter < 1) {
+    return;
+  }
+
+  const existingGroupSummaries = await loadGroupSummaryStore(sessionFilePath);
+  const individualSummaries = await loadSummaryStore(sessionFilePath);
+
+  const windows = findEligibleWindows({
+    messages,
+    config,
+    existingGroupSummaries,
+  });
+
+  if (windows.length === 0) {
+    return;
+  }
+
+  // Resolve API key for the model's provider
+  const apiKey = await authStorage.getApiKey(model.provider);
+  if (!apiKey) {
+    log.warn(
+      `context-decay: no API key found for provider "${model.provider}"; skipping group summarization`,
+    );
+    return;
+  }
+
+  log.info(
+    `context-decay: group-summarizing ${windows.length} window(s) with ${model.provider}/${model.id}`,
+  );
+
+  const turnAges = computeTurnAges(messages);
+  const updatedStore = [...existingGroupSummaries];
+  let didUpdate = false;
+
+  for (const win of windows) {
+    if (abortSignal?.aborted) {
+      break;
+    }
+
+    try {
+      const prompt = buildGroupSummarizationPrompt({
+        messages,
+        window: win,
+        turnAges,
+        individualSummaries,
+      });
+
+      const summaryMessages: AgentMessage[] = [
+        {
+          role: "user",
+          content: prompt,
+          timestamp: Date.now(),
+        } as AgentMessage,
+      ];
+
+      const summaryText = await generateSummary(
+        summaryMessages,
+        model,
+        GROUP_SUMMARY_RESERVE_TOKENS,
+        apiKey,
+        abortSignal ?? new AbortController().signal,
+      );
+
+      if (summaryText && summaryText.length > 0) {
+        const originalTokenEstimate = estimateWindowTokens(messages, win.indices);
+        const summaryMsg = {
+          role: "user",
+          content: summaryText,
+          timestamp: Date.now(),
+        } as AgentMessage;
+
+        const entry: GroupSummaryEntry = {
+          summary: summaryText,
+          anchorIndex: win.anchorIndex,
+          indices: win.indices,
+          turnRange: win.turnRange,
+          originalTokenEstimate,
+          summaryTokenEstimate: estimateTokens(summaryMsg),
+          summarizedAt: new Date().toISOString(),
+          model: `${model.provider}/${model.id}`,
+        };
+        updatedStore.push(entry);
+        didUpdate = true;
+      }
+    } catch (err) {
+      log.warn(
+        `context-decay: failed to group-summarize window [turns ${win.turnRange[0]}-${win.turnRange[1]}]: ${String(err)}`,
+      );
+    }
+  }
+
+  if (didUpdate) {
+    try {
+      await saveGroupSummaryStore(sessionFilePath, updatedStore);
+      log.info(`context-decay: saved ${updatedStore.length} group summaries`);
+    } catch (err) {
+      log.warn(`context-decay: failed to save group summary store: ${String(err)}`);
+    }
+  }
+}

--- a/src/agents/context-decay/group-summarizer.ts
+++ b/src/agents/context-decay/group-summarizer.ts
@@ -2,9 +2,9 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { type AuthStorage, estimateTokens, generateSummary } from "@mariozechner/pi-coding-agent";
 import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
-import type { GroupSummaryEntry, GroupSummaryStore, SummaryStore } from "./summary-store.js";
 import { log } from "../pi-embedded-runner/logger.js";
 import { extractContentText, extractToolInfo } from "./message-utils.js";
+import type { GroupSummaryEntry, GroupSummaryStore, SummaryStore } from "./summary-store.js";
 import { loadGroupSummaryStore, loadSummaryStore, saveGroupSummaryStore } from "./summary-store.js";
 import { computeTurnAges, groupIndicesByTurn } from "./turn-ages.js";
 

--- a/src/agents/context-decay/hint-generator.test.ts
+++ b/src/agents/context-decay/hint-generator.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { generateHeuristicHint } from "./hint-generator.js";
+
+describe("generateHeuristicHint", () => {
+  describe("file read tools", () => {
+    it("generates hint for TypeScript file read", () => {
+      const hint = generateHeuristicHint({
+        toolName: "Read",
+        args: '"/src/utils.ts"',
+        content: 'export function resolveUserPath(input: string): string {\n  return input.trim();\n}\n\nexport function formatDuration(ms: number): string {\n  return `${ms}ms`;\n}',
+      });
+      expect(hint).toContain("TypeScript");
+      expect(hint).toContain("lines");
+      expect(hint).toContain("resolveUserPath");
+    });
+
+    it("detects Python language from args", () => {
+      const hint = generateHeuristicHint({
+        toolName: "Read",
+        args: '"app/main.py"',
+        content: "def main():\n    print('hello')\n",
+      });
+      expect(hint).toContain("Python");
+    });
+
+    it("handles file read with no exports", () => {
+      const hint = generateHeuristicHint({
+        toolName: "Read",
+        args: '"config.json"',
+        content: '{\n  "key": "value"\n}',
+      });
+      expect(hint).toContain("JSON");
+      expect(hint).toContain("3 lines");
+    });
+  });
+
+  describe("search tools", () => {
+    it("generates hint for grep results", () => {
+      const hint = generateHeuristicHint({
+        toolName: "Grep",
+        args: '"resolveUserPath"',
+        content: "/src/utils.ts:236:export function resolveUserPath\n/src/compact.ts:42:  resolveUserPath(input)\n/tests/utils.test.ts:10:  resolveUserPath\n",
+      });
+      expect(hint).toContain("result lines");
+      expect(hint).toContain("/src/utils.ts");
+    });
+
+    it("generates hint for glob results", () => {
+      const hint = generateHeuristicHint({
+        toolName: "Glob",
+        args: '"**/*.test.ts"',
+        content: "/src/foo.test.ts\n/src/bar.test.ts\n",
+      });
+      expect(hint).toContain("result lines");
+      expect(hint).toContain("Files:");
+    });
+  });
+
+  describe("exec tools", () => {
+    it("generates hint for bash output with exit code", () => {
+      const hint = generateHeuristicHint({
+        toolName: "Bash",
+        args: '"npm test"',
+        content: "Running tests...\nTest 1 passed\nTest 2 passed\nAll tests passed\nexit code: 0\n",
+      });
+      expect(hint).toContain("exit 0");
+      expect(hint).toContain("lines");
+    });
+
+    it("generates hint for bash output without exit code", () => {
+      const hint = generateHeuristicHint({
+        toolName: "Bash",
+        args: '"ls"',
+        content: "file1.ts\nfile2.ts\nfile3.ts\n",
+      });
+      expect(hint).toContain("lines");
+      expect(hint).toContain("file1.ts");
+    });
+  });
+
+  describe("default tool", () => {
+    it("generates hint for unknown tool", () => {
+      const hint = generateHeuristicHint({
+        toolName: "CustomTool",
+        args: '{}',
+        content: "Some result content\nwith multiple lines\nand more data\n",
+      });
+      expect(hint).toContain("lines");
+      expect(hint).toContain("chars");
+    });
+
+    it("includes error messages when present", () => {
+      const hint = generateHeuristicHint({
+        toolName: "CustomTool",
+        args: '{}',
+        content: "Error: file not found\nfailed to read config\n",
+      });
+      expect(hint).toContain("Errors:");
+    });
+  });
+
+  describe("truncation", () => {
+    it("truncates hint to maxHintChars", () => {
+      const hint = generateHeuristicHint({
+        toolName: "Read",
+        args: '"file.ts"',
+        content: "a".repeat(10000),
+        maxHintChars: 50,
+      });
+      expect(hint.length).toBeLessThanOrEqual(50);
+      expect(hint.endsWith("...")).toBe(true);
+    });
+  });
+});

--- a/src/agents/context-decay/hint-generator.test.ts
+++ b/src/agents/context-decay/hint-generator.test.ts
@@ -7,7 +7,8 @@ describe("generateHeuristicHint", () => {
       const hint = generateHeuristicHint({
         toolName: "Read",
         args: '"/src/utils.ts"',
-        content: 'export function resolveUserPath(input: string): string {\n  return input.trim();\n}\n\nexport function formatDuration(ms: number): string {\n  return `${ms}ms`;\n}',
+        content:
+          "export function resolveUserPath(input: string): string {\n  return input.trim();\n}\n\nexport function formatDuration(ms: number): string {\n  return `${ms}ms`;\n}",
       });
       expect(hint).toContain("TypeScript");
       expect(hint).toContain("lines");
@@ -39,7 +40,8 @@ describe("generateHeuristicHint", () => {
       const hint = generateHeuristicHint({
         toolName: "Grep",
         args: '"resolveUserPath"',
-        content: "/src/utils.ts:236:export function resolveUserPath\n/src/compact.ts:42:  resolveUserPath(input)\n/tests/utils.test.ts:10:  resolveUserPath\n",
+        content:
+          "/src/utils.ts:236:export function resolveUserPath\n/src/compact.ts:42:  resolveUserPath(input)\n/tests/utils.test.ts:10:  resolveUserPath\n",
       });
       expect(hint).toContain("result lines");
       expect(hint).toContain("/src/utils.ts");
@@ -82,7 +84,7 @@ describe("generateHeuristicHint", () => {
     it("generates hint for unknown tool", () => {
       const hint = generateHeuristicHint({
         toolName: "CustomTool",
-        args: '{}',
+        args: "{}",
         content: "Some result content\nwith multiple lines\nand more data\n",
       });
       expect(hint).toContain("lines");
@@ -92,7 +94,7 @@ describe("generateHeuristicHint", () => {
     it("includes error messages when present", () => {
       const hint = generateHeuristicHint({
         toolName: "CustomTool",
-        args: '{}',
+        args: "{}",
         content: "Error: file not found\nfailed to read config\n",
       });
       expect(hint).toContain("Errors:");

--- a/src/agents/context-decay/hint-generator.ts
+++ b/src/agents/context-decay/hint-generator.ts
@@ -1,6 +1,8 @@
 const FILE_PATH_RE = /(?:\/[\w./-]+|[A-Za-z]:\\[\w.\\/-]+)/g;
-const ERROR_RE = /(?:error|Error|ERROR|exception|Exception|EXCEPTION|fail(?:ed|ure)?|FAIL)[:. ].{0,100}/g;
-const EXPORT_RE = /export\s+(?:default\s+)?(?:function|class|const|let|type|interface|enum)\s+(\w+)/g;
+const ERROR_RE =
+  /(?:error|Error|ERROR|exception|Exception|EXCEPTION|fail(?:ed|ure)?|FAIL)[:. ].{0,100}/g;
+const EXPORT_RE =
+  /export\s+(?:default\s+)?(?:function|class|const|let|type|interface|enum)\s+(\w+)/g;
 
 const EXT_TO_LANG: Record<string, string> = {
   ".ts": "TypeScript",
@@ -36,10 +38,14 @@ function detectLanguage(args: string): string | undefined {
 }
 
 function countLines(text: string): number {
-  if (text.length === 0) return 0;
+  if (text.length === 0) {
+    return 0;
+  }
   let count = 1;
   for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === 10) count++;
+    if (text.charCodeAt(i) === 10) {
+      count++;
+    }
   }
   return count;
 }

--- a/src/agents/context-decay/hint-generator.ts
+++ b/src/agents/context-decay/hint-generator.ts
@@ -1,0 +1,151 @@
+const FILE_PATH_RE = /(?:\/[\w./-]+|[A-Za-z]:\\[\w.\\/-]+)/g;
+const ERROR_RE = /(?:error|Error|ERROR|exception|Exception|EXCEPTION|fail(?:ed|ure)?|FAIL)[:. ].{0,100}/g;
+const EXPORT_RE = /export\s+(?:default\s+)?(?:function|class|const|let|type|interface|enum)\s+(\w+)/g;
+
+const EXT_TO_LANG: Record<string, string> = {
+  ".ts": "TypeScript",
+  ".tsx": "TSX",
+  ".js": "JavaScript",
+  ".jsx": "JSX",
+  ".py": "Python",
+  ".go": "Go",
+  ".rs": "Rust",
+  ".java": "Java",
+  ".rb": "Ruby",
+  ".c": "C",
+  ".cpp": "C++",
+  ".cs": "C#",
+  ".json": "JSON",
+  ".yaml": "YAML",
+  ".yml": "YAML",
+  ".md": "Markdown",
+  ".html": "HTML",
+  ".css": "CSS",
+  ".sh": "Shell",
+  ".sql": "SQL",
+};
+
+function detectLanguage(args: string): string | undefined {
+  // Try to extract file extension from args (file path in read/grep tools)
+  const pathMatch = args.match(/["']?([^"'\s]+\.\w{1,6})["']?/);
+  if (pathMatch) {
+    const ext = pathMatch[1].slice(pathMatch[1].lastIndexOf(".")).toLowerCase();
+    return EXT_TO_LANG[ext];
+  }
+  return undefined;
+}
+
+function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  let count = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) count++;
+  }
+  return count;
+}
+
+function firstNLines(text: string, n: number): string {
+  const lines: string[] = [];
+  let start = 0;
+  for (let i = 0; i < text.length && lines.length < n; i++) {
+    if (text.charCodeAt(i) === 10) {
+      lines.push(text.slice(start, i));
+      start = i + 1;
+    }
+  }
+  if (lines.length < n && start < text.length) {
+    lines.push(text.slice(start));
+  }
+  return lines.join("\n");
+}
+
+function lastLine(text: string): string {
+  const idx = text.lastIndexOf("\n");
+  return idx === -1 ? text : text.slice(idx + 1);
+}
+
+function extractExports(content: string, max: number): string[] {
+  const names: string[] = [];
+  let match: RegExpExecArray | null;
+  EXPORT_RE.lastIndex = 0;
+  while ((match = EXPORT_RE.exec(content)) !== null && names.length < max) {
+    names.push(match[1]);
+  }
+  return names;
+}
+
+function extractFilePaths(content: string, max: number): string[] {
+  const paths: string[] = [];
+  let match: RegExpExecArray | null;
+  FILE_PATH_RE.lastIndex = 0;
+  while ((match = FILE_PATH_RE.exec(content)) !== null && paths.length < max) {
+    paths.push(match[0]);
+  }
+  return paths;
+}
+
+function extractErrors(content: string, max: number): string[] {
+  const errors: string[] = [];
+  let match: RegExpExecArray | null;
+  ERROR_RE.lastIndex = 0;
+  while ((match = ERROR_RE.exec(content)) !== null && errors.length < max) {
+    errors.push(match[0].trim());
+  }
+  return errors;
+}
+
+const READ_TOOLS = new Set(["Read", "cat", "read_file", "ReadFile"]);
+const SEARCH_TOOLS = new Set(["Grep", "grep", "rg", "search", "Search", "Glob", "glob", "find"]);
+const EXEC_TOOLS = new Set(["Bash", "bash", "exec", "run", "shell", "Execute"]);
+
+/**
+ * Generate a heuristic hint from tool result content without LLM calls.
+ * The hint is a short text summarizing the content for context window display.
+ */
+export function generateHeuristicHint(params: {
+  toolName: string;
+  args: string;
+  content: string;
+  maxHintChars?: number;
+}): string {
+  const { toolName, args, content, maxHintChars = 200 } = params;
+  const lines = countLines(content);
+
+  let hint: string;
+
+  if (READ_TOOLS.has(toolName)) {
+    // File read: show line count, language, first few lines, exports
+    const lang = detectLanguage(args);
+    const langTag = lang ? `, ${lang}` : "";
+    const exports = extractExports(content, 5);
+    const exportTag = exports.length > 0 ? `. Exports: ${exports.join(", ")}` : "";
+    const preview = firstNLines(content, 2).trim();
+    hint = `[${lines} lines${langTag}] ${preview}${exportTag}`;
+  } else if (SEARCH_TOOLS.has(toolName)) {
+    // Search results: match count, first few file paths
+    const paths = extractFilePaths(content, 4);
+    const pathTag = paths.length > 0 ? ` Files: ${paths.join(", ")}` : "";
+    hint = `[${lines} result lines]${pathTag}`;
+  } else if (EXEC_TOOLS.has(toolName)) {
+    // Exec: exit code + first/last lines
+    const exitMatch = content.match(/exit code[:\s]*(\d+)/i);
+    const exitTag = exitMatch ? `exit ${exitMatch[1]}, ` : "";
+    const first = firstNLines(content, 1).trim();
+    const last = lastLine(content).trim();
+    const body = first === last ? first : `${first} ... ${last}`;
+    hint = `[${exitTag}${lines} lines] ${body}`;
+  } else {
+    // Default: first 2 lines + stats
+    const preview = firstNLines(content, 2).trim();
+    const errors = extractErrors(content, 2);
+    const errorTag = errors.length > 0 ? ` Errors: ${errors.join("; ")}` : "";
+    const paths = extractFilePaths(content, 3);
+    const pathTag = paths.length > 0 && errors.length === 0 ? ` Paths: ${paths.join(", ")}` : "";
+    hint = `[${lines} lines, ${content.length} chars] ${preview}${errorTag}${pathTag}`;
+  }
+
+  if (hint.length > maxHintChars) {
+    return hint.slice(0, maxHintChars - 3) + "...";
+  }
+  return hint;
+}

--- a/src/agents/context-decay/message-utils.ts
+++ b/src/agents/context-decay/message-utils.ts
@@ -1,0 +1,56 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+/**
+ * Extract text content from a message at the given index.
+ * Handles both string content and structured content blocks.
+ */
+export function extractContentText(msg: AgentMessage): string {
+  const msgUnk = msg as unknown as { content: unknown };
+  if (typeof msgUnk.content === "string") {
+    return msgUnk.content;
+  }
+  if (!Array.isArray(msgUnk.content)) {
+    return JSON.stringify(msgUnk.content);
+  }
+  return (msgUnk.content as Array<Record<string, unknown>>)
+    .filter((b) => b.type === "text")
+    .map((b) => b.text as string)
+    .join("\n");
+}
+
+/**
+ * Find the tool name and args by looking up the matching tool_use block.
+ * Walks backward from the tool result to find the assistant message with the matching tool_use.
+ */
+export function extractToolInfo(
+  messages: AgentMessage[],
+  toolResultIndex: number,
+): { toolName: string; args: string } {
+  const toolResultMsg = messages[toolResultIndex] as unknown as Record<string, unknown>;
+  const toolCallId = toolResultMsg.toolCallId as string | undefined;
+
+  if (!toolCallId) {
+    return { toolName: "unknown", args: "{}" };
+  }
+
+  for (let i = toolResultIndex - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "assistant") {
+      continue;
+    }
+    const msgContent = (msg as unknown as { content: unknown }).content;
+    if (!Array.isArray(msgContent)) {
+      continue;
+    }
+    for (const block of msgContent) {
+      if (block.type === "tool_use" && block.id === toolCallId) {
+        return {
+          toolName: (block.name as string) ?? "unknown",
+          args: JSON.stringify(block.input ?? {}),
+        };
+      }
+    }
+  }
+
+  return { toolName: "unknown", args: "{}" };
+}

--- a/src/agents/context-decay/resolve-config.test.ts
+++ b/src/agents/context-decay/resolve-config.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import { resolveContextDecayConfig, isContextDecayActive } from "./resolve-config.js";
+
+function makeConfig(overrides: {
+  defaults?: ContextDecayConfig;
+  channels?: Record<string, unknown>;
+}): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        contextDecay: overrides.defaults,
+      },
+    },
+    channels: overrides.channels,
+  } as OpenClawConfig;
+}
+
+describe("resolveContextDecayConfig", () => {
+  it("returns undefined when config is undefined", () => {
+    expect(resolveContextDecayConfig("discord:direct:123", undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when no contextDecay is configured anywhere", () => {
+    const config = {} as OpenClawConfig;
+    expect(resolveContextDecayConfig("discord:direct:123", config)).toBeUndefined();
+  });
+
+  it("returns global defaults when no session key", () => {
+    const config = makeConfig({
+      defaults: { stripThinkingAfterTurns: 3 },
+    });
+    expect(resolveContextDecayConfig(undefined, config)).toEqual({
+      stripThinkingAfterTurns: 3,
+    });
+  });
+
+  it("returns global defaults when session key has no channel match", () => {
+    const config = makeConfig({
+      defaults: { stripThinkingAfterTurns: 3, maxContextMessages: 50 },
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    expect(result).toEqual({
+      stripThinkingAfterTurns: 3,
+      maxContextMessages: 50,
+    });
+  });
+
+  it("per-account overrides global defaults", () => {
+    const config = makeConfig({
+      defaults: { stripThinkingAfterTurns: 3, maxContextMessages: 50 },
+      channels: {
+        discord: {
+          contextDecay: { stripThinkingAfterTurns: 5 },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    expect(result?.stripThinkingAfterTurns).toBe(5);
+    expect(result?.maxContextMessages).toBe(50); // inherited from global
+  });
+
+  it("per-DM overrides per-account and global", () => {
+    const config = makeConfig({
+      defaults: { stripThinkingAfterTurns: 3, maxContextMessages: 50 },
+      channels: {
+        telegram: {
+          contextDecay: { stripThinkingAfterTurns: 5 },
+          dms: {
+            "456": {
+              contextDecay: { stripThinkingAfterTurns: 10, stripToolResultsAfterTurns: 7 },
+            },
+          },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("telegram:direct:456", config);
+    expect(result?.stripThinkingAfterTurns).toBe(10); // DM override
+    expect(result?.stripToolResultsAfterTurns).toBe(7); // DM-specific
+    expect(result?.maxContextMessages).toBe(50); // inherited from global
+  });
+
+  it("DM override does not apply to non-direct session keys", () => {
+    const config = makeConfig({
+      defaults: { stripThinkingAfterTurns: 3 },
+      channels: {
+        discord: {
+          dms: {
+            "123": {
+              contextDecay: { stripThinkingAfterTurns: 99 },
+            },
+          },
+        },
+      },
+    });
+    // Group session key, not "direct" or "dm"
+    const result = resolveContextDecayConfig("discord:group:123", config);
+    expect(result?.stripThinkingAfterTurns).toBe(3); // global only
+  });
+
+  it("handles agent-prefixed session keys", () => {
+    const config = makeConfig({
+      defaults: { stripThinkingAfterTurns: 3 },
+      channels: {
+        whatsapp: {
+          contextDecay: { stripThinkingAfterTurns: 8 },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("agent:myagent:whatsapp:direct:+1234", config);
+    expect(result?.stripThinkingAfterTurns).toBe(8);
+  });
+
+  it("treats N=0 as disabled (not merged)", () => {
+    // Note: ContextDecaySchema uses z.number().int().positive() which rejects 0
+    // at parse time. This test documents the defensive behavior of mergeDecayConfig
+    // for any programmatic callers that bypass Zod validation.
+    const config = makeConfig({
+      defaults: { stripThinkingAfterTurns: 3, maxContextMessages: 50 },
+      channels: {
+        discord: {
+          contextDecay: { stripThinkingAfterTurns: 0 }, // 0 = disabled
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    // 0 is not >= 1, so global value (3) persists
+    expect(result?.stripThinkingAfterTurns).toBe(3);
+  });
+
+  it("returns config even when only summarizationModel is set (isContextDecayActive gates activation)", () => {
+    const config = makeConfig({
+      defaults: { summarizationModel: "haiku" }, // model alone doesn't activate
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    // resolveContextDecayConfig returns the merged config; callers use isContextDecayActive to gate
+    expect(result).toEqual({ summarizationModel: "haiku" });
+  });
+
+  it("strips thread suffix from userId", () => {
+    const config = makeConfig({
+      defaults: { stripThinkingAfterTurns: 3 },
+      channels: {
+        telegram: {
+          dms: {
+            "789": {
+              contextDecay: { stripThinkingAfterTurns: 20 },
+            },
+          },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("telegram:direct:789:thread:42", config);
+    expect(result?.stripThinkingAfterTurns).toBe(20);
+  });
+});
+
+describe("isContextDecayActive", () => {
+  it("returns false for undefined", () => {
+    expect(isContextDecayActive(undefined)).toBe(false);
+  });
+
+  it("returns false for empty config", () => {
+    expect(isContextDecayActive({})).toBe(false);
+  });
+
+  it("returns true when stripThinkingAfterTurns is set", () => {
+    expect(isContextDecayActive({ stripThinkingAfterTurns: 2 })).toBe(true);
+  });
+
+  it("returns true when maxContextMessages is set", () => {
+    expect(isContextDecayActive({ maxContextMessages: 100 })).toBe(true);
+  });
+
+  it("returns true when summarizeToolResultsAfterTurns is set", () => {
+    expect(isContextDecayActive({ summarizeToolResultsAfterTurns: 3 })).toBe(true);
+  });
+
+  it("returns true when stripToolResultsAfterTurns is set", () => {
+    expect(isContextDecayActive({ stripToolResultsAfterTurns: 5 })).toBe(true);
+  });
+
+  it("returns false when all numeric fields are 0", () => {
+    expect(
+      isContextDecayActive({
+        stripThinkingAfterTurns: 0,
+        summarizeToolResultsAfterTurns: 0,
+        stripToolResultsAfterTurns: 0,
+        maxContextMessages: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when only summarizationModel is set", () => {
+    expect(isContextDecayActive({ summarizationModel: "haiku" })).toBe(false);
+  });
+
+  it("returns true when summarizeWindowAfterTurns is set", () => {
+    expect(isContextDecayActive({ summarizeWindowAfterTurns: 6 })).toBe(true);
+  });
+
+  it("returns false when only groupSummarizationModel is set", () => {
+    expect(isContextDecayActive({ groupSummarizationModel: "sonnet" })).toBe(false);
+  });
+});
+
+describe("mergeDecayConfig — new group fields", () => {
+  it("merges summarizeWindowAfterTurns from global", () => {
+    const config = makeConfig({
+      defaults: { summarizeWindowAfterTurns: 6, summarizeWindowSize: 3 },
+    });
+    const result = resolveContextDecayConfig(undefined, config);
+    expect(result?.summarizeWindowAfterTurns).toBe(6);
+    expect(result?.summarizeWindowSize).toBe(3);
+  });
+
+  it("per-account overrides summarizeWindowAfterTurns", () => {
+    const config = makeConfig({
+      defaults: { summarizeWindowAfterTurns: 6, summarizeWindowSize: 4 },
+      channels: {
+        discord: {
+          contextDecay: { summarizeWindowAfterTurns: 10 },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    expect(result?.summarizeWindowAfterTurns).toBe(10);
+    expect(result?.summarizeWindowSize).toBe(4); // inherited from global
+  });
+
+  it("merges groupSummarizationModel", () => {
+    const config = makeConfig({
+      defaults: { summarizeWindowAfterTurns: 6, groupSummarizationModel: "sonnet" },
+    });
+    const result = resolveContextDecayConfig(undefined, config);
+    expect(result?.groupSummarizationModel).toBe("sonnet");
+  });
+
+  it("override groupSummarizationModel takes precedence", () => {
+    const config = makeConfig({
+      defaults: { summarizeWindowAfterTurns: 6, groupSummarizationModel: "haiku" },
+      channels: {
+        discord: {
+          contextDecay: { groupSummarizationModel: "opus" },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    expect(result?.groupSummarizationModel).toBe("opus");
+  });
+
+  it("returns undefined when channel provides only groupSummarizationModel (no activation field)", () => {
+    const config = makeConfig({
+      channels: {
+        discord: {
+          contextDecay: { groupSummarizationModel: "sonnet" },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    // Model-only config has no numeric activation fields, so mergeDecayConfig
+    // returns undefined (hasAnything check filters it out).
+    expect(result).toBeUndefined();
+  });
+
+  it("preserves groupSummarizationModel when merged with an activation field", () => {
+    const config = makeConfig({
+      defaults: { summarizeWindowAfterTurns: 6 },
+      channels: {
+        discord: {
+          contextDecay: { groupSummarizationModel: "sonnet" },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    expect(result?.summarizeWindowAfterTurns).toBe(6);
+    expect(result?.groupSummarizationModel).toBe("sonnet");
+  });
+
+  it("auto-clamps stripToolResultsAfterTurns when <= summarizeToolResultsAfterTurns", () => {
+    const config = makeConfig({
+      defaults: {
+        summarizeToolResultsAfterTurns: 5,
+        stripToolResultsAfterTurns: 3, // strip < summarize — misconfigured
+      },
+    });
+    const result = resolveContextDecayConfig(undefined, config);
+    // Should be auto-clamped to summarize + 1 = 6
+    expect(result?.stripToolResultsAfterTurns).toBe(6);
+    expect(result?.summarizeToolResultsAfterTurns).toBe(5);
+  });
+
+  it("does not clamp strip vs summarizeWindowAfterTurns (group summarizer reads raw transcript)", () => {
+    const config = makeConfig({
+      defaults: {
+        summarizeWindowAfterTurns: 8,
+        stripToolResultsAfterTurns: 5, // strip < groupSummarize — intentional, group reads raw
+      },
+    });
+    const result = resolveContextDecayConfig(undefined, config);
+    // NOT clamped — group summarizer reads raw snapshot, not the decayed view
+    expect(result?.stripToolResultsAfterTurns).toBe(5);
+    expect(result?.summarizeWindowAfterTurns).toBe(8);
+  });
+
+  it("only clamps strip against individual summarize, not group", () => {
+    const config = makeConfig({
+      defaults: {
+        summarizeToolResultsAfterTurns: 4,
+        summarizeWindowAfterTurns: 7,
+        stripToolResultsAfterTurns: 3, // below both, but only individual matters
+      },
+    });
+    const result = resolveContextDecayConfig(undefined, config);
+    // Clamped to individual summarize + 1 = 5, NOT max(4, 7) + 1 = 8
+    expect(result?.stripToolResultsAfterTurns).toBe(5);
+  });
+
+  it("does not clamp stripToolResultsAfterTurns when already above summarization thresholds", () => {
+    const config = makeConfig({
+      defaults: {
+        summarizeToolResultsAfterTurns: 3,
+        summarizeWindowAfterTurns: 6,
+        stripToolResultsAfterTurns: 10, // already above both
+      },
+    });
+    const result = resolveContextDecayConfig(undefined, config);
+    expect(result?.stripToolResultsAfterTurns).toBe(10); // unchanged
+  });
+
+  it("auto-clamps when strip equals summarize (edge case)", () => {
+    const config = makeConfig({
+      defaults: {
+        summarizeToolResultsAfterTurns: 5,
+        stripToolResultsAfterTurns: 5, // equal — summaries would never display
+      },
+    });
+    const result = resolveContextDecayConfig(undefined, config);
+    expect(result?.stripToolResultsAfterTurns).toBe(6);
+  });
+
+  it("treats summarizeWindowAfterTurns=0 as disabled", () => {
+    const config = makeConfig({
+      defaults: { summarizeWindowAfterTurns: 6 },
+      channels: {
+        discord: {
+          contextDecay: { summarizeWindowAfterTurns: 0 },
+        },
+      },
+    });
+    const result = resolveContextDecayConfig("discord:direct:123", config);
+    expect(result?.summarizeWindowAfterTurns).toBe(6);
+  });
+});

--- a/src/agents/context-decay/resolve-config.ts
+++ b/src/agents/context-decay/resolve-config.ts
@@ -1,0 +1,209 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import { log } from "../pi-embedded-runner/logger.js";
+
+const THREAD_SUFFIX_REGEX = /^(.*)(?::(?:thread|topic):\d+)$/i;
+
+function stripThreadSuffix(value: string): string {
+  const match = value.match(THREAD_SUFFIX_REGEX);
+  return match?.[1] ?? value;
+}
+
+/**
+ * Merge two ContextDecayConfig objects. Fields from `override` take precedence.
+ * Only positive integer fields are accepted (0/negative/null = disabled = skip).
+ */
+function mergeDecayConfig(
+  base: ContextDecayConfig | undefined,
+  override: ContextDecayConfig | undefined,
+): ContextDecayConfig | undefined {
+  if (!base && !override) {
+    return undefined;
+  }
+  const merged: ContextDecayConfig = {};
+
+  const pickPositiveInt = (a: number | undefined, b: number | undefined): number | undefined => {
+    if (typeof b === "number" && Number.isInteger(b) && b >= 1) {
+      return b;
+    }
+    if (typeof a === "number" && Number.isInteger(a) && a >= 1) {
+      return a;
+    }
+    return undefined;
+  };
+
+  merged.stripThinkingAfterTurns = pickPositiveInt(
+    base?.stripThinkingAfterTurns,
+    override?.stripThinkingAfterTurns,
+  );
+  merged.summarizeToolResultsAfterTurns = pickPositiveInt(
+    base?.summarizeToolResultsAfterTurns,
+    override?.summarizeToolResultsAfterTurns,
+  );
+  merged.summarizeWindowAfterTurns = pickPositiveInt(
+    base?.summarizeWindowAfterTurns,
+    override?.summarizeWindowAfterTurns,
+  );
+  merged.summarizeWindowSize = pickPositiveInt(
+    base?.summarizeWindowSize,
+    override?.summarizeWindowSize,
+  );
+  merged.stripToolResultsAfterTurns = pickPositiveInt(
+    base?.stripToolResultsAfterTurns,
+    override?.stripToolResultsAfterTurns,
+  );
+  merged.maxContextMessages = pickPositiveInt(
+    base?.maxContextMessages,
+    override?.maxContextMessages,
+  );
+  merged.summarizationModel = override?.summarizationModel ?? base?.summarizationModel;
+  merged.groupSummarizationModel =
+    override?.groupSummarizationModel ?? base?.groupSummarizationModel;
+
+  // Check if anything is actually enabled
+  const hasAnything =
+    merged.stripThinkingAfterTurns !== undefined ||
+    merged.summarizeToolResultsAfterTurns !== undefined ||
+    merged.summarizeWindowAfterTurns !== undefined ||
+    merged.stripToolResultsAfterTurns !== undefined ||
+    merged.maxContextMessages !== undefined;
+
+  if (!hasAnything) {
+    return undefined;
+  }
+
+  return merged;
+}
+
+/**
+ * Enforce graduated decay ordering: stripping must happen AFTER individual summarization.
+ * If strip <= summarize, summaries would be generated but never displayed (wasted API calls).
+ * Auto-clamps stripToolResultsAfterTurns to summarizeToolResultsAfterTurns + 1.
+ * Mutates the config in-place and returns it for chaining.
+ */
+function enforceDecayOrdering(config: ContextDecayConfig): ContextDecayConfig {
+  const summarize = config.summarizeToolResultsAfterTurns;
+  const groupSummarize = config.summarizeWindowAfterTurns;
+  const strip = config.stripToolResultsAfterTurns;
+
+  // Only enforce strip > individual summarize. Individual summaries are consumed
+  // by the VIEW, so stripping before summarization wastes API calls.
+  if (typeof strip === "number" && typeof summarize === "number" && strip <= summarize) {
+    const clamped = summarize + 1;
+    config.stripToolResultsAfterTurns = clamped;
+    log.info(
+      `context-decay: stripToolResultsAfterTurns ${strip} -> ${clamped} (must be > summarizeToolResultsAfterTurns=${summarize})`,
+    );
+  }
+
+  // Advisory only: group summarizer reads the raw snapshot, not the decayed view,
+  // so strip < groupSummarize is fine — no enforcement needed.
+  if (typeof strip === "number" && typeof groupSummarize === "number" && strip <= groupSummarize) {
+    log.info(
+      `context-decay: stripToolResultsAfterTurns (${strip}) <= summarizeWindowAfterTurns (${groupSummarize}); OK — group summarizer reads raw transcript`,
+    );
+  }
+
+  // Advisory: individual summaries should ideally fire before group summaries
+  // to provide input to group prompts. Both still work regardless.
+  if (
+    typeof summarize === "number" &&
+    typeof groupSummarize === "number" &&
+    summarize >= groupSummarize
+  ) {
+    log.info(
+      `context-decay: summarizeToolResultsAfterTurns (${summarize}) >= summarizeWindowAfterTurns (${groupSummarize}); individual summaries should fire before group summaries`,
+    );
+  }
+
+  return config;
+}
+
+/**
+ * Resolve the effective ContextDecayConfig for a session by walking the config hierarchy.
+ *
+ * Resolution order (most specific wins per field):
+ * 1. Per-DM: channels.<provider>.dms.<userId>.contextDecay
+ * 2. Per-account/channel: channels.<provider>.contextDecay
+ * 3. Global: agents.defaults.contextDecay
+ *
+ * After resolution, enforces graduated decay ordering: stripToolResultsAfterTurns is
+ * auto-clamped to be > summarizeToolResultsAfterTurns so that summarization always
+ * has a chance to run before stripping.
+ */
+export function resolveContextDecayConfig(
+  sessionKey: string | undefined,
+  config: OpenClawConfig | undefined,
+): ContextDecayConfig | undefined {
+  const globalDecay = config?.agents?.defaults?.contextDecay;
+
+  /** Return global-only config with decay ordering enforced, or undefined. */
+  const globalOnly = (): ContextDecayConfig | undefined =>
+    globalDecay ? enforceDecayOrdering({ ...globalDecay }) : undefined;
+
+  if (!sessionKey || !config) {
+    return globalOnly();
+  }
+
+  // Parse session key: "agent:<agentId>:<provider>:<kind>:<userId>" or "<provider>:<kind>:<userId>"
+  const parts = sessionKey.split(":");
+  const providerParts = parts.length >= 3 && parts[0] === "agent" ? parts.slice(2) : parts;
+
+  const provider = providerParts[0]?.toLowerCase();
+  if (!provider) {
+    return globalOnly();
+  }
+
+  const kind = providerParts[1]?.toLowerCase();
+  const userIdRaw = providerParts.slice(2).join(":");
+  const userId = stripThreadSuffix(userIdRaw);
+
+  // Resolve provider config from channels
+  const channels = config.channels;
+  if (!channels || typeof channels !== "object") {
+    return globalOnly();
+  }
+
+  const providerConfig = (channels as Record<string, unknown>)[provider];
+  if (!providerConfig || typeof providerConfig !== "object" || Array.isArray(providerConfig)) {
+    return globalOnly();
+  }
+
+  const pc = providerConfig as Record<string, unknown>;
+
+  // Layer 1: Per-DM override
+  let dmDecay: ContextDecayConfig | undefined;
+  if ((kind === "direct" || kind === "dm") && userId) {
+    const dms = pc.dms as Record<string, { contextDecay?: ContextDecayConfig }> | undefined;
+    dmDecay = dms?.[userId]?.contextDecay;
+  }
+
+  // Layer 2: Per-account contextDecay
+  const accountDecay = pc.contextDecay as ContextDecayConfig | undefined;
+
+  // Build effective config: global → account → dm (most specific wins)
+  let effective = globalDecay;
+  effective = mergeDecayConfig(effective, accountDecay);
+  effective = mergeDecayConfig(effective, dmDecay);
+
+  return effective ? enforceDecayOrdering(effective) : undefined;
+}
+
+/**
+ * Check whether the resolved config has any active decay features.
+ */
+export function isContextDecayActive(config: ContextDecayConfig | undefined): boolean {
+  if (!config) {
+    return false;
+  }
+  return (
+    (typeof config.stripThinkingAfterTurns === "number" && config.stripThinkingAfterTurns >= 1) ||
+    (typeof config.summarizeToolResultsAfterTurns === "number" &&
+      config.summarizeToolResultsAfterTurns >= 1) ||
+    (typeof config.summarizeWindowAfterTurns === "number" &&
+      config.summarizeWindowAfterTurns >= 1) ||
+    (typeof config.stripToolResultsAfterTurns === "number" &&
+      config.stripToolResultsAfterTurns >= 1) ||
+    (typeof config.maxContextMessages === "number" && config.maxContextMessages >= 1)
+  );
+}

--- a/src/agents/context-decay/resolve-config.ts
+++ b/src/agents/context-decay/resolve-config.ts
@@ -52,10 +52,7 @@ function mergeDecayConfig(
     base?.swapToolResultsAfterTurns,
     override?.swapToolResultsAfterTurns,
   );
-  merged.swapMinChars = pickPositiveInt(
-    base?.swapMinChars,
-    override?.swapMinChars,
-  );
+  merged.swapMinChars = pickPositiveInt(base?.swapMinChars, override?.swapMinChars);
   merged.stripToolResultsAfterTurns = pickPositiveInt(
     base?.stripToolResultsAfterTurns,
     override?.stripToolResultsAfterTurns,

--- a/src/agents/context-decay/summarizer.ts
+++ b/src/agents/context-decay/summarizer.ts
@@ -1,0 +1,173 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { type AuthStorage, estimateTokens, generateSummary } from "@mariozechner/pi-coding-agent";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import type { SummaryEntry } from "./summary-store.js";
+import { log } from "../pi-embedded-runner/logger.js";
+import { extractContentText, extractToolInfo } from "./message-utils.js";
+import { loadSummaryStore, saveSummaryStore } from "./summary-store.js";
+import { computeTurnAges } from "./turn-ages.js";
+
+/** Reserve tokens for the summarization model response. */
+const SUMMARY_RESERVE_TOKENS = 500;
+
+/**
+ * Build the summarization prompt for a tool result.
+ */
+function buildSummarizationPrompt(toolName: string, args: string, content: string): string {
+  return [
+    "Summarize this tool call result concisely. Preserve: file paths, function names, error messages, key values, line numbers. Omit raw content that can be re-fetched.",
+    "",
+    `Tool: ${toolName}`,
+    `Arguments: ${args}`,
+    "",
+    "Result:",
+    content,
+  ].join("\n");
+}
+
+/**
+ * Summarize aged tool results that don't yet have summaries.
+ * This is fire-and-forget — failures are logged but don't affect the agent run.
+ */
+export async function summarizeAgedToolResults(params: {
+  sessionFilePath: string;
+  messages: AgentMessage[];
+  config: ContextDecayConfig;
+  model: NonNullable<ExtensionContext["model"]>;
+  authStorage: AuthStorage;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const { sessionFilePath, messages, config, model, authStorage, abortSignal } = params;
+
+  const summarizeAfter = config.summarizeToolResultsAfterTurns;
+
+  if (!summarizeAfter || summarizeAfter < 1) {
+    return;
+  }
+
+  const existingSummaries = await loadSummaryStore(sessionFilePath);
+  const turnAges = computeTurnAges(messages);
+  const toSummarize: Array<{ index: number; toolName: string; args: string; content: string }> = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    if (abortSignal?.aborted) {
+      return;
+    }
+
+    const msg = messages[i];
+    if (msg.role !== "toolResult") {
+      continue;
+    }
+
+    const age = turnAges.get(i) ?? 0;
+    if (age < summarizeAfter) {
+      continue;
+    }
+    // Skip tool results past the strip threshold — they'll be stripped in the view anyway,
+    // so summarizing them would waste API calls on summaries that are never displayed.
+    if (config.stripToolResultsAfterTurns && age >= config.stripToolResultsAfterTurns) {
+      continue;
+    }
+    if (existingSummaries[i]) {
+      continue;
+    }
+
+    const content = extractContentText(msg);
+    // Skip very short results (not worth summarizing)
+    if (content.length < 200) {
+      continue;
+    }
+
+    const { toolName, args } = extractToolInfo(messages, i);
+    toSummarize.push({ index: i, toolName, args, content });
+  }
+
+  if (toSummarize.length === 0) {
+    return;
+  }
+
+  // Resolve API key from auth storage for the model's provider
+  const apiKey = await authStorage.getApiKey(model.provider);
+  if (!apiKey) {
+    log.warn(
+      `context-decay: no API key found for provider "${model.provider}"; skipping summarization`,
+    );
+    return;
+  }
+
+  log.info(
+    `context-decay: summarizing ${toSummarize.length} aged tool result(s) with ${model.provider}/${model.id}`,
+  );
+
+  const updatedStore = { ...existingSummaries };
+  let didUpdate = false;
+
+  for (const item of toSummarize) {
+    if (abortSignal?.aborted) {
+      break;
+    }
+
+    try {
+      // Truncate args independently to prevent them from pushing tool result content off the end
+      const truncatedArgs = item.args.length > 500 ? item.args.slice(0, 500) + "..." : item.args;
+      const prompt = buildSummarizationPrompt(item.toolName, truncatedArgs, item.content);
+
+      // Truncate very long content to avoid excessive summarization costs
+      const maxPromptChars = 50_000;
+      const truncatedPrompt =
+        prompt.length > maxPromptChars ? prompt.slice(0, maxPromptChars) + "\n[truncated]" : prompt;
+
+      const summaryMessages: AgentMessage[] = [
+        {
+          role: "user",
+          content: truncatedPrompt,
+          timestamp: Date.now(),
+        } as AgentMessage,
+      ];
+
+      const summaryText = await generateSummary(
+        summaryMessages,
+        model,
+        SUMMARY_RESERVE_TOKENS,
+        apiKey,
+        abortSignal ?? new AbortController().signal,
+      );
+
+      if (summaryText && summaryText.length > 0) {
+        const originalMsg = {
+          role: "user",
+          content: item.content,
+          timestamp: Date.now(),
+        } as AgentMessage;
+        const summaryMsg = {
+          role: "user",
+          content: summaryText,
+          timestamp: Date.now(),
+        } as AgentMessage;
+        const entry: SummaryEntry = {
+          summary: summaryText,
+          originalTokenEstimate: estimateTokens(originalMsg),
+          summaryTokenEstimate: estimateTokens(summaryMsg),
+          summarizedAt: new Date().toISOString(),
+          model: `${model.provider}/${model.id}`,
+        };
+        updatedStore[item.index] = entry;
+        didUpdate = true;
+      }
+    } catch (err) {
+      log.warn(
+        `context-decay: failed to summarize tool result at index ${item.index}: ${String(err)}`,
+      );
+    }
+  }
+
+  if (didUpdate) {
+    try {
+      await saveSummaryStore(sessionFilePath, updatedStore);
+      log.info(`context-decay: saved ${Object.keys(updatedStore).length} summaries`);
+    } catch (err) {
+      log.warn(`context-decay: failed to save summary store: ${String(err)}`);
+    }
+  }
+}

--- a/src/agents/context-decay/summarizer.ts
+++ b/src/agents/context-decay/summarizer.ts
@@ -2,9 +2,9 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { type AuthStorage, estimateTokens, generateSummary } from "@mariozechner/pi-coding-agent";
 import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
-import type { SummaryEntry } from "./summary-store.js";
 import { log } from "../pi-embedded-runner/logger.js";
 import { extractContentText, extractToolInfo } from "./message-utils.js";
+import type { SummaryEntry } from "./summary-store.js";
 import { loadSummaryStore, saveSummaryStore } from "./summary-store.js";
 import { computeTurnAges } from "./turn-ages.js";
 

--- a/src/agents/context-decay/summary-store.test.ts
+++ b/src/agents/context-decay/summary-store.test.ts
@@ -1,0 +1,300 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { GroupSummaryStore, SummaryStore } from "./summary-store.js";
+import {
+  clearGroupSummaryStore,
+  clearSummaryStore,
+  loadGroupSummaryStore,
+  loadGroupSummaryStoreSync,
+  loadSummaryStore,
+  loadSummaryStoreSync,
+  saveGroupSummaryStore,
+  saveSummaryStore,
+} from "./summary-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function sessionPath(): string {
+  return path.join(tmpDir, "session.jsonl");
+}
+
+function summaryPath(): string {
+  return path.join(tmpDir, "session.summaries.json");
+}
+
+function groupSummaryPath(): string {
+  return path.join(tmpDir, "session.group-summaries.json");
+}
+
+function makeSampleStore(): SummaryStore {
+  return {
+    2: {
+      summary: "Read file /src/foo.ts, found function bar()",
+      originalTokenEstimate: 450,
+      summaryTokenEstimate: 12,
+      summarizedAt: "2026-01-15T10:00:00.000Z",
+      model: "anthropic/claude-haiku-4-5",
+    },
+    5: {
+      summary: "Search returned 3 matches in utils.ts",
+      originalTokenEstimate: 200,
+      summaryTokenEstimate: 8,
+      summarizedAt: "2026-01-15T10:01:00.000Z",
+      model: "anthropic/claude-haiku-4-5",
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "summary-store-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("summary-store", () => {
+  describe("loadSummaryStore (async)", () => {
+    it("returns empty store when file does not exist", async () => {
+      const store = await loadSummaryStore(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("returns empty store when file contains invalid JSON", async () => {
+      await fs.writeFile(summaryPath(), "not json!", "utf-8");
+      const store = await loadSummaryStore(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("returns empty store when file contains a JSON array", async () => {
+      await fs.writeFile(summaryPath(), "[1,2,3]", "utf-8");
+      const store = await loadSummaryStore(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("loads a valid store", async () => {
+      const sample = makeSampleStore();
+      await fs.writeFile(summaryPath(), JSON.stringify(sample), "utf-8");
+      const store = await loadSummaryStore(sessionPath());
+      expect(store).toEqual(sample);
+    });
+  });
+
+  describe("loadSummaryStoreSync", () => {
+    it("returns empty store when file does not exist", () => {
+      const store = loadSummaryStoreSync(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("returns empty store when file contains invalid JSON", async () => {
+      await fs.writeFile(summaryPath(), "{broken", "utf-8");
+      const store = loadSummaryStoreSync(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("loads a valid store", async () => {
+      const sample = makeSampleStore();
+      await fs.writeFile(summaryPath(), JSON.stringify(sample), "utf-8");
+      const store = loadSummaryStoreSync(sessionPath());
+      expect(store).toEqual(sample);
+    });
+  });
+
+  describe("saveSummaryStore", () => {
+    it("creates directories and saves a round-trippable store", async () => {
+      const nestedSession = path.join(tmpDir, "a", "b", "session.jsonl");
+      const sample = makeSampleStore();
+
+      await saveSummaryStore(nestedSession, sample);
+
+      const loaded = await loadSummaryStore(nestedSession);
+      expect(loaded).toEqual(sample);
+    });
+
+    it("overwrites an existing store", async () => {
+      const sample1 = makeSampleStore();
+      await saveSummaryStore(sessionPath(), sample1);
+
+      const sample2: SummaryStore = {
+        10: {
+          summary: "Updated summary",
+          originalTokenEstimate: 100,
+          summaryTokenEstimate: 5,
+          summarizedAt: "2026-02-01T00:00:00.000Z",
+          model: "haiku",
+        },
+      };
+      await saveSummaryStore(sessionPath(), sample2);
+
+      const loaded = await loadSummaryStore(sessionPath());
+      expect(loaded).toEqual(sample2);
+      expect(loaded[2]).toBeUndefined(); // old entry gone
+    });
+
+    it("writes pretty-printed JSON", async () => {
+      await saveSummaryStore(sessionPath(), makeSampleStore());
+      const raw = await fs.readFile(summaryPath(), "utf-8");
+      // Pretty-printed JSON has newlines and indentation
+      expect(raw).toContain("\n");
+      expect(raw).toContain("  ");
+    });
+  });
+
+  describe("clearSummaryStore", () => {
+    it("removes an existing summary store file", async () => {
+      await saveSummaryStore(sessionPath(), makeSampleStore());
+      // File exists
+      await expect(fs.access(summaryPath())).resolves.toBeUndefined();
+
+      await clearSummaryStore(sessionPath());
+
+      // File is gone — load returns empty
+      const store = await loadSummaryStore(sessionPath());
+      expect(store).toEqual({});
+    });
+
+    it("is a no-op when the file does not exist", async () => {
+      // Should not throw
+      await expect(clearSummaryStore(sessionPath())).resolves.toBeUndefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group Summary Store Tests
+// ---------------------------------------------------------------------------
+
+function makeSampleGroupStore(): GroupSummaryStore {
+  return [
+    {
+      summary: "User asked to read auth.ts. Tool found null check at line 42. Fix was applied.",
+      anchorIndex: 0,
+      indices: [0, 1, 2, 3, 4, 5],
+      turnRange: [6, 3],
+      originalTokenEstimate: 800,
+      summaryTokenEstimate: 30,
+      summarizedAt: "2026-01-15T10:00:00.000Z",
+      model: "anthropic/claude-sonnet-4-5",
+    },
+  ];
+}
+
+describe("group-summary-store", () => {
+  describe("loadGroupSummaryStore (async)", () => {
+    it("returns empty array when file does not exist", async () => {
+      const store = await loadGroupSummaryStore(sessionPath());
+      expect(store).toEqual([]);
+    });
+
+    it("returns empty array when file contains invalid JSON", async () => {
+      await fs.writeFile(groupSummaryPath(), "not json!", "utf-8");
+      const store = await loadGroupSummaryStore(sessionPath());
+      expect(store).toEqual([]);
+    });
+
+    it("returns empty array when file contains a JSON object (not array)", async () => {
+      await fs.writeFile(groupSummaryPath(), '{"key": "value"}', "utf-8");
+      const store = await loadGroupSummaryStore(sessionPath());
+      expect(store).toEqual([]);
+    });
+
+    it("loads a valid store", async () => {
+      const sample = makeSampleGroupStore();
+      await fs.writeFile(groupSummaryPath(), JSON.stringify(sample), "utf-8");
+      const store = await loadGroupSummaryStore(sessionPath());
+      expect(store).toEqual(sample);
+    });
+  });
+
+  describe("loadGroupSummaryStoreSync", () => {
+    it("returns empty array when file does not exist", () => {
+      const store = loadGroupSummaryStoreSync(sessionPath());
+      expect(store).toEqual([]);
+    });
+
+    it("returns empty array when file contains invalid JSON", async () => {
+      await fs.writeFile(groupSummaryPath(), "{broken", "utf-8");
+      const store = loadGroupSummaryStoreSync(sessionPath());
+      expect(store).toEqual([]);
+    });
+
+    it("loads a valid store", async () => {
+      const sample = makeSampleGroupStore();
+      await fs.writeFile(groupSummaryPath(), JSON.stringify(sample), "utf-8");
+      const store = loadGroupSummaryStoreSync(sessionPath());
+      expect(store).toEqual(sample);
+    });
+  });
+
+  describe("saveGroupSummaryStore", () => {
+    it("creates directories and saves a round-trippable store", async () => {
+      const nestedSession = path.join(tmpDir, "a", "b", "session.jsonl");
+      const sample = makeSampleGroupStore();
+
+      await saveGroupSummaryStore(nestedSession, sample);
+
+      const loaded = await loadGroupSummaryStore(nestedSession);
+      expect(loaded).toEqual(sample);
+    });
+
+    it("overwrites an existing store", async () => {
+      const sample1 = makeSampleGroupStore();
+      await saveGroupSummaryStore(sessionPath(), sample1);
+
+      const sample2: GroupSummaryStore = [
+        {
+          summary: "New group summary",
+          anchorIndex: 10,
+          indices: [10, 11, 12],
+          turnRange: [4, 2],
+          originalTokenEstimate: 300,
+          summaryTokenEstimate: 15,
+          summarizedAt: "2026-02-01T00:00:00.000Z",
+          model: "haiku",
+        },
+      ];
+      await saveGroupSummaryStore(sessionPath(), sample2);
+
+      const loaded = await loadGroupSummaryStore(sessionPath());
+      expect(loaded).toEqual(sample2);
+      expect(loaded).toHaveLength(1);
+    });
+
+    it("writes pretty-printed JSON", async () => {
+      await saveGroupSummaryStore(sessionPath(), makeSampleGroupStore());
+      const raw = await fs.readFile(groupSummaryPath(), "utf-8");
+      expect(raw).toContain("\n");
+      expect(raw).toContain("  ");
+    });
+  });
+
+  describe("clearGroupSummaryStore", () => {
+    it("removes an existing group summary store file", async () => {
+      await saveGroupSummaryStore(sessionPath(), makeSampleGroupStore());
+      await expect(fs.access(groupSummaryPath())).resolves.toBeUndefined();
+
+      await clearGroupSummaryStore(sessionPath());
+
+      const store = await loadGroupSummaryStore(sessionPath());
+      expect(store).toEqual([]);
+    });
+
+    it("is a no-op when the file does not exist", async () => {
+      await expect(clearGroupSummaryStore(sessionPath())).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/agents/context-decay/summary-store.ts
+++ b/src/agents/context-decay/summary-store.ts
@@ -1,0 +1,184 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface SummaryEntry {
+  /** The summarized text replacing the original tool result. */
+  summary: string;
+  /** Estimated token count of the original content. */
+  originalTokenEstimate: number;
+  /** Estimated token count of the summary. */
+  summaryTokenEstimate: number;
+  /** ISO timestamp of when the summary was created. */
+  summarizedAt: string;
+  /** Model used for summarization. */
+  model: string;
+}
+
+/** Maps message index (position in transcript) to its summary. */
+export type SummaryStore = Record<number, SummaryEntry>;
+
+export interface GroupSummaryEntry {
+  /** The coherent summary for the entire window. */
+  summary: string;
+  /** Index of the anchor message (first user message in window). */
+  anchorIndex: number;
+  /** All message indices in this window. */
+  indices: number[];
+  /** [oldest turn age, newest turn age] at summarization time. */
+  turnRange: [number, number];
+  /** Estimated token count of original window content. */
+  originalTokenEstimate: number;
+  /** Estimated token count of the summary. */
+  summaryTokenEstimate: number;
+  /** ISO timestamp of when the summary was created. */
+  summarizedAt: string;
+  /** Model used for summarization. */
+  model: string;
+}
+
+export type GroupSummaryStore = GroupSummaryEntry[];
+
+function summaryStorePath(sessionFilePath: string): string {
+  const dir = path.dirname(sessionFilePath);
+  const base = path.basename(sessionFilePath, path.extname(sessionFilePath));
+  return path.join(dir, `${base}.summaries.json`);
+}
+
+/**
+ * Load the summary store for a session (async). Returns empty store on missing/invalid file.
+ * Note: individual entries are not validated beyond `typeof === "object"` — callers trust
+ * the local file as a persistence boundary. Zod validation happens at config load time.
+ */
+export async function loadSummaryStore(sessionFilePath: string): Promise<SummaryStore> {
+  const filePath = summaryStorePath(sessionFilePath);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as SummaryStore;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Load the summary store for a session (synchronous). Returns empty store on missing/invalid file. */
+export function loadSummaryStoreSync(sessionFilePath: string): SummaryStore {
+  const filePath = summaryStorePath(sessionFilePath);
+  try {
+    const raw = fsSync.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as SummaryStore;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Remove the summary store file for a session. No-op if the file doesn't exist. */
+export async function clearSummaryStore(sessionFilePath: string): Promise<void> {
+  const filePath = summaryStorePath(sessionFilePath);
+  try {
+    await fs.unlink(filePath);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Group Summary Store
+// ---------------------------------------------------------------------------
+
+function groupSummaryStorePath(sessionFilePath: string): string {
+  const dir = path.dirname(sessionFilePath);
+  const base = path.basename(sessionFilePath, path.extname(sessionFilePath));
+  return path.join(dir, `${base}.group-summaries.json`);
+}
+
+/** Load the group summary store for a session (async). Returns empty array on missing/invalid file. */
+export async function loadGroupSummaryStore(sessionFilePath: string): Promise<GroupSummaryStore> {
+  const filePath = groupSummaryStorePath(sessionFilePath);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed as GroupSummaryStore;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/** Load the group summary store for a session (synchronous). Returns empty array on missing/invalid file. */
+export function loadGroupSummaryStoreSync(sessionFilePath: string): GroupSummaryStore {
+  const filePath = groupSummaryStorePath(sessionFilePath);
+  try {
+    const raw = fsSync.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed as GroupSummaryStore;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/** Remove the group summary store file for a session. No-op if the file doesn't exist. */
+export async function clearGroupSummaryStore(sessionFilePath: string): Promise<void> {
+  const filePath = groupSummaryStorePath(sessionFilePath);
+  try {
+    await fs.unlink(filePath);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Atomic write helper
+// ---------------------------------------------------------------------------
+
+/** Atomically write JSON data to a file (tmp + rename). Creates directories as needed. */
+async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  try {
+    await fs.writeFile(tmpPath, JSON.stringify(data, null, 2), "utf-8");
+    await fs.rename(tmpPath, filePath);
+  } catch (err) {
+    await fs.unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual Summary Store (persistence)
+// ---------------------------------------------------------------------------
+
+/** Atomically persist the summary store (tmp + rename). Creates directories as needed. */
+export async function saveSummaryStore(
+  sessionFilePath: string,
+  store: SummaryStore,
+): Promise<void> {
+  const filePath = summaryStorePath(sessionFilePath);
+  await atomicWriteJson(filePath, store);
+}
+
+/** Atomically persist the group summary store (tmp + rename). Creates directories as needed. */
+export async function saveGroupSummaryStore(
+  sessionFilePath: string,
+  store: GroupSummaryStore,
+): Promise<void> {
+  const filePath = groupSummaryStorePath(sessionFilePath);
+  await atomicWriteJson(filePath, store);
+}

--- a/src/agents/context-decay/turn-ages.ts
+++ b/src/agents/context-decay/turn-ages.ts
@@ -1,0 +1,35 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+/**
+ * Count turns backward from end. A "turn" is defined by user messages as boundaries.
+ * Returns a Map from message index to the turn age (0 = current turn, 1 = previous, etc.)
+ */
+export function computeTurnAges(messages: AgentMessage[]): Map<number, number> {
+  const ages = new Map<number, number>();
+  let turnAge = 0;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    ages.set(i, turnAge);
+    if (messages[i].role === "user" && i > 0) {
+      turnAge++;
+    }
+  }
+  return ages;
+}
+
+/**
+ * Group message indices by their turn age.
+ * Returns a Map from turn age → array of message indices belonging to that turn (insertion order; caller must sort if needed).
+ */
+export function groupIndicesByTurn(turnAges: Map<number, number>): Map<number, number[]> {
+  const groups = new Map<number, number[]>();
+  for (const [i, age] of turnAges) {
+    const list = groups.get(age);
+    if (list) {
+      list.push(i);
+    } else {
+      groups.set(age, [i]);
+    }
+  }
+  return groups;
+}

--- a/src/agents/context-lifecycle/emitter.test.ts
+++ b/src/agents/context-lifecycle/emitter.test.ts
@@ -139,6 +139,24 @@ describe("ContextLifecycleEmitter", () => {
     expect(JSON.parse(lines[0]).rule).toBe("compact:compaction");
   });
 
+  it("creates parent directories on first flush", async () => {
+    const nested = path.join(tmpDir, "nested", "deep", "lifecycle.jsonl");
+    const emitter = new ContextLifecycleEmitter(nested, "sk", "sid", 200_000);
+
+    emitter.emit({
+      turn: 1,
+      rule: "decay:pass",
+      beforeTokens: 80_000,
+      freedTokens: 5_000,
+      afterTokens: 75_000,
+    });
+
+    await emitter.flush();
+
+    const raw = await fs.readFile(nested, "utf-8");
+    expect(raw.trim().split("\n")).toHaveLength(1);
+  });
+
   it("includes details when provided", async () => {
     const emitter = new ContextLifecycleEmitter(filePath, "sk", "sid", 200_000);
 

--- a/src/agents/context-lifecycle/emitter.test.ts
+++ b/src/agents/context-lifecycle/emitter.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ContextLifecycleEmitter } from "./emitter.js";
+
+describe("ContextLifecycleEmitter", () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "lifecycle-emitter-"));
+    filePath = path.join(tmpDir, "test-lifecycle.jsonl");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes a single event to JSONL after flush", async () => {
+    const emitter = new ContextLifecycleEmitter(filePath, "session:test", "sid-1", 200_000);
+
+    emitter.emit({
+      turn: 5,
+      rule: "decay:pass",
+      beforeTokens: 80_000,
+      freedTokens: 5_000,
+      afterTokens: 75_000,
+    });
+
+    await emitter.flush();
+
+    const raw = await fs.readFile(filePath, "utf-8");
+    const lines = raw.trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const event = JSON.parse(lines[0]);
+    expect(event.sessionKey).toBe("session:test");
+    expect(event.sessionId).toBe("sid-1");
+    expect(event.rule).toBe("decay:pass");
+    expect(event.beforeTokens).toBe(80_000);
+    expect(event.freedTokens).toBe(5_000);
+    expect(event.afterTokens).toBe(75_000);
+    expect(event.contextWindow).toBe(200_000);
+    expect(event.beforePct).toBe(40);
+    expect(event.afterPct).toBe(38);
+    expect(event.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("computes percentages correctly", async () => {
+    const emitter = new ContextLifecycleEmitter(filePath, "sk", "sid", 100_000);
+
+    emitter.emit({
+      turn: 1,
+      rule: "prune:pass",
+      beforeTokens: 71_000,
+      freedTokens: 4_000,
+      afterTokens: 67_000,
+    });
+
+    await emitter.flush();
+
+    const event = JSON.parse((await fs.readFile(filePath, "utf-8")).trim());
+    expect(event.beforePct).toBe(71);
+    expect(event.afterPct).toBe(67);
+  });
+
+  it("handles zero context window without division error", async () => {
+    const emitter = new ContextLifecycleEmitter(filePath, "sk", "sid", 0);
+
+    emitter.emit({
+      turn: 1,
+      rule: "decay:pass",
+      beforeTokens: 1000,
+      freedTokens: 500,
+      afterTokens: 500,
+    });
+
+    await emitter.flush();
+
+    const event = JSON.parse((await fs.readFile(filePath, "utf-8")).trim());
+    expect(event.beforePct).toBe(0);
+    expect(event.afterPct).toBe(0);
+  });
+
+  it("buffers multiple events and writes them all on flush", async () => {
+    const emitter = new ContextLifecycleEmitter(filePath, "sk", "sid", 200_000);
+
+    for (let i = 0; i < 5; i++) {
+      emitter.emit({
+        turn: i,
+        rule: "decay:strip_thinking",
+        beforeTokens: 80_000 - i * 1_000,
+        freedTokens: 1_000,
+        afterTokens: 79_000 - i * 1_000,
+      });
+    }
+
+    await emitter.flush();
+
+    const raw = await fs.readFile(filePath, "utf-8");
+    const lines = raw.trim().split("\n");
+    expect(lines).toHaveLength(5);
+
+    for (let i = 0; i < 5; i++) {
+      const event = JSON.parse(lines[i]);
+      expect(event.turn).toBe(i);
+    }
+  });
+
+  it("flush is a no-op when buffer is empty", async () => {
+    const emitter = new ContextLifecycleEmitter(filePath, "sk", "sid", 200_000);
+
+    await emitter.flush();
+
+    const exists = await fs.access(filePath).then(
+      () => true,
+      () => false,
+    );
+    expect(exists).toBe(false);
+  });
+
+  it("dispose triggers a flush", async () => {
+    const emitter = new ContextLifecycleEmitter(filePath, "sk", "sid", 200_000);
+
+    emitter.emit({
+      turn: 1,
+      rule: "compact:compaction",
+      beforeTokens: 160_000,
+      freedTokens: 60_000,
+      afterTokens: 100_000,
+    });
+
+    await emitter.dispose();
+
+    const raw = await fs.readFile(filePath, "utf-8");
+    const lines = raw.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).rule).toBe("compact:compaction");
+  });
+
+  it("includes details when provided", async () => {
+    const emitter = new ContextLifecycleEmitter(filePath, "sk", "sid", 200_000);
+
+    emitter.emit({
+      turn: 10,
+      rule: "decay:pass",
+      beforeTokens: 80_000,
+      freedTokens: 5_000,
+      afterTokens: 75_000,
+      details: { thinkingBlocksStripped: 3, summarizedCount: 2 },
+    });
+
+    await emitter.flush();
+
+    const event = JSON.parse((await fs.readFile(filePath, "utf-8")).trim());
+    expect(event.details).toEqual({ thinkingBlocksStripped: 3, summarizedCount: 2 });
+  });
+});

--- a/src/agents/context-lifecycle/emitter.ts
+++ b/src/agents/context-lifecycle/emitter.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import type { ContextLifecycleEvent } from "./types.js";
+
+const FLUSH_INTERVAL_MS = 1_000;
+const FLUSH_THRESHOLD = 10;
+
+/**
+ * Per-session lifecycle event emitter.
+ * Buffers events and writes them to a JSONL file asynchronously.
+ */
+export class ContextLifecycleEmitter {
+  private buffer: string[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private flushing = false;
+
+  constructor(
+    private filePath: string,
+    private sessionKey: string,
+    private sessionId: string,
+    private contextWindow: number,
+  ) {}
+
+  emit(
+    event: Omit<
+      ContextLifecycleEvent,
+      "timestamp" | "sessionKey" | "sessionId" | "contextWindow" | "beforePct" | "afterPct"
+    >,
+  ): void {
+    const full: ContextLifecycleEvent = {
+      ...event,
+      timestamp: new Date().toISOString(),
+      sessionKey: this.sessionKey,
+      sessionId: this.sessionId,
+      contextWindow: this.contextWindow,
+      beforePct:
+        this.contextWindow > 0 ? Math.round((event.beforeTokens / this.contextWindow) * 100) : 0,
+      afterPct:
+        this.contextWindow > 0 ? Math.round((event.afterTokens / this.contextWindow) * 100) : 0,
+    };
+    let line: string;
+    try {
+      line = JSON.stringify(full);
+    } catch {
+      return;
+    }
+    this.buffer.push(line);
+
+    if (this.buffer.length >= FLUSH_THRESHOLD) {
+      void this.flush();
+    } else if (!this.flushTimer) {
+      this.flushTimer = setTimeout(() => void this.flush(), FLUSH_INTERVAL_MS);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.flushing || this.buffer.length === 0) {
+      return;
+    }
+    this.flushing = true;
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    const lines = this.buffer.splice(0);
+    try {
+      await fs.appendFile(this.filePath, lines.join("\n") + "\n");
+    } catch {
+      // Best-effort — instrumentation must never block the agent pipeline
+    }
+    this.flushing = false;
+    // Reschedule if events were buffered during the async write
+    if (this.buffer.length > 0 && !this.flushTimer) {
+      this.flushTimer = setTimeout(() => void this.flush(), FLUSH_INTERVAL_MS);
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    await this.flush();
+  }
+}

--- a/src/agents/context-lifecycle/types.ts
+++ b/src/agents/context-lifecycle/types.ts
@@ -1,0 +1,31 @@
+export type ContextLifecycleRule =
+  // Context decay rules (from our extension)
+  | "decay:strip_thinking"
+  | "decay:summarize_tool_result"
+  | "decay:summarize_group"
+  | "decay:strip_tool_result"
+  | "decay:file_swap"
+  | "decay:max_messages"
+  | "decay:pass"
+  // Session pruning rules (existing core)
+  | "prune:soft_trim"
+  | "prune:hard_clear"
+  | "prune:pass"
+  // Compaction
+  | "compact:memory_flush"
+  | "compact:compaction";
+
+export interface ContextLifecycleEvent {
+  timestamp: string;
+  sessionKey: string;
+  sessionId: string;
+  turn: number;
+  rule: ContextLifecycleRule;
+  beforeTokens: number;
+  beforePct: number;
+  freedTokens: number;
+  afterTokens: number;
+  afterPct: number;
+  contextWindow: number;
+  details?: Record<string, unknown>;
+}

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -26,6 +26,7 @@ import { resolveSessionAgentIds } from "../agent-scope.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
+import { clearAllDecayStores } from "../context-decay/clear-stores.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
@@ -700,6 +701,13 @@ export async function compactEmbeddedPiSessionDirect(
               `delta.estTokens=${typeof preMetrics.estTokens === "number" && typeof postMetrics.estTokens === "number" ? postMetrics.estTokens - preMetrics.estTokens : "unknown"}`,
           );
         }
+        // Clear stale decay stores — indices are positional and become invalid after compaction.
+        try {
+          await clearAllDecayStores(params.sessionFile);
+        } catch (clearErr) {
+          log.warn(`failed to clear decay stores after compaction: ${String(clearErr)}`);
+        }
+
         if (lifecycleEmitter) {
           try {
             const beforeTokens = result.tokensBefore;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -536,7 +536,8 @@ export async function compactEmbeddedPiSessionDirect(
         settingsManager,
         minReserveTokens: resolveCompactionReserveTokensFloor(params.config),
       });
-      // Call for side effects (sets compaction/pruning runtime state)
+      // Call for side effects (sets compaction/pruning runtime state).
+      // Context decay is not active during compaction (no sessionKey/sessionFile).
       buildEmbeddedExtensionPaths({
         cfg: params.config,
         sessionManager,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -701,16 +701,20 @@ export async function compactEmbeddedPiSessionDirect(
           );
         }
         if (lifecycleEmitter) {
-          const beforeTokens = result.tokensBefore;
-          lifecycleEmitter.emit({
-            turn: 0,
-            rule: "compact:compaction",
-            beforeTokens,
-            afterTokens: tokensAfter ?? beforeTokens,
-            freedTokens: tokensAfter != null ? Math.max(0, beforeTokens - tokensAfter) : 0,
-            details: { trigger, diagId, manual: true },
-          });
-          void lifecycleEmitter.dispose();
+          try {
+            const beforeTokens = result.tokensBefore;
+            lifecycleEmitter.emit({
+              turn: 0,
+              rule: "compact:compaction",
+              beforeTokens,
+              afterTokens: tokensAfter ?? beforeTokens,
+              freedTokens: tokensAfter != null ? Math.max(0, beforeTokens - tokensAfter) : 0,
+              details: { trigger, diagId, manual: true },
+            });
+            void lifecycleEmitter.dispose();
+          } catch (err) {
+            log.warn(`lifecycle emit failed: ${String(err)}`);
+          }
         }
         return {
           ok: true,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -63,7 +63,7 @@ import {
   compactWithSafetyTimeout,
   EMBEDDED_COMPACTION_TIMEOUT_MS,
 } from "./compaction-safety-timeout.js";
-import { buildEmbeddedExtensionPaths } from "./extensions.js";
+import { buildEmbeddedExtensions } from "./extensions.js";
 import {
   logToolSchemasForGoogle,
   sanitizeSessionHistory,
@@ -543,7 +543,7 @@ export async function compactEmbeddedPiSessionDirect(
       });
       // Call for side effects (sets compaction/pruning runtime state + lifecycle emitter).
       // Context decay is not active during compaction (no sessionFile).
-      const { lifecycleEmitter } = buildEmbeddedExtensionPaths({
+      const { lifecycleEmitter } = buildEmbeddedExtensions({
         cfg: params.config,
         sessionManager,
         provider,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -93,6 +93,7 @@ function resolveLifecycleEmitter(params: {
     return undefined;
   }
   const fileTemplate = logCfg.filePath ?? "logs/context-lifecycle.jsonl";
+  // Sanitize sessionKey: basename strips traversal, regexes remove separators and dot sequences.
   const safeSessionKey = path
     .basename(params.sessionKey)
     .replace(/[\\/:]/g, "_")

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -3,9 +3,16 @@ import { fileURLToPath } from "node:url";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import {
+  resolveContextDecayConfig,
+  isContextDecayActive,
+} from "../context-decay/resolve-config.js";
+import { loadGroupSummaryStoreSync, loadSummaryStoreSync } from "../context-decay/summary-store.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { setCompactionSafeguardRuntime } from "../pi-extensions/compaction-safeguard-runtime.js";
+import { setContextDecayRuntime } from "../pi-extensions/context-decay/runtime.js";
 import { setContextPruningRuntime } from "../pi-extensions/context-pruning/runtime.js";
 import { computeEffectiveSettings } from "../pi-extensions/context-pruning/settings.js";
 import { makeToolPrunablePredicate } from "../pi-extensions/context-pruning/tools.js";
@@ -67,6 +74,32 @@ function buildContextPruningExtension(params: {
   };
 }
 
+function buildContextDecayExtension(params: {
+  cfg: OpenClawConfig | undefined;
+  sessionManager: SessionManager;
+  sessionKey?: string;
+  sessionFile?: string;
+}): { additionalExtensionPaths?: string[]; resolvedConfig?: ContextDecayConfig } {
+  const config = resolveContextDecayConfig(params.sessionKey, params.cfg);
+  if (!isContextDecayActive(config)) {
+    return {};
+  }
+
+  const summaryStore = params.sessionFile ? loadSummaryStoreSync(params.sessionFile) : {};
+  const groupSummaryStore = params.sessionFile ? loadGroupSummaryStoreSync(params.sessionFile) : [];
+
+  setContextDecayRuntime(params.sessionManager, {
+    config: config!,
+    summaryStore,
+    groupSummaryStore,
+  });
+
+  return {
+    additionalExtensionPaths: [resolvePiExtensionPath("context-decay")],
+    resolvedConfig: config,
+  };
+}
+
 function resolveCompactionMode(cfg?: OpenClawConfig): "default" | "safeguard" {
   return cfg?.agents?.defaults?.compaction?.mode === "safeguard" ? "safeguard" : "default";
 }
@@ -77,7 +110,9 @@ export function buildEmbeddedExtensionPaths(params: {
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
-}): string[] {
+  sessionKey?: string;
+  sessionFile?: string;
+}): { paths: string[]; contextDecayConfig?: ContextDecayConfig } {
   const paths: string[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {
     const compactionCfg = params.cfg?.agents?.defaults?.compaction;
@@ -98,7 +133,16 @@ export function buildEmbeddedExtensionPaths(params: {
   if (pruning.additionalExtensionPaths) {
     paths.push(...pruning.additionalExtensionPaths);
   }
-  return paths;
+  const decay = buildContextDecayExtension({
+    cfg: params.cfg,
+    sessionManager: params.sessionManager,
+    sessionKey: params.sessionKey,
+    sessionFile: params.sessionFile,
+  });
+  if (decay.additionalExtensionPaths) {
+    paths.push(...decay.additionalExtensionPaths);
+  }
+  return { paths, contextDecayConfig: decay.resolvedConfig };
 }
 
 export { ensurePiCompactionReserveTokens };

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -20,6 +20,7 @@ import { computeEffectiveSettings } from "../pi-extensions/context-pruning/setti
 import { makeToolPrunablePredicate } from "../pi-extensions/context-pruning/tools.js";
 import { ensurePiCompactionReserveTokens } from "../pi-settings.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
+import { log } from "./logger.js";
 
 function resolvePiExtensionPath(id: string): string {
   const self = fileURLToPath(import.meta.url);
@@ -189,6 +190,13 @@ export function buildEmbeddedExtensionPaths(params: {
   });
   if (decay.additionalExtensionPaths) {
     paths.push(...decay.additionalExtensionPaths);
+  }
+  if (pruning.additionalExtensionPaths && decay.additionalExtensionPaths) {
+    log.warn(
+      "contextDecay and contextPruning (cache-ttl) are both active — " +
+        "they serve overlapping purposes and may interfere. " +
+        "Consider setting contextPruning.mode to 'off' when using contextDecay.",
+    );
   }
   return { paths, contextDecayConfig: decay.resolvedConfig, lifecycleEmitter };
 }

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -8,6 +8,7 @@ import {
   resolveContextDecayConfig,
   isContextDecayActive,
 } from "../context-decay/resolve-config.js";
+import { loadSwappedFileStoreSync } from "../context-decay/file-store.js";
 import { loadGroupSummaryStoreSync, loadSummaryStoreSync } from "../context-decay/summary-store.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
@@ -87,11 +88,13 @@ function buildContextDecayExtension(params: {
 
   const summaryStore = params.sessionFile ? loadSummaryStoreSync(params.sessionFile) : {};
   const groupSummaryStore = params.sessionFile ? loadGroupSummaryStoreSync(params.sessionFile) : [];
+  const swappedFileStore = params.sessionFile ? loadSwappedFileStoreSync(params.sessionFile) : {};
 
   setContextDecayRuntime(params.sessionManager, {
     config: config!,
     summaryStore,
     groupSummaryStore,
+    swappedFileStore,
   });
 
   return {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -813,6 +813,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey ?? params.sessionId,
         lifecycleEmitter: extensionResult.lifecycleEmitter,
+        sessionFile: params.sessionFile,
       });
 
       const {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -556,6 +556,7 @@ export async function runEmbeddedAttempt(
         modelId: params.modelId,
         model: params.model,
         sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
         sessionFile: params.sessionFile,
       });
       const contextDecayConfig = extensionResult.contextDecayConfig;
@@ -791,6 +792,7 @@ export async function runEmbeddedAttempt(
         enforceFinalTag: params.enforceFinalTag,
         config: params.config,
         sessionKey: params.sessionKey ?? params.sessionId,
+        lifecycleEmitter: extensionResult.lifecycleEmitter,
       });
 
       const {

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
-import { clearSwappedFileStore } from "../context-decay/file-store.js";
-import { clearGroupSummaryStore, clearSummaryStore } from "../context-decay/summary-store.js";
+import { clearAllDecayStores } from "../context-decay/clear-stores.js";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
@@ -46,10 +45,8 @@ export async function prepareSessionManagerForRun(params: {
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
     await fs.writeFile(params.sessionFile, "", "utf-8");
-    // Clear stale summary stores — indices are positional and become invalid on reset.
-    await clearSummaryStore(params.sessionFile);
-    await clearGroupSummaryStore(params.sessionFile);
-    await clearSwappedFileStore(params.sessionFile);
+    // Clear stale decay stores — indices are positional and become invalid on reset.
+    await clearAllDecayStores(params.sessionFile);
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { clearGroupSummaryStore, clearSummaryStore } from "../context-decay/summary-store.js";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
@@ -44,6 +45,9 @@ export async function prepareSessionManagerForRun(params: {
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
     await fs.writeFile(params.sessionFile, "", "utf-8");
+    // Clear stale summary stores — indices are positional and become invalid on reset.
+    await clearSummaryStore(params.sessionFile);
+    await clearGroupSummaryStore(params.sessionFile);
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { clearSwappedFileStore } from "../context-decay/file-store.js";
 import { clearGroupSummaryStore, clearSummaryStore } from "../context-decay/summary-store.js";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
@@ -48,6 +49,7 @@ export async function prepareSessionManagerForRun(params: {
     // Clear stale summary stores — indices are positional and become invalid on reset.
     await clearSummaryStore(params.sessionFile);
     await clearGroupSummaryStore(params.sessionFile);
+    await clearSwappedFileStore(params.sessionFile);
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -4,6 +4,7 @@ import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 
 // Rough heuristic: average English text runs ~4 characters per token.
+// Heuristic for rough telemetry: ~4 chars per token across common models.
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 
 /**

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -1,7 +1,7 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
-import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 
 // Rough heuristic: average English text runs ~4 characters per token.
 // Heuristic for rough telemetry: ~4 chars per token across common models.

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -61,6 +61,7 @@ export type EmbeddedPiSubscribeState = {
   lastReasoningSent?: string;
 
   compactionInFlight: boolean;
+  compactionPreEstTokens?: number;
   pendingCompactionRetry: number;
   compactionRetryResolve?: () => void;
   compactionRetryReject?: (reason?: unknown) => void;

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -39,6 +39,7 @@ export type SubscribeEmbeddedPiSessionParams = {
   config?: OpenClawConfig;
   sessionKey?: string;
   lifecycleEmitter?: ContextLifecycleEmitter;
+  sessionFile?: string;
 };
 
 export type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -2,6 +2,7 @@ import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { ReasoningLevel, VerboseLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookRunner } from "../plugins/hooks.js";
+import type { ContextLifecycleEmitter } from "./context-lifecycle/emitter.js";
 import type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";
 
 export type ToolResultFormat = "markdown" | "plain";
@@ -37,6 +38,7 @@ export type SubscribeEmbeddedPiSessionParams = {
   enforceFinalTag?: boolean;
   config?: OpenClawConfig;
   sessionKey?: string;
+  lifecycleEmitter?: ContextLifecycleEmitter;
 };
 
 export type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";

--- a/src/agents/pi-extensions/context-decay.test.ts
+++ b/src/agents/pi-extensions/context-decay.test.ts
@@ -1,0 +1,638 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import type { ContextDecayConfig } from "../../config/types.agent-defaults.js";
+import type { SummaryStore } from "../context-decay/summary-store.js";
+import { applyContextDecay } from "./context-decay/decay.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(text: string): AgentMessage {
+  return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function makeAssistant(text: string, withThinking = false): AgentMessage {
+  const content: Array<Record<string, unknown>> = [];
+  if (withThinking) {
+    content.push({ type: "thinking", thinking: "internal reasoning..." });
+  }
+  content.push({ type: "text", text });
+  return {
+    role: "assistant",
+    content,
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "fake",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function makeAssistantWithToolUse(toolCallId: string, toolName: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Let me call a tool." },
+      { type: "tool_use", id: toolCallId, name: toolName, input: {} },
+    ],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "fake",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+    stopReason: "tool_use",
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function makeToolResult(toolCallId: string, toolName: string, text: string): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName,
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: Date.now(),
+  };
+}
+
+function getContentText(msg: AgentMessage): string {
+  if (typeof msg.content === "string") {
+    return msg.content;
+  }
+  if (Array.isArray(msg.content)) {
+    return (msg.content as Array<Record<string, unknown>>)
+      .filter((b) => b.type === "text")
+      .map((b) => b.text as string)
+      .join("\n");
+  }
+  return "";
+}
+
+function hasThinkingBlock(msg: AgentMessage): boolean {
+  if (!Array.isArray(msg.content)) {
+    return false;
+  }
+  return (msg.content as Array<Record<string, unknown>>).some((b) => b.type === "thinking");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("applyContextDecay", () => {
+  const emptySummaryStore: SummaryStore = {};
+
+  describe("disabled config", () => {
+    it("returns messages unchanged when config is empty", () => {
+      const messages = [makeUser("hi"), makeAssistant("hello")];
+      const config: ContextDecayConfig = {};
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+      expect(result).toBe(messages); // same reference
+    });
+
+    it("returns messages unchanged when all values are 0", () => {
+      const messages = [makeUser("hi"), makeAssistant("hello")];
+      const config: ContextDecayConfig = {
+        stripThinkingAfterTurns: 0,
+        summarizeToolResultsAfterTurns: 0,
+        stripToolResultsAfterTurns: 0,
+        maxContextMessages: 0,
+      };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+      expect(result).toBe(messages);
+    });
+
+    it("returns empty array unchanged", () => {
+      const messages: AgentMessage[] = [];
+      const config: ContextDecayConfig = { stripThinkingAfterTurns: 1 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+      expect(result).toBe(messages);
+    });
+  });
+
+  describe("stripThinkingAfterTurns", () => {
+    it("strips thinking blocks from assistant messages older than N turns", () => {
+      // Turn 0 (current): user3 + assistant3
+      // Turn 1: user2 + assistant2
+      // Turn 2: user1 + assistant1 (with thinking)
+      const messages = [
+        makeUser("user1"),
+        makeAssistant("response1", true), // has thinking, turn age 2
+        makeUser("user2"),
+        makeAssistant("response2", true), // has thinking, turn age 1
+        makeUser("user3"),
+        makeAssistant("response3", true), // has thinking, turn age 0
+      ];
+
+      const config: ContextDecayConfig = { stripThinkingAfterTurns: 2 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+
+      // Turn age 2 (assistant at idx 1) should have thinking stripped
+      expect(hasThinkingBlock(result[1])).toBe(false);
+      expect(getContentText(result[1])).toBe("response1");
+
+      // Turn age 1 (assistant at idx 3) should keep thinking
+      expect(hasThinkingBlock(result[3])).toBe(true);
+
+      // Turn age 0 (assistant at idx 5) should keep thinking
+      expect(hasThinkingBlock(result[5])).toBe(true);
+    });
+
+    it("preserves thinking blocks within N turns", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistant("response1", true),
+        makeUser("user2"),
+        makeAssistant("response2", true),
+      ];
+
+      const config: ContextDecayConfig = { stripThinkingAfterTurns: 5 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+      // All within 5 turns — nothing stripped
+      expect(result).toBe(messages);
+    });
+  });
+
+  describe("summarizeToolResultsAfterTurns", () => {
+    it("replaces tool result content with summary when summary exists in store", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "very long file content..."),
+        makeUser("user2"),
+        makeAssistant("response"),
+        makeUser("user3"),
+        makeAssistant("latest"),
+      ];
+
+      const summaryStore: SummaryStore = {
+        2: {
+          summary: "File contains a config module.",
+          originalTokenEstimate: 100,
+          summaryTokenEstimate: 10,
+          summarizedAt: new Date().toISOString(),
+          model: "haiku",
+        },
+      };
+
+      const config: ContextDecayConfig = { summarizeToolResultsAfterTurns: 1 };
+      const result = applyContextDecay({ messages, config, summaryStore });
+
+      // Tool result at index 2 (turn age >= 1) should be summarized
+      expect(getContentText(result[2])).toContain("[Summarized]");
+      expect(getContentText(result[2])).toContain("File contains a config module.");
+    });
+
+    it("does not apply summary if no entry exists in store", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "original content"),
+        makeUser("user2"),
+        makeAssistant("response"),
+      ];
+
+      const config: ContextDecayConfig = { summarizeToolResultsAfterTurns: 1 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+
+      // No summary in store, content unchanged
+      expect(getContentText(result[2])).toBe("original content");
+    });
+  });
+
+  describe("stripToolResultsAfterTurns", () => {
+    it("replaces tool result content with placeholder after N turns", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "very long file content..."),
+        makeUser("user2"),
+        makeAssistant("response"),
+        makeUser("user3"),
+        makeAssistant("latest"),
+      ];
+
+      const config: ContextDecayConfig = { stripToolResultsAfterTurns: 1 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+
+      // Tool result at index 2 (turn age 2, threshold 1) should be stripped
+      expect(getContentText(result[2])).toContain("[Tool result removed");
+      expect(getContentText(result[2])).toContain("aged past 1 turns");
+    });
+
+    it("preserves tool results within N turns", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "content"),
+        makeUser("user2"),
+        makeAssistant("response"),
+      ];
+
+      const config: ContextDecayConfig = { stripToolResultsAfterTurns: 5 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+      expect(getContentText(result[2])).toBe("content");
+    });
+  });
+
+  describe("graduated decay", () => {
+    it("summarizes at lower threshold, strips at higher threshold", () => {
+      // 5 turns of history
+      const messages: AgentMessage[] = [];
+      for (let i = 0; i < 5; i++) {
+        messages.push(makeUser(`user${i}`));
+        messages.push(makeAssistantWithToolUse(`call_${i}`, "tool"));
+        messages.push(makeToolResult(`call_${i}`, "tool", `result ${i} with enough text`));
+      }
+      messages.push(makeUser("latest"));
+      messages.push(makeAssistant("latest response"));
+
+      // Summarize at 3 turns, strip at 5 turns
+      const summaryStore: SummaryStore = {};
+      // Add summaries for old tool results (indices 2, 5, 8)
+      summaryStore[2] = {
+        summary: "Summary of result 0",
+        originalTokenEstimate: 50,
+        summaryTokenEstimate: 5,
+        summarizedAt: new Date().toISOString(),
+        model: "haiku",
+      };
+      summaryStore[5] = {
+        summary: "Summary of result 1",
+        originalTokenEstimate: 50,
+        summaryTokenEstimate: 5,
+        summarizedAt: new Date().toISOString(),
+        model: "haiku",
+      };
+
+      const config: ContextDecayConfig = {
+        summarizeToolResultsAfterTurns: 3,
+        stripToolResultsAfterTurns: 5,
+      };
+
+      const result = applyContextDecay({ messages, config, summaryStore });
+
+      // Tool result at turn age 5 (oldest) → stripped (age >= stripAfter=5)
+      expect(getContentText(result[2])).toContain("[Tool result removed");
+
+      // Tool result at turn age 4 → summarized (age >= summarizeAfter=3, < stripAfter=5, summary exists)
+      expect(getContentText(result[5])).toContain("[Summarized]");
+      expect(getContentText(result[5])).toContain("Summary of result 1");
+
+      // Tool result at turn age 3 → no summary in store, untouched
+      expect(getContentText(result[8])).toBe("result 2 with enough text");
+
+      // Tool result at turn age 2 → recent, untouched
+      expect(getContentText(result[11])).toBe("result 3 with enough text");
+
+      // Tool result at turn age 1 → recent, untouched
+      expect(getContentText(result[14])).toBe("result 4 with enough text");
+    });
+  });
+
+  describe("maxContextMessages", () => {
+    it("drops oldest messages beyond the cap", () => {
+      const messages = [
+        makeUser("old1"),
+        makeAssistant("old2"),
+        makeUser("old3"),
+        makeAssistant("old4"),
+        makeUser("recent1"),
+        makeAssistant("recent2"),
+      ];
+
+      const config: ContextDecayConfig = { maxContextMessages: 4 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+
+      expect(result).toHaveLength(4);
+      expect(getContentText(result[0])).toBe("old3");
+      expect(getContentText(result[3])).toBe("recent2");
+    });
+
+    it("does nothing when message count is within cap", () => {
+      const messages = [makeUser("hi"), makeAssistant("hello")];
+      const config: ContextDecayConfig = { maxContextMessages: 10 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+      expect(result).toBe(messages);
+    });
+
+    it("repairs orphaned tool results when cap slices mid-tool-call pair", () => {
+      // The cap cuts between an assistant tool_use and its toolResult
+      const messages = [
+        makeUser("old"),
+        makeAssistantWithToolUse("call_old", "read_file"), // will be dropped
+        makeToolResult("call_old", "read_file", "old result"), // orphaned toolResult
+        makeUser("recent"),
+        makeAssistant("response"),
+      ];
+
+      const config: ContextDecayConfig = { maxContextMessages: 3 };
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+
+      // After slicing to last 3: [toolResult(orphan), user("recent"), assistant("response")]
+      // repairToolUseResultPairing should handle the orphaned toolResult
+      expect(result.length).toBeLessThanOrEqual(3);
+      // All remaining messages should have valid pairing (no orphaned toolResults)
+      // After repair, no orphaned toolResults should remain
+      for (const msg of result) {
+        if (msg.role !== "toolResult") {
+          continue;
+        }
+        const trMsg = msg as unknown as { toolCallId?: string };
+        const idx = result.indexOf(msg);
+        const hasMatchingToolUse = result.slice(0, idx).some((m) => {
+          if (m.role !== "assistant" || !Array.isArray(m.content)) {
+            return false;
+          }
+          return (m.content as Array<Record<string, unknown>>).some(
+            (b) => b.type === "tool_use" && b.id === trMsg.toolCallId,
+          );
+        });
+        expect(hasMatchingToolUse).toBe(true);
+      }
+    });
+  });
+
+  describe("group summaries", () => {
+    it("replaces anchor message with group summary text", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "file content here"),
+        makeUser("user2"),
+        makeAssistant("response2"),
+        makeUser("user3"),
+        makeAssistant("latest"),
+      ];
+
+      const groupSummaryStore = [
+        {
+          summary: "User asked to read a file. Tool read /src/foo.ts and found function bar().",
+          anchorIndex: 0,
+          indices: [0, 1, 2],
+          turnRange: [2, 2] as [number, number],
+          originalTokenEstimate: 100,
+          summaryTokenEstimate: 20,
+          summarizedAt: new Date().toISOString(),
+          model: "sonnet",
+        },
+      ];
+
+      const config: ContextDecayConfig = { summarizeWindowAfterTurns: 2 };
+      const result = applyContextDecay({
+        messages,
+        config,
+        summaryStore: emptySummaryStore,
+        groupSummaryStore,
+      });
+
+      // Anchor message (index 0, user) should have group summary
+      expect(getContentText(result[0])).toContain("[Group Summary");
+      expect(getContentText(result[0])).toContain("User asked to read a file");
+    });
+
+    it("replaces absorbed messages with placeholder", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "file content here"),
+        makeUser("user2"),
+        makeAssistant("response2"),
+        makeUser("user3"),
+        makeAssistant("latest"),
+      ];
+
+      const groupSummaryStore = [
+        {
+          summary: "Group summary text.",
+          anchorIndex: 0,
+          indices: [0, 1, 2],
+          turnRange: [2, 2] as [number, number],
+          originalTokenEstimate: 100,
+          summaryTokenEstimate: 20,
+          summarizedAt: new Date().toISOString(),
+          model: "sonnet",
+        },
+      ];
+
+      const config: ContextDecayConfig = { summarizeWindowAfterTurns: 2 };
+      const result = applyContextDecay({
+        messages,
+        config,
+        summaryStore: emptySummaryStore,
+        groupSummaryStore,
+      });
+
+      // Absorbed assistant (index 1)
+      expect(getContentText(result[1])).toContain("[Absorbed into group summary above]");
+      // Absorbed toolResult (index 2)
+      expect(getContentText(result[2])).toContain("[Absorbed into group summary above]");
+    });
+
+    it("preserves tool_use blocks structurally in absorbed assistant messages", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "file content"),
+        makeUser("user2"),
+        makeAssistant("latest"),
+      ];
+
+      const groupSummaryStore = [
+        {
+          summary: "Summary.",
+          anchorIndex: 0,
+          indices: [0, 1, 2],
+          turnRange: [1, 1] as [number, number],
+          originalTokenEstimate: 100,
+          summaryTokenEstimate: 10,
+          summarizedAt: new Date().toISOString(),
+          model: "sonnet",
+        },
+      ];
+
+      const config: ContextDecayConfig = { summarizeWindowAfterTurns: 1 };
+      const result = applyContextDecay({
+        messages,
+        config,
+        summaryStore: emptySummaryStore,
+        groupSummaryStore,
+      });
+
+      // Absorbed assistant should still have tool_use block for pairing
+      const assistantContent = result[1].content as Array<Record<string, unknown>>;
+      const toolUseBlocks = assistantContent.filter((b) => b.type === "tool_use");
+      expect(toolUseBlocks).toHaveLength(1);
+      expect(toolUseBlocks[0].id).toBe("call_1");
+      expect(toolUseBlocks[0].name).toBe("read_file");
+      expect(toolUseBlocks[0].input).toEqual({});
+    });
+
+    it("preserves toolCallId on absorbed toolResult messages", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "file content"),
+        makeUser("user2"),
+        makeAssistant("latest"),
+      ];
+
+      const groupSummaryStore = [
+        {
+          summary: "Summary.",
+          anchorIndex: 0,
+          indices: [0, 1, 2],
+          turnRange: [1, 1] as [number, number],
+          originalTokenEstimate: 100,
+          summaryTokenEstimate: 10,
+          summarizedAt: new Date().toISOString(),
+          model: "sonnet",
+        },
+      ];
+
+      const config: ContextDecayConfig = { summarizeWindowAfterTurns: 1 };
+      const result = applyContextDecay({
+        messages,
+        config,
+        summaryStore: emptySummaryStore,
+        groupSummaryStore,
+      });
+
+      // Absorbed toolResult should preserve toolCallId
+      const toolResult = result[2] as unknown as { toolCallId?: string };
+      expect(toolResult.toolCallId).toBe("call_1");
+    });
+
+    it("skips individual summarization for messages in group summaries", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "file content"),
+        makeUser("user2"),
+        makeAssistant("response"),
+        makeUser("user3"),
+        makeAssistant("latest"),
+      ];
+
+      // Both individual and group summaries exist for index 2
+      const summaryStore: SummaryStore = {
+        2: {
+          summary: "Individual summary of file content.",
+          originalTokenEstimate: 50,
+          summaryTokenEstimate: 10,
+          summarizedAt: new Date().toISOString(),
+          model: "haiku",
+        },
+      };
+
+      const groupSummaryStore = [
+        {
+          summary: "Group summary that covers everything.",
+          anchorIndex: 0,
+          indices: [0, 1, 2],
+          turnRange: [2, 2] as [number, number],
+          originalTokenEstimate: 200,
+          summaryTokenEstimate: 20,
+          summarizedAt: new Date().toISOString(),
+          model: "sonnet",
+        },
+      ];
+
+      const config: ContextDecayConfig = {
+        summarizeToolResultsAfterTurns: 1,
+        summarizeWindowAfterTurns: 2,
+      };
+      const result = applyContextDecay({
+        messages,
+        config,
+        summaryStore,
+        groupSummaryStore,
+      });
+
+      // Index 2 should have the absorbed placeholder, NOT the individual summary
+      expect(getContentText(result[2])).toContain("[Absorbed into group summary above]");
+      expect(getContentText(result[2])).not.toContain("[Summarized]");
+    });
+
+    it("does not strip tool results that are already in a group summary", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "file content"),
+        makeUser("user2"),
+        makeAssistant("response"),
+        makeUser("user3"),
+        makeAssistant("latest"),
+      ];
+
+      const groupSummaryStore = [
+        {
+          summary: "Group summary.",
+          anchorIndex: 0,
+          indices: [0, 1, 2],
+          turnRange: [2, 2] as [number, number],
+          originalTokenEstimate: 200,
+          summaryTokenEstimate: 20,
+          summarizedAt: new Date().toISOString(),
+          model: "sonnet",
+        },
+      ];
+
+      const config: ContextDecayConfig = {
+        stripToolResultsAfterTurns: 1,
+        summarizeWindowAfterTurns: 2,
+      };
+      const result = applyContextDecay({
+        messages,
+        config,
+        summaryStore: emptySummaryStore,
+        groupSummaryStore,
+      });
+
+      // Index 2 should be absorbed, not stripped
+      expect(getContentText(result[2])).toContain("[Absorbed into group summary above]");
+      expect(getContentText(result[2])).not.toContain("[Tool result removed");
+    });
+
+    it("returns same reference when no group summaries exist and no other decay applies", () => {
+      const messages = [makeUser("hi"), makeAssistant("hello")];
+      const config: ContextDecayConfig = { summarizeWindowAfterTurns: 5 };
+      const result = applyContextDecay({
+        messages,
+        config,
+        summaryStore: emptySummaryStore,
+        groupSummaryStore: [],
+      });
+      expect(result).toBe(messages);
+    });
+  });
+
+  describe("combined features", () => {
+    it("strips thinking and tool results together", () => {
+      const messages = [
+        makeUser("user1"),
+        makeAssistant("thinking response", true), // has thinking
+        makeAssistantWithToolUse("call_1", "read_file"),
+        makeToolResult("call_1", "read_file", "file content"),
+        makeUser("user2"),
+        makeAssistant("latest", true), // has thinking
+      ];
+
+      const config: ContextDecayConfig = {
+        stripThinkingAfterTurns: 1,
+        stripToolResultsAfterTurns: 1,
+      };
+
+      const result = applyContextDecay({ messages, config, summaryStore: emptySummaryStore });
+
+      // Old thinking (turn age 1) stripped
+      expect(hasThinkingBlock(result[1])).toBe(false);
+      // Current thinking (turn age 0) preserved
+      expect(hasThinkingBlock(result[5])).toBe(true);
+      // Old tool result stripped
+      expect(getContentText(result[3])).toContain("[Tool result removed");
+    });
+  });
+});

--- a/src/agents/pi-extensions/context-decay/decay.test.ts
+++ b/src/agents/pi-extensions/context-decay/decay.test.ts
@@ -55,7 +55,9 @@ describe("applyContextDecay — file swap step", () => {
 
     // Index 2 should have swapped content
     const swapped = result[2] as unknown as { content: Array<{ text: string }> };
-    expect(swapped.content[0].text).toContain("[Tool result saved to /tmp/results/1700000000-Read.txt]");
+    expect(swapped.content[0].text).toContain(
+      "[Tool result saved to /tmp/results/1700000000-Read.txt]",
+    );
     expect(swapped.content[0].text).toContain("[50 lines, TypeScript] function foo()");
   });
 

--- a/src/agents/pi-extensions/context-decay/decay.test.ts
+++ b/src/agents/pi-extensions/context-decay/decay.test.ts
@@ -1,0 +1,163 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import type { SwappedFileStore } from "../../context-decay/file-store.js";
+import type { SummaryStore } from "../../context-decay/summary-store.js";
+import { applyContextDecay } from "./decay.js";
+
+/**
+ * Build a minimal transcript: user → assistant(tool_use) → toolResult, repeated per turn.
+ * Final user message = current turn.
+ */
+function buildTranscript(turnCount: number): AgentMessage[] {
+  const msgs: AgentMessage[] = [];
+  for (let t = 0; t < turnCount; t++) {
+    msgs.push({ role: "user", content: `Turn ${t}`, timestamp: Date.now() } as AgentMessage);
+    msgs.push({
+      role: "assistant",
+      content: [
+        { type: "text", text: "Checking..." },
+        { type: "tool_use", id: `call-${t}`, name: "Read", input: {} },
+      ],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage);
+    msgs.push({
+      role: "toolResult",
+      toolCallId: `call-${t}`,
+      content: [{ type: "text", text: `Result for turn ${t} with lots of content` }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage);
+  }
+  // Current turn user message
+  msgs.push({ role: "user", content: "Current", timestamp: Date.now() } as AgentMessage);
+  return msgs;
+}
+
+describe("applyContextDecay — file swap step", () => {
+  it("replaces tool result content with file path + hint", () => {
+    const messages = buildTranscript(5);
+    // toolResult indices: 2, 5, 8, 11, 14 (every 3rd starting from 2)
+    const swappedFileStore: SwappedFileStore = {
+      2: {
+        filePath: "/tmp/results/1700000000-Read.txt",
+        toolName: "Read",
+        hint: "[50 lines, TypeScript] function foo()",
+        originalChars: 2000,
+        swappedAt: "2026-01-15T10:00:00Z",
+      },
+    };
+
+    const result = applyContextDecay({
+      messages,
+      config: { swapToolResultsAfterTurns: 2 },
+      summaryStore: {},
+      swappedFileStore,
+    });
+
+    // Index 2 should have swapped content
+    const swapped = result[2] as unknown as { content: Array<{ text: string }> };
+    expect(swapped.content[0].text).toContain("[Tool result saved to /tmp/results/1700000000-Read.txt]");
+    expect(swapped.content[0].text).toContain("[50 lines, TypeScript] function foo()");
+  });
+
+  it("summary takes precedence over swap when both exist", () => {
+    const messages = buildTranscript(5);
+    const swappedFileStore: SwappedFileStore = {
+      2: {
+        filePath: "/tmp/results/test.txt",
+        toolName: "Read",
+        hint: "Swap hint",
+        originalChars: 2000,
+        swappedAt: "2026-01-15T10:00:00Z",
+      },
+    };
+    const summaryStore: SummaryStore = {
+      2: {
+        summary: "LLM summary of the tool result",
+        originalTokenEstimate: 500,
+        summaryTokenEstimate: 20,
+        summarizedAt: "2026-01-15T10:01:00Z",
+        model: "haiku",
+      },
+    };
+
+    const result = applyContextDecay({
+      messages,
+      config: {
+        swapToolResultsAfterTurns: 2,
+        summarizeToolResultsAfterTurns: 3,
+      },
+      summaryStore,
+      swappedFileStore,
+    });
+
+    // Index 2 (age 5) is past summarize threshold AND has a summary → summary wins
+    const content = result[2] as unknown as { content: Array<{ text: string }> };
+    expect(content.content[0].text).toContain("[Summarized]");
+    expect(content.content[0].text).not.toContain("[Tool result saved to");
+  });
+
+  it("strip takes precedence over swap", () => {
+    const messages = buildTranscript(5);
+    const swappedFileStore: SwappedFileStore = {
+      2: {
+        filePath: "/tmp/results/test.txt",
+        toolName: "Read",
+        hint: "Swap hint",
+        originalChars: 2000,
+        swappedAt: "2026-01-15T10:00:00Z",
+      },
+    };
+
+    const result = applyContextDecay({
+      messages,
+      config: {
+        swapToolResultsAfterTurns: 2,
+        stripToolResultsAfterTurns: 3,
+      },
+      summaryStore: {},
+      swappedFileStore,
+    });
+
+    // Index 2 (age 5) is past strip threshold → strip wins
+    const content = result[2] as unknown as { content: Array<{ text: string }> };
+    expect(content.content[0].text).toContain("[Tool result removed");
+    expect(content.content[0].text).not.toContain("[Tool result saved to");
+  });
+
+  it("does not apply swap when store is empty", () => {
+    const messages = buildTranscript(3);
+    const result = applyContextDecay({
+      messages,
+      config: { swapToolResultsAfterTurns: 1 },
+      summaryStore: {},
+      swappedFileStore: {},
+    });
+
+    // No changes — original messages returned
+    expect(result).toBe(messages);
+  });
+
+  it("does not apply swap to messages below age threshold", () => {
+    const messages = buildTranscript(3);
+    // Index 8 = turn 2 = age 1 (below threshold of 2)
+    const swappedFileStore: SwappedFileStore = {
+      8: {
+        filePath: "/tmp/results/recent.txt",
+        toolName: "Read",
+        hint: "Recent result",
+        originalChars: 500,
+        swappedAt: "2026-01-15T10:00:00Z",
+      },
+    };
+
+    const result = applyContextDecay({
+      messages,
+      config: { swapToolResultsAfterTurns: 2 },
+      summaryStore: {},
+      swappedFileStore,
+    });
+
+    // No changes — age 1 < threshold 2
+    expect(result).toBe(messages);
+  });
+});

--- a/src/agents/pi-extensions/context-decay/decay.ts
+++ b/src/agents/pi-extensions/context-decay/decay.ts
@@ -1,0 +1,213 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ContextDecayConfig } from "../../../config/types.agent-defaults.js";
+import type { GroupSummaryStore, SummaryStore } from "../../context-decay/summary-store.js";
+import { computeTurnAges } from "../../context-decay/turn-ages.js";
+import { repairToolUseResultPairing } from "../../session-transcript-repair.js";
+
+function isEnabled(value: number | undefined | null): value is number {
+  return typeof value === "number" && value >= 1;
+}
+
+/**
+ * Apply graduated context decay to messages.
+ * Processing order:
+ * 1. Strip thinking blocks from old assistant messages
+ * 2. Apply group summaries (replace anchor + absorbed messages in-place)
+ * 3. Apply pre-computed individual summaries for old tool results (skip grouped messages)
+ * 4. Strip tool results past the strip threshold
+ * 5. Apply maxContextMessages hard cap
+ * 6. Repair tool use/result pairing
+ */
+export function applyContextDecay(params: {
+  messages: AgentMessage[];
+  config: ContextDecayConfig;
+  summaryStore: SummaryStore;
+  groupSummaryStore?: GroupSummaryStore;
+}): AgentMessage[] {
+  const { messages, config, summaryStore, groupSummaryStore } = params;
+
+  if (messages.length === 0) {
+    return messages;
+  }
+
+  // Check if any decay is actually enabled
+  const hasStripThinking = isEnabled(config.stripThinkingAfterTurns);
+  const hasSummarize = isEnabled(config.summarizeToolResultsAfterTurns);
+  const hasGroupSummarize = isEnabled(config.summarizeWindowAfterTurns);
+  const hasStrip = isEnabled(config.stripToolResultsAfterTurns);
+  const hasMaxMessages = isEnabled(config.maxContextMessages);
+
+  if (!hasStripThinking && !hasSummarize && !hasGroupSummarize && !hasStrip && !hasMaxMessages) {
+    return messages;
+  }
+
+  // Validate graduated decay: summarize should fire before strip
+  if (hasSummarize && hasStrip) {
+    if (config.summarizeToolResultsAfterTurns! >= config.stripToolResultsAfterTurns!) {
+      // Misconfigured: summarize threshold >= strip threshold.
+      // Summarize is effectively skipped by the per-message guard below.
+    }
+  }
+
+  // Build lookup sets from group summary store
+  const anchorIndices = new Set<number>();
+  const absorbedIndices = new Set<number>();
+  const anchorToSummary = new Map<number, string>();
+
+  if (groupSummaryStore && groupSummaryStore.length > 0) {
+    for (const entry of groupSummaryStore) {
+      anchorIndices.add(entry.anchorIndex);
+      const label = `[Group Summary — Turns ${entry.turnRange[0]}-${entry.turnRange[1]}]\n${entry.summary}`;
+      anchorToSummary.set(entry.anchorIndex, label);
+      for (const idx of entry.indices) {
+        if (idx !== entry.anchorIndex) {
+          absorbedIndices.add(idx);
+        }
+      }
+    }
+  }
+
+  const turnAges = computeTurnAges(messages);
+  let changed = false;
+  let result = messages.map((msg, idx) => {
+    const age = turnAges.get(idx) ?? 0;
+    let mutated = false;
+    let current = msg;
+
+    // 1. Strip thinking blocks from old assistant messages
+    if (
+      hasStripThinking &&
+      current.role === "assistant" &&
+      age >= config.stripThinkingAfterTurns!
+    ) {
+      if (Array.isArray(current.content)) {
+        const filtered = current.content.filter(
+          (block: unknown) => (block as Record<string, unknown>)?.type !== "thinking",
+        );
+        if (filtered.length !== current.content.length) {
+          current = { ...current, content: filtered };
+          mutated = true;
+        }
+      }
+    }
+
+    // 2. Apply group summaries
+    if (anchorIndices.has(idx)) {
+      // Anchor message: replace content with group summary
+      const summaryText = anchorToSummary.get(idx)!;
+      if (current.role === "user") {
+        current = { ...current, content: summaryText } as AgentMessage;
+      } else {
+        current = {
+          ...current,
+          content: [{ type: "text", text: summaryText }],
+        } as AgentMessage;
+      }
+      mutated = true;
+    } else if (absorbedIndices.has(idx)) {
+      // Absorbed message: replace with placeholder, preserve structure
+      if (current.role === "user") {
+        current = {
+          ...current,
+          content: "[Absorbed into group summary above]",
+        } as AgentMessage;
+        mutated = true;
+      } else if (current.role === "assistant") {
+        // Preserve tool_use blocks structurally (id, name, empty input) for pairing
+        if (Array.isArray(current.content)) {
+          const contentArr = current.content as unknown as Array<Record<string, unknown>>;
+          const preserved = contentArr
+            .filter((block) => block.type === "tool_use")
+            .map((block) => ({
+              type: "tool_use" as const,
+              id: block.id,
+              name: block.name,
+              input: {},
+            }));
+          const newContent = [
+            { type: "text" as const, text: "[Absorbed into group summary above]" },
+            ...preserved,
+          ];
+          current = { ...current, content: newContent } as unknown as AgentMessage;
+        } else {
+          current = {
+            ...current,
+            content: [{ type: "text", text: "[Absorbed into group summary above]" }],
+          } as unknown as AgentMessage;
+        }
+        mutated = true;
+      } else if (current.role === "toolResult") {
+        // Preserve toolCallId and toolName for pairing
+        current = {
+          ...current,
+          content: [{ type: "text", text: "[Absorbed into group summary above]" }],
+        } as AgentMessage;
+        mutated = true;
+      }
+    }
+
+    // 3. Apply pre-computed individual summaries for old tool results (skip grouped msgs)
+    if (
+      hasSummarize &&
+      !anchorIndices.has(idx) &&
+      !absorbedIndices.has(idx) &&
+      current.role === "toolResult" &&
+      age >= config.summarizeToolResultsAfterTurns! &&
+      summaryStore[idx]
+    ) {
+      // Only apply summary if we're not past the strip threshold
+      const skipSummarize = hasStrip && age >= config.stripToolResultsAfterTurns!;
+      if (!skipSummarize) {
+        const entry = summaryStore[idx];
+        current = {
+          ...current,
+          content: [{ type: "text", text: `[Summarized] ${entry.summary}` }],
+        } as AgentMessage;
+        mutated = true;
+      }
+    }
+
+    // 4. Strip tool results past the strip threshold
+    if (hasStrip && current.role === "toolResult" && age >= config.stripToolResultsAfterTurns!) {
+      // Don't re-strip messages already handled by group summaries
+      if (!anchorIndices.has(idx) && !absorbedIndices.has(idx)) {
+        current = {
+          ...current,
+          content: [
+            {
+              type: "text",
+              text: `[Tool result removed — aged past ${config.stripToolResultsAfterTurns} turns]`,
+            },
+          ],
+        } as AgentMessage;
+        mutated = true;
+      }
+    }
+
+    if (mutated) {
+      changed = true;
+    }
+    return current;
+  });
+
+  // 5. Apply maxContextMessages hard cap
+  let truncated = false;
+  if (hasMaxMessages && result.length > config.maxContextMessages!) {
+    result = result.slice(result.length - config.maxContextMessages!);
+    changed = true;
+    truncated = true;
+  }
+
+  if (!changed) {
+    return messages;
+  }
+
+  // 6. Repair tool use/result pairing after message truncation.
+  //    Only needed when maxContextMessages dropped messages from the front,
+  //    which can orphan tool_use or toolResult entries.
+  if (truncated) {
+    result = repairToolUseResultPairing(result).messages;
+  }
+
+  return result;
+}

--- a/src/agents/pi-extensions/context-decay/extension.ts
+++ b/src/agents/pi-extensions/context-decay/extension.ts
@@ -1,0 +1,31 @@
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { applyContextDecay } from "./decay.js";
+import { getContextDecayRuntime } from "./runtime.js";
+
+/**
+ * Pi extension that applies graduated context decay before each LLM call.
+ * Hooks into the SDK "context" event to strip thinking blocks, apply
+ * pre-computed tool-result summaries, strip aged tool results, and
+ * enforce a hard message cap.
+ */
+export default function contextDecayExtension(api: ExtensionAPI): void {
+  api.on("context", (event: ContextEvent, ctx: ExtensionContext) => {
+    const runtime = getContextDecayRuntime(ctx.sessionManager);
+    if (!runtime) {
+      return undefined;
+    }
+
+    const next = applyContextDecay({
+      messages: event.messages,
+      config: runtime.config,
+      summaryStore: runtime.summaryStore,
+      groupSummaryStore: runtime.groupSummaryStore,
+    });
+
+    if (next === event.messages) {
+      return undefined;
+    }
+
+    return { messages: next };
+  });
+}

--- a/src/agents/pi-extensions/context-decay/extension.ts
+++ b/src/agents/pi-extensions/context-decay/extension.ts
@@ -45,7 +45,7 @@ export default function contextDecayExtension(api: ExtensionAPI): void {
       stats,
     });
 
-    if (next !== event.messages && emitter && stats) {
+    if (emitter && stats) {
       const beforeTokens = sumEstimateTokens(event.messages);
       const afterTokens = sumEstimateTokens(next);
       emitter.emit({

--- a/src/agents/pi-extensions/context-decay/extension.ts
+++ b/src/agents/pi-extensions/context-decay/extension.ts
@@ -20,6 +20,7 @@ export default function contextDecayExtension(api: ExtensionAPI): void {
       config: runtime.config,
       summaryStore: runtime.summaryStore,
       groupSummaryStore: runtime.groupSummaryStore,
+      swappedFileStore: runtime.swappedFileStore,
     });
 
     if (next === event.messages) {

--- a/src/agents/pi-extensions/context-decay/runtime.ts
+++ b/src/agents/pi-extensions/context-decay/runtime.ts
@@ -1,0 +1,35 @@
+import type { ContextDecayConfig } from "../../../config/types.agent-defaults.js";
+import type { GroupSummaryStore, SummaryStore } from "../../context-decay/summary-store.js";
+
+/** Per-session runtime state for the context-decay extension. */
+export type ContextDecayRuntimeValue = {
+  config: ContextDecayConfig;
+  summaryStore: SummaryStore;
+  groupSummaryStore: GroupSummaryStore;
+};
+
+const REGISTRY = new WeakMap<object, ContextDecayRuntimeValue>();
+
+/** Register context-decay config + summary store for a session. Pass null to clear. */
+export function setContextDecayRuntime(
+  sessionManager: unknown,
+  value: ContextDecayRuntimeValue | null,
+): void {
+  if (!sessionManager || typeof sessionManager !== "object") {
+    return;
+  }
+  const key = sessionManager;
+  if (value === null) {
+    REGISTRY.delete(key);
+    return;
+  }
+  REGISTRY.set(key, value);
+}
+
+/** Retrieve the context-decay runtime for a session, or null if not registered. */
+export function getContextDecayRuntime(sessionManager: unknown): ContextDecayRuntimeValue | null {
+  if (!sessionManager || typeof sessionManager !== "object") {
+    return null;
+  }
+  return REGISTRY.get(sessionManager) ?? null;
+}

--- a/src/agents/pi-extensions/context-decay/runtime.ts
+++ b/src/agents/pi-extensions/context-decay/runtime.ts
@@ -1,6 +1,7 @@
 import type { ContextDecayConfig } from "../../../config/types.agent-defaults.js";
 import type { SwappedFileStore } from "../../context-decay/file-store.js";
 import type { GroupSummaryStore, SummaryStore } from "../../context-decay/summary-store.js";
+import type { ContextLifecycleEmitter } from "../../context-lifecycle/emitter.js";
 
 /** Per-session runtime state for the context-decay extension. */
 export type ContextDecayRuntimeValue = {
@@ -8,6 +9,7 @@ export type ContextDecayRuntimeValue = {
   summaryStore: SummaryStore;
   groupSummaryStore: GroupSummaryStore;
   swappedFileStore: SwappedFileStore;
+  lifecycleEmitter?: ContextLifecycleEmitter;
 };
 
 const REGISTRY = new WeakMap<object, ContextDecayRuntimeValue>();

--- a/src/agents/pi-extensions/context-decay/runtime.ts
+++ b/src/agents/pi-extensions/context-decay/runtime.ts
@@ -1,4 +1,5 @@
 import type { ContextDecayConfig } from "../../../config/types.agent-defaults.js";
+import type { SwappedFileStore } from "../../context-decay/file-store.js";
 import type { GroupSummaryStore, SummaryStore } from "../../context-decay/summary-store.js";
 
 /** Per-session runtime state for the context-decay extension. */
@@ -6,6 +7,7 @@ export type ContextDecayRuntimeValue = {
   config: ContextDecayConfig;
   summaryStore: SummaryStore;
   groupSummaryStore: GroupSummaryStore;
+  swappedFileStore: SwappedFileStore;
 };
 
 const REGISTRY = new WeakMap<object, ContextDecayRuntimeValue>();

--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -50,7 +50,7 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
       stats,
     });
 
-    if (next !== event.messages && emitter && stats) {
+    if (emitter && stats) {
       const beforeTokens = sumEstimateTokens(event.messages);
       const afterTokens = sumEstimateTokens(next);
       emitter.emit({

--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -1,13 +1,31 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { pruneContextMessages } from "./pruner.js";
+import { estimateTokens } from "@mariozechner/pi-coding-agent";
+import { createEmptyPruneStats, pruneContextMessages } from "./pruner.js";
 import { getContextPruningRuntime } from "./runtime.js";
 
+function sumEstimateTokens(messages: AgentMessage[]): number {
+  let total = 0;
+  for (const msg of messages) {
+    try {
+      total += estimateTokens(msg);
+    } catch {
+      // estimateTokens can fail on malformed messages — skip
+    }
+  }
+  return total;
+}
+
 export default function contextPruningExtension(api: ExtensionAPI): void {
+  let turnCounter = 0;
+
   api.on("context", (event: ContextEvent, ctx: ExtensionContext) => {
     const runtime = getContextPruningRuntime(ctx.sessionManager);
     if (!runtime) {
       return undefined;
     }
+
+    turnCounter++;
 
     if (runtime.settings.mode === "cache-ttl") {
       const ttlMs = runtime.settings.ttlMs;
@@ -20,13 +38,30 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
       }
     }
 
+    const emitter = runtime.lifecycleEmitter;
+    const stats = emitter ? createEmptyPruneStats() : undefined;
+
     const next = pruneContextMessages({
       messages: event.messages,
       settings: runtime.settings,
       ctx,
       isToolPrunable: runtime.isToolPrunable,
       contextWindowTokensOverride: runtime.contextWindowTokens ?? undefined,
+      stats,
     });
+
+    if (next !== event.messages && emitter && stats) {
+      const beforeTokens = sumEstimateTokens(event.messages);
+      const afterTokens = sumEstimateTokens(next);
+      emitter.emit({
+        turn: turnCounter,
+        rule: "prune:pass",
+        beforeTokens,
+        afterTokens,
+        freedTokens: beforeTokens - afterTokens,
+        details: { ...stats },
+      });
+    }
 
     if (next === event.messages) {
       return undefined;

--- a/src/agents/pi-extensions/context-pruning/pruner.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.test.ts
@@ -1,0 +1,200 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import type { EffectiveContextPruningSettings } from "./settings.js";
+import { createEmptyPruneStats, pruneContextMessages } from "./pruner.js";
+
+function makeToolResult(params: {
+  toolCallId: string;
+  toolName: string;
+  text: string;
+}): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: params.toolCallId,
+    toolName: params.toolName,
+    content: [{ type: "text", text: params.text }],
+    isError: false,
+    timestamp: Date.now(),
+  };
+}
+
+function makeAssistant(text: string, toolCallId?: string): AgentMessage {
+  const content: unknown[] = [{ type: "text", text }];
+  if (toolCallId) {
+    content.push({ type: "toolCall", id: toolCallId, name: "test_tool", arguments: {} });
+  }
+  return {
+    role: "assistant",
+    content,
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function makeUser(text: string): AgentMessage {
+  return { role: "user", content: text, timestamp: Date.now() } as AgentMessage;
+}
+
+const CHARS_PER_TOKEN = 4;
+
+function makeSettings(
+  overrides?: Partial<EffectiveContextPruningSettings>,
+): EffectiveContextPruningSettings {
+  return {
+    mode: "cache-ttl" as const,
+    ttlMs: 300_000,
+    keepLastAssistants: 2,
+    softTrimRatio: 0.5,
+    hardClearRatio: 0.8,
+    minPrunableToolChars: 0,
+    softTrim: { maxChars: 200, headChars: 50, tailChars: 50 },
+    hardClear: { enabled: true, placeholder: "[Pruned]" },
+    tools: {},
+    ...overrides,
+  };
+}
+
+describe("PruneStats instrumentation", () => {
+  it("createEmptyPruneStats returns zeroed stats", () => {
+    const stats = createEmptyPruneStats();
+    expect(stats).toEqual({
+      totalCharsBefore: 0,
+      totalCharsAfter: 0,
+      charRatio: 0,
+      softTrimCount: 0,
+      hardClearCount: 0,
+    });
+  });
+
+  it("populates stats when soft-trim fires", () => {
+    // Build messages that exceed softTrimRatio (0.5) of a small context window
+    const bigText = "x".repeat(2000);
+    const messages: AgentMessage[] = [
+      makeUser("hello"),
+      makeAssistant("thinking...", "tc1"),
+      makeToolResult({ toolCallId: "tc1", toolName: "read", text: bigText }),
+      makeAssistant("response 1", "tc2"),
+      makeToolResult({ toolCallId: "tc2", toolName: "read", text: bigText }),
+      makeAssistant("final answer"),
+    ];
+
+    const stats = createEmptyPruneStats();
+    // Context window small enough that ratio > 0.5
+    const contextWindowTokens = 600; // 600 * 4 = 2400 char window, ~4000 chars in messages
+    const result = pruneContextMessages({
+      messages,
+      settings: makeSettings(),
+      ctx: { model: { contextWindow: contextWindowTokens } as never },
+      contextWindowTokensOverride: contextWindowTokens,
+      stats,
+    });
+
+    expect(result).not.toBe(messages);
+    expect(stats.totalCharsBefore).toBeGreaterThan(0);
+    expect(stats.totalCharsAfter).toBeGreaterThan(0);
+    expect(stats.totalCharsAfter).toBeLessThanOrEqual(stats.totalCharsBefore);
+    expect(stats.softTrimCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("populates stats when hard-clear fires", () => {
+    const bigText = "x".repeat(5000);
+    const messages: AgentMessage[] = [
+      makeUser("hello"),
+      makeAssistant("thinking...", "tc1"),
+      makeToolResult({ toolCallId: "tc1", toolName: "read", text: bigText }),
+      makeAssistant("thinking more...", "tc2"),
+      makeToolResult({ toolCallId: "tc2", toolName: "read", text: bigText }),
+      makeAssistant("final answer"),
+    ];
+
+    const stats = createEmptyPruneStats();
+    // Very small window to force hard-clear (ratio > 0.8)
+    const contextWindowTokens = 400; // 400 * 4 = 1600 char window, ~10k chars in messages
+    const result = pruneContextMessages({
+      messages,
+      settings: makeSettings(),
+      ctx: { model: { contextWindow: contextWindowTokens } as never },
+      contextWindowTokensOverride: contextWindowTokens,
+      stats,
+    });
+
+    expect(result).not.toBe(messages);
+    expect(stats.hardClearCount).toBeGreaterThanOrEqual(1);
+    expect(stats.totalCharsAfter).toBeLessThan(stats.totalCharsBefore);
+    expect(stats.charRatio).toBeLessThan(
+      stats.totalCharsBefore / (contextWindowTokens * CHARS_PER_TOKEN),
+    );
+  });
+
+  it("does not throw when stats is undefined", () => {
+    const bigText = "x".repeat(2000);
+    const messages: AgentMessage[] = [
+      makeUser("hello"),
+      makeAssistant("thinking...", "tc1"),
+      makeToolResult({ toolCallId: "tc1", toolName: "read", text: bigText }),
+      makeAssistant("response 1", "tc2"),
+      makeToolResult({ toolCallId: "tc2", toolName: "read", text: bigText }),
+      makeAssistant("final answer"),
+    ];
+
+    // Should not throw when stats is undefined
+    const result = pruneContextMessages({
+      messages,
+      settings: makeSettings(),
+      ctx: { model: { contextWindow: 600 } as never },
+      contextWindowTokensOverride: 600,
+    });
+
+    expect(result).not.toBe(messages);
+  });
+
+  it("stats reflect early return when ratio below softTrimRatio", () => {
+    const messages: AgentMessage[] = [makeUser("hello"), makeAssistant("hi")];
+
+    const stats = createEmptyPruneStats();
+    // Large window — ratio well below 0.5
+    const result = pruneContextMessages({
+      messages,
+      settings: makeSettings(),
+      ctx: { model: { contextWindow: 100_000 } as never },
+      contextWindowTokensOverride: 100_000,
+      stats,
+    });
+
+    // No pruning happened — stats stay zeroed
+    expect(result).toBe(messages);
+    expect(stats.totalCharsBefore).toBe(0);
+    expect(stats.softTrimCount).toBe(0);
+    expect(stats.hardClearCount).toBe(0);
+  });
+
+  it("counts both soft-trim and hard-clear in the same pass", () => {
+    // Multiple tool results: some will be soft-trimmed first, others hard-cleared
+    const bigText = "x".repeat(3000);
+    const messages: AgentMessage[] = [
+      makeUser("hello"),
+      makeAssistant("a", "tc1"),
+      makeToolResult({ toolCallId: "tc1", toolName: "read", text: bigText }),
+      makeAssistant("b", "tc2"),
+      makeToolResult({ toolCallId: "tc2", toolName: "read", text: bigText }),
+      makeAssistant("c", "tc3"),
+      makeToolResult({ toolCallId: "tc3", toolName: "read", text: bigText }),
+      makeAssistant("final answer"),
+    ];
+
+    const stats = createEmptyPruneStats();
+    // Window that forces both soft-trim and hard-clear
+    const contextWindowTokens = 500; // 500 * 4 = 2000 char window, ~9000 chars in messages
+    pruneContextMessages({
+      messages,
+      settings: makeSettings({ softTrimRatio: 0.3, hardClearRatio: 0.6 }),
+      ctx: { model: { contextWindow: contextWindowTokens } as never },
+      contextWindowTokensOverride: contextWindowTokens,
+      stats,
+    });
+
+    // At least some operations should have fired
+    expect(stats.softTrimCount + stats.hardClearCount).toBeGreaterThanOrEqual(1);
+    expect(stats.totalCharsBefore).toBeGreaterThan(0);
+    expect(stats.totalCharsAfter).toBeLessThan(stats.totalCharsBefore);
+  });
+});

--- a/src/agents/pi-extensions/context-pruning/pruner.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.test.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
-import type { EffectiveContextPruningSettings } from "./settings.js";
 import { createEmptyPruneStats, pruneContextMessages } from "./pruner.js";
+import type { EffectiveContextPruningSettings } from "./settings.js";
 
 function makeToolResult(params: {
   toolCallId: string;

--- a/src/agents/pi-extensions/context-pruning/runtime.ts
+++ b/src/agents/pi-extensions/context-pruning/runtime.ts
@@ -1,11 +1,13 @@
-import { createSessionManagerRuntimeRegistry } from "../session-manager-runtime-registry.js";
+import type { ContextLifecycleEmitter } from "../../context-lifecycle/emitter.js";
 import type { EffectiveContextPruningSettings } from "./settings.js";
+import { createSessionManagerRuntimeRegistry } from "../session-manager-runtime-registry.js";
 
 export type ContextPruningRuntimeValue = {
   settings: EffectiveContextPruningSettings;
   contextWindowTokens?: number | null;
   isToolPrunable: (toolName: string) => boolean;
   lastCacheTouchAt?: number | null;
+  lifecycleEmitter?: ContextLifecycleEmitter;
 };
 
 // Important: this relies on Pi passing the same SessionManager object instance into

--- a/src/agents/pi-extensions/context-pruning/runtime.ts
+++ b/src/agents/pi-extensions/context-pruning/runtime.ts
@@ -1,6 +1,6 @@
 import type { ContextLifecycleEmitter } from "../../context-lifecycle/emitter.js";
-import type { EffectiveContextPruningSettings } from "./settings.js";
 import { createSessionManagerRuntimeRegistry } from "../session-manager-runtime-registry.js";
+import type { EffectiveContextPruningSettings } from "./settings.js";
 
 export type ContextPruningRuntimeValue = {
   settings: EffectiveContextPruningSettings;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -48,6 +48,25 @@ export type AgentContextPruningConfig = {
   };
 };
 
+export type ContextDecayConfig = {
+  /** Remove thinking blocks from assistant messages after N turns. */
+  stripThinkingAfterTurns?: number;
+  /** Replace tool results with LLM summary after N turns. */
+  summarizeToolResultsAfterTurns?: number;
+  /** Group-summarize a window of turns after N turns of age. */
+  summarizeWindowAfterTurns?: number;
+  /** Number of turns per group-summarization window (default: 4). */
+  summarizeWindowSize?: number;
+  /** Replace tool results with placeholder after N turns. */
+  stripToolResultsAfterTurns?: number;
+  /** Hard cap on total messages in context. */
+  maxContextMessages?: number;
+  /** Model ref for summarization (e.g., "haiku", "anthropic/claude-haiku-4-5"). */
+  summarizationModel?: string;
+  /** Model for group summaries (falls back to summarizationModel if unset). */
+  groupSummarizationModel?: string;
+};
+
 export type CliBackendConfig = {
   /** CLI command to execute (absolute path or on PATH). */
   command: string;
@@ -160,6 +179,8 @@ export type AgentDefaultsConfig = {
   cliBackends?: Record<string, CliBackendConfig>;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
   contextPruning?: AgentContextPruningConfig;
+  /** Context decay settings (strip thinking, summarize/strip tool results after N turns). */
+  contextDecay?: ContextDecayConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
   /** Vector memory search configuration (per-agent overrides supported). */

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -57,6 +57,10 @@ export type ContextDecayConfig = {
   summarizeWindowAfterTurns?: number;
   /** Number of turns per group-summarization window (default: 4). */
   summarizeWindowSize?: number;
+  /** Swap tool results to file after N turns (replaces content with file path + hint). */
+  swapToolResultsAfterTurns?: number;
+  /** Minimum tool result size in chars to qualify for file swap (default: 256). */
+  swapMinChars?: number;
   /** Replace tool results with placeholder after N turns. */
   stripToolResultsAfterTurns?: number;
   /** Hard cap on total messages in context. */

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -185,6 +185,8 @@ export type AgentDefaultsConfig = {
   contextPruning?: AgentContextPruningConfig;
   /** Context decay settings (strip thinking, summarize/strip tool results after N turns). */
   contextDecay?: ContextDecayConfig;
+  /** Optional context lifecycle event logging (JSONL). */
+  contextLifecycleLog?: ContextLifecycleLogConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
   /** Vector memory search configuration (per-agent overrides supported). */
@@ -307,6 +309,13 @@ export type AgentDefaultsConfig = {
     /** Auto-prune sandbox containers. */
     prune?: SandboxPruneSettings;
   };
+};
+
+export type ContextLifecycleLogConfig = {
+  /** Enable context lifecycle event logging. Default: false. */
+  enabled?: boolean;
+  /** Output file path (JSONL). Supports {sessionKey} placeholder. Default: 'logs/context-lifecycle.jsonl'. */
+  filePath?: string;
 };
 
 export type AgentCompactionMode = "default" | "safeguard";

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -1,4 +1,5 @@
 import type { DiscordPluralKitConfig } from "../discord/pluralkit.js";
+import type { ContextDecayConfig } from "./types.agent-defaults.js";
 import type {
   BlockStreamingCoalesceConfig,
   DmPolicy,
@@ -42,6 +43,8 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** Context decay settings for this channel. Note: guild/channel-level resolution is not yet implemented; only global, per-account, and per-DM levels are resolved. */
+  contextDecay?: ContextDecayConfig;
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";
@@ -165,6 +168,8 @@ export type DiscordAccountConfig = {
   historyLimit?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
+  /** Context decay settings for this account. */
+  contextDecay?: ContextDecayConfig;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   /** Retry policy for outbound Discord API calls. */

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -1,3 +1,4 @@
+import type { ContextDecayConfig } from "./types.agent-defaults.js";
 import type { QueueDropPolicy, QueueMode, QueueModeByProvider } from "./types.queue.js";
 import type { TtsConfig } from "./types.tts.js";
 
@@ -8,6 +9,7 @@ export type GroupChatConfig = {
 
 export type DmConfig = {
   historyLimit?: number;
+  contextDecay?: ContextDecayConfig;
 };
 
 export type QueueConfig = {

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -1,3 +1,4 @@
+import type { ContextDecayConfig } from "./types.agent-defaults.js";
 import type {
   BlockStreamingCoalesceConfig,
   DmPolicy,
@@ -42,6 +43,8 @@ export type SlackChannelConfig = {
   skills?: string[];
   /** Optional system prompt for this channel. */
   systemPrompt?: string;
+  /** Context decay settings for this channel. */
+  contextDecay?: ContextDecayConfig;
 };
 
 export type SlackReactionNotificationMode = "off" | "own" | "all" | "allowlist";
@@ -117,6 +120,8 @@ export type SlackAccountConfig = {
   historyLimit?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
+  /** Context decay settings for this account. */
+  contextDecay?: ContextDecayConfig;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   textChunkLimit?: number;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -1,3 +1,4 @@
+import type { ContextDecayConfig } from "./types.agent-defaults.js";
 import type {
   BlockStreamingChunkConfig,
   BlockStreamingCoalesceConfig,
@@ -87,6 +88,8 @@ export type TelegramAccountConfig = {
   historyLimit?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
+  /** Context decay settings for this account. */
+  contextDecay?: ContextDecayConfig;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
@@ -162,6 +165,8 @@ export type TelegramTopicConfig = {
   allowFrom?: Array<string | number>;
   /** Optional system prompt snippet for this topic. */
   systemPrompt?: string;
+  /** Context decay settings for this topic. */
+  contextDecay?: ContextDecayConfig;
 };
 
 export type TelegramGroupConfig = {
@@ -181,6 +186,8 @@ export type TelegramGroupConfig = {
   allowFrom?: Array<string | number>;
   /** Optional system prompt snippet for this group. */
   systemPrompt?: string;
+  /** Context decay settings for this group. */
+  contextDecay?: ContextDecayConfig;
 };
 
 export type TelegramConfig = {

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -1,3 +1,4 @@
+import type { ContextDecayConfig } from "./types.agent-defaults.js";
 import type {
   BlockStreamingCoalesceConfig,
   DmPolicy,
@@ -80,6 +81,8 @@ export type WhatsAppConfig = {
   historyLimit?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
+  /** Context decay settings for this account. */
+  contextDecay?: ContextDecayConfig;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
@@ -133,6 +136,8 @@ export type WhatsAppAccountConfig = {
   historyLimit?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
+  /** Context decay settings for this account. */
+  contextDecay?: ContextDecayConfig;
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   textChunkLimit?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -9,6 +9,7 @@ import {
   BlockStreamingChunkSchema,
   BlockStreamingCoalesceSchema,
   CliBackendSchema,
+  ContextDecaySchema,
   HumanDelaySchema,
 } from "./zod-schema.core.js";
 
@@ -88,6 +89,7 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    contextDecay: ContextDecaySchema,
     compaction: z
       .object({
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -10,6 +10,7 @@ import {
   BlockStreamingCoalesceSchema,
   CliBackendSchema,
   ContextDecaySchema,
+  ContextLifecycleLogSchema,
   HumanDelaySchema,
 } from "./zod-schema.core.js";
 
@@ -90,6 +91,7 @@ export const AgentDefaultsSchema = z
       .strict()
       .optional(),
     contextDecay: ContextDecaySchema,
+    contextLifecycleLog: ContextLifecycleLogSchema,
     compaction: z
       .object({
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -98,9 +98,24 @@ export const GroupChatSchema = z
   .strict()
   .optional();
 
+export const ContextDecaySchema = z
+  .object({
+    stripThinkingAfterTurns: z.number().int().positive().optional(),
+    summarizeToolResultsAfterTurns: z.number().int().positive().optional(),
+    summarizeWindowAfterTurns: z.number().int().positive().optional(),
+    summarizeWindowSize: z.number().int().positive().optional(),
+    stripToolResultsAfterTurns: z.number().int().positive().optional(),
+    maxContextMessages: z.number().int().positive().optional(),
+    summarizationModel: z.string().optional(),
+    groupSummarizationModel: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
 export const DmConfigSchema = z
   .object({
     historyLimit: z.number().int().min(0).optional(),
+    contextDecay: ContextDecaySchema,
   })
   .strict();
 

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -104,6 +104,8 @@ export const ContextDecaySchema = z
     summarizeToolResultsAfterTurns: z.number().int().positive().optional(),
     summarizeWindowAfterTurns: z.number().int().positive().optional(),
     summarizeWindowSize: z.number().int().positive().optional(),
+    swapToolResultsAfterTurns: z.number().int().positive().optional(),
+    swapMinChars: z.number().int().positive().optional(),
     stripToolResultsAfterTurns: z.number().int().positive().optional(),
     maxContextMessages: z.number().int().positive().optional(),
     summarizationModel: z.string().optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -114,6 +114,14 @@ export const ContextDecaySchema = z
   .strict()
   .optional();
 
+export const ContextLifecycleLogSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    filePath: z.string().trim().min(1).optional(),
+  })
+  .strict()
+  .optional();
+
 export const DmConfigSchema = z
   .object({
     historyLimit: z.number().int().min(0).optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -9,6 +9,7 @@ import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
 import {
   BlockStreamingChunkSchema,
   BlockStreamingCoalesceSchema,
+  ContextDecaySchema,
   DmConfigSchema,
   DmPolicySchema,
   ExecutableTokenSchema,
@@ -51,6 +52,7 @@ export const TelegramTopicSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    contextDecay: ContextDecaySchema,
   })
   .strict();
 
@@ -64,6 +66,7 @@ export const TelegramGroupSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    contextDecay: ContextDecaySchema,
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
   })
   .strict();
@@ -115,6 +118,7 @@ export const TelegramAccountSchemaBase = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
+    contextDecay: ContextDecaySchema,
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
@@ -239,6 +243,7 @@ export const DiscordGuildChannelSchema = z
     roles: DiscordIdListSchema.optional(),
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
+    contextDecay: ContextDecaySchema,
     autoThread: z.boolean().optional(),
   })
   .strict();
@@ -282,6 +287,7 @@ export const DiscordAccountSchema = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
+    contextDecay: ContextDecaySchema,
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
@@ -502,6 +508,7 @@ export const SlackChannelSchema = z
     users: z.array(z.union([z.string(), z.number()])).optional(),
     skills: z.array(z.string()).optional(),
     systemPrompt: z.string().optional(),
+    contextDecay: ContextDecaySchema,
   })
   .strict();
 
@@ -541,6 +548,7 @@ export const SlackAccountSchema = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
+    contextDecay: ContextDecaySchema,
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -3,6 +3,7 @@ import { ToolPolicySchema } from "./zod-schema.agent-runtime.js";
 import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
 import {
   BlockStreamingCoalesceSchema,
+  ContextDecaySchema,
   DmConfigSchema,
   DmPolicySchema,
   GroupPolicySchema,
@@ -45,6 +46,7 @@ const WhatsAppSharedSchema = z.object({
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),
+  contextDecay: ContextDecaySchema,
   dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
   textChunkLimit: z.number().int().positive().optional(),
   chunkMode: z.enum(["length", "newline"]).optional(),


### PR DESCRIPTION
## Summary

Adds an **experimental context decay system** for proactive context window management. Instead of waiting for API context overflow errors (reactive compaction), this system gradually strips, summarizes, and drops older conversation content to prevent forced compaction.

**Disabled by default.** No behavior change unless explicitly configured.

### Features

- **Strip thinking blocks** after N turns (no LLM needed, zero cost)
- **File-swap tool results** after N turns (lossless, zero LLM cost — writes to disk, replaces with path + heuristic hint)
- **Summarize tool results** after N turns via a configurable summarization model (async, post-delivery)
- **Group-in-place window summarization** — groups aged turns into windows, generates coherent multi-turn summaries
- **Strip tool results** after N turns (replace with placeholder)
- **Hard cap** on total context messages
- **Graduated decay** — file-swap first, summarize next, strip later (configurable thresholds)
- **Per-source/per-channel config** via existing 7-level config hierarchy
- **Lifecycle telemetry** — structured JSONL event logging for observability and tuning

### Config Example

```json5
agents: {
  defaults: {
    contextDecay: {
      stripThinkingAfterTurns: 2,
      swapToolResultsAfterTurns: 3,
      summarizeToolResultsAfterTurns: 5,
      stripToolResultsAfterTurns: 10,
      summarizeWindowAfterTurns: 6,
      summarizeWindowSize: 4,
      maxContextMessages: 40,
      summarizationModel: "haiku",
      groupSummarizationModel: "sonnet"
    },
    // Optional: enable lifecycle event logging
    contextLifecycleLog: {
      enabled: true,
      filePath: "logs/context-lifecycle.jsonl"  // supports {sessionKey} placeholder
    }
  }
}
```

### Lifecycle Telemetry

When `contextLifecycleLog.enabled` is set, the system writes structured JSONL events for every decay pass, pruning pass, and compaction. Each event includes before/after token counts, percentage of context window used, and rule-specific details.

Analyze with the included script:
```bash
tsx scripts/context-lifecycle-report.ts logs/context-lifecycle.jsonl
# Or machine-readable:
tsx scripts/context-lifecycle-report.ts logs/context-lifecycle.jsonl --json
```

### Cache-TTL Interaction Note

If `contextPruning.mode` is set to `cache-ttl` and `contextDecay` is also active, a runtime warning is logged. These features serve overlapping purposes and may interfere — consider setting `contextPruning.mode` to `off` when using `contextDecay`.

### Architecture

- **Context decay extension** — Pi extension hooking into the context event (synchronous, no LLM calls during context building)
- **Async post-delivery summarizer** — fire-and-forget after agent_end hook, pre-computes summaries for next turn
- **File swap tier** — writes aged tool results to disk, replaces with file path + heuristic hint (zero LLM cost, lossless)
- **Summary store** — per-session .summaries.json and .group-summaries.json files alongside session JSONL (non-destructive, originals preserved)
- **Config resolution** — walks global → per-account → per-DM hierarchy
- **Lifecycle emitter** — buffered JSONL writer with 10-event / 1s flush thresholds

### New Files

| File | Purpose |
|---|---|
| src/agents/context-decay/resolve-config.ts | Config resolution through hierarchy |
| src/agents/context-decay/summary-store.ts | Summary persistence (individual + group) |
| src/agents/context-decay/summarizer.ts | Async individual tool result summarization |
| src/agents/context-decay/group-summarizer.ts | Async group window summarization |
| src/agents/context-decay/turn-ages.ts | Turn age computation utilities |
| src/agents/context-decay/message-utils.ts | Shared message content extraction helpers |
| src/agents/context-decay/file-store.ts | Swapped file store persistence |
| src/agents/context-decay/file-swapper.ts | Async file-swap pipeline |
| src/agents/context-decay/hint-generator.ts | Heuristic hint generation for swapped results |
| src/agents/context-lifecycle/types.ts | Lifecycle event types |
| src/agents/context-lifecycle/emitter.ts | Buffered JSONL lifecycle emitter |
| src/agents/pi-extensions/context-decay/extension.ts | Pi extension (context event hook) |
| src/agents/pi-extensions/context-decay/decay.ts | Core decay logic with stats tracking |
| src/agents/pi-extensions/context-decay/runtime.ts | Session-scoped runtime registry |
| scripts/context-lifecycle-report.ts | Analysis script for lifecycle JSONL |

### Tests

- 135 tests across 9 test files
- Covers: config resolution, summary store persistence, decay logic, group summarization, graduated ordering, file swap, hint generation, lifecycle emitter, pruner stats

## Test plan

- [x] pnpm tsgo — zero new type errors
- [x] pnpm vitest run (all decay/lifecycle tests) — 135/135 pass
- [x] No fork-only files leaked (CLAUDE.md, FORK-CHANGES.md, git-hooks/, .omc/)
- [ ] Manual: add contextDecay config, verify graduated decay applies
- [ ] Manual: enable contextLifecycleLog, verify JSONL events written
- [ ] Manual: run context-lifecycle-report.ts against JSONL, verify output