### PR TITLE
fix(models): add Z.ai GLM-5 forward-compat model resolution

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -19,7 +19,7 @@ const CODEX_MODELS = [
   "gpt-5.1-codex-max",
 ];
 const GOOGLE_PREFIXES = ["gemini-3"];
-const ZAI_PREFIXES = ["glm-4.7"];
+const ZAI_PREFIXES = ["glm-5", "glm-4.7"];
 const MINIMAX_PREFIXES = ["minimax-m2.1"];
 const XAI_PREFIXES = ["grok-4"];
 

--- a/src/agents/opencode-zen-models.test.ts
+++ b/src/agents/opencode-zen-models.test.ts
@@ -45,6 +45,7 @@ describe("resolveOpencodeZenModelApi", () => {
     expect(resolveOpencodeZenModelApi("alpha-gd4")).toBe("openai-completions");
     expect(resolveOpencodeZenModelApi("big-pickle")).toBe("openai-completions");
     expect(resolveOpencodeZenModelApi("glm-4.7")).toBe("openai-completions");
+    expect(resolveOpencodeZenModelApi("glm-5")).toBe("openai-completions");
     expect(resolveOpencodeZenModelApi("some-unknown-model")).toBe("openai-completions");
   });
 });
@@ -53,7 +54,7 @@ describe("getOpencodeZenStaticFallbackModels", () => {
   it("returns an array of models", () => {
     const models = getOpencodeZenStaticFallbackModels();
     expect(Array.isArray(models)).toBe(true);
-    expect(models.length).toBe(10);
+    expect(models.length).toBe(11);
   });
 
   it("includes Claude, GPT, Gemini, and GLM models", () => {
@@ -66,6 +67,7 @@ describe("getOpencodeZenStaticFallbackModels", () => {
     expect(ids).toContain("gpt-5.1-codex");
     expect(ids).toContain("gemini-3-pro");
     expect(ids).toContain("glm-4.7");
+    expect(ids).toContain("glm-5");
   });
 
   it("returns valid ModelDefinitionConfig objects", () => {
@@ -88,7 +90,7 @@ describe("OPENCODE_ZEN_MODEL_ALIASES", () => {
     expect(OPENCODE_ZEN_MODEL_ALIASES.codex).toBe("gpt-5.1-codex");
     expect(OPENCODE_ZEN_MODEL_ALIASES.gpt5).toBe("gpt-5.2");
     expect(OPENCODE_ZEN_MODEL_ALIASES.gemini).toBe("gemini-3-pro");
-    expect(OPENCODE_ZEN_MODEL_ALIASES.glm).toBe("glm-4.7");
+    expect(OPENCODE_ZEN_MODEL_ALIASES.glm).toBe("glm-5");
     expect(OPENCODE_ZEN_MODEL_ALIASES["opus-4.5"]).toBe("claude-opus-4-5");
 
     // Legacy aliases (kept for backward compatibility).

--- a/src/agents/opencode-zen-models.ts
+++ b/src/agents/opencode-zen-models.ts
@@ -72,8 +72,10 @@ export const OPENCODE_ZEN_MODEL_ALIASES: Record<string, string> = {
   "gemini-2.5-flash": "gemini-3-flash",
 
   // GLM (free)
-  glm: "glm-4.7",
-  "glm-free": "glm-4.7",
+  glm: "glm-5",
+  "glm-5": "glm-5",
+  "glm-free": "glm-5",
+  "glm-4.7": "glm-4.7",
 };
 
 /**
@@ -133,6 +135,7 @@ const MODEL_COSTS: Record<
     cacheWrite: 0,
   },
   "gpt-5.1": { input: 1.07, output: 8.5, cacheRead: 0.107, cacheWrite: 0 },
+  "glm-5": { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   "glm-4.7": { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   "gemini-3-flash": { input: 0.5, output: 3, cacheRead: 0.05, cacheWrite: 0 },
   "gpt-5.1-codex-max": {
@@ -153,6 +156,7 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "gemini-3-pro": 1048576,
   "gpt-5.1-codex-mini": 400000,
   "gpt-5.1": 400000,
+  "glm-5": 200000,
   "glm-4.7": 204800,
   "gemini-3-flash": 1048576,
   "gpt-5.1-codex-max": 400000,
@@ -170,6 +174,7 @@ const MODEL_MAX_TOKENS: Record<string, number> = {
   "gemini-3-pro": 65536,
   "gpt-5.1-codex-mini": 128000,
   "gpt-5.1": 128000,
+  "glm-5": 131072,
   "glm-4.7": 131072,
   "gemini-3-flash": 65536,
   "gpt-5.1-codex-max": 128000,
@@ -207,6 +212,7 @@ const MODEL_NAMES: Record<string, string> = {
   "gemini-3-pro": "Gemini 3 Pro",
   "gpt-5.1-codex-mini": "GPT-5.1 Codex Mini",
   "gpt-5.1": "GPT-5.1",
+  "glm-5": "GLM-5",
   "glm-4.7": "GLM-4.7",
   "gemini-3-flash": "Gemini 3 Flash",
   "gpt-5.1-codex-max": "GPT-5.1 Codex Max",
@@ -235,6 +241,7 @@ export function getOpencodeZenStaticFallbackModels(): ModelDefinitionConfig[] {
     "gemini-3-pro",
     "gpt-5.1-codex-mini",
     "gpt-5.1",
+    "glm-5",
     "glm-4.7",
     "gemini-3-flash",
     "gpt-5.1-codex-max",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -23,6 +23,13 @@ const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
+// Z.ai GLM-5 forward-compat: pi-ai's catalog may not include glm-5 yet.
+// Clone from glm-4.7 (same API shape, same provider) with updated metadata.
+const ZAI_GLM5_MODEL_ID = "glm-5";
+const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7", "glm-4.6"] as const;
+const ZAI_GLM5_CONTEXT_WINDOW = 200_000;
+const ZAI_GLM5_MAX_TOKENS = 131_072;
+
 // pi-ai's built-in Anthropic catalog can lag behind OpenClaw's defaults/docs.
 // Add forward-compat fallbacks for known-new IDs by cloning an older template model.
 const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
@@ -114,6 +121,103 @@ function resolveAnthropicOpus46ForwardCompatModel(
   return undefined;
 }
 
+/**
+ * Forward-compat fallback for Z.ai GLM-5.
+ *
+ * When the pi-ai model catalog hasn't been updated to include glm-5 yet,
+ * clone from glm-4.7 (same openai-completions API shape) and override the ID.
+ * Works for both direct zai provider and openrouter (where modelId = "z-ai/glm-5").
+ */
+function resolveZaiGlm5ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+
+  // Direct zai provider: modelId is "glm-5"
+  if (normalizedProvider === "zai") {
+    const trimmedModelId = modelId.trim().toLowerCase();
+    if (
+      trimmedModelId !== ZAI_GLM5_MODEL_ID &&
+      !trimmedModelId.startsWith(`${ZAI_GLM5_MODEL_ID}-`)
+    ) {
+      return undefined;
+    }
+    for (const templateId of ZAI_GLM5_TEMPLATE_MODEL_IDS) {
+      const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
+      if (!template) {
+        continue;
+      }
+      return normalizeModelCompat({
+        ...template,
+        id: modelId.trim(),
+        name: modelId.trim(),
+        contextWindow: ZAI_GLM5_CONTEXT_WINDOW,
+        maxTokens: ZAI_GLM5_MAX_TOKENS,
+        reasoning: true,
+      } as Model<Api>);
+    }
+
+    // Hard fallback: no template found, build from scratch
+    return normalizeModelCompat({
+      id: modelId.trim(),
+      name: modelId.trim(),
+      api: "openai-completions",
+      provider: normalizedProvider,
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: ZAI_GLM5_CONTEXT_WINDOW,
+      maxTokens: ZAI_GLM5_MAX_TOKENS,
+    } as Model<Api>);
+  }
+
+  // OpenRouter provider: modelId is "z-ai/glm-5"
+  if (normalizedProvider === "openrouter" || normalizedProvider === "opencode") {
+    const trimmedModelId = modelId.trim().toLowerCase();
+    const isZaiGlm5 =
+      trimmedModelId === "z-ai/glm-5" ||
+      trimmedModelId === "zai/glm-5" ||
+      trimmedModelId.startsWith("z-ai/glm-5-") ||
+      trimmedModelId.startsWith("zai/glm-5-");
+    if (!isZaiGlm5) {
+      return undefined;
+    }
+    // Try cloning from existing OpenRouter z-ai model
+    for (const templateId of ZAI_GLM5_TEMPLATE_MODEL_IDS) {
+      const orTemplateId = `z-ai/${templateId}`;
+      const template = modelRegistry.find(normalizedProvider, orTemplateId) as Model<Api> | null;
+      if (!template) {
+        continue;
+      }
+      return normalizeModelCompat({
+        ...template,
+        id: modelId.trim(),
+        name: modelId.trim(),
+        contextWindow: ZAI_GLM5_CONTEXT_WINDOW,
+        maxTokens: ZAI_GLM5_MAX_TOKENS,
+        reasoning: true,
+      } as Model<Api>);
+    }
+
+    // Hard fallback for OpenRouter
+    return normalizeModelCompat({
+      id: modelId.trim(),
+      name: modelId.trim(),
+      api: "openai-completions",
+      provider: normalizedProvider,
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: ZAI_GLM5_CONTEXT_WINDOW,
+      maxTokens: ZAI_GLM5_MAX_TOKENS,
+    } as Model<Api>);
+  }
+
+  return undefined;
+}
+
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
 ): InlineModelEntry[] {
@@ -198,6 +302,10 @@ export function resolveModel(
     );
     if (anthropicForwardCompat) {
       return { model: anthropicForwardCompat, authStorage, modelRegistry };
+    }
+    const zaiForwardCompat = resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry);
+    if (zaiForwardCompat) {
+      return { model: zaiForwardCompat, authStorage, modelRegistry };
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {


### PR DESCRIPTION
#### Summary

Z.ai GLM-5 fails model resolution before any API call is made. `resolveModel()` returns `Unknown model: zai/glm-5` because GLM-5 is absent from the pi-ai catalog and no forward-compat fallback exists for Z.ai models (unlike Anthropic Opus 4.6 and OpenAI Codex 5.3, which both have dedicated handlers). This PR adds the missing forward-compat path following the identical pattern already established in `model.ts`.

lobster-biscuit

🤖 **AI-Assisted PR** — Generated with Claude Opus 4.6. Lightly tested (code review + static analysis only; no local `pnpm test` execution against the full repo). I understand what the code does: it adds a template-cloning fallback for GLM-5 that mirrors the existing Anthropic and OpenAI forward-compat handlers.

#### Repro Steps

1. Set primary model to `z-ai/glm-5` (or `openrouter/z-ai/glm-5`) in agent config
2. Start agent
3. Agent fails immediately: `⚠️ Agent failed before reply: Unknown model: zai/glm-5`
4. Failure occurs in `resolveModel()` before any API call — fallback models never trigger

#### Root Cause

Three independent failures compound:

1. **`normalizeProviderId()`** (`model-selection.ts:35`): `z-ai` → `zai` (by design — all Z.ai variants normalize to `zai`)
2. **`resolveModel()`** (`pi-embedded-runner/model.ts:153-225`): Five-step resolution cascade all fail — `modelRegistry.find("zai", "glm-5")` returns null (pi-ai catalog only has `glm-4.7`), no inline config match, Codex forward-compat skips (wrong provider), Anthropic forward-compat skips (wrong provider), no `zai` provider config entry → `Unknown model`
3. **`isModernModelRef()`** (`live-model-filter.ts:22`): `ZAI_PREFIXES = ["glm-4.7"]` — GLM-5 invisible in model picker even if resolution were fixed

#### Behavior Changes

- `zai/glm-5` and `openrouter/z-ai/glm-5` now resolve successfully via forward-compat when pi-ai catalog lacks GLM-5
- GLM-5 appears in model picker / live model filter
- `glm` and `glm-free` aliases now point to `glm-5` (previously `glm-4.7`; `glm-4.7` remains accessible via explicit alias)
- Zero-cost model ($0 input/output)
- Context window: 200,000 tokens; max output: 131,072 tokens (from OpenRouter listing — should be verified against Z.ai docs when available)

#### Codebase and GitHub Search

- Searched open issues for `glm-5`, `unknown model`, `z-ai`, `hyphen`, `model ID` — no exact match
- Closest related: #10088 (fallback on Unknown model errors), #9498 (provider integration gaps), #6829 (provider normalization mismatches), #4179 (model selection validation)
- Searched codebase for existing Z.ai forward-compat: none exists. Only `glm-4.7` in pi-ai catalog
- Confirmed existing forward-compat pattern in `resolveAnthropicOpus46ForwardCompatModel()` and `resolveOpenAICodexGpt53FallbackModel()` as implementation templates

#### Tests

- No new test files added (suggested test cases below for maintainer consideration)
- Existing `model.test.ts` mocks `discoverModels` with `find: () => null`, which exercises the fallback path this PR adds

Suggested additions:
```typescript
it("resolves zai/glm-5 via forward-compat when not in registry", () => {
  const result = resolveModel("zai", "glm-5", "/tmp/test-agent");
  expect(result.model).toBeDefined();
  expect(result.model?.id).toBe("glm-5");
  expect(result.error).toBeUndefined();
});

it("resolves openrouter/z-ai/glm-5 via forward-compat", () => {
  const result = resolveModel("openrouter", "z-ai/glm-5", "/tmp/test-agent");
  expect(result.model).toBeDefined();
  expect(result.model?.id).toBe("z-ai/glm-5");
  expect(result.error).toBeUndefined();
});
```

#### Manual Testing

##### Prerequisites

- OpenClaw instance with OpenRouter API key configured
- Z.ai GLM-5 accessible via OpenRouter (`z-ai/glm-5`)

##### Steps

1. Apply patch, set primary model to `openrouter/z-ai/glm-5`
2. Start agent — should resolve model and reach API call (no more `Unknown model` error)
3. Verify `glm-5` appears in model picker
4. Verify `glm-4.7` still resolves correctly (no regression)

#### Evidence

Files changed (3):

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/model.ts` | Add `resolveZaiGlm5ForwardCompatModel()` + wire into `resolveModel()` cascade |
| `src/agents/live-model-filter.ts` | Add `"glm-5"` to `ZAI_PREFIXES` |
| `src/agents/opencode-zen-models.ts` | Add GLM-5 aliases, cost, context window, max tokens, display name, static fallback |

Forward-compat handler behavior:
- Direct `zai` provider: matches `modelId === "glm-5"`, clones from `glm-4.7` template
- OpenRouter routing: matches `modelId` containing `z-ai/glm-5` or `zai/glm-5`
- Hard fallback: builds model definition from scratch if no template exists (same pattern as Codex 5.3 handler)
- Becomes no-op once pi-ai catalog includes GLM-5 natively

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort (self-reported): AI-generated patch with human-directed root cause analysis and codebase investigation. Human reviewed all output and verified alignment with existing forward-compat patterns.
- Agent notes: Context window (200,000) and max tokens (131,072) are estimates from OpenRouter's GLM-5 listing. `reasoning: true` flag set based on GLM-5 marketing as a reasoning model — if Z.ai's API doesn't support extended thinking parameters, `normalizeModelCompat` already handles this by setting `supportsDeveloperRole: false` for Z.ai models.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a Z.ai GLM-5 “forward-compat” resolution path to `resolveModel()` by cloning an older GLM template when the local pi-ai model registry doesn’t yet contain `glm-5`. It also updates the live model filter to surface GLM-5 in pickers, and updates the OpenCode Zen static catalog/aliases to prefer `glm-5` over `glm-4.7` (with costs/context/max tokens metadata).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the GLM-5 forward-compat matcher is too broad and can mis-resolve other model IDs.
- The PR is small and follows existing forward-compat patterns, but the new Z.ai resolver uses prefix checks that will incorrectly treat other model IDs beginning with `glm-5` / `z-ai/glm-5` as GLM-5 and override their metadata. Tightening the match removes that correctness risk.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->