### PR TITLE
feat(config): support per-agent compaction overrides (#14446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: expose `/compact` in the native command menu. (#10352) Thanks @akramcodez.
 - Discord: add role-based allowlists and role-based agent routing. (#10650) Thanks @Minidoracat.
 - Config: avoid redacting `maxTokens`-like fields during config snapshot redaction, preventing round-trip validation failures in `/config`. (#14006) Thanks @constansino.
+- Config: support per-agent compaction overrides via `agents.list[].compaction`. (#14446)
 
 ### Breaking
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -50,12 +50,35 @@ describe("resolveAgentConfig", () => {
       workspace: "~/openclaw",
       agentDir: "~/.openclaw/agents/main",
       model: "anthropic/claude-opus-4",
+      compaction: undefined,
       identity: undefined,
       groupChat: undefined,
       subagents: undefined,
       sandbox: undefined,
       tools: undefined,
     });
+  });
+
+  it("returns per-agent compaction overrides (#14446)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "coordinator",
+            compaction: {
+              maxHistoryShare: 0.8,
+            },
+          },
+          {
+            id: "worker",
+          },
+        ],
+      },
+    };
+    expect(resolveAgentConfig(cfg, "coordinator")?.compaction).toEqual({
+      maxHistoryShare: 0.8,
+    });
+    expect(resolveAgentConfig(cfg, "worker")?.compaction).toBeUndefined();
   });
 
   it("supports per-agent model primary+fallbacks", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -21,6 +21,7 @@ type ResolvedAgentConfig = {
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
+  compaction?: AgentEntry["compaction"];
   heartbeat?: AgentEntry["heartbeat"];
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
@@ -115,6 +116,7 @@ export function resolveAgentConfig(
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,
+    compaction: entry.compaction,
     heartbeat: entry.heartbeat,
     identity: entry.identity,
     groupChat: entry.groupChat,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -393,6 +393,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
+        agentId: sessionAgentId,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -454,6 +454,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        agentId: params.agentId,
       });
 
       // Get hook runner early so it's available when creating tools

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,5 +1,5 @@
 import type { ChatType } from "../channels/chat-type.js";
-import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
+import type { AgentCompactionConfig, AgentDefaultsConfig } from "./types.agent-defaults.js";
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type {
@@ -30,6 +30,8 @@ export type AgentConfig = {
   memorySearch?: MemorySearchConfig;
   /** Human-like delay between block replies for this agent. */
   humanDelay?: HumanDelayConfig;
+  /** Optional per-agent compaction overrides. */
+  compaction?: AgentCompactionConfig;
   /** Optional per-agent heartbeat overrides. */
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -448,6 +448,23 @@ export const AgentEntrySchema = z
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
+    compaction: z
+      .object({
+        mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+        reserveTokensFloor: z.number().int().nonnegative().optional(),
+        maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
+        memoryFlush: z
+          .object({
+            enabled: z.boolean().optional(),
+            softThresholdTokens: z.number().int().nonnegative().optional(),
+            prompt: z.string().optional(),
+            systemPrompt: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,


### PR DESCRIPTION
## Summary
Fixes #14446

## Problem
`agents.defaults.compaction.maxHistoryShare` applies globally to all agents. In multi-agent systems, coordinator agents benefit from higher retention while execution agents benefit from earlier compaction. There is no way to set per-agent compaction overrides.

## Fix
Add optional `compaction` field to per-agent config (`agents.list[].compaction`), following the same pattern as existing per-agent overrides (`humanDelay`, `heartbeat`, `memorySearch`).

### Config example
```yaml
agents:
  defaults:
    compaction:
      mode: safeguard
      maxHistoryShare: 0.5
  list:
    - id: coordinator
      compaction:
        maxHistoryShare: 0.8   # retain more history
    - id: worker
      # inherits defaults (0.5)
```

### Resolution order
```
agents.list[].compaction.{field} ?? agents.defaults.compaction.{field}
```

### Changes
1. **Type definition** (`src/config/types.agents.ts`): add `compaction?: AgentCompactionConfig` to `AgentConfig`
2. **Zod schema** (`src/config/zod-schema.agent-runtime.ts`): add compaction validation to `AgentEntrySchema`
3. **Agent resolution** (`src/agents/agent-scope.ts`): add `compaction` to `ResolvedAgentConfig` and `resolveAgentConfig`
4. **Runtime** (`src/agents/pi-embedded-runner/extensions.ts`): new `resolveCompactionConfig()` merges defaults with per-agent overrides; `buildEmbeddedExtensionPaths` accepts optional `agentId`
5. **Callers** (`attempt.ts`, `compact.ts`): pass `agentId` to `buildEmbeddedExtensionPaths`

## Reproduction & Verification

### Before fix (main branch):
- `agents.list[].compaction` is not a valid config field (Zod rejects it).
- `buildEmbeddedExtensionPaths` reads only `cfg.agents.defaults.compaction` — no per-agent override path.
- `resolveAgentConfig` does not return `compaction`.

### After fix — All verified:
```
✓ should return undefined when no agents config exists
✓ should return undefined when agent id does not exist
✓ should return basic agent config
✓ returns per-agent compaction overrides (#14446)
✓ supports per-agent model primary+fallbacks
✓ should return agent-specific sandbox config
✓ should return agent-specific tools config
✓ should return both sandbox and tools config
✓ should normalize agent id
✓ uses OPENCLAW_HOME for default agent workspace
✓ uses OPENCLAW_HOME for default agentDir
11 tests pass (pnpm vitest run src/agents/agent-scope.test.ts)
```

## Testing
- ✅ 11 tests pass (`pnpm vitest run src/agents/agent-scope.test.ts`)
- ✅ 7 config validation tests pass
- ✅ Lint passes
