### PR TITLE
CI: add PR size autolabel workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -25,6 +25,95 @@ jobs:
           configuration-path: .github/labeler.yml
           repo-token: ${{ steps.app-token.outputs.token }}
           sync-labels: true
+      - name: Apply PR size label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) {
+              return;
+            }
+
+            const sizeLabels = ["size: XS", "size: S", "size: M", "size: L", "size: XL"];
+            const labelColor = "fbca04";
+
+            for (const label of sizeLabels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                });
+              } catch (error) {
+                if (error?.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: labelColor,
+                });
+              }
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+
+            const excludedLockfiles = new Set(["pnpm-lock.yaml", "package-lock.json", "yarn.lock", "bun.lockb"]);
+            const totalChangedLines = files.reduce((total, file) => {
+              const path = file.filename ?? "";
+              if (path === "docs.acp.md" || path.startsWith("docs/") || excludedLockfiles.has(path)) {
+                return total;
+              }
+              return total + (file.additions ?? 0) + (file.deletions ?? 0);
+            }, 0);
+
+            let targetSizeLabel = "size: XL";
+            if (totalChangedLines < 50) {
+              targetSizeLabel = "size: XS";
+            } else if (totalChangedLines < 200) {
+              targetSizeLabel = "size: S";
+            } else if (totalChangedLines < 500) {
+              targetSizeLabel = "size: M";
+            } else if (totalChangedLines < 1000) {
+              targetSizeLabel = "size: L";
+            }
+
+            const currentLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              per_page: 100,
+            });
+
+            for (const label of currentLabels) {
+              const name = label.name ?? "";
+              if (!sizeLabels.includes(name)) {
+                continue;
+              }
+              if (name === targetSizeLabel) {
+                continue;
+              }
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                name,
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              labels: [targetSizeLabel],
+            });
       - name: Apply maintainer label for org members
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:

--- a/scripts/sync-labels.ts
+++ b/scripts/sync-labels.ts
@@ -14,10 +14,14 @@ const COLOR_BY_PREFIX = new Map<string, string>([
   ["docs", "0075ca"],
   ["cli", "f9d0c4"],
   ["gateway", "d4c5f9"],
+  ["size", "fbca04"],
 ]);
 
 const configPath = resolve(".github/labeler.yml");
-const labelNames = extractLabelNames(readFileSync(configPath, "utf8"));
+const EXTRA_LABELS = ["size: XS", "size: S", "size: M", "size: L", "size: XL"] as const;
+const labelNames = [
+  ...new Set([...extractLabelNames(readFileSync(configPath, "utf8")), ...EXTRA_LABELS]),
+];
 
 if (!labelNames.length) {
   throw new Error("labeler.yml must declare at least one label.");


### PR DESCRIPTION
## Summary
- add PR size auto-labeling in labeler workflow
- exclude docs and lockfiles from size count
- add size labels to sync-labels bootstrap list

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the existing `.github/workflows/labeler.yml` workflow to automatically apply a PR size label (XS–XL) based on total changed lines, excluding docs and common lockfiles, and updates `scripts/sync-labels.ts` to ensure the new size labels exist when bootstrapping labels.

The main workflow computes additions+deletions across PR files (via `pulls.listFiles`) and then uses the Issues API to remove any previous size labels and add the computed one. The sync script now includes `size:*` labels in its label set and maps the `size` prefix to the same color used by the workflow.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but will fail to apply size labels due to missing workflow permissions.
- The added workflow step performs label mutations via the GitHub Issues API without granting `issues: write` permission to the job, which will cause runtime failures. Aside from that, changes are localized and consistent with existing patterns.
- .github/workflows/labeler.yml

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->