### PR TITLE
fix(cli-runner): map Anthropic cache_creation_input_tokens

### DIFF
--- a/src/agents/cli-runner/helpers.test.ts
+++ b/src/agents/cli-runner/helpers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import type { CliBackendConfig } from "../../config/types.js";
+import { parseCliJson } from "./helpers.js";
+
+const backend = {} as CliBackendConfig;
+
+describe("parseCliJson usage normalization", () => {
+  it("maps Anthropic cache_creation_input_tokens to cacheWrite", () => {
+    const out = parseCliJson(
+      JSON.stringify({
+        message: { text: "ok" },
+        usage: {
+          input_tokens: 120,
+          output_tokens: 30,
+          cache_creation_input_tokens: 45,
+          cache_read_input_tokens: 10,
+        },
+      }),
+      backend,
+    );
+
+    expect(out?.usage).toEqual({
+      input: 120,
+      output: 30,
+      cacheRead: 10,
+      cacheWrite: 45,
+      total: undefined,
+    });
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -272,7 +272,8 @@ function toUsage(raw: Record<string, unknown>): CliUsage | undefined {
   const output = pick("output_tokens") ?? pick("outputTokens");
   const cacheRead =
     pick("cache_read_input_tokens") ?? pick("cached_input_tokens") ?? pick("cacheRead");
-  const cacheWrite = pick("cache_write_input_tokens") ?? pick("cacheWrite");
+  const cacheWrite =
+    pick("cache_write_input_tokens") ?? pick("cache_creation_input_tokens") ?? pick("cacheWrite");
   const total = pick("total_tokens") ?? pick("total");
   if (!input && !output && !cacheRead && !cacheWrite && !total) {
     return undefined;


### PR DESCRIPTION
## Summary
- map `usage.cache_creation_input_tokens` to `cacheWrite` in `toUsage()`
- keep existing aliases (`cache_write_input_tokens`, `cacheWrite`) intact
- add a unit test for usage normalization to prevent regression

## Why
Anthropic reports cache creation usage under `cache_creation_input_tokens`. Without this mapping we under-report cache write tokens.

Closes #14366

## Validation
- [x] `npx pnpm build`
- [x] `npx pnpm check`
- [x] `npx pnpm exec vitest run src/agents/cli-runner/helpers.test.ts`

## AI assistance
- [x] AI-assisted
- Testing: locally validated with targeted and repo checks above

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI runner’s usage normalization so that Anthropic’s `usage.cache_creation_input_tokens` is counted as `cacheWrite` (in addition to the existing aliases), and adds a small Vitest unit test to prevent regressions in the JSON parsing path.

The change is localized to `src/agents/cli-runner/helpers.ts`’s `toUsage()` normalization logic, which feeds `parseCliJson()` and therefore impacts how token usage is reported across CLI backends.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge after tightening the new test fixture to avoid type-unsafe configuration casting.
- The production change is a straightforward additional alias mapping in `toUsage()` and is covered by a targeted unit test. The main concern is the new test using an empty object cast to `CliBackendConfig`, which can hide future breaking changes to required config fields and reduce the test’s value.
- src/agents/cli-runner/helpers.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->