### PR TITLE
fix(whatsapp): catch connection-phase errors in reconnect loop

### DIFF
--- a/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
+++ b/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
@@ -103,7 +103,7 @@ describe("web auto-reply", () => {
     let runError: unknown = null;
     const run = monitorWebChannel(
       false,
-      listenerFactory,
+      listenerFactory as never,
       true,
       async () => ({ text: "ok" }),
       runtime as never,

--- a/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
+++ b/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
@@ -1,0 +1,127 @@
+import "./test-helpers.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+
+import { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
+import { resetLogger, setLoggerOverride } from "../logging.js";
+import { monitorWebChannel } from "./auto-reply.js";
+import { resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
+
+let previousHome: string | undefined;
+let tempHome: string | undefined;
+
+const rmDirWithRetries = async (dir: string): Promise<void> => {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      const code =
+        err && typeof err === "object" && "code" in err
+          ? String((err as { code?: unknown }).code)
+          : null;
+      if (code === "ENOTEMPTY" || code === "EBUSY" || code === "EPERM") {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  await fs.rm(dir, { recursive: true, force: true });
+};
+
+beforeEach(async () => {
+  resetInboundDedupe();
+  previousHome = process.env.HOME;
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-web-home-"));
+  process.env.HOME = tempHome;
+});
+
+afterEach(async () => {
+  process.env.HOME = previousHome;
+  if (tempHome) {
+    await rmDirWithRetries(tempHome);
+    tempHome = undefined;
+  }
+});
+
+describe("web auto-reply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetBaileysMocks();
+    resetLoadConfigMock();
+  });
+
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+    vi.useRealTimers();
+  });
+
+  it("retries after initial connection failure", async () => {
+    const sleep = vi.fn(async () => {});
+    let attempts = 0;
+    const closeResolvers: Array<(reason?: unknown) => void> = [];
+    const listenerFactory = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("ENOTFOUND web.whatsapp.com");
+      }
+      let resolveClose: (reason?: unknown) => void = () => {};
+      const onClose = new Promise<unknown>((res) => {
+        resolveClose = res;
+        closeResolvers.push(res);
+      });
+      return {
+        close: vi.fn(),
+        onClose,
+        signalClose: (reason?: unknown) => resolveClose(reason),
+      };
+    });
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const controller = new AbortController();
+    let runError: unknown = null;
+    const run = monitorWebChannel(
+      false,
+      listenerFactory,
+      true,
+      async () => ({ text: "ok" }),
+      runtime as never,
+      controller.signal,
+      {
+        heartbeatSeconds: 1,
+        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1, jitter: 0 },
+        sleep,
+      },
+    ).catch((err) => {
+      runError = err;
+    });
+
+    await vi.waitFor(() => expect(listenerFactory).toHaveBeenCalledTimes(2), {
+      timeout: 1000,
+    });
+    expect(sleep).toHaveBeenCalled();
+    expect(listenerFactory).toHaveBeenCalledTimes(2);
+    expect(runError).toBeNull();
+
+    controller.abort();
+    closeResolvers[0]?.({ status: 499, isLoggedOut: false });
+    await run;
+  });
+});

