### PR TITLE
feat: add message routing hook for model selection

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -714,6 +714,7 @@ export async function runEmbeddedAttempt(
               {
                 prompt: params.prompt,
                 messages: activeSession.messages,
+                modelId: `${params.model.provider}/${params.modelId}`,
               },
               {
                 agentId: params.sessionKey?.split(":")[0] ?? "main",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -153,7 +153,6 @@ export async function runAgentTurnWithFallback(params: {
           const hookResult = await hookRunner.runBeforeAgentStart(
             {
               prompt: params.commandBody,
-              messages: params.followupRun.run.messages,
               modelId: `${routedProvider}/${routedModel}`,
             },
             {
@@ -186,7 +185,7 @@ export async function runAgentTurnWithFallback(params: {
             }
           }
         } catch (hookErr) {
-          defaultRuntime.log.warn(`before_agent_start hook failed: ${String(hookErr)}`);
+          defaultRuntime.log(`before_agent_start hook failed: ${String(hookErr)}`);
         }
       }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -153,6 +153,7 @@ export async function runAgentTurnWithFallback(params: {
           const hookResult = await hookRunner.runBeforeAgentStart(
             {
               prompt: params.commandBody,
+              messages: params.followupRun.run.messages,
               modelId: `${routedProvider}/${routedModel}`,
             },
             {
@@ -163,20 +164,24 @@ export async function runAgentTurnWithFallback(params: {
             },
           );
           if (hookResult?.modelId) {
+            const originalModelId = `${params.followupRun.run.provider}/${params.followupRun.run.model}`;
             const parts = hookResult.modelId.trim().split("/");
+            let routingApplied = false;
+
             if (parts.length === 2) {
               routedProvider = parts[0];
               routedModel = parts[1];
+              routingApplied = true;
             } else if (parts.length === 1) {
               // If only model name provided, keep the same provider
               routedModel = parts[0];
+              routingApplied = true;
             }
-            if (
-              hookResult.modelId !==
-              `${params.followupRun.run.provider}/${params.followupRun.run.model}`
-            ) {
+            // If parts.length > 2, ignore (invalid format)
+
+            if (routingApplied && hookResult.modelId !== originalModelId) {
               logVerbose(
-                `before_agent_start hook routed model: ${params.followupRun.run.provider}/${params.followupRun.run.model} → ${routedProvider}/${routedModel}`,
+                `before_agent_start hook routed model: ${originalModelId} → ${routedProvider}/${routedModel}`,
               );
             }
           }

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -489,21 +489,38 @@ async function resolveAutoEntries(params: {
 }): Promise<MediaUnderstandingModelConfig[]> {
   const activeEntry = await resolveActiveModelEntry(params);
   if (activeEntry) {
+    if (shouldLogVerbose()) {
+      logVerbose(`${params.capability}: using active model (${activeEntry.provider})`);
+    }
     return [activeEntry];
   }
   if (params.capability === "audio") {
     const localAudio = await resolveLocalAudioEntry();
     if (localAudio) {
+      if (shouldLogVerbose()) {
+        logVerbose(`audio: detected local CLI (${localAudio.command})`);
+      }
       return [localAudio];
+    } else if (shouldLogVerbose()) {
+      logVerbose("audio: no local CLI detected (whisper, whisper-cli, sherpa-onnx)");
     }
   }
   const gemini = await resolveGeminiCliEntry(params.capability);
   if (gemini) {
+    if (shouldLogVerbose()) {
+      logVerbose(`${params.capability}: detected gemini CLI`);
+    }
     return [gemini];
   }
   const keys = await resolveKeyEntry(params);
   if (keys) {
+    if (shouldLogVerbose()) {
+      logVerbose(`${params.capability}: using provider with API key (${keys.provider})`);
+    }
     return [keys];
+  }
+  if (shouldLogVerbose()) {
+    logVerbose(`${params.capability}: auto-detection found no models`);
   }
   return [];
 }
@@ -1257,6 +1274,13 @@ export async function runCapability(params: {
     });
   }
   if (resolvedEntries.length === 0) {
+    if (capability === "audio") {
+      console.warn(
+        "[media-understanding] Audio transcription skipped: no models configured and auto-detection found no CLI tools or API keys. " +
+          "To enable: configure a provider API key (OpenAI, Groq, Deepgram) or install whisper CLI. " +
+          "See: https://github.com/openclaw/openclaw/blob/main/docs/nodes/audio.md",
+      );
+    }
     return {
       outputs: [],
       decision: {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -194,6 +194,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           acc?.prependContext && next.prependContext
             ? `${acc.prependContext}\n\n${next.prependContext}`
             : (next.prependContext ?? acc?.prependContext),
+        modelId: next.modelId ?? acc?.modelId,
       }),
     );
   }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -314,11 +314,15 @@ export type PluginHookAgentContext = {
 export type PluginHookBeforeAgentStartEvent = {
   prompt: string;
   messages?: unknown[];
+  /** Current model being used for this turn. Format: "provider/model". */
+  modelId?: string;
 };
 
 export type PluginHookBeforeAgentStartResult = {
   systemPrompt?: string;
   prependContext?: string;
+  /** Override the model for this agent turn. Format: "provider/model" or just "model". */
+  modelId?: string;
 };
 
 // agent_end hook


### PR DESCRIPTION
## Feature
Allow plugins to route messages to different models before agent execution.

## Implementation
- Extended `before_agent_start` hook with `modelId` override capability
- Plugins can inspect message content and dynamically select models
- Format: `provider/model` or just `model`

## Use Cases
- Route technical questions to coding-optimized models
- Use cheaper models for simple queries
- A/B test different models
- Language-specific model routing

## Example
```typescript
registry.registerHook({
  hookName: 'before_agent_start',
  handler: async (event) => {
    if (event.prompt.includes('code')) {
      return { modelId: 'anthropic/claude-opus-4' };
    }
    return {};
  },
});
```

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `before_agent_start` plugin hook to optionally return a `modelId` override so plugins can route a turn to a different provider/model, and wires that into the auto-reply agent runner before `runWithModelFallback`. It also adds some extra verbose logging for media-understanding model auto-detection.

Key integration points are `src/plugins/types.ts` (new `modelId` fields on the hook event/result), `src/plugins/hooks.ts` (merge behavior updated to carry `modelId`), and `src/auto-reply/reply/agent-runner-execution.ts` (invokes the hook and applies the override when selecting the model).

<h3>Confidence Score: 3/5</h3>

- Mergeable after fixing hook consistency and routing log correctness.
- Core changes are straightforward, but the new hook contract is currently inconsistent across execution paths (embedded vs auto-reply), which will break plugins relying on `modelId` routing; additionally, routing logs can be incorrect for multi-slash model IDs.
- src/auto-reply/reply/agent-runner-execution.ts; src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->