### PR TITLE
fix(telegram): surface REACTION_INVALID as non-fatal warning

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -109,11 +109,21 @@ export async function handleTelegramAction(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
-    await reactMessageTelegram(chatId ?? "", messageId ?? 0, emoji ?? "", {
-      token,
-      remove,
-      accountId: accountId ?? undefined,
-    });
+    try {
+      await reactMessageTelegram(chatId ?? "", messageId ?? 0, emoji ?? "", {
+        token,
+        remove,
+        accountId: accountId ?? undefined,
+      });
+    } catch (err) {
+      if (/REACTION_INVALID/i.test(String(err))) {
+        return jsonResult({
+          ok: false,
+          error: `Invalid reaction emoji "${emoji}". Telegram does not support this emoji as a reaction.`,
+        });
+      }
+      throw err;
+    }
     if (!remove && !isEmpty) {
       return jsonResult({ ok: true, added: emoji });
     }

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -596,7 +596,7 @@ export async function reactMessageTelegram(
   messageIdInput: string | number,
   emoji: string,
   opts: TelegramReactionOpts = {},
-): Promise<{ ok: true }> {
+): Promise<{ ok: true } | { ok: false; warning: string }> {
   const cfg = loadConfig();
   const account = resolveTelegramAccount({
     cfg,
@@ -633,7 +633,16 @@ export async function reactMessageTelegram(
   if (typeof api.setMessageReaction !== "function") {
     throw new Error("Telegram reactions are unavailable in this bot API.");
   }
-  await requestWithDiag(() => api.setMessageReaction(chatId, messageId, reactions), "reaction");
+  try {
+    await requestWithDiag(() => api.setMessageReaction(chatId, messageId, reactions), "reaction");
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/REACTION_INVALID/i.test(msg)) {
+      logHttpError("reaction", err);
+      return { ok: false as const, warning: `Reaction unavailable: ${trimmedEmoji}` };
+    }
+    throw err;
+  }
   return { ok: true };
 }
 


### PR DESCRIPTION
## Summary

When Telegram's `setMessageReaction` fails with `REACTION_INVALID`, the error was silently swallowed in two code paths:

1. **Ack reactions** (`bot-message-context.ts`): Only logged via `logVerbose` (invisible without verbose mode)
2. **Agent tool reactions** (`telegram-actions.ts`): Raw exception propagated without actionable context

## Changes

- **Agent tool path**: Catch `REACTION_INVALID` specifically and return `{ok: false, error: ...}` with a clear message instead of throwing — the agent sees the failure and can inform the user
- **Ack reaction path**: Log `REACTION_INVALID` at warn level with a config hint (`channels.telegram.ackReaction.emoji`) so admins know what to fix
- All other Telegram API errors propagate unchanged
- Total: +23 lines, -6 lines

Fixes #14316

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Surfaces `REACTION_INVALID` errors from Telegram's `setMessageReaction` API as non-fatal warnings instead of silently swallowing them or propagating raw exceptions. Improves observability for admins (warn-level log with config hint) and gives agents an actionable error message.

- `send.ts`: `reactMessageTelegram` now catches `REACTION_INVALID` and returns `{ ok: false, warning }` instead of throwing, with a widened return type.
- `bot-message-context.ts`: Ack reaction path logs `REACTION_INVALID` at warn level with a `channels.telegram.ackReaction.emoji` config hint. Added optional `warn` to `TelegramLogger` type.
- **Bug in `telegram-actions.ts`**: The try/catch at line 112-126 is now dead code for `REACTION_INVALID` — since `reactMessageTelegram` no longer throws this error (it returns `{ ok: false }`), the catch block never fires, and the agent incorrectly receives `{ ok: true }`. The return value of `reactMessageTelegram` needs to be checked instead.

<h3>Confidence Score: 2/5</h3>

- Contains a logic bug where REACTION_INVALID is silently treated as success in the agent tool path.
- The change to `send.ts` (return instead of throw for REACTION_INVALID) creates a semantic mismatch with the caller in `telegram-actions.ts` that still expects a thrown error. The agent will see `{ ok: true }` for invalid reactions, which is the opposite of the intended fix.
- `src/agents/tools/telegram-actions.ts` — the try/catch at lines 112-126 is dead code for REACTION_INVALID and needs to check the return value instead.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->