### PR TITLE
fix: add types condition to plugin-sdk export for moduleResolution NodeNext

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./plugin-sdk": "./dist/plugin-sdk/index.js",
+    "./plugin-sdk": {
+      "types": "./dist/plugin-sdk/index.d.ts",
+      "default": "./dist/plugin-sdk/index.js"
+    },
     "./cli-entry": "./openclaw.mjs"
   },
   "scripts": {


### PR DESCRIPTION
Fixes #14291

TypeScript's `moduleResolution: NodeNext` requires an explicit `types` condition in `package.json` exports. Without it, `import type { ... } from 'openclaw/plugin-sdk'` fails.

Adds the `types` condition pointing to the existing `dist/plugin-sdk/index.d.ts`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the root `package.json` `exports` map for the `./plugin-sdk` subpath to use a conditional export object with an explicit `types` condition pointing at `./dist/plugin-sdk/index.d.ts`, while keeping the runtime entry at `./dist/plugin-sdk/index.js` via the `default` condition.

This aligns the published package’s export map with TypeScript’s `moduleResolution: NodeNext` behavior for type-only imports from subpath exports, and leverages the existing build step (`scripts/write-plugin-sdk-entry-dts.ts`) that writes the stable `dist/plugin-sdk/index.d.ts` file.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to the package export map for a single subpath and points at an already-generated .d.ts file under dist/; no runtime code paths change.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->