### PR TITLE
fix(memory-lancedb): add baseURL and dimensions config for non-OpenAI embedding providers

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -165,8 +165,9 @@ class Embeddings {
   constructor(
     apiKey: string,
     private model: string,
+    baseURL?: string,
   ) {
-    this.client = new OpenAI({ apiKey });
+    this.client = new OpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) });
   }
 
   async embed(text: string): Promise<number[]> {
@@ -249,9 +250,16 @@ const memoryPlugin = {
   register(api: OpenClawPluginApi) {
     const cfg = memoryConfigSchema.parse(api.pluginConfig);
     const resolvedDbPath = api.resolvePath(cfg.dbPath!);
-    const vectorDim = vectorDimsForModel(cfg.embedding.model ?? "text-embedding-3-small");
+    const vectorDim = vectorDimsForModel(
+      cfg.embedding.model ?? "text-embedding-3-small",
+      cfg.embedding.dimensions,
+    );
     const db = new MemoryDB(resolvedDbPath, vectorDim);
-    const embeddings = new Embeddings(cfg.embedding.apiKey, cfg.embedding.model!);
+    const embeddings = new Embeddings(
+      cfg.embedding.apiKey,
+      cfg.embedding.model!,
+      cfg.embedding.baseURL,
+    );
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 


### PR DESCRIPTION
Closes #14541

The Embeddings class was hardcoded to OpenAI's API endpoint. NVIDIA, Azure, and other OpenAI-compatible providers couldn't be used.

**Changes:**
- Add `embedding.baseURL` for custom API endpoints
- Add `embedding.dimensions` for custom vector dimensions
- Improve error message when model dimensions are unknown (suggests setting `dimensions` explicitly)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `memory-lancedb` plugin embedding configuration to support OpenAI-compatible providers by adding `embedding.baseURL` (custom API endpoint) and `embedding.dimensions` (override vector size when model isn’t in the built-in dimension map). The plugin now passes `baseURL` into the OpenAI client and uses `dimensions` when creating the LanceDB table schema.

Main issue to address before merge: there’s no runtime check that the embedding vector length returned by the provider matches the configured/derived `vectorDim`, so misconfiguration or provider/model changes will surface as LanceDB runtime errors during store/search/recall instead of a clear config error.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but needs a runtime guard for embedding/vector dimension mismatches to avoid hard-to-diagnose production failures.
- Changes are small and scoped, but the new `embedding.dimensions`/custom-provider support introduces a deterministic failure mode when the provider returns vectors of a different length than the configured/derived dimension; current code passes vectors into LanceDB without validation, so a mismatch will crash store/search paths at runtime.
- extensions/memory-lancedb/index.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->