### PR TITLE
docs: recommend Tailscale Serve for HTTPS access (#14513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - CLI/Plugins: add `openclaw plugins uninstall <id>` with `--dry-run`, `--force`, and `--keep-files` options, including safe uninstall path handling and plugin uninstall docs. (#5985) Thanks @JustasMonkev.
+- Docs: recommend `tailscale serve` as a quick HTTPS solution for the Control UI. (#14513)
 - CLI: add `openclaw logs --local-time` to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
 - Telegram: render blockquotes as native `<blockquote>` tags instead of stripping them. (#14608)
 - Telegram: expose `/compact` in the native command menu. (#10352) Thanks @akramcodez.

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -36,6 +36,22 @@ headers.
 To require explicit credentials, set `gateway.auth.allowTailscale: false` or
 force `gateway.auth.mode: "password"`.
 
+## Quick start (manual Tailscale Serve)
+
+If you just want HTTPS access to the Control UI without configuring OpenClaw's
+integrated Tailscale automation, run:
+
+```bash
+tailscale serve --bg http://127.0.0.1:18789
+```
+
+Then open `https://<your-machine>.<tailnet>.ts.net/` — you get a valid HTTPS
+certificate, tailnet-only access, and no need for `allowInsecureAuth`.
+
+To stop serving: `tailscale serve --bg off`.
+
+For automatic start/stop with the Gateway, use the integrated config below.
+
 ## Config examples
 
 ### Tailnet-only (Serve)

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -45,8 +45,9 @@ integrated Tailscale automation, run:
 tailscale serve --bg http://127.0.0.1:18789
 ```
 
-Then open `https://<your-machine>.<tailnet>.ts.net/` — you get a valid HTTPS
-certificate, tailnet-only access, and no need for `allowInsecureAuth`.
+Then open `https://<your-machine>.<tailnet>.ts.net/` (append your
+`gateway.controlUi.basePath` if configured) — you get a valid HTTPS certificate,
+tailnet-only access, and no need for `allowInsecureAuth`.
 
 To stop serving: `tailscale serve --bg off`.
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -139,6 +139,23 @@ OpenClaw **blocks** Control UI connections without device identity.
 - `https://<magicdns>/` (Serve)
 - `http://127.0.0.1:18789/` (on the gateway host)
 
+### Quick fix with Tailscale Serve
+
+If you already have Tailscale installed, one command gives you HTTPS access with a valid certificate:
+
+```bash
+tailscale serve --bg http://127.0.0.1:18789
+```
+
+Then open `https://<your-machine>.<tailnet>.ts.net/` in your browser. This provides:
+
+- Automatic HTTPS certificate (no manual TLS setup)
+- Tailnet-only access (secure by default)
+- No need for `allowInsecureAuth` workaround
+
+For OpenClaw's integrated Tailscale automation (auto-start/stop with the Gateway), see
+[Tailscale](/gateway/tailscale).
+
 **Downgrade example (token-only over HTTP):**
 
 ```json5

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -147,7 +147,8 @@ If you already have Tailscale installed, one command gives you HTTPS access with
 tailscale serve --bg http://127.0.0.1:18789
 ```
 
-Then open `https://<your-machine>.<tailnet>.ts.net/` in your browser. This provides:
+Then open `https://<your-machine>.<tailnet>.ts.net/` (or `https://…/<basePath>/` if
+`gateway.controlUi.basePath` is set) in your browser. This provides:
 
 - Automatic HTTPS certificate (no manual TLS setup)
 - Tailnet-only access (secure by default)


### PR DESCRIPTION
## Summary

Fixes #14513

## Problem

When users access the Control UI over plain HTTP from a non-localhost address, they see:

```
control ui requires HTTPS or localhost (secure context)
```

The error message points toward `allowInsecureAuth: true` as a workaround, but the docs don't prominently recommend **Tailscale Serve** as a simpler, more secure one-command solution.

## Fix

Add a "Quick fix with Tailscale Serve" section to two docs pages:

- **`docs/web/control-ui.md`** — added a subsection under "Insecure HTTP" showing the one-command `tailscale serve` approach
- **`docs/gateway/tailscale.md`** — added a "Quick start (manual Tailscale Serve)" section before the integrated config examples

Both sections show:

```bash
tailscale serve --bg http://127.0.0.1:18789
```

And explain the benefits (automatic HTTPS, tailnet-only, no `allowInsecureAuth` needed).

## Effect on User Experience

**Before fix:**
Users seeing the HTTPS error had to either:
1. Read through the full Tailscale integration docs to configure `gateway.tailscale.mode`
2. Use the insecure `allowInsecureAuth: true` workaround

**After fix:**
Users can immediately try `tailscale serve --bg http://127.0.0.1:18789` — one command, zero OpenClaw config changes, instant HTTPS.

## Testing

- ✅ Docs-only change, no code modified
- ✅ Links use root-relative paths without `.md` extension (Mintlify convention)
- ✅ CHANGELOG updated

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the documentation to highlight **Tailscale Serve** as the recommended “one-command” way to access the Gateway Control UI over HTTPS, avoiding the insecure `allowInsecureAuth` workaround. It adds a quick-start section to `docs/web/control-ui.md` and a manual Serve quick-start section to `docs/gateway/tailscale.md`, and records the change in the changelog.

The change fits cleanly into the existing web/tailscale docs structure by giving users an immediate HTTPS path before the deeper integrated configuration examples.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; the main risk is minor user confusion from incomplete URLs in the new quick-start sections.
- Changes are docs-only and align with existing guidance, but the new quick-start instructions don’t account for `gateway.controlUi.basePath`, which can cause users to open the wrong path when Serve is enabled.
- docs/web/control-ui.md, docs/gateway/tailscale.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->