### PR TITLE
Allow zai/glm-5 in modern model filter

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -19,7 +19,7 @@ const CODEX_MODELS = [
   "gpt-5.1-codex-max",
 ];
 const GOOGLE_PREFIXES = ["gemini-3"];
-const ZAI_PREFIXES = ["glm-4.7"];
+const ZAI_PREFIXES = ["glm-4.7", "glm-5"];
 const MINIMAX_PREFIXES = ["minimax-m2.1"];
 const XAI_PREFIXES = ["grok-4"];
 


### PR DESCRIPTION
### Problem

OpenClaw currently treats `zai/glm-5` as missing/unknown, while `zai/glm-4.7` is available.

### Evidence

`src/agents/live-model-filter.ts` hardcodes the ZAI model allowlist:

```ts
const ZAI_PREFIXES = ["glm-4.7"];

This blocks new GLM versions (e.g. `glm-5`).

### Change

Extend the allowlist to include `glm-5`:
const ZAI_PREFIXES = ["glm-4.7", "glm-5"];

### Notes

This is a conservative change (explicitly adding `glm-5`) to avoid widening the match to all `glm-*` unexpectedly.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the modern-model allowlist for the `zai` provider by extending `ZAI_PREFIXES` in `src/agents/live-model-filter.ts` to include `"glm-5"` alongside `"glm-4.7"`. This allows `isModernModelRef()` to treat `zai/glm-5` as a modern model, consistent with the existing prefix-based matching strategy used for other providers.

The change also implicitly affects the `openrouter`/`opencode` paths where `isModernModelRef()` uses substring matching against the same prefix lists; with `"glm-5"` added, any OpenRouter/OpenCode model IDs containing `glm-5` will now be classified as modern, aligning with current behavior for other model families.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a single allowlist entry addition in `isModernModelRef` and matches existing prefix/substring matching patterns; no behavioral changes outside modern-model classification for glm-5 references.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->