### PR TITLE
fix(agents): remove hardcoded 60s cap on announce delivery timeout

### DIFF
--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -31,7 +31,7 @@ export async function runSessionsSendA2AFlow(params: {
     let primaryReply = params.roundOneReply;
     let latestReply = params.roundOneReply;
     if (!primaryReply && params.waitRunId) {
-      const waitMs = Math.min(params.announceTimeoutMs, 60_000);
+      const waitMs = params.announceTimeoutMs;
       const wait = await callGateway<{ status: string }>({
         method: "agent.wait",
         params: {


### PR DESCRIPTION
Fixes #14540

`Math.min(params.announceTimeoutMs, 60_000)` capped the announce timeout to 60s regardless of the configured value. Cron jobs taking >60s silently failed delivery.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the hardcoded 60s cap when waiting for an agent run to complete in the A2A announce flow (`runSessionsSendA2AFlow`), so the `agent.wait` call respects the configured `announceTimeoutMs`. This aligns the A2A background delivery wait behavior with the user-provided timeout, preventing long-running cron-style jobs (>60s) from being cut off prematurely.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped (removes an unintended timeout cap) and the upstream caller already bounds/sanitizes the timeout value; gateway calls also clamp timer durations, so this should behave correctly for larger configured timeouts.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->