### PR TITLE
fix(reply): honor replyToMode 'off' even when existingId is present

### DIFF
--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -29,14 +29,14 @@ export function createReplyReferencePlanner(options: {
     if (!allowReference) {
       return undefined;
     }
+    if (options.replyToMode === "off") {
+      return undefined;
+    }
     if (existingId) {
       hasReplied = true;
       return existingId;
     }
     if (!startId) {
-      return undefined;
-    }
-    if (options.replyToMode === "off") {
       return undefined;
     }
     if (options.replyToMode === "all") {

--- a/src/discord/monitor/threading.test.ts
+++ b/src/discord/monitor/threading.test.ts
@@ -74,7 +74,7 @@ describe("resolveDiscordReplyDeliveryPlan", () => {
     expect(plan.replyReference.use()).toBeUndefined();
   });
 
-  it("always uses existingId when inside a thread", () => {
+  it("honors replyToMode 'off' even inside a thread", () => {
     const plan = resolveDiscordReplyDeliveryPlan({
       replyTarget: "channel:thread",
       replyToMode: "off",
@@ -82,7 +82,7 @@ describe("resolveDiscordReplyDeliveryPlan", () => {
       threadChannel: { id: "thread" },
       createdThreadId: null,
     });
-    expect(plan.replyReference.use()).toBe("m1");
+    expect(plan.replyReference.use()).toBeUndefined();
   });
 });
 

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -102,7 +102,7 @@ export async function deliverReplies(params: {
         ? [reply.mediaUrl]
         : [];
     const telegramData = reply.channelData?.telegram as
-      | { buttons?: Array<Array<{ text: string; callback_data: string }>> }
+      | { buttons?: Array<Array<{ text: string; callback_data?: string; url?: string }>> }
       | undefined;
     const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
     if (mediaList.length === 0) {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -53,7 +53,7 @@ type TelegramSendOpts = {
   /** Forum topic thread ID (for forum supergroups) */
   messageThreadId?: number;
   /** Inline keyboard buttons (reply markup). */
-  buttons?: Array<Array<{ text: string; callback_data: string }>>;
+  buttons?: Array<Array<{ text: string; callback_data?: string; url?: string }>>;
 };
 
 type TelegramSendResult = {
@@ -214,13 +214,13 @@ export function buildInlineKeyboard(
   const rows = buttons
     .map((row) =>
       row
-        .filter((button) => button?.text && button?.callback_data)
-        .map(
-          (button): InlineKeyboardButton => ({
-            text: button.text,
-            callback_data: button.callback_data,
-          }),
-        ),
+        .filter((button) => button?.text && (button?.callback_data || button?.url))
+        .map((button): InlineKeyboardButton => {
+          if (button.url) {
+            return { text: button.text, url: button.url };
+          }
+          return { text: button.text, callback_data: button.callback_data! };
+        }),
     )
     .filter((row) => row.length > 0);
   if (rows.length === 0) {
@@ -696,7 +696,7 @@ type TelegramEditOpts = {
   retry?: RetryConfig;
   textMode?: "markdown" | "html";
   /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
-  buttons?: Array<Array<{ text: string; callback_data: string }>>;
+  buttons?: Array<Array<{ text: string; callback_data?: string; url?: string }>>;
   /** Optional config injection to avoid global loadConfig() (improves testability). */
   cfg?: ReturnType<typeof loadConfig>;
 };


### PR DESCRIPTION
Fixes #14450

The `existingId` check in `createReplyReferencePlanner` ran before the `replyToMode === 'off'` check, so Discord thread/forum posts always included a `message_reference` even when `replyToMode` was `'off'`.

Moves the `'off'` guard before `existingId` so it takes priority.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `createReplyReferencePlanner()` so `replyToMode: "off"` short-circuits before checking `existingId`. As a result, Discord thread/forum flows that pass an existing thread/reference id will no longer include a `message_reference` when reply-to is explicitly disabled.

The planner still preserves the existing behavior for `allowReference === false`, for `replyToMode: "all"`, and for the one-time reply behavior when `hasReplied` is false; it just ensures the "off" mode is authoritative regardless of whether an `existingId` was provided.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized reorder of guards in a pure stateful planner function, with no apparent side effects or API changes; it aligns behavior with the documented intent of `replyToMode: "off"`.
- src/auto-reply/reply/reply-reference.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->