### PR TITLE
feat: update default GLM model to glm-5

### DIFF
--- a/docs/providers/glm.md
+++ b/docs/providers/glm.md
@@ -9,7 +9,7 @@ title: "GLM Models"
 # GLM models
 
 GLM is a **model family** (not a company) available through the Z.AI platform. In OpenClaw, GLM
-models are accessed via the `zai` provider and model IDs like `zai/glm-4.7`.
+models are accessed via the `zai` provider and model IDs like `zai/glm-5`.
 
 ## CLI setup
 
@@ -22,12 +22,12 @@ openclaw onboard --auth-choice zai-api-key
 ```json5
 {
   env: { ZAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "zai/glm-4.7" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5" } } },
 }
 ```
 
 ## Notes
 
 - GLM versions and availability can change; check Z.AI's docs for the latest.
-- Example model IDs include `glm-4.7` and `glm-4.6`.
+- Example model IDs include `glm-5`, `glm-4.7`, and `glm-4.6`.
 - For provider details, see [/providers/zai](/providers/zai).

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -25,12 +25,12 @@ openclaw onboard --zai-api-key "$ZAI_API_KEY"
 ```json5
 {
   env: { ZAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "zai/glm-4.7" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5" } } },
 }
 ```
 
 ## Notes
 
-- GLM models are available as `zai/<model>` (example: `zai/glm-4.7`).
+- GLM models are available as `zai/<model>` (example: `zai/glm-5`).
 - See [/providers/glm](/providers/glm) for the model family overview.
 - Z.AI uses Bearer auth with your API key.

--- a/docs/zh-CN/providers/glm.md
+++ b/docs/zh-CN/providers/glm.md
@@ -15,7 +15,7 @@ x-i18n:
 
 # GLM 模型
 
-GLM 是一个**模型系列**（而非公司），通过 Z.AI 平台提供。在 OpenClaw 中，GLM 模型通过 `zai` 提供商访问，模型 ID 格式如 `zai/glm-4.7`。
+GLM 是一个**模型系列**（而非公司），通过 Z.AI 平台提供。在 OpenClaw 中，GLM 模型通过 `zai` 提供商访问，模型 ID 格式如 `zai/glm-5`。
 
 ## CLI 设置
 
@@ -28,12 +28,12 @@ openclaw onboard --auth-choice zai-api-key
 ```json5
 {
   env: { ZAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "zai/glm-4.7" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5" } } },
 }
 ```
 
 ## 注意事项
 
 - GLM 版本和可用性可能会变化；请查阅 Z.AI 的文档获取最新信息。
-- 示例模型 ID 包括 `glm-4.7` 和 `glm-4.6`。
+- 示例模型 ID 包括 `glm-5`、`glm-4.7` 和 `glm-4.6`。
 - 有关提供商的详细信息，请参阅 [/providers/zai](/providers/zai)。

--- a/docs/zh-CN/providers/zai.md
+++ b/docs/zh-CN/providers/zai.md
@@ -30,12 +30,12 @@ openclaw onboard --zai-api-key "$ZAI_API_KEY"
 ```json5
 {
   env: { ZAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "zai/glm-4.7" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5" } } },
 }
 ```
 
 ## 注意事项
 
-- GLM 模型以 `zai/<model>` 的形式提供（例如：`zai/glm-4.7`）。
+- GLM 模型以 `zai/<model>` 的形式提供（例如：`zai/glm-5`）。
 - 参阅 [/providers/glm](/providers/glm) 了解模型系列概览。
 - Z.AI 使用 Bearer 认证方式配合你的 API 密钥。

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -92,7 +92,7 @@ const AUTH_CHOICE_GROUP_DEFS: {
   },
   {
     value: "zai",
-    label: "Z.AI (GLM 4.7)",
+    label: "Z.AI (GLM 5)",
     hint: "API key",
     choices: ["zai-api-key"],
   },
@@ -242,7 +242,7 @@ export function buildAuthChoiceOptions(params: {
     label: "Google Gemini CLI OAuth",
     hint: "Uses the bundled Gemini CLI auth plugin",
   });
-  options.push({ value: "zai-api-key", label: "Z.AI (GLM 4.7) API key" });
+  options.push({ value: "zai-api-key", label: "Z.AI (GLM 5) API key" });
   options.push({
     value: "xiaomi-api-key",
     label: "Xiaomi API key",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -115,7 +115,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
   });
 }
 
-export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
+export const ZAI_DEFAULT_MODEL_REF = "zai/glm-5";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 export const TOGETHER_DEFAULT_MODEL_REF = "together/moonshotai/Kimi-K2.5";

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -47,7 +47,7 @@ export const DEFAULT_IMAGE_MODELS: Record<string, string> = {
   anthropic: "claude-opus-4-6",
   google: "gemini-3-flash-preview",
   minimax: "MiniMax-VL-01",
-  zai: "glm-4.6v",
+  zai: "glm-5v",
 };
 export const CLI_OUTPUT_MAX_BUFFER = 5 * MB;
 export const DEFAULT_MEDIA_CONCURRENCY = 2;


### PR DESCRIPTION
## Summary

Update the default GLM model reference from `glm-4.7` to `glm-5` across the codebase to support the latest GLM model release from Z.AI.

## Changes

- **Auth choice labels**: Updated from "GLM 4.7" to "GLM 5" in the onboarding wizard
- **Default image model**: Updated from `glm-4.6v` to `glm-5v` for media understanding
- **Documentation**: Updated examples in both English and Chinese provider docs

## Files Modified

| File | Change |
|------|--------|
| `src/commands/auth-choice-options.ts` | Updated auth choice labels |
| `src/media-understanding/defaults.ts` | Updated default vision model |
| `docs/providers/glm.md` | Updated model examples |
| `docs/providers/zai.md` | Updated model examples |
| `docs/zh-CN/providers/glm.md` | Updated Chinese documentation |
| `docs/zh-CN/providers/zai.md` | Updated Chinese documentation |

## Test Plan

- [ ] Verify `openclaw models list` shows glm-5 as the default for zai provider
- [ ] Verify onboarding wizard shows "Z.AI (GLM 5)" as the label
- [ ] Verify image understanding uses glm-5v as default for zai provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Z.AI/GLM defaults and docs to reference the new `glm-5` generation model and `glm-5v` vision model, including onboarding labels and provider documentation examples. The change is centralized via `ZAI_DEFAULT_MODEL_REF` (`src/commands/onboard-auth.credentials.ts`) and the media-understanding default image model map (`src/media-understanding/defaults.ts`).

One required follow-up: the Z.AI live test still hardcodes `glm-4.7`, which will be inconsistent with the new default and can break if the older model is retired.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one test reference should be updated to avoid live-test breakage.
- Core changes are straightforward string/default updates across onboarding, media defaults, and docs. The only concrete issue found is a live Z.AI integration test still targeting `glm-4.7`, which may fail in environments where that model is no longer available.
- src/agents/zai.live.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->