### PR TITLE
feat: add Claude Opus 4.6 Fast model support

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -18,6 +18,7 @@ export type ModelAliasIndex = {
 
 const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
   "opus-4.6": "claude-opus-4-6",
+  "opus-4.6-fast": "claude-opus-4-6-fast",
   "opus-4.5": "claude-opus-4-5",
   "sonnet-4.5": "claude-sonnet-4-5",
 };

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -17,6 +17,7 @@ type GatewayAuthChoice = "token" | "password";
 
 const ANTHROPIC_OAUTH_MODEL_KEYS = [
   "anthropic/claude-opus-4-6",
+  "anthropic/claude-opus-4-6-fast",
   "anthropic/claude-opus-4-5",
   "anthropic/claude-sonnet-4-5",
   "anthropic/claude-haiku-4-5",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -14,6 +14,7 @@ type AnthropicAuthDefaultsMode = "api_key" | "oauth";
 const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
   opus: "anthropic/claude-opus-4-6",
+  "opus-fast": "anthropic/claude-opus-4-6-fast",
   sonnet: "anthropic/claude-sonnet-4-5",
 
   // OpenAI

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -14,6 +14,9 @@ const DEFAULT_MODEL_IDS = [
   "o1",
   "o1-mini",
   "o3-mini",
+  "claude-opus-4-6",
+  "claude-opus-4-6-fast",
+  "claude-sonnet-4-5",
 ] as const;
 
 export function getDefaultCopilotModelIds(): string[] {


### PR DESCRIPTION
## Summary

Adds support for **Claude Opus 4.6 Fast** — Anthropic's faster inference variant of Opus 4.6 (2.5x faster, same intelligence). Released Feb 7, 2026 as a research preview.

## Changes

| File | Change |
|------|--------|
| `src/providers/github-copilot-models.ts` | Add Anthropic models (`claude-opus-4-6`, `claude-opus-4-6-fast`, `claude-sonnet-4-5`) to default Copilot model IDs |
| `src/agents/model-selection.ts` | Add `opus-4.6-fast` → `claude-opus-4-6-fast` alias normalization |
| `src/config/defaults.ts` | Add `opus-fast` short alias |
| `src/commands/configure.gateway-auth.ts` | Include fast variant in Anthropic OAuth model keys |

## Usage after merge

```yaml
# Config
model:
  primary: "anthropic/claude-opus-4-6-fast"

# Or via alias
model:
  primary: "opus-fast"

# Via GitHub Copilot provider
model:
  primary: "github-copilot/claude-opus-4-6-fast"
```

## Context

- Already available on GitHub Copilot for Pro+ and Enterprise users
- [GitHub blog announcement](https://github.blog/changelog/2026-02-07-claude-opus-4-6-fast-is-now-in-public-preview-for-github-copilot/)
- Ref: #10374

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds identifiers and alias normalization for the new Anthropic model `claude-opus-4-6-fast` across the model-selection and onboarding surfaces.

Changes are limited to:
- Adding `opus-4.6-fast` -> `claude-opus-4-6-fast` normalization in `src/agents/model-selection.ts`.
- Adding a default config alias `opus-fast` -> `anthropic/claude-opus-4-6-fast` in `src/config/defaults.ts`.
- Allowing the fast model in the Anthropic OAuth onboarding allowlist in `src/commands/configure.gateway-auth.ts`.
- Adding the Anthropic model IDs to the default GitHub Copilot model ID list in `src/providers/github-copilot-models.ts`.

I didn’t find any merge-blocking issues introduced by these changes; they are additive and consistent with existing patterns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are straightforward additions of model IDs and alias mappings across a few well-scoped files, with no behavior changes outside model name normalization and allowlist expansion. No runtime/type issues were identified in the updated code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->