### PR TITLE
fix: preserve $include directives during config write-back

### DIFF
--- a/src/config/include-preserve-io.test.ts
+++ b/src/config/include-preserve-io.test.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createConfigIO } from "./io.js";
+
+async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-include-io-"));
+  try {
+    await run(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("$include preservation via createConfigIO", () => {
+  it("preserves $include directive after write roundtrip", async () => {
+    await withTempDir(async (dir) => {
+      const basePath = path.join(dir, "base.json");
+      const configPathFile = path.join(dir, "openclaw.json");
+
+      // Base file provides gateway config
+      await fs.writeFile(
+        basePath,
+        JSON.stringify({
+          gateway: { port: 4000 },
+        }),
+      );
+
+      await fs.writeFile(
+        configPathFile,
+        JSON.stringify(
+          {
+            $include: "./base.json",
+            agents: { list: [{ id: "main", name: "Main" }] },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const io = createConfigIO({ configPath: configPathFile });
+      const snapshot = await io.readConfigFileSnapshot();
+
+      // Write back with a change to a sibling key
+      const updated = {
+        ...snapshot.config,
+        agents: {
+          ...snapshot.config.agents,
+          list: [{ id: "main", name: "Updated" }],
+        },
+      };
+      await io.writeConfigFile(updated);
+
+      // Read the raw file — $include should still be there
+      const written = JSON.parse(await fs.readFile(configPathFile, "utf-8"));
+      expect(written.$include).toBe("./base.json");
+      expect(written.agents).toBeDefined();
+      expect(written.agents.list[0].name).toBe("Updated");
+    });
+  });
+
+  it("does not inline keys from $include that were not changed", async () => {
+    await withTempDir(async (dir) => {
+      const basePath = path.join(dir, "base.json");
+      const configPathFile = path.join(dir, "openclaw.json");
+
+      await fs.writeFile(
+        basePath,
+        JSON.stringify({
+          gateway: { port: 4000 },
+        }),
+      );
+
+      await fs.writeFile(
+        configPathFile,
+        JSON.stringify(
+          {
+            $include: "./base.json",
+            agents: { list: [{ id: "main" }] },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const io = createConfigIO({ configPath: configPathFile });
+      const snapshot = await io.readConfigFileSnapshot();
+
+      // Write back unchanged
+      await io.writeConfigFile(snapshot.config);
+
+      const written = JSON.parse(await fs.readFile(configPathFile, "utf-8"));
+      expect(written.$include).toBe("./base.json");
+      // gateway comes from include — should NOT be present as inlined key
+      // (though defaults may add other gateway keys, the raw gateway from include should not be inlined)
+      expect(written.agents).toBeDefined();
+    });
+  });
+
+  it("preserves nested $include directives", async () => {
+    await withTempDir(async (dir) => {
+      const gatewayPath = path.join(dir, "gateway.json");
+      const configPathFile = path.join(dir, "openclaw.json");
+
+      await fs.writeFile(gatewayPath, JSON.stringify({ port: 4000 }));
+
+      await fs.writeFile(
+        configPathFile,
+        JSON.stringify(
+          {
+            gateway: {
+              $include: "./gateway.json",
+            },
+            agents: { list: [{ id: "main", name: "Bot" }] },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const io = createConfigIO({ configPath: configPathFile });
+      const snapshot = await io.readConfigFileSnapshot();
+
+      const updated = {
+        ...snapshot.config,
+        agents: {
+          ...snapshot.config.agents,
+          list: [{ id: "main", name: "Updated" }],
+        },
+      };
+      await io.writeConfigFile(updated);
+
+      const written = JSON.parse(await fs.readFile(configPathFile, "utf-8"));
+      expect(written.gateway.$include).toBe("./gateway.json");
+      expect(written.agents.list[0].name).toBe("Updated");
+    });
+  });
+
+  it("works normally when config has no $include", async () => {
+    await withTempDir(async (dir) => {
+      const configPathFile = path.join(dir, "openclaw.json");
+
+      await fs.writeFile(
+        configPathFile,
+        JSON.stringify({ agents: { list: [{ id: "main", name: "Bot" }] } }, null, 2),
+      );
+
+      const io = createConfigIO({ configPath: configPathFile });
+      const snapshot = await io.readConfigFileSnapshot();
+
+      const updated = {
+        ...snapshot.config,
+        agents: {
+          ...snapshot.config.agents,
+          list: [{ id: "main", name: "Updated" }],
+        },
+      };
+      await io.writeConfigFile(updated);
+
+      const written = JSON.parse(await fs.readFile(configPathFile, "utf-8"));
+      expect(written.agents.list[0].name).toBe("Updated");
+      expect(written.$include).toBeUndefined();
+    });
+  });
+});

--- a/src/config/include-preserve.test.ts
+++ b/src/config/include-preserve.test.ts
@@ -1,0 +1,371 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { IncludeResolver } from "./includes.js";
+import { hasIncludeDirective, restoreIncludeDirectives } from "./include-preserve.js";
+
+const ROOT_DIR = path.parse(process.cwd()).root;
+const CONFIG_DIR = path.join(ROOT_DIR, "config");
+const DEFAULT_CONFIG_PATH = path.join(CONFIG_DIR, "openclaw.json");
+
+function createMockResolver(files: Record<string, unknown>): IncludeResolver {
+  return {
+    readFile: (filePath: string) => {
+      if (filePath in files) {
+        return JSON.stringify(files[filePath]);
+      }
+      throw new Error(`ENOENT: no such file: ${filePath}`);
+    },
+    parseJson: JSON.parse,
+  };
+}
+
+function configPath(...parts: string[]) {
+  return path.join(CONFIG_DIR, ...parts);
+}
+
+describe("hasIncludeDirective", () => {
+  it("returns false for primitives", () => {
+    expect(hasIncludeDirective("hello")).toBe(false);
+    expect(hasIncludeDirective(42)).toBe(false);
+    expect(hasIncludeDirective(null)).toBe(false);
+  });
+
+  it("returns false for objects without $include", () => {
+    expect(hasIncludeDirective({ foo: "bar" })).toBe(false);
+    expect(hasIncludeDirective({ nested: { deep: true } })).toBe(false);
+  });
+
+  it("returns true for top-level $include", () => {
+    expect(hasIncludeDirective({ $include: "./base.json" })).toBe(true);
+  });
+
+  it("returns true for nested $include", () => {
+    expect(hasIncludeDirective({ models: { $include: "./models.json" } })).toBe(true);
+  });
+
+  it("returns false for arrays", () => {
+    expect(hasIncludeDirective([{ $include: "./base.json" }])).toBe(false);
+  });
+});
+
+describe("restoreIncludeDirectives", () => {
+  it("returns incoming unchanged when rawParsed has no $include", () => {
+    const incoming = { name: "bot", models: { default: "claude-3" } };
+    const rawParsed = { name: "bot", models: { default: "claude-3" } };
+    const resolver = createMockResolver({});
+
+    const result = restoreIncludeDirectives(incoming, rawParsed, DEFAULT_CONFIG_PATH, resolver);
+    expect(result).toEqual(incoming);
+  });
+
+  it("preserves $include directive on roundtrip", () => {
+    const baseFile = configPath("base.json");
+    const files = {
+      [baseFile]: { models: { default: "claude-3" }, gateway: { port: 3000 } },
+    };
+    const resolver = createMockResolver(files);
+
+    const rawParsed = {
+      $include: "./base.json",
+      name: "my-bot",
+    };
+
+    // Simulates what the caller gets after full resolution + defaults
+    const incoming = {
+      models: { default: "claude-3" },
+      gateway: { port: 3000 },
+      name: "updated-bot",
+    };
+
+    const result = restoreIncludeDirectives(incoming, rawParsed, DEFAULT_CONFIG_PATH, resolver);
+
+    // $include should be preserved
+    expect((result as Record<string, unknown>).$include).toBe("./base.json");
+    // Sibling key should be updated
+    expect((result as Record<string, unknown>).name).toBe("updated-bot");
+    // Keys from include should NOT be inlined (they match include content)
+    expect((result as Record<string, unknown>).models).toBeUndefined();
+    expect((result as Record<string, unknown>).gateway).toBeUndefined();
+  });
+
+  it("writes override when included key value is changed", () => {
+    const baseFile = configPath("base.json");
+    const files = {
+      [baseFile]: { models: { default: "claude-3" } },
+    };
+    const resolver = createMockResolver(files);
+
+    const rawParsed = {
+      $include: "./base.json",
+      name: "my-bot",
+    };
+
+    const incoming = {
+      models: { default: "gpt-4" }, // Changed from include value
+      name: "my-bot",
+    };
+
+    const result = restoreIncludeDirectives(
+      incoming,
+      rawParsed,
+      DEFAULT_CONFIG_PATH,
+      resolver,
+    ) as Record<string, unknown>;
+
+    expect(result.$include).toBe("./base.json");
+    expect(result.name).toBe("my-bot");
+    // Changed included key should be written as sibling override
+    expect(result.models).toEqual({ default: "gpt-4" });
+  });
+
+  it("adds new keys not from includes", () => {
+    const baseFile = configPath("base.json");
+    const files = {
+      [baseFile]: { models: { default: "claude-3" } },
+    };
+    const resolver = createMockResolver(files);
+
+    const rawParsed = {
+      $include: "./base.json",
+    };
+
+    const incoming = {
+      models: { default: "claude-3" },
+      newFeature: { enabled: true }, // New key not from include
+    };
+
+    const result = restoreIncludeDirectives(
+      incoming,
+      rawParsed,
+      DEFAULT_CONFIG_PATH,
+      resolver,
+    ) as Record<string, unknown>;
+
+    expect(result.$include).toBe("./base.json");
+    expect(result.models).toBeUndefined(); // From include, unchanged
+    expect(result.newFeature).toEqual({ enabled: true }); // New, should be written
+  });
+
+  it("handles array $include", () => {
+    const aFile = configPath("a.json");
+    const bFile = configPath("b.json");
+    const files = {
+      [aFile]: { models: { default: "claude-3" } },
+      [bFile]: { gateway: { port: 3000 } },
+    };
+    const resolver = createMockResolver(files);
+
+    const rawParsed = {
+      $include: ["./a.json", "./b.json"],
+      name: "my-bot",
+    };
+
+    const incoming = {
+      models: { default: "claude-3" },
+      gateway: { port: 3000 },
+      name: "updated-bot",
+    };
+
+    const result = restoreIncludeDirectives(
+      incoming,
+      rawParsed,
+      DEFAULT_CONFIG_PATH,
+      resolver,
+    ) as Record<string, unknown>;
+
+    expect(result.$include).toEqual(["./a.json", "./b.json"]);
+    expect(result.name).toBe("updated-bot");
+    expect(result.models).toBeUndefined();
+    expect(result.gateway).toBeUndefined();
+  });
+
+  it("handles nested $include in sub-objects", () => {
+    const modelsFile = configPath("models.json");
+    const files = {
+      [modelsFile]: {
+        default: "claude-3",
+        providers: { anthropic: { apiKey: "sk-123" } },
+      },
+    };
+    const resolver = createMockResolver(files);
+
+    const rawParsed = {
+      name: "my-bot",
+      models: {
+        $include: "./models.json",
+      },
+    };
+
+    const incoming = {
+      name: "my-bot",
+      models: {
+        default: "claude-3",
+        providers: { anthropic: { apiKey: "sk-123" } },
+      },
+    };
+
+    const result = restoreIncludeDirectives(
+      incoming,
+      rawParsed,
+      DEFAULT_CONFIG_PATH,
+      resolver,
+    ) as Record<string, unknown>;
+
+    expect(result.name).toBe("my-bot");
+    // Nested $include should be preserved
+    const models = result.models as Record<string, unknown>;
+    expect(models.$include).toBe("./models.json");
+    // Keys from the nested include should not be inlined
+    expect(models.default).toBeUndefined();
+    expect(models.providers).toBeUndefined();
+  });
+
+  it("preserves sibling overrides alongside nested $include", () => {
+    const modelsFile = configPath("models.json");
+    const files = {
+      [modelsFile]: { default: "claude-3" },
+    };
+    const resolver = createMockResolver(files);
+
+    const rawParsed = {
+      models: {
+        $include: "./models.json",
+        temperature: 0.7, // Sibling override
+      },
+    };
+
+    const incoming = {
+      models: {
+        default: "claude-3",
+        temperature: 0.9, // Updated sibling
+      },
+    };
+
+    const result = restoreIncludeDirectives(
+      incoming,
+      rawParsed,
+      DEFAULT_CONFIG_PATH,
+      resolver,
+    ) as Record<string, unknown>;
+
+    const models = result.models as Record<string, unknown>;
+    expect(models.$include).toBe("./models.json");
+    expect(models.temperature).toBe(0.9);
+    expect(models.default).toBeUndefined(); // From include, unchanged
+  });
+
+  it("falls back to incoming when include resolution fails", () => {
+    const resolver = createMockResolver({}); // No files available
+
+    const rawParsed = {
+      $include: "./missing.json",
+      name: "my-bot",
+    };
+
+    const incoming = {
+      name: "my-bot",
+      extra: "value",
+    };
+
+    const result = restoreIncludeDirectives(incoming, rawParsed, DEFAULT_CONFIG_PATH, resolver);
+    expect(result).toEqual(incoming);
+  });
+
+  it("handles non-object incoming gracefully", () => {
+    const resolver = createMockResolver({});
+    const rawParsed = { $include: "./base.json" };
+
+    expect(restoreIncludeDirectives("string", rawParsed, DEFAULT_CONFIG_PATH, resolver)).toBe(
+      "string",
+    );
+    expect(restoreIncludeDirectives(42, rawParsed, DEFAULT_CONFIG_PATH, resolver)).toBe(42);
+    expect(restoreIncludeDirectives(null, rawParsed, DEFAULT_CONFIG_PATH, resolver)).toBe(null);
+  });
+
+  it("handles non-object rawParsed gracefully", () => {
+    const resolver = createMockResolver({});
+    const incoming = { name: "bot" };
+
+    expect(restoreIncludeDirectives(incoming, "string", DEFAULT_CONFIG_PATH, resolver)).toEqual(
+      incoming,
+    );
+    expect(restoreIncludeDirectives(incoming, null, DEFAULT_CONFIG_PATH, resolver)).toEqual(
+      incoming,
+    );
+  });
+
+  it("removes sibling keys that were deleted from incoming", () => {
+    const baseFile = configPath("base.json");
+    const files = { [baseFile]: { models: { default: "claude-3" } } };
+    const resolver = createMockResolver(files);
+
+    const rawParsed = {
+      $include: "./base.json",
+      name: "my-bot",
+      obsoleteKey: "old-value",
+    };
+
+    const incoming = {
+      models: { default: "claude-3" },
+      name: "my-bot",
+      // obsoleteKey intentionally removed
+    };
+
+    const result = restoreIncludeDirectives(
+      incoming,
+      rawParsed,
+      DEFAULT_CONFIG_PATH,
+      resolver,
+    ) as Record<string, unknown>;
+
+    expect(result.$include).toBe("./base.json");
+    expect(result.name).toBe("my-bot");
+    expect(result.obsoleteKey).toBeUndefined();
+  });
+
+  it("preserves $include with multiple levels of nesting", () => {
+    const baseFile = configPath("base.json");
+    const modelsFile = configPath("models.json");
+    const files = {
+      [baseFile]: { gateway: { port: 3000 } },
+      [modelsFile]: { default: "claude-3" },
+    };
+    const resolver = createMockResolver(files);
+
+    const rawParsed = {
+      $include: "./base.json",
+      name: "my-bot",
+      models: {
+        $include: "./models.json",
+        temperature: 0.5,
+      },
+    };
+
+    const incoming = {
+      gateway: { port: 3000 },
+      name: "updated",
+      models: {
+        default: "claude-3",
+        temperature: 0.8,
+      },
+    };
+
+    const result = restoreIncludeDirectives(
+      incoming,
+      rawParsed,
+      DEFAULT_CONFIG_PATH,
+      resolver,
+    ) as Record<string, unknown>;
+
+    // Top-level $include preserved
+    expect(result.$include).toBe("./base.json");
+    expect(result.name).toBe("updated");
+    expect(result.gateway).toBeUndefined(); // From top-level include
+
+    // Nested $include preserved
+    const models = result.models as Record<string, unknown>;
+    expect(models.$include).toBe("./models.json");
+    expect(models.temperature).toBe(0.8);
+    expect(models.default).toBeUndefined(); // From nested include
+  });
+});

--- a/src/config/include-preserve.ts
+++ b/src/config/include-preserve.ts
@@ -1,0 +1,175 @@
+/**
+ * Preserves `$include` directives during config write-back.
+ *
+ * When config is read, `$include` directives are resolved and their contents
+ * are merged into the config object. When writing back, callers pass the
+ * fully-resolved config. This module detects which keys originated from
+ * `$include` directives and reconstructs the file with directives intact,
+ * so they survive config round-trips.
+ *
+ * A key is kept in the output if:
+ * 1. It existed as a sibling key in the raw (pre-resolution) config, OR
+ * 2. It is a new key not provided by any `$include` (caller-added), OR
+ * 3. It was provided by an `$include` but the caller changed its value
+ *    (written as a sibling override)
+ *
+ * The `$include` directive itself is always preserved verbatim.
+ */
+
+import { INCLUDE_KEY, type IncludeResolver, resolveConfigIncludes } from "./includes.js";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.prototype.toString.call(value) === "[object Object]"
+  );
+}
+
+/**
+ * Shallow-ish structural equality check. Compares JSON serializations to
+ * detect whether a value was meaningfully changed from its included source.
+ * This is intentionally conservative: if serialization differs at all, the
+ * value is treated as changed and written as a sibling override.
+ */
+function structurallyEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a === null || b === null || a === undefined || b === undefined) {
+    return false;
+  }
+  if (typeof a !== typeof b) {
+    return false;
+  }
+  if (typeof a !== "object") {
+    return a === b;
+  }
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether a parsed config object (or any nested object within it)
+ * contains a `$include` directive at any depth.
+ */
+export function hasIncludeDirective(obj: unknown): boolean {
+  if (!isPlainObject(obj)) {
+    return false;
+  }
+  if (INCLUDE_KEY in obj) {
+    return true;
+  }
+  return Object.values(obj).some((v) => hasIncludeDirective(v));
+}
+
+/**
+ * Resolve only the `$include` portion of an object, excluding sibling keys.
+ * Returns the content that the include directive(s) contribute.
+ */
+function resolveIncludeOnly(
+  includeValue: unknown,
+  configPath: string,
+  resolver: IncludeResolver,
+): unknown {
+  const includeOnlyObj = { [INCLUDE_KEY]: includeValue };
+  return resolveConfigIncludes(includeOnlyObj, configPath, resolver);
+}
+
+/**
+ * Recursively restore `$include` directives in the config being written.
+ *
+ * @param incoming  - The fully-resolved config about to be written
+ * @param rawParsed - The current file's pre-resolution parsed content
+ * @param configPath - Absolute path to the config file (for include resolution)
+ * @param resolver  - File reader / JSON parser for include files
+ * @returns A config object with `$include` directives preserved
+ */
+export function restoreIncludeDirectives(
+  incoming: unknown,
+  rawParsed: unknown,
+  configPath: string,
+  resolver: IncludeResolver,
+): unknown {
+  if (!isPlainObject(incoming) || !isPlainObject(rawParsed)) {
+    return incoming;
+  }
+
+  // If this level has no $include, recurse into nested objects that might
+  if (!(INCLUDE_KEY in rawParsed)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(incoming)) {
+      if (
+        key in rawParsed &&
+        isPlainObject(rawParsed[key]) &&
+        hasIncludeDirective(rawParsed[key])
+      ) {
+        result[key] = restoreIncludeDirectives(value, rawParsed[key], configPath, resolver);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  // This level has $include — preserve it and reconstruct sibling keys
+  let fromInclude: Record<string, unknown> = {};
+  try {
+    const resolved = resolveIncludeOnly(rawParsed[INCLUDE_KEY], configPath, resolver);
+    if (isPlainObject(resolved)) {
+      fromInclude = resolved;
+    }
+  } catch {
+    // Include resolution failed at write time — fall back to writing everything
+    return incoming;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  // 1. Preserve the $include directive verbatim
+  result[INCLUDE_KEY] = rawParsed[INCLUDE_KEY];
+
+  // 2. Copy all non-$include keys from the raw file, updated with incoming values.
+  //    These are the "sibling overrides" the user explicitly put in the root file.
+  for (const key of Object.keys(rawParsed)) {
+    if (key === INCLUDE_KEY) {
+      continue;
+    }
+    if (key in incoming) {
+      // Recurse into nested objects that may themselves contain $include
+      if (isPlainObject(rawParsed[key]) && hasIncludeDirective(rawParsed[key])) {
+        result[key] = restoreIncludeDirectives(incoming[key], rawParsed[key], configPath, resolver);
+      } else {
+        result[key] = incoming[key];
+      }
+    }
+    // If key not in incoming, it was intentionally removed — don't include
+  }
+
+  // 3. Check for keys in incoming that weren't in the raw file.
+  //    If they came from the include with the same value → skip (include provides them).
+  //    If they came from the include but were changed → write as sibling override.
+  //    If they're entirely new → write them.
+  for (const key of Object.keys(incoming)) {
+    if (key in result || key === INCLUDE_KEY) {
+      continue;
+    }
+
+    if (key in fromInclude) {
+      // Key exists in include — only write if the value was changed
+      if (!structurallyEqual(incoming[key], fromInclude[key])) {
+        result[key] = incoming[key];
+      }
+      // else: unchanged from include, skip
+    } else {
+      // New key not from include — add it
+      result[key] = incoming[key];
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Fixes #11696 — CLI commands flatten `$include` directives, inlining their contents into `openclaw.json`.

## Problem

`writeConfigFile()` uses `JSON.stringify` which serializes the fully-resolved config. This means any `$include` directives are replaced with their resolved contents, breaking infrastructure setups that split config into base (infra-managed) + instance overrides.

## Solution

Following the same pattern as #11560 (env var `${VAR}` preservation), this PR adds `$include` directive preservation during config write-back:

1. **Before writing**, read the current file's raw (pre-resolution) content
2. **Identify** `$include` directives and what keys they contribute (by resolving just the include portion)
3. **Reconstruct** the output with `$include` directives intact
4. **Only write** keys that were sibling overrides in the original file, or genuinely new/changed keys

### New module: `include-preserve.ts`

- `hasIncludeDirective(obj)` — detects `$include` at any depth
- `restoreIncludeDirectives(incoming, rawParsed, configPath, resolver)` — reconstructs config preserving `$include`

### Edge cases handled

- Nested `$include` (e.g., `models: { $include: "./models.json" }`)
- Array `$include` (multiple files merged)
- Sibling overrides alongside `$include`
- Keys removed from incoming (intentional deletion)
- Keys changed from include values (written as sibling overrides)
- Include resolution failure at write time (falls back to writing everything)

## Tests

- **17 unit tests** in `include-preserve.test.ts` covering all edge cases
- **4 integration tests** in `include-preserve-io.test.ts` testing the full `createConfigIO` roundtrip
- **0 regressions** — all 383 existing config tests pass

## Example

Config before CLI command:
```json
{
  "$include": "./base.json",
  "agents": { "list": [{ "id": "main", "name": "Bot" }] }
}
```

After `openclaw config set ...` (before this fix): `$include` gone, everything inlined.
After this fix: `$include` preserved, only changed keys updated.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes config write-back to preserve `$include` directives instead of serializing the fully-resolved config. It introduces a new `include-preserve.ts` helper that compares the resolved config being written (`incoming`) against the current on-disk, pre-resolution JSON5 (`rawParsed`), and reconstructs output such that `$include` remains in place while only writing sibling overrides/new keys/changed-from-include keys. `createConfigIO().writeConfigFile()` now re-reads/parses the current file before writing and runs this restoration when `$include` is present. The PR also adds unit tests for `hasIncludeDirective`/`restoreIncludeDirectives` plus integration tests covering a `createConfigIO` roundtrip.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and aligns with existing include-resolution semantics.
- Core logic is small and well-covered by new unit/integration tests, and the write path only activates include restoration when the existing on-disk config parses and actually contains `$include`. I did not find any definite runtime bugs introduced by these changes; remaining concerns are mostly about test strictness and minor TOCTOU/sync-read style choices rather than correctness failures.
- src/config/io.ts (write path change), src/config/include-preserve.ts (include restoration logic)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->