### PR TITLE
fix: execDocker spawn error handler + cron executeJob persist

### DIFF
--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -22,6 +22,13 @@ export function execDocker(args: string[], opts?: { allowFailure?: boolean }) {
     child.stderr?.on("data", (chunk) => {
       stderr += chunk.toString();
     });
+    child.on("error", (err) => {
+      if (opts?.allowFailure) {
+        resolve({ stdout, stderr: err.message, code: -1 });
+      } else {
+        reject(new Error(`docker spawn failed: ${err.message}`));
+      }
+    });
     child.on("close", (code) => {
       const exitCode = code ?? 0;
       if (exitCode !== 0 && !opts?.allowFailure) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -534,6 +534,11 @@ export async function executeJob(
     state.store.jobs = state.store.jobs.filter((j) => j.id !== job.id);
     emit(state, { jobId: job.id, action: "removed" });
   }
+
+  // Persist state after execution to prevent stale nextRunAtMs on crash-restart.
+  // Without this, runMissedJobs() updates in-memory state but if the process crashes
+  // before the caller's persist(), the old nextRunAtMs is restored from disk → infinite re-execution.
+  await persist(state);
 }
 
 export function wake(


### PR DESCRIPTION
## Summary

Two defense-in-depth fixes that prevent gateway crashes and infinite cron re-execution loops:

- **`execDocker` spawn error handler** (`src/agents/sandbox/docker.ts`): Adds missing `child.on("error")` handler to `execDocker()`. Without it, `spawn("docker", ...)` on a host where Docker is unavailable (ENOENT/EACCES) emits an unhandled error event → uncaught exception → `process.exit(1)`, crashing the entire gateway.

- **`executeJob` persist** (`src/cron/service/timer.ts`): Adds `await persist(state)` at the end of `executeJob()`. Currently, `applyJobResult()` updates `nextRunAtMs` in memory but if the process crashes before the caller persists, the stale state is restored from disk → `runMissedJobs()` re-triggers the same job → infinite re-execution loop.

## Details

### execDocker (`docker.ts`)

The `child.on("error")` handler follows the existing `allowFailure` pattern:
- `allowFailure: true` → resolves with `code: -1`
- `allowFailure: false/undefined` → rejects (caller's catch handles it)

### executeJob (`timer.ts`)

The added `persist()` call is safe because:
- All `executeJob()` callers (`runMissedJobs`, `runDueJobs`) already hold the `locked()` mutex
- `persist()` is idempotent — extra persist calls from callers are harmless
- This mirrors the pattern already used in `runDueJobs` (line 275) and `start` (line 182)

## Test plan

- [ ] Verify `execDocker` gracefully handles missing Docker binary (ENOENT)
- [ ] Verify cron job state persists after execution (kill -9 and restart should not re-execute)
- [ ] Existing cron and sandbox tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two defensive fixes:

- `src/agents/sandbox/docker.ts`: adds a `child.on("error")` handler in `execDocker()` so missing/blocked Docker binaries (e.g. ENOENT/EACCES) don’t crash the process via an unhandled `error` event.
- `src/cron/service/timer.ts`: persists cron state at the end of `executeJob()` to avoid restart loops where in-memory `nextRunAtMs` updates are lost if the process crashes before a later persist.

These changes fit into the existing sandbox/cron infrastructure by hardening process-spawn error handling and ensuring cron job state transitions are durably recorded.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe, but one concurrency/locking concern should be addressed before merging.
- The docker spawn error handler change is straightforward and reduces crash risk. The new unconditional `persist(state)` in `executeJob()` changes write timing/ownership; if `executeJob()` is ever invoked outside an existing `locked()` critical section it can violate the store-path mutex guarantees and race with other operations. Confirming call contexts or adding locking would raise confidence.
- src/cron/service/timer.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->