### PR TITLE
Fix Telegram default account listing and CLI cache-write usage mapping

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { parseCliJson, parseCliJsonl } from "./cli-runner/helpers.js";
 
 describe("cli runner usage parsing", () => {

--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCliJson, parseCliJsonl } from "./cli-runner/helpers.js";
+
+describe("cli runner usage parsing", () => {
+  it("maps Anthropic cache_creation_input_tokens to cacheWrite in JSON mode", () => {
+    const parsed = parseCliJson(
+      JSON.stringify({
+        message: { text: "ok" },
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 20,
+          cache_read_input_tokens: 3,
+        },
+      }),
+      { command: "mock" },
+    );
+
+    expect(parsed).toMatchObject({
+      text: "ok",
+      usage: {
+        input: 10,
+        output: 5,
+        cacheRead: 3,
+        cacheWrite: 20,
+      },
+    });
+  });
+
+  it("maps Anthropic cache_creation_input_tokens to cacheWrite in JSONL mode", () => {
+    const parsed = parseCliJsonl(
+      [
+        JSON.stringify({
+          item: { type: "assistant_message", text: "hello" },
+          usage: {
+            input_tokens: 7,
+            output_tokens: 8,
+            cache_creation_input_tokens: 9,
+          },
+        }),
+      ].join("\n"),
+      { command: "mock" },
+    );
+
+    expect(parsed).toMatchObject({
+      text: "hello",
+      usage: {
+        input: 7,
+        output: 8,
+        cacheWrite: 9,
+      },
+    });
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -272,7 +272,8 @@ function toUsage(raw: Record<string, unknown>): CliUsage | undefined {
   const output = pick("output_tokens") ?? pick("outputTokens");
   const cacheRead =
     pick("cache_read_input_tokens") ?? pick("cached_input_tokens") ?? pick("cacheRead");
-  const cacheWrite = pick("cache_write_input_tokens") ?? pick("cacheWrite");
+  const cacheWrite =
+    pick("cache_creation_input_tokens") ?? pick("cache_write_input_tokens") ?? pick("cacheWrite");
   const total = pick("total_tokens") ?? pick("total");
   if (!input && !output && !cacheRead && !cacheWrite && !total) {
     return undefined;

--- a/src/telegram/accounts.test.ts
+++ b/src/telegram/accounts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveTelegramAccount } from "./accounts.js";
+import { listTelegramAccountIds, resolveTelegramAccount } from "./accounts.js";
 
 describe("resolveTelegramAccount", () => {
   it("falls back to the first configured account when accountId is omitted", () => {
@@ -93,5 +93,37 @@ describe("resolveTelegramAccount", () => {
         process.env.TELEGRAM_BOT_TOKEN = prevTelegramToken;
       }
     }
+  });
+});
+
+describe("listTelegramAccountIds", () => {
+  it("includes default account when top-level botToken is configured with named accounts", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-default",
+          accounts: {
+            life: { botToken: "tok-life" },
+          },
+        },
+      },
+    };
+
+    expect(listTelegramAccountIds(cfg)).toEqual(["default", "life"]);
+  });
+
+  it("includes default account when top-level tokenFile is configured with named accounts", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          tokenFile: "/tmp/telegram-default.token",
+          accounts: {
+            life: { botToken: "tok-life" },
+          },
+        },
+      },
+    };
+
+    expect(listTelegramAccountIds(cfg)).toEqual(["default", "life"]);
   });
 });

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -35,10 +35,20 @@ function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
   return [...ids];
 }
 
+function hasConfiguredDefaultTelegramTokenSource(cfg: OpenClawConfig): boolean {
+  const telegram = cfg.channels?.telegram;
+  const botToken = telegram?.botToken?.trim();
+  const tokenFile = telegram?.tokenFile?.trim();
+  return Boolean(botToken || tokenFile);
+}
+
 export function listTelegramAccountIds(cfg: OpenClawConfig): string[] {
   const ids = Array.from(
     new Set([...listConfiguredAccountIds(cfg), ...listBoundAccountIds(cfg, "telegram")]),
   );
+  if (hasConfiguredDefaultTelegramTokenSource(cfg) && !ids.includes(DEFAULT_ACCOUNT_ID)) {
+    ids.push(DEFAULT_ACCOUNT_ID);
+  }
   debugAccounts("listTelegramAccountIds", ids);
   if (ids.length === 0) {
     return [DEFAULT_ACCOUNT_ID];


### PR DESCRIPTION
## Summary
- include the `default` Telegram account in `listTelegramAccountIds()` whenever top-level `channels.telegram.botToken` or `tokenFile` is configured, even when named accounts exist
- map Anthropic `cache_creation_input_tokens` to CLI `cacheWrite` usage in `parseCliJson()` / `parseCliJsonl()` so usage + cost reporting is accurate
- add focused regression tests for both fixes in `src/telegram/accounts.test.ts` and new `src/agents/cli-runner.helpers.test.ts`

## Test plan
- [x] `pnpm lint`
- [x] `pnpm exec vitest run src/telegram/accounts.test.ts src/agents/cli-runner.helpers.test.ts`

## Linked issues
- fixes #14366
- fixes #14454

## Notes
- AI-assisted: yes

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts two areas:

- **CLI runner usage parsing**: `toUsage()` now maps Anthropic’s `cache_creation_input_tokens` field into the internal `usage.cacheWrite` field so usage/cost reporting counts cache writes correctly.
- **Telegram account enumeration**: `listTelegramAccountIds()` now includes the implicit `default` Telegram account when a top-level `channels.telegram.botToken` or `tokenFile` is configured, even if named accounts exist. This is used by onboarding/inline-buttons flows and other account selection logic.

It also adds targeted Vitest coverage for both behaviors (`src/agents/cli-runner.helpers.test.ts`, `src/telegram/accounts.test.ts`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, targeted, and consistent with existing normalization logic (e.g., usage.ts already maps cache_creation_input_tokens). Telegram default-account inclusion is gated on an actual configured top-level token source, preventing spurious IDs while fixing missing-default listings. Added focused tests cover the regressions.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->