### PR TITLE
fix(telegram): handle no-text message in model picker editMessageText

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -504,7 +504,16 @@ export const registerTelegramHandlers = ({
             );
           } catch (editErr) {
             const errStr = String(editErr);
-            if (!errStr.includes("message is not modified")) {
+            if (errStr.includes("no text in the message")) {
+              try {
+                await bot.api.deleteMessage(callbackMessage.chat.id, callbackMessage.message_id);
+              } catch {}
+              await bot.api.sendMessage(
+                callbackMessage.chat.id,
+                text,
+                keyboard ? { reply_markup: keyboard } : undefined,
+              );
+            } else if (!errStr.includes("message is not modified")) {
               throw editErr;
             }
           }


### PR DESCRIPTION
When the original message has no text content (only reply_markup buttons), `editMessageText` fails with "there is no text in the message to edit". This adds a fallback: delete the old message and send a new one with both text and buttons.

Fixes #14357

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the Telegram model-picker callback handler to cope with Telegram’s `editMessageText` limitation when the original message contains only inline buttons (no text). On the specific "no text in the message" edit failure, it now deletes the old message and sends a new message containing both the desired text and inline keyboard; other edit failures still bubble up except for the existing "message is not modified" case.

The change is localized to the model picker’s `editMessageWithButtons` helper inside `src/telegram/bot-handlers.ts`, and is meant to keep the interactive model-selection flow working even when the picker message was created as markup-only.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the new fallback can leave duplicate/out-of-sync picker messages when deletion fails.
- Change is small and scoped to a single error case, but it introduces a silent `deleteMessage` failure path that can break the intended UX without any signal, and it relies on matching a specific error string.
- src/telegram/bot-handlers.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->