### PR TITLE
fix(routing): normalize incoming peer.kind in resolveAgentRoute

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -171,7 +171,12 @@ function matchesTeam(match: { teamId?: string | undefined } | undefined, teamId:
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
-  const peer = input.peer ? { kind: input.peer.kind, id: normalizeId(input.peer.id) } : null;
+  const peer = input.peer
+    ? {
+        kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
+        id: normalizeId(input.peer.id),
+      }
+    : null;
   const guildId = normalizeId(input.guildId);
   const teamId = normalizeId(input.teamId);
 


### PR DESCRIPTION
Fixes #14612

`matchesPeer()` normalized the config-side `peer.kind` via `normalizeChatType()` but the incoming `peer.kind` from plugin input was used as-is. When a plugin passes `"dm"` instead of `"direct"`, peer-based agent routing always falls through to the default agent.

One-line fix: normalize `input.peer.kind` in `resolveAgentRoute()` before comparison.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `resolveAgentRoute()` to normalize the incoming `peer.kind` (e.g. treating `"dm"` as `"direct"`) before matching against routing bindings, aligning runtime/plugin input behavior with `matchesPeer()` which already normalizes the config-side `peer.kind`.

Routing continues to filter candidate bindings by `channel` and `accountId`, then selects the most specific match (peer → parent peer → guild → team → account/channel fallbacks), producing both a resolved `agentId` and derived session keys.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge but leaves one routing path inconsistent.
- The change is small and correct for `input.peer.kind`, but `input.parentPeer.kind` remains unnormalized, so thread parent inheritance can still fail for legacy/plugin inputs (e.g., "dm" vs "direct"). No other behavioral or safety issues were found in the touched code.
- src/routing/resolve-route.ts (parentPeer normalization)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->