### PR TITLE
fix: preserve session overrides (verbose, model) across /new or /rese…

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -237,6 +237,15 @@ export async function initSessionState(params: {
     isNewSession = true;
     systemSent = false;
     abortedLastRun = false;
+
+    if (resetTriggered && entry) {
+      persistedThinking = entry.thinkingLevel;
+      persistedVerbose = entry.verboseLevel;
+      persistedReasoning = entry.reasoningLevel;
+      persistedTtsAuto = entry.ttsAuto;
+      persistedModelOverride = entry.modelOverride;
+      persistedProviderOverride = entry.providerOverride;
+    }
   }
 
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;


### PR DESCRIPTION
…t resets

Fixes #10787. Ensures thinkingLevel, verboseLevel, reasoningLevel, ttsAuto, modelOverride, and providerOverride are inherited when a session is explicitly reset via triggers like /new.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `initSessionState` to preserve per-session override fields (thinking/verbose/reasoning, TTS auto, and model/provider overrides) when a session is explicitly reset via configured triggers like `/new`, and adds a regression test ensuring `verboseLevel` and `modelOverride` carry forward while generating a new `sessionId`.

The logic fits into the session initialization path by capturing override fields from the prior `SessionEntry` during reset-triggered new-session creation, then reapplying them when building the new `sessionEntry` that’s written back to the session store.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing the reset/override authorization edge case noted in the review comment.
- The change is small and covered by a targeted test, but the interaction between reset authorization and override persistence needs tightening to avoid preserving overrides across non-command session resets (e.g., staleness-driven new sessions) if that’s not intended.
- src/auto-reply/reply/session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->