### PR TITLE
ops: add Azure VM bootstrap script and Kubernetes manifests

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,62 @@
+# OpenClaw Kubernetes Deployment
+
+This directory contains standard Kubernetes manifests for deploying OpenClaw Gateway.
+
+## Prerequisites
+
+- A running Kubernetes cluster (k8s or k3s).
+- `kubectl` configured to communicate with your cluster.
+- An OpenClaw Docker image (either pulled from a registry or built locally and imported).
+
+## Setup Instructions
+
+### 1. Configure Secrets
+
+Edit `secret.yaml` to set your secure gateway token.
+
+```bash
+# Generate a token
+openssl rand -hex 32
+
+# Update the file
+nano secret.yaml
+```
+
+### 2. Apply Manifests
+
+Apply the configuration in the following order:
+
+```bash
+kubectl apply -f secret.yaml
+kubectl apply -f pvc.yaml
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml
+```
+
+### 3. Verify Deployment
+
+Check the status of the pods:
+
+```bash
+kubectl get pods
+kubectl logs -f deployment/openclaw-gateway
+```
+
+## Accessing the Gateway
+
+By default, the service is of type `ClusterIP`. To access it:
+
+- **Port Forwarding:**
+
+  ```bash
+  kubectl port-forward service/openclaw-service 18789:18789
+  ```
+
+- **NodePort / LoadBalancer:**
+  Edit `service.yaml` and change `type: ClusterIP` to `NodePort` or `LoadBalancer`.
+
+## Customization
+
+- **Image:** Update `deployment.yaml` to point to your specific Docker image tag.
+- **Resources:** Adjust CPU and memory limits in `deployment.yaml` based on your cluster capacity.
+- **Storage:** Check `pvc.yaml` to adjust the storage size (default 10Gi).

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -8,6 +8,13 @@ This directory contains standard Kubernetes manifests for deploying OpenClaw Gat
 - `kubectl` configured to communicate with your cluster.
 - An OpenClaw Docker image (either pulled from a registry or built locally and imported).
 
