### PR TITLE
fix: skip duplicate plugin id warning for bundled plugins

### DIFF
--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -162,12 +162,17 @@ export function loadPluginManifestRegistry(params: {
     }
 
     if (seenIds.has(manifest.id)) {
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
-      });
+      // Bundled plugins are lowest priority – silently skip the warning when a
+      // higher-priority origin (config / workspace / global) already registered
+      // the same id.  This avoids spurious warnings during onboarding (#14255).
+      if (candidate.origin !== "bundled") {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        });
+      }
     } else {
       seenIds.add(manifest.id);
     }


### PR DESCRIPTION
## Problem

During `openclaw onboard --install-daemon`, the feishu plugin triggers a spurious duplicate plugin ID warning because it is discovered both from a higher-priority origin (global/workspace extensions) and as a bundled plugin.

## Fix

When a duplicate plugin ID is detected and the candidate's origin is `bundled`, silently skip it instead of emitting a warning. Bundled plugins are lowest priority in the discovery order (config → workspace → global → bundled), so they should yield to any copy already registered from a higher-priority origin.

**7 lines changed, 0 lines removed.**

Closes #14255

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adjusts plugin manifest registry loading to suppress duplicate-plugin-id warnings when the *later* candidate is from the `bundled` origin.

In `src/plugins/manifest-registry.ts`, when a plugin id is already registered (`seenIds.has(manifest.id)`), the code now checks `candidate.origin === "bundled"` and silently skips that candidate instead of emitting a warning. This matches the discovery priority order implemented in `src/plugins/discovery.ts` (config → workspace → global → bundled), where bundled plugins are lowest priority and should yield to any higher-priority installation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to the duplicate-plugin-id warning path and is consistent with the existing discovery precedence (bundled candidates are appended last). It only suppresses warnings for bundled duplicates and does not affect higher-priority origins’ behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->