### PR TITLE
fix(relay): allow Docker bridge connections with OPENCLAW_RELAY_ALLOW_PRIVATE

### DIFF
--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -4,7 +4,7 @@ import type { Duplex } from "node:stream";
 import { randomBytes } from "node:crypto";
 import { createServer } from "node:http";
 import WebSocket, { WebSocketServer } from "ws";
-import { isLoopbackAddress, isLoopbackHost } from "../gateway/net.js";
+import { isLoopbackAddress, isLoopbackHost, isPrivateNetworkAddress } from "../gateway/net.js";
 import { rawDataToString } from "../infra/ws.js";
 
 type CdpCommand = {
@@ -456,7 +456,8 @@ export async function ensureChromeExtensionRelayServer(opts: {
     const pathname = url.pathname;
     const remote = req.socket.remoteAddress;
 
-    if (!isLoopbackAddress(remote)) {
+    const allowPrivate = process.env.OPENCLAW_RELAY_ALLOW_PRIVATE === "1";
+    if (!isLoopbackAddress(remote) && !(allowPrivate && isPrivateNetworkAddress(remote))) {
       rejectUpgrade(socket, 403, "Forbidden");
       return;
     }

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { pickPrimaryLanIPv4, resolveGatewayListenHosts } from "./net.js";
+import { isPrivateNetworkAddress, pickPrimaryLanIPv4, resolveGatewayListenHosts } from "./net.js";
 
 describe("resolveGatewayListenHosts", () => {
   it("returns the input host when not loopback", async () => {
@@ -75,5 +75,54 @@ describe("pickPrimaryLanIPv4", () => {
       ] as unknown as os.NetworkInterfaceInfo[],
     });
     expect(pickPrimaryLanIPv4()).toBeUndefined();
+  });
+});
+
+describe("isPrivateNetworkAddress", () => {
+  it("accepts Docker bridge addresses (172.17.x.x)", () => {
+    expect(isPrivateNetworkAddress("172.17.0.1")).toBe(true);
+    expect(isPrivateNetworkAddress("172.17.0.2")).toBe(true);
+  });
+
+  it("accepts full 172.16.0.0/12 range", () => {
+    expect(isPrivateNetworkAddress("172.16.0.1")).toBe(true);
+    expect(isPrivateNetworkAddress("172.31.255.254")).toBe(true);
+  });
+
+  it("rejects 172.x outside /12 range", () => {
+    expect(isPrivateNetworkAddress("172.15.0.1")).toBe(false);
+    expect(isPrivateNetworkAddress("172.32.0.1")).toBe(false);
+  });
+
+  it("accepts 10.0.0.0/8 range", () => {
+    expect(isPrivateNetworkAddress("10.0.0.1")).toBe(true);
+    expect(isPrivateNetworkAddress("10.255.255.254")).toBe(true);
+  });
+
+  it("accepts 192.168.0.0/16 range", () => {
+    expect(isPrivateNetworkAddress("192.168.0.1")).toBe(true);
+    expect(isPrivateNetworkAddress("192.168.255.254")).toBe(true);
+  });
+
+  it("accepts IPv4-mapped IPv6 private addresses", () => {
+    expect(isPrivateNetworkAddress("::ffff:172.17.0.1")).toBe(true);
+    expect(isPrivateNetworkAddress("::ffff:10.0.0.1")).toBe(true);
+    expect(isPrivateNetworkAddress("::ffff:192.168.1.1")).toBe(true);
+  });
+
+  it("rejects public IPs", () => {
+    expect(isPrivateNetworkAddress("8.8.8.8")).toBe(false);
+    expect(isPrivateNetworkAddress("203.0.113.1")).toBe(false);
+  });
+
+  it("rejects loopback (handled by isLoopbackAddress)", () => {
+    expect(isPrivateNetworkAddress("127.0.0.1")).toBe(false);
+  });
+
+  it("returns false for undefined/empty/invalid", () => {
+    expect(isPrivateNetworkAddress(undefined)).toBe(false);
+    expect(isPrivateNetworkAddress("")).toBe(false);
+    expect(isPrivateNetworkAddress("not-an-ip")).toBe(false);
+    expect(isPrivateNetworkAddress("::1")).toBe(false);
   });
 });

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -44,6 +44,35 @@ export function isLoopbackAddress(ip: string | undefined): boolean {
   return false;
 }
 
+/**
+ * Check whether an IP belongs to an RFC 1918 private network range.
+ * Covers Docker bridge (172.16-31.x.x), common LAN (192.168.x.x, 10.x.x.x),
+ * and their IPv4-mapped IPv6 equivalents.
+ */
+export function isPrivateNetworkAddress(ip: string | undefined): boolean {
+  if (!ip) {
+    return false;
+  }
+  const raw = ip.startsWith("::ffff:") ? ip.slice("::ffff:".length) : ip;
+  const parts = raw.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) {
+    return false;
+  }
+  // 10.0.0.0/8
+  if (parts[0] === 10) {
+    return true;
+  }
+  // 172.16.0.0/12
+  if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) {
+    return true;
+  }
+  // 192.168.0.0/16
+  if (parts[0] === 192 && parts[1] === 168) {
+    return true;
+  }
+  return false;
+}
+
 function normalizeIPv4MappedAddress(ip: string): string {
   if (ip.startsWith("::ffff:")) {
     return ip.slice("::ffff:".length);


### PR DESCRIPTION
## Problem

When running OpenClaw in Docker, the extension relay rejects all connections from the Docker bridge network (`172.x.x.x`) with a 403 error. `isLoopbackAddress()` only allows `127.0.0.1`/`::1`, making browser automation unusable in containerized deployments.

## Fix

- Add `isPrivateNetworkAddress()` to `gateway/net.ts` — detects RFC 1918 private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) including their IPv4-mapped IPv6 forms (`::ffff:172.17.0.1`)
- The extension relay accepts private network connections when `OPENCLAW_RELAY_ALLOW_PRIVATE=1` is set
- Default behavior is unchanged (loopback only) — no security regression

## Usage

```dockerfile
ENV OPENCLAW_RELAY_ALLOW_PRIVATE=1
```

## Tests

10 test cases for `isPrivateNetworkAddress()` covering all RFC 1918 ranges, IPv6-mapped variants, boundary values, and rejection of public/loopback/invalid IPs.

Closes #14433

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `isPrivateNetworkAddress()` (RFC1918 + IPv4-mapped IPv6) in `src/gateway/net.ts` and updates the extension relay’s websocket upgrade path to optionally accept private-network clients when `OPENCLAW_RELAY_ALLOW_PRIVATE=1` is set. It also adds unit tests covering common private ranges and IPv4-mapped variants.

Overall the change is localized to connection-allowlisting for the extension relay; default behavior remains loopback-only unless the env var is enabled.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but has a small correctness/security edge case in IP parsing.
- The relay gating change is straightforward and guarded by an env var. The main issue is `isPrivateNetworkAddress()` accepting out-of-range IPv4 octets, which can incorrectly treat malformed addresses as private when the allow-private mode is enabled.
- src/gateway/net.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->