### PR TITLE
feat: support per-agent compaction overrides in agents.list[]

### DIFF
--- a/src/agents/agent-scope.e2e.test.ts
+++ b/src/agents/agent-scope.e2e.test.ts
@@ -444,6 +444,34 @@ describe("resolveAgentCompaction", () => {
     expect(result?.memoryFlush?.enabled).toBe(false);
   });
 
+  it("per-agent memoryFlush with no default memoryFlush does not throw", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          compaction: {
+            mode: "safeguard",
+            // no memoryFlush at all
+          },
+        },
+        list: [
+          {
+            id: "agent",
+            compaction: {
+              memoryFlush: {
+                enabled: false,
+                softThresholdTokens: 3000,
+              },
+            },
+          },
+        ],
+      },
+    };
+    const result = resolveAgentCompaction(cfg, "agent");
+    expect(result?.mode).toBe("safeguard"); // inherited
+    expect(result?.memoryFlush?.enabled).toBe(false);
+    expect(result?.memoryFlush?.softThresholdTokens).toBe(3000);
+  });
+
   it("no memoryFlush in either per-agent or defaults returns undefined", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -27,6 +27,7 @@ type ResolvedAgentConfig = {
   groupChat?: AgentEntry["groupChat"];
   subagents?: AgentEntry["subagents"];
   compaction?: AgentEntry["compaction"];
+  contextPruning?: AgentEntry["contextPruning"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
 };
@@ -122,6 +123,7 @@ export function resolveAgentConfig(
     groupChat: entry.groupChat,
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
     compaction: entry.compaction,
+    contextPruning: entry.contextPruning,
     sandbox: entry.sandbox,
     tools: entry.tools,
   };
@@ -156,6 +158,21 @@ export function resolveAgentCompaction(
         ? { ...defaults.memoryFlush, ...perAgent.memoryFlush }
         : undefined,
   };
+}
+
+/**
+ * Resolve the effective context pruning mode for an agent.
+ * Per-agent `contextPruning.mode` overrides the global default.
+ */
+export function resolveAgentContextPruningMode(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): "off" | "cache-ttl" | undefined {
+  const perAgent = agentId ? resolveAgentConfig(cfg, agentId)?.contextPruning : undefined;
+  if (perAgent?.mode) {
+    return perAgent.mode;
+  }
+  return cfg?.agents?.defaults?.contextPruning?.mode;
 }
 
 export function resolveAgentSkillsFilter(

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -527,7 +527,7 @@ export async function compactEmbeddedPiSessionDirect(
       const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
       ensurePiCompactionReserveTokens({
         settingsManager,
-        minReserveTokens: resolveCompactionReserveTokensFloor(params.config),
+        minReserveTokens: resolveCompactionReserveTokensFloor(params.config, sessionAgentId),
       });
       // Call for side effects (sets compaction/pruning runtime state)
       buildEmbeddedExtensionPaths({
@@ -536,6 +536,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
+        agentId: sessionAgentId,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -47,7 +47,7 @@ function buildContextPruningExtension(params: {
   // Per-agent contextPruning.mode overrides the global default.
   const effectiveMode = params.cfg
     ? resolveAgentContextPruningMode(params.cfg, params.agentId)
-    : params.cfg?.agents?.defaults?.contextPruning?.mode;
+    : undefined;
   if (effectiveMode !== "cache-ttl") {
     return {};
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -509,7 +509,7 @@ export async function runEmbeddedAttempt(
       const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
       ensurePiCompactionReserveTokens({
         settingsManager,
-        minReserveTokens: resolveCompactionReserveTokensFloor(params.config),
+        minReserveTokens: resolveCompactionReserveTokensFloor(params.config, sessionAgentId),
       });
 
       // Call for side effects (sets compaction/pruning runtime state)
@@ -519,6 +519,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        agentId: sessionAgentId,
       });
 
       // Get hook runner early so it's available when creating tools

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -19,7 +19,7 @@ import { resolveUserPath } from "../../../utils.js";
 import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
-import { resolveSessionAgentIds } from "../../agent-scope.js";
+import { resolveAgentCompaction, resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
@@ -507,10 +507,15 @@ export async function runEmbeddedAttempt(
       });
 
       const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
-      ensurePiCompactionReserveTokens({
-        settingsManager,
-        minReserveTokens: resolveCompactionReserveTokensFloor(params.config, sessionAgentId),
-      });
+      const compactionMode = params.config
+        ? (resolveAgentCompaction(params.config, sessionAgentId)?.mode ?? "default")
+        : "default";
+      if (compactionMode !== "off") {
+        ensurePiCompactionReserveTokens({
+          settingsManager,
+          minReserveTokens: resolveCompactionReserveTokensFloor(params.config, sessionAgentId),
+        });
+      }
 
       // Call for side effects (sets compaction/pruning runtime state)
       buildEmbeddedExtensionPaths({

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentCompaction } from "./agent-scope.js";
 
 export const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
 
@@ -25,8 +26,12 @@ export function ensurePiCompactionReserveTokens(params: {
   return { didOverride: true, reserveTokens: minReserveTokens };
 }
 
-export function resolveCompactionReserveTokensFloor(cfg?: OpenClawConfig): number {
-  const raw = cfg?.agents?.defaults?.compaction?.reserveTokensFloor;
+export function resolveCompactionReserveTokensFloor(
+  cfg?: OpenClawConfig,
+  agentId?: string,
+): number {
+  const compaction = cfg ? resolveAgentCompaction(cfg, agentId) : undefined;
+  const raw = compaction?.reserveTokensFloor;
   if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
     return Math.floor(raw);
   }

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -38,7 +38,8 @@ export async function runMemoryFlushIfNeeded(params: {
   storePath?: string;
   isHeartbeat: boolean;
 }): Promise<SessionEntry | undefined> {
-  const memoryFlushSettings = resolveMemoryFlushSettings(params.cfg);
+  const agentId = params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined;
+  const memoryFlushSettings = resolveMemoryFlushSettings(params.cfg, agentId);
   if (!memoryFlushSettings) {
     return params.sessionEntry;
   }

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveAgentCompaction } from "../../agents/agent-scope.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../../agents/pi-settings.js";
@@ -36,18 +37,22 @@ const normalizeNonNegativeInt = (value: unknown): number | null => {
   return int >= 0 ? int : null;
 };
 
-export function resolveMemoryFlushSettings(cfg?: OpenClawConfig): MemoryFlushSettings | null {
-  const defaults = cfg?.agents?.defaults?.compaction?.memoryFlush;
-  const enabled = defaults?.enabled ?? true;
+export function resolveMemoryFlushSettings(
+  cfg?: OpenClawConfig,
+  agentId?: string,
+): MemoryFlushSettings | null {
+  const compaction = cfg ? resolveAgentCompaction(cfg, agentId) : undefined;
+  const flushCfg = compaction?.memoryFlush;
+  const enabled = flushCfg?.enabled ?? true;
   if (!enabled) {
     return null;
   }
   const softThresholdTokens =
-    normalizeNonNegativeInt(defaults?.softThresholdTokens) ?? DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
-  const prompt = defaults?.prompt?.trim() || DEFAULT_MEMORY_FLUSH_PROMPT;
-  const systemPrompt = defaults?.systemPrompt?.trim() || DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT;
+    normalizeNonNegativeInt(flushCfg?.softThresholdTokens) ?? DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
+  const prompt = flushCfg?.prompt?.trim() || DEFAULT_MEMORY_FLUSH_PROMPT;
+  const systemPrompt = flushCfg?.systemPrompt?.trim() || DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT;
   const reserveTokensFloor =
-    normalizeNonNegativeInt(cfg?.agents?.defaults?.compaction?.reserveTokensFloor) ??
+    normalizeNonNegativeInt(compaction?.reserveTokensFloor) ??
     DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR;
 
   return {

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -42,6 +42,9 @@ export function resolveMemoryFlushSettings(
   agentId?: string,
 ): MemoryFlushSettings | null {
   const compaction = cfg ? resolveAgentCompaction(cfg, agentId) : undefined;
+  if (compaction?.mode === "off") {
+    return null;
+  }
   const flushCfg = compaction?.memoryFlush;
   const enabled = flushCfg?.enabled ?? true;
   if (!enabled) {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -243,7 +243,7 @@ export type AgentDefaultsConfig = {
   };
 };
 
-export type AgentCompactionMode = "default" | "safeguard";
+export type AgentCompactionMode = "default" | "safeguard" | "off";
 
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -64,6 +64,10 @@ export type AgentConfig = {
   };
   /** Per-agent compaction overrides (mode, reserveTokensFloor, maxHistoryShare, memoryFlush). */
   compaction?: AgentCompactionConfig;
+  /** Per-agent context pruning overrides (mode: off | cache-ttl). */
+  contextPruning?: {
+    mode?: "off" | "cache-ttl";
+  };
   tools?: AgentToolsConfig;
 };
 

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,5 +1,5 @@
 import type { ChatType } from "../channels/chat-type.js";
-import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
+import type { AgentCompactionConfig, AgentDefaultsConfig } from "./types.agent-defaults.js";
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type {
@@ -62,6 +62,8 @@ export type AgentConfig = {
     /** Auto-prune overrides for this agent. */
     prune?: SandboxPruneSettings;
   };
+  /** Per-agent compaction overrides (mode, reserveTokensFloor, maxHistoryShare, memoryFlush). */
+  compaction?: AgentCompactionConfig;
   tools?: AgentToolsConfig;
 };
 

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  CompactionSchema,
   HeartbeatSchema,
   MemorySearchSchema,
   SandboxBrowserSchema,
@@ -88,23 +89,7 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
-    compaction: z
-      .object({
-        mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
-        reserveTokensFloor: z.number().int().nonnegative().optional(),
-        maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
-        memoryFlush: z
-          .object({
-            enabled: z.boolean().optional(),
-            softThresholdTokens: z.number().int().nonnegative().optional(),
-            prompt: z.string().optional(),
-            systemPrompt: z.string().optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict()
-      .optional(),
+    compaction: CompactionSchema,
     thinkingDefault: z
       .union([
         z.literal("off"),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -316,6 +316,24 @@ export const AgentToolsSchema = z
   })
   .optional();
 
+export const CompactionSchema = z
+  .object({
+    mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+    reserveTokensFloor: z.number().int().nonnegative().optional(),
+    maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
+    memoryFlush: z
+      .object({
+        enabled: z.boolean().optional(),
+        softThresholdTokens: z.number().int().nonnegative().optional(),
+        prompt: z.string().optional(),
+        systemPrompt: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
 export const MemorySearchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -470,6 +488,7 @@ export const AgentEntrySchema = z
       })
       .strict()
       .optional(),
+    compaction: CompactionSchema,
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
   })

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -318,7 +318,7 @@ export const AgentToolsSchema = z
 
 export const CompactionSchema = z
   .object({
-    mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+    mode: z.union([z.literal("default"), z.literal("safeguard"), z.literal("off")]).optional(),
     reserveTokensFloor: z.number().int().nonnegative().optional(),
     maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
     memoryFlush: z
@@ -489,6 +489,12 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     compaction: CompactionSchema,
+    contextPruning: z
+      .object({
+        mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
+      })
+      .strict()
+      .optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
   })


### PR DESCRIPTION
## Summary

Adds optional `compaction` configuration to individual agent entries in `agents.list[]`, allowing per-agent override of `agents.defaults.compaction` settings. When a per-agent compaction config is present, it takes precedence over the global defaults for that agent. When absent, the agent inherits the global defaults — no behavioral change for existing configurations.

## Motivation

Multi-agent deployments often need different context management strategies for different agents. A long-running research agent benefits from aggressive memory flushing and a high `reserveTokensFloor`, while a quick-turnaround chat agent may need earlier compaction via a lower `maxHistoryShare`. An orchestration agent might use `safeguard` mode while execution agents stay on `default`.

Today, `compaction` is only configurable globally in `agents.defaults.compaction`, which forces all agents into the same strategy. Other agent-level settings like `heartbeat`, `humanDelay`, `memorySearch`, and `tools` already support per-agent overrides — compaction is the notable gap.

**Example:**

```yaml
agents:
  defaults:
    compaction:
      mode: default
      reserveTokensFloor: 20000
      memoryFlush:
        enabled: true
        softThresholdTokens: 50000
  list:
    - id: researcher
      compaction:
        reserveTokensFloor: 40000  # Higher floor — preserve more context
        maxHistoryShare: 0.8       # Compact later
    - id: executor
      compaction:
        maxHistoryShare: 0.4       # Compact earlier — short-lived tasks
        memoryFlush:
          enabled: false           # No pre-compaction flush needed
    - id: chat
      # No compaction override — inherits defaults
```

## Changes

- Extract compaction Zod schema into reusable `CompactionSchema` constant, add to `AgentEntrySchema` (`zod-schema.agent-runtime.ts`, `zod-schema.agent-defaults.ts`)
- Add `compaction` to `ResolvedAgentConfig` and `resolveAgentConfig()` output (`agent-scope.ts`)
- Add `resolveAgentCompaction(cfg, agentId?)` helper — merges per-agent overrides with global defaults:
  - Top-level fields: per-agent wins, falls back to default
  - `memoryFlush` sub-object: shallow-merged one level deeper so partial overrides (e.g., `enabled: false`) don't wipe the default `prompt`/`systemPrompt`
  - Returns `undefined` when neither per-agent nor defaults are set
- Update `resolveCompactionMode()`, `resolveCompactionReserveTokensFloor()`, `resolveMemoryFlushSettings()` to accept optional `agentId` and use merged config (`extensions.ts`, `pi-settings.ts`, `memory-flush.ts`)
- Thread `agentId` (via `sessionAgentId`) through all callsites in `compact.ts`, `run/attempt.ts`, `agent-runner-memory.ts`

## How Resolution Works

```
Per-agent (agents.list[].compaction)
  ↓ overrides
Global defaults (agents.defaults.compaction)
  ↓ falls back to
Hardcoded defaults (DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR, etc.)
```

For `memoryFlush`, the merge is one level deeper:

```typescript
// Per-agent memoryFlush = { enabled: false }
// Default memoryFlush = { enabled: true, softThresholdTokens: 50000, prompt: "..." }
// Resolved = { enabled: false, softThresholdTokens: 50000, prompt: "..." }
```

## Testing

12 test cases in `agent-scope.test.ts` covering:
- Per-agent override takes precedence over defaults
- Fallback to defaults when no per-agent config
- Partial override merges correctly (e.g., only `maxHistoryShare` set, inherits `mode` and `memoryFlush`)
- `memoryFlush` sub-object shallow merge — partial override preserves unrelated default fields
- Unknown agent falls back to global defaults
- No config at all returns `undefined` (hardcoded fallbacks apply)
- NaN safety on `reserveTokensFloor`

## Backward Compatibility

Fully backward compatible. The `compaction` field on agent entries is optional. Existing configs with no per-agent compaction work exactly as before — all three resolution functions fall back to `agents.defaults.compaction`. No new required fields.

## Monkey Patch (for immediate use)

A standalone patch script for current OpenClaw releases is available at [curtismercier/openclaw-mods](https://github.com/curtismercier/openclaw-mods/tree/main/patches/per-agent-compaction) — apply/revert/status with version tracking and pre-flight safety checks.

Closes #13736
Closes #14446

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds per-agent `compaction` overrides under `agents.list[]`, reusing a shared `CompactionSchema`, and threads an `agentId` through compaction/memory-flush resolution so individual agents can override `agents.defaults.compaction`.

The main behavioral change is centralized in `resolveAgentCompaction(cfg, agentId?)` (src/agents/agent-scope.ts), which merges per-agent and default compaction settings (including a one-level-deeper merge for `memoryFlush`). Call sites in embedded runner setup and memory flush now pass the session’s effective agent id so the right compaction settings are applied per agent.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a confirmed runtime crash in compaction resolution when only per-agent memoryFlush is configured.
- The new `resolveAgentCompaction` merge logic can throw a TypeError by spreading `undefined` when an agent defines `compaction.memoryFlush` but defaults omit it. This is a straightforward, high-impact runtime failure in a newly introduced codepath. Other changes look consistent and well-covered by tests, but this edge case isn’t exercised by the current test suite.
- src/agents/agent-scope.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->