### PR TITLE
docs: add GLM-5 to Z.AI and GLM model documentation

### DIFF
--- a/docs/providers/glm.md
+++ b/docs/providers/glm.md
@@ -29,5 +29,5 @@ openclaw onboard --auth-choice zai-api-key
 ## Notes
 
 - GLM versions and availability can change; check Z.AI's docs for the latest.
-- Example model IDs include `glm-4.7` and `glm-4.6`.
+- Example model IDs include `glm-4.7`, `glm-4.6`, and `glm-5`.
 - For provider details, see [/providers/zai](/providers/zai).

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -32,5 +32,6 @@ openclaw onboard --zai-api-key "$ZAI_API_KEY"
 ## Notes
 
 - GLM models are available as `zai/<model>` (example: `zai/glm-4.7`).
+- Available models include `glm-4.7`, `glm-4.6`, and `glm-5`.
 - See [/providers/glm](/providers/glm) for the model family overview.
 - Z.AI uses Bearer auth with your API key.


### PR DESCRIPTION
Closing this PR. Will submit a more complete PR that actually enables GLM-5 usage.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the provider documentation for Z.AI/GLM to mention the newly released `glm-5` model by adding it to the example/available model lists in `docs/providers/zai.md` and `docs/providers/glm.md`.

Within the broader codebase, Z.AI models are referenced using `zai/<model>` IDs, and some runtime flows apply explicit model-ID filtering (e.g., the “modern model” filter used in live model/profile paths).

<h3>Confidence Score: 3/5</h3>

- Mostly safe documentation change, but it appears to document a model ID the runtime may not recognize yet.
- The change is docs-only, but it claims `glm-5` is available while the codebase currently filters Z.AI models by a hardcoded `glm-4.7` prefix in `isModernModelRef`, which can cause `zai/glm-5` to be excluded in model listing/profile flows.
- docs/providers/zai.md (and matching claim in docs/providers/glm.md); if kept, update src/agents/live-model-filter.ts accordingly.

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->