### PR TITLE
fix(memory): prevent memory loss from SQLite contention, race conditi…

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -14,8 +14,8 @@ import {
   type SessionEntry,
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
-import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { buildThreadingToolContext, resolveEnforceFinalTag } from "./agent-runner-utils.js";
 import {
   resolveMemoryFlushContextWindowTokens,

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -29,7 +29,7 @@ import { parseQmdQueryJson } from "./qmd-query-parser.js";
 const log = createSubsystemLogger("memory");
 
 const SNIPPET_HEADER_RE = /@@\s*-([0-9]+),([0-9]+)/;
-const SEARCH_PENDING_UPDATE_WAIT_MS = 500;
+const SEARCH_PENDING_UPDATE_WAIT_MS = 2000;
 
 type CollectionRoot = {
   path: string;
@@ -471,6 +471,9 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private enqueueForcedUpdate(reason: string): Promise<void> {
+    if (this.closed) {
+      return Promise.resolve();
+    }
     this.queuedForcedRuns += 1;
     if (!this.queuedForcedUpdate) {
       this.queuedForcedUpdate = this.drainForcedUpdates(reason).finally(() => {
@@ -599,7 +602,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     const { DatabaseSync } = requireNodeSqlite();
     this.db = new DatabaseSync(this.indexPath, { readOnly: true });
     // Keep QMD recall responsive when the updater holds a write lock.
-    this.db.exec("PRAGMA busy_timeout = 1");
+    this.db.exec("PRAGMA busy_timeout = 100");
     return this.db;
   }
 
@@ -623,7 +626,9 @@ export class QmdMemoryManager implements MemorySearchManager {
         continue;
       }
       const target = path.join(exportDir, `${path.basename(sessionFile, ".jsonl")}.md`);
-      await fs.writeFile(target, this.renderSessionMarkdown(entry), "utf-8");
+      const tmpTarget = `${target}.tmp`;
+      await fs.writeFile(tmpTarget, this.renderSessionMarkdown(entry), "utf-8");
+      await fs.rename(tmpTarget, target);
       keep.add(target);
     }
     const exported = await fs.readdir(exportDir).catch(() => []);
@@ -680,8 +685,8 @@ export class QmdMemoryManager implements MemorySearchManager {
         .get(`${normalized}%`) as { collection: string; path: string } | undefined;
     } catch (err) {
       if (this.isSqliteBusyError(err)) {
-        log.debug(`qmd index is busy while resolving doc path: ${String(err)}`);
-        throw this.createQmdBusyError(err);
+        log.warn(`qmd index is busy while resolving doc path, skipping entry: ${String(err)}`);
+        return null;
       }
       throw err;
     }

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1,5 +1,5 @@
-import crypto from "node:crypto";
 import { spawn } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -626,7 +627,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         continue;
       }
       const target = path.join(exportDir, `${path.basename(sessionFile, ".jsonl")}.md`);
-      const tmpTarget = `${target}.tmp`;
+      const tmpTarget = `${target}.${crypto.randomUUID()}.tmp`;
       await fs.writeFile(tmpTarget, this.renderSessionMarkdown(entry), "utf-8");
       await fs.rename(tmpTarget, target);
       keep.add(target);


### PR DESCRIPTION
…ons, and silent failures

- Increase SQLite busy_timeout from 1ms to 100ms to reduce SQLITE_BUSY errors
- Gracefully skip entries on SQLITE_BUSY instead of aborting entire search
- Use atomic write (tmp + rename) for session exports to prevent data loss during indexing
- Add closed guard to enqueueForcedUpdate to prevent queuing after shutdown
- Increase search pending-update wait from 500ms to 2000ms for large repos
- Upgrade memory flush failure logging from verbose to warn for visibility
- Add warning when memory flush is skipped due to read-only workspace

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves memory/QMD robustness under contention by increasing SQLite `busy_timeout`, skipping entries on SQLITE_BUSY during doc-path resolution, making session-export writes atomic (tmp + rename), preventing forced updates from being queued after shutdown, increasing the “pending update” wait before search, and elevating memory-flush failure/skip logging to `warn`.

The main correctness risk is around concurrency: `getMemorySearchManager` populates the QMD manager cache with a non-atomic check/await/set, which can create multiple `QmdMemoryManager` instances for the same agent/config under concurrent callers. That can lead to duplicate update timers and concurrent access to the same per-agent QMD SQLite DB/session export dir—undermining the contention fixes this PR is trying to deliver. Additionally, the new atomic export uses a deterministic `*.tmp` name, which is unsafe if concurrent exports occur for the same target file.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has a real concurrency bug that can reintroduce contention and data-loss scenarios.
- Most changes are localized and improve resilience (busy_timeout, skipping SQLITE_BUSY, atomic rename, shutdown guard, better logging). However, `getMemorySearchManager` can instantiate multiple QMD managers concurrently for the same cache key, leading to duplicate background updaters and concurrent writes/reads against the same per-agent SQLite DB/export dir, and the deterministic `*.tmp` export path can corrupt exports under such concurrency.
- src/memory/search-manager.ts and src/memory/qmd-manager.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->