### PR TITLE
feat(gateway): add --harden flag for security-hardened mode

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -327,6 +327,45 @@ This is social engineering 101. Create distrust, encourage snooping.
 
 ## Configuration Hardening (examples)
 
+### Quick hardening: `--harden` flag
+
+For maximum security with minimal configuration, start the gateway with:
+
+```bash
+export OPENCLAW_GATEWAY_TOKEN="your-secure-token"
+openclaw gateway run --harden
+```
+
+This single flag automatically enforces:
+
+| Security Control          | What `--harden` Does                                                                                      |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Network binding**       | Forces loopback (127.0.0.1 only)                                                                          |
+| **Authentication**        | Requires token auth (`OPENCLAW_GATEWAY_TOKEN`)                                                            |
+| **TLS**                   | Forces enabled (auto-generates certs if needed)                                                           |
+| **Control UI**            | Disables `dangerouslyDisableDeviceAuth` and `allowInsecureAuth`                                           |
+| **Tool profile**          | Sets to `minimal`, clears `tools.allow` list                                                              |
+| **Dangerous tools**       | Blocks `exec`, `process`, `write`, `edit`, `apply_patch`, `gateway`, `cron`, `nodes`, `browser`, `canvas` |
+| **Elevated access**       | Disabled                                                                                                  |
+| **Agent-to-agent**        | Disabled                                                                                                  |
+| **Sandbox isolation**     | `network: "none"`, `readOnlyRoot: true`, `capDrop: ["ALL"]`                                               |
+| **Command blocking**      | Blocks dangerous patterns (`rm -rf`, `chmod 777`, pipe chains, etc.)                                      |
+| **Hot-reload protection** | Re-applies hardening when config file changes                                                             |
+
+**When to use:**
+
+- Running in untrusted environments
+- Exposing the gateway to external networks (even via Tailscale)
+- Multi-tenant or shared-host deployments
+- When you want defense-in-depth without manual config
+
+**Limitations:**
+
+- Command deny patterns use substring matching (defense-in-depth, not a complete sandbox)
+- Some legitimate workflows may be blocked; use manual config if you need granular control
+
+For granular control over individual settings, see the numbered sections below.
+
 ### 0) File permissions
 
 Keep config + state private on the gateway host:
@@ -564,7 +603,9 @@ We may add a single `readOnlyMode` flag later to simplify this configuration.
 
 ### 5) Secure baseline (copy/paste)
 
