### PR TITLE
feat(telegram): add message read via inbound message store

### DIFF
--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -84,10 +84,12 @@ Name lookup:
   - Optional: `--limit`
 
 - `read`
-  - Channels: Discord/Slack
+  - Channels: Discord/Slack/Telegram
   - Required: `--target`
   - Optional: `--limit`, `--before`, `--after`
-  - Discord only: `--around`
+  - Discord only: `--around`, `--offset`
+  - Telegram: `--target` must be a numeric chat ID; reads from the inbound message store (messages received while the bot is running, up to 24h / ~200 per chat); `--before` and `--after` filter by message_id
+  - Requires `actions.messages: true` in Telegram config
 
 - `edit`
   - Channels: Discord/Slack

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -12,6 +12,7 @@ import {
   deleteMessageTelegram,
   editMessageTelegram,
   reactMessageTelegram,
+  readMessagesTelegram,
   sendMessageTelegram,
   sendStickerTelegram,
 } from "../../telegram/send.js";
@@ -367,6 +368,30 @@ export async function handleTelegramAction(
       topicId: result.topicId,
       name: result.name,
       chatId: result.chatId,
+    });
+  }
+
+  if (action === "read" || action === "readMessages") {
+    if (!isActionEnabled("messages")) {
+      throw new Error("Telegram message reads are disabled.");
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const limit = readNumberParam(params, "limit", { integer: true });
+    const before = readNumberParam(params, "before", { integer: true });
+    const after = readNumberParam(params, "after", { integer: true });
+    const messages = readMessagesTelegram(chatId ?? "", {
+      limit: limit ?? undefined,
+      before: before ?? undefined,
+      after: after ?? undefined,
+    });
+    return jsonResult({
+      ok: true,
+      count: messages.length,
+      messages,
+      source: "inbound-store",
+      note: "Only messages received while the bot is running (up to 24h, ~200 per chat).",
     });
   }
 

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -72,6 +72,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (gate("createForumTopic")) {
       actions.add("topic-create");
     }
+    if (gate("messages")) {
+      actions.add("read");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -182,6 +185,27 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           fileId,
           replyToMessageId: replyToMessageId ?? undefined,
           messageThreadId: messageThreadId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "read") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringOrNumberParam(params, "channelId") ??
+        readStringOrNumberParam(params, "to", { required: true });
+      const limit = readNumberParam(params, "limit", { integer: true });
+      const before = readNumberParam(params, "before", { integer: true });
+      const after = readNumberParam(params, "after", { integer: true });
+      return await handleTelegramAction(
+        {
+          action: "readMessages",
+          chatId,
+          limit: limit ?? undefined,
+          before: before ?? undefined,
+          after: after ?? undefined,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -20,6 +20,8 @@ export type TelegramActionConfig = {
   sticker?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
+  /** Enable reading messages from inbound message store. */
+  messages?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -49,6 +49,7 @@ import {
   evaluateTelegramGroupPolicyAccess,
 } from "./group-access.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
+import { recordInboundMessage } from "./inbound-message-store.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import {
   buildModelsKeyboard,
@@ -1085,6 +1086,11 @@ export const registerTelegramHandlers = ({
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
       }
+
+      // Record for inbound message store (enables chat history reads).
+      // Placed before access checks so the store reflects what the bot received,
+      // not what it acted on. The store is in-memory with TTL — no disk persistence.
+      recordInboundMessage(event.msg);
 
       const groupAllowContext = await resolveTelegramGroupAllowFromContext({
         chatId: event.chatId,

--- a/src/telegram/inbound-message-store.test.ts
+++ b/src/telegram/inbound-message-store.test.ts
@@ -1,0 +1,139 @@
+import type { Chat, Message, User } from "@grammyjs/types";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordInboundMessage,
+  readInboundMessages,
+  clearInboundStore,
+  setMaxPerChat,
+  inboundStoreStats,
+} from "./inbound-message-store.js";
+
+function makeMessage(overrides: Partial<Message> & { message_id: number; chat: Chat }): Message {
+  return {
+    date: Math.floor(Date.now() / 1000),
+    from: {
+      id: 100,
+      is_bot: false,
+      first_name: "Test",
+    } as User,
+    text: "hello",
+    ...overrides,
+  } as Message;
+}
+
+const chat: Chat = { id: -5001, type: "group", title: "Test Group" } as Chat;
+
+describe("inbound-message-store", () => {
+  beforeEach(() => {
+    clearInboundStore();
+    setMaxPerChat(200);
+  });
+
+  it("records and reads messages", () => {
+    recordInboundMessage(makeMessage({ message_id: 1, chat }));
+    recordInboundMessage(makeMessage({ message_id: 2, chat, text: "world" }));
+
+    const msgs = readInboundMessages(-5001);
+    expect(msgs).toHaveLength(2);
+    // Newest first
+    expect(msgs[0].messageId).toBe(2);
+    expect(msgs[1].messageId).toBe(1);
+  });
+
+  it("deduplicates by message_id", () => {
+    recordInboundMessage(makeMessage({ message_id: 1, chat }));
+    recordInboundMessage(makeMessage({ message_id: 1, chat }));
+
+    const msgs = readInboundMessages(-5001);
+    expect(msgs).toHaveLength(1);
+  });
+
+  it("isolates chats", () => {
+    const chat2: Chat = { id: -5002, type: "group", title: "Other" } as Chat;
+    recordInboundMessage(makeMessage({ message_id: 1, chat }));
+    recordInboundMessage(makeMessage({ message_id: 2, chat: chat2 }));
+
+    expect(readInboundMessages(-5001)).toHaveLength(1);
+    expect(readInboundMessages(-5002)).toHaveLength(1);
+    expect(readInboundMessages(-9999)).toHaveLength(0);
+  });
+
+  it("respects limit", () => {
+    for (let i = 1; i <= 10; i++) {
+      recordInboundMessage(makeMessage({ message_id: i, chat }));
+    }
+    const msgs = readInboundMessages(-5001, { limit: 3 });
+    expect(msgs).toHaveLength(3);
+    expect(msgs[0].messageId).toBe(10);
+    expect(msgs[2].messageId).toBe(8);
+  });
+
+  it("supports before filter", () => {
+    for (let i = 1; i <= 5; i++) {
+      recordInboundMessage(makeMessage({ message_id: i, chat }));
+    }
+    const msgs = readInboundMessages(-5001, { before: 4 });
+    expect(msgs.map((m) => m.messageId)).toEqual([3, 2, 1]);
+  });
+
+  it("supports after filter", () => {
+    for (let i = 1; i <= 5; i++) {
+      recordInboundMessage(makeMessage({ message_id: i, chat }));
+    }
+    const msgs = readInboundMessages(-5001, { after: 3 });
+    expect(msgs.map((m) => m.messageId)).toEqual([5, 4]);
+  });
+
+  it("evicts oldest when over capacity", () => {
+    setMaxPerChat(10);
+    for (let i = 1; i <= 15; i++) {
+      recordInboundMessage(makeMessage({ message_id: i, chat }));
+    }
+    const msgs = readInboundMessages(-5001, { limit: 100 });
+    expect(msgs).toHaveLength(10);
+    // Oldest should be 6 (1-5 evicted)
+    expect(msgs[msgs.length - 1].messageId).toBe(6);
+  });
+
+  it("normalizes message fields", () => {
+    recordInboundMessage(
+      makeMessage({
+        message_id: 42,
+        chat,
+        text: "test msg",
+        from: {
+          id: 777,
+          is_bot: false,
+          first_name: "Alice",
+          last_name: "Smith",
+          username: "alice",
+        } as User,
+      }),
+    );
+    const [msg] = readInboundMessages(-5001);
+    expect(msg.messageId).toBe(42);
+    expect(msg.chatId).toBe(-5001);
+    expect(msg.text).toBe("test msg");
+    expect(msg.from?.id).toBe(777);
+    expect(msg.from?.username).toBe("alice");
+    expect(msg.from?.isBot).toBe(false);
+  });
+
+  it("reports stats", () => {
+    recordInboundMessage(makeMessage({ message_id: 1, chat }));
+    recordInboundMessage(makeMessage({ message_id: 2, chat }));
+    const stats = inboundStoreStats();
+    expect(stats.chatCount).toBe(1);
+    expect(stats.totalMessages).toBe(2);
+  });
+
+  it("clamps limit to 1-100", () => {
+    for (let i = 1; i <= 5; i++) {
+      recordInboundMessage(makeMessage({ message_id: i, chat }));
+    }
+    // limit: 0 should become 1
+    expect(readInboundMessages(-5001, { limit: 0 })).toHaveLength(1);
+    // limit: 999 should cap at 100 (but only 5 exist)
+    expect(readInboundMessages(-5001, { limit: 999 })).toHaveLength(5);
+  });
+});

--- a/src/telegram/inbound-message-store.ts
+++ b/src/telegram/inbound-message-store.ts
@@ -1,0 +1,173 @@
+/**
+ * In-memory ring buffer of inbound Telegram messages per chat.
+ *
+ * Messages are recorded as they flow through the bot handler pipeline,
+ * enabling chat history reads without calling getUpdates (which conflicts
+ * with the running long-poll loop and doesn't support per-chat retrieval).
+ *
+ * Design mirrors sent-message-cache.ts: lightweight, in-memory, TTL-based
+ * eviction, no disk persistence. Messages are available only while the
+ * process is running — this is intentional to avoid storing user content
+ * on disk without explicit opt-in.
+ */
+
+import type { Message } from "@grammyjs/types";
+
+/** Maximum messages retained per chat. */
+const DEFAULT_MAX_PER_CHAT = 200;
+
+/** Messages older than this are evicted on next access. */
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/** Normalized message stored in the ring buffer. */
+export interface StoredMessage {
+  messageId: number;
+  chatId: number;
+  date: number; // Unix timestamp from Telegram
+  storedAt: number; // Date.now() for TTL
+  from?: {
+    id: number;
+    firstName?: string;
+    lastName?: string;
+    username?: string;
+    isBot: boolean;
+  };
+  text?: string;
+  caption?: string;
+  replyToMessageId?: number;
+}
+
+type ChatBuffer = {
+  messages: StoredMessage[];
+  /** Set of message IDs for O(1) dedup. */
+  seen: Set<number>;
+};
+
+const store = new Map<string, ChatBuffer>();
+
+let maxPerChat = DEFAULT_MAX_PER_CHAT;
+
+function chatKey(chatId: number | string): string {
+  return String(chatId);
+}
+
+/** Extract the fields we need — nothing more. Minimizes retained data. */
+function normalize(msg: Message): StoredMessage {
+  return {
+    messageId: msg.message_id,
+    chatId: msg.chat.id,
+    date: msg.date,
+    storedAt: Date.now(),
+    from: msg.from
+      ? {
+          id: msg.from.id,
+          firstName: msg.from.first_name,
+          lastName: msg.from.last_name,
+          username: msg.from.username,
+          isBot: msg.from.is_bot,
+        }
+      : undefined,
+    text: msg.text,
+    caption: msg.caption,
+    replyToMessageId: msg.reply_to_message?.message_id,
+  };
+}
+
+function evictExpired(buf: ChatBuffer): void {
+  const cutoff = Date.now() - TTL_MS;
+  let i = 0;
+  while (i < buf.messages.length && buf.messages[i].storedAt < cutoff) {
+    buf.seen.delete(buf.messages[i].messageId);
+    i++;
+  }
+  if (i > 0) {
+    buf.messages.splice(0, i);
+  }
+}
+
+/**
+ * Record an inbound message. Call from the bot handler pipeline.
+ * Ignores duplicates (same message_id in same chat).
+ */
+export function recordInboundMessage(msg: Message): void {
+  const key = chatKey(msg.chat.id);
+  let buf = store.get(key);
+  if (!buf) {
+    buf = { messages: [], seen: new Set() };
+    store.set(key, buf);
+  }
+
+  // Dedup — media groups and edits can trigger multiple handler calls
+  if (buf.seen.has(msg.message_id)) {
+    return;
+  }
+
+  buf.messages.push(normalize(msg));
+  buf.seen.add(msg.message_id);
+
+  // Evict oldest if over capacity
+  while (buf.messages.length > maxPerChat) {
+    const evicted = buf.messages.shift();
+    if (evicted) {
+      buf.seen.delete(evicted.messageId);
+    }
+  }
+}
+
+export interface ReadOptions {
+  limit?: number;
+  before?: number; // message_id — return messages before this
+  after?: number; // message_id — return messages after this
+}
+
+/**
+ * Read messages from the inbound store for a given chat.
+ * Returns newest-first (consistent with Discord's readMessages).
+ */
+export function readInboundMessages(
+  chatId: string | number,
+  opts: ReadOptions = {},
+): StoredMessage[] {
+  const key = chatKey(chatId);
+  const buf = store.get(key);
+  if (!buf) {
+    return [];
+  }
+
+  evictExpired(buf);
+
+  let filtered = buf.messages;
+
+  if (opts.before != null) {
+    filtered = filtered.filter((m) => m.messageId < opts.before!);
+  }
+  if (opts.after != null) {
+    filtered = filtered.filter((m) => m.messageId > opts.after!);
+  }
+
+  const limit = opts.limit != null ? Math.min(Math.max(Math.floor(opts.limit), 1), 100) : 50;
+
+  // Return newest first — slice from end
+  const sliced = filtered.slice(-limit);
+  sliced.reverse();
+  return sliced;
+}
+
+/** Number of chats currently tracked. */
+export function inboundStoreStats(): { chatCount: number; totalMessages: number } {
+  let totalMessages = 0;
+  for (const buf of store.values()) {
+    totalMessages += buf.messages.length;
+  }
+  return { chatCount: store.size, totalMessages };
+}
+
+/** Configure max messages per chat (for testing or config). */
+export function setMaxPerChat(n: number): void {
+  maxPerChat = Math.max(n, 10);
+}
+
+/** Clear all stored messages (for testing). */
+export function clearInboundStore(): void {
+  store.clear();
+}

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -26,6 +26,7 @@ import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
+import { type StoredMessage, readInboundMessages } from "./inbound-message-store.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
@@ -1177,4 +1178,45 @@ export async function createForumTopicTelegram(
     name: result.name ?? trimmedName,
     chatId: normalizedChatId,
   };
+}
+
+type TelegramReadOpts = {
+  token?: string;
+  accountId?: string;
+};
+
+type TelegramMessageQuery = {
+  limit?: number;
+  before?: number;
+  after?: number;
+};
+
+/**
+ * Read recent messages from a Telegram chat.
+ *
+ * Reads from the in-memory inbound message store, which records messages
+ * as they flow through the bot handler pipeline. This avoids calling
+ * getUpdates (which conflicts with the running long-poll loop and doesn't
+ * support per-chat history retrieval).
+ *
+ * **Limitations:**
+ * - Only messages received while the process is running are available.
+ * - Messages older than 24 hours are evicted.
+ * - Maximum ~200 messages retained per chat.
+ *
+ * @param chatId - Telegram chat ID (numeric or string)
+ * @param query - Query parameters (limit, before, after — by message_id)
+ * @param _opts - Options (unused — no API call needed, kept for interface consistency)
+ * @returns Array of stored messages, newest first
+ */
+export function readMessagesTelegram(
+  chatId: string | number,
+  query: TelegramMessageQuery = {},
+  _opts: TelegramReadOpts = {},
+): StoredMessage[] {
+  return readInboundMessages(chatId, {
+    limit: query.limit,
+    before: query.before,
+    after: query.after,
+  });
 }


### PR DESCRIPTION
## Summary
- add in-memory inbound message store (`src/telegram/inbound-message-store.ts`) — per-chat ring buffer (~200 msgs, 24h TTL) that records messages as they flow through the bot handler pipeline
- rewrite `readMessagesTelegram` to read from local store instead of calling `getUpdates` (which conflicts with the running long-poll loop and doesn't support per-chat history)
- wire up `read`/`readMessages` action in `telegram-actions.ts` with `before`/`after` pagination by message_id
- add `messages` to `TelegramActionConfig` for action gating
- update `docs/cli/message.md` with Telegram read docs
- add 10 unit tests for the inbound store

## Context

The Telegram Bot API has no per-chat message history endpoint (unlike Discord's REST API). The previous approach using `getUpdates` was fundamentally broken:

1. **409 Conflict** — `getUpdates` from a second `Bot` instance conflicts with the running `@grammyjs/runner` long-poll loop
2. **Consumes updates** — calling `getUpdates` with an offset acknowledges updates, causing the main bot to miss messages
3. **Not chat-specific** — returns ALL unprocessed updates across all chats, not history for a specific chat

The fix: record messages into a lightweight in-memory store as they arrive, then read from that store. No API calls needed.

Closes #12756

## Test

```bash
pnpm vitest run src/telegram/inbound-message-store.test.ts
```

10 tests covering: record/read, dedup, chat isolation, limit/before/after pagination, capacity eviction, field normalization, stats, edge cases.

## Design Decisions

- **In-memory only, no disk persistence** — avoids storing user message content on disk without explicit opt-in. Trade-off: messages lost on restart.
- **Records before access checks** — store reflects what the bot received (consistent with `sent-message-cache.ts`). Action gating controls read access separately.
- **Synchronous reads** — no API call, just a filtered slice from the buffer.
- **`before`/`after` by message_id** — matches Discord's pagination model.

## Limitations

- Only messages received while the process is running
- 24h eviction, ~200 per chat capacity
- No full chat history retrieval (Telegram platform constraint for bots)

## AI Disclosure

🤖 AI-assisted (Claude Opus 4.6 via OpenClaw). Fully tested, code reviewed by human. Both contributors understand the implementation and the Telegram Bot API constraints that motivated this approach.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an in-memory inbound message store for Telegram and updates the Telegram action tool to support reading messages from that store (instead of using `getUpdates`). It also adds config gating (`actions.messages`) and docs/test coverage for the store.

However, the new Telegram `read`/`readMessages` support is not wired into the channel action adapter used by `openclaw message read`. The Telegram plugin adapter does not implement the `read` action, so the CLI will still throw `Action read is not supported for provider telegram`. Additionally, the new handler expects `chatId`, while the CLI target plumbing maps `--target` to `to` for the `read` action, so even after wiring it, the parameter name mismatch would still break reads unless aligned.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged until the Telegram read action is correctly wired end-to-end.
- Core inbound store logic looks coherent, but the advertised `openclaw message read` support for Telegram is currently broken: the Telegram channel action adapter does not implement `read`, and the new handler expects `chatId` while CLI target plumbing provides `to`. This makes the feature non-functional as shipped.
- src/channels/plugins/actions/telegram.ts, src/agents/tools/telegram-actions.ts, src/infra/outbound/message-action-spec.ts, src/infra/outbound/channel-target.ts, docs/cli/message.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - docs/cli/agents.md ([source](https://app.greptile.com/review/custom-context?memory=057a11aa-5c5f-48bb-8d53-91b27b0fe3a2))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
</details>


<!-- /greptile_comment -->