### PR TITLE
feat(skills): improve descriptions with routing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Skills: refine skill-description routing boundaries with explicit "Use when"/"NOT for" guidance for coding-agent/github/weather, and clarify PTY/browser fallback wording. (#14577) Thanks @DylanWoodAkers.
 - Agents/Subagents: add an accepted response note for `sessions_spawn` explaining polling subagents are disabled for one-off calls. Thanks @tyler6204.
 - Agents/Subagents: prefix spawned subagent task messages with context to preserve source information in downstream handling. Thanks @tyler6204.
 - iMessage: support `replyToId` on outbound text/media sends and normalize leading `[[reply_to:<id>]]` tags so replies target the intended iMessage. Thanks @tyler6204.

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-agent
-description: Run Codex CLI, Claude Code, OpenCode, or Pi Coding Agent via background process for programmatic control.
+description: "Delegate coding tasks to Codex, Claude Code, or Pi agents via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-liner fixes (just edit), reading code (use read tool), or any work in ~/clawd workspace (never spawn agents here). Requires PTY mode."
 metadata:
   {
     "openclaw": { "emoji": "🧩", "requires": { "anyBins": ["claude", "codex", "opencode", "pi"] } },

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-agent
-description: "Delegate coding tasks to Codex, Claude Code, or Pi agents via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-liner fixes (just edit), reading code (use read tool), or any work in ~/clawd workspace (never spawn agents here). Requires PTY mode."
+description: "Delegate coding tasks to Codex, Claude Code, or Pi agents via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-liner fixes (just edit), reading code (use read tool), or any work in ~/clawd workspace (never spawn agents here). Requires a bash tool that supports pty:true."
 metadata:
   {
     "openclaw": { "emoji": "🧩", "requires": { "anyBins": ["claude", "codex", "opencode", "pi"] } },

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-description: "Interact with GitHub using the `gh` CLI. Use `gh issue`, `gh pr`, `gh run`, and `gh api` for issues, PRs, CI runs, and advanced queries."
+description: "GitHub operations via `gh` CLI: issues, PRs, CI runs, code review, API queries. Use when: (1) checking PR status or CI, (2) creating/commenting on issues, (3) listing/filtering PRs or issues, (4) viewing run logs. NOT for: complex web UI interactions (use browser), bulk operations across many repos (script with gh api), or when gh auth is not configured."
 metadata:
   {
     "openclaw":

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-description: "GitHub operations via `gh` CLI: issues, PRs, CI runs, code review, API queries. Use when: (1) checking PR status or CI, (2) creating/commenting on issues, (3) listing/filtering PRs or issues, (4) viewing run logs. NOT for: complex web UI interactions (use browser), bulk operations across many repos (script with gh api), or when gh auth is not configured."
+description: "GitHub operations via `gh` CLI: issues, PRs, CI runs, code review, API queries. Use when: (1) checking PR status or CI, (2) creating/commenting on issues, (3) listing/filtering PRs or issues, (4) viewing run logs. NOT for: complex web UI interactions requiring manual browser flows (use browser tooling when available), bulk operations across many repos (script with gh api), or when gh auth is not configured."
 metadata:
   {
     "openclaw":

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weather
-description: Get current weather and forecasts (no API key required).
+description: "Get current weather and forecasts via wttr.in or Open-Meteo. Use when: user asks about weather, temperature, or forecasts for any location. NOT for: historical weather data, severe weather alerts, or detailed meteorological analysis. No API key needed."
 homepage: https://wttr.in/:help
 metadata: { "openclaw": { "emoji": "🌤️", "requires": { "bins": ["curl"] } } }
 ---


### PR DESCRIPTION
## Summary

Apply OpenAI's recommended pattern for skill descriptions based on their [Shell + Skills + Compaction](https://developers.openai.com/blog/skills-shell-tips/) blog post.

## Changes

Each skill description now follows the pattern:
- **What it does** (1 line)
- **Use when:** (specific triggering conditions)
- **NOT for:** (negative examples to reduce misfires)

### Skills updated:
- **coding-agent**: Clarify when to delegate to agents vs direct edit
- **github**: Add boundaries vs browser/scripting approaches  
- **weather**: Add scope limitations

## Why

From the OpenAI article:
> Your skill's description is effectively the model's decision boundary. It should answer: When should I use this? When should I NOT use this?

Glean (early OpenAI skills customer) reported:
> Skill-based routing initially dropped triggering by about 20% in targeted evals, then recovered after they added negative examples and edge case coverage in descriptions.

## Testing

Tested locally with Clawdbot - skills route correctly with clearer boundaries.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

These changes update the `description` frontmatter for three skills (`coding-agent`, `github`, `weather`) to follow a stricter “what it does / use when / not for” routing pattern.

The main integration point is the router’s use of skill `description` as a decision boundary; tightening these strings can improve triggers, but only if the descriptions stay consistent with the repo’s actual tool capabilities.

Two descriptions currently introduce hard routing dead-ends: `coding-agent` mandates a PTY flag that isn’t available on the Bash tool in this environment, and `github` advises switching to a “browser” tool that isn’t present. These should be corrected so routing leads to executable actions.

<h3>Confidence Score: 3/5</h3>

- This PR is low-risk but contains routing guidance that can lead to non-executable actions.
- Changes are limited to skill description strings, but two of those strings conflict with the repo’s available tooling (PTY flag and a browser fallback), which can degrade routing and cause user flows to fail when these skills trigger.
- skills/coding-agent/SKILL.md, skills/github/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->