-One “safe default” config that keeps the Gateway private, requires DM pairing, and avoids always-on group bots:
+> **Tip:** For even stricter defaults with zero config, use `openclaw gateway run --harden` instead. See [Quick hardening](#quick-hardening---harden-flag) above.
+
+One "safe default" config that keeps the Gateway private, requires DM pairing, and avoids always-on group bots:
 
 ```json5
 {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -100,19 +100,19 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     // Force loopback bind (warn if user tried to override)
     if (opts.bind && opts.bind !== "loopback") {
       gatewayLog.warn(
-        `harden: ignoring --bind ${opts.bind}; hardened mode forces loopback binding`,
+        `harden: ignoring --bind ${String(opts.bind)}; hardened mode forces loopback binding`,
       );
     }
     // Force token auth mode
     if (opts.auth && opts.auth !== "token") {
       gatewayLog.warn(
-        `harden: ignoring --auth ${opts.auth}; hardened mode forces token authentication`,
+        `harden: ignoring --auth ${String(opts.auth)}; hardened mode forces token authentication`,
       );
     }
     // Warn about tailscale in hardened mode
     if (opts.tailscale && opts.tailscale !== "off") {
       gatewayLog.warn(
-        `harden: ignoring --tailscale ${opts.tailscale}; hardened mode disables external exposure`,
+        `harden: ignoring --tailscale ${String(opts.tailscale)}; hardened mode disables external exposure`,
       );
     }
   }

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -100,19 +100,19 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     // Force loopback bind (warn if user tried to override)
     if (opts.bind && opts.bind !== "loopback") {
       gatewayLog.warn(
-        `harden: ignoring --bind ${String(opts.bind)}; hardened mode forces loopback binding`,
+        `harden: ignoring --bind ${JSON.stringify(opts.bind)}; hardened mode forces loopback binding`,
       );
     }
     // Force token auth mode
     if (opts.auth && opts.auth !== "token") {
       gatewayLog.warn(
-        `harden: ignoring --auth ${String(opts.auth)}; hardened mode forces token authentication`,
+        `harden: ignoring --auth ${JSON.stringify(opts.auth)}; hardened mode forces token authentication`,
       );
     }
     // Warn about tailscale in hardened mode
     if (opts.tailscale && opts.tailscale !== "off") {
       gatewayLog.warn(
-        `harden: ignoring --tailscale ${String(opts.tailscale)}; hardened mode disables external exposure`,
+        `harden: ignoring --tailscale ${JSON.stringify(opts.tailscale)}; hardened mode disables external exposure`,
       );
     }
   }

--- a/src/gateway/harden-config.test.ts
+++ b/src/gateway/harden-config.test.ts
@@ -1,0 +1,569 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { applyHardenedConfigOverrides } from "./harden-config.js";
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => createMockLogger()),
+  } as unknown as ReturnType<typeof import("../logging/subsystem.js").createSubsystemLogger>;
+}
+
+describe("applyHardenedConfigOverrides", () => {
+  describe("TLS enforcement", () => {
+    it("forces TLS enabled when not configured", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.tls?.enabled).toBe(true);
+      expect(result.gateway?.tls?.autoGenerate).toBe(true);
+      expect(log.info).toHaveBeenCalledWith("harden: TLS forced enabled");
+    });
+
+    it("forces TLS enabled even when explicitly disabled", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          tls: {
+            enabled: false,
+            autoGenerate: false,
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.tls?.enabled).toBe(true);
+    });
+
+    it("preserves autoGenerate=false if user set it", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          tls: {
+            enabled: true,
+            autoGenerate: false,
+            certPath: "/custom/cert.pem",
+            keyPath: "/custom/key.pem",
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.tls?.enabled).toBe(true);
+      expect(result.gateway?.tls?.autoGenerate).toBe(false);
+      expect(result.gateway?.tls?.certPath).toBe("/custom/cert.pem");
+    });
+  });
+
+  describe("Control UI security", () => {
+    it("disables dangerouslyDisableDeviceAuth", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          controlUi: {
+            dangerouslyDisableDeviceAuth: true,
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.controlUi?.dangerouslyDisableDeviceAuth).toBe(false);
+    });
+
+    it("disables allowInsecureAuth", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          controlUi: {
+            allowInsecureAuth: true,
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.controlUi?.allowInsecureAuth).toBe(false);
+    });
+
+    it("disables both dangerous options when both are enabled", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          controlUi: {
+            dangerouslyDisableDeviceAuth: true,
+            allowInsecureAuth: true,
+            enabled: true,
+            basePath: "/custom",
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.controlUi?.dangerouslyDisableDeviceAuth).toBe(false);
+      expect(result.gateway?.controlUi?.allowInsecureAuth).toBe(false);
+      expect(result.gateway?.controlUi?.enabled).toBe(true);
+      expect(result.gateway?.controlUi?.basePath).toBe("/custom");
+      expect(log.info).toHaveBeenCalledWith("harden: dangerous Control UI overrides disabled");
+    });
+  });
+
+  describe("tool restrictions", () => {
+    it("sets profile to minimal", () => {
+      const cfg: OpenClawConfig = {
+        tools: {
+          profile: "standard",
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.tools?.profile).toBe("minimal");
+    });
+
+    it("adds dangerous tools to deny list", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      const denyList = result.tools?.deny ?? [];
+      expect(denyList).toContain("exec");
+      expect(denyList).toContain("process");
+      expect(denyList).toContain("write");
+      expect(denyList).toContain("edit");
+      expect(denyList).toContain("apply_patch");
+      expect(denyList).toContain("gateway");
+      expect(denyList).toContain("cron");
+      expect(denyList).toContain("nodes");
+      expect(denyList).toContain("browser");
+      expect(denyList).toContain("canvas");
+    });
+
+    it("merges with existing deny list (does not replace)", () => {
+      const cfg: OpenClawConfig = {
+        tools: {
+          deny: ["custom_dangerous_tool", "another_tool"],
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      const denyList = result.tools?.deny ?? [];
+      expect(denyList).toContain("custom_dangerous_tool");
+      expect(denyList).toContain("another_tool");
+      expect(denyList).toContain("exec");
+      expect(denyList).toContain("process");
+    });
+
+    it("disables elevated tool access", () => {
+      const cfg: OpenClawConfig = {
+        tools: {
+          elevated: {
+            enabled: true,
+            allowedTools: ["some_tool"],
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.tools?.elevated?.enabled).toBe(false);
+    });
+
+    it("disables agent-to-agent messaging", () => {
+      const cfg: OpenClawConfig = {
+        tools: {
+          agentToAgent: {
+            enabled: true,
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.tools?.agentToAgent?.enabled).toBe(false);
+    });
+
+    it("logs tool restriction message", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      applyHardenedConfigOverrides(cfg, log);
+
+      expect(log.info).toHaveBeenCalledWith(
+        "harden: tool profile set to minimal with restricted permissions",
+      );
+    });
+  });
+
+  describe("dangerous commands blocking", () => {
+    it("blocks data exfiltration commands", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      const denyCommands = result.gateway?.nodes?.denyCommands ?? [];
+      expect(denyCommands).toContain("camera.snap");
+      expect(denyCommands).toContain("camera.clip");
+      expect(denyCommands).toContain("screen.record");
+    });
+
+    it("blocks PII modification commands", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      const denyCommands = result.gateway?.nodes?.denyCommands ?? [];
+      expect(denyCommands).toContain("contacts.add");
+      expect(denyCommands).toContain("calendar.add");
+      expect(denyCommands).toContain("reminders.add");
+      expect(denyCommands).toContain("sms.send");
+    });
+
+    it("blocks dangerous shell patterns", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      const denyCommands = result.gateway?.nodes?.denyCommands ?? [];
+      expect(denyCommands).toContain("rm -rf");
+      expect(denyCommands).toContain("rm -fr");
+      expect(denyCommands).toContain("curl|");
+      expect(denyCommands).toContain("wget|");
+      expect(denyCommands).toContain("git push --force");
+      expect(denyCommands).toContain("git push -f");
+      expect(denyCommands).toContain("git reset --hard");
+      expect(denyCommands).toContain("mkfs");
+      expect(denyCommands).toContain("dd if=");
+      expect(denyCommands).toContain("chmod 777");
+      expect(denyCommands).toContain("nc -e");
+      expect(denyCommands).toContain("bash -i");
+    });
+
+    it("merges with existing denyCommands (does not replace)", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          nodes: {
+            denyCommands: ["custom_command", "another_blocked"],
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      const denyCommands = result.gateway?.nodes?.denyCommands ?? [];
+      expect(denyCommands).toContain("custom_command");
+      expect(denyCommands).toContain("another_blocked");
+      expect(denyCommands).toContain("rm -rf");
+    });
+
+    it("deduplicates merged denyCommands", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          nodes: {
+            denyCommands: ["rm -rf", "custom_command", "curl|"],
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      const denyCommands = result.gateway?.nodes?.denyCommands ?? [];
+      const rmRfCount = denyCommands.filter((cmd) => cmd === "rm -rf").length;
+      const curlCount = denyCommands.filter((cmd) => cmd === "curl|").length;
+      expect(rmRfCount).toBe(1);
+      expect(curlCount).toBe(1);
+    });
+
+    it("logs the count of blocked commands", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      applyHardenedConfigOverrides(cfg, log);
+
+      expect(log.info).toHaveBeenCalledWith(
+        expect.stringMatching(/harden: \d+ dangerous commands blocked/),
+      );
+    });
+  });
+
+  describe("sandbox isolation", () => {
+    it("sets network isolation to none", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.agents?.defaults?.sandbox?.docker?.network).toBe("none");
+    });
+
+    it("clears DNS and extraHosts", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: {
+              docker: {
+                dns: ["8.8.8.8", "1.1.1.1"],
+                extraHosts: ["host.docker.internal:host-gateway"],
+              },
+            },
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.agents?.defaults?.sandbox?.docker?.dns).toEqual([]);
+      expect(result.agents?.defaults?.sandbox?.docker?.extraHosts).toEqual([]);
+    });
+
+    it("sets readOnlyRoot to true", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: {
+              docker: {
+                readOnlyRoot: false,
+              },
+            },
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.agents?.defaults?.sandbox?.docker?.readOnlyRoot).toBe(true);
+    });
+
+    it("configures tmpfs mounts for writable directories", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      const tmpfs = result.agents?.defaults?.sandbox?.docker?.tmpfs ?? [];
+      expect(tmpfs).toContain("/tmp:size=100m,mode=1777");
+      expect(tmpfs).toContain("/var/tmp:size=50m,mode=1777");
+    });
+
+    it("drops all capabilities", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: {
+              docker: {
+                capDrop: ["NET_RAW"],
+                capAdd: ["SYS_ADMIN"],
+              },
+            },
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.agents?.defaults?.sandbox?.docker?.capDrop).toEqual(["ALL"]);
+    });
+
+    it("uses default resource limits when not configured", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.agents?.defaults?.sandbox?.docker?.memory).toBe("1g");
+      expect(result.agents?.defaults?.sandbox?.docker?.memorySwap).toBe("1g");
+      expect(result.agents?.defaults?.sandbox?.docker?.cpus).toBe(2);
+      expect(result.agents?.defaults?.sandbox?.docker?.pidsLimit).toBe(256);
+    });
+
+    it("preserves user-configured resource limits", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: {
+              docker: {
+                memory: "4g",
+                memorySwap: "8g",
+                cpus: 8,
+                pidsLimit: 1024,
+              },
+            },
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.agents?.defaults?.sandbox?.docker?.memory).toBe("4g");
+      expect(result.agents?.defaults?.sandbox?.docker?.memorySwap).toBe("8g");
+      expect(result.agents?.defaults?.sandbox?.docker?.cpus).toBe(8);
+      expect(result.agents?.defaults?.sandbox?.docker?.pidsLimit).toBe(1024);
+    });
+
+    it("logs sandbox isolation message", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      applyHardenedConfigOverrides(cfg, log);
+
+      expect(log.info).toHaveBeenCalledWith(
+        "harden: sandbox isolation enforced (network=none, readOnlyRoot, capDrop=ALL)",
+      );
+    });
+  });
+
+  describe("config preservation", () => {
+    it("preserves unrelated gateway config", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          bind: "lan",
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: "secret",
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.bind).toBe("lan");
+      expect(result.gateway?.mode).toBe("local");
+      expect(result.gateway?.auth?.mode).toBe("token");
+      expect(result.gateway?.auth?.token).toBe("secret");
+    });
+
+    it("preserves unrelated top-level config", () => {
+      const cfg: OpenClawConfig = {
+        models: {
+          default: "claude-3-opus",
+        },
+        skills: {
+          remote: {
+            enabled: true,
+          },
+        },
+        channels: {
+          discord: {
+            enabled: true,
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.models?.default).toBe("claude-3-opus");
+      expect(result.skills?.remote?.enabled).toBe(true);
+      expect(result.channels?.discord?.enabled).toBe(true);
+    });
+
+    it("returns a new object (does not mutate original)", () => {
+      const cfg: OpenClawConfig = {
+        gateway: {
+          tls: {
+            enabled: false,
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result).not.toBe(cfg);
+      expect(cfg.gateway?.tls?.enabled).toBe(false);
+      expect(result.gateway?.tls?.enabled).toBe(true);
+    });
+  });
+
+  describe("logging", () => {
+    it("logs all hardening steps", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      applyHardenedConfigOverrides(cfg, log);
+
+      expect(log.info).toHaveBeenCalledTimes(5);
+      expect(log.info).toHaveBeenCalledWith("harden: TLS forced enabled");
+      expect(log.info).toHaveBeenCalledWith("harden: dangerous Control UI overrides disabled");
+      expect(log.info).toHaveBeenCalledWith(
+        "harden: tool profile set to minimal with restricted permissions",
+      );
+      expect(log.info).toHaveBeenCalledWith(
+        expect.stringMatching(/harden: \d+ dangerous commands blocked/),
+      );
+      expect(log.info).toHaveBeenCalledWith(
+        "harden: sandbox isolation enforced (network=none, readOnlyRoot, capDrop=ALL)",
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty config", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.tls?.enabled).toBe(true);
+      expect(result.gateway?.controlUi?.dangerouslyDisableDeviceAuth).toBe(false);
+      expect(result.tools?.profile).toBe("minimal");
+      expect(result.agents?.defaults?.sandbox?.docker?.network).toBe("none");
+    });
+
+    it("handles undefined nested properties", () => {
+      const cfg: OpenClawConfig = {
+        gateway: undefined,
+        tools: undefined,
+        agents: undefined,
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.gateway?.tls?.enabled).toBe(true);
+      expect(result.tools?.profile).toBe("minimal");
+      expect(result.agents?.defaults?.sandbox?.docker?.network).toBe("none");
+    });
+
+    it("handles deeply nested undefined properties", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: undefined,
+          },
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.agents?.defaults?.sandbox?.docker?.network).toBe("none");
+      expect(result.agents?.defaults?.sandbox?.docker?.capDrop).toEqual(["ALL"]);
+    });
+  });
+});

--- a/src/gateway/harden-config.test.ts
+++ b/src/gateway/harden-config.test.ts
@@ -197,14 +197,49 @@ describe("applyHardenedConfigOverrides", () => {
       expect(result.tools?.agentToAgent?.enabled).toBe(false);
     });
 
-    it("logs tool restriction message", () => {
+    it("clears the allow list for defense in depth", () => {
+      const cfg: OpenClawConfig = {
+        tools: {
+          allow: ["exec", "process", "dangerous_tool", "custom_tool"],
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.tools?.allow).toEqual([]);
+    });
+
+    it("clears allow list even when empty", () => {
+      const cfg: OpenClawConfig = {
+        tools: {
+          allow: [],
+        },
+      };
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.tools?.allow).toEqual([]);
+    });
+
+    it("clears allow list when not configured", () => {
+      const cfg: OpenClawConfig = {};
+      const log = createMockLogger();
+
+      const result = applyHardenedConfigOverrides(cfg, log);
+
+      expect(result.tools?.allow).toEqual([]);
+    });
+
+    it("logs tool restriction message with cleared allow list", () => {
       const cfg: OpenClawConfig = {};
       const log = createMockLogger();
 
       applyHardenedConfigOverrides(cfg, log);
 
       expect(log.info).toHaveBeenCalledWith(
-        "harden: tool profile set to minimal with restricted permissions",
+        "harden: tool profile set to minimal with cleared allow list",
       );
     });
   });
@@ -511,7 +546,7 @@ describe("applyHardenedConfigOverrides", () => {
       expect(log.info).toHaveBeenCalledWith("harden: TLS forced enabled");
       expect(log.info).toHaveBeenCalledWith("harden: dangerous Control UI overrides disabled");
       expect(log.info).toHaveBeenCalledWith(
-        "harden: tool profile set to minimal with restricted permissions",
+        "harden: tool profile set to minimal with cleared allow list",
       );
       expect(log.info).toHaveBeenCalledWith(
         expect.stringMatching(/harden: \d+ dangerous commands blocked/),

--- a/src/gateway/harden-config.ts
+++ b/src/gateway/harden-config.ts
@@ -1,0 +1,140 @@
+import type { loadConfig } from "../config/config.js";
+import type { createSubsystemLogger } from "../logging/subsystem.js";
+
+/**
+ * Default dangerous commands to block in hardened mode.
+ * These commands can exfiltrate data, modify contacts/calendar, or access camera/screen.
+ */
+const HARDENED_DENY_COMMANDS = [
+  // Data exfiltration risks
+  "camera.snap",
+  "camera.clip",
+  "screen.record",
+  // PII modification risks
+  "contacts.add",
+  "calendar.add",
+  "reminders.add",
+  "sms.send",
+  // Dangerous shell patterns (for node.invoke)
+  "rm -rf",
+  "rm -fr",
+  "curl|",
+  "wget|",
+  "git push --force",
+  "git push -f",
+  "git reset --hard",
+  "mkfs",
+  "dd if=",
+  "chmod 777",
+  "nc -e",
+  "bash -i",
+];
+
+/**
+ * Applies security-hardened configuration overrides.
+ * This mutates the config to enforce strict security defaults.
+ */
+export function applyHardenedConfigOverrides(
+  cfg: ReturnType<typeof loadConfig>,
+  log: ReturnType<typeof createSubsystemLogger>,
+): ReturnType<typeof loadConfig> {
+  const hardened = { ...cfg };
+
+  // 1. Force TLS enabled
+  hardened.gateway = {
+    ...hardened.gateway,
+    tls: {
+      ...hardened.gateway?.tls,
+      enabled: true,
+      autoGenerate: hardened.gateway?.tls?.autoGenerate ?? true,
+    },
+  };
+  log.info("harden: TLS forced enabled");
+
+  // 2. Disable dangerous Control UI overrides
+  hardened.gateway = {
+    ...hardened.gateway,
+    controlUi: {
+      ...hardened.gateway?.controlUi,
+      dangerouslyDisableDeviceAuth: false,
+      allowInsecureAuth: false,
+    },
+  };
+  log.info("harden: dangerous Control UI overrides disabled");
+
+  // 3. Apply restricted tool profile (minimal)
+  hardened.tools = {
+    ...hardened.tools,
+    profile: "minimal",
+    // Explicitly deny dangerous tools
+    deny: [
+      ...(hardened.tools?.deny ?? []),
+      "exec",
+      "process",
+      "write",
+      "edit",
+      "apply_patch",
+      "gateway",
+      "cron",
+      "nodes",
+      "browser",
+      "canvas",
+    ],
+    // Disable elevated tool access
+    elevated: {
+      ...hardened.tools?.elevated,
+      enabled: false,
+    },
+    // Disable agent-to-agent messaging
+    agentToAgent: {
+      ...hardened.tools?.agentToAgent,
+      enabled: false,
+    },
+  };
+  log.info("harden: tool profile set to minimal with restricted permissions");
+
+  // 4. Block dangerous commands
+  const existingDenyCommands = hardened.gateway?.nodes?.denyCommands ?? [];
+  const mergedDenyCommands = Array.from(
+    new Set([...existingDenyCommands, ...HARDENED_DENY_COMMANDS]),
+  );
+  hardened.gateway = {
+    ...hardened.gateway,
+    nodes: {
+      ...hardened.gateway?.nodes,
+      denyCommands: mergedDenyCommands,
+    },
+  };
+  log.info(`harden: ${mergedDenyCommands.length} dangerous commands blocked`);
+
+  // 5. Enforce strict sandbox settings
+  hardened.agents = {
+    ...hardened.agents,
+    defaults: {
+      ...hardened.agents?.defaults,
+      sandbox: {
+        ...hardened.agents?.defaults?.sandbox,
+        docker: {
+          ...hardened.agents?.defaults?.sandbox?.docker,
+          // Network isolation
+          network: "none",
+          dns: [],
+          extraHosts: [],
+          // Filesystem protection
+          readOnlyRoot: true,
+          tmpfs: ["/tmp:size=100m,mode=1777", "/var/tmp:size=50m,mode=1777"],
+          // Capability restrictions
+          capDrop: ["ALL"],
+          // Resource limits
+          memory: hardened.agents?.defaults?.sandbox?.docker?.memory ?? "1g",
+          memorySwap: hardened.agents?.defaults?.sandbox?.docker?.memorySwap ?? "1g",
+          cpus: hardened.agents?.defaults?.sandbox?.docker?.cpus ?? 2,
+          pidsLimit: hardened.agents?.defaults?.sandbox?.docker?.pidsLimit ?? 256,
+        },
+      },
+    },
+  };
+  log.info("harden: sandbox isolation enforced (network=none, readOnlyRoot, capDrop=ALL)");
+
+  return hardened;
+}

--- a/src/gateway/harden-config.ts
+++ b/src/gateway/harden-config.ts
@@ -66,6 +66,10 @@ export function applyHardenedConfigOverrides(
   hardened.tools = {
     ...hardened.tools,
     profile: "minimal",
+    // Explicitly clear allow list - defense in depth
+    // Even though deny list blocks dangerous tools, clearing allow prevents
+    // user-configured allow lists from enabling tools outside the minimal profile
+    allow: [],
     // Explicitly deny dangerous tools
     deny: [
       ...(hardened.tools?.deny ?? []),
@@ -91,7 +95,7 @@ export function applyHardenedConfigOverrides(
       enabled: false,
     },
   };
-  log.info("harden: tool profile set to minimal with restricted permissions");
+  log.info("harden: tool profile set to minimal with cleared allow list");
 
   // 4. Block dangerous commands
   const existingDenyCommands = hardened.gateway?.nodes?.denyCommands ?? [];

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -92,7 +92,7 @@ describe("createGatewayReloadHandlers", () => {
       const { applyHotReload } = createGatewayReloadHandlers({
         deps: createMockDeps(),
         broadcast: vi.fn(),
-        getState: () => mockState as ReturnType<typeof createMockState>,
+        getState: () => mockState,
         setState: vi.fn(),
         startChannel: vi.fn().mockResolvedValue(undefined),
         stopChannel: vi.fn().mockResolvedValue(undefined),
@@ -141,7 +141,7 @@ describe("createGatewayReloadHandlers", () => {
       const { applyHotReload } = createGatewayReloadHandlers({
         deps: createMockDeps(),
         broadcast: vi.fn(),
-        getState: () => mockState as ReturnType<typeof createMockState>,
+        getState: () => mockState,
         setState: vi.fn(),
         startChannel: vi.fn().mockResolvedValue(undefined),
         stopChannel: vi.fn().mockResolvedValue(undefined),
@@ -174,7 +174,7 @@ describe("createGatewayReloadHandlers", () => {
       const { applyHotReload } = createGatewayReloadHandlers({
         deps: createMockDeps(),
         broadcast: vi.fn(),
-        getState: () => mockState as ReturnType<typeof createMockState>,
+        getState: () => mockState,
         setState: vi.fn(),
         startChannel: vi.fn().mockResolvedValue(undefined),
         stopChannel: vi.fn().mockResolvedValue(undefined),
@@ -224,7 +224,7 @@ describe("createGatewayReloadHandlers", () => {
       const { applyHotReload } = createGatewayReloadHandlers({
         deps: createMockDeps(),
         broadcast: vi.fn(),
-        getState: () => mockState as ReturnType<typeof createMockState>,
+        getState: () => mockState,
         setState: vi.fn(),
         startChannel: vi.fn().mockResolvedValue(undefined),
         stopChannel: vi.fn().mockResolvedValue(undefined),
@@ -257,7 +257,7 @@ describe("createGatewayReloadHandlers", () => {
       const { applyHotReload } = createGatewayReloadHandlers({
         deps: createMockDeps(),
         broadcast: vi.fn(),
-        getState: () => mockState as ReturnType<typeof createMockState>,
+        getState: () => mockState,
         setState: vi.fn(),
         startChannel: vi.fn().mockResolvedValue(undefined),
         stopChannel: vi.fn().mockResolvedValue(undefined),
@@ -297,7 +297,7 @@ describe("createGatewayReloadHandlers", () => {
       const { requestGatewayRestart } = createGatewayReloadHandlers({
         deps: createMockDeps(),
         broadcast: vi.fn(),
-        getState: () => mockState as ReturnType<typeof createMockState>,
+        getState: () => mockState,
         setState: vi.fn(),
         startChannel: vi.fn().mockResolvedValue(undefined),
         stopChannel: vi.fn().mockResolvedValue(undefined),

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayReloadPlan } from "./config-reload.js";
+import { createGatewayReloadHandlers } from "./server-reload-handlers.js";
+
+// Mock dependencies that have side effects
+vi.mock("../infra/restart.js", () => ({
+  setGatewaySigusr1RestartPolicy: vi.fn(),
+  authorizeGatewaySigusr1Restart: vi.fn(),
+}));
+
+vi.mock("../infra/outbound/target-resolver.js", () => ({
+  resetDirectoryCache: vi.fn(),
+}));
+
+vi.mock("../process/command-queue.js", () => ({
+  setCommandLaneConcurrency: vi.fn(),
+}));
+
+vi.mock("../process/lanes.js", () => ({
+  CommandLane: { Cron: "cron", Main: "main", Subagent: "subagent" },
+}));
+
+vi.mock("../config/agent-limits.js", () => ({
+  resolveAgentMaxConcurrent: vi.fn().mockReturnValue(1),
+  resolveSubagentMaxConcurrent: vi.fn().mockReturnValue(1),
+}));
+
+vi.mock("./hooks.js", () => ({
+  resolveHooksConfig: vi.fn().mockReturnValue({}),
+}));
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => createMockLogger()),
+  } as unknown as ReturnType<typeof import("../logging/subsystem.js").createSubsystemLogger>;
+}
+
+function createMinimalReloadPlan(): GatewayReloadPlan {
+  return {
+    changedPaths: [],
+    restartGateway: false,
+    restartReasons: [],
+    hotReasons: [],
+    reloadHooks: false,
+    restartGmailWatcher: false,
+    restartBrowserControl: false,
+    restartCron: false,
+    restartHeartbeat: false,
+    restartChannels: new Set(),
+    noopPaths: [],
+  };
+}
+
+function createMockDeps() {
+  return {} as ReturnType<typeof import("../cli/deps.js").createDefaultDeps>;
+}
+
+function createMockState() {
+  return {
+    hooksConfig: {},
+    heartbeatRunner: { updateConfig: vi.fn(), stop: vi.fn() },
+    cronState: {
+      cron: { start: vi.fn().mockResolvedValue(undefined), stop: vi.fn() },
+      storePath: "/tmp/cron",
+    },
+    browserControl: null,
+  };
+}
+
+describe("createGatewayReloadHandlers", () => {
+  let mockState: ReturnType<typeof createMockState>;
+
+  beforeEach(() => {
+    mockState = createMockState();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("applyHotReload with hardenMode", () => {
+    it("re-applies hardening overrides when hardenMode is true", async () => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      const logHarden = createMockLogger();
+
+      const { applyHotReload } = createGatewayReloadHandlers({
+        deps: createMockDeps(),
+        broadcast: vi.fn(),
+        getState: () => mockState as ReturnType<typeof createMockState>,
+        setState: vi.fn(),
+        startChannel: vi.fn().mockResolvedValue(undefined),
+        stopChannel: vi.fn().mockResolvedValue(undefined),
+        logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        logBrowser: { error: vi.fn() },
+        logChannels: { info: vi.fn(), error: vi.fn() },
+        logCron: { error: vi.fn() },
+        logReload,
+        hardenMode: true,
+        logHarden,
+      });
+
+      // Config with dangerous settings that should be overridden by hardening
+      const insecureConfig: OpenClawConfig = {
+        gateway: {
+          tls: { enabled: false },
+          controlUi: {
+            dangerouslyDisableDeviceAuth: true,
+            allowInsecureAuth: true,
+          },
+        },
+        tools: {
+          profile: "standard",
+          elevated: { enabled: true },
+        },
+      };
+
+      const plan = createMinimalReloadPlan();
+      await applyHotReload(plan, insecureConfig);
+
+      // Verify hardening was re-applied (logged)
+      expect(logReload.info).toHaveBeenCalledWith(
+        "harden: re-applying security overrides to hot-reloaded config",
+      );
+
+      // Verify the hardening function logged its actions
+      expect(logHarden.info).toHaveBeenCalledWith("harden: TLS forced enabled");
+      expect(logHarden.info).toHaveBeenCalledWith(
+        "harden: dangerous Control UI overrides disabled",
+      );
+    });
+
+    it("does not apply hardening when hardenMode is false", async () => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+
+      const { applyHotReload } = createGatewayReloadHandlers({
+        deps: createMockDeps(),
+        broadcast: vi.fn(),
+        getState: () => mockState as ReturnType<typeof createMockState>,
+        setState: vi.fn(),
+        startChannel: vi.fn().mockResolvedValue(undefined),
+        stopChannel: vi.fn().mockResolvedValue(undefined),
+        logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        logBrowser: { error: vi.fn() },
+        logChannels: { info: vi.fn(), error: vi.fn() },
+        logCron: { error: vi.fn() },
+        logReload,
+        hardenMode: false,
+      });
+
+      const insecureConfig: OpenClawConfig = {
+        gateway: {
+          tls: { enabled: false },
+        },
+      };
+
+      const plan = createMinimalReloadPlan();
+      await applyHotReload(plan, insecureConfig);
+
+      // Verify hardening was NOT applied
+      expect(logReload.info).not.toHaveBeenCalledWith(
+        "harden: re-applying security overrides to hot-reloaded config",
+      );
+    });
+
+    it("does not apply hardening when hardenMode is true but logHarden is not provided", async () => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+
+      const { applyHotReload } = createGatewayReloadHandlers({
+        deps: createMockDeps(),
+        broadcast: vi.fn(),
+        getState: () => mockState as ReturnType<typeof createMockState>,
+        setState: vi.fn(),
+        startChannel: vi.fn().mockResolvedValue(undefined),
+        stopChannel: vi.fn().mockResolvedValue(undefined),
+        logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        logBrowser: { error: vi.fn() },
+        logChannels: { info: vi.fn(), error: vi.fn() },
+        logCron: { error: vi.fn() },
+        logReload,
+        hardenMode: true,
+        // logHarden intentionally not provided
+      });
+
+      const insecureConfig: OpenClawConfig = {
+        gateway: {
+          tls: { enabled: false },
+        },
+      };
+
+      const plan = createMinimalReloadPlan();
+      await applyHotReload(plan, insecureConfig);
+
+      // Verify hardening was NOT applied (because logHarden is required)
+      expect(logReload.info).not.toHaveBeenCalledWith(
+        "harden: re-applying security overrides to hot-reloaded config",
+      );
+    });
+
+    it("applies hardening before processing other reload actions", async () => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      const logHarden = createMockLogger();
+      const logHooks = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      // Track call order
+      const callOrder: string[] = [];
+      logReload.info = vi.fn((msg: string) => {
+        if (msg.includes("harden: re-applying")) {
+          callOrder.push("harden");
+        }
+      });
+
+      const { resolveHooksConfig } = await import("./hooks.js");
+      (resolveHooksConfig as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callOrder.push("resolveHooksConfig");
+        return {};
+      });
+
+      const { applyHotReload } = createGatewayReloadHandlers({
+        deps: createMockDeps(),
+        broadcast: vi.fn(),
+        getState: () => mockState as ReturnType<typeof createMockState>,
+        setState: vi.fn(),
+        startChannel: vi.fn().mockResolvedValue(undefined),
+        stopChannel: vi.fn().mockResolvedValue(undefined),
+        logHooks,
+        logBrowser: { error: vi.fn() },
+        logChannels: { info: vi.fn(), error: vi.fn() },
+        logCron: { error: vi.fn() },
+        logReload,
+        hardenMode: true,
+        logHarden,
+      });
+
+      const plan = createMinimalReloadPlan();
+      plan.reloadHooks = true;
+
+      await applyHotReload(plan, {});
+
+      // Hardening should happen before hooks resolution
+      expect(callOrder[0]).toBe("harden");
+      expect(callOrder[1]).toBe("resolveHooksConfig");
+    });
+
+    it("passes hardened config to downstream reload operations", async () => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      const logHarden = createMockLogger();
+
+      const updateConfigSpy = vi.fn();
+      mockState.heartbeatRunner.updateConfig = updateConfigSpy;
+
+      const { applyHotReload } = createGatewayReloadHandlers({
+        deps: createMockDeps(),
+        broadcast: vi.fn(),
+        getState: () => mockState as ReturnType<typeof createMockState>,
+        setState: vi.fn(),
+        startChannel: vi.fn().mockResolvedValue(undefined),
+        stopChannel: vi.fn().mockResolvedValue(undefined),
+        logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        logBrowser: { error: vi.fn() },
+        logChannels: { info: vi.fn(), error: vi.fn() },
+        logCron: { error: vi.fn() },
+        logReload,
+        hardenMode: true,
+        logHarden,
+      });
+
+      // Config that would have TLS disabled
+      const insecureConfig: OpenClawConfig = {
+        gateway: {
+          tls: { enabled: false },
+        },
+      };
+
+      const plan = createMinimalReloadPlan();
+      plan.restartHeartbeat = true;
+
+      await applyHotReload(plan, insecureConfig);
+
+      // Verify heartbeatRunner received the hardened config (with TLS enabled)
+      expect(updateConfigSpy).toHaveBeenCalledTimes(1);
+      const passedConfig = updateConfigSpy.mock.calls[0][0];
+      expect(passedConfig.gateway?.tls?.enabled).toBe(true);
+    });
+  });
+
+  describe("requestGatewayRestart", () => {
+    it("does not apply hardening (restart will re-apply at startup)", async () => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      const logHarden = createMockLogger();
+
+      const { requestGatewayRestart } = createGatewayReloadHandlers({
+        deps: createMockDeps(),
+        broadcast: vi.fn(),
+        getState: () => mockState as ReturnType<typeof createMockState>,
+        setState: vi.fn(),
+        startChannel: vi.fn().mockResolvedValue(undefined),
+        stopChannel: vi.fn().mockResolvedValue(undefined),
+        logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        logBrowser: { error: vi.fn() },
+        logChannels: { info: vi.fn(), error: vi.fn() },
+        logCron: { error: vi.fn() },
+        logReload,
+        hardenMode: true,
+        logHarden,
+      });
+
+      const plan = createMinimalReloadPlan();
+      plan.restartGateway = true;
+      plan.restartReasons = ["gateway.port"];
+
+      // requestGatewayRestart should not call harden (restart handles it)
+      requestGatewayRestart(plan, {});
+
+      // Hardening function should NOT be called during restart request
+      expect(logHarden.info).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -27,6 +27,8 @@ export type GatewayRuntimeConfig = {
   tailscaleMode: "off" | "serve" | "funnel";
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
   canvasHostEnabled: boolean;
+  /** Whether hardened mode is active */
+  hardenMode: boolean;
 };
 
 export async function resolveGatewayRuntimeConfig(params: {
@@ -39,6 +41,8 @@ export async function resolveGatewayRuntimeConfig(params: {
   openResponsesEnabled?: boolean;
   auth?: GatewayAuthConfig;
   tailscale?: GatewayTailscaleConfig;
+  /** Apply security-hardened defaults */
+  harden?: boolean;
 }): Promise<GatewayRuntimeConfig> {
   const bindMode = params.bind ?? params.cfg.gateway?.bind ?? "loopback";
   const customBindHost = params.cfg.gateway?.customBindHost;
@@ -116,5 +120,6 @@ export async function resolveGatewayRuntimeConfig(params: {
     tailscaleMode,
     hooksConfig,
     canvasHostEnabled,
+    hardenMode: Boolean(params.harden),
   };
 }

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -12,6 +12,7 @@ export function logGatewayStartup(params: {
   tlsEnabled?: boolean;
   log: { info: (msg: string, meta?: Record<string, unknown>) => void };
   isNixMode: boolean;
+  hardenMode?: boolean;
 }) {
   const { provider: agentProvider, model: agentModel } = resolveConfiguredModelRef({
     cfg: params.cfg,
@@ -36,5 +37,11 @@ export function logGatewayStartup(params: {
   params.log.info(`log file: ${getResolvedLoggerSettings().file}`);
   if (params.isNixMode) {
     params.log.info("gateway: running in Nix mode (config managed externally)");
+  }
+  if (params.hardenMode) {
+    params.log.info(
+      "security: hardened mode active (loopback only, token auth required, TLS enabled)",
+      { consoleMessage: chalk.green("security: hardened mode active") },
+    );
   }
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -600,6 +600,8 @@ export async function startGatewayServer(
     logChannels,
     logCron,
     logReload,
+    hardenMode,
+    logHarden: hardenMode ? log : undefined,
   });
 
   const configReloader = startGatewayConfigReloader({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -150,6 +150,13 @@ export type GatewayServerOptions = {
     runtime: import("../runtime.js").RuntimeEnv,
     prompter: import("../wizard/prompts.js").WizardPrompter,
   ) => Promise<void>;
+  /**
+   * Apply security-hardened defaults:
+   * - Force TLS enabled
+   * - Disable dangerous Control UI overrides
+   * - Enforce stricter default tool restrictions
+   */
+  harden?: boolean;
 };
 
 export async function startGatewayServer(
@@ -253,6 +260,7 @@ export async function startGatewayServer(
     openResponsesEnabled: opts.openResponsesEnabled,
     auth: opts.auth,
     tailscale: opts.tailscale,
+    harden: opts.harden,
   });
   const {
     bindHost,
@@ -265,6 +273,7 @@ export async function startGatewayServer(
     resolvedAuth,
     tailscaleConfig,
     tailscaleMode,
+    hardenMode,
   } = runtimeConfig;
   let hooksConfig = runtimeConfig.hooksConfig;
   const canvasHostEnabled = runtimeConfig.canvasHostEnabled;
@@ -535,6 +544,7 @@ export async function startGatewayServer(
     tlsEnabled: gatewayTls.enabled,
     log,
     isNixMode,
+    hardenMode,
   });
   scheduleGatewayUpdateCheck({ cfg: cfgAtStart, log, isNixMode });
   const tailscaleCleanup = await startGatewayTailscaleExposure({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -44,6 +44,7 @@ import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js
 import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { applyHardenedConfigOverrides } from "./harden-config.js";
 import { NodeRegistry } from "./node-registry.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
@@ -224,7 +225,14 @@ export async function startGatewayServer(
     }
   }
 
-  const cfgAtStart = loadConfig();
+  let cfgAtStart = loadConfig();
+
+  // Apply security hardening overrides when hardenMode is active
+  if (opts.harden) {
+    log.info("harden: applying security-hardened configuration overrides");
+    cfgAtStart = applyHardenedConfigOverrides(cfgAtStart, log);
+  }
+
   const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();


### PR DESCRIPTION
## Summary

Adds a `--harden` CLI flag to the gateway run command that applies comprehensive security hardening.

## What it does

When `--harden` is passed:

### 1. Gateway Binding & Auth (CLI layer)
- Forces bind mode to **loopback** (127.0.0.1 only)
- Forces auth mode to **token** (requires OPENCLAW_GATEWAY_TOKEN)
- Disables **Tailscale exposure** completely

### 2. TLS Enforcement
- Forces `gateway.tls.enabled: true`
- Auto-generates self-signed certs if none configured

### 3. Control UI Security
- Forces `controlUi.dangerouslyDisableDeviceAuth: false`
- Forces `controlUi.allowInsecureAuth: false`

### 4. Tool Restrictions
- Sets `tools.profile: "minimal"`
- **Clears `tools.allow` list** - prevents user-configured allow lists from bypassing restrictions
- Denies dangerous tools: `exec`, `process`, `write`, `edit`, `apply_patch`, `gateway`, `cron`, `nodes`, `browser`, `canvas`
- Disables `tools.elevated.enabled`
- Disables `tools.agentToAgent.enabled`

### 5. Command Blocking
Blocks dangerous commands via `nodes.denyCommands`:
- Data exfiltration: `camera.snap`, `camera.clip`, `screen.record`
- PII modification: `contacts.add`, `calendar.add`, `reminders.add`, `sms.send`
- Shell dangers: `rm -rf`, `curl|`, `wget|`, `git push --force`, `mkfs`, `dd if=`, `chmod 777`, `nc -e`, `bash -i`

### 6. Sandbox Isolation
- `network: "none"` (complete network isolation)
- `readOnlyRoot: true`
- `capDrop: ["ALL"]`
- `tmpfs` for /tmp and /var/tmp only
- Resource limits: memory, cpus, pidsLimit

### 7. Hot-Reload Protection
- Hardening overrides are **re-applied** on config hot-reload
- Prevents attackers from bypassing security by modifying config files at runtime

## Usage

```bash
openclaw gateway run --harden
```

## Files Changed

- `src/cli/gateway-cli/run.ts` - Added `--harden` flag and CLI-level enforcement
- `src/gateway/harden-config.ts` - **NEW** - `applyHardenedConfigOverrides()` function
- `src/gateway/harden-config.test.ts` - **NEW** - 36 unit tests for hardening function
- `src/gateway/server.impl.ts` - Apply hardened config when flag is set
- `src/gateway/server-runtime-config.ts` - Pass through hardenMode
- `src/gateway/server-startup-log.ts` - Log hardened mode status
- `src/gateway/server-reload-handlers.ts` - Re-apply hardening on hot-reload
- `src/gateway/server-reload-handlers.test.ts` - **NEW** - 6 unit tests for hot-reload hardening
- `docs/gateway/security/index.md` - **UPDATED** - Added `--harden` flag documentation

## Test plan

- [x] Unit tests added for `applyHardenedConfigOverrides()` (36 tests)
  - TLS enforcement (3 tests)
  - Control UI security (3 tests)
  - Tool restrictions (9 tests) - includes allow list clearing
  - Dangerous commands blocking (6 tests)
  - Sandbox isolation (8 tests)
  - Config preservation (3 tests)
  - Logging verification (1 test)
  - Edge cases (3 tests)
- [x] Unit tests added for hot-reload hardening (6 tests)
  - Re-applies hardening when hardenMode is true
  - Does not apply hardening when hardenMode is false
  - Applies hardening before other reload actions
  - Passes hardened config to downstream operations
- [x] Run `openclaw gateway run --harden` and verify all settings applied
  - Verified: Gateway listens on `wss://127.0.0.1:18789`
- [x] Verify TLS is enabled
  - Verified: URL uses `wss://` (WebSocket Secure)
- [x] Verify loopback binding
  - Verified: Bound to `127.0.0.1` only
- [x] Verify dangerous tools are blocked
  - Verified via unit tests: deny list includes exec, process, write, edit, etc.
- [x] Verify sandbox has network isolation
  - Verified via unit tests: network=none, dns=[], extraHosts=[]
- [x] Documentation updated
  - Added "Quick hardening: `--harden` flag" section to security docs

## Security Review

A differential security review was performed. Key findings:
- **Resolved:** Unit tests added for critical security function
- **Resolved:** Hot-reload now re-applies hardening (config-based bypass prevented)
- **Resolved:** `tools.allow` list now explicitly cleared (defense in depth)
- **Medium:** Command deny patterns use substring matching (defense-in-depth, documented limitation)

## AI-Assisted Development

- [x] Mark as AI-assisted (Claude Opus 4.5)
- [x] I understand what the code does

🤖 Generated with [Claude Code](https://claude.com/claude-code)