### PR TITLE
fix(agents): use AbortController for venice model discovery timeout

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -334,9 +334,11 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
     return VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
   }
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
   try {
     const response = await fetch(`${VENICE_BASE_URL}/models`, {
-      signal: AbortSignal.timeout(5000),
+      signal: controller.signal,
     });
 
     if (!response.ok) {
@@ -389,5 +391,7 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
   } catch (error) {
     console.warn(`[venice-models] Discovery failed: ${String(error)}, using static catalog`);
     return VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
+  } finally {
+    clearTimeout(timeout);
   }
 }


### PR DESCRIPTION
## Summary

Ref #14281

Replace `AbortSignal.timeout()` with manual `AbortController` + `setTimeout` and `clearTimeout` in `finally` block. This ensures the timeout is properly cleaned up, preventing potential unhandled promise rejections during gateway startup.

## Change

1 file, +5/-1 lines.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Venice model discovery (`src/agents/venice-models.ts`) to avoid `AbortSignal.timeout()` by introducing a manual `AbortController` plus `setTimeout`, then clearing the timeout in a `finally` block. This keeps the discovery fetch bounded while ensuring the timer is always cleaned up, and preserves the existing fallback behavior to the static `VENICE_MODEL_CATALOG` when discovery fails.

This function is used when building the Venice provider (`src/agents/models-config.providers.ts`), so the change affects gateway/provider startup behavior when Venice model discovery is attempted.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and localized to Venice model discovery; the new AbortController timeout is correctly cleared in a finally block and preserves existing fallback behavior on failure.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->