### PR TITLE
fix(telegram): skip General topic thread ID for all chat types (#14383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: skip General topic thread ID (1) for all chat types, fixing proactive sends in private chats with Topics enabled (Premium). (#14383)
 - Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -138,7 +138,7 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("keeps message_thread_id=1 when allowed", async () => {
+  it("omits message_thread_id=1 for dm threads (Premium Topics)", async () => {
     const runtime = { error: vi.fn(), log: vi.fn() };
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 4,
@@ -160,7 +160,7 @@ describe("deliverReplies", () => {
     expect(sendMessage).toHaveBeenCalledWith(
       "123",
       expect.any(String),
-      expect.objectContaining({
+      expect.not.objectContaining({
         message_thread_id: 1,
       }),
     );

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,9 +43,13 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("keeps thread id=1 for dm threads", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
-      message_thread_id: 1,
+  it("omits General topic thread id for dm threads (Premium Topics)", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
+  });
+
+  it("includes non-General topic thread ids for dm threads", () => {
+    expect(buildTelegramThreadParams({ id: 42, scope: "dm" })).toEqual({
+      message_thread_id: 42,
     });
   });
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -56,15 +56,16 @@ export function resolveTelegramThreadSpec(params: {
 
 /**
  * Build thread params for Telegram API calls (messages, media).
- * General forum topic (id=1) must be treated like a regular supergroup send:
- * Telegram rejects sendMessage/sendMedia with message_thread_id=1 ("thread not found").
+ * General topic (id=1) must be omitted for all chat types:
+ * Telegram rejects sendMessage/sendMedia with message_thread_id=1 ("thread not found")
+ * in both forum supergroups and private chats with Topics enabled (Premium).
  */
 export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
   if (!thread?.id) {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);
-  if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
+  if (normalized === TELEGRAM_GENERAL_TOPIC_ID) {
     return undefined;
   }
   return { message_thread_id: normalized };

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -34,7 +34,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
   });
 
-  it("keeps message_thread_id for dm threads", () => {
+  it("omits message_thread_id=1 for dm threads (Premium Topics)", () => {
     const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
     const stream = createTelegramDraftStream({
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -46,8 +46,23 @@ describe("createTelegramDraftStream", () => {
 
     stream.update("Hello");
 
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
+  });
+
+  it("keeps non-General message_thread_id for dm threads", () => {
+    const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
+    const stream = createTelegramDraftStream({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      api: api as any,
+      chatId: 123,
+      draftId: 42,
+      thread: { id: 77, scope: "dm" },
+    });
+
+    stream.update("Hello");
+
     expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
-      message_thread_id: 1,
+      message_thread_id: 77,
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #14383

## Problem
When a Telegram Premium user enables Topics in a private bot chat, incoming messages include `message_thread_id: 1`. OpenClaw stores this thread context with `scope: "dm"`. On proactive sends (cron announcements, etc.), it passes `message_thread_id: 1` back to the Telegram API, which rejects it with:

```
GrammyError: Call to 'sendMessage' failed! (400: Bad Request: message thread not found)
```

### Root Cause
`buildTelegramThreadParams` in `src/telegram/bot/helpers.ts` only skipped thread ID 1 (General topic) when `scope === "forum"`:

```typescript
if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
  return undefined;
}
```

Private chat topics (Bot API 9.3+, Dec 2025) use `scope: "dm"`, so thread ID 1 was not skipped for DM chats.

## Fix
Remove the `&& thread.scope === "forum"` condition so thread ID 1 is skipped for **all** chat types. Telegram rejects `message_thread_id=1` regardless of whether the chat is a forum supergroup or a private chat with Topics enabled.

**Before:**
```typescript
if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
```

**After:**
```typescript
if (normalized === TELEGRAM_GENERAL_TOPIC_ID) {
```

## Effect on User Experience

**Before fix:**
Proactive sends (cron jobs, announcements) to Telegram Premium users with Topics enabled in private bot chats fail with `400: Bad Request: message thread not found`.

**After fix:**
Proactive sends succeed by omitting `message_thread_id` when the thread ID is 1 (General topic), matching the behavior already in place for forum supergroups.

## Testing
- ✅ 39 tests pass (`pnpm vitest run src/telegram/bot/helpers.test.ts src/telegram/bot/delivery.test.ts src/telegram/draft-stream.test.ts`)
- ✅ Lint passes (`pnpm oxlint` on changed files)
- Updated 3 test files to match new behavior
- Added regression tests for non-General DM thread IDs (id=42, id=77) to ensure they still pass through

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Telegram thread parameter construction so that `message_thread_id=1` (the “General” topic) is omitted for *all* chat types, not just forum supergroups. This addresses a failure mode where private bot chats with Topics enabled (Premium) include `message_thread_id: 1` on inbound messages, and OpenClaw would echo that back on proactive sends, causing Telegram to reject the request.

Tests were updated/added across delivery and draft stream paths to assert that DM threads with id=1 now omit `message_thread_id`, while non-General DM thread IDs still pass through.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to `buildTelegramThreadParams` behavior for `message_thread_id=1`, and corresponding tests were updated/added to lock in the new behavior across delivery and draft-stream code paths. No other thread-handling helpers were modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->