### PR TITLE
fix: treat 'fetch failed' as transient regardless of cause

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -86,6 +86,15 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("returns true for fetch failed even with unrecognized cause", () => {
+    // This is the key fix: "fetch failed" should always be transient,
+    // even if the cause is not recognized as a known network error code.
+    // This happens when Telegram API is unreachable due to packet loss.
+    const cause = Object.assign(new Error("unknown network issue"), { code: "UNKNOWN" });
+    const error = Object.assign(new TypeError("fetch failed"), { cause });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns true for nested cause chain with network error", () => {
     const innerCause = Object.assign(new Error("connection reset"), { code: "ECONNRESET" });
     const outerCause = Object.assign(new Error("wrapper"), { cause: innerCause });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -95,11 +95,9 @@ export function isTransientNetworkError(err: unknown): boolean {
   }
 
   // "fetch failed" TypeError from undici (Node's native fetch)
+  // This is always a transient network error, regardless of the cause.
+  // Previously, if cause existed but wasn't recognized, it returned false - that was wrong.
   if (err instanceof TypeError && err.message === "fetch failed") {
-    const cause = getErrorCause(err);
-    if (cause) {
-      return isTransientNetworkError(cause);
-    }
     return true;
   }
 


### PR DESCRIPTION
## Summary

Fixes #14345

Previously, `isTransientNetworkError` would check the cause of a 'fetch failed' TypeError and return `false` if the cause wasn't recognized as a known network error code. This caused the gateway to crash on transient network issues.

## Root Cause

When Telegram API is unreachable due to packet loss or network instability, Node's undici throws:
```
TypeError: fetch failed
```

The old logic in `isTransientNetworkError`:
```typescript
if (err instanceof TypeError && err.message === "fetch failed") {
  const cause = getErrorCause(err);
  if (cause) {
    return isTransientNetworkError(cause);  // Returns false if cause unrecognized!
  }
  return true;
}
```

If the cause existed but wasn't in our list of known network error codes, it would return `false`, causing the gateway to crash.

## Fix

`fetch failed` from Node's undici is **always** a network-related error. It should always be treated as transient and recoverable, regardless of the underlying cause:

```typescript
if (err instanceof TypeError && err.message === "fetch failed") {
  return true;  // Always transient
}
```

## Testing

Added test case for the previously-broken scenario:
```typescript
it("returns true for fetch failed even with unrecognized cause", () => {
  const cause = Object.assign(new Error("unknown network issue"), { code: "UNKNOWN" });
  const error = Object.assign(new TypeError("fetch failed"), { cause });
  expect(isTransientNetworkError(error)).toBe(true);
});
```

## Logs from the issue

```
2026-02-11T10:09:49.336Z [clawdbot] Unhandled promise rejection: TypeError: fetch failed
clawdbot-gateway.service: Main process exited, code=exited, status=1/FAILURE
```

Network diagnostics showed 50% packet loss to api.telegram.org during the crashes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `isTransientNetworkError` so that undici’s `TypeError("fetch failed")` is always classified as transient, regardless of any attached `cause`. This prevents the unhandled rejection handler from terminating the gateway when the Telegram API is temporarily unreachable but the nested cause code is not in the known transient list.

The accompanying test suite adds coverage for the previously failing scenario (`fetch failed` with an unrecognized `cause.code`) and keeps existing coverage for recognized transient codes, cause chains, and `AggregateError` wrappers. The change is isolated to infra-level unhandled rejection handling and does not affect other modules.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped, matches the stated incident/root cause, and is backed by a targeted regression test. The new logic only broadens transient classification for a specific undici error string and keeps existing cause-chain/aggregate handling intact.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->