### PR TITLE
fix: remove debug console.log from skills filter and node-host runner

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -53,12 +53,10 @@ function filterSkillEntries(
   if (skillFilter !== undefined) {
     const normalized = skillFilter.map((entry) => String(entry).trim()).filter(Boolean);
     const label = normalized.length > 0 ? normalized.join(", ") : "(none)";
-    console.log(`[skills] Applying skill filter: ${label}`);
     filtered =
       normalized.length > 0
         ? filtered.filter((entry) => normalized.includes(entry.skill.name))
         : [];
-    console.log(`[skills] After filter: ${filtered.map((entry) => entry.skill.name).join(", ")}`);
   }
   return filtered;
 }

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -570,8 +570,6 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const scheme = gateway.tls ? "wss" : "ws";
   const url = `${scheme}://${host}:${port}`;
   const pathEnv = ensureNodePathEnv();
-  // eslint-disable-next-line no-console
-  console.log(`node host PATH: ${pathEnv}`);
 
   const client = new GatewayClient({
     url,


### PR DESCRIPTION
Removes leftover debug `console.log` calls that leak internal state to stdout:

- `skills/workspace.ts`: logged skill filter names on every agent run
- `node-host/runner.ts`: logged PATH env var on startup

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes two leftover debug `console.log` statements:
- `src/agents/skills/workspace.ts`: stops printing the applied skill filter and post-filter skills on each run.
- `src/node-host/runner.ts`: stops printing the node host `PATH` environment variable at startup.

These changes reduce stdout noise and avoid leaking internal environment/state via logs. The only functional concern is that removing the log left an unused local (`label`) in `filterSkillEntries`, which may break CI if unused locals are enforced.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing a small CI-risk unused variable.
- The PR is a minimal change (removing debug stdout logging) and should not alter runtime behavior. One unused local variable (`label`) remains and could fail builds if unused locals are enforced, so it should be cleaned up before merging.
- src/agents/skills/workspace.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->