### PR TITLE
fix(hooks): use configured model for session-memory slug generation

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -11,6 +11,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 
 /**
@@ -26,6 +27,7 @@ export async function generateSlugViaLLM(params: {
     const agentId = resolveDefaultAgentId(params.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
+    const modelRef = resolveDefaultModelForAgent({ cfg: params.cfg, agentId });
 
     // Create a temporary session file for this one-off LLM call
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
@@ -46,6 +48,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       workspaceDir,
       agentDir,
       config: params.cfg,
+      provider: modelRef.provider,
+      model: modelRef.model,
       prompt,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,


### PR DESCRIPTION
Fixes #14272

`generateSlugViaLLM()` always defaulted to `anthropic/claude-opus-4-6` because it didn't pass `provider`/`model` to `runEmbeddedPiAgent()`. Users without an Anthropic key got auth errors from the session-memory hook.

Now uses `resolveConfiguredModelRef()` to pick up the user's configured default model.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the session-memory hook slug generator to respect the user’s configured default model. `generateSlugViaLLM()` now resolves a `provider/model` pair via `resolveConfiguredModelRef()` and passes it into `runEmbeddedPiAgent()`, preventing unintended fallback to the hardcoded Anthropic default (and avoiding auth errors for users without Anthropic credentials).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and localized: it threads an already-supported `provider`/`model` into `runEmbeddedPiAgent()` using an existing config resolver that always returns a ModelRef. No behavioral changes beyond selecting the configured model for slug generation were found.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->