### PR TITLE
feat: improve audio transcription auto-detection and UX

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -1264,7 +1264,9 @@ export async function runCapability(params: {
     providerRegistry: params.providerRegistry,
   });
   let resolvedEntries = entries;
+  let attemptedAutoDetection = false;
   if (resolvedEntries.length === 0) {
+    attemptedAutoDetection = true;
     resolvedEntries = await resolveAutoEntries({
       cfg,
       agentDir: params.agentDir,
@@ -1274,7 +1276,9 @@ export async function runCapability(params: {
     });
   }
   if (resolvedEntries.length === 0) {
-    if (capability === "audio") {
+    // Only warn for audio if auto-detection was attempted and found nothing
+    // (don't warn if user explicitly configured zero models)
+    if (capability === "audio" && attemptedAutoDetection) {
       console.warn(
         "[media-understanding] Audio transcription skipped: no models configured and auto-detection found no CLI tools or API keys. " +
           "To enable: configure a provider API key (OpenAI, Groq, Deepgram) or install whisper CLI. " +

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -489,21 +489,38 @@ async function resolveAutoEntries(params: {
 }): Promise<MediaUnderstandingModelConfig[]> {
   const activeEntry = await resolveActiveModelEntry(params);
   if (activeEntry) {
+    if (shouldLogVerbose()) {
+      logVerbose(`${params.capability}: using active model (${activeEntry.provider})`);
+    }
     return [activeEntry];
   }
   if (params.capability === "audio") {
     const localAudio = await resolveLocalAudioEntry();
     if (localAudio) {
+      if (shouldLogVerbose()) {
+        logVerbose(`audio: detected local CLI (${localAudio.command})`);
+      }
       return [localAudio];
+    } else if (shouldLogVerbose()) {
+      logVerbose("audio: no local CLI detected (whisper, whisper-cli, sherpa-onnx)");
     }
   }
   const gemini = await resolveGeminiCliEntry(params.capability);
   if (gemini) {
+    if (shouldLogVerbose()) {
+      logVerbose(`${params.capability}: detected gemini CLI`);
+    }
     return [gemini];
   }
   const keys = await resolveKeyEntry(params);
   if (keys) {
+    if (shouldLogVerbose()) {
+      logVerbose(`${params.capability}: using provider with API key (${keys.provider})`);
+    }
     return [keys];
+  }
+  if (shouldLogVerbose()) {
+    logVerbose(`${params.capability}: auto-detection found no models`);
   }
   return [];
 }
@@ -1257,6 +1274,13 @@ export async function runCapability(params: {
     });
   }
   if (resolvedEntries.length === 0) {
+    if (capability === "audio") {
+      console.warn(
+        "[media-understanding] Audio transcription skipped: no models configured and auto-detection found no CLI tools or API keys. " +
+          "To enable: configure a provider API key (OpenAI, Groq, Deepgram) or install whisper CLI. " +
+          "See: https://github.com/openclaw/openclaw/blob/main/docs/nodes/audio.md",
+      );
+    }
     return {
       outputs: [],
       decision: {


### PR DESCRIPTION
## Problem
Voice notes appear as `<media:audio>` placeholders with no feedback about why transcription didn't happen.

## Solution
- Added warning when no transcription models found
- Improved verbose logging for debugging
- Better user guidance to enable transcription
- Documents auto-detection fallback chain

## Impact
✅ Users know why transcription isn't working
✅ Clear path to enable transcription
✅ Better debugging information

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves media-understanding audio auto-detection UX by adding verbose debug logs for the auto-detection decision chain (active model → local CLI → gemini CLI → API key providers), and emitting a user-facing warning when audio transcription is skipped due to no configured/auto-detected models.

The changes are localized to `src/media-understanding/runner.ts` and primarily affect the `resolveAutoEntries` and `runCapability` flow for the `audio` capability.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with one UX/logging behavior to confirm is intended.
- Changes are additive (verbose logs + an audio-only warning) and don’t alter core transcription logic. The main concern is that the new warning may show up in situations where users intentionally have no audio models configured, creating noisy output.
- src/media-understanding/runner.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->