### PR TITLE
docs: add guide for openclaw-bridge-remote (MCP)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1011,6 +1011,7 @@
                 "group": "Remote access and deployment",
                 "pages": [
                   "gateway/remote",
+                  "gateway/mcp-bridge",
                   "gateway/remote-gateway-readme",
                   "gateway/tailscale",
                   "platforms/fly",

--- a/docs/gateway/mcp-bridge.md
+++ b/docs/gateway/mcp-bridge.md
@@ -1,0 +1,65 @@
+---
+title: "MCP Bridge (AI Agents)"
+summary: "Connect remote AI agents to local OpenClaw via Model Context Protocol"
+---
+
+# MCP Bridge (AI Agents)
+
+The **[openclaw-bridge-remote](https://github.com/lucas-jo/openclaw-bridge-remote)** allows you to connect remote AI agents (like OpenCode, Cursor, or Windsurf running on remote servers) to your local OpenClaw instance.
+
+This is particularly useful when developing on powerful remote machines (GPU clusters, cloud instances) but needing to perform actions on your local machine, such as browser automation or local shell execution.
+
+## Key Features
+
+- **Remote-to-Local Bridge**: Gives remote agents "eyes and hands" on your desk.
+- **MCP Native**: Exposes OpenClaw tools via the industry-standard Model Context Protocol.
+- **Secure**: Implements OpenClaw's Ed25519 signing protocol and adds its own API Key layer.
+- **One-liner Setup**: Easy installation on macOS via a simple install script.
+
+## Architecture
+
+```mermaid
+graph LR
+    subgraph Remote_Server
+        A[AI Agent] -- "MCP (SSE)" --> B[Bridge]
+    end
+    
+    subgraph Local_Machine
+        B -- "Network/VPN" --> C[OpenClaw Gateway]
+        C -- "WebSocket" --> D[Browser / Shell]
+    end
+```
+
+## Quick Start
+
+### 1. Install on your local machine
+
+Run the following command in your local terminal:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/lucas-jo/openclaw-bridge-remote/main/install.sh | bash
+```
+
+### 2. Configure your Remote Agent
+
+Add the bridge URL to your agent's MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "openclaw-remote": {
+      "type": "remote",
+      "url": "http://<LOCAL_IP>:3100/sse?apiKey=<BRIDGE_API_KEY>"
+    }
+  }
+}
+```
+
+<Tip>
+We recommend using **Tailscale** for secure connectivity between your remote machine and local bridge.
+</Tip>
+
+## More Information
+
+- **Repository**: [lucas-jo/openclaw-bridge-remote](https://github.com/lucas-jo/openclaw-bridge-remote)
+- **Concepts**: [Remote Access](/gateway/remote), [Architecture](/concepts/architecture)

--- a/docs/gateway/mcp-bridge.md
+++ b/docs/gateway/mcp-bridge.md
@@ -34,10 +34,12 @@ graph LR
 
 ### 1. Install on your local machine
 
-Run the following command in your local terminal:
+Install the bridge using the provided installer script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/lucas-jo/openclaw-bridge-remote/main/install.sh | bash
+git clone https://github.com/lucas-jo/openclaw-bridge-remote.git
+cd openclaw-bridge-remote
+./install.sh
 ```
 
 ### 2. Configure your Remote Agent


### PR DESCRIPTION
## Summary
This PR adds a documentation guide for **openclaw-bridge-remote**, an MCP bridge that enables remote AI agents to control local OpenClaw instances.

### Changes
- Added `docs/gateway/mcp-bridge.md`: A quick-start guide for the bridge.
- Updated `docs/docs.json`: Added the new guide to the 'Infrastructure' sidebar.

### Context
Many developers use OpenClaw on their local machines but develop primarily on remote GPU clusters or cloud instances. This bridge fills the gap by providing a secure, MCP-native way to delegate browser and shell tasks to the local machine from a remote agent.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Mintlify doc page (`docs/gateway/mcp-bridge.md`) describing how to use the `openclaw-bridge-remote` MCP bridge to connect remote AI agents to a local OpenClaw gateway, and wires the page into the Infrastructure → Remote access and deployment sidebar via `docs/docs.json`.

The guide includes a mermaid architecture diagram, a quick-start install command, and an example MCP server config snippet for remote agent clients.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but the new doc contains a formatting typo and promotes an unsafe installation pattern.
- Changes are limited to documentation and sidebar navigation, with no runtime impact. Two doc issues should be addressed: a stray quote that will break rendering, and a `curl | bash` one-liner that’s inappropriate for official security-sensitive documentation.
- docs/gateway/mcp-bridge.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->