### PR TITLE
fix(slack): change default replyToMode from "off" to "all"

### DIFF
--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -112,7 +112,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
   const reactionMode = slackCfg.reactionNotifications ?? "own";
   const reactionAllowlist = slackCfg.reactionAllowlist ?? [];
-  const replyToMode = slackCfg.replyToMode ?? "off";
+  const replyToMode = slackCfg.replyToMode ?? "all";
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);


### PR DESCRIPTION
## Summary

- Changes the default value of `replyToMode` in the Slack monitor provider from `"off"` to `"all"` so that bot responses are always threaded replies instead of new top-level messages.

### Why

The previous default (`"off"`) caused all bot responses to appear as new messages rather than threaded replies. This led to:
- Poor message organisation — unrelated conversations cluttered the channel/DM
- Bloated sessions — independent questions were merged into a single session, mixing unrelated context
- Excessive token usage — longer sessions meant more tokens consumed with increasingly irrelevant context

Setting the default to `"all"` ensures each message is replied to in the same thread, giving each thread its own session. This improves organisation, keeps sessions focused, and reduces token consumption. It also aligns Slack reply behaviour with other channel integrations.

Users who prefer the old behaviour can still explicitly set `replyToMode: "off"` in their Slack configuration.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm check` (format, typecheck, lint) — passes, 0 warnings, 0 errors
- [x] `pnpm test` — all 267 tests pass across 44 test files
- [ ] Manual verification: deploy with default config and confirm Slack bot replies in-thread

---

*AI-assisted PR (Cursor + Claude) — lightly tested locally, fully tested via CI-equivalent checks.*

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Slack monitor provider’s default `replyToMode` from `"off"` to `"all"` in `src/slack/monitor/provider.ts`, so that (when users don’t explicitly configure a mode) bot replies are posted as threaded replies rather than new top-level messages. The value is passed into `createSlackMonitorContext`, which is then used by the Slack message handling/event registration flow (`createSlackMessageHandler`, `registerSlackMonitorEvents`, `registerSlackMonitorSlashCommands`) to determine reply behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line default-value update, and the new default is only applied when users have not set `replyToMode`. No other logic paths are modified, and there are no apparent type/runtime hazards introduced in the changed file context.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->