### PR TITLE
fix: suppress EPIPE error in restartLaunchAgent stdout write

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -460,5 +460,11 @@ export async function restartLaunchAgent({
   if (res.code !== 0) {
     throw new Error(`launchctl kickstart failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+  try {
+    stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+      throw err;
+    }
+  }
 }


### PR DESCRIPTION
When the gateway restarts via `launchctl kickstart`, the stdout stream may already be closed by the time we write the status message, causing an uncaught `write EPIPE` exception. The gateway restarts successfully but the error pollutes logs.

This wraps the non-critical status write in a try/catch that silently ignores EPIPE while re-throwing other errors.

Closes #14234

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Two changes in a single commit: (1) wraps a non-critical `stdout.write` in `restartLaunchAgent` with a try/catch that silently ignores EPIPE errors, fixing a log-polluting uncaught exception when the stdout stream closes before the status message is written after `launchctl kickstart`, and (2) replaces `AbortSignal.timeout(5000)` with a manual `AbortController` + `setTimeout` pattern in `discoverVeniceModels`, adding a `finally` block to `clearTimeout`.

- `src/daemon/launchd.ts`: EPIPE suppression for the restart status write — targeted and correct.
- `src/agents/venice-models.ts`: Timeout handling refactor from `AbortSignal.timeout` to manual `AbortController` — functionally equivalent on Node.js 22+, adds explicit timer cleanup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — both changes are defensive and functionally correct.
- The launchd.ts change is a targeted, correct fix for a real observed EPIPE error on a non-critical status write. The venice-models.ts change is a safe refactor replacing AbortSignal.timeout with an equivalent manual AbortController pattern that adds explicit timer cleanup. Neither change alters application behavior or introduces regressions.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->