### PR TITLE
fix: clean up plist file when launchctl bootstrap fails

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -436,6 +436,7 @@ export async function installLaunchAgent({
   await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
+    await fs.unlink(plistPath).catch(() => {});
     throw new Error(`launchctl bootstrap failed: ${boot.stderr || boot.stdout}`.trim());
   }
   await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);


### PR DESCRIPTION
When `launchctl bootstrap` fails (e.g. user denies macOS security dialog during onboarding), the plist file was left on disk, leaving an orphan LaunchAgent that runs invisibly.

This adds a one-line cleanup: delete the plist before throwing so no ghost daemon persists after a failed install.

Closes #14315

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds plist file cleanup when `launchctl bootstrap` fails during LaunchAgent installation, preventing orphan daemon files from persisting on disk after a failed onboarding (e.g., when the user denies the macOS security dialog).

- Deletes the plist file via `fs.unlink` before throwing the bootstrap error, using `.catch(() => {})` to silently handle cases where the file may already be gone — consistent with the existing legacy plist cleanup pattern in the same function.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a single-line defensive cleanup that follows existing patterns in the same function.
- The change is a one-line addition that deletes a file on an already-failing code path. It uses an established error-swallowing pattern consistent with the rest of the function, and the worst case (unlink itself failing) is harmlessly caught. No behavioral change to the success path.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->