### PR TITLE
feat(telegram): add support for URL-type inline buttons

### DIFF
--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -62,7 +62,12 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     const replyToMessageId = parseReplyToMessageId(replyToId);
     const messageThreadId = parseThreadId(threadId);
     const telegramData = payload.channelData?.telegram as
-      | { buttons?: Array<Array<{ text: string; callback_data: string }>>; quoteText?: string }
+      | {
+          buttons?: Array<
+            Array<{ text: string; callback_data: string } | { text: string; url: string }>
+          >;
+          quoteText?: string;
+        }
       | undefined;
     const quoteText =
       typeof telegramData?.quoteText === "string" ? telegramData.quoteText : undefined;

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -8,7 +8,10 @@
  * - mdl_back              - back to providers list
  */
 
-export type ButtonRow = Array<{ text: string; callback_data: string }>;
+export type ButtonRow = Array<
+  | { text: string; callback_data: string }
+  | { text: string; url: string }
+>;
 
 export type ParsedModelCallback =
   | { type: "providers" }

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -53,7 +53,9 @@ type TelegramSendOpts = {
   /** Forum topic thread ID (for forum supergroups) */
   messageThreadId?: number;
   /** Inline keyboard buttons (reply markup). */
-  buttons?: Array<Array<{ text: string; callback_data: string }>>;
+  buttons?: Array<
+    Array<{ text: string; callback_data: string } | { text: string; url: string }>
+  >;
 };
 
 type TelegramSendResult = {
@@ -214,13 +216,22 @@ export function buildInlineKeyboard(
   const rows = buttons
     .map((row) =>
       row
-        .filter((button) => button?.text && button?.callback_data)
-        .map(
-          (button): InlineKeyboardButton => ({
+        .filter((button) => {
+          if (!button?.text) return false;
+          return "callback_data" in button || "url" in button;
+        })
+        .map((button): InlineKeyboardButton => {
+          if ("callback_data" in button) {
+            return {
+              text: button.text,
+              callback_data: button.callback_data,
+            };
+          }
+          return {
             text: button.text,
-            callback_data: button.callback_data,
-          }),
-        ),
+            url: button.url,
+          };
+        }),
     )
     .filter((row) => row.length > 0);
   if (rows.length === 0) {
@@ -696,7 +707,9 @@ type TelegramEditOpts = {
   retry?: RetryConfig;
   textMode?: "markdown" | "html";
   /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
-  buttons?: Array<Array<{ text: string; callback_data: string }>>;
+  buttons?: Array<
+    Array<{ text: string; callback_data: string } | { text: string; url: string }>
+  >;
   /** Optional config injection to avoid global loadConfig() (improves testability). */
   cfg?: ReturnType<typeof loadConfig>;
 };


### PR DESCRIPTION
## Summary

This PR adds support for Telegram URL-type inline buttons, enabling bots to include buttons that open links directly when tapped.

## Changes

- **Updated button types** to support both `callback_data` and `url`
  - `src/telegram/model-buttons.ts`: Updated `ButtonRow` type
  - `src/agents/tools/telegram-actions.ts`: Updated `TelegramButton` type
  - `src/telegram/send.ts`: Updated `TelegramSendOpts` and `TelegramEditOpts`
  - `src/channels/plugins/outbound/telegram.ts`: Updated channel data types

- **Enhanced validation** in `readTelegramButtons`
  - Accepts buttons with either `callback_data` OR `url` (but not both)
  - Clear error messages for invalid button configurations

- **Updated `buildInlineKeyboard`** to handle both button types
  - Passes `callback_data` buttons through as before (backward compatible)
  - Passes `url` buttons to Telegram's InlineKeyboardButton API

## Testing

The changes are backward compatible:
- Existing `callback_data` buttons work exactly as before
- New `url` buttons can now be used

Example usage:
```typescript
// URL button
buttons: [[{ text: "View PR", url: "https://github.com/openclaw/openclaw/pull/123" }]]

// Callback button (existing behavior)
buttons: [[{ text: "Approve", callback_data: "approve_123" }]]

// Mixed row
buttons: [[
  { text: "View", url: "https://example.com" },
  { text: "Delete", callback_data: "delete_123" }
]]
```

## Closes

Fixes #14548

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change extends Telegram inline keyboard support to allow URL buttons in addition to callback buttons.

Updates include widening button types across the agent tool parser (`src/agents/tools/telegram-actions.ts`), outbound plugin payload typing (`src/channels/plugins/outbound/telegram.ts`), model button row type (`src/telegram/model-buttons.ts`), and send/edit option types plus keyboard construction (`src/telegram/send.ts`). The core behavior change is in `buildInlineKeyboard`, which now maps either `{ text, callback_data }` or `{ text, url }` into Telegram’s `InlineKeyboardButton` shape.

<h3>Confidence Score: 3/5</h3>

- Moderately safe, but there are a couple of end-to-end correctness gaps for URL buttons.
- Types and mapping for URL buttons are mostly consistent, but one bot delivery path still hard-casts buttons as callback-only, and `buildInlineKeyboard` can accept malformed button objects from unvalidated channelData (leading to Telegram API errors).
- src/telegram/bot/delivery.ts, src/telegram/send.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->