### PR TITLE
fix(ui): save button dead after model change on single-agent setups (#13338)

### DIFF
--- a/ui/src/ui/app-render.ensure-agent-list.node.test.ts
+++ b/ui/src/ui/app-render.ensure-agent-list.node.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigState } from "./controllers/config.ts";
+import { ensureAgentListEntry } from "./app-render.ts";
+
+function createConfigState(form: Record<string, unknown> | null): ConfigState {
+  return {
+    applySessionKey: "main",
+    client: null,
+    configActiveSection: null,
+    configActiveSubsection: null,
+    configApplying: false,
+    configForm: form,
+    configFormDirty: false,
+    configFormMode: "form",
+    configFormOriginal: null,
+    configIssues: [],
+    configLoading: false,
+    configRaw: "",
+    configRawOriginal: "",
+    configSaving: false,
+    configSchema: null,
+    configSchemaLoading: false,
+    configSchemaVersion: null,
+    configSearchQuery: "",
+    configSnapshot: null,
+    configUiHints: {},
+    configValid: null,
+    connected: false,
+    lastError: null,
+    updateRunning: false,
+  };
+}
+
+describe("ensureAgentListEntry", () => {
+  it("returns -1 when configValue is null", () => {
+    const state = createConfigState(null);
+    const index = ensureAgentListEntry(state, null, "main");
+    expect(index).toBe(-1);
+  });
+
+  it("creates agents.list when missing and returns index 0", () => {
+    const config: Record<string, unknown> = { gateway: { mode: "local" } };
+    const state = createConfigState(config);
+    const index = ensureAgentListEntry(state, config, "main");
+    expect(index).toBe(0);
+    expect(state.configFormDirty).toBe(true);
+    const form = state.configForm as { agents?: { list?: Array<{ id: string }> } };
+    expect(form?.agents?.list?.[0]?.id).toBe("main");
+  });
+
+  it("appends agent when agents.list exists but agent is missing", () => {
+    const config: Record<string, unknown> = {
+      agents: { list: [{ id: "other-agent" }] },
+    };
+    const state = createConfigState(config);
+    const index = ensureAgentListEntry(state, config, "main");
+    expect(index).toBe(1);
+    expect(state.configFormDirty).toBe(true);
+    const form = state.configForm as { agents?: { list?: Array<{ id: string }> } };
+    expect(form?.agents?.list?.[1]?.id).toBe("main");
+  });
+
+  it("returns existing index when agent is already in the list", () => {
+    const config: Record<string, unknown> = {
+      agents: { list: [{ id: "main", model: "gpt-4o" }] },
+    };
+    const state = createConfigState(config);
+    const index = ensureAgentListEntry(state, config, "main");
+    expect(index).toBe(0);
+    // Should not have mutated the form since agent already exists.
+    expect(state.configFormDirty).toBe(false);
+  });
+
+  it("creates agents.list when agents exists but list is not an array", () => {
+    const config: Record<string, unknown> = {
+      agents: { defaults: { model: "gpt-4o" } },
+    };
+    const state = createConfigState(config);
+    const index = ensureAgentListEntry(state, config, "main");
+    expect(index).toBe(0);
+    expect(state.configFormDirty).toBe(true);
+  });
+});

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -17,6 +17,7 @@ import {
   saveConfig,
   updateConfigFormValue,
   removeConfigFormValue,
+  type ConfigState,
 } from "./controllers/config.ts";
 import {
   loadCronRuns,
@@ -95,6 +96,45 @@ function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
     return candidate;
   }
   return identity?.avatarUrl;
