### PR TITLE
feat(bluebubbles): handle iMessage edit events in webhook

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2381,4 +2381,189 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
   });
+
+  describe("message edit handling", () => {
+    it("processes updated-message with dateEdited as an edit", async () => {
+      const account = createMockAccount({ dmPolicy: "open" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      // First, send the original message so it's cached with a short ID.
+      const originalPayload = {
+        type: "new-message",
+        data: {
+          text: "hello world",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-edit-1",
+          date: Date.now(),
+        },
+      };
+      await handleBlueBubblesWebhookRequest(
+        createMockRequest("POST", "/bluebubbles-webhook", originalPayload),
+        createMockResponse(),
+      );
+      await flushAsync();
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+
+      mockDispatchReplyWithBufferedBlockDispatcher.mockClear();
+
+      // Now send the edit event.
+      const editPayload = {
+        type: "updated-message",
+        data: {
+          text: "hello universe",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-edit-1",
+          date: Date.now(),
+          dateEdited: Date.now(),
+        },
+      };
+      const req = createMockRequest("POST", "/bluebubbles-webhook", editPayload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(res.statusCode).toBe(200);
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      const callArgs = mockDispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
+      // Body should contain the [[edit:N]] tag referencing the original short ID
+      expect(callArgs.ctx.Body).toContain("[[edit:");
+      expect(callArgs.ctx.Body).toContain("hello universe");
+      // Should NOT contain the old text
+      expect(callArgs.ctx.Body).not.toContain("hello world");
+    });
+
+    it("ignores updated-message without dateEdited (e.g. delivery receipt)", async () => {
+      const account = createMockAccount({ dmPolicy: "open" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "updated-message",
+        data: {
+          text: "hello world",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-status-1",
+          date: Date.now(),
+          dateRead: Date.now(),
+          // No dateEdited — this is a delivery/read receipt, not an edit
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(res.statusCode).toBe(200);
+      // Should NOT dispatch — no reaction and no edit
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    });
+
+    it("edit from-me updates cache but does not dispatch to AI", async () => {
+      const account = createMockAccount({ dmPolicy: "open" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const editPayload = {
+        type: "updated-message",
+        data: {
+          text: "corrected text",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: true,
+          guid: "msg-my-edit-1",
+          date: Date.now(),
+          dateEdited: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", editPayload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(res.statusCode).toBe(200);
+      // from-me messages are cached but not dispatched
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    });
+
+    it("edit without prior cache still dispatches with [[edit]] tag", async () => {
+      const account = createMockAccount({ dmPolicy: "open" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      // Send an edit for a message we never received the original for.
+      const editPayload = {
+        type: "updated-message",
+        data: {
+          text: "surprise edit",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-unknown-orig",
+          date: Date.now(),
+          dateEdited: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", editPayload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(res.statusCode).toBe(200);
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      const callArgs = mockDispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
+      // Should have the [[edit]] tag without a short ID since the original was never cached
+      expect(callArgs.ctx.Body).toContain("[[edit]]");
+      expect(callArgs.ctx.Body).toContain("surprise edit");
+    });
+  });
 });

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -933,6 +933,8 @@ type NormalizedWebhookMessage = {
   replyToId?: string;
   replyToBody?: string;
   replyToSender?: string;
+  /** Set when this message is an edit of a previously sent message. */
+  dateEdited?: number;
 };
 
 type NormalizedWebhookReaction = {
@@ -1272,6 +1274,15 @@ function normalizeWebhookMessage(
         : timestampRaw * 1000
       : undefined;
 
+  const dateEditedRaw =
+    readNumberLike(message, "dateEdited") ?? readNumberLike(message, "date_edited");
+  const dateEdited =
+    typeof dateEditedRaw === "number"
+      ? dateEditedRaw > 1_000_000_000_000
+        ? dateEditedRaw
+        : dateEditedRaw * 1000
+      : undefined;
+
   const normalizedSender = normalizeBlueBubblesHandle(senderId);
   if (!normalizedSender) {
     return null;
@@ -1300,7 +1311,32 @@ function normalizeWebhookMessage(
     replyToId: replyMetadata.replyToId,
     replyToBody: replyMetadata.replyToBody,
     replyToSender: replyMetadata.replyToSender,
+    dateEdited,
   };
+}
+
+/**
+ * Attempts to normalize an `updated-message` webhook payload as a message edit.
+ * Returns a NormalizedWebhookMessage with `dateEdited` set when the update
+ * represents an edit (i.e. has dateEdited and is not a tapback/reaction).
+ * Returns null when the payload is not an edit.
+ */
+function normalizeWebhookEdit(
+  payload: Record<string, unknown>,
+): NormalizedWebhookMessage | null {
+  const message = normalizeWebhookMessage(payload);
+  if (!message) {
+    return null;
+  }
+  // Only treat as edit when dateEdited is present and the message is not a tapback
+  if (!message.dateEdited) {
+    return null;
+  }
+  if (message.associatedMessageGuid) {
+    // This is a tapback/reaction update, not a text edit
+    return null;
+  }
+  return message;
 }
 
 function normalizeWebhookReaction(
@@ -1493,11 +1529,19 @@ export async function handleBlueBubblesWebhookRequest(
     return true;
   }
   const reaction = normalizeWebhookReaction(payload);
+
+  // For updated-message events that aren't reactions, check if this is a message edit.
+  let editMessage: NormalizedWebhookMessage | null = null;
+  if (eventType === "updated-message" && !reaction) {
+    editMessage = normalizeWebhookEdit(payload);
+  }
+
   if (
     (eventType === "updated-message" ||
       eventType === "message-reaction" ||
       eventType === "reaction") &&
-    !reaction
+    !reaction &&
+    !editMessage
   ) {
     res.statusCode = 200;
     res.end("ok");
@@ -1505,12 +1549,12 @@ export async function handleBlueBubblesWebhookRequest(
       logVerbose(
         firstTarget.core,
         firstTarget.runtime,
-        `webhook ignored ${eventType || "event"} without reaction`,
+        `webhook ignored ${eventType || "event"} without reaction or edit`,
       );
     }
     return true;
   }
-  const message = reaction ? null : normalizeWebhookMessage(payload);
+  const message = editMessage ?? (reaction ? null : normalizeWebhookMessage(payload));
   if (!message && !reaction) {
     res.statusCode = 400;
     res.end("invalid payload");
@@ -1581,10 +1625,11 @@ export async function handleBlueBubblesWebhookRequest(
     }
   } else if (message) {
     if (firstTarget) {
+      const editTag = message.dateEdited ? " (edit)" : "";
       logVerbose(
         firstTarget.core,
         firstTarget.runtime,
-        `webhook accepted sender=${message.senderId} group=${message.isGroup} chatGuid=${message.chatGuid ?? ""} chatId=${message.chatId ?? ""}`,
+        `webhook accepted${editTag} sender=${message.senderId} group=${message.isGroup} chatGuid=${message.chatGuid ?? ""} chatId=${message.chatId ?? ""}`,
       );
     }
   }
@@ -1603,21 +1648,33 @@ async function processMessage(
   const text = message.text.trim();
   const attachments = message.attachments ?? [];
   const placeholder = buildMessagePlaceholder(message);
-  // Check if text is a tapback pattern (e.g., 'Loved "hello"') and transform to emoji format
-  // For tapbacks, we'll append [[reply_to:N]] at the end; for regular messages, prepend it
-  const tapbackContext = resolveTapbackContext(message);
-  const tapbackParsed = parseTapbackText({
-    text,
-    emojiHint: tapbackContext?.emojiHint,
-    actionHint: tapbackContext?.actionHint,
-    requireQuoted: !tapbackContext,
-  });
+  const isEdit = Boolean(message.dateEdited);
+
+  // For edits, resolve the original message's short ID so we can reference it.
+  // The GUID stays the same across edits, so the reply cache may already have it.
+  let editOriginalShortId: string | undefined;
+  if (isEdit && message.messageId) {
+    editOriginalShortId = getShortIdForUuid(message.messageId);
+  }
+
+  // Skip tapback detection for edits — edited text should never be misinterpreted as a tapback.
+  const tapbackContext = isEdit ? undefined : resolveTapbackContext(message);
+  const tapbackParsed = isEdit
+    ? undefined
+    : parseTapbackText({
+        text,
+        emojiHint: tapbackContext?.emojiHint,
+        actionHint: tapbackContext?.actionHint,
+        requireQuoted: !tapbackContext,
+      });
   const isTapbackMessage = Boolean(tapbackParsed);
-  const rawBody = tapbackParsed
-    ? tapbackParsed.action === "removed"
-      ? `removed ${tapbackParsed.emoji} reaction`
-      : `reacted with ${tapbackParsed.emoji}`
-    : text || placeholder;
+  const rawBody = isEdit
+    ? text || placeholder
+    : tapbackParsed
+      ? tapbackParsed.action === "removed"
+        ? `removed ${tapbackParsed.emoji} reaction`
+        : `reacted with ${tapbackParsed.emoji}`
+      : text || placeholder;
 
   const cacheMessageId = message.messageId?.trim();
   let messageShortId: string | undefined;
@@ -1984,11 +2041,19 @@ async function processMessage(
   // For tapbacks/reactions: append at end (e.g., "reacted with ❤️ [[reply_to:4]]")
   // For regular replies: prepend at start (e.g., "[[reply_to:4]] Awesome")
   const replyTag = formatReplyTag({ replyToId, replyToShortId });
-  const baseBody = replyTag
-    ? isTapbackMessage
-      ? `${rawBody} ${replyTag}`
-      : `${replyTag} ${rawBody}`
-    : rawBody;
+  // For edits, prefix with [[edit:N]] tag so the AI knows which message was changed.
+  const editTag = isEdit
+    ? editOriginalShortId
+      ? `[[edit:${editOriginalShortId}]] `
+      : "[[edit]] "
+    : "";
+  const baseBody = editTag
+    ? `${editTag}${rawBody}`
+    : replyTag
+      ? isTapbackMessage
+        ? `${rawBody} ${replyTag}`
+        : `${replyTag} ${rawBody}`
+      : rawBody;
   const fromLabel = isGroup ? undefined : message.senderName || `user:${message.senderId}`;
   const groupSubject = isGroup ? message.chatName?.trim() || undefined : undefined;
   const groupMembers = isGroup


### PR DESCRIPTION
## Summary

- Detect iMessage edit events from BlueBubbles `updated-message` webhooks by checking for the `dateEdited` field
- Route edit events through the normal message pipeline instead of silently dropping them
- Tag edited messages with `[[edit:N]]` referencing the original message's short ID so the AI knows which message was corrected
- Update the reply cache with the new text so future references reflect the edit

## Problem

When a user edits an iMessage, BlueBubbles sends an `updated-message` webhook event. The existing handler only expected reactions/tapbacks from this event type. Non-reaction `updated-message` events (including edits) were silently dropped at the webhook handler level with "webhook ignored updated-message without reaction".

This meant edits were completely invisible to the AI — the original text persisted and the correction was lost.

## Changes

**`extensions/bluebubbles/src/monitor.ts`**:
- Added `dateEdited` field to `NormalizedWebhookMessage` type
- Added `dateEdited` parsing in `normalizeWebhookMessage()` (handles both camelCase and snake_case)
- Added `normalizeWebhookEdit()` function that identifies edits (has `dateEdited`, no `associatedMessageGuid`)
- Modified webhook handler to check for edits before dropping `updated-message` events
- Modified `processMessage()` to skip tapback detection for edits and format with `[[edit:N]]` tag

**`extensions/bluebubbles/src/monitor.test.ts`**:
- Added 4 tests covering: edit with cached original, delivery receipt ignored, from-me edit, and edit without prior cache

## Test plan

- [x] All 55 existing + new tests pass (`vitest run extensions/bluebubbles/src/monitor.test.ts`)
- [x] Zero TypeScript errors in changed files
- [ ] Manual test: send an iMessage, edit it, verify the AI receives `[[edit:N]] corrected text`
- [ ] Manual test: verify delivery/read receipts are still silently dropped
- [ ] Manual test: verify reactions/tapbacks still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR teaches the BlueBubbles webhook monitor to treat `updated-message` payloads with a `dateEdited` field as message edits (instead of dropping them as “updated-message without reaction”). It normalizes the edit timestamp, routes edits through the normal message pipeline, prefixes edited bodies with an `[[edit…]]` tag, and updates the reply cache so later references use the edited text. Tests were added to cover edit vs receipt handling and from-me behavior.

Main issues to address before merge are around formatting/tagging: edited messages currently bypass reply tagging logic (so an edited reply can lose `[[reply_to:N]]` context), and the code often emits `[[edit]]` even though a shortId is assigned later in the same processing call for previously-unknown GUIDs.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge after fixing edit-tag formatting edge cases.
- Core normalization/routing changes are straightforward and covered by tests, but the current body composition for edits drops reply context tags and can emit `[[edit]]` even when a shortId is available later in the same processing flow, which can reduce correctness of the AI context.
- extensions/bluebubbles/src/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->