### PR TITLE
fix(heartbeat): skip poll when active session lane is busy

### DIFF
--- a/src/infra/heartbeat-runner.skips-session-busy.test.ts
+++ b/src/infra/heartbeat-runner.skips-session-busy.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import * as replyModule from "../auto-reply/reply.js";
+import { resolveAgentMainSessionKey } from "../config/sessions.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+describe("runHeartbeatOnce - busy session lane", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips heartbeat when the active session lane has in-flight work", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-session-busy-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+            },
+          },
+          list: [{ id: "main", default: true }],
+        },
+        session: { store: storePath },
+        channels: { discord: { enabled: true, token: "x", allowFrom: ["*"] } },
+      };
+
+      const sessionKey = resolveAgentMainSessionKey({ cfg, agentId: "main" });
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            [sessionKey]: {
+              sessionId: "sid-1",
+              updatedAt: Date.now(),
+              lastChannel: "discord",
+              lastTo: "user:1",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          nowMs: () => Date.now(),
+          getQueueSize: (lane?: string) => (lane === `session:${sessionKey}` ? 1 : 0),
+        },
+      });
+
+      expect(result).toEqual({ status: "skipped", reason: "requests-in-flight" });
+      expect(replySpy).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #13573

## Summary
Heartbeat polling previously only checked the global main queue lane before running. Embedded Pi runs are queued in per-session lanes (`session:<key>`), so a session could be actively busy while heartbeat still fired and collided with that run.

This change makes heartbeat skip when either:
- the global main lane has in-flight work, or
- the resolved heartbeat session lane has in-flight work.

## Changes
- Resolve heartbeat session earlier in `runHeartbeatOnce`
- Check queue depth for both `main` and `session:<heartbeatSessionKey>` lanes
- Return `skipped: requests-in-flight` when either lane is busy
- Add regression test: `heartbeat-runner.skips-session-busy.test.ts`

## Validation
- `pnpm -s vitest run src/infra/heartbeat-runner.skips-session-busy.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `runHeartbeatOnce` to resolve the heartbeat session key earlier and skip heartbeat execution when either the global `CommandLane.Main` queue or the resolved per-session `session:` lane has in-flight work, preventing heartbeat from colliding with active embedded Pi runs. It also adds a regression test that asserts heartbeats are skipped when the active session lane reports queued work via the injected `getQueueSize` dependency.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe but may regress delivery of exec/cron completion events when a session lane stays busy.
- The core change is small and well-targeted (additional queue-depth check), and the new test covers the intended regression. However, the skip condition is evaluated before exec/cron event handling, which can prevent those events from being processed if the session lane remains in-flight, changing user-visible behavior in a way that seems unintended for exec/cron notifications.
- src/infra/heartbeat-runner.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->