### PR TITLE
fix(cron): isolate schedule errors to prevent one bad job from breaking all jobs

### DIFF
--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CronJob, CronStoreFile } from "../types.js";
+import type { CronServiceState } from "./state.js";
+import { recomputeNextRuns } from "./jobs.js";
+
+function createMockState(jobs: CronJob[]): CronServiceState {
+  const store: CronStoreFile = { version: 1, jobs };
+  return {
+    deps: {
+      cronEnabled: true,
+      nowMs: () => Date.now(),
+      log: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runHeartbeatOnce: vi.fn(),
+      runIsolatedAgentJob: vi.fn(),
+      onEvent: vi.fn(),
+      persistence: {
+        read: vi.fn(),
+        write: vi.fn(),
+      },
+    },
+    store,
+    timer: null,
+    running: false,
+  } as unknown as CronServiceState;
+}
+
+function createJob(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: "test-job-1",
+    name: "Test Job",
+    enabled: true,
+    createdAtMs: Date.now() - 100_000,
+    updatedAtMs: Date.now() - 100_000,
+    schedule: { kind: "cron", expr: "0 * * * *" }, // Every hour
+    sessionTarget: "main",
+    wakeMode: "now",
+    payload: { kind: "systemEvent", text: "test" },
+    state: {},
+    ...overrides,
+  };
+}
+
+describe("cron schedule error isolation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-15T10:30:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("continues processing other jobs when one has a malformed schedule", () => {
+    const goodJob1 = createJob({ id: "good-1", name: "Good Job 1" });
+    const badJob = createJob({
+      id: "bad-job",
+      name: "Bad Job",
+      schedule: { kind: "cron", expr: "invalid cron expression" },
+    });
+    const goodJob2 = createJob({ id: "good-2", name: "Good Job 2" });
+
+    const state = createMockState([goodJob1, badJob, goodJob2]);
+
+    const changed = recomputeNextRuns(state);
+
+    expect(changed).toBe(true);
+    // Good jobs should have their nextRunAtMs computed
+    expect(goodJob1.state.nextRunAtMs).toBeDefined();
+    expect(goodJob2.state.nextRunAtMs).toBeDefined();
+    // Bad job should have undefined nextRunAtMs and an error recorded
+    expect(badJob.state.nextRunAtMs).toBeUndefined();
+    expect(badJob.state.lastError).toMatch(/schedule error/);
+    expect(badJob.state.scheduleErrorCount).toBe(1);
+    // Job should still be enabled after first error
+    expect(badJob.enabled).toBe(true);
+  });
+
+  it("logs a warning for the first schedule error", () => {
+    const badJob = createJob({
+      id: "bad-job",
+      name: "Bad Job",
+      schedule: { kind: "cron", expr: "not valid" },
+    });
+    const state = createMockState([badJob]);
+
+    recomputeNextRuns(state);
+
+    expect(state.deps.log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "bad-job",
+        name: "Bad Job",
+        errorCount: 1,
+      }),
+      expect.stringContaining("failed to compute next run"),
+    );
+  });
+
+  it("auto-disables job after 3 consecutive schedule errors", () => {
+    const badJob = createJob({
+      id: "bad-job",
+      name: "Bad Job",
+      schedule: { kind: "cron", expr: "garbage" },
+      state: { scheduleErrorCount: 2 }, // Already had 2 errors
+    });
+    const state = createMockState([badJob]);
+
+    recomputeNextRuns(state);
+
+    // After 3rd error, job should be disabled
+    expect(badJob.enabled).toBe(false);
+    expect(badJob.state.scheduleErrorCount).toBe(3);
+    expect(state.deps.log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "bad-job",
+        name: "Bad Job",
+        errorCount: 3,
+      }),
+      expect.stringContaining("auto-disabled job"),
+    );
+  });
+
+  it("clears scheduleErrorCount when schedule computation succeeds", () => {
+    const job = createJob({
+      id: "recovering-job",
+      name: "Recovering Job",
+      schedule: { kind: "cron", expr: "0 * * * *" }, // Valid
+      state: { scheduleErrorCount: 2 }, // Had previous errors
+    });
+    const state = createMockState([job]);
+
+    const changed = recomputeNextRuns(state);
+
+    expect(changed).toBe(true);
+    expect(job.state.nextRunAtMs).toBeDefined();
+    expect(job.state.scheduleErrorCount).toBeUndefined();
+  });
+
+  it("does not modify disabled jobs", () => {
+    const disabledBadJob = createJob({
+      id: "disabled-bad",
+      name: "Disabled Bad Job",
+      enabled: false,
+      schedule: { kind: "cron", expr: "invalid" },
+    });
+    const state = createMockState([disabledBadJob]);
+
+    recomputeNextRuns(state);
+
+    // Should not attempt to compute schedule for disabled jobs
+    expect(disabledBadJob.state.scheduleErrorCount).toBeUndefined();
+    expect(state.deps.log.warn).not.toHaveBeenCalled();
+  });
+
+  it("increments error count on each failed computation", () => {
+    const badJob = createJob({
+      id: "bad-job",
+      name: "Bad Job",
+      schedule: { kind: "cron", expr: "@@@@" },
+      state: { scheduleErrorCount: 1 },
+    });
+    const state = createMockState([badJob]);
+
+    recomputeNextRuns(state);
+
+    expect(badJob.state.scheduleErrorCount).toBe(2);
+    expect(badJob.enabled).toBe(true); // Not yet at threshold
+  });
+
+  it("stores error message in lastError", () => {
+    const badJob = createJob({
+      id: "bad-job",
+      name: "Bad Job",
+      schedule: { kind: "cron", expr: "invalid expression here" },
+    });
+    const state = createMockState([badJob]);
+
+    recomputeNextRuns(state);
+
+    expect(badJob.state.lastError).toMatch(/^schedule error:/);
+    expect(badJob.state.lastError).toBeTruthy();
+  });
+});

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -61,6 +61,8 @@ export type CronJobState = {
   lastDurationMs?: number;
   /** Number of consecutive execution errors (reset on success). Used for backoff. */
   consecutiveErrors?: number;
+  /** Number of consecutive schedule computation errors. Auto-disables job after threshold. */
+  scheduleErrorCount?: number;
 };
 
 export type CronJob = {


### PR DESCRIPTION
## Problem

If one cron job has a malformed schedule expression (e.g. invalid cron syntax), the error propagates up and breaks the entire scheduler loop in `recomputeNextRuns()`. This means one misconfigured job prevents **ALL** cron jobs from running.

## Solution

Wrap per-job schedule computation in try/catch and implement graceful error handling:

1. **Error isolation**: Catch exceptions from `computeJobNextRunAtMs()` per-job, allowing other jobs to continue
2. **Error tracking**: New `scheduleErrorCount` field in `CronJobState` tracks consecutive failures
3. **Clear logging**: Warnings include job ID, name, and error count for easy debugging
4. **Auto-disable**: Jobs are automatically disabled after 3 consecutive schedule errors (with error-level log)
5. **Recovery**: Error count resets when schedule computation succeeds (e.g., after fixing the schedule)

## Changes

- `src/cron/service/jobs.ts`: Added try/catch in `recomputeNextRuns()` with error tracking
- `src/cron/types.ts`: Added `scheduleErrorCount` field to `CronJobState`
- `src/cron/service/jobs.schedule-error-isolation.test.ts`: New test file with 7 test cases

## Testing

- All 114 existing cron tests pass
- 7 new tests specifically for error isolation:
  - Continues processing other jobs when one has a malformed schedule
  - Logs warning for first schedule error
  - Auto-disables job after 3 consecutive schedule errors
  - Clears scheduleErrorCount when schedule computation succeeds
  - Does not modify disabled jobs
  - Increments error count on each failed computation
  - Stores error message in lastError

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes the cron scheduler more robust by isolating per-job schedule computation errors inside `recomputeNextRuns()`. It adds a new `scheduleErrorCount` field to `CronJobState` to track consecutive schedule failures, logs warnings/errors with job context, and auto-disables jobs after repeated schedule errors. A new test suite covers the error-isolation behavior and auto-disable threshold.

Overall, the change fits into the existing cron service flow where `recomputeNextRuns()` is called from timer ticks and management ops (status/list/run) to keep `nextRunAtMs` current without advancing still-future schedules.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge after fixing one state-consistency issue in the auto-disable path.
- The error-isolation behavior is well-scoped and covered by targeted tests, and it prevents a single malformed cron schedule from breaking the scheduler loop. The main remaining issue is that auto-disabling a job during recomputation can leave a stale `runningAtMs` marker persisted for that disabled job, which can confuse status/diagnostics until a later cleanup pass.
- src/cron/service/jobs.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->