+}
+
+/**
+ * Ensure the agent has an entry in the config form's `agents.list` array.
+ * When the config has no explicit `agents.list` (common for single-agent
+ * setups), model/skill/tool changes silently fail because the handlers
+ * cannot find the agent by id. This helper creates the list and/or entry
+ * on demand so the subsequent `updateConfigFormValue` call succeeds.
+ *
+ * Returns the index of the agent entry, or -1 if configValue is null.
+ */
+export function ensureAgentListEntry(
+  state: ConfigState,
+  configValue: Record<string, unknown> | null,
+  agentId: string,
+): number {
+  if (!configValue) {
+    return -1;
+  }
+  const agents = configValue.agents as { list?: unknown[] } | undefined;
+  let list = agents?.list;
+  if (!Array.isArray(list)) {
+    // Create agents.list with a stub entry for this agent.
+    updateConfigFormValue(state, ["agents", "list"], [{ id: agentId }]);
+    return 0;
+  }
+  const index = list.findIndex(
+    (entry) =>
+      entry &&
+      typeof entry === "object" &&
+      "id" in entry &&
+      (entry as { id?: string }).id === agentId,
+  );
+  if (index >= 0) {
+    return index;
+  }
+  // Agent not in the list — append a stub entry.
+  updateConfigFormValue(state, ["agents", "list", list.length], { id: agentId });
+  return list.length;
 }
 
 export function renderApp(state: AppViewState) {
@@ -864,29 +904,21 @@ export function renderApp(state: AppViewState) {
                   updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
                 },
                 onModelChange: (agentId, modelId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index = ensureAgentListEntry(state, configValue, agentId);
                   if (index < 0) {
                     return;
                   }
-                  const basePath = ["agents", "list", index, "model"];
+                  const basePath = ["agents", "list", index, "model"] as Array<string | number>;
                   if (!modelId) {
                     removeConfigFormValue(state, basePath);
                     return;
                   }
-                  const entry = list[index] as { model?: unknown };
+                  // Re-read the list after ensureAgentListEntry may have mutated configForm.
+                  const list = (state.configForm as { agents?: { list?: unknown[] } } | null)
+                    ?.agents?.list;
+                  const entry = Array.isArray(list)
+                    ? (list[index] as { model?: unknown } | undefined)
+                    : undefined;
                   const existing = entry?.model;
                   if (existing && typeof existing === "object" && !Array.isArray(existing)) {
                     const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
@@ -900,27 +932,19 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onModelFallbacksChange: (agentId, fallbacks) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index = ensureAgentListEntry(state, configValue, agentId);
                   if (index < 0) {
                     return;
                   }
-                  const basePath = ["agents", "list", index, "model"];
-                  const entry = list[index] as { model?: unknown };
+                  const basePath = ["agents", "list", index, "model"] as Array<string | number>;
+                  // Re-read the list after ensureAgentListEntry may have mutated configForm.
+                  const list = (state.configForm as { agents?: { list?: unknown[] } } | null)
+                    ?.agents?.list;
+                  const entry = Array.isArray(list)
+                    ? (list[index] as { model?: unknown } | undefined)
+                    : undefined;
                   const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const existing = entry.model;
+                  const existing = entry?.model;
                   const resolvePrimary = () => {
                     if (typeof existing === "string") {
                       return existing.trim() || null;


### PR DESCRIPTION
## Summary

Save button doesn't enable when you change the model or fallbacks on the Dashboard's Agents → Overview page. The handler bails early if the agent isn't in `agents.list`, which is the default for single-agent setups.

Added `ensureAgentListEntry()` that auto-creates a minimal `{ id: agentId }` entry in `agents.list` before the model update runs, so `updateConfigFormValue` succeeds and the form gets marked dirty.

Closes #13338

lobster-biscuit

## Repro Steps

1. Fresh install with default config (no `agents.list` in config)
2. Open Dashboard → Agents → main → Overview
3. Change Primary model dropdown to any other model
4. Save button stays disabled — no save call is made

## Root Cause

`onModelChange` in `ui/src/ui/app-render.ts` reads `configValue.agents?.list` from the config form. Single-agent setups don't populate that array (model lives in `agents.defaults.model`), so `Array.isArray(list)` returns false and the handler returns early. `configFormDirty` never flips, Save stays disabled. Same pattern in `onModelFallbacksChange`.

## Changes

- Before: changing model/fallbacks for agents not in `agents.list` does nothing; Save button stays disabled
- After: `ensureAgentListEntry()` creates the list entry on demand, `updateConfigFormValue` goes through, Save enables

## Note on env vars (also mentioned in #13338)

The original issue also mentions env vars can't be edited via Dashboard. I checked the code — env vars editing goes through the generic config form path (`onFormPatch` → `updateConfigFormValue` on the `env` key), not through the `agents.list` lookup. So it's a different code path and not affected by this fix. That part may need a separate investigation or may already be resolved in a newer version.

## Tests

- `ui/src/ui/app-render.ensure-agent-list.node.test.ts` — 5 tests covering null config, missing agents.list, missing agent entry, existing entry, and agents object without list array
- `pnpm build` and `pnpm check` pass
- All UI node tests (4 files, 40 tests) pass
