### PR TITLE
fix(feishu): cache health check probe to avoid API quota exhaustion

### DIFF
--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -1,12 +1,25 @@
 import type { FeishuProbeResult } from "./types.js";
 import { createFeishuClient, type FeishuClientCredentials } from "./client.js";
 
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const probeCache = new Map<string, { result: FeishuProbeResult; cachedAt: number }>();
+
+function cacheKey(creds: FeishuClientCredentials): string {
+  return `${creds.appId ?? ""}:${creds.domain ?? ""}`;
+}
+
 export async function probeFeishu(creds?: FeishuClientCredentials): Promise<FeishuProbeResult> {
   if (!creds?.appId || !creds?.appSecret) {
     return {
       ok: false,
       error: "missing credentials (appId, appSecret)",
     };
+  }
+
+  const key = cacheKey(creds);
+  const cached = probeCache.get(key);
+  if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
+    return cached.result;
   }
 
   try {
@@ -28,12 +41,14 @@ export async function probeFeishu(creds?: FeishuClientCredentials): Promise<Feis
     }
 
     const bot = response.bot || response.data?.bot;
-    return {
+    const result: FeishuProbeResult = {
       ok: true,
       appId: creds.appId,
       botName: bot?.bot_name,
       botOpenId: bot?.open_id,
     };
+    probeCache.set(key, { result, cachedAt: Date.now() });
+    return result;
   } catch (err) {
     return {
       ok: false,

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -5,7 +5,8 @@ const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const probeCache = new Map<string, { result: FeishuProbeResult; cachedAt: number }>();
 
 function cacheKey(creds: FeishuClientCredentials): string {
-  return `${creds.appId ?? ""}:${creds.domain ?? ""}`;
+  const secretTail = (creds.appSecret ?? "").slice(-6);
+  return `${creds.appId ?? ""}:${creds.domain ?? ""}:${secretTail}`;
 }
 
 export async function probeFeishu(creds?: FeishuClientCredentials): Promise<FeishuProbeResult> {


### PR DESCRIPTION
Fixes #14480

Feishu health check calls `/open-apis/bot/v3/info` every 60s, burning ~43,200 API calls/month against the 10,000/month quota.

Adds a 10-minute in-memory cache for successful probe results. Failed probes are not cached so credential issues are detected immediately.

~43,200/month → ~4,320/month.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reduces Feishu API quota usage by adding a 10-minute in-memory cache for successful `/open-apis/bot/v3/info` probe results in `extensions/feishu/src/probe.ts`. Call sites (status/onboarding/monitor) will now reuse cached `ok: true` probe results and avoid hitting Feishu on every periodic health check; failures are still returned immediately (not cached).

The main correctness risk is cache invalidation: the current cache key does not include `appSecret`, so rotating credentials can return a stale success result for up to the TTL even if the secret is now invalid.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one cache invalidation bug to address.
- The change is small and localized, but the cache key currently ignores `appSecret`, which can cause incorrect `ok: true` probe results to be reused after secret rotation for up to 10 minutes. Fixing the key/invalidation should make the caching behavior match the PR’s stated intent (don’t mask credential issues).
- extensions/feishu/src/probe.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->