### PR TITLE
fix(discord): respect replyToMode 'off' in thread/forum channels

### DIFF
--- a/src/auto-reply/reply/formatting.test.ts
+++ b/src/auto-reply/reply/formatting.test.ts
@@ -200,14 +200,14 @@ describe("createReplyReferencePlanner", () => {
     expect(planner.use()).toBe("parent");
   });
 
-  it("prefers existing thread id regardless of mode", () => {
+  it("returns undefined for existing thread id when mode is off", () => {
     const planner = createReplyReferencePlanner({
       replyToMode: "off",
       existingId: "thread-1",
       startId: "parent",
     });
-    expect(planner.use()).toBe("thread-1");
-    expect(planner.hasReplied()).toBe(true);
+    expect(planner.use()).toBeUndefined();
+    expect(planner.hasReplied()).toBe(false);
   });
 
   it("honors allowReference=false", () => {

--- a/src/auto-reply/reply/reply-reference.test.ts
+++ b/src/auto-reply/reply/reply-reference.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { createReplyReferencePlanner } from "./reply-reference.js";
+
+describe("createReplyReferencePlanner", () => {
+  it("returns existingId when replyToMode is not off", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "all",
+      existingId: "thread-123",
+      startId: "msg-1",
+    });
+    expect(planner.use()).toBe("thread-123");
+    expect(planner.hasReplied()).toBe(true);
+  });
+
+  it("returns undefined when replyToMode is off even with existingId", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "off",
+      existingId: "thread-123",
+      startId: "msg-1",
+    });
+    expect(planner.use()).toBeUndefined();
+    expect(planner.hasReplied()).toBe(false);
+  });
+
+  it("returns undefined when replyToMode is off without existingId", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "off",
+      startId: "msg-1",
+    });
+    expect(planner.use()).toBeUndefined();
+  });
+
+  it("returns startId on first call for replyToMode first", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "first",
+      startId: "msg-1",
+    });
+    expect(planner.use()).toBe("msg-1");
+    expect(planner.use()).toBeUndefined();
+  });
+
+  it("returns startId on every call for replyToMode all", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "all",
+      startId: "msg-1",
+    });
+    expect(planner.use()).toBe("msg-1");
+    expect(planner.use()).toBe("msg-1");
+  });
+
+  it("returns undefined when allowReference is false", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "all",
+      existingId: "thread-123",
+      allowReference: false,
+    });
+    expect(planner.use()).toBeUndefined();
+  });
+
+  it("markSent updates hasReplied", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "first",
+      startId: "msg-1",
+    });
+    expect(planner.hasReplied()).toBe(false);
+    planner.markSent();
+    expect(planner.hasReplied()).toBe(true);
+    expect(planner.use()).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -29,14 +29,14 @@ export function createReplyReferencePlanner(options: {
     if (!allowReference) {
       return undefined;
     }
+    if (options.replyToMode === "off") {
+      return undefined;
+    }
     if (existingId) {
       hasReplied = true;
       return existingId;
     }
     if (!startId) {
-      return undefined;
-    }
-    if (options.replyToMode === "off") {
       return undefined;
     }
     if (options.replyToMode === "all") {

--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -11,7 +11,7 @@ export type ReplyReferencePlanner = {
 
 export function createReplyReferencePlanner(options: {
   replyToMode: ReplyToMode;
-  /** Existing thread/reference id (always used when present). */
+  /** Existing thread/reference id (used when present and replyToMode is not "off"). */
   existingId?: string;
   /** Id to start a new thread/reference when allowed (e.g., parent message id). */
   startId?: string;


### PR DESCRIPTION
When `replyToMode` is `"off"`, replies in Discord thread channels (including forum posts) still get a `message_reference` attached, showing unwanted quote headers.

The issue is that `createReplyReferencePlanner` checks `existingId` before checking `replyToMode === "off"`. Thread channels always have an `existingId`, so the setting gets bypassed.

Moved the `"off"` guard above the `existingId` check so it actually works regardless of thread context. Added unit tests covering all reply modes.

Fixes #14450