### PR TITLE
feat(telegram): support URL-type inline buttons

### DIFF
--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -62,7 +62,10 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     const replyToMessageId = parseReplyToMessageId(replyToId);
     const messageThreadId = parseThreadId(threadId);
     const telegramData = payload.channelData?.telegram as
-      | { buttons?: Array<Array<{ text: string; callback_data: string }>>; quoteText?: string }
+      | {
+          buttons?: Array<Array<{ text: string; callback_data?: string; url?: string }>>;
+          quoteText?: string;
+        }
       | undefined;
     const quoteText =
       typeof telegramData?.quoteText === "string" ? telegramData.quoteText : undefined;

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -102,7 +102,7 @@ export async function deliverReplies(params: {
         ? [reply.mediaUrl]
         : [];
     const telegramData = reply.channelData?.telegram as
-      | { buttons?: Array<Array<{ text: string; callback_data: string }>> }
+      | { buttons?: Array<Array<{ text: string; callback_data?: string; url?: string }>> }
       | undefined;
     const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
     if (mediaList.length === 0) {

--- a/src/telegram/send.returns-undefined-empty-input.test.ts
+++ b/src/telegram/send.returns-undefined-empty-input.test.ts
@@ -71,6 +71,35 @@ describe("buildInlineKeyboard", () => {
     });
   });
 
+  it("builds inline keyboards with URL buttons", () => {
+    const result = buildInlineKeyboard([
+      [{ text: "Visit Site", url: "https://example.com" }],
+      [
+        { text: "Callback", callback_data: "cmd:a" },
+        { text: "Link", url: "https://docs.example.com" },
+      ],
+    ]);
+    expect(result).toEqual({
+      inline_keyboard: [
+        [{ text: "Visit Site", url: "https://example.com" }],
+        [
+          { text: "Callback", callback_data: "cmd:a" },
+          { text: "Link", url: "https://docs.example.com" },
+        ],
+      ],
+    });
+  });
+
+  it("filters URL buttons with missing text", () => {
+    const result = buildInlineKeyboard([
+      [{ text: "", url: "https://example.com" }],
+      [{ text: "Valid", url: "https://example.com" }],
+    ]);
+    expect(result).toEqual({
+      inline_keyboard: [[{ text: "Valid", url: "https://example.com" }]],
+    });
+  });
+
   it("filters invalid buttons and empty rows", () => {
     const result = buildInlineKeyboard([
       [

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -52,8 +52,8 @@ type TelegramSendOpts = {
   quoteText?: string;
   /** Forum topic thread ID (for forum supergroups) */
   messageThreadId?: number;
-  /** Inline keyboard buttons (reply markup). */
-  buttons?: Array<Array<{ text: string; callback_data: string }>>;
+  /** Inline keyboard buttons (reply markup). Supports callback_data and url types. */
+  buttons?: Array<Array<{ text: string; callback_data?: string; url?: string }>>;
 };
 
 type TelegramSendResult = {
@@ -214,13 +214,13 @@ export function buildInlineKeyboard(
   const rows = buttons
     .map((row) =>
       row
-        .filter((button) => button?.text && button?.callback_data)
-        .map(
-          (button): InlineKeyboardButton => ({
-            text: button.text,
-            callback_data: button.callback_data,
-          }),
-        ),
+        .filter((button) => button?.text && (button?.callback_data || button?.url))
+        .map((button): InlineKeyboardButton => {
+          if (button.url) {
+            return { text: button.text, url: button.url };
+          }
+          return { text: button.text, callback_data: button.callback_data! };
+        }),
     )
     .filter((row) => row.length > 0);
   if (rows.length === 0) {


### PR DESCRIPTION
Closes #14548

Adds support for Telegram URL-type inline buttons alongside the existing callback_data buttons.

```json
{"buttons": [[{"text": "Open PR", "url": "https://github.com/..."}]]}
```

Previously, buttons with `url` instead of `callback_data` were silently dropped.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Telegram inline keyboard handling to support URL-type buttons in addition to `callback_data`. It updates the outbound Telegram plugin’s `channelData.telegram.buttons` typing to allow either `callback_data` or `url`, and adjusts `buildInlineKeyboard` in `src/telegram/send.ts` to preserve URL buttons instead of silently dropping them.

Main integration point is `buildInlineKeyboard`, which is used both by direct sends (`sendMessageTelegram`) and other Telegram delivery utilities.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but needs a small follow-up to keep Telegram delivery paths consistent and tested.
- Core change is localized and straightforward, but one internal Telegram delivery path still types buttons as callback-only, and URL button behavior isn’t covered by tests, making regressions more likely.
- src/telegram/bot/delivery.ts; src/telegram/send.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->