### PR TITLE
gateway: support chat.send attachment paths

### DIFF
--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildMessageWithAttachments,
@@ -209,5 +212,49 @@ describe("parseMessageWithAttachments", () => {
     expect(parsed.images[0]?.mimeType).toBe("image/png");
     expect(parsed.images[0]?.data).toBe(PNG_1x1);
     expect(logs.some((l) => /non-image/i.test(l))).toBe(true);
+  });
+
+  it("loads image from workspace-relative path", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-att-"));
+    const relPath = path.join("media", "inbound", "dot.png");
+    const absPath = path.join(workspaceDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, Buffer.from(PNG_1x1, "base64"));
+    try {
+      const parsed = await parseMessageWithAttachments(
+        "see this",
+        [
+          {
+            type: "image",
+            fileName: "dot.png",
+            path: relPath,
+          },
+        ],
+        { log: { warn: () => {} }, workspaceDir },
+      );
+      expect(parsed.images).toHaveLength(1);
+      expect(parsed.images[0]?.mimeType).toBe("image/png");
+      expect(parsed.images[0]?.data).toBe(PNG_1x1);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers path over base64 content when both are present", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-att-"));
+    const relPath = "dot.png";
+    await fs.writeFile(path.join(workspaceDir, relPath), Buffer.from(PNG_1x1, "base64"));
+    const invalidB64 = "%not-base64%";
+    try {
+      const parsed = await parseMessageWithAttachments(
+        "x",
+        [{ type: "image", path: relPath, content: invalidB64 }],
+        { log: { warn: () => {} }, workspaceDir },
+      );
+      expect(parsed.images).toHaveLength(1);
+      expect(parsed.images[0]?.data).toBe(PNG_1x1);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -257,4 +257,22 @@ describe("parseMessageWithAttachments", () => {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects paths that escape workspace directory", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-att-"));
+    const workspaceDir = path.join(root, "workspace");
+    const outsidePath = path.join(root, "outside.png");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(outsidePath, Buffer.from(PNG_1x1, "base64"));
+    try {
+      await expect(
+        parseMessageWithAttachments("x", [{ type: "image", path: "../outside.png" }], {
+          log: { warn: () => {} },
+          workspaceDir,
+        }),
+      ).rejects.toThrow(/escapes workspace directory/i);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import nodePath from "node:path";
 import { detectMime } from "../media/mime.js";
 
 export type ChatAttachment = {
@@ -5,6 +7,7 @@ export type ChatAttachment = {
   mimeType?: string;
   fileName?: string;
   content?: unknown;
+  path?: string;
 };
 
 export type ChatImageContent = {
@@ -54,6 +57,33 @@ function isImageMime(mime?: string): boolean {
   return typeof mime === "string" && mime.startsWith("image/");
 }
 
+async function loadImageFromPath(
+  filePath: string,
+  workspaceDir: string,
+  opts?: { maxBytes?: number; log?: AttachmentLog },
+): Promise<ChatImageContent> {
+  const maxBytes = opts?.maxBytes ?? 5_000_000;
+  const absPath = nodePath.isAbsolute(filePath) ? filePath : nodePath.join(workspaceDir, filePath);
+
+  const stat = await fs.stat(absPath);
+  if (stat.size > maxBytes) {
+    throw new Error(`image file exceeds size limit (${stat.size} > ${maxBytes} bytes)`);
+  }
+
+  const buffer = await fs.readFile(absPath);
+  const sniffed = await detectMime({ buffer });
+  const mime = sniffed ?? "image/jpeg";
+  if (!isImageMime(mime)) {
+    throw new Error(`file is not an image (${mime})`);
+  }
+
+  return {
+    type: "image",
+    data: buffer.toString("base64"),
+    mimeType: mime,
+  };
+}
+
 /**
  * Parse attachments and extract images as structured content blocks.
  * Returns the message text and an array of image content blocks
@@ -62,7 +92,7 @@ function isImageMime(mime?: string): boolean {
 export async function parseMessageWithAttachments(
   message: string,
   attachments: ChatAttachment[] | undefined,
-  opts?: { maxBytes?: number; log?: AttachmentLog },
+  opts?: { maxBytes?: number; log?: AttachmentLog; workspaceDir?: string },
 ): Promise<ParsedMessageWithImages> {
   const maxBytes = opts?.maxBytes ?? 5_000_000; // 5 MB
   const log = opts?.log;
@@ -79,6 +109,15 @@ export async function parseMessageWithAttachments(
     const mime = att.mimeType ?? "";
     const content = att.content;
     const label = att.fileName || att.type || `attachment-${idx + 1}`;
+    if (att.path && opts?.workspaceDir) {
+      try {
+        const img = await loadImageFromPath(att.path, opts.workspaceDir, { maxBytes, log });
+        images.push(img);
+      } catch (err) {
+        throw new Error(`attachment ${label}: ${String(err)}`, { cause: err });
+      }
+      continue;
+    }
 
     if (typeof content !== "string") {
       throw new Error(`attachment ${label}: content must be base64 string`);

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -63,7 +63,12 @@ async function loadImageFromPath(
   opts?: { maxBytes?: number; log?: AttachmentLog },
 ): Promise<ChatImageContent> {
   const maxBytes = opts?.maxBytes ?? 5_000_000;
-  const absPath = nodePath.isAbsolute(filePath) ? filePath : nodePath.join(workspaceDir, filePath);
+  const workspaceRoot = nodePath.resolve(workspaceDir);
+  const absPath = nodePath.resolve(workspaceRoot, filePath);
+  const relative = nodePath.relative(workspaceRoot, absPath);
+  if (relative.startsWith("..") || nodePath.isAbsolute(relative)) {
+    throw new Error("attachment path escapes workspace directory");
+  }
 
   const stat = await fs.stat(absPath);
   if (stat.size > maxBytes) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -356,7 +356,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           type: typeof a?.type === "string" ? a.type : undefined,
           mimeType: typeof a?.mimeType === "string" ? a.mimeType : undefined,
           fileName: typeof a?.fileName === "string" ? a.fileName : undefined,
-          path: typeof a?.path === "string" ? a.path : undefined,
+          path: typeof a?.path === "string" ? a.path.trim() : undefined,
           content:
             typeof a?.content === "string"
               ? a.content
@@ -496,15 +496,18 @@ export const chatHandlers: GatewayRequestHandlers = {
         SenderUsername: clientInfo?.displayName,
         GatewayClientScopes: client?.connect?.scopes,
       };
-      const mediaPaths = normalizedAttachments
-        .map((a) => (typeof a.path === "string" ? a.path : undefined))
-        .filter((p): p is string => Boolean(p));
-      if (mediaPaths.length > 0) {
-        ctx.MediaPath = mediaPaths[0];
-        ctx.MediaPaths = mediaPaths;
-        ctx.MediaTypes = normalizedAttachments
-          .map((a) => (a.path && typeof a.mimeType === "string" ? a.mimeType : undefined))
-          .filter((m): m is string => Boolean(m));
+      const pathAttachments = normalizedAttachments.filter(
+        (a): a is typeof a & { path: string } => typeof a.path === "string" && a.path.length > 0,
+      );
+      if (pathAttachments.length > 0) {
+        const paths = pathAttachments.map((a) => a.path);
+        ctx.MediaPath = paths[0];
+        ctx.MediaPaths = paths;
+        ctx.MediaTypes = pathAttachments.map((a) =>
+          typeof a.mimeType === "string" && a.mimeType.trim().length > 0
+            ? a.mimeType
+            : "application/octet-stream",
+        );
       }
 
       const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({

--- a/src/gateway/server.chat.gateway-server-chat.e2e.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.e2e.test.ts
@@ -6,6 +6,7 @@ import { WebSocket } from "ws";
 import { emitAgentEvent, registerAgentRunContext } from "../infra/agent-events.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
+  agentCommand,
   connectOk,
   getReplyFromConfig,
   installGatewayTestHooks,


### PR DESCRIPTION
#### Summary
This adds `attachments[].path` support to `chat.send` so clients can upload images to workspace storage first, then send only a file path (instead of base64 payloads).

#### Use Cases
- Web UI uploads an image file into the agent workspace and sends `chat.send` with `attachments[].path`.
- Existing clients continue sending `attachments[].content` (base64) unchanged.

#### Behavior Changes
- `chat.send` now accepts `attachments[].path?: string` in addition to `attachments[].content?: string`.
- Attachment normalization now keeps entries when either `content` or `path` is present (previously content-only).
- Path attachment resolution in `parseMessageWithAttachments`:
  - If `path` exists, load bytes from filesystem (`absolute` path or `workspaceDir`-relative path).
  - Enforce existing 5 MB limit.
  - MIME-sniff file bytes and require image MIME (`image/*`).
  - Convert loaded bytes to base64 image content block for downstream model input.
- Path precedence:
  - If both `path` and `content` are provided, `path` is used first.
  - This preserves behavior for clients that include stale/invalid base64 while migrating to path mode.
- Session context plumbing:
  - Path-based attachments now populate `MsgContext.MediaPath`, `MsgContext.MediaPaths`, and `MsgContext.MediaTypes` in `chat.send` flow.

#### Backward Compatibility
- Base64 attachment flow remains supported and unchanged for callers that do not send `path`.
- No protocol break: `path` is additive and optional.

#### Existing Functionality Check
- [x] I searched the codebase for existing functionality.
  Searches performed:
  - `rg -n "parseMessageWithAttachments|chat.send" src/gateway`
  - `rg -n "MediaPath|MediaPaths|MediaTypes" src/gateway src/auto-reply src/telegram src/discord src/imessage`
- [x] I searched GitHub for prior matching work.
  - `gh search issues "chat.send attachment path" --repo openclaw/openclaw --limit 5` (no direct matches)
  - `gh search prs "gateway attachment path" --repo openclaw/openclaw --limit 5` (no direct matches)

#### Tests
- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm test` ✅

Targeted coverage added/updated:
- `src/gateway/chat-attachments.test.ts`
  - loads image from workspace-relative path
  - prefers path over base64 content when both exist
- `src/gateway/server.chat.gateway-server-chat.e2e.test.ts`
  - `chat.send` with `attachments[].path` delivers image content to reply pipeline

#### Manual Testing (omit if N/A)
N/A (automated coverage for gateway path + compatibility behavior).

**Sign-Off**
- Models used: GPT-5 Codex
- Submitter effort (self-reported): medium
- Agent notes (optional, cite evidence): behavior and compatibility statements are based on the committed diffs in `src/gateway/chat-attachments.ts`, `src/gateway/server-methods/chat.ts`, and associated tests.

lobster-biscuit
