### PR TITLE
fix: remove leftover debug console.log statements

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -52,13 +52,10 @@ function filterSkillEntries(
   // If skillFilter is provided, only include skills in the filter list.
   if (skillFilter !== undefined) {
     const normalized = skillFilter.map((entry) => String(entry).trim()).filter(Boolean);
-    const label = normalized.length > 0 ? normalized.join(", ") : "(none)";
-    console.log(`[skills] Applying skill filter: ${label}`);
     filtered =
       normalized.length > 0
         ? filtered.filter((entry) => normalized.includes(entry.skill.name))
         : [];
-    console.log(`[skills] After filter: ${filtered.map((entry) => entry.skill.name).join(", ")}`);
   }
   return filtered;
 }

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -570,8 +570,6 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const scheme = gateway.tls ? "wss" : "ws";
   const url = `${scheme}://${host}:${port}`;
   const pathEnv = ensureNodePathEnv();
-  // eslint-disable-next-line no-console
-  console.log(`node host PATH: ${pathEnv}`);
 
   const client = new GatewayClient({
     url,


### PR DESCRIPTION
Removes debug `console.log` calls that shouldn't be in production:

- **node-host/runner.ts**: Leaked `PATH` environment variable to stdout on every node host startup
- **skills/workspace.ts**: Skill filter debug logs cluttered output during normal operation

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes leftover debug `console.log` statements from two runtime paths:

- `src/node-host/runner.ts`: removes logging of the computed `PATH` value during node host startup (while still computing `pathEnv` and passing it into `GatewayClient`).
- `src/agents/skills/workspace.ts`: removes two logs in `filterSkillEntries()` that printed the applied `skillFilter` and the resulting skill list.

These changes reduce stdout noise and avoid leaking environment details during normal operation, without changing the underlying filtering or node host initialization behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff only removes debug logging statements and does not alter control flow or data used by the node host or skill filtering logic; the surrounding code still computes and uses the same values.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->