### PR TITLE
fix(cli): guard zsh completion with compinit check

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -352,6 +352,9 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
 function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
+# Ensure compdef is available (e.g. when sourced before compinit)
+if ! type compdef &>/dev/null; then autoload -Uz compinit && compinit -i; fi
+
 #compdef ${rootCmd}
 
 _${rootCmd}_root_completion() {


### PR DESCRIPTION
## Problem

`source <(openclaw completion --shell zsh)` fails with `command not found: compdef` when the user hasn't run `compinit` first.

## Fix

Add a guard before the generated zsh completion script that checks if `compdef` is available, and if not, initializes the completion system via `autoload -Uz compinit && compinit -i`.

4-line diff.

Closes #14289

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR bundles three independent fixes across different subsystems:

- **zsh completion** (`completion-cli.ts`): Adds a `compinit` guard so `source <(openclaw completion --shell zsh)` works even when `compinit` hasn't been called yet. The guard is duplicated (before and after `#compdef`) — only the first is needed.
- **Model context lookup** (`context.ts`): Falls back to stripping the provider prefix (e.g. `amazon-bedrock/`) when looking up context window sizes, fixing lookups for provider-qualified model IDs. New tests cover `undefined` and empty-string edge cases.
- **Telegram reactions** (`send.ts`): Catches `REACTION_INVALID` errors gracefully instead of throwing, but introduces a return type mismatch (`Promise<{ ok: true }>` vs the new `{ ok: false, warning }` branch) that needs to be fixed.

<h3>Confidence Score: 3/5</h3>

- The zsh and model-lookup fixes are safe; the Telegram return type mismatch should be corrected before merging.
- The zsh completion guard and model context fallback are low-risk improvements. However, the Telegram change introduces a return type inconsistency that will either fail type-checking or silently mislead callers into treating a failed reaction as successful.
- `src/telegram/send.ts` — return type needs to be updated to reflect the new `ok: false` branch, and callers should handle it.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->