+## Community Helm Charts
+
+If you prefer using Helm, there are community-maintained charts available:
+
+- **[Chrisbattarbee/openclaw-helm](https://github.com/Chrisbattarbee/openclaw-helm)**: A comprehensive chart with support for configuration injection, persistence, and ingress.
+- **[serhanekicii/openclaw-helm](https://github.com/serhanekicii/openclaw-helm)**: Another popular community chart.
+
 ## Setup Instructions
 
 ### 1. Configure Secrets

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-gateway
+  labels:
+    app: openclaw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw
+  template:
+    metadata:
+      labels:
+        app: openclaw
+    spec:
+      securityContext:
+        fsGroup: 1000 # Ensure 'node' user can write to the volume
+      containers:
+        - name: gateway
+          # Replace with your image registry path or use a local image if configured
+          image: ghcr.io/openclaw/openclaw:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - dist/index.js
+            - gateway
+            - --bind
+            - lan
+            - --port
+            - "18789"
+          ports:
+            - containerPort: 18789
+              name: gateway
+            - containerPort: 18790
+              name: bridge
+          env:
+            - name: HOME
+              value: /home/node
+            - name: OPENCLAW_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secret
+                  key: OPENCLAW_GATEWAY_TOKEN
+          volumeMounts:
+            - name: config-volume
+              mountPath: /home/node/.openclaw
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+      volumes:
+        - name: config-volume
+          persistentVolumeClaim:
+            claimName: openclaw-pvc

--- a/k8s/pvc.yaml
+++ b/k8s/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-secret
+type: Opaque
+stringData:
+  # Replace with a generated secure token
+  # You can generate one with: openssl rand -hex 32
+  OPENCLAW_GATEWAY_TOKEN: "replace-me-with-secure-token"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-service
+spec:
+  selector:
+    app: openclaw
+  ports:
+    - protocol: TCP
+      port: 18789
+      targetPort: 18789
+      name: gateway
+    - protocol: TCP
+      port: 18790
+      targetPort: 18790
+      name: bridge
+  type: ClusterIP
+  # Use NodePort or LoadBalancer if you need external access
+  # type: NodePort

--- a/scripts/k8s-deploy.sh
+++ b/scripts/k8s-deploy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# k8s-deploy.sh
+# Deploys OpenClaw to the current Kubernetes context.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+K8S_DIR="$ROOT_DIR/k8s"
+
+echo "==> OpenClaw Kubernetes Deployer"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+    echo "Error: kubectl is not installed."
+    exit 1
+fi
+
+# Check connection
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo "Error: Cannot connect to Kubernetes cluster."
+    exit 1
+fi
+
+echo "==> Cluster: $(kubectl config current-context)"
+
+# Generate Token if not set
+TOKEN="${OPENCLAW_GATEWAY_TOKEN:-}"
+if [[ -z "$TOKEN" ]]; then
+    echo "Generating secure gateway token..."
+    TOKEN="$(openssl rand -hex 32)"
+    echo "Token: $TOKEN"
+fi
+
+echo "==> Applying Secrets..."
+# We use imperative creation to avoid storing the secret in git, 
+# or we render the template.
+# Let's verify if secret exists
+if kubectl get secret openclaw-secret >/dev/null 2>&1; then
+    echo "Secret 'openclaw-secret' already exists. Skipping creation."
+else
+    kubectl create secret generic openclaw-secret \
+        --from-literal=OPENCLAW_GATEWAY_TOKEN="$TOKEN"
+    echo "Secret 'openclaw-secret' created."
+fi
+
+echo "==> Applying Manifests..."
+kubectl apply -f "$K8S_DIR/pvc.yaml"
+kubectl apply -f "$K8S_DIR/deployment.yaml"
+kubectl apply -f "$K8S_DIR/service.yaml"
+
+echo ""
+echo "==> Deployment initiated."
+echo "Check status with: kubectl get pods -l app=openclaw"
+echo "Gateway Token: $TOKEN"

--- a/scripts/vm-bootstrap.sh
+++ b/scripts/vm-bootstrap.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# vm-bootstrap.sh
+# Bootstraps a fresh Ubuntu/Debian VM for OpenClaw deployment.
+# Installs Docker, Git, and runs the main docker-setup.sh script.
+
+echo "==> OpenClaw VM Bootstrap"
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root (or via sudo)"
+   exit 1
+fi
+
+echo "==> Updating package lists..."
+apt-get update
+
+echo "==> Installing prerequisites (git, curl)..."
+apt-get install -y git curl
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "==> Installing Docker..."
+    # Standard installation for Ubuntu/Debian
+    apt-get install -y docker.io
+    # Start and enable docker
+    systemctl start docker
+    systemctl enable docker
+else
+    echo "Docker already installed."
+fi
+
+# Ensure docker compose plugin is available (docker compose v2)
+if ! docker compose version >/dev/null 2>&1; then
+    echo "==> Installing Docker Compose Plugin..."
+    apt-get install -y docker-compose-plugin || {
+        echo "Failed to install docker-compose-plugin via apt. Trying standalone install..."
+        mkdir -p /usr/local/lib/docker/cli-plugins
+        curl -SL https://github.com/docker/compose/releases/download/v2.23.3/docker-compose-linux-$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose
+        chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+    }
+fi
+
+# Verify docker compose works
+if ! docker compose version >/dev/null 2>&1; then
+    echo "Error: docker compose is still not available."
+    exit 1
+fi
+
+# Directory setup
+INSTALL_DIR="/opt/openclaw"
+if [[ -d .git && -f "package.json" ]]; then
+    echo "Already inside a repository. Using current directory."
+    INSTALL_DIR="$(pwd)"
+else
+    if [[ ! -d "$INSTALL_DIR" ]]; then
+        echo "==> Cloning OpenClaw repository to $INSTALL_DIR..."
+        git clone https://github.com/openclaw/openclaw.git "$INSTALL_DIR"
+    else
+        echo "Directory $INSTALL_DIR exists. Pulling latest changes..."
+        cd "$INSTALL_DIR" && git pull
+    fi
+    cd "$INSTALL_DIR"
+fi
+
+echo "==> Running docker-setup.sh..."
+# Allow running docker setup as current user if possible, but we are root here.
+# If we want to run as a specific user, we might need adjustments, 
+# but for a dedicated VM, running as root/default user is often acceptable 
+# or expected for initial setup. 
+# docker-setup.sh uses local directory binds.
+
+./docker-setup.sh
+
+echo ""
+echo "==> VM Bootstrap Complete!"
+echo "You can manage the service using 'docker compose' in $INSTALL_DIR"


### PR DESCRIPTION
## Summary

Adds deployment scripts and manifests to simplify running OpenClaw on Azure VMs and Kubernetes clusters.

### Changes

- **VM Bootstrap (`scripts/vm-bootstrap.sh`)**:
    - A script to set up a fresh Ubuntu/Debian VM (e.g., Azure VM).
    - Installs prerequisites: Git, Docker, Docker Compose.
    - Clones the repo (if needed) and invokes existing `docker-setup.sh`.
- **Kubernetes Support (`k8s/`)**:
    - Added standard manifests: `deployment.yaml`, `service.yaml`, `pvc.yaml`, `secret.yaml`.
    - Added `README.md` with deployment instructions.

### Testing

- Syntax checked `scripts/vm-bootstrap.sh` (`bash -n`).
- Dry-run validation of Kubernetes manifests (`kubectl apply --dry-run=client`).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an ops-focused VM bootstrap script (`scripts/vm-bootstrap.sh`) plus a small set of Kubernetes manifests under `k8s/` (Deployment/Service/PVC/Secret) and a README describing how to apply them.

The new VM script is intended to prepare a fresh Debian/Ubuntu VM with git + Docker + Compose, clone the repo into `/opt/openclaw` when needed, then invoke the existing `docker-setup.sh` flow. The Kubernetes manifests aim to run the gateway container with a persisted config volume and a token provided via a Secret, exposing ports 18789 (gateway) and 18790 (bridge).

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but there are a few real bootstrapping/deployment footguns that can cause immediate failures or unexpected versions being deployed.
- Changes are isolated to ops scripts/manifests, but the VM bootstrap script’s Compose fallback can fail on common architectures, and both the VM and k8s paths have assumptions that can lead to deploying the wrong code or crash-looping depending on the image build output.
- scripts/vm-bootstrap.sh, k8s/deployment.yaml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->