### PR TITLE
fix(agents): strip provider prefix in MODEL_CACHE lookup for context window

### DIFF
--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { lookupContextTokens } from "./context.js";
+
+describe("lookupContextTokens", () => {
+  it("returns undefined for undefined modelId", () => {
+    expect(lookupContextTokens(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(lookupContextTokens("")).toBeUndefined();
+  });
+});

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -36,5 +36,9 @@ export function lookupContextTokens(modelId?: string): number | undefined {
   }
   // Best-effort: kick off loading, but don't block.
   void loadPromise;
-  return MODEL_CACHE.get(modelId);
+
+  // Try the full model id first (e.g. "amazon-bedrock/eu.anthropic.claude-opus-4-6-v1"),
+  // then fall back to the bare id after stripping the provider prefix.
+  // MODEL_CACHE stores entries by bare id from model discovery.
+  return MODEL_CACHE.get(modelId) ?? MODEL_CACHE.get(modelId.replace(/^[^/]+\//, ""));
 }


### PR DESCRIPTION
## Summary

Fixes #14332

`lookupContextTokens()` receives the full provider-prefixed model ref (e.g. `amazon-bedrock/eu.anthropic.claude-opus-4-6-v1`) but `MODEL_CACHE` stores entries by bare model id (e.g. `eu.anthropic.claude-opus-4-6-v1`). This causes a cache miss, falling back to `DEFAULT_CONTEXT_TOKENS` (200k) even when users configured a larger context window.

## Fix

Try the full id first, then strip the provider prefix (`model.replace(/^[^/]+\//, '')`) as fallback. One-line change.

## Test

Added basic unit tests for `lookupContextTokens`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a cache miss in `lookupContextTokens` where provider-prefixed model IDs (e.g. `amazon-bedrock/eu.anthropic.claude-opus-4-6-v1`) failed to match bare IDs in `MODEL_CACHE`, incorrectly falling back to `DEFAULT_CONTEXT_TOKENS`. The fix tries the full ID first, then strips the provider prefix as fallback. Also includes a zsh completion robustness fix and graceful handling of `REACTION_INVALID` errors in Telegram reactions.

- **Core fix** (`context.ts`): Correct and minimal — adds `?? MODEL_CACHE.get(modelId.replace(/^[^/]+\//, ""))` fallback.
- **Type mismatch** (`send.ts`): The `reactMessageTelegram` return type annotation is `Promise<{ ok: true }>` but the new `REACTION_INVALID` branch returns `{ ok: false, warning }`. This will fail type-checking and should be updated.
- **Tests** (`context.test.ts`): Only cover the `undefined`/empty-string edge cases; no test exercises the actual provider-prefix stripping logic (the bug being fixed).

<h3>Confidence Score: 3/5</h3>

- Core context-window fix is correct and safe; Telegram change has a return type mismatch that will fail type-checking.
- The primary fix in context.ts is clean and correct. However, the Telegram change in send.ts introduces a type error — the declared return type doesn't cover the new error branch. The zsh completion change is benign. Tests for the core fix don't cover the actual bug scenario.
- `src/telegram/send.ts` — return type annotation mismatch needs fixing before merge.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->