--- a/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
+++ b/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
@@ -88,6 +88,10 @@ describe("web auto-reply", () => {
         close: vi.fn(),
         onClose,
         signalClose: (reason?: unknown) => resolveClose(reason),
+        sendMessage: vi.fn(),
+        sendPoll: vi.fn(),
+        sendReaction: vi.fn(),
+        sendComposingTo: vi.fn(),
       };
     });
     const runtime = {

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -189,24 +189,63 @@ export async function monitorWebChannel(
       return !hasControlCommand(msg.body, cfg);
     };
 
-    const listener = await (listenerFactory ?? monitorWebInbox)({
-      verbose,
-      accountId: account.accountId,
-      authDir: account.authDir,
-      mediaMaxMb: account.mediaMaxMb,
-      sendReadReceipts: account.sendReadReceipts,
-      debounceMs: inboundDebounceMs,
-      shouldDebounce,
-      onMessage: async (msg: WebInboundMsg) => {
-        handledMessages += 1;
-        lastMessageAt = Date.now();
-        status.lastMessageAt = lastMessageAt;
-        status.lastEventAt = lastMessageAt;
-        emitStatus();
-        _lastInboundMsg = msg;
-        await onMessage(msg);
-      },
-    });
+    // Wrap listener creation in try-catch so connection-phase errors
+    // (e.g. ECONNRESET during TLS handshake) enter the retry path
+    // instead of crashing the reconnect loop.
+    let listener: Awaited<ReturnType<typeof monitorWebInbox>>;
+    try {
+      listener = await (listenerFactory ?? monitorWebInbox)({
+        verbose,
+        accountId: account.accountId,
+        authDir: account.authDir,
+        mediaMaxMb: account.mediaMaxMb,
+        sendReadReceipts: account.sendReadReceipts,
+        debounceMs: inboundDebounceMs,
+        shouldDebounce,
+        onMessage: async (msg: WebInboundMsg) => {
+          handledMessages += 1;
+          lastMessageAt = Date.now();
+          status.lastMessageAt = lastMessageAt;
+          status.lastEventAt = lastMessageAt;
+          emitStatus();
+          _lastInboundMsg = msg;
+          await onMessage(msg);
+        },
+      });
+    } catch (connectErr) {
+      const errorStr = formatError(connectErr);
+      reconnectLogger.warn(
+        { connectionId, error: errorStr, reconnectAttempts },
+        "web reconnect: listener creation failed; treating as retryable disconnect",
+      );
+      reconnectAttempts += 1;
+      status.reconnectAttempts = reconnectAttempts;
+      status.lastError = errorStr;
+      status.lastEventAt = Date.now();
+      status.lastDisconnect = {
+        at: status.lastEventAt,
+        status: undefined,
+        error: errorStr,
+        loggedOut: false,
+      };
+      emitStatus();
+      if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
+        runtime.error(
+          `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Stopping web monitoring.`,
+        );
+        break;
+      }
+      const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
+      runtime.error(
+        `WhatsApp Web connection failed. Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationMs(delay)}… (${errorStr})`,
+      );
+      try {
+        await sleep(delay, abortSignal);
+      } catch {
+        break;
+      }
+      continue;
+    }
 
     status.connected = true;
     status.lastConnectedAt = Date.now();

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -237,7 +237,7 @@ export async function monitorWebChannel(
       }
       const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
       runtime.error(
-        `WhatsApp Web connection failed. Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationMs(delay)}… (${errorStr})`,
+        `WhatsApp Web connection failed. Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(delay)}… (${errorStr})`,
       );
       try {
         await sleep(delay, abortSignal);

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -40,7 +40,15 @@ export async function monitorWebInbox(options: {
   const sock = await createWaSocket(false, options.verbose, {
     authDir: options.authDir,
   });
-  await waitForWaConnection(sock);
+  try {
+    await waitForWaConnection(sock);
+  } catch (err) {
+    // Close the socket to avoid leaking connections/FDs on connect failure.
+    try {
+      sock.ws?.close();
+    } catch {}
+    throw err;
+  }
   const connectedAtMs = Date.now();
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;


### PR DESCRIPTION
## Summary

- `monitorWebInbox()` inside the `while(true)` reconnect loop was not wrapped in try-catch
- If the connection attempt itself failed (e.g. `ECONNRESET` during TLS handshake to `web.whatsapp.com`), the exception propagated out of the loop, permanently killing the WhatsApp channel — even with `maxAttempts: 0` (unlimited retries)
- Wrap listener creation in try-catch so connection-phase errors enter the same backoff/retry path as post-connection closes

## Root cause

The reconnect loop handles two phases differently:

| Phase | Error handling | Result |
|-------|---------------|--------|
| **After** connection (line 337, `listener.onClose`) | `.catch()` → retryable | Reconnects correctly |
| **During** connection (line 192, `monitorWebInbox()`) | No try-catch | Exception crashes the loop |

Real-world failure sequence observed:
1. Status 428 disconnect → retry starts
2. Retry calls `monitorWebInbox()` → `waitForWaConnection()` → TLS handshake
3. `ECONNRESET` on `web.whatsapp.com:443` → promise rejects
4. Exception propagates out of `while(true)` → channel exits permanently

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (6492 passed, 4 pre-existing failures unrelated)
- [x] Deployed to local Docker gateway, WhatsApp connects normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change wraps WhatsApp Web listener creation inside the reconnect `while (true)` loop with a `try/catch`, so connection-phase failures (e.g. errors thrown by `monitorWebInbox()` / `waitForWaConnection()`) flow through the same backoff/retry path as post-connection closes.

The logic fits the existing reconnect design (backoff via `computeBackoff`, status emission via `tuning.statusSink`, and disconnect events via `enqueueSystemEvent`).

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but repeated connection failures can now leak sockets during retries.
- The reconnect-loop try/catch is correct for preventing permanent shutdowns, but `monitorWebInbox` allocates a socket before awaiting connection and does not close it on connection-phase rejection; with the new retry behavior that can accumulate resources in real-world flaky-network scenarios.
- src/web/inbound/monitor.ts (connection setup cleanup path)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->