### PR TITLE
test(reply): add comprehensive tests for createReplyReferencePlanner

### DIFF
--- a/src/auto-reply/reply/reply-reference.test.ts
+++ b/src/auto-reply/reply/reply-reference.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { createReplyReferencePlanner } from "./reply-reference.js";
+
+describe("createReplyReferencePlanner", () => {
+  it("returns existingId when replyToMode is not off", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "first",
+      existingId: "thread-123",
+    });
+    expect(planner.use()).toBe("thread-123");
+    expect(planner.hasReplied()).toBe(true);
+  });
+
+  it("returns existingId when replyToMode is off (stays in existing thread)", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "off",
+      existingId: "thread-123",
+    });
+    // existingId means we're already inside a thread — always stay in it
+    expect(planner.use()).toBe("thread-123");
+    expect(planner.hasReplied()).toBe(true);
+  });
+
+  it("returns undefined when replyToMode is off with startId", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "off",
+      startId: "msg-456",
+    });
+    expect(planner.use()).toBeUndefined();
+  });
+
+  it("returns startId on first call when replyToMode is first", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "first",
+      startId: "msg-456",
+    });
+    expect(planner.use()).toBe("msg-456");
+    expect(planner.use()).toBeUndefined();
+  });
+
+  it("returns startId on every call when replyToMode is all", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "all",
+      startId: "msg-456",
+    });
+    expect(planner.use()).toBe("msg-456");
+    expect(planner.use()).toBe("msg-456");
+  });
+
+  it("returns undefined when allowReference is false", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "all",
+      existingId: "thread-123",
+      allowReference: false,
+    });
+    expect(planner.use()).toBeUndefined();
+  });
+
+  it("markSent prevents startId on second call for first mode", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "first",
+      startId: "msg-456",
+    });
+    planner.markSent();
+    expect(planner.use()).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -29,6 +29,9 @@ export function createReplyReferencePlanner(options: {
     if (!allowReference) {
       return undefined;
     }
+    // existingId means we're already inside a thread — always stay in it,
+    // regardless of replyToMode. replyToMode only controls whether we
+    // *start* a new quote/thread via startId.
     if (existingId) {
       hasReplied = true;
       return existingId;


### PR DESCRIPTION
## Context

Investigated #14450 (`replyToMode=off` in Discord threads). After analysis, the current behavior is correct: `existingId` (thread context) should always be used regardless of `replyToMode`, because it keeps messages inside an existing thread. `replyToMode` only controls whether a *new* quote/thread is started via `startId`.

The reported quote headers in threads likely come from a different layer (Discord message_reference handling), not from this planner.

## Changes

- Added clarifying comments documenting the existingId vs startId distinction
- Added comprehensive test suite for `createReplyReferencePlanner` covering all mode/context combinations (7 tests)

Related to #14450