### PR TITLE
feat(hooks): add message:sent hook for outbound messages

### DIFF
--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,7 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -164,6 +164,40 @@ export function createInternalHookEvent(
     timestamp: new Date(),
     messages: [],
   };
+}
+
+export type MessageSentHookContext = {
+  /** The channel the message was sent through (e.g., 'telegram', 'signal', 'discord') */
+  channel: string;
+  /** The recipient identifier */
+  to: string;
+  /** The message text that was sent */
+  text: string;
+  /** Any media URLs included in the message */
+  mediaUrls?: string[];
+  /** The account ID used for sending (if applicable) */
+  accountId?: string;
+  /** The agent ID that sent the message */
+  agentId?: string;
+  /** Number of message chunks/results delivered */
+  resultCount: number;
+};
+
+export type MessageSentHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "sent";
+  context: MessageSentHookContext;
+};
+
+export function isMessageSentEvent(event: InternalHookEvent): event is MessageSentHookEvent {
+  if (event.type !== "message" || event.action !== "sent") {
+    return false;
+  }
+  const context = event.context as Partial<MessageSentHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.channel === "string" && typeof context.to === "string";
 }
 
 export function isAgentBootstrapEvent(event: InternalHookEvent): event is AgentBootstrapHookEvent {


### PR DESCRIPTION
Obviously this was missing. The 'Future Events' section promised message:sent but nobody implemented it. So here it is.

Fires after successful delivery in deliverOutboundPayloads. Provides everything you'd need for custom TTS, logging, or whatever else you're too lazy to build into core:

Context includes:
- channel (telegram, signal, discord, etc.)
- to (recipient)
- text (the actual message, obviously)
- mediaUrls (attachments, if any)
- accountId, agentId, sessionKey, resultCount

Also added proper TypeScript types because we're not savages:
- MessageSentHookContext
- MessageSentHookEvent
- isMessageSentEvent() type guard

Tests pass. Build passes. You're welcome.

— Ram 🩷

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new internal hook event (`message:sent`) for outbound message delivery.

- Extends the internal hook event types to include `type: "message"` and adds `MessageSentHookContext` / `MessageSentHookEvent` plus an `isMessageSentEvent()` type guard in `src/hooks/internal-hooks.ts`.
- Triggers the hook at the end of `deliverOutboundPayloads` after at least one outbound delivery result is produced, emitting channel/to plus combined text/media URLs and delivery `resultCount`.

This fits into the existing internal hooks system (`createInternalHookEvent` + `triggerInternalHook`) and lets hook handlers observe outbound delivery events for logging/TTS/etc.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of correctness issues in the new hook contract that should be addressed first.
- Core implementation is small and follows existing hook infrastructure, but the new event can be emitted with an empty sessionKey (breaking correlation expectations) and the new type guard is currently unsound versus its declared required context fields.
- src/infra/outbound/deliver.ts, src/hooks/internal-hooks.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->