### PR TITLE
fix(agents): strip provider prefix in MODEL_CACHE lookup for context window

### DIFF
--- a/src/agents/context.lookup-strips-provider-prefix.test.ts
+++ b/src/agents/context.lookup-strips-provider-prefix.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// We need to test lookupContextTokens with a pre-populated cache.
+// Since MODEL_CACHE is module-private, we mock the discovery to populate it.
+
+describe("lookupContextTokens provider-prefix stripping", () => {
+  let lookupContextTokens: (modelId?: string) => number | undefined;
+
+  beforeEach(async () => {
+    // Reset module cache to re-run the IIFE
+    vi.resetModules();
+
+    // Mock the discovery to populate MODEL_CACHE with bare IDs
+    vi.doMock("./pi-model-discovery.js", () => ({
+      discoverAuthStorage: () => ({}),
+      discoverModels: () => ({
+        getAll: () => [
+          { id: "eu.anthropic.claude-opus-4-6-v1", contextWindow: 1_000_000 },
+          { id: "claude-3-5-sonnet-20241022", contextWindow: 200_000 },
+        ],
+      }),
+    }));
+    vi.doMock("../config/config.js", () => ({ loadConfig: () => ({}) }));
+    vi.doMock("./agent-paths.js", () => ({ resolveOpenClawAgentDir: () => "/tmp" }));
+    vi.doMock("./models-config.js", () => ({ ensureOpenClawModelsJson: async () => {} }));
+
+    const mod = await import("./context.js");
+    lookupContextTokens = mod.lookupContextTokens;
+
+    // Allow the async IIFE to settle
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  it("returns exact match for bare model ID", () => {
+    expect(lookupContextTokens("eu.anthropic.claude-opus-4-6-v1")).toBe(1_000_000);
+  });
+
+  it("strips provider prefix and finds the model (#14332)", () => {
+    expect(lookupContextTokens("amazon-bedrock/eu.anthropic.claude-opus-4-6-v1")).toBe(1_000_000);
+  });
+
+  it("returns undefined for unknown model", () => {
+    expect(lookupContextTokens("unknown/model")).toBeUndefined();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(lookupContextTokens(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`lookupContextTokens()` receives provider-prefixed model refs (e.g. `amazon-bedrock/eu.anthropic.claude-opus-4-6-v1`) but `MODEL_CACHE` is keyed by bare model IDs (e.g. `eu.anthropic.claude-opus-4-6-v1`). This causes a cache miss, falling back to `DEFAULT_CONTEXT_TOKENS` (200k) instead of the configured context window.

Users see `/status` reporting 200k context window even when they configured 1M.

## Fix

On cache miss, strip the provider prefix (everything before the first `/`) and retry the lookup. Exact matches still take priority.

**2 files changed**: 1 source fix + 1 test file.

Fixes #14332

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes `lookupContextTokens()` to handle provider-prefixed model IDs (e.g., `amazon-bedrock/eu.anthropic.claude-opus-4-6-v1`) by stripping the prefix on cache miss and retrying with the bare model ID. This resolves `/status` incorrectly reporting 200k context window instead of the configured value.

- Added fallback logic in `lookupContextTokens()`: exact match first, then strip provider prefix and retry
- Added test file covering exact match, prefix stripping, unknown model, and undefined input cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, additive fix with no behavioral change for existing exact-match lookups.
- The change is small and well-scoped: on cache miss, it strips a provider prefix and retries. Exact matches still take priority, so no existing behavior changes. The fix is consistent with how `parseModelRef` already splits on `/` elsewhere in the codebase. Tests cover all relevant cases.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->