### PR TITLE
Fix Codex auth not being applied to the session/token after login.

### DIFF
--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -1,4 +1,3 @@
-import { loginOpenAICodex } from "@mariozechner/pi-ai";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { resolveEnvApiKey } from "../agents/model-auth.js";
 import { upsertSharedEnvVar } from "../infra/env-file.js";
@@ -9,13 +8,13 @@ import {
 } from "./auth-choice.api-key.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 import { isRemoteEnvironment } from "./oauth-env.js";
-import { createVpsAwareOAuthHandlers } from "./oauth-flow.js";
 import { applyAuthProfileConfig, writeOAuthCredentials } from "./onboard-auth.js";
 import { openUrl } from "./onboard-helpers.js";
 import {
   applyOpenAICodexModelDefault,
   OPENAI_CODEX_DEFAULT_MODEL,
 } from "./openai-codex-model-default.js";
+import { loginOpenAICodexOAuth } from "./openai-codex-oauth.js";
 import {
   applyOpenAIConfig,
   applyOpenAIProviderConfig,
@@ -125,42 +124,20 @@ export async function applyAuthChoiceOpenAI(
       );
     };
 
-    const isRemote = isRemoteEnvironment();
-    await params.prompter.note(
-      isRemote
-        ? [
-            "You are running in a remote/VPS environment.",
-            "A URL will be shown for you to open in your LOCAL browser.",
-            "After signing in, paste the redirect URL back here.",
-          ].join("\n")
-        : [
-            "Browser will open for OpenAI authentication.",
-            "If the callback doesn't auto-complete, paste the redirect URL.",
-            "OpenAI OAuth uses localhost:1455 for the callback.",
-          ].join("\n"),
-      "OpenAI Codex OAuth",
-    );
-    const spin = params.prompter.progress("Starting OAuth flow…");
     try {
-      const { onAuth, onPrompt } = createVpsAwareOAuthHandlers({
-        isRemote,
+      const creds = await loginOpenAICodexOAuth({
         prompter: params.prompter,
         runtime: params.runtime,
-        spin,
+        isRemote: isRemoteEnvironment(),
         openUrl,
-        localBrowserMessage: "Complete sign-in in browser…",
       });
-
-      const creds = await loginOpenAICodex({
-        onAuth,
-        onPrompt,
-        onProgress: (msg) => spin.update(msg),
-      });
-      spin.stop("OpenAI OAuth complete");
       if (creds) {
+        const email =
+          typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
+        const profileId = `openai-codex:${email}`;
         await writeOAuthCredentials("openai-codex", creds, params.agentDir);
         nextConfig = applyAuthProfileConfig(nextConfig, {
-          profileId: "openai-codex:default",
+          profileId,
           provider: "openai-codex",
           mode: "oauth",
         });
@@ -178,13 +155,8 @@ export async function applyAuthChoiceOpenAI(
           await noteAgentModel(OPENAI_CODEX_DEFAULT_MODEL);
         }
       }
-    } catch (err) {
-      spin.stop("OpenAI OAuth failed");
-      params.runtime.error(String(err));
-      await params.prompter.note(
-        "Trouble with OAuth? See https://docs.openclaw.ai/start/faq",
-        "OAuth help",
-      );
+    } catch {
+      // Errors are handled in loginOpenAICodexOAuth.
     }
     return { config: nextConfig, agentModelOverride };
   }

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -26,6 +26,8 @@ import { isRemoteEnvironment } from "../oauth-env.js";
 import { createVpsAwareOAuthHandlers } from "../oauth-flow.js";
 import { applyAuthProfileConfig } from "../onboard-auth.js";
 import { openUrl } from "../onboard-helpers.js";
+import { OPENAI_CODEX_DEFAULT_MODEL } from "../openai-codex-model-default.js";
+import { loginOpenAICodexOAuth } from "../openai-codex-oauth.js";
 import { updateConfig } from "./shared.js";
 
 const confirm = (params: Parameters<typeof clackConfirm>[0]) =>
@@ -342,14 +344,66 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
   const workspaceDir =
     resolveAgentWorkspaceDir(config, defaultAgentId) ?? resolveDefaultAgentWorkspaceDir();
 
+  const prompter = createClackPrompter();
+  const requestedProvider = opts.provider ? normalizeProviderId(opts.provider) : null;
+  if (requestedProvider === "openai-codex") {
+    const method = opts.method?.trim().toLowerCase();
+    if (method && method !== "oauth") {
+      throw new Error('OpenAI Codex auth only supports --method "oauth".');
+    }
+
+    const creds = await loginOpenAICodexOAuth({
+      prompter,
+      runtime,
+      isRemote: isRemoteEnvironment(),
+      openUrl,
+    });
+    if (!creds) {
+      return;
+    }
+
+    const email =
+      typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
+    const profileId = `openai-codex:${email}`;
+
+    upsertAuthProfile({
+      profileId,
+      credential: {
+        type: "oauth",
+        provider: "openai-codex",
+        ...creds,
+      },
+      agentDir,
+    });
+
+    await updateConfig((cfg) => {
+      let next = applyAuthProfileConfig(cfg, {
+        profileId,
+        provider: "openai-codex",
+        mode: "oauth",
+      });
+      if (opts.setDefault) {
+        next = applyDefaultModel(next, OPENAI_CODEX_DEFAULT_MODEL);
+      }
+      return next;
+    });
+
+    logConfigUpdated(runtime);
+    runtime.log(`Auth profile: ${profileId} (openai-codex/oauth)`);
+    runtime.log(
+      opts.setDefault
+        ? `Default model set to ${OPENAI_CODEX_DEFAULT_MODEL}`
+        : `Default model available: ${OPENAI_CODEX_DEFAULT_MODEL} (use --set-default to apply)`,
+    );
+    return;
+  }
+
   const providers = resolvePluginProviders({ config, workspaceDir });
   if (providers.length === 0) {
     throw new Error(
       `No provider plugins found. Install one via \`${formatCliCommand("openclaw plugins install")}\`.`,
     );
   }
-
-  const prompter = createClackPrompter();
   const selectedProvider =
     resolveProviderMatch(providers, opts.provider) ??
     (await prompter

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -1,0 +1,55 @@
+import type { OAuthCredentials } from "@mariozechner/pi-ai";
+import { loginOpenAICodex } from "@mariozechner/pi-ai";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { createVpsAwareOAuthHandlers } from "./oauth-flow.js";
+
+export async function loginOpenAICodexOAuth(params: {
+  prompter: WizardPrompter;
+  runtime: RuntimeEnv;
+  isRemote: boolean;
+  openUrl: (url: string) => Promise<void>;
+  localBrowserMessage?: string;
+}): Promise<OAuthCredentials | null> {
+  const { prompter, runtime, isRemote, openUrl, localBrowserMessage } = params;
+
+  await prompter.note(
+    isRemote
+      ? [
+          "You are running in a remote/VPS environment.",
+          "A URL will be shown for you to open in your LOCAL browser.",
+          "After signing in, paste the redirect URL back here.",
+        ].join("\n")
+      : [
+          "Browser will open for OpenAI authentication.",
+          "If the callback doesn't auto-complete, paste the redirect URL.",
+          "OpenAI OAuth uses localhost:1455 for the callback.",
+        ].join("\n"),
+    "OpenAI Codex OAuth",
+  );
+
+  const spin = prompter.progress("Starting OAuth flow…");
+  try {
+    const { onAuth, onPrompt } = createVpsAwareOAuthHandlers({
+      isRemote,
+      prompter,
+      runtime,
+      spin,
+      openUrl,
+      localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser…",
+    });
+
+    const creds = await loginOpenAICodex({
+      onAuth,
+      onPrompt,
+      onProgress: (msg) => spin.update(msg),
+    });
+    spin.stop("OpenAI OAuth complete");
+    return creds ?? null;
+  } catch (err) {
+    spin.stop("OpenAI OAuth failed");
+    runtime.error(String(err));
+    await prompter.note("Trouble with OAuth? See https://docs.openclaw.ai/start/faq", "OAuth help");
+    throw err;
+  }
+}


### PR DESCRIPTION
In the current version, Codex authentication is not applied correctly after login. This patch fixes the issue.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors the OpenAI Codex OAuth login flow into a shared helper (`src/commands/openai-codex-oauth.ts`) and updates both the interactive onboarding flow (`src/commands/auth-choice.apply.openai.ts`) and the `models auth login` CLI command (`src/commands/models/auth.ts`) to use it. It also changes Codex profiles to be keyed by the OAuth email (`openai-codex:<email>`) rather than always `openai-codex:default`, which should allow the correct profile to be selected/applied after login.

Main issue to address before merge: error handling is currently inconsistent—`loginOpenAICodexOAuth` both emits user-facing errors and rethrows, while at least one caller catches and ignores the exception. This can lead to either silent failure or confusing duplicate reporting depending on the entrypoint.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge but has inconsistent OAuth error handling that can lead to confusing behavior.
- Core change (routing Codex OAuth through a shared helper and applying the resulting auth profile) is straightforward, but the helper currently both logs and rethrows while callers handle errors inconsistently (one swallows exceptions). That can cause silent auth failure or duplicate error reporting depending on the command path.
- src/commands/openai-codex-oauth.ts; src/commands/auth-choice.apply.openai.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->