### PR TITLE
fix(infra): exempt wake events from empty HEARTBEAT.md skip

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -431,6 +431,7 @@ export async function runHeartbeatOnce(opts: {
   // to process regardless of HEARTBEAT.md content.
   const isExecEventReason = opts.reason === "exec-event";
   const isCronEventReason = Boolean(opts.reason?.startsWith("cron:"));
+  const isWakeReason = opts.reason === "wake";
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
@@ -438,7 +439,8 @@ export async function runHeartbeatOnce(opts: {
     if (
       isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) &&
       !isExecEventReason &&
-      !isCronEventReason
+      !isCronEventReason &&
+      !isWakeReason
     ) {
       emitHeartbeatEvent({
         status: "skipped",


### PR DESCRIPTION
Fixes #14527

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `runHeartbeatOnce` to treat `reason === "wake"` as an exception to the “empty HEARTBEAT.md” early-skip logic, alongside the existing `exec-event` and `cron:*` exceptions.

In the current codebase, `cron/service/timer.wake()` enqueues a system event and (when invoked in `mode: "now"`) triggers a heartbeat with reason `"wake"`, so skipping solely due to an effectively-empty `HEARTBEAT.md` would prevent the queued wake message from being delivered.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow, well-scoped condition update in `runHeartbeatOnce` that aligns with how `wake` is used (to deliver an enqueued system event). No other behavior is altered, and the diff introduces no type or runtime hazards.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->