### PR TITLE
fix: prevent Docker setup hang at onboarding

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -15,6 +15,22 @@ require_cmd() {
   fi
 }
 
+# Resolve timeout command (timeout on Linux, gtimeout on macOS, or empty if unavailable)
+resolve_timeout() {
+  if command -v timeout >/dev/null 2>&1; then
+    echo "timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    echo "gtimeout"
+  else
+    echo ""
+  fi
+}
+
+TIMEOUT_CMD=$(resolve_timeout)
+if [[ -z "$TIMEOUT_CMD" ]]; then
+  echo "Warning: timeout command not found (install coreutils for timeout support)"
+fi
+
 require_cmd docker
 if ! docker compose version >/dev/null 2>&1; then
   echo "Docker Compose not available (try: docker compose version)" >&2
@@ -186,15 +202,27 @@ echo "  - Gateway token: $OPENCLAW_GATEWAY_TOKEN"
 echo "  - Tailscale exposure: Off"
 echo "  - Install Gateway daemon: No"
 echo ""
-timeout 120 docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard \
-  --non-interactive \
-  --no-install-daemon \
-  --gateway-bind lan \
-  --gateway-auth token \
-  --gateway-token "$OPENCLAW_GATEWAY_TOKEN" || {
-    echo "Error: Onboarding timed out or failed. Check Docker logs for details."
-    exit 1
-  }
+if [[ -n "$TIMEOUT_CMD" ]]; then
+  $TIMEOUT_CMD 120 docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard \
+    --non-interactive \
+    --no-install-daemon \
+    --gateway-bind lan \
+    --gateway-auth token \
+    --gateway-token "$OPENCLAW_GATEWAY_TOKEN" || {
+      echo "Error: Onboarding timed out or failed. Check Docker logs for details."
+      exit 1
+    }
+else
+  docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard \
+    --non-interactive \
+    --no-install-daemon \
+    --gateway-bind lan \
+    --gateway-auth token \
+    --gateway-token "$OPENCLAW_GATEWAY_TOKEN" || {
+      echo "Error: Onboarding failed. Check Docker logs for details."
+      exit 1
+    }
+fi
 
 echo ""
 echo "==> Provider setup (optional)"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -178,15 +178,23 @@ docker build \
   "$ROOT_DIR"
 
 echo ""
-echo "==> Onboarding (interactive)"
-echo "When prompted:"
+echo "==> Onboarding (non-interactive)"
+echo "Configuring with defaults:"
 echo "  - Gateway bind: lan"
 echo "  - Gateway auth: token"
 echo "  - Gateway token: $OPENCLAW_GATEWAY_TOKEN"
 echo "  - Tailscale exposure: Off"
 echo "  - Install Gateway daemon: No"
 echo ""
-docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard --no-install-daemon
+timeout 120 docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard \
+  --non-interactive \
+  --no-install-daemon \
+  --gateway-bind lan \
+  --gateway-auth token \
+  --gateway-token "$OPENCLAW_GATEWAY_TOKEN" || {
+    echo "Error: Onboarding timed out or failed. Check Docker logs for details."
+    exit 1
+  }
 
 echo ""
 echo "==> Provider setup (optional)"


### PR DESCRIPTION
## Problem
`docker-setup.sh` hangs at 'Onboarding complete' waiting for input.

## Solution
- Made onboarding fully non-interactive with `--non-interactive` flag
- Added explicit config flags for non-interactive setup
- Added 120s timeout as safety net

## Impact
✅ Docker setup completes without hanging
✅ Better error messages on timeout

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh` to make the onboarding step non-interactive by passing explicit `openclaw-cli onboard` flags (gateway bind/auth/token, and `--non-interactive`) and wraps the onboarding command in a 120s `timeout` to prevent hanging.

The change fits into the existing Docker install flow by keeping the same compose-based invocation (`docker compose ... run --rm openclaw-cli onboard`) while eliminating prompts that could stall automated/CI-driven setup.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but has a portability regression for environments lacking `timeout`.
- The change is small and the onboarding flags appear to be valid, but introducing an unvalidated external dependency (`timeout`) can cause the installer to fail outright on some supported developer environments (notably macOS without coreutils).
- docker-setup.sh

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->