### PR TITLE
fix(cron): exclude sandbox from shallow merge in isolated agent config

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -123,7 +123,14 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentConfigOverride = normalizedRequested
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
-  const { model: overrideModel, ...agentOverrideRest } = agentConfigOverride ?? {};
+  // Exclude sandbox from the shallow merge — sandbox resolution is handled separately
+  // by resolveSandboxConfigForAgent which properly merges agents.defaults.sandbox
+  // with the per-agent sandbox config from agents.list[].sandbox.
+  const {
+    model: overrideModel,
+    sandbox: _sandboxOverride,
+    ...agentOverrideRest
+  } = agentConfigOverride ?? {};
   // Use the requested agentId even when there is no explicit agent config entry.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).


### PR DESCRIPTION
## Summary

- **Bug**: When a per-agent `sandbox` config contains only `docker` overrides (e.g. `workdir`, `network`, `binds`), the `Object.assign` shallow merge in `runCronIsolatedAgentTurn` replaces the entire `agents.defaults.sandbox` — losing `mode`, `scope`, and `workspaceAccess`. This causes `resolveSandboxConfigForAgent` to fall back to `mode: "off"`, resulting in cron isolated agents executing directly on the **host** instead of inside the sandbox container.
- **Fix**: Exclude `sandbox` from the destructured agent config override. Sandbox resolution is already handled separately by `resolveSandboxConfigForAgent`, which properly merges global defaults with per-agent overrides via `agents.list[].sandbox`.

## Reproduction

1. Set `agents.defaults.sandbox.mode: "all"` and `scope: "agent"`
2. Add a per-agent `sandbox.docker` override (e.g. custom `workdir`, `network`, or `binds`) in `agents.list[]`
3. Create a cron job with `sessionTarget: "isolated"` for that agent
4. Run the cron job and execute `hostname && whoami` — it prints the **host** hostname and user instead of the container's

## Root cause

```
src/cron/isolated-agent/run.ts:130-136

Object.assign({},
  params.cfg.agents.defaults,       // sandbox: { mode:"all", scope:"agent", ... }
  agentOverrideRest,                // sandbox: { docker: { ... } }  ← overwrites entirely
)
// Result: sandbox.mode is gone → defaults to "off"
```

Related: #4171

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the cron isolated-agent runner to avoid shallow-merging a per-agent `sandbox` override into `agents.defaults`.

Previously, `runCronIsolatedAgentTurn` built `cfgWithAgentDefaults` by doing a top-level `Object.assign({}, agents.defaults, agentOverrideRest)`. If the per-agent override included only `sandbox.docker` keys, that shallow merge replaced the entire `sandbox` object and dropped `mode/scope/workspaceAccess`, causing downstream sandbox resolution to fall back to `mode: "off"` and run cron “isolated” turns on the host.

The fix destructures `sandbox` out of the per-agent override before the shallow merge, relying on the existing `resolveSandboxConfigForAgent` path (which merges `agents.defaults.sandbox` with `agents.list[].sandbox` field-by-field) to handle sandbox configuration correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The commit is narrowly scoped (excludes `sandbox` from a shallow merge) and aligns with the existing sandbox resolution flow (`resolveSandboxConfigForAgent` merges global defaults with per-agent overrides). No other files are touched in the head SHA, and the change prevents a real configuration regression without affecting unrelated agent defaults.
- src/cron/isolated-agent/run.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->