### PR TITLE
fix(feishu): remove workspace protocol from devDependencies

### DIFF
--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -8,9 +8,6 @@
     "@sinclair/typebox": "0.34.48",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
## Problem
The feishu plugin fails to install via npm with error:
  Unsupported URL Type "workspace:": workspace:*

## Root Cause
package.json contains "openclaw": "workspace:*" in devDependencies. The workspace:* protocol is only supported by monorepo tools (pnpm/yarn), not by standard npm.

## Solution
Remove the openclaw devDependency as it's only needed during development in a monorepo context, not for runtime plugin usage.

## Testing
- Verified npm install works correctly after the change
- All 51 dependencies install successfully
- No security vulnerabilities detected

Fixes installation failures for users installing the plugin via npm.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes a `devDependencies` entry (`openclaw: "workspace:*"`) from `extensions/feishu/package.json` so the Feishu plugin can be installed with plain `npm` (which rejects the `workspace:` protocol).

The Feishu extension appears to be intended for standalone npm installation (per its `openclaw.install.npmSpec` metadata). Removing the workspace-only dev dependency avoids `npm install` failing with `Unsupported URL Type "workspace:"` while leaving runtime `dependencies` unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to package metadata (removing an npm-incompatible `workspace:*` devDependency) and does not alter runtime dependencies or shipped code paths. Repository-wide resolution for `openclaw/plugin-sdk` is handled via root TypeScript path mapping, so this should not break builds while fixing npm installation.
- extensions/feishu/package.json

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->