### PR TITLE
fix: strip incomplete tool_use blocks from errored/aborted messages to prevent permanent 400 loops

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -475,6 +475,13 @@ export function formatAssistantErrorText(
     );
   }
 
+  if (isCorruptedToolUsePairingError(raw)) {
+    return (
+      "Session history contains a corrupted tool call pair (likely from an interrupted response). " +
+      "Use /new to start a fresh session."
+    );
+  }
+
   const invalidRequest = raw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
   if (invalidRequest?.[1]) {
     return `LLM request rejected: ${invalidRequest[1]}`;
@@ -685,6 +692,15 @@ export function isMissingToolCallInputError(raw: string): boolean {
     return false;
   }
   return TOOL_CALL_INPUT_MISSING_RE.test(raw) || TOOL_CALL_INPUT_PATH_RE.test(raw);
+}
+
+const CORRUPTED_TOOL_USE_PAIRING_RE = /unexpected tool_use_id found in tool_result blocks/i;
+
+export function isCorruptedToolUsePairingError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return CORRUPTED_TOOL_USE_PAIRING_RE.test(raw);
 }
 
 export function isBillingAssistantError(msg: AssistantMessage | undefined): boolean {

--- a/src/agents/session-transcript-repair.e2e.test.ts
+++ b/src/agents/session-transcript-repair.e2e.test.ts
@@ -290,7 +290,7 @@ describe("sanitizeToolCallInputs", () => {
   it("drops tool calls with partialJson: true even when input is present", () => {
     // When streaming is interrupted, tool_use blocks may have partialJson: true
     // and an empty/incomplete input object. These should be treated as incomplete.
-    const input: AgentMessage[] = [
+    const input = [
       {
         role: "assistant",
         content: [
@@ -298,7 +298,7 @@ describe("sanitizeToolCallInputs", () => {
         ],
       },
       { role: "user", content: "hello" },
-    ];
+    ] as unknown as AgentMessage[];
 
     const out = sanitizeToolCallInputs(input);
     expect(out.map((m) => m.role)).toEqual(["user"]);

--- a/src/agents/session-transcript-repair.e2e.test.ts
+++ b/src/agents/session-transcript-repair.e2e.test.ts
@@ -106,10 +106,12 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
+  it("strips tool_use blocks from errored assistant messages to prevent 400 loops", () => {
     // When an assistant message has stopReason: "error", its tool_use blocks may be
-    // incomplete/malformed. We should NOT create synthetic tool_results for them,
-    // as this causes API 400 errors: "unexpected tool_use_id found in tool_result blocks"
+    // incomplete (partialJson: true). Leaving them in the transcript causes permanent
+    // 400 errors: "unexpected tool_use_id found in tool_result blocks".
+    // The fix: strip tool_use blocks, keep text content.
+    // See: https://github.com/openclaw/openclaw/issues/14322
     const input = [
       {
         role: "assistant",
@@ -123,15 +125,15 @@ describe("sanitizeToolUseResultPairing", () => {
 
     // Should NOT add synthetic tool results for errored messages
     expect(result.added).toHaveLength(0);
-    // The assistant message should be passed through unchanged
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
-    expect(result.messages).toHaveLength(2);
+    // The tool-only assistant message should be dropped entirely
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'aborted'", () => {
+  it("strips tool_use blocks from aborted assistant messages to prevent 400 loops", () => {
     // When a request is aborted mid-stream, the assistant message may have incomplete
-    // tool_use blocks (with partialJson). We should NOT create synthetic tool_results.
+    // tool_use blocks (with partialJson). Leaving them causes permanent 400 errors.
+    // See: https://github.com/openclaw/openclaw/issues/14322
     const input = [
       {
         role: "assistant",
@@ -145,9 +147,35 @@ describe("sanitizeToolUseResultPairing", () => {
 
     // Should NOT add synthetic tool results for aborted messages
     expect(result.added).toHaveLength(0);
-    // Messages should be passed through without synthetic insertions
+    // The tool-only assistant message should be dropped
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
+  });
+
+  it("preserves text content from errored assistant messages while stripping tool_use", () => {
+    // When an errored assistant message contains both text and tool_use blocks,
+    // keep the text (partial reasoning) but strip the tool_use blocks.
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me run that command..." },
+          { type: "toolCall", id: "call_partial", name: "Bash", arguments: {} },
+        ],
+        stopReason: "error",
+      },
+      { role: "user", content: "what happened?" },
+    ] as AgentMessage[];
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
     expect(result.messages).toHaveLength(2);
     expect(result.messages[0]?.role).toBe("assistant");
+    // Only text content should remain
+    const content = (result.messages[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect((content[0] as { type: string }).type).toBe("text");
     expect(result.messages[1]?.role).toBe("user");
   });
 
@@ -170,9 +198,8 @@ describe("sanitizeToolUseResultPairing", () => {
   });
 
   it("drops orphan tool results that follow an aborted assistant message", () => {
-    // When an assistant message is aborted, any tool results that follow should be
-    // dropped as orphans (since we skip extracting tool calls from aborted messages).
-    // This addresses the edge case where a partial tool result was persisted before abort.
+    // When an assistant message is aborted, tool_use blocks are stripped and any
+    // tool results that follow become orphans and should be dropped.
     const input = [
       {
         role: "assistant",
@@ -191,11 +218,10 @@ describe("sanitizeToolUseResultPairing", () => {
 
     const result = repairToolUseResultPairing(input);
 
-    // The orphan tool result should be dropped
+    // The orphan tool result should be dropped, and the tool-only assistant message too
     expect(result.droppedOrphanCount).toBe(1);
-    expect(result.messages).toHaveLength(2);
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
     // No synthetic results should be added
     expect(result.added).toHaveLength(0);
   });
@@ -259,5 +285,79 @@ describe("sanitizeToolCallInputs", () => {
       ? assistant.content.map((block) => (block as { type?: unknown }).type)
       : [];
     expect(types).toEqual(["text", "toolUse"]);
+  });
+
+  it("drops tool calls with partialJson: true even when input is present", () => {
+    // When streaming is interrupted, tool_use blocks may have partialJson: true
+    // and an empty/incomplete input object. These should be treated as incomplete.
+    const input: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "call_partial", name: "Bash", input: {}, partialJson: true },
+        ],
+      },
+      { role: "user", content: "hello" },
+    ];
+
+    const out = sanitizeToolCallInputs(input);
+    expect(out.map((m) => m.role)).toEqual(["user"]);
+  });
+});
+
+describe("issue #14322: corrupted tool_use/tool_result pair from interrupted streaming", () => {
+  it("full scenario: interrupted stream does not poison session permanently", () => {
+    // Reproduces the exact scenario from issue #14322:
+    // 1. Normal tool calls complete successfully
+    // 2. A tool call gets interrupted mid-stream (stopReason: "error", partialJson: true)
+    // 3. User sends another message
+    // Expected: the session should be cleaned up so the next API call works
+    const input = [
+      // Normal completed tool call
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_ok", name: "read", arguments: { path: "a.txt" } }],
+        stopReason: "toolUse",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_ok",
+        toolName: "read",
+        content: [{ type: "text", text: "file contents" }],
+        isError: false,
+      },
+      // Interrupted tool call with partialJson
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me also check..." },
+          { type: "toolUse", id: "call_broken", name: "Bash", input: {}, partialJson: true },
+        ],
+        stopReason: "error",
+      },
+      // User retries
+      { role: "user", content: "please try again" },
+    ] as AgentMessage[];
+
+    // First sanitize tool call inputs (drops partialJson blocks)
+    const afterInputSanitize = sanitizeToolCallInputs(input);
+    // Then repair pairing
+    const result = repairToolUseResultPairing(afterInputSanitize);
+
+    // The normal tool call/result pair should be preserved
+    expect(result.messages[0]?.role).toBe("assistant");
+    expect(result.messages[1]?.role).toBe("toolResult");
+    // The errored assistant message should have text content preserved
+    // but no tool_use blocks (they were stripped by sanitizeToolCallInputs
+    // because of partialJson, leaving only text, so errored-stripping
+    // in repairToolUseResultPairing keeps the text-only message)
+    expect(result.messages[2]?.role).toBe("assistant");
+    const content = (result.messages[2] as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect((content[0] as { type: string }).type).toBe("text");
+    // User message preserved
+    expect(result.messages[3]?.role).toBe("user");
+    // No synthetic results added for the broken call
+    expect(result.added).toHaveLength(0);
   });
 });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -219,13 +219,7 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     const stopReason = (assistant as { stopReason?: string }).stopReason;
     if (stopReason === "error" || stopReason === "aborted") {
       if (Array.isArray(assistant.content)) {
-        const nonToolContent = assistant.content.filter((block) => {
-          if (!block || typeof block !== "object") {
-            return true;
-          }
-          const type = (block as { type?: unknown }).type;
-          return typeof type !== "string" || !TOOL_CALL_TYPES.has(type);
-        });
+        const nonToolContent = assistant.content.filter((block) => !isToolCallBlock(block));
         if (nonToolContent.length > 0) {
           out.push({ ...msg, content: nonToolContent } as AgentMessage);
           changed = true;

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -21,6 +21,10 @@ function isToolCallBlock(block: unknown): block is ToolCallBlock {
 }
 
 function hasToolCallInput(block: ToolCallBlock): boolean {
+  // Blocks flagged as partial (interrupted mid-stream) are never complete.
+  if ("partialJson" in block && (block as { partialJson?: unknown }).partialJson === true) {
+    return false;
+  }
   const hasInput = "input" in block ? block.input !== undefined && block.input !== null : false;
   const hasArguments =
     "arguments" in block ? block.arguments !== undefined && block.arguments !== null : false;
@@ -205,15 +209,33 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
 
-    // Skip tool call extraction for aborted or errored assistant messages.
     // When stopReason is "error" or "aborted", the tool_use blocks may be incomplete
-    // (e.g., partialJson: true) and should not have synthetic tool_results created.
-    // Creating synthetic results for incomplete tool calls causes API 400 errors:
-    // "unexpected tool_use_id found in tool_result blocks"
+    // (e.g., partialJson: true). Leaving them in the transcript causes permanent 400
+    // errors from the Anthropic API ("unexpected tool_use_id found in tool_result blocks")
+    // because the incomplete tool_use has no matching tool_result.
+    // Strip tool_use blocks entirely; keep any text/thinking content.
     // See: https://github.com/openclaw/openclaw/issues/4597
+    // See: https://github.com/openclaw/openclaw/issues/14322
     const stopReason = (assistant as { stopReason?: string }).stopReason;
     if (stopReason === "error" || stopReason === "aborted") {
-      out.push(msg);
+      if (Array.isArray(assistant.content)) {
+        const nonToolContent = assistant.content.filter((block) => {
+          if (!block || typeof block !== "object") {
+            return true;
+          }
+          const type = (block as { type?: unknown }).type;
+          return typeof type !== "string" || !TOOL_CALL_TYPES.has(type);
+        });
+        if (nonToolContent.length > 0) {
+          out.push({ ...msg, content: nonToolContent } as AgentMessage);
+          changed = true;
+        } else {
+          // Entire message was tool_use blocks with no text — drop it.
+          changed = true;
+        }
+      } else {
+        out.push(msg);
+      }
       continue;
     }
 


### PR DESCRIPTION
#### Summary

Fixes a critical session-poisoning bug where an interrupted streaming response permanently breaks the session with a 400 error loop. When a tool call is interrupted mid-stream (network error, timeout, user abort), the assistant message contains incomplete `tool_use` blocks (with `partialJson: true`). The previous fix (#4597) correctly avoided creating synthetic `tool_result` entries for these, but still left the malformed `tool_use` blocks in the transcript. On every subsequent API call, Anthropic rejects the request:

```
400 messages.244.content.1: unexpected tool_use_id found in tool_result blocks:
toolu_01PfLjsziXFMs7pAQCtBLn1f
```

The error is baked into the session history, so every message hits the same 400. Only `/new` or `/reset` recovers.

lobster-biscuit

#### Repro Steps

1. Start a long session with many tool calls
2. Have a tool call interrupted mid-stream (network issue, timeout, abort)
3. OpenClaw persists the assistant message with `stopReason: "error"` and incomplete `tool_use` blocks
4. Send any new message -> permanent 400 loop

#### Root Cause

Three interconnected issues:

1. **`repairToolUseResultPairing()` passed errored messages through unchanged** (line 224-227 before this fix) — the incomplete `tool_use` blocks remained in the transcript with no matching `tool_result`, causing the 400
2. **`hasToolCallInput()` didn't detect `partialJson: true`** — blocks flagged as partial (interrupted mid-stream) with an empty `input: {}` passed the completeness check
3. **No user-friendly error** for the specific 400 pattern "unexpected tool_use_id found in tool_result blocks"

#### Behavior Changes

- **Errored/aborted assistant messages**: `tool_use`/`toolCall`/`functionCall` blocks are now stripped from the content array. Text and thinking blocks are preserved (partial reasoning is still valuable). If no content remains after stripping, the entire message is dropped.
- **`partialJson: true` tool calls**: Now detected as incomplete by `hasToolCallInput()` and dropped during the `sanitizeToolCallInputs` pass, even when `input` is present.
- **User-facing error**: If the 400 still reaches the user (e.g. from an older session file), `formatAssistantErrorText()` now returns a clear message instead of raw JSON.

#### Codebase and GitHub Search

- Searched for `partialJson`, `unexpected tool_use_id`, `stopReason.*error`, `tool_result blocks` across the codebase
- Found the existing partial fix from #4597 and understood why it was insufficient
- Verified `sanitizeToolCallInputs` runs before `repairToolUseResultPairing` in the sanitization pipeline (`google.ts:352-354`)
- Confirmed compaction already calls `repairToolUseResultPairing` after dropping chunks (`compaction.ts:343`)

#### Tests

All existing tests updated + 3 new tests added:

- `strips tool_use blocks from errored assistant messages to prevent 400 loops` — verifies tool-only errored message is dropped
- `strips tool_use blocks from aborted assistant messages to prevent 400 loops` — same for aborted
- `preserves text content from errored assistant messages while stripping tool_use` — verifies text/thinking blocks survive
- `drops tool calls with partialJson: true even when input is present` — verifies the `hasToolCallInput()` fix
- `full scenario: interrupted stream does not poison session permanently` — end-to-end test reproducing the exact #14322 scenario through both sanitization passes

```
pnpm vitest run src/agents/session-transcript-repair.test.ts  # 13/13 pass
pnpm vitest run src/agents/session-tool-result-guard.test.ts  # 10/10 pass
pnpm vitest run src/agents/pi-embedded-runner.sanitize-session-history.test.ts  # 9/9 pass
pnpm vitest run src/agents/compaction.test.ts  # 10/10 pass
pnpm vitest run src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts  # 10/10 pass
pnpm check  # format + typecheck + lint all pass
pnpm build  # clean build
```

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: Deep codebase analysis, traced the full session history -> context assembly -> API call pipeline, identified three interconnected root causes, implemented multi-layer defense
- Agent notes: AI-assisted PR. The fix is surgical — 3 files, ~160 lines added, all focused on the bug. No unrelated changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a session-poisoning bug where interrupted streaming responses (network errors, timeouts, user aborts) permanently break sessions with 400 error loops. The root cause: incomplete `tool_use` blocks with `partialJson: true` were left in the transcript, causing every subsequent API call to be rejected by Anthropic.

- **`hasToolCallInput()`** now detects `partialJson: true` blocks as incomplete, so `sanitizeToolCallInputs` drops them during the first sanitization pass
- **`repairToolUseResultPairing()`** now strips tool call blocks from errored/aborted assistant messages instead of passing them through unchanged; text and thinking content is preserved
- **`formatAssistantErrorText()`** adds a user-friendly error message for the specific "unexpected tool_use_id found in tool_result blocks" 400 pattern
- Tests updated and expanded with 3 new test cases plus an end-to-end scenario reproducing the exact issue

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a critical session-poisoning bug with well-scoped, defensive changes and thorough test coverage.
- The fix is surgical and well-reasoned: 3 files changed with ~160 lines added, all directly targeting the bug. The multi-layer defense (sanitizeToolCallInputs catches partialJson, repairToolUseResultPairing strips remaining tool blocks from errored messages, formatAssistantErrorText provides a fallback user message) is appropriate. Tests cover the key scenarios including an end-to-end reproduction. The only minor gap is the lack of a direct unit test for isCorruptedToolUsePairingError and its integration into formatAssistantErrorText, though the existing test suite for that function passes.
- No files require special attention. All changes are focused and correct.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->