### PR TITLE
feat(extensions): add telegram-files Mini App

### DIFF
--- a/extensions/telegram-files/README.md
+++ b/extensions/telegram-files/README.md
@@ -1,0 +1,187 @@
+# @openclaw/telegram-files
+
+Telegram Mini App for managing agent workspace files on mobile.
+
+## Overview
+
+This plugin adds a `/files` command that opens a Telegram Mini App (WebApp) directly inside Telegram, allowing you to:
+
+- Browse directories on the agent's filesystem
+- View and edit text files with a mobile-friendly editor
+- Create new files and folders
+- Delete files and directories
+- Search for files by name
+- Toggle hidden file visibility
+
+All operations are secured with token-based authentication, path whitelisting, and automatic token expiration.
+
+## Installation
+
+```bash
+openclaw plugins install @openclaw/telegram-files
+```
+
+## Quick Setup
+
+1. Expose your gateway over HTTPS (e.g. via Tailscale Funnel, Cloudflare Tunnel, or ngrok):
+
+   ```bash
+   # Example with Tailscale
+   tailscale funnel 3117
+   ```
+
+2. Configure the plugin with your external URL:
+
+   ```bash
+   openclaw config set plugins.entries.telegram-files.config.externalUrl "https://your-host.ts.net"
+   ```
+
+3. (Optional) Restrict filesystem access to specific directories:
+
+   ```bash
+   openclaw config set plugins.entries.telegram-files.config.allowedPaths '["/home/user", "/opt/projects"]'
+   ```
+
+4. Restart the gateway, then send `/files` in Telegram.
+
+## Configuration
+
+| Key            | Type     | Default          | Description                                                               |
+| -------------- | -------- | ---------------- | ------------------------------------------------------------------------- |
+| `externalUrl`  | string   | required         | HTTPS URL where the gateway is reachable (used for Mini App button URL)   |
+| `allowedPaths` | string[] | `[os.homedir()]` | Allowed filesystem paths. If empty, defaults to the user's home directory |
+
+### Example Config
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "telegram-files": {
+        "config": {
+          "externalUrl": "https://my-server.ts.net",
+          "allowedPaths": ["/home/user", "/opt/openclaw"]
+        }
+      }
+    }
+  }
+}
+```
+
+## Usage
+
+1. Send `/files` to your bot in Telegram
+2. Tap the **Open File Manager** button
+3. Browse, edit, create, or delete files from your phone
+
+### Features
+
+- **Directory browsing** — navigate the filesystem with breadcrumb path display
+- **File editing** — full-screen textarea with save via Telegram MainButton
+- **File metadata** — file size (KB/MB) and relative modification time (e.g. "2h ago")
+- **Hidden files toggle** — show/hide dotfiles, preference saved in localStorage
+- **New file** — tap "+ New File", enter a name, and start editing
+- **New folder** — tap "+ New Folder" to create directories
+- **Delete** — delete files or folders with confirmation dialog
+- **Search** — search files by name within current directory (recursive, max 5 levels deep)
+- **Binary protection** — binary files show a friendly "cannot edit" notice instead of garbled text
+
+## Security
+
+### Authentication Flow
+
+1. User sends `/files` in Telegram
+2. Bot generates a one-time pairing code (5-minute TTL)
+3. Mini App exchanges the code for a session token
+4. Session token expires after **24 hours** — user must re-run `/files` to get a new one
+
+### Path Whitelisting
+
+All API endpoints enforce path restrictions:
+
+- If `allowedPaths` is configured, only those directories (and their children) are accessible
+- If `allowedPaths` is empty (default), only the home directory is accessible
+- Attempting to access paths outside the whitelist returns `403 Forbidden`
+
+### Operation Logging
+
+All write operations are logged to the gateway console:
+
+```
+[telegram-files] WRITE /home/user/file.txt by token a1b2c3d4...
+[telegram-files] DELETE /home/user/old.txt by token a1b2c3d4...
+[telegram-files] MKDIR /home/user/new-dir by token a1b2c3d4...
+```
+
+## API Reference
+
+All endpoints are under `/plugins/telegram-files/api/` and require `Authorization: Bearer <token>` (except exchange).
+
+| Method | Endpoint        | Description                      |
+| ------ | --------------- | -------------------------------- |
+| POST   | `/api/exchange` | Exchange pairing code for token  |
+| GET    | `/api/ls`       | List directory (`?path=`)        |
+| GET    | `/api/read`     | Read file content (`?path=`)     |
+| POST   | `/api/write`    | Write file (`{ path, content }`) |
+| POST   | `/api/mkdir`    | Create directory (`{ path }`)    |
+| DELETE | `/api/delete`   | Delete file/dir (`?path=`)       |
+| GET    | `/api/search`   | Search files (`?path=&q=`)       |
+
+## Layout
+
+```
+telegram-files/
+├── openclaw.plugin.json     # Plugin metadata and config schema
+├── package.json
+├── index.ts                 # Plugin entry point
+├── src/
+│   ├── register.ts          # Command + HTTP API handler
+│   ├── pairing.ts           # One-time pairing code store
+│   ├── runtime.ts           # OpenClaw runtime bridge
+│   └── static-server.ts     # Static file server for webapp
+└── webapp/
+    ├── index.html
+    ├── vite.config.ts
+    └── src/
+        ├── main.ts           # Webapp entry
+        ├── app.ts            # Routing (dir list ↔ editor)
+        ├── services/
+        │   ├── auth.ts       # Token exchange
+        │   ├── files-api.ts  # REST client
+        │   └── telegram.ts   # Telegram WebApp SDK
+        ├── views/
+        │   ├── file-list.ts  # Directory browser
+        │   └── file-editor.ts # File editor
+        └── styles/
+            └── theme.css     # Telegram theme integration
+```
+
+## Troubleshooting
+
+### "Please set externalUrl" error
+
+Set the external URL where your gateway is reachable over HTTPS:
+
+```bash
+openclaw config set plugins.entries.telegram-files.config.externalUrl "https://your-host"
+```
+
+### Mini App shows "unauthorized"
+
+The session token has expired (24h TTL). Send `/files` again to get a fresh pairing code.
+
+### Cannot access certain directories
+
+Check your `allowedPaths` configuration. By default, only the home directory is accessible. Add paths as needed:
+
+```bash
+openclaw config set plugins.entries.telegram-files.config.allowedPaths '["/path/to/allow"]'
+```
+
+### Binary file error
+
+Binary files (images, executables, etc.) cannot be edited as text. The editor will show a "Binary File" notice.
+
+## License
+
+MIT

--- a/extensions/telegram-files/index.ts
+++ b/extensions/telegram-files/index.ts
@@ -1,0 +1,29 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { registerAll } from "./src/register.js";
+import { setFilesRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "telegram-files",
+  name: "Telegram File Manager",
+  description: "Telegram Mini App for editing agent workspace files on mobile",
+  configSchema: {
+    parse(value: unknown) {
+      const raw =
+        value && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
+          : {};
+      return {
+        externalUrl: typeof raw.externalUrl === "string" ? raw.externalUrl : undefined,
+        allowedPaths: Array.isArray(raw.allowedPaths)
+          ? (raw.allowedPaths as unknown[]).filter((p): p is string => typeof p === "string")
+          : [],
+      };
+    },
+  },
+  register(api: OpenClawPluginApi) {
+    setFilesRuntime(api.runtime);
+    registerAll(api);
+  },
+};
+
+export default plugin;

--- a/extensions/telegram-files/openclaw.plugin.json
+++ b/extensions/telegram-files/openclaw.plugin.json
@@ -1,0 +1,19 @@
+{
+  "id": "telegram-files",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "externalUrl": {
+        "type": "string",
+        "description": "HTTPS URL where the gateway is reachable (e.g. Tailscale HTTPS). Used for Telegram Mini App button URL."
+      },
+      "allowedPaths": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Allowed filesystem paths. If empty, defaults to user home directory.",
+        "default": []
+      }
+    }
+  }
+}

--- a/extensions/telegram-files/package.json
+++ b/extensions/telegram-files/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openclaw/telegram-files",
+  "version": "2026.2.10",
+  "private": true,
+  "description": "Telegram Mini App for managing agent workspace files on mobile",
+  "type": "module",
+  "scripts": {
+    "build": "cd webapp && npx vite build"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*",
+    "vite": "7.3.1"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/telegram-files/src/api-handlers.ts
+++ b/extensions/telegram-files/src/api-handlers.ts
@@ -1,0 +1,344 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { issueSessionToken, jsonResponse, readJsonBody, tokenTag } from "./auth.js";
+import { exchangePairingCode } from "./pairing.js";
+import {
+  isAllowedRoot,
+  isPathAllowed,
+  safePath,
+  sanitizeError,
+  searchFiles,
+} from "./path-utils.js";
+
+const MAX_FILENAME_LENGTH = 255;
+
+/** Handle POST /api/exchange — pair code → session token (no auth required). */
+export async function handleExchange(
+  req: IncomingMessage,
+  res: ServerResponse,
+  corsOrigin: string,
+): Promise<void> {
+  const body = await readJsonBody(req);
+  const pairCode = typeof body?.pairCode === "string" ? body.pairCode : "";
+  const valid = exchangePairingCode(pairCode);
+
+  if (!valid) {
+    jsonResponse(res, 401, { error: "invalid or expired pairing code" }, corsOrigin);
+    return;
+  }
+
+  const sessionToken = issueSessionToken();
+  jsonResponse(res, 200, { token: sessionToken }, corsOrigin);
+}
+
+/** Handle GET /api/home — return the default start directory. */
+export function handleHome(res: ServerResponse, allowedPaths: string[], corsOrigin: string): void {
+  const home = allowedPaths.length > 0 ? path.resolve(allowedPaths[0]) : os.homedir();
+  jsonResponse(res, 200, { path: home }, corsOrigin);
+}
+
+/** Handle GET /api/ls?path= — list directory contents. */
+export async function handleLs(
+  url: URL,
+  res: ServerResponse,
+  allowedPaths: string[],
+  corsOrigin: string,
+): Promise<void> {
+  const dirPath = await safePath(url.searchParams.get("path") || "/");
+  if (!dirPath || !(await isPathAllowed(dirPath, allowedPaths))) {
+    jsonResponse(res, 403, { error: "path not allowed" }, corsOrigin);
+    return;
+  }
+
+  try {
+    const stat = await fs.stat(dirPath);
+    if (!stat.isDirectory()) {
+      jsonResponse(res, 400, { error: "not a directory" }, corsOrigin);
+      return;
+    }
+
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    const items = await Promise.all(
+      entries.map(async (e) => {
+        const fullPath = path.join(dirPath, e.name);
+        let size = 0;
+        let mtime = 0;
+        try {
+          const s = await fs.stat(fullPath);
+          size = s.size;
+          mtime = s.mtimeMs;
+        } catch {
+          /* permission denied etc */
+        }
+        return {
+          name: e.name,
+          isDir: e.isDirectory(),
+          isFile: e.isFile(),
+          isSymlink: e.isSymbolicLink(),
+          size,
+          mtime,
+        };
+      }),
+    );
+
+    // Sort: dirs first, then files, alphabetical
+    items.sort((a, b) => {
+      if (a.isDir !== b.isDir) {
+        return a.isDir ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    jsonResponse(res, 200, { path: dirPath, items }, corsOrigin);
+  } catch (err) {
+    jsonResponse(res, 500, { error: `Failed to list: ${sanitizeError(err)}` }, corsOrigin);
+  }
+}
+
+/** Handle GET /api/read?path= — read file content. */
+export async function handleRead(
+  url: URL,
+  res: ServerResponse,
+  allowedPaths: string[],
+  corsOrigin: string,
+): Promise<void> {
+  const filePath = await safePath(url.searchParams.get("path") || "");
+  if (!filePath || !(await isPathAllowed(filePath, allowedPaths))) {
+    jsonResponse(res, 403, { error: "path not allowed" }, corsOrigin);
+    return;
+  }
+
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      jsonResponse(res, 400, { error: "not a file" }, corsOrigin);
+      return;
+    }
+    if (stat.size > 2 * 1024 * 1024) {
+      jsonResponse(res, 400, { error: "file too large (max 2MB)" }, corsOrigin);
+      return;
+    }
+
+    // Binary detection: check first 512 bytes for null bytes
+    const fd = await fs.open(filePath, "r");
+    let isBinary = false;
+    try {
+      const probe = Buffer.alloc(512);
+      const { bytesRead } = await fd.read(probe, 0, 512, 0);
+      isBinary = probe.subarray(0, bytesRead).includes(0);
+    } finally {
+      await fd.close();
+    }
+    if (isBinary) {
+      jsonResponse(res, 400, { error: "binary file — cannot edit" }, corsOrigin);
+      return;
+    }
+
+    const content = await fs.readFile(filePath, "utf-8");
+    jsonResponse(res, 200, { path: filePath, content, size: stat.size }, corsOrigin);
+  } catch (err) {
+    jsonResponse(res, 500, { error: `Failed to read: ${sanitizeError(err)}` }, corsOrigin);
+  }
+}
+
+/** Handle POST /api/write — save file content. */
+export async function handleWrite(
+  req: IncomingMessage,
+  res: ServerResponse,
+  allowedPaths: string[],
+  corsOrigin: string,
+): Promise<void> {
+  const body = await readJsonBody(req);
+  const filePath = await safePath(typeof body?.path === "string" ? body.path : "");
+  const content = typeof body?.content === "string" ? body.content : null;
+
+  if (!filePath || content === null) {
+    jsonResponse(res, 400, { error: "path and content required" }, corsOrigin);
+    return;
+  }
+
+  if (!(await isPathAllowed(filePath, allowedPaths))) {
+    jsonResponse(res, 403, { error: "path not allowed" }, corsOrigin);
+    return;
+  }
+
+  try {
+    const dir = path.dirname(filePath);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(filePath, content, "utf-8");
+    console.log(`[telegram-files] WRITE ${filePath} by token ${tokenTag(req)}`);
+    jsonResponse(res, 200, { ok: true, path: filePath }, corsOrigin);
+  } catch (err) {
+    jsonResponse(res, 500, { error: `Failed to write: ${sanitizeError(err)}` }, corsOrigin);
+  }
+}
+
+/** Handle POST /api/upload — raw binary upload. */
+export async function handleUpload(
+  req: IncomingMessage,
+  url: URL,
+  res: ServerResponse,
+  allowedPaths: string[],
+  corsOrigin: string,
+): Promise<void> {
+  const targetDir = await safePath(url.searchParams.get("dir") || "");
+  const fileName = url.searchParams.get("name") || "";
+
+  if (
+    !targetDir ||
+    !fileName ||
+    fileName.length > MAX_FILENAME_LENGTH ||
+    fileName.includes("/") ||
+    fileName.includes("\\") ||
+    fileName.includes("\0") ||
+    fileName === ".." ||
+    fileName === "."
+  ) {
+    jsonResponse(res, 400, { error: "dir and valid name required" }, corsOrigin);
+    return;
+  }
+
+  const constructedPath = path.join(targetDir, fileName);
+  const filePath = await safePath(constructedPath);
+  if (!filePath || !(await isPathAllowed(filePath, allowedPaths))) {
+    jsonResponse(res, 403, { error: "path not allowed" }, corsOrigin);
+    return;
+  }
+
+  // Read raw body (max 50MB)
+  const maxUpload = 50 * 1024 * 1024;
+  const chunks: Buffer[] = [];
+  let size = 0;
+  let overflow = false;
+  let requestError = false;
+
+  await new Promise<void>((resolve) => {
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > maxUpload) {
+        overflow = true;
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve());
+    req.on("error", () => {
+      requestError = true;
+      resolve();
+    });
+    req.on("close", () => resolve());
+  });
+
+  if (overflow) {
+    jsonResponse(res, 413, { error: "file too large (max 50MB)" }, corsOrigin);
+    return;
+  }
+  if (requestError) {
+    jsonResponse(res, 500, { error: "upload stream error" }, corsOrigin);
+    return;
+  }
+
+  try {
+    const dir = path.dirname(filePath);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(filePath, Buffer.concat(chunks));
+    console.log(`[telegram-files] UPLOAD ${filePath} (${size} bytes) by token ${tokenTag(req)}`);
+    jsonResponse(res, 200, { ok: true, path: filePath, size }, corsOrigin);
+  } catch (err) {
+    jsonResponse(res, 500, { error: `Failed to upload: ${sanitizeError(err)}` }, corsOrigin);
+  }
+}
+
+/** Handle POST /api/mkdir — create directory. */
+export async function handleMkdir(
+  req: IncomingMessage,
+  res: ServerResponse,
+  allowedPaths: string[],
+  corsOrigin: string,
+): Promise<void> {
+  const body = await readJsonBody(req);
+  const dirPath = await safePath(typeof body?.path === "string" ? body.path : "");
+
+  if (!dirPath) {
+    jsonResponse(res, 400, { error: "path required" }, corsOrigin);
+    return;
+  }
+
+  if (!(await isPathAllowed(dirPath, allowedPaths))) {
+    jsonResponse(res, 403, { error: "path not allowed" }, corsOrigin);
+    return;
+  }
+
+  try {
+    await fs.mkdir(dirPath, { recursive: true });
+    console.log(`[telegram-files] MKDIR ${dirPath} by token ${tokenTag(req)}`);
+    jsonResponse(res, 200, { ok: true, path: dirPath }, corsOrigin);
+  } catch (err) {
+    jsonResponse(res, 500, { error: `Failed to mkdir: ${sanitizeError(err)}` }, corsOrigin);
+  }
+}
+
+/** Handle DELETE /api/delete?path= — remove file or directory. */
+export async function handleDelete(
+  req: IncomingMessage,
+  url: URL,
+  res: ServerResponse,
+  allowedPaths: string[],
+  corsOrigin: string,
+): Promise<void> {
+  const targetPath = await safePath(url.searchParams.get("path") || "");
+  if (!targetPath) {
+    jsonResponse(res, 400, { error: "invalid path" }, corsOrigin);
+    return;
+  }
+
+  if (!(await isPathAllowed(targetPath, allowedPaths))) {
+    jsonResponse(res, 403, { error: "path not allowed" }, corsOrigin);
+    return;
+  }
+
+  // Prevent deleting allowed root directories (e.g. home dir)
+  if (await isAllowedRoot(targetPath, allowedPaths)) {
+    jsonResponse(res, 403, { error: "cannot delete a root allowed path" }, corsOrigin);
+    return;
+  }
+
+  try {
+    await fs.rm(targetPath, { recursive: true });
+    console.log(`[telegram-files] DELETE ${targetPath} by token ${tokenTag(req)}`);
+    jsonResponse(res, 200, { ok: true }, corsOrigin);
+  } catch (err) {
+    jsonResponse(res, 500, { error: `Failed to delete: ${sanitizeError(err)}` }, corsOrigin);
+  }
+}
+
+/** Handle GET /api/search?path=&q= — recursive file search. */
+export async function handleSearch(
+  url: URL,
+  res: ServerResponse,
+  allowedPaths: string[],
+  corsOrigin: string,
+): Promise<void> {
+  const basePath = await safePath(url.searchParams.get("path") || "/");
+  const query = (url.searchParams.get("q") || "").trim();
+
+  if (!basePath || !(await isPathAllowed(basePath, allowedPaths))) {
+    jsonResponse(res, 403, { error: "path not allowed" }, corsOrigin);
+    return;
+  }
+
+  if (query.length < 1 || query.length > 256) {
+    jsonResponse(res, 400, { error: "query parameter 'q' required (1-256 chars)" }, corsOrigin);
+    return;
+  }
+
+  try {
+    const results = await searchFiles(basePath, query);
+    jsonResponse(res, 200, { path: basePath, query, results }, corsOrigin);
+  } catch (err) {
+    jsonResponse(res, 500, { error: `Failed to search: ${sanitizeError(err)}` }, corsOrigin);
+  }
+}

--- a/extensions/telegram-files/src/auth.ts
+++ b/extensions/telegram-files/src/auth.ts
@@ -1,0 +1,136 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import crypto from "node:crypto";
+
+// --- Token TTL (24h) ---
+const MAX_ACTIVE_TOKENS = 200;
+const activeTokens = new Map<string, number>(); // token → expiresAt
+const TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+/** Lazily evict a batch of expired tokens (called on each auth check). */
+function evictExpiredTokens() {
+  const now = Date.now();
+  let cleaned = 0;
+  for (const [token, exp] of activeTokens) {
+    if (cleaned >= 20) {
+      break;
+    }
+    if (now > exp) {
+      activeTokens.delete(token);
+      cleaned++;
+    }
+  }
+}
+
+/** Extract bearer token from Authorization header. */
+export function extractBearerToken(req: IncomingMessage): string | null {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith("Bearer ")) {
+    return null;
+  }
+  return auth.slice(7);
+}
+
+/** Check bearer token with TTL expiration. */
+export function checkAuth(req: IncomingMessage): boolean {
+  const token = extractBearerToken(req);
+  if (!token) {
+    return false;
+  }
+  const expiresAt = activeTokens.get(token);
+  if (!expiresAt) {
+    return false;
+  }
+  if (Date.now() > expiresAt) {
+    activeTokens.delete(token);
+    return false;
+  }
+  // Lazily clean up expired tokens on each successful auth check
+  evictExpiredTokens();
+  return true;
+}
+
+/** Issue a new session token (256-bit), evicting the oldest if at capacity. */
+export function issueSessionToken(): string {
+  if (activeTokens.size >= MAX_ACTIVE_TOKENS) {
+    let oldestKey: string | null = null;
+    let oldestExp = Infinity;
+    for (const [k, v] of activeTokens) {
+      if (v < oldestExp) {
+        oldestExp = v;
+        oldestKey = k;
+      }
+    }
+    if (oldestKey) {
+      activeTokens.delete(oldestKey);
+    }
+  }
+
+  const sessionToken = crypto.randomBytes(32).toString("hex");
+  activeTokens.set(sessionToken, Date.now() + TOKEN_TTL_MS);
+  return sessionToken;
+}
+
+/** Truncate token for logging (first 8 chars). */
+export function tokenTag(req: IncomingMessage): string {
+  const t = extractBearerToken(req);
+  return t ? t.slice(0, 8) + "..." : "unknown";
+}
+
+/** Send a JSON response with standard security headers. */
+export function jsonResponse(
+  res: ServerResponse,
+  status: number,
+  data: unknown,
+  corsOrigin: string,
+) {
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Access-Control-Allow-Origin", corsOrigin);
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.statusCode = status;
+  res.end(JSON.stringify(data));
+}
+
+/** Read a JSON body from an IncomingMessage. */
+export function readJsonBody(
+  req: IncomingMessage,
+  maxBytes = 5 * 1024 * 1024,
+): Promise<Record<string, unknown> | null> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let settled = false;
+    req.on("data", (chunk: Buffer) => {
+      if (settled) {
+        return;
+      }
+      size += chunk.length;
+      if (size > maxBytes) {
+        settled = true;
+        resolve(null);
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      try {
+        const text = Buffer.concat(chunks).toString("utf-8");
+        resolve(JSON.parse(text) as Record<string, unknown>);
+      } catch {
+        resolve(null);
+      }
+    });
+    req.on("error", () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(null);
+    });
+  });
+}

--- a/extensions/telegram-files/src/pairing.ts
+++ b/extensions/telegram-files/src/pairing.ts
@@ -1,0 +1,49 @@
+import crypto from "node:crypto";
+
+const store = new Map<string, { expiresAt: number }>();
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_PAIRING_CODES = 100;
+
+function evictExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    if (entry.expiresAt <= now) {
+      store.delete(key);
+    }
+  }
+}
+
+/** Create a one-time pairing code. */
+export function createPairingCode(): string {
+  evictExpired();
+
+  // Evict oldest if at capacity
+  if (store.size >= MAX_PAIRING_CODES) {
+    let oldestKey: string | null = null;
+    let oldestTime = Infinity;
+    for (const [key, entry] of store) {
+      if (entry.expiresAt < oldestTime) {
+        oldestTime = entry.expiresAt;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey) {
+      store.delete(oldestKey);
+    }
+  }
+
+  const code = crypto.randomBytes(32).toString("hex");
+  store.set(code, { expiresAt: Date.now() + TTL_MS });
+  return code;
+}
+
+/** Exchange a pairing code. One-time use. Returns true if valid. */
+export function exchangePairingCode(code: string): boolean {
+  evictExpired();
+  const entry = store.get(code);
+  if (!entry) {
+    return false;
+  }
+  store.delete(code);
+  return true;
+}

--- a/extensions/telegram-files/src/path-utils.ts
+++ b/extensions/telegram-files/src/path-utils.ts
@@ -1,0 +1,132 @@
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+/** Prevent path traversal: resolve and verify the path is absolute. Resolves symlinks including parent dirs. */
+export async function safePath(rawPath: string): Promise<string | null> {
+  if (!rawPath || rawPath.includes("\0")) {
+    return null;
+  }
+  const resolved = path.resolve(rawPath);
+  try {
+    return await fs.realpath(resolved);
+  } catch {
+    // Path doesn't exist yet (write/mkdir) — resolve the deepest existing parent
+    // and preserve all non-existent path components as a tail suffix.
+    let current = resolved;
+    let tail = "";
+    while (current !== path.dirname(current)) {
+      const parent = path.dirname(current);
+      tail = tail ? path.join(path.basename(current), tail) : path.basename(current);
+      try {
+        const realParent = await fs.realpath(parent);
+        return path.join(realParent, tail);
+      } catch {
+        current = parent;
+      }
+    }
+    // No ancestor could be resolved — reject rather than returning an unresolved path.
+    return null;
+  }
+}
+
+/** Check if a resolved path is within allowed paths. */
+export async function isPathAllowed(
+  resolvedPath: string,
+  allowedPaths: string[],
+): Promise<boolean> {
+  const paths = allowedPaths.length > 0 ? allowedPaths : [os.homedir()];
+  for (const base of paths) {
+    let resolvedBase: string;
+    try {
+      resolvedBase = await fs.realpath(path.resolve(base));
+    } catch {
+      resolvedBase = path.resolve(base);
+    }
+    if (resolvedPath === resolvedBase || resolvedPath.startsWith(resolvedBase + path.sep)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Check if a path is an allowed root itself (prevent deleting root allowed dirs). */
+export async function isAllowedRoot(
+  resolvedPath: string,
+  allowedPaths: string[],
+): Promise<boolean> {
+  const paths = allowedPaths.length > 0 ? allowedPaths : [os.homedir()];
+  for (const base of paths) {
+    let resolvedBase: string;
+    try {
+      resolvedBase = await fs.realpath(path.resolve(base));
+    } catch {
+      resolvedBase = path.resolve(base);
+    }
+    if (resolvedPath === resolvedBase) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Sanitize error message to avoid leaking internal paths. */
+export function sanitizeError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.replace(/\/[^\s,)]+/g, "[path]");
+}
+
+/** Async recursive file name search. */
+export async function searchFiles(
+  basePath: string,
+  query: string,
+  maxResults = 50,
+  maxDepth = 5,
+): Promise<{ path: string; name: string; isDir: boolean }[]> {
+  const results: { path: string; name: string; isDir: boolean }[] = [];
+  const lowerQuery = query.toLowerCase();
+  const visited = new Set<string>();
+
+  async function walk(dir: string, depth: number) {
+    if (depth > maxDepth || results.length >= maxResults) {
+      return;
+    }
+
+    // Detect symlink cycles
+    try {
+      const realDir = await fs.realpath(dir);
+      if (visited.has(realDir)) {
+        return;
+      }
+      visited.add(realDir);
+    } catch {
+      return;
+    }
+
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return; // permission denied etc
+    }
+    for (const e of entries) {
+      if (results.length >= maxResults) {
+        return;
+      }
+      if (e.name.startsWith(".")) {
+        continue; // skip hidden
+      }
+      const full = path.join(dir, e.name);
+      if (e.name.toLowerCase().includes(lowerQuery)) {
+        results.push({ path: full, name: e.name, isDir: e.isDirectory() });
+      }
+      if (e.isDirectory()) {
+        await walk(full, depth + 1);
+      }
+    }
+  }
+
+  await walk(basePath, 0);
+  return results;
+}

--- a/extensions/telegram-files/src/register.ts
+++ b/extensions/telegram-files/src/register.ts
@@ -1,0 +1,181 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  handleDelete,
+  handleExchange,
+  handleHome,
+  handleLs,
+  handleMkdir,
+  handleRead,
+  handleSearch,
+  handleUpload,
+  handleWrite,
+} from "./api-handlers.js";
+import { checkAuth, jsonResponse } from "./auth.js";
+import { createPairingCode } from "./pairing.js";
+import { getFilesRuntime } from "./runtime.js";
+import { serveStaticAsset } from "./static-server.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST_WEBAPP = path.resolve(__dirname, "..", "dist", "webapp");
+
+export type TelegramFilesPluginConfig = {
+  externalUrl?: string;
+  allowedPaths?: string[];
+};
+
+export function registerAll(api: OpenClawPluginApi) {
+  const raw = api.pluginConfig as Record<string, unknown> | undefined;
+  const pluginConfig: TelegramFilesPluginConfig = {
+    externalUrl: typeof raw?.externalUrl === "string" ? raw.externalUrl : undefined,
+    allowedPaths: Array.isArray(raw?.allowedPaths)
+      ? (raw.allowedPaths as unknown[]).filter((p): p is string => typeof p === "string")
+      : [],
+  };
+  const allowedPaths = pluginConfig.allowedPaths ?? [];
+
+  // Derive CORS origin from externalUrl (deny cross-origin when unconfigured or malformed)
+  let corsOrigin = "null";
+  if (pluginConfig.externalUrl) {
+    try {
+      const parsed = new URL(pluginConfig.externalUrl);
+      corsOrigin = parsed.origin;
+    } catch {
+      // Malformed URL — keep "null" to deny cross-origin requests
+    }
+  }
+
+  // 1. Register /files command
+  api.registerCommand({
+    name: "files",
+    description: "Open file manager on mobile (optional: /files /path/to/dir)",
+    acceptsArgs: true,
+    handler: async (ctx) => {
+      const cfg = ctx.config;
+      const externalUrl = pluginConfig.externalUrl;
+
+      if (!externalUrl) {
+        return {
+          text: 'Please set externalUrl: openclaw config set plugins.entries.telegram-files.config.externalUrl "https://your-host"',
+        };
+      }
+
+      const gatewayToken = cfg.gateway?.auth?.token;
+      if (!gatewayToken) {
+        return {
+          text: "Gateway auth token not found. Set gateway.auth.token in config.",
+        };
+      }
+
+      const code = createPairingCode();
+
+      // Build Mini App URL with optional start path
+      const startPath = ctx.args?.trim() || "";
+      let miniAppUrl = `${externalUrl}/plugins/telegram-files/?pair=${code}`;
+      if (startPath) {
+        miniAppUrl += `&path=${encodeURIComponent(startPath)}`;
+      }
+
+      if (ctx.channel === "telegram" && ctx.senderId) {
+        const runtime = getFilesRuntime();
+        const { token } = runtime.channel.telegram.resolveTelegramToken(cfg);
+        if (token) {
+          try {
+            const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                chat_id: ctx.senderId,
+                text: "Tap to open file manager:",
+                reply_markup: {
+                  inline_keyboard: [
+                    [
+                      {
+                        text: "Open File Manager",
+                        web_app: { url: miniAppUrl },
+                      },
+                    ],
+                  ],
+                },
+              }),
+            });
+            if (resp.ok) {
+              return { text: "" };
+            }
+          } catch {
+            // Fall through to text fallback
+          }
+        }
+      }
+
+      return { text: `Open file manager: ${miniAppUrl}` };
+    },
+  });
+
+  // 2. Register HTTP handler
+  api.registerHttpHandler(async (req: IncomingMessage, res: ServerResponse) => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    const prefix = "/plugins/telegram-files";
+
+    if (!url.pathname.startsWith(prefix)) {
+      return false;
+    }
+
+    const subPath = url.pathname.slice(prefix.length) || "/";
+
+    // CORS preflight
+    if (req.method === "OPTIONS") {
+      res.setHeader("Access-Control-Allow-Origin", corsOrigin);
+      res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+      res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+      res.setHeader("Referrer-Policy", "no-referrer");
+      res.statusCode = 204;
+      res.end();
+      return true;
+    }
+
+    // Token exchange (no auth required)
+    if (req.method === "POST" && subPath === "/api/exchange") {
+      await handleExchange(req, res, corsOrigin);
+      return true;
+    }
+
+    // All other API endpoints require auth
+    if (subPath.startsWith("/api/")) {
+      if (!checkAuth(req)) {
+        jsonResponse(res, 401, { error: "unauthorized" }, corsOrigin);
+        return true;
+      }
+
+      if (req.method === "GET" && subPath === "/api/home") {
+        handleHome(res, allowedPaths, corsOrigin);
+      } else if (req.method === "GET" && subPath === "/api/ls") {
+        await handleLs(url, res, allowedPaths, corsOrigin);
+      } else if (req.method === "GET" && subPath === "/api/read") {
+        await handleRead(url, res, allowedPaths, corsOrigin);
+      } else if (req.method === "POST" && subPath === "/api/write") {
+        await handleWrite(req, res, allowedPaths, corsOrigin);
+      } else if (req.method === "POST" && subPath === "/api/upload") {
+        await handleUpload(req, url, res, allowedPaths, corsOrigin);
+      } else if (req.method === "POST" && subPath === "/api/mkdir") {
+        await handleMkdir(req, res, allowedPaths, corsOrigin);
+      } else if (req.method === "DELETE" && subPath === "/api/delete") {
+        await handleDelete(req, url, res, allowedPaths, corsOrigin);
+      } else if (req.method === "GET" && subPath === "/api/search") {
+        await handleSearch(url, res, allowedPaths, corsOrigin);
+      } else {
+        jsonResponse(res, 404, { error: "unknown API endpoint" }, corsOrigin);
+      }
+      return true;
+    }
+
+    // Static assets (GET)
+    if (req.method === "GET") {
+      return await serveStaticAsset(req, res, subPath, DIST_WEBAPP);
+    }
+
+    return false;
+  });
+}

--- a/extensions/telegram-files/src/runtime.ts
+++ b/extensions/telegram-files/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setFilesRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getFilesRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("telegram-files runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/telegram-files/src/static-server.ts
+++ b/extensions/telegram-files/src/static-server.ts
@@ -1,0 +1,122 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import fs from "node:fs";
+import fsAsync from "node:fs/promises";
+import path from "node:path";
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff2": "font/woff2",
+};
+
+/**
+ * Serve static assets from the dist/webapp/ directory.
+ * Adds Telegram-friendly CSP headers so the page can load inside the
+ * Telegram Mini App iframe.
+ */
+export async function serveStaticAsset(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  urlPath: string,
+  distRoot: string,
+): Promise<boolean> {
+  // Default to index.html for root or SPA fallback
+  const safePath = urlPath === "/" || urlPath === "" ? "/index.html" : urlPath;
+
+  // Prevent directory traversal
+  const resolved = path.resolve(distRoot, safePath.replace(/^\//, ""));
+  if (!resolved.startsWith(distRoot)) {
+    res.statusCode = 403;
+    res.end("Forbidden");
+    return true;
+  }
+
+  // Resolve symlinks and re-verify
+  let realPath: string;
+  try {
+    realPath = await fsAsync.realpath(resolved);
+  } catch {
+    // File doesn't exist — try SPA fallback
+    const indexPath = path.join(distRoot, "index.html");
+    try {
+      await fsAsync.access(indexPath);
+      return sendFile(res, indexPath, ".html");
+    } catch {
+      res.statusCode = 404;
+      res.end("Not Found");
+      return true;
+    }
+  }
+
+  let distRootReal: string;
+  try {
+    distRootReal = await fsAsync.realpath(distRoot);
+  } catch {
+    res.statusCode = 500;
+    res.end("Internal Server Error");
+    return true;
+  }
+
+  if (!realPath.startsWith(distRootReal)) {
+    res.statusCode = 403;
+    res.end("Forbidden");
+    return true;
+  }
+
+  try {
+    const stat = await fsAsync.stat(realPath);
+    if (stat.isDirectory()) {
+      const indexPath = path.join(distRoot, "index.html");
+      try {
+        await fsAsync.access(indexPath);
+        return sendFile(res, indexPath, ".html");
+      } catch {
+        res.statusCode = 404;
+        res.end("Not Found");
+        return true;
+      }
+    }
+  } catch {
+    res.statusCode = 404;
+    res.end("Not Found");
+    return true;
+  }
+
+  const ext = path.extname(realPath).toLowerCase();
+  return sendFile(res, realPath, ext);
+}
+
+function sendFile(res: ServerResponse, filePath: string, ext: string): boolean {
+  const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
+  res.setHeader("Content-Type", contentType);
+  // Allow Telegram to embed in iframe
+  res.setHeader(
+    "Content-Security-Policy",
+    "default-src 'self'; script-src 'self' https://telegram.org; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors https://web.telegram.org https://*.telegram.org",
+  );
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  // Immutable cache for hashed assets, short cache for html
+  if (ext === ".html") {
+    res.setHeader("Cache-Control", "no-cache");
+  } else {
+    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+  }
+  res.statusCode = 200;
+  const stream = fs.createReadStream(filePath);
+  stream.on("error", () => {
+    if (!res.headersSent) {
+      res.statusCode = 500;
+      res.end("Internal Server Error");
+    } else {
+      res.destroy();
+    }
+  });
+  stream.pipe(res);
+  return true;
+}

--- a/extensions/telegram-files/src/static-server.ts
+++ b/extensions/telegram-files/src/static-server.ts
@@ -30,7 +30,7 @@ export async function serveStaticAsset(
 
   // Prevent directory traversal
   const resolved = path.resolve(distRoot, safePath.replace(/^\//, ""));
-  if (!resolved.startsWith(distRoot)) {
+  if (!resolved.startsWith(distRoot.endsWith(path.sep) ? distRoot : distRoot + path.sep)) {
     res.statusCode = 403;
     res.end("Forbidden");
     return true;
@@ -62,7 +62,9 @@ export async function serveStaticAsset(
     return true;
   }
 
-  if (!realPath.startsWith(distRootReal)) {
+  if (
+    !realPath.startsWith(distRootReal.endsWith(path.sep) ? distRootReal : distRootReal + path.sep)
+  ) {
     res.statusCode = 403;
     res.end("Forbidden");
     return true;

--- a/extensions/telegram-files/webapp/index.html
+++ b/extensions/telegram-files/webapp/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <title>OpenClaw File Manager</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <link rel="stylesheet" href="./src/styles/theme.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/extensions/telegram-files/webapp/src/app.ts
+++ b/extensions/telegram-files/webapp/src/app.ts
@@ -1,0 +1,75 @@
+import { FilesApiClient } from "./services/files-api.js";
+import { getTelegramWebApp } from "./services/telegram.js";
+import { renderFileEditor } from "./views/file-editor.js";
+import { loadAndRenderFileList } from "./views/file-list.js";
+
+export function mountApp(container: HTMLElement, client: FilesApiClient): void {
+  const webapp = getTelegramWebApp();
+  let currentPath = "/";
+  let homeDir = "/";
+  let currentBackHandler: (() => void) | null = null;
+
+  // Check URL for a start path (from /files /some/path)
+  const urlParams = new URLSearchParams(window.location.search);
+  const startPath = urlParams.get("path");
+
+  // Ask the server for the default start directory
+  client
+    .home()
+    .then((result) => {
+      homeDir = result.path;
+      showDir(startPath || result.path);
+    })
+    .catch(() => showDir(startPath || "/"));
+
+  function showDir(dirPath: string) {
+    currentPath = dirPath;
+
+    // Clean up previous back handler to prevent handler accumulation
+    if (currentBackHandler) {
+      webapp.BackButton.offClick(currentBackHandler);
+      currentBackHandler = null;
+    }
+    webapp.BackButton.hide();
+    webapp.MainButton.hide();
+
+    // Show back button only if we're deeper than the home directory
+    if (dirPath !== "/" && dirPath !== homeDir) {
+      webapp.BackButton.show();
+      const handleBack = () => {
+        webapp.BackButton.offClick(handleBack);
+        currentBackHandler = null;
+        // Normalize trailing slashes before computing parent
+        const normalized = dirPath.replace(/\/+$/, "");
+        const parent = normalized.substring(0, normalized.lastIndexOf("/")) || "/";
+        showDir(parent);
+      };
+      currentBackHandler = handleBack;
+      webapp.BackButton.onClick(handleBack);
+    }
+
+    loadAndRenderFileList({
+      container,
+      client,
+      dirPath,
+      homeDir,
+      onNavigate: (path) => showDir(path),
+      onFileOpen: (path) => showEditor(path),
+    });
+  }
+
+  function showEditor(filePath: string) {
+    // Clean up back handler before entering editor
+    if (currentBackHandler) {
+      webapp.BackButton.offClick(currentBackHandler);
+      currentBackHandler = null;
+    }
+    renderFileEditor({
+      container,
+      client,
+      filePath,
+      webapp,
+      onBack: () => showDir(currentPath),
+    });
+  }
+}

--- a/extensions/telegram-files/webapp/src/main.ts
+++ b/extensions/telegram-files/webapp/src/main.ts
@@ -1,0 +1,151 @@
+import type { TelegramWebApp } from "./services/telegram.js";
+import { mountApp } from "./app.js";
+import { restoreToken, saveToken, clearToken, exchangePairCode } from "./services/auth.js";
+import { FilesApiClient } from "./services/files-api.js";
+import { getTelegramWebApp } from "./services/telegram.js";
+import { errorMessage } from "./utils.js";
+
+async function main() {
+  const app = document.getElementById("app");
+  if (!app) {
+    document.body.textContent = "Fatal: #app element not found";
+    return;
+  }
+  const webapp = getTelegramWebApp();
+
+  webapp.ready();
+  webapp.expand();
+
+  showStatus(app, "Connecting...");
+
+  try {
+    const token = await authenticate();
+    const client = new FilesApiClient(token);
+
+    // Strip pair code from URL after successful auth
+    const url = new URL(window.location.href);
+    if (url.searchParams.has("pair")) {
+      url.searchParams.delete("pair");
+      history.replaceState(null, "", url.toString());
+    }
+
+    app.replaceChildren();
+    mountApp(app, client);
+  } catch (err) {
+    const msg = errorMessage(err);
+    if (isAuthError(msg)) {
+      // Clear stale token so next open doesn't repeat
+      try {
+        await clearToken();
+      } catch {
+        /* ignore */
+      }
+      showExpiredUI(app, webapp);
+    } else {
+      showStatus(app, `Connection failed: ${msg}`, true);
+    }
+  }
+}
+
+function isAuthError(msg: string): boolean {
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes("unauthorized") ||
+    lower.includes("expired") ||
+    lower.includes("no saved token") ||
+    lower.includes("invalid") ||
+    lower.includes("pairing")
+  );
+}
+
+async function authenticate(): Promise<string> {
+  // 1. Check URL for pairing code FIRST (fresh code takes priority)
+  const url = new URL(window.location.href);
+  const pairCode = url.searchParams.get("pair");
+
+  if (pairCode) {
+    try {
+      const token = await exchangePairCode(pairCode);
+
+      // Save (best-effort)
+      try {
+        await saveToken(token);
+      } catch {
+        /* CloudStorage unavailable */
+      }
+
+      // Validate the fresh token actually works
+      const client = new FilesApiClient(token);
+      await client.home();
+
+      return token;
+    } catch {
+      // Pairing code already used or expired — fall through to saved token
+    }
+  }
+
+  // 2. Try saved token
+  try {
+    const saved = await restoreToken();
+    if (saved && saved.length > 0) {
+      // Validate token is still active on server
+      const client = new FilesApiClient(saved);
+      await client.home();
+      return saved;
+    }
+  } catch {
+    // Token invalid or CloudStorage unavailable — clear and continue
+    try {
+      await clearToken();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  throw new Error("No saved token. Send /files in Telegram to get started.");
+}
+
+/** Show a friendly UI when the session has expired. */
+function showExpiredUI(container: HTMLElement, webapp: TelegramWebApp) {
+  container.replaceChildren();
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "status-message";
+
+  const icon = document.createElement("div");
+  icon.style.fontSize = "48px";
+  icon.style.marginBottom = "12px";
+  icon.textContent = "\u{1F511}";
+
+  const title = document.createElement("div");
+  title.style.fontWeight = "600";
+  title.style.fontSize = "16px";
+  title.style.marginBottom = "8px";
+  title.textContent = "Session Expired";
+
+  const desc = document.createElement("div");
+  desc.style.marginBottom = "16px";
+  desc.textContent = "Send /files in Telegram to get a new link.";
+
+  const closeBtn = document.createElement("button");
+  closeBtn.style.cssText =
+    "padding:10px 24px;border-radius:8px;border:none;background:var(--tg-theme-button-color);color:var(--tg-theme-button-text-color);font-size:14px;font-weight:600;cursor:pointer;";
+  closeBtn.textContent = "Close";
+  closeBtn.addEventListener("click", () => webapp.close());
+
+  wrapper.appendChild(icon);
+  wrapper.appendChild(title);
+  wrapper.appendChild(desc);
+  wrapper.appendChild(closeBtn);
+  container.appendChild(wrapper);
+}
+
+function showStatus(container: HTMLElement, message: string, isError = false) {
+  container.replaceChildren();
+  const div = document.createElement("div");
+  div.className = `status-message ${isError ? "error-text" : ""}`;
+  div.textContent = message;
+  container.appendChild(div);
+}
+
+main();

--- a/extensions/telegram-files/webapp/src/services/auth.ts
+++ b/extensions/telegram-files/webapp/src/services/auth.ts
@@ -1,0 +1,44 @@
+import { cloudStorageGet, cloudStorageSet } from "./telegram.js";
+
+const TOKEN_KEY = "fs_token";
+
+/** Try to restore a saved token from Telegram CloudStorage. */
+export async function restoreToken(): Promise<string | null> {
+  return await cloudStorageGet(TOKEN_KEY);
+}
+
+/** Save token to Telegram CloudStorage. */
+export async function saveToken(token: string): Promise<void> {
+  await cloudStorageSet(TOKEN_KEY, token);
+}
+
+/** Clear saved token from Telegram CloudStorage. */
+export async function clearToken(): Promise<void> {
+  await cloudStorageSet(TOKEN_KEY, "");
+}
+
+/**
+ * Exchange a one-time pairing code for a session token.
+ */
+export async function exchangePairCode(pairCode: string): Promise<string> {
+  const base = window.location.origin;
+  const resp = await fetch(`${base}/plugins/telegram-files/api/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pairCode }),
+  });
+
+  let data: unknown;
+  const contentType = resp.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    data = await resp.json();
+  } else {
+    const text = await resp.text();
+    data = { error: text || `HTTP ${resp.status}` };
+  }
+
+  if (!resp.ok || !data || typeof data !== "object" || !("token" in data)) {
+    throw new Error((data as Record<string, string> | null)?.error ?? "Exchange failed");
+  }
+  return (data as { token: string }).token;
+}

--- a/extensions/telegram-files/webapp/src/services/files-api.ts
+++ b/extensions/telegram-files/webapp/src/services/files-api.ts
@@ -1,0 +1,125 @@
+/** HTTP REST client for the file system API. */
+
+export type FileItem = {
+  name: string;
+  isDir: boolean;
+  isFile: boolean;
+  isSymlink: boolean;
+  size: number;
+  mtime: number;
+};
+
+export type LsResult = {
+  path: string;
+  items: FileItem[];
+};
+
+export type ReadResult = {
+  path: string;
+  content: string;
+  size: number;
+};
+
+export type SearchResult = {
+  path: string;
+  name: string;
+  isDir: boolean;
+};
+
+export type SearchResponse = {
+  path: string;
+  query: string;
+  results: SearchResult[];
+};
+
+export class FilesApiClient {
+  private token: string;
+  private baseUrl: string;
+
+  constructor(token: string) {
+    this.token = token;
+    this.baseUrl = `${window.location.origin}/plugins/telegram-files/api`;
+  }
+
+  /** Parse response body and throw on non-ok status. */
+  private async parseResponse(resp: Response): Promise<unknown> {
+    let data: unknown;
+    const contentType = resp.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      data = await resp.json();
+    } else {
+      const text = await resp.text();
+      data = { error: text || `HTTP ${resp.status}` };
+    }
+
+    if (!resp.ok) {
+      const errorObj = data as Record<string, unknown> | null;
+      const message =
+        errorObj && typeof errorObj.error === "string" ? errorObj.error : `HTTP ${resp.status}`;
+      throw new Error(message);
+    }
+    return data;
+  }
+
+  private async request(method: string, endpoint: string, body?: unknown): Promise<unknown> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+    };
+    const opts: RequestInit = { method, headers };
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      opts.body = JSON.stringify(body);
+    }
+    const resp = await fetch(`${this.baseUrl}${endpoint}`, opts);
+    return this.parseResponse(resp);
+  }
+
+  async ls(dirPath: string): Promise<LsResult> {
+    const encoded = encodeURIComponent(dirPath);
+    return (await this.request("GET", `/ls?path=${encoded}`)) as LsResult;
+  }
+
+  async read(filePath: string): Promise<ReadResult> {
+    const encoded = encodeURIComponent(filePath);
+    return (await this.request("GET", `/read?path=${encoded}`)) as ReadResult;
+  }
+
+  async write(filePath: string, content: string): Promise<void> {
+    await this.request("POST", "/write", { path: filePath, content });
+  }
+
+  async delete(targetPath: string): Promise<void> {
+    const encoded = encodeURIComponent(targetPath);
+    await this.request("DELETE", `/delete?path=${encoded}`);
+  }
+
+  async mkdir(dirPath: string): Promise<void> {
+    await this.request("POST", "/mkdir", { path: dirPath });
+  }
+
+  async home(): Promise<{ path: string }> {
+    return (await this.request("GET", "/home")) as { path: string };
+  }
+
+  async upload(dirPath: string, file: File): Promise<void> {
+    const encodedDir = encodeURIComponent(dirPath);
+    const encodedName = encodeURIComponent(file.name);
+    const resp = await fetch(`${this.baseUrl}/upload?dir=${encodedDir}&name=${encodedName}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: file,
+    });
+    await this.parseResponse(resp);
+  }
+
+  async search(basePath: string, query: string): Promise<SearchResponse> {
+    const encodedPath = encodeURIComponent(basePath);
+    const encodedQuery = encodeURIComponent(query);
+    return (await this.request(
+      "GET",
+      `/search?path=${encodedPath}&q=${encodedQuery}`,
+    )) as SearchResponse;
+  }
+}

--- a/extensions/telegram-files/webapp/src/services/telegram.ts
+++ b/extensions/telegram-files/webapp/src/services/telegram.ts
@@ -1,0 +1,82 @@
+/** Telegram WebApp SDK type helpers. */
+
+export interface TelegramWebApp {
+  initData: string;
+  initDataUnsafe: Record<string, unknown>;
+  colorScheme: "light" | "dark";
+  themeParams: Record<string, string>;
+  isExpanded: boolean;
+  viewportHeight: number;
+  viewportStableHeight: number;
+  MainButton: TelegramMainButton;
+  BackButton: TelegramBackButton;
+  close: () => void;
+  ready: () => void;
+  expand: () => void;
+  onEvent: (event: string, cb: () => void) => void;
+  offEvent: (event: string, cb: () => void) => void;
+  CloudStorage: TelegramCloudStorage;
+}
+
+export interface TelegramMainButton {
+  text: string;
+  color: string;
+  textColor: string;
+  isVisible: boolean;
+  isActive: boolean;
+  isProgressVisible: boolean;
+  setText: (text: string) => void;
+  onClick: (cb: () => void) => void;
+  offClick: (cb: () => void) => void;
+  show: () => void;
+  hide: () => void;
+  enable: () => void;
+  disable: () => void;
+  showProgress: (leaveActive?: boolean) => void;
+  hideProgress: () => void;
+}
+
+export interface TelegramBackButton {
+  isVisible: boolean;
+  onClick: (cb: () => void) => void;
+  offClick: (cb: () => void) => void;
+  show: () => void;
+  hide: () => void;
+}
+
+export interface TelegramCloudStorage {
+  setItem: (key: string, value: string, cb?: (err: Error | null, ok?: boolean) => void) => void;
+  getItem: (key: string, cb: (err: Error | null, value?: string) => void) => void;
+  removeItem: (key: string, cb?: (err: Error | null, ok?: boolean) => void) => void;
+}
+
+/** Get the Telegram WebApp instance from the global scope. */
+export function getTelegramWebApp(): TelegramWebApp {
+  const win = window as unknown as { Telegram?: { WebApp?: TelegramWebApp } };
+  if (!win.Telegram?.WebApp) {
+    throw new Error("Telegram WebApp SDK not available");
+  }
+  return win.Telegram.WebApp;
+}
+
+/** Promisified CloudStorage.getItem. */
+export function cloudStorageGet(key: string): Promise<string | null> {
+  const wa = getTelegramWebApp();
+  return new Promise((resolve) => {
+    wa.CloudStorage.getItem(key, (err, value) => {
+      if (err || !value) resolve(null);
+      else resolve(value);
+    });
+  });
+}
+
+/** Promisified CloudStorage.setItem. */
+export function cloudStorageSet(key: string, value: string): Promise<void> {
+  const wa = getTelegramWebApp();
+  return new Promise((resolve, reject) => {
+    wa.CloudStorage.setItem(key, value, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}

--- a/extensions/telegram-files/webapp/src/styles/theme.css
+++ b/extensions/telegram-files/webapp/src/styles/theme.css
@@ -1,0 +1,366 @@
+:root {
+  --tg-theme-bg-color: var(--tg-color-scheme, #ffffff);
+  --tg-theme-text-color: #000000;
+  --tg-theme-hint-color: #999999;
+  --tg-theme-link-color: #2481cc;
+  --tg-theme-button-color: #2481cc;
+  --tg-theme-button-text-color: #ffffff;
+  --tg-theme-secondary-bg-color: #f0f0f0;
+
+  --font-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+  --radius: 8px;
+  --gap: 12px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--tg-theme-bg-color);
+  color: var(--tg-theme-text-color);
+  min-height: 100vh;
+  -webkit-text-size-adjust: 100%;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: var(--gap);
+}
+
+/* Toolbar (path + toggle) */
+.list-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.list-toolbar .path-header {
+  flex: 1;
+  padding: 0;
+}
+
+/* Path header / Breadcrumb */
+.path-header {
+  font-size: 13px;
+  font-family: var(--font-mono);
+  color: var(--tg-theme-hint-color);
+  padding: 8px 0;
+  white-space: nowrap;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.breadcrumb-link {
+  color: var(--tg-theme-link-color);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.breadcrumb-link:active {
+  opacity: 0.6;
+}
+
+.breadcrumb-current {
+  color: var(--tg-theme-text-color);
+  font-weight: 600;
+}
+
+.breadcrumb-sep {
+  color: var(--tg-theme-hint-color);
+}
+
+.breadcrumb-disabled {
+  color: var(--tg-theme-hint-color);
+}
+
+/* Toggle hidden files button */
+.toggle-hidden-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--tg-theme-hint-color);
+  background: transparent;
+  color: var(--tg-theme-hint-color);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.toggle-hidden-btn:active {
+  opacity: 0.7;
+}
+
+/* Search bar */
+.search-bar {
+  padding: 4px 0 8px;
+}
+
+.search-input {
+  width: 100%;
+  padding: 10px var(--gap);
+  font-size: 14px;
+  border: 1px solid var(--tg-theme-hint-color);
+  border-radius: var(--radius);
+  background: var(--tg-theme-secondary-bg-color);
+  color: var(--tg-theme-text-color);
+  outline: none;
+  -webkit-appearance: none;
+}
+
+.search-input:focus {
+  border-color: var(--tg-theme-button-color);
+}
+
+.search-input::placeholder {
+  color: var(--tg-theme-hint-color);
+}
+
+/* Search results */
+.search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* File list */
+.file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  gap: var(--gap);
+  padding: 14px var(--gap);
+  border-radius: var(--radius);
+  background: var(--tg-theme-secondary-bg-color);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.file-item:active {
+  opacity: 0.7;
+}
+
+.file-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+  width: 28px;
+  text-align: center;
+}
+
+.file-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.file-name {
+  font-weight: 600;
+  font-size: 15px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-meta {
+  font-size: 12px;
+  color: var(--tg-theme-hint-color);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.file-badge.exists {
+  background: #e6f4ea;
+  color: #1e8e3e;
+}
+
+.file-badge.missing {
+  background: #fef3e6;
+  color: #e37400;
+}
+
+/* Delete button on items */
+.item-delete-btn {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+
+.item-delete-btn:active {
+  opacity: 1;
+}
+
+/* Action buttons bar */
+.actions-bar {
+  display: flex;
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.action-btn {
+  flex: 1;
+  padding: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  border: 2px dashed var(--tg-theme-hint-color);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--tg-theme-hint-color);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.action-btn:active {
+  opacity: 0.7;
+}
+
+/* Editor */
+.editor-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: var(--gap);
+}
+
+.editor-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.editor-filename {
+  font-weight: 600;
+  font-size: 16px;
+  flex: 1;
+}
+
+.editor-status {
+  font-size: 12px;
+  color: var(--tg-theme-hint-color);
+}
+
+.editor-textarea {
+  flex: 1;
+  width: 100%;
+  min-height: 300px;
+  padding: var(--gap);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+  border: 1px solid var(--tg-theme-hint-color);
+  border-radius: var(--radius);
+  background: var(--tg-theme-secondary-bg-color);
+  color: var(--tg-theme-text-color);
+  resize: vertical;
+  outline: none;
+  -webkit-appearance: none;
+}
+
+.editor-textarea:focus {
+  border-color: var(--tg-theme-button-color);
+}
+
+/* Binary file notice */
+.binary-notice {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px var(--gap);
+  text-align: center;
+  gap: 8px;
+}
+
+.binary-icon {
+  font-size: 48px;
+}
+
+.binary-title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.binary-desc {
+  font-size: 14px;
+  color: var(--tg-theme-hint-color);
+}
+
+/* Agent selector */
+.agent-selector {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 4px 0 var(--gap);
+  -webkit-overflow-scrolling: touch;
+}
+
+.agent-chip {
+  padding: 6px 14px;
+  border-radius: 16px;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  background: var(--tg-theme-secondary-bg-color);
+  color: var(--tg-theme-text-color);
+  border: none;
+  transition: background 0.15s;
+}
+
+.agent-chip.active {
+  background: var(--tg-theme-button-color);
+  color: var(--tg-theme-button-text-color);
+}
+
+/* Status messages */
+.status-message {
+  text-align: center;
+  padding: 40px var(--gap);
+  color: var(--tg-theme-hint-color);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.status-message .emoji {
+  font-size: 40px;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.error-text {
+  color: #e53935;
+}
+
+/* Header */
+.page-header {
+  font-size: 18px;
+  font-weight: 700;
+  padding: 8px 0 4px;
+}

--- a/extensions/telegram-files/webapp/src/utils.ts
+++ b/extensions/telegram-files/webapp/src/utils.ts
@@ -1,0 +1,7 @@
+/** Extract a human-readable error message from an unknown throw value. */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/extensions/telegram-files/webapp/src/views/file-editor.ts
+++ b/extensions/telegram-files/webapp/src/views/file-editor.ts
@@ -1,0 +1,172 @@
+import type { FilesApiClient } from "../services/files-api.js";
+import type { TelegramWebApp } from "../services/telegram.js";
+import { errorMessage } from "../utils.js";
+
+/** Render the file editor view. */
+export function renderFileEditor(params: {
+  container: HTMLElement;
+  client: FilesApiClient;
+  filePath: string;
+  webapp: TelegramWebApp;
+  onBack: () => void;
+}): void {
+  const { container, client, filePath, webapp, onBack } = params;
+  container.replaceChildren();
+
+  const editorContainer = document.createElement("div");
+  editorContainer.className = "editor-container";
+
+  const header = document.createElement("div");
+  header.className = "editor-header";
+
+  const fileNameEl = document.createElement("span");
+  fileNameEl.className = "editor-filename";
+  // Show just the filename, full path in subtitle
+  const parts = filePath.split("/");
+  fileNameEl.textContent = parts[parts.length - 1] || filePath;
+
+  const statusEl = document.createElement("span");
+  statusEl.className = "editor-status";
+  statusEl.textContent = "Loading...";
+
+  header.appendChild(fileNameEl);
+  header.appendChild(statusEl);
+
+  const pathEl = document.createElement("div");
+  pathEl.className = "file-meta";
+  pathEl.style.padding = "0 0 8px";
+  pathEl.textContent = filePath;
+
+  const textarea = document.createElement("textarea");
+  textarea.className = "editor-textarea";
+  textarea.placeholder = "Loading...";
+  textarea.disabled = true;
+  textarea.spellcheck = false;
+
+  editorContainer.appendChild(header);
+  editorContainer.appendChild(pathEl);
+  editorContainer.appendChild(textarea);
+  container.appendChild(editorContainer);
+
+  let originalContent = "";
+  let dirty = false;
+  let isBinary = false;
+  let isNewFile = false;
+  let saving = false;
+
+  textarea.addEventListener("input", () => {
+    if (isBinary) return;
+    const isDirty = textarea.value !== originalContent;
+    if (isDirty !== dirty) {
+      dirty = isDirty;
+      statusEl.textContent = dirty ? "Modified" : isNewFile ? "New file" : "Saved";
+      if (dirty) {
+        webapp.MainButton.setText("Save");
+        webapp.MainButton.show();
+      } else {
+        webapp.MainButton.hide();
+      }
+    }
+  });
+
+  // Back button
+  webapp.BackButton.show();
+  const handleBack = () => {
+    if (dirty && !confirm("You have unsaved changes. Discard?")) return;
+    cleanup();
+    onBack();
+  };
+  webapp.BackButton.onClick(handleBack);
+
+  // Save
+  const handleSave = async () => {
+    if (isBinary || saving) return;
+    saving = true;
+    webapp.MainButton.showProgress(true);
+    webapp.MainButton.disable();
+    statusEl.textContent = "Saving...";
+
+    try {
+      await client.write(filePath, textarea.value);
+      originalContent = textarea.value;
+      dirty = false;
+      isNewFile = false;
+      statusEl.textContent = "Saved";
+      webapp.MainButton.hide();
+    } catch (err) {
+      statusEl.textContent = `Error: ${errorMessage(err)}`;
+    } finally {
+      saving = false;
+      webapp.MainButton.hideProgress();
+      webapp.MainButton.enable();
+    }
+  };
+  webapp.MainButton.onClick(handleSave);
+
+  function cleanup() {
+    webapp.BackButton.hide();
+    webapp.BackButton.offClick(handleBack);
+    webapp.MainButton.hide();
+    webapp.MainButton.offClick(handleSave);
+  }
+
+  loadContent();
+
+  async function loadContent() {
+    try {
+      const result = await client.read(filePath);
+      originalContent = result.content;
+      textarea.value = result.content;
+      textarea.disabled = false;
+      statusEl.textContent = "Ready";
+    } catch (err) {
+      const msg = errorMessage(err);
+
+      // Binary file detection
+      if (msg.includes("binary file")) {
+        isBinary = true;
+        textarea.style.display = "none";
+        statusEl.textContent = "";
+
+        const notice = document.createElement("div");
+        notice.className = "binary-notice";
+
+        const iconEl = document.createElement("div");
+        iconEl.className = "binary-icon";
+        iconEl.textContent = "\u{1F512}";
+
+        const titleEl = document.createElement("div");
+        titleEl.className = "binary-title";
+        titleEl.textContent = "Binary File";
+
+        const descEl = document.createElement("div");
+        descEl.className = "binary-desc";
+        descEl.textContent = "This file cannot be edited as text.";
+
+        notice.appendChild(iconEl);
+        notice.appendChild(titleEl);
+        notice.appendChild(descEl);
+        editorContainer.appendChild(notice);
+        return;
+      }
+
+      // New file (doesn't exist yet) — allow editing empty content
+      if (msg.includes("ENOENT") || msg.includes("no such file")) {
+        isNewFile = true;
+        originalContent = "";
+        textarea.value = "";
+        textarea.disabled = false;
+        textarea.placeholder = "Start typing...";
+        statusEl.textContent = "New file";
+        // Show save button immediately for new files
+        webapp.MainButton.setText("Save");
+        webapp.MainButton.show();
+        dirty = true;
+        return;
+      }
+
+      statusEl.textContent = `Error: ${msg}`;
+      textarea.placeholder = "Failed to load file.";
+    }
+  }
+}

--- a/extensions/telegram-files/webapp/src/views/file-list.ts
+++ b/extensions/telegram-files/webapp/src/views/file-list.ts
@@ -1,0 +1,468 @@
+import type { FilesApiClient, FileItem, SearchResult } from "../services/files-api.js";
+import { errorMessage } from "../utils.js";
+
+/** Join base path with a name, avoiding double slashes. */
+function joinPath(base: string, name: string): string {
+  return base.endsWith("/") ? `${base}${name}` : `${base}/${name}`;
+}
+
+/** Format bytes to human-readable size. */
+function formatSize(bytes: number): string {
+  if (bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const val = bytes / Math.pow(1024, i);
+  return `${val < 10 ? val.toFixed(1) : Math.round(val)} ${units[i]}`;
+}
+
+/** Format mtime to relative or short date. */
+function formatTime(mtimeMs: number): string {
+  if (!mtimeMs) return "";
+  const diff = Date.now() - mtimeMs;
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const date = new Date(mtimeMs);
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  return `${months[date.getMonth()]} ${date.getDate()}`;
+}
+
+/** Create a delete button for a file or directory item. */
+function createDeleteButton(
+  itemPath: string,
+  itemName: string,
+  isDir: boolean,
+  client: FilesApiClient,
+  onRefresh: () => void,
+): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.className = "item-delete-btn";
+  btn.textContent = "\u{1F5D1}";
+  btn.addEventListener("click", async (e) => {
+    e.stopPropagation();
+    if ((btn as HTMLButtonElement).disabled) return;
+    const confirmMsg = isDir
+      ? `Delete folder "${itemName}" and all its contents?`
+      : `Delete "${itemName}"?`;
+    if (!confirm(confirmMsg)) return;
+    btn.disabled = true;
+    try {
+      await client.delete(itemPath);
+      onRefresh();
+    } catch (err) {
+      btn.disabled = false;
+      alert(`Delete failed: ${errorMessage(err)}`);
+    }
+  });
+  return btn;
+}
+
+const MAX_DISPLAY_ITEMS = 500;
+
+/** Render the directory listing view. */
+export function renderFileList(params: {
+  container: HTMLElement;
+  currentPath: string;
+  items: FileItem[];
+  client: FilesApiClient;
+  homeDir: string;
+  onNavigate: (path: string) => void;
+  onFileOpen: (path: string) => void;
+  onRefresh: () => void;
+}): void {
+  const { container, currentPath, items, client, homeDir, onNavigate, onFileOpen, onRefresh } =
+    params;
+  container.replaceChildren();
+
+  // --- Toolbar: path + hidden toggle ---
+  const toolbar = document.createElement("div");
+  toolbar.className = "list-toolbar";
+
+  const header = document.createElement("div");
+  header.className = "path-header";
+
+  // Build clickable breadcrumb segments
+  const segments = currentPath.split("/").filter(Boolean);
+  for (let i = 0; i < segments.length; i++) {
+    if (i > 0) {
+      const sep = document.createElement("span");
+      sep.className = "breadcrumb-sep";
+      sep.textContent = " / ";
+      header.appendChild(sep);
+    }
+    const segPath = "/" + segments.slice(0, i + 1).join("/");
+    const link = document.createElement("span");
+    link.textContent = segments[i];
+    if (i === segments.length - 1) {
+      // Current segment — not clickable
+      link.className = "breadcrumb-current";
+    } else if (segPath.length >= homeDir.length && segPath.startsWith(homeDir)) {
+      // Within or equal to homeDir — clickable
+      link.className = "breadcrumb-link";
+      link.addEventListener("click", () => onNavigate(segPath));
+    } else {
+      // Above homeDir — not clickable (would be 403)
+      link.className = "breadcrumb-disabled";
+    }
+    header.appendChild(link);
+  }
+  if (segments.length === 0) {
+    header.textContent = "/";
+  }
+
+  const toggleBtn = document.createElement("button");
+  toggleBtn.className = "toggle-hidden-btn";
+  const showHidden = localStorage.getItem("tgfiles-show-hidden") === "1";
+  toggleBtn.textContent = showHidden ? "Hide .*" : "Show .*";
+  toggleBtn.addEventListener("click", () => {
+    const next = localStorage.getItem("tgfiles-show-hidden") === "1" ? "0" : "1";
+    localStorage.setItem("tgfiles-show-hidden", next);
+    onRefresh();
+  });
+
+  toolbar.appendChild(header);
+  toolbar.appendChild(toggleBtn);
+  container.appendChild(toolbar);
+
+  // --- Search bar ---
+  const searchBar = document.createElement("div");
+  searchBar.className = "search-bar";
+  const searchInput = document.createElement("input");
+  searchInput.type = "text";
+  searchInput.placeholder = "Search files...";
+  searchInput.className = "search-input";
+  searchBar.appendChild(searchInput);
+  container.appendChild(searchBar);
+
+  // Search results container (hidden by default)
+  const searchResults = document.createElement("div");
+  searchResults.className = "search-results";
+  searchResults.style.display = "none";
+  container.appendChild(searchResults);
+
+  let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+  let searchGeneration = 0;
+  searchInput.addEventListener("input", () => {
+    if (searchTimeout) clearTimeout(searchTimeout);
+    const query = searchInput.value.trim();
+    if (!query) {
+      searchResults.style.display = "none";
+      fileListEl.style.display = "";
+      actionsBar.style.display = "";
+      return;
+    }
+    searchTimeout = setTimeout(async () => {
+      const thisGeneration = ++searchGeneration;
+      searchResults.replaceChildren();
+      const loadingMsg = document.createElement("div");
+      loadingMsg.className = "status-message";
+      loadingMsg.textContent = "Searching...";
+      searchResults.appendChild(loadingMsg);
+      searchResults.style.display = "";
+      fileListEl.style.display = "none";
+      actionsBar.style.display = "none";
+      try {
+        const resp = await client.search(currentPath, query);
+        if (thisGeneration !== searchGeneration) return; // stale, discard
+        renderSearchResults(searchResults, resp.results, onNavigate, onFileOpen);
+      } catch (err) {
+        if (thisGeneration !== searchGeneration) return;
+        searchResults.replaceChildren();
+        const errMsg = document.createElement("div");
+        errMsg.className = "status-message error-text";
+        errMsg.textContent = `Search failed: ${errorMessage(err)}`;
+        searchResults.appendChild(errMsg);
+      }
+    }, 300);
+  });
+
+  // --- File list ---
+  const fileListEl = document.createElement("div");
+  fileListEl.className = "file-list";
+
+  // Filter hidden files
+  const filteredItems = showHidden ? items : items.filter((i) => !i.name.startsWith("."));
+
+  // Cap displayed items to prevent DOM overload on mobile
+  const displayItems = filteredItems.slice(0, MAX_DISPLAY_ITEMS);
+
+  if (displayItems.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "status-message";
+    empty.textContent = "Empty directory";
+    fileListEl.appendChild(empty);
+  } else {
+    for (const item of displayItems) {
+      const el = document.createElement("div");
+      el.className = "file-item";
+
+      const icon = document.createElement("span");
+      icon.className = "file-icon";
+      icon.textContent = item.isDir
+        ? "\u{1F4C1}"
+        : item.isSymlink
+          ? "\u{1F517}"
+          : getFileIcon(item.name);
+
+      const info = document.createElement("div");
+      info.className = "file-info";
+
+      const nameText = document.createElement("div");
+      nameText.className = "file-name";
+      nameText.textContent = item.name;
+      info.appendChild(nameText);
+
+      // Show size + mtime for files
+      if (item.isFile) {
+        const meta = document.createElement("div");
+        meta.className = "file-meta";
+        const parts: string[] = [];
+        if (item.size !== undefined) parts.push(formatSize(item.size));
+        if (item.mtime) parts.push(formatTime(item.mtime));
+        meta.textContent = parts.join(" \u00B7 ");
+        info.appendChild(meta);
+      }
+
+      el.appendChild(icon);
+      el.appendChild(info);
+
+      const itemPath = joinPath(currentPath, item.name);
+
+      if (item.isDir) {
+        el.addEventListener("click", () => onNavigate(itemPath));
+        el.appendChild(createDeleteButton(itemPath, item.name, true, client, onRefresh));
+      } else if (item.isFile) {
+        el.appendChild(createDeleteButton(itemPath, item.name, false, client, onRefresh));
+        el.addEventListener("click", () => onFileOpen(itemPath));
+      }
+
+      fileListEl.appendChild(el);
+    }
+  }
+
+  if (filteredItems.length > MAX_DISPLAY_ITEMS) {
+    const notice = document.createElement("div");
+    notice.className = "status-message";
+    notice.textContent = `Showing ${MAX_DISPLAY_ITEMS} of ${filteredItems.length} items. Use search to find specific files.`;
+    fileListEl.appendChild(notice);
+  }
+
+  container.appendChild(fileListEl);
+
+  // --- Action buttons: New File + New Folder + Upload ---
+  const actionsBar = document.createElement("div");
+  actionsBar.className = "actions-bar";
+
+  const newFileBtn = document.createElement("button");
+  newFileBtn.className = "action-btn";
+  newFileBtn.textContent = "+ New File";
+  newFileBtn.addEventListener("click", () => {
+    const name = prompt("Enter file name:");
+    if (!name || !name.trim()) return;
+    const trimmed = name.trim();
+    if (
+      trimmed.includes("/") ||
+      trimmed.includes("\\") ||
+      trimmed.includes("\0") ||
+      trimmed === ".." ||
+      trimmed === "."
+    ) {
+      alert("Invalid file name.");
+      return;
+    }
+    onFileOpen(joinPath(currentPath, trimmed));
+  });
+
+  const newFolderBtn = document.createElement("button");
+  newFolderBtn.className = "action-btn";
+  newFolderBtn.textContent = "+ New Folder";
+  newFolderBtn.addEventListener("click", async () => {
+    const name = prompt("Enter folder name:");
+    if (!name || !name.trim()) return;
+    const trimmed = name.trim();
+    if (
+      trimmed.includes("/") ||
+      trimmed.includes("\\") ||
+      trimmed.includes("\0") ||
+      trimmed === ".." ||
+      trimmed === "."
+    ) {
+      alert("Invalid folder name.");
+      return;
+    }
+    newFolderBtn.disabled = true;
+    newFolderBtn.textContent = "Creating...";
+    try {
+      await client.mkdir(joinPath(currentPath, trimmed));
+      onRefresh();
+    } catch (err) {
+      newFolderBtn.disabled = false;
+      newFolderBtn.textContent = "+ New Folder";
+      alert(`Failed to create folder: ${errorMessage(err)}`);
+    }
+  });
+
+  const uploadBtn = document.createElement("button");
+  uploadBtn.className = "action-btn";
+  uploadBtn.textContent = "\u2191 Upload";
+  const fileInput = document.createElement("input");
+  fileInput.type = "file";
+  fileInput.multiple = true;
+  fileInput.style.display = "none";
+  uploadBtn.addEventListener("click", () => fileInput.click());
+  fileInput.addEventListener("change", async () => {
+    const files = fileInput.files;
+    if (!files || files.length === 0) return;
+    uploadBtn.disabled = true;
+    uploadBtn.textContent = "Uploading...";
+    let failed = 0;
+    for (const file of Array.from(files)) {
+      try {
+        await client.upload(currentPath, file);
+      } catch (err) {
+        failed++;
+        alert(`Upload failed (${file.name}): ${errorMessage(err)}`);
+      }
+    }
+    uploadBtn.disabled = false;
+    uploadBtn.textContent = "\u2191 Upload";
+    fileInput.value = "";
+    onRefresh();
+  });
+
+  actionsBar.appendChild(newFileBtn);
+  actionsBar.appendChild(newFolderBtn);
+  actionsBar.appendChild(uploadBtn);
+  container.appendChild(actionsBar);
+}
+
+/** Render search results. */
+function renderSearchResults(
+  container: HTMLElement,
+  results: SearchResult[],
+  onNavigate: (path: string) => void,
+  onFileOpen: (path: string) => void,
+): void {
+  container.replaceChildren();
+  if (results.length === 0) {
+    const noResults = document.createElement("div");
+    noResults.className = "status-message";
+    noResults.textContent = "No results found";
+    container.appendChild(noResults);
+    return;
+  }
+
+  for (const item of results) {
+    const el = document.createElement("div");
+    el.className = "file-item";
+
+    const icon = document.createElement("span");
+    icon.className = "file-icon";
+    icon.textContent = item.isDir ? "\u{1F4C1}" : getFileIcon(item.name);
+
+    const info = document.createElement("div");
+    info.className = "file-info";
+
+    const nameText = document.createElement("div");
+    nameText.className = "file-name";
+    nameText.textContent = item.name;
+    info.appendChild(nameText);
+
+    const pathText = document.createElement("div");
+    pathText.className = "file-meta";
+    pathText.textContent = item.path;
+    info.appendChild(pathText);
+
+    el.appendChild(icon);
+    el.appendChild(info);
+
+    el.addEventListener("click", () => {
+      if (item.isDir) {
+        onNavigate(item.path);
+      } else {
+        onFileOpen(item.path);
+      }
+    });
+
+    container.appendChild(el);
+  }
+}
+
+/** Load directory listing and render. */
+let loadGeneration = 0;
+export async function loadAndRenderFileList(params: {
+  container: HTMLElement;
+  client: FilesApiClient;
+  dirPath: string;
+  homeDir: string;
+  onNavigate: (path: string) => void;
+  onFileOpen: (path: string) => void;
+}): Promise<void> {
+  const thisGeneration = ++loadGeneration;
+  const { container, client, dirPath, homeDir, onNavigate, onFileOpen } = params;
+  container.replaceChildren();
+  const loadingMsg = document.createElement("div");
+  loadingMsg.className = "status-message";
+  loadingMsg.textContent = "Loading...";
+  container.appendChild(loadingMsg);
+
+  try {
+    const result = await client.ls(dirPath);
+    if (thisGeneration !== loadGeneration) return; // stale navigation
+    renderFileList({
+      container,
+      currentPath: result.path,
+      items: result.items,
+      client,
+      homeDir,
+      onNavigate,
+      onFileOpen,
+      onRefresh: () => loadAndRenderFileList(params),
+    });
+  } catch (err) {
+    if (thisGeneration !== loadGeneration) return;
+    container.replaceChildren();
+    const errMsg = document.createElement("div");
+    errMsg.className = "status-message error-text";
+    errMsg.textContent = `Failed: ${errorMessage(err)}`;
+    container.appendChild(errMsg);
+  }
+}
+
+function getFileIcon(name: string): string {
+  const lower = name.toLowerCase();
+  if (lower.endsWith(".md")) return "\u{1F4DD}";
+  if (lower.endsWith(".json") || lower.endsWith(".json5")) return "\u2699\uFE0F";
+  if (lower.endsWith(".ts") || lower.endsWith(".js")) return "\u{1F4DC}";
+  if (lower.endsWith(".sh")) return "\u{1F41A}";
+  if (lower.endsWith(".log")) return "\u{1F4CB}";
+  if (
+    lower.endsWith(".png") ||
+    lower.endsWith(".jpg") ||
+    lower.endsWith(".jpeg") ||
+    lower.endsWith(".gif") ||
+    lower.endsWith(".svg")
+  )
+    return "\u{1F5BC}\uFE0F";
+  if (lower.endsWith(".zip") || lower.endsWith(".tar") || lower.endsWith(".gz")) return "\u{1F4E6}";
+  if (lower.startsWith(".")) return "\u{1F527}";
+  return "\u{1F4C4}";
+}

--- a/extensions/telegram-files/webapp/vite.config.ts
+++ b/extensions/telegram-files/webapp/vite.config.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: path.resolve(__dirname),
+  base: "/plugins/telegram-files/",
+  build: {
+    outDir: path.resolve(__dirname, "..", "dist", "webapp"),
+    emptyOutDir: true,
+    target: "es2020",
+  },
+  server: {
+    port: 5173,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,6 +487,15 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/telegram-files:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+      vite:
+        specifier: 7.3.1
+        version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
   extensions/tlon:
     dependencies:
       '@urbit/aura':


### PR DESCRIPTION
## Summary

- Adds `telegram-files` extension: Telegram Mini App for managing agent workspace files from mobile
- File browser, text editor, search, upload, and directory management via `/files` command
- Secure pairing flow: one-time codes (5min TTL) → session tokens (24h TTL) via Telegram CloudStorage
- Path traversal prevention via `fs.realpath()` + allowed path whitelist
- Webapp built with Vite (vanilla TS, no framework); build: `pnpm --filter @openclaw/telegram-files build`

## Security

- All file operations scoped to configured `allowedPaths`
- CORS origin derived from `externalUrl` config; malformed URL defaults to deny
- Token eviction: max 200 active, lazy cleanup of expired tokens
- Pairing store capped at 100 codes to prevent memory growth
- Error sanitization: internal paths stripped from responses
- CSP headers restrict iframe embedding to Telegram origins
- X-Content-Type-Options: nosniff on all JSON responses

## Test plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] All source files under 500 LOC limit
- [x] Manually tested all file operations (ls, read, write, mkdir, delete, upload, search)
- [x] Verified path traversal attempts are blocked
- [x] Tested pairing code expiry and token lifecycle
- [x] Tested Mini App in Telegram iOS and Android

🤖 AI-assisted development (Claude). Code has been thoroughly reviewed, security-hardened, and locally tested on VM. I understand what the code does.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `telegram-files` extension that exposes a Telegram Mini App (served under `/plugins/telegram-files/`) plus an authenticated HTTP API (`/plugins/telegram-files/api/*`) to browse, read, edit, upload, mkdir, delete, and search within configured `allowedPaths`. It also registers a `/files` command that generates a one-time pairing code and links to the Mini App, which exchanges that code for a 24h session token stored in Telegram CloudStorage.

Main issue to address before merge: the custom static asset server’s directory traversal protection is implemented using naive string prefix checks and can be bypassed in certain path layouts (see comment).

<h3>Confidence Score: 3/5</h3>

- This PR has a must-fix security issue in static asset path validation before it’s safe to merge.
- Most changes are additive and include basic auth/whitelisting, but the static file server’s traversal protection relies on `startsWith` without enforcing a path-segment boundary, which can allow serving files outside the intended dist directory in certain filesystem layouts.
- extensions/telegram-files/src/static-server.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->