### PR TITLE
feat: add GLM-5 model support

### DIFF
--- a/src/agents/synthetic-models.ts
+++ b/src/agents/synthetic-models.ts
@@ -156,6 +156,14 @@ export const SYNTHETIC_MODEL_CATALOG = [
     maxTokens: 128000,
   },
   {
+    id: "hf:zai-org/GLM-5",
+    name: "GLM-5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 256000,
+    maxTokens: 128000,
+  },
+  {
     id: "hf:deepseek-ai/DeepSeek-V3",
     name: "DeepSeek V3",
     reasoning: false,


### PR DESCRIPTION
## Feature
Add ZhipuAI's GLM-5 model to OpenClaw model catalog.

## Implementation
- Added GLM-5 to synthetic models catalog
- Supports reasoning, text, and image inputs
- 256K context window, 128K max output tokens

## Usage
```bash
openclaw agent --model zhipuai/glm-5
```

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new entry to `SYNTHETIC_MODEL_CATALOG` for the GLM-5 model (`hf:zai-org/GLM-5`) with reasoning enabled and support for both text and image inputs, along with configured context window (256K) and max output tokens (128K). This integrates into the existing synthetic provider flow via `buildSyntheticModelDefinition`, making the model selectable wherever synthetic catalog entries are enumerated.

Main issue to address before merge: the PR description’s CLI usage (`--model zhipuai/glm-5`) does not match the actual synthetic catalog id/ref that was added, so the documented invocation likely won’t work as-is.

<h3>Confidence Score: 4/5</h3>

- This PR is small and low-risk, but the documented model identifier appears inconsistent with the implemented catalog entry.
- Only one catalog entry is added and it follows existing patterns; however, the mismatch between the PR’s stated `--model zhipuai/glm-5` usage and the actual synthetic catalog id/ref likely prevents users from selecting the new model as documented.
- src/agents/synthetic-models.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->