### PR TITLE
fix(telegram): surface REACTION_INVALID as non-fatal warning

### DIFF
--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -59,6 +59,37 @@ describe("handleTelegramAction", () => {
     );
   });
 
+  it("surfaces non-fatal reaction warnings", async () => {
+    reactMessageTelegram.mockResolvedValueOnce({
+      ok: false,
+      warning: "Reaction unavailable: ✅",
+    });
+    const cfg = {
+      channels: { telegram: { botToken: "tok", reactionLevel: "minimal" } },
+    } as OpenClawConfig;
+    const result = await handleTelegramAction(
+      {
+        action: "react",
+        chatId: "123",
+        messageId: "456",
+        emoji: "✅",
+      },
+      cfg,
+    );
+    const textPayload = result.content.find((item) => item.type === "text");
+    expect(textPayload?.type).toBe("text");
+    const parsed = JSON.parse((textPayload as { type: "text"; text: string }).text) as {
+      ok: boolean;
+      warning?: string;
+      added?: string;
+    };
+    expect(parsed).toMatchObject({
+      ok: false,
+      warning: "Reaction unavailable: ✅",
+      added: "✅",
+    });
+  });
+
   it("adds reactions when reactionLevel is extensive", async () => {
     const cfg = {
       channels: { telegram: { botToken: "tok", reactionLevel: "extensive" } },

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -109,11 +109,18 @@ export async function handleTelegramAction(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
-    await reactMessageTelegram(chatId ?? "", messageId ?? 0, emoji ?? "", {
+    const reactionResult = await reactMessageTelegram(chatId ?? "", messageId ?? 0, emoji ?? "", {
       token,
       remove,
       accountId: accountId ?? undefined,
     });
+    if (!reactionResult.ok) {
+      return jsonResult({
+        ok: false,
+        warning: reactionResult.warning,
+        ...(remove || isEmpty ? { removed: true } : { added: emoji }),
+      });
+    }
     if (!remove && !isEmpty) {
       return jsonResult({ ok: true, added: emoji });
     }

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -596,7 +596,7 @@ export async function reactMessageTelegram(
   messageIdInput: string | number,
   emoji: string,
   opts: TelegramReactionOpts = {},
-): Promise<{ ok: true }> {
+): Promise<{ ok: true } | { ok: false; warning: string }> {
   const cfg = loadConfig();
   const account = resolveTelegramAccount({
     cfg,
@@ -633,7 +633,16 @@ export async function reactMessageTelegram(
   if (typeof api.setMessageReaction !== "function") {
     throw new Error("Telegram reactions are unavailable in this bot API.");
   }
-  await requestWithDiag(() => api.setMessageReaction(chatId, messageId, reactions), "reaction");
+  try {
+    await requestWithDiag(() => api.setMessageReaction(chatId, messageId, reactions), "reaction");
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/REACTION_INVALID/i.test(msg)) {
+      logHttpError("reaction", err);
+      return { ok: false as const, warning: `Reaction unavailable: ${trimmedEmoji}` };
+    }
+    throw err;
+  }
   return { ok: true };
 }
 

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -638,7 +638,6 @@ export async function reactMessageTelegram(
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     if (/REACTION_INVALID/i.test(msg)) {
-      logHttpError("reaction", err);
       return { ok: false as const, warning: `Reaction unavailable: ${trimmedEmoji}` };
     }
     throw err;


### PR DESCRIPTION
## Summary

Fixes #14316

When `setMessageReaction` fails with `REACTION_INVALID`, the error is silently swallowed. The agent continues without any indication that the reaction failed.

## Fix

Catch the specific `REACTION_INVALID` error and return a warning result (`{ ok: false, warning: '...' }`) instead of silently succeeding. Other errors are still thrown as before.

**1 file changed, 11 insertions, 2 deletions.**

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Catches `REACTION_INVALID` errors from Telegram's `setMessageReaction` API and returns a non-fatal `{ ok: false, warning }` result instead of silently succeeding.

- **Caller doesn't use the warning**: The main caller in `src/agents/tools/telegram-actions.ts` discards the return value and unconditionally reports `{ ok: true }` to the agent, so the warning never surfaces.
- **Double logging**: `logHttpError` is called both inside `requestWithDiag`'s `.catch()` and again in the new outer catch block, resulting in duplicate diagnostic log entries for the same error.

<h3>Confidence Score: 2/5</h3>

- The fix doesn't fully achieve its goal — the warning is lost at the call site.
- The change in `send.ts` is correct in isolation, but the primary caller in `telegram-actions.ts` discards the return value, so the agent never sees the warning. This means the bug from #14316 (silent failure) is not actually fixed for the main usage path. There's also a minor double-logging issue.
- `src/agents/tools/telegram-actions.ts` needs to be updated to propagate the warning.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->