### PR TITLE
feat(config): add agents.defaults.reasoningDefault for default reasoning visibility (#13607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - CLI: add `openclaw logs --local-time` to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
 - Telegram: render blockquotes as native `<blockquote>` tags instead of stripping them. (#14608)
 - Config: avoid redacting `maxTokens`-like fields during config snapshot redaction, preventing round-trip validation failures in `/config`. (#14006) Thanks @constansino.
+- Config: add `agents.defaults.reasoningDefault` to set the default reasoning visibility level for new sessions. (#13607)
 
 ### Fixes
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -357,6 +357,7 @@ export async function resolveReplyDirectives(params: {
   const resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -207,6 +207,30 @@ describe("buildStatusMessage", () => {
     expect(optionsLine).not.toContain("elevated");
   });
 
+  it("shows reasoning level from reasoningDefault config (#13607)", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5", reasoningDefault: "stream" },
+      sessionEntry: { sessionId: "r1", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).toContain("Reasoning: stream");
+  });
+
+  it("defaults reasoning to off when no reasoningDefault is set", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5" },
+      sessionEntry: { sessionId: "r2", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).not.toContain("Reasoning:");
+  });
+
   it("prefers model overrides over last-run model", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -356,7 +356,7 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
   const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const reasoningLevel = args.resolvedReasoning ?? args.agent?.reasoningDefault ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -356,7 +356,11 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
   const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? args.agent?.reasoningDefault ?? "off";
+  const reasoningLevel =
+    args.resolvedReasoning ??
+    (args.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    args.agent?.reasoningDefault ??
+    "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -138,6 +138,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Default reasoning visibility level when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -116,6 +116,7 @@ export const AgentDefaultsSchema = z
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),


### PR DESCRIPTION
## Summary
Fixes #13607

## Problem
There is no way to set a default reasoning visibility level for agents. Users who want reasoning output (e.g. `medium` or `high`) must set it per-session or per-directive. The `agents.defaults` config supports `thinkingDefault` and `verboseDefault` but not `reasoningDefault`.

## Fix
Add `reasoningDefault` to `AgentDefaultsConfig` (type + Zod schema), and wire it into the reasoning level resolution chain in both `get-reply-directives.ts` and `status.ts`, following the same pattern as `thinkingDefault` and `verboseDefault`.

### Resolution order
```
directives.reasoningLevel ?? session.reasoningLevel ?? agentCfg.reasoningDefault ?? "off"
```

## Reproduction & Verification

### Before fix (main branch):
- `agents.defaults` has no `reasoningDefault` field.
- `resolvedReasoningLevel` in `get-reply-directives.ts` falls through to `"off"` with no config fallback.
- `status.ts` shows reasoning as `off` regardless of any config.

### After fix — All verified:
```
✓ shows reasoning level from reasoningDefault config (#13607)
✓ defaults reasoning to off when no reasoningDefault is set
... (19 more tests)
21 tests pass (pnpm vitest run src/auto-reply/status.test.ts)
```

## Testing
- ✅ 21 tests pass (`pnpm vitest run src/auto-reply/status.test.ts`)
- ✅ Lint passes
