### PR TITLE
feat(hooks): add entire-checkpoints bundled hook for AI session tracking

### DIFF
--- a/src/hooks/bundled/entire-checkpoints/HOOK.md
+++ b/src/hooks/bundled/entire-checkpoints/HOOK.md
@@ -1,0 +1,77 @@
+---
+name: entire-checkpoints
+description: "Track AI coding sessions with Entire CLI checkpoints"
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📸",
+        "events": ["command:new", "command:reset", "command:stop", "gateway:startup"],
+        "requires": { "anyBins": ["entire"] },
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Entire Checkpoints Hook
+
+Automatically tracks AI coding sessions using [Entire CLI](https://entire.dev) checkpoints. This enables full session-level observability: every AI interaction is recorded as a checkpoint that can be reviewed, diffed, and shared.
+
+## What It Does
+
+This hook integrates OpenClaw with Entire CLI's agent hook system. It maps OpenClaw lifecycle events to Entire checkpoint verbs:
+
+| OpenClaw Event     | Entire Verb                          | Description                              |
+| ------------------ | ------------------------------------ | ---------------------------------------- |
+| `gateway:startup`  | `session-start`                      | Begins a new Entire tracking session     |
+| `command:new`      | `stop` → `session-end`              | Ends current checkpoint, closes session  |
+| `command:reset`    | `stop` → `session-end`              | Ends current checkpoint, closes session  |
+| `command:stop`     | `stop`                               | Ends the current checkpoint              |
+
+Each call pipes a JSON payload to `entire hooks openclaw <verb>` via stdin:
+
+```json
+{
+  "session_id": "<session-id>",
+  "transcript_path": "<path-to-session-file>",
+  "prompt": "<first-user-message>"
+}
+```
+
+## Requirements
+
+- **Entire CLI** must be installed and available in `PATH` (`entire` binary)
+- **Project must be Entire-enabled**: run `entire enable --agent openclaw` in your project root
+- The hook checks for `.entire/settings.json` in the workspace directory and silently skips if not found
+
+## Configuration
+
+No additional configuration is needed. The hook activates automatically when:
+
+1. The `entire` binary is found in `PATH`
+2. The current workspace has `.entire/settings.json`
+
+## Disabling
+
+```bash
+openclaw hooks disable entire-checkpoints
+```
+
+Or in your config:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "entire-checkpoints": { "enabled": false }
+      }
+    }
+  }
+}
+```
+
+## Learn More
+
+- [Entire CLI documentation](https://entire.dev/docs)
+- [Agent integration (entireio/cli#297)](https://github.com/entireio/cli/pull/297)

--- a/src/hooks/bundled/entire-checkpoints/HOOK.md
+++ b/src/hooks/bundled/entire-checkpoints/HOOK.md
@@ -21,12 +21,12 @@ Automatically tracks AI coding sessions using [Entire CLI](https://entire.dev) c
 
 This hook integrates OpenClaw with Entire CLI's agent hook system. It maps OpenClaw lifecycle events to Entire checkpoint verbs:
 
-| OpenClaw Event     | Entire Verb                          | Description                              |
-| ------------------ | ------------------------------------ | ---------------------------------------- |
-| `gateway:startup`  | `session-start`                      | Begins a new Entire tracking session     |
-| `command:new`      | `stop` → `session-end`              | Ends current checkpoint, closes session  |
-| `command:reset`    | `stop` → `session-end`              | Ends current checkpoint, closes session  |
-| `command:stop`     | `stop`                               | Ends the current checkpoint              |
+| OpenClaw Event    | Entire Verb            | Description                             |
+| ----------------- | ---------------------- | --------------------------------------- |
+| `gateway:startup` | `session-start`        | Begins a new Entire tracking session    |
+| `command:new`     | `stop` → `session-end` | Ends current checkpoint, closes session |
+| `command:reset`   | `stop` → `session-end` | Ends current checkpoint, closes session |
+| `command:stop`    | `stop`                 | Ends the current checkpoint             |
 
 Each call pipes a JSON payload to `entire hooks openclaw <verb>` via stdin:
 

--- a/src/hooks/bundled/entire-checkpoints/handler.test.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookHandler } from "../../hooks.js";
-import { createHookEvent } from "../../hooks.js";
 import { makeTempWorkspace } from "../../../test-helpers/workspace.js";
+import { createHookEvent } from "../../hooks.js";
 
 // Mock child_process.execFile
 const mockExecFile = vi.fn();

--- a/src/hooks/bundled/entire-checkpoints/handler.test.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, it, vi } from "vitest";
 import type { HookHandler } from "../../hooks.js";
 import { makeTempWorkspace } from "../../../test-helpers/workspace.js";
 import { createHookEvent } from "../../hooks.js";
@@ -13,13 +13,13 @@ vi.mock("node:child_process", () => ({
 
 // Mock node:util promisify to return our mock
 vi.mock("node:util", async (importOriginal) => {
-  const orig = (await importOriginal()) as Record<string, unknown>;
+  const orig = await importOriginal();
   return {
     ...orig,
     promisify: (fn: unknown) => {
       // If it's the mocked execFile, return a promisified version
       if (fn === mockExecFile) {
-        return (...args: unknown[]) => {
+        return (..._args: unknown[]) => {
           const mockStdin = {
             write: vi.fn(),
             end: vi.fn(),

--- a/src/hooks/bundled/entire-checkpoints/handler.test.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.test.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookHandler } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+import { makeTempWorkspace } from "../../../test-helpers/workspace.js";
+
+// Mock child_process.execFile
+const mockExecFile = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => mockExecFile(...args),
+}));
+
+// Mock node:util promisify to return our mock
+vi.mock("node:util", async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    promisify: (fn: unknown) => {
+      // If it's the mocked execFile, return a promisified version
+      if (fn === mockExecFile) {
+        return (...args: unknown[]) => {
+          const mockStdin = {
+            write: vi.fn(),
+            end: vi.fn(),
+          };
+          return Object.assign(Promise.resolve({ stdout: "", stderr: "" }), {
+            child: { stdin: mockStdin },
+          });
+        };
+      }
+      return orig.promisify(fn);
+    },
+  };
+});
+
+let handler: HookHandler;
+
+beforeAll(async () => {
+  ({ default: handler } = await import("./handler.js"));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("entire-checkpoints hook", () => {
+  it("skips when event type does not match", async () => {
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", {});
+    await handler(event);
+    // No calls to entire should be made — execFile not called for `which` even
+    // (actually `which` would be called, but since we mock it, just verify no crash)
+  });
+
+  it("skips when entire binary is not found", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-entire-");
+
+    // `which` will fail (default mock returns empty), handler should skip gracefully
+    const event = createHookEvent("gateway", "startup", "agent:main:main", {
+      workspaceDir: tempDir,
+    });
+
+    await handler(event);
+    // Should not throw
+  });
+
+  it("skips when .entire/settings.json does not exist", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-entire-");
+
+    // Even if `which` succeeds, no .entire/settings.json → skip
+    const event = createHookEvent("gateway", "startup", "agent:main:main", {
+      workspaceDir: tempDir,
+    });
+
+    await handler(event);
+    // Should not throw
+  });
+
+  it("processes gateway:startup event when entire is available", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-entire-");
+    // Create .entire/settings.json
+    await fs.mkdir(path.join(tempDir, ".entire"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, ".entire", "settings.json"), "{}", "utf-8");
+
+    const event = createHookEvent("gateway", "startup", "agent:main:main", {
+      workspaceDir: tempDir,
+      sessionEntry: { sessionId: "sess-1", sessionFile: "/tmp/sess.jsonl" },
+    });
+
+    // Handler will call `which` then `entire hooks openclaw session-start`
+    // With our mocks both will resolve (mock returns empty stdout for which,
+    // which means entireBin = null → skip). This test mainly verifies no crash.
+    await handler(event);
+  });
+
+  it("processes command:stop event without crashing", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-entire-");
+    await fs.mkdir(path.join(tempDir, ".entire"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, ".entire", "settings.json"), "{}", "utf-8");
+
+    const event = createHookEvent("command", "stop", "agent:main:main", {
+      workspaceDir: tempDir,
+    });
+
+    await handler(event);
+  });
+
+  it("processes command:new event without crashing", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-entire-");
+    await fs.mkdir(path.join(tempDir, ".entire"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, ".entire", "settings.json"), "{}", "utf-8");
+
+    const event = createHookEvent("command", "new", "agent:main:main", {
+      workspaceDir: tempDir,
+      previousSessionEntry: { sessionId: "sess-old" },
+      firstUserMessage: "Hello world",
+    });
+
+    await handler(event);
+  });
+});

--- a/src/hooks/bundled/entire-checkpoints/handler.test.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.test.ts
@@ -1,32 +1,62 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeAll, beforeEach, describe, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookHandler } from "../../hooks.js";
 import { makeTempWorkspace } from "../../../test-helpers/workspace.js";
 import { createHookEvent } from "../../hooks.js";
 
-// Mock child_process.execFile
-const mockExecFile = vi.fn();
-vi.mock("node:child_process", () => ({
-  execFile: (...args: unknown[]) => mockExecFile(...args),
-}));
+// Track all promisified calls with their args
+const promisifiedCalls: unknown[][] = [];
+const mockStdinInstances: Array<{
+  write: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+}> = [];
 
-// Mock node:util promisify to return our mock
+// The wrapper function that child_process.execFile will be
+let execFileWrapper: (...args: unknown[]) => unknown;
+
+// Mock child_process.execFile
+vi.mock("node:child_process", () => {
+  execFileWrapper = (..._args: unknown[]) => {
+    // This is the raw callback-based execFile; we don't use it directly
+  };
+  return {
+    execFile: execFileWrapper,
+  };
+});
+
+// Mock node:util promisify to return our async mock
 vi.mock("node:util", async (importOriginal) => {
   const orig = await importOriginal();
   return {
     ...orig,
     promisify: (fn: unknown) => {
-      // If it's the mocked execFile, return a promisified version
-      if (fn === mockExecFile) {
-        return (..._args: unknown[]) => {
-          const mockStdin = {
-            write: vi.fn(),
-            end: vi.fn(),
-          };
-          return Object.assign(Promise.resolve({ stdout: "", stderr: "" }), {
-            child: { stdin: mockStdin },
-          });
+      // If it's our mocked execFile (the wrapper), return the promisified version
+      if (fn === execFileWrapper) {
+        return (...args: unknown[]) => {
+          promisifiedCalls.push(args);
+          const cmd = args[0] as string;
+          const cmdArgs = args[1] as string[] | undefined;
+
+          // `entire --version` check → succeed
+          if (cmd === "entire" && cmdArgs?.[0] === "--version") {
+            return Object.assign(Promise.resolve({ stdout: "1.0.0", stderr: "" }), {
+              child: { stdin: null },
+            });
+          }
+
+          // `entire hooks openclaw <verb>` → succeed with stdin mock
+          if (cmd === "entire" && cmdArgs?.[0] === "hooks") {
+            const mockStdin = { write: vi.fn(), end: vi.fn() };
+            mockStdinInstances.push(mockStdin);
+            return Object.assign(Promise.resolve({ stdout: "", stderr: "" }), {
+              child: { stdin: mockStdin },
+            });
+          }
+
+          // Anything else → ENOENT
+          const err = Object.assign(new Error(`spawn ${cmd} ENOENT`), { code: "ENOENT" });
+          return Object.assign(Promise.reject(err), { child: { stdin: null } });
         };
       }
       return orig.promisify(fn);
@@ -42,73 +72,90 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  promisifiedCalls.length = 0;
+  mockStdinInstances.length = 0;
 });
+
+/** Helper: create a temp workspace with .entire/settings.json */
+async function makeEntireWorkspace(): Promise<string> {
+  const tempDir = await makeTempWorkspace("openclaw-entire-");
+  await fs.mkdir(path.join(tempDir, ".entire"), { recursive: true });
+  await fs.writeFile(path.join(tempDir, ".entire", "settings.json"), "{}", "utf-8");
+  return tempDir;
+}
+
+/** Extract the verb from a promisified call like ["entire", ["hooks", "openclaw", <verb>], ...] */
+function extractVerbs(): string[] {
+  return promisifiedCalls
+    .filter((c) => {
+      const args = c[1] as string[] | undefined;
+      return c[0] === "entire" && args?.[0] === "hooks" && args?.[1] === "openclaw";
+    })
+    .map((c) => (c[1] as string[])[2]);
+}
 
 describe("entire-checkpoints hook", () => {
   it("skips when event type does not match", async () => {
     const event = createHookEvent("agent", "bootstrap", "agent:main:main", {});
     await handler(event);
-    // No calls to entire should be made — execFile not called for `which` even
-    // (actually `which` would be called, but since we mock it, just verify no crash)
+    expect(promisifiedCalls).toHaveLength(0);
   });
 
-  it("skips when entire binary is not found", async () => {
+  it("skips when entire binary is not found (ENOENT)", async () => {
     const tempDir = await makeTempWorkspace("openclaw-entire-");
-
-    // `which` will fail (default mock returns empty), handler should skip gracefully
+    // No .entire/settings.json — but also entire --version would succeed.
+    // The handler checks binary first, then settings. Since binary succeeds
+    // but no settings.json → skip.
     const event = createHookEvent("gateway", "startup", "agent:main:main", {
       workspaceDir: tempDir,
     });
 
     await handler(event);
-    // Should not throw
+    expect(extractVerbs()).toHaveLength(0);
   });
 
   it("skips when .entire/settings.json does not exist", async () => {
     const tempDir = await makeTempWorkspace("openclaw-entire-");
 
-    // Even if `which` succeeds, no .entire/settings.json → skip
     const event = createHookEvent("gateway", "startup", "agent:main:main", {
       workspaceDir: tempDir,
     });
 
     await handler(event);
-    // Should not throw
+    expect(extractVerbs()).toHaveLength(0);
   });
 
-  it("processes gateway:startup event when entire is available", async () => {
-    const tempDir = await makeTempWorkspace("openclaw-entire-");
-    // Create .entire/settings.json
-    await fs.mkdir(path.join(tempDir, ".entire"), { recursive: true });
-    await fs.writeFile(path.join(tempDir, ".entire", "settings.json"), "{}", "utf-8");
+  it("processes gateway:startup event", async () => {
+    const tempDir = await makeEntireWorkspace();
 
     const event = createHookEvent("gateway", "startup", "agent:main:main", {
       workspaceDir: tempDir,
       sessionEntry: { sessionId: "sess-1", sessionFile: "/tmp/sess.jsonl" },
     });
 
-    // Handler will call `which` then `entire hooks openclaw session-start`
-    // With our mocks both will resolve (mock returns empty stdout for which,
-    // which means entireBin = null → skip). This test mainly verifies no crash.
     await handler(event);
+
+    const verbs = extractVerbs();
+    expect(verbs).toContain("session-start");
+    expect(verbs).toContain("user-prompt-submit");
   });
 
-  it("processes command:stop event without crashing", async () => {
-    const tempDir = await makeTempWorkspace("openclaw-entire-");
-    await fs.mkdir(path.join(tempDir, ".entire"), { recursive: true });
-    await fs.writeFile(path.join(tempDir, ".entire", "settings.json"), "{}", "utf-8");
+  it("processes command:stop event", async () => {
+    const tempDir = await makeEntireWorkspace();
 
     const event = createHookEvent("command", "stop", "agent:main:main", {
       workspaceDir: tempDir,
     });
 
     await handler(event);
+
+    const verbs = extractVerbs();
+    expect(verbs).toContain("stop");
+    expect(verbs).toHaveLength(1);
   });
 
-  it("processes command:new event without crashing", async () => {
-    const tempDir = await makeTempWorkspace("openclaw-entire-");
-    await fs.mkdir(path.join(tempDir, ".entire"), { recursive: true });
-    await fs.writeFile(path.join(tempDir, ".entire", "settings.json"), "{}", "utf-8");
+  it("processes command:new event", async () => {
+    const tempDir = await makeEntireWorkspace();
 
     const event = createHookEvent("command", "new", "agent:main:main", {
       workspaceDir: tempDir,
@@ -117,5 +164,11 @@ describe("entire-checkpoints hook", () => {
     });
 
     await handler(event);
+
+    const verbs = extractVerbs();
+    expect(verbs).toContain("stop");
+    expect(verbs).toContain("session-end");
+    expect(verbs).toContain("session-start");
+    expect(verbs).toContain("user-prompt-submit");
   });
 });

--- a/src/hooks/bundled/entire-checkpoints/handler.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.ts
@@ -1,0 +1,135 @@
+/**
+ * Entire Checkpoints hook handler
+ *
+ * Tracks AI coding sessions with Entire CLI checkpoints.
+ * Maps OpenClaw lifecycle events to Entire's agent hook verbs.
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { HookHandler } from "../../hooks.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+
+const log = createSubsystemLogger("hooks/entire-checkpoints");
+const execFileAsync = promisify(execFile);
+
+/**
+ * Resolve the path to the `entire` binary, or null if not found.
+ */
+async function findEntireBin(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("which", ["entire"]);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if the workspace has Entire enabled (.entire/settings.json exists).
+ */
+function isEntireEnabled(workspaceDir: string | undefined): boolean {
+  if (!workspaceDir) return false;
+  try {
+    return fs.existsSync(path.join(workspaceDir, ".entire", "settings.json"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the JSON payload to pipe to `entire hooks openclaw <verb>`.
+ */
+function buildPayload(event: Parameters<HookHandler>[0]): Record<string, unknown> {
+  const context = event.context || {};
+  // Use previousSessionEntry for command:new/reset (pre-reset session),
+  // fall back to sessionEntry for other events
+  const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<
+    string,
+    unknown
+  >;
+
+  return {
+    session_id: (sessionEntry.sessionId as string) || event.sessionKey,
+    transcript_path: (sessionEntry.sessionFile as string) || undefined,
+    prompt: undefined,
+  };
+}
+
+/**
+ * Call `entire hooks openclaw <verb>` with payload on stdin.
+ */
+async function callEntire(
+  entireBin: string,
+  verb: string,
+  payload: Record<string, unknown>,
+  workspaceDir?: string,
+): Promise<void> {
+  const args = ["hooks", "openclaw", verb];
+  log.debug(`Calling: entire ${args.join(" ")}`);
+
+  try {
+    const child = execFileAsync(entireBin, args, {
+      timeout: 10_000,
+      env: { ...process.env },
+      cwd: workspaceDir || process.cwd(),
+    });
+
+    // Pipe payload to stdin
+    if (child.child.stdin) {
+      child.child.stdin.write(JSON.stringify(payload));
+      child.child.stdin.end();
+    }
+
+    await child;
+    log.debug(`entire ${verb} completed`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`entire ${verb} failed: ${msg}`);
+  }
+}
+
+/**
+ * Hook handler: dispatch OpenClaw events to Entire CLI.
+ */
+const entireCheckpoints: HookHandler = async (event) => {
+  // Determine which verbs to call based on event
+  let verbs: string[];
+
+  if (event.type === "gateway" && event.action === "startup") {
+    verbs = ["session-start"];
+  } else if (
+    event.type === "command" &&
+    (event.action === "new" || event.action === "reset")
+  ) {
+    verbs = ["stop", "session-end"];
+  } else if (event.type === "command" && event.action === "stop") {
+    verbs = ["stop"];
+  } else {
+    return;
+  }
+
+  // Check if `entire` binary is available
+  const entireBin = await findEntireBin();
+  if (!entireBin) {
+    log.debug("entire binary not found in PATH, skipping");
+    return;
+  }
+
+  // Check if project has Entire enabled
+  const workspaceDir = (event.context?.workspaceDir as string) || undefined;
+  if (!isEntireEnabled(workspaceDir)) {
+    log.debug("Entire not enabled for workspace, skipping");
+    return;
+  }
+
+  const payload = buildPayload(event);
+
+  for (const verb of verbs) {
+    await callEntire(entireBin, verb, payload, workspaceDir);
+  }
+};
+
+export default entireCheckpoints;

--- a/src/hooks/bundled/entire-checkpoints/handler.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.ts
@@ -99,9 +99,11 @@ const entireCheckpoints: HookHandler = async (event) => {
   let verbs: string[];
 
   if (event.type === "gateway" && event.action === "startup") {
-    verbs = ["session-start"];
+    // Initialize session fully on startup so every subsequent commit gets checkpointed
+    verbs = ["session-start", "user-prompt-submit"];
   } else if (event.type === "command" && (event.action === "new" || event.action === "reset")) {
-    verbs = ["stop", "session-end"];
+    // Save checkpoint, end old session, start fresh
+    verbs = ["stop", "session-end", "session-start", "user-prompt-submit"];
   } else if (event.type === "command" && event.action === "stop") {
     verbs = ["stop"];
   } else {

--- a/src/hooks/bundled/entire-checkpoints/handler.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.ts
@@ -100,10 +100,7 @@ const entireCheckpoints: HookHandler = async (event) => {
 
   if (event.type === "gateway" && event.action === "startup") {
     verbs = ["session-start"];
-  } else if (
-    event.type === "command" &&
-    (event.action === "new" || event.action === "reset")
-  ) {
+  } else if (event.type === "command" && (event.action === "new" || event.action === "reset")) {
     verbs = ["stop", "session-end"];
   } else if (event.type === "command" && event.action === "stop") {
     verbs = ["stop"];

--- a/src/hooks/bundled/entire-checkpoints/handler.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.ts
@@ -31,7 +31,9 @@ async function findEntireBin(): Promise<string | null> {
  * Check if the workspace has Entire enabled (.entire/settings.json exists).
  */
 function isEntireEnabled(workspaceDir: string | undefined): boolean {
-  if (!workspaceDir) return false;
+  if (!workspaceDir) {
+    return false;
+  }
   try {
     return fs.existsSync(path.join(workspaceDir, ".entire", "settings.json"));
   } catch {

--- a/src/hooks/bundled/entire-checkpoints/handler.ts
+++ b/src/hooks/bundled/entire-checkpoints/handler.ts
@@ -20,10 +20,14 @@ const execFileAsync = promisify(execFile);
  */
 async function findEntireBin(): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync("which", ["entire"]);
-    return stdout.trim() || null;
-  } catch {
-    return null;
+    await execFileAsync("entire", ["--version"]);
+    return "entire";
+  } catch (err: unknown) {
+    if ((err as Record<string, unknown>)?.code === "ENOENT") {
+      return null;
+    }
+    // entire exists but --version failed? Still usable.
+    return "entire";
   }
 }
 
@@ -56,7 +60,7 @@ function buildPayload(event: Parameters<HookHandler>[0]): Record<string, unknown
   return {
     session_id: (sessionEntry.sessionId as string) || event.sessionKey,
     transcript_path: (sessionEntry.sessionFile as string) || undefined,
-    prompt: undefined,
+    prompt: (context.firstUserMessage as string) || undefined,
   };
 }
 


### PR DESCRIPTION
Summary

Adds a bundled hook that integrates OpenClaw with Entire CLI for automatic AI coding session checkpoint tracking.

Entire CLI (by ex-GitHub CEO Thomas Dohmke) captures full session context — prompts, transcripts, file attribution — and stores them on a Git orphan branch alongside your code.

Companion PR

This hook works with the OpenClaw agent integration in Entire CLI: entireio/cli#297

How it works

The hook maps OpenClaw lifecycle events to Entire's agent hook verbs:

| OpenClaw Event              | Entire CLI Verb    | Purpose                      |
| --------------------------- | ------------------ | ---------------------------- |
| gateway:startup             | session-start      | Initialize tracking          |
| command:new / command:reset | stop → session-end | Save checkpoint before reset |
| command:stop                | stop               | Save final checkpoint        |Files

• src/hooks/bundled/entire-checkpoints/HOOK.md — Hook metadata + docs
• src/hooks/bundled/entire-checkpoints/handler.ts — Event handler
• src/hooks/bundled/entire-checkpoints/handler.test.ts — Tests
Requirements

• entire CLI in PATH
• Project enabled with entire enable --agent openclaw
Testing

• E2E tested: gateway startup → file change → commit → checkpoint with Entire-Checkpoint trailer ✅
• Hook auto-discovered by bundled-dir scanner ✅

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new bundled internal hook (`entire-checkpoints`) that invokes the external `entire` CLI on key OpenClaw lifecycle events (gateway startup, command new/reset/stop) to create checkpoints for AI session tracking. The hook is discovered via the existing bundled hook directory scanner (HOCK.md + handler.ts), and it gates execution on the presence of the `entire` binary and an `.entire/settings.json` marker file in the workspace.

The handler maps events to Entire verbs (`session-start`, `stop`, `session-end`) and pipes a JSON payload to `entire hooks openclaw <verb>` over stdin. Tests were added, but currently they primarily validate that the handler doesn’t throw and do not assert that the expected `entire` invocations happen.


<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge, but has a few functional gaps that should be addressed first.
- Core hook wiring is straightforward and gated, but the implementation doesn’t match documented behavior (payload prompt is never set) and relies on `which` for binary discovery, which can cause silent non-operation in some environments. The test suite added here doesn’t assert the intended `entire` invocations and would pass even if the hook never ran.
- src/hooks/bundled/entire-checkpoints/handler.ts; src/hooks/bundled/entire-checkpoints/handler.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->