### PR TITLE
fix(media): strip MEDIA: lines with local paths instead of leaking as visible text

### DIFF
--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -191,6 +191,10 @@ export function splitMediaFromOutput(raw: string): {
         if (invalidParts.length > 0) {
           pieces.push(invalidParts.join(" "));
         }
+      } else if (looksLikeLocalPath) {
+        // Strip MEDIA: lines with local paths even when invalid (e.g. absolute paths
+        // from internal tools like TTS). They should never leak as visible text.
+        foundMediaToken = true;
       } else {
         // If no valid media was found in this match, keep the original token text.
         pieces.push(match[0]);


### PR DESCRIPTION
## Summary

Fixes #14365

When internal tools like TTS emit `MEDIA:/tmp/tts-xxx/voice.mp3`, `isValidMedia()` correctly rejects the absolute path (security). But the rejected line was kept as visible text — users see `MEDIA:/tmp/...` alongside the audio.

## Fix

When a `MEDIA:` line contains what looks like a local path but fails validation, strip it from the output instead of keeping it as visible text. 

**+4 lines, 1 file.**

## Root Cause

`splitMediaFromOutput()` had two paths for rejected MEDIA tokens:
- Valid → extract as media attachment  
- Invalid → keep as visible text ← **this leaked the path**

Now: Invalid + looks like local path → strip silently.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `splitMediaFromOutput()` (`src/media/parse.ts`) to avoid leaking absolute/local filesystem paths from invalid `MEDIA:` tokens as user-visible text, by stripping invalid tokens that appear to be local paths.

The function is used by reply directive parsing (`src/auto-reply/reply/*`) to split assistant output into text + media attachments, so this affects what users see across channels when tool/model output includes `MEDIA:` directives.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but has a user-visible parsing regression risk.
- The security/privacy motivation is sound, but the new stripping condition treats many non-filesystem strings (any no-scheme value containing '/') as a local path, which can silently delete intended user-visible content and also triggers additional whitespace normalization via foundMediaToken.
- src/media/parse.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->