### PR TITLE
feat(slack): include thread metadata (thread_ts, parent_user_id) in agent context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: fix webhook auth bypass via loopback proxy trust. (#13787) Thanks @coygeek.
 - Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
+- Slack: include thread reply metadata in inbound message footer context (`thread_ts`, `parent_user_id`) while keeping top-level `thread_ts == ts` events unthreaded. (#14625) Thanks @bennewton999.
 - Signal: enforce E.164 validation for the Signal bot account prompt so mistyped numbers are caught early. (#15063) Thanks @Duartemartins.
 - Discord: process DM reactions instead of silently dropping them. (#10418) Thanks @mcaxtr.
 - Discord: treat Administrator as full permissions in channel permission checks. Thanks @thewilloftheshadow.

--- a/src/slack/monitor/message-handler/prepare.inbound-contract.test.ts
+++ b/src/slack/monitor/message-handler/prepare.inbound-contract.test.ts
@@ -306,7 +306,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared).toBeTruthy();
     // Verify thread metadata is in the message footer
     expect(prepared!.ctxPayload.Body).toMatch(
-      /\[slack message id: 1\.002 channel: D123 thread_ts: 1\.000 parent_user: U2\]/,
+      /\[slack message id: 1\.002 channel: D123 thread_ts: 1\.000 parent_user_id: U2\]/,
     );
   });
 
@@ -379,5 +379,77 @@ describe("slack prepareSlackMessage inbound contract", () => {
     // Top-level messages should NOT have thread_ts in the footer
     expect(prepared!.ctxPayload.Body).toMatch(/\[slack message id: 1\.000 channel: D123\]$/);
     expect(prepared!.ctxPayload.Body).not.toContain("thread_ts");
+  });
+
+  it("excludes thread metadata when thread_ts equals ts without parent_user_id", async () => {
+    const slackCtx = createSlackMonitorContext({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      accountId: "default",
+      botToken: "token",
+      app: { client: {} } as App,
+      runtime: {} as RuntimeEnv,
+      botUserId: "B1",
+      teamId: "T1",
+      apiAppId: "A1",
+      historyLimit: 0,
+      sessionScope: "per-sender",
+      mainKey: "main",
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: [],
+      groupDmEnabled: true,
+      groupDmChannels: [],
+      defaultRequireMention: true,
+      groupPolicy: "open",
+      useAccessGroups: false,
+      reactionMode: "off",
+      reactionAllowlist: [],
+      replyToMode: "off",
+      threadHistoryScope: "thread",
+      threadInheritParent: false,
+      slashCommand: {
+        enabled: false,
+        name: "openclaw",
+        sessionPrefix: "slack:slash",
+        ephemeral: true,
+      },
+      textLimit: 4000,
+      ackReactionScope: "group-mentions",
+      mediaMaxBytes: 1024,
+      removeAckAfterReply: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const account: ResolvedSlackAccount = {
+      accountId: "default",
+      enabled: true,
+      botTokenSource: "config",
+      appTokenSource: "config",
+      config: {},
+    };
+
+    const message: SlackMessageEvent = {
+      channel: "D123",
+      channel_type: "im",
+      user: "U1",
+      text: "top level",
+      ts: "1.000",
+      thread_ts: "1.000",
+    } as SlackMessageEvent;
+
+    const prepared = await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message,
+      opts: { source: "message" },
+    });
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.Body).toMatch(/\[slack message id: 1\.000 channel: D123\]$/);
+    expect(prepared!.ctxPayload.Body).not.toContain("thread_ts");
+    expect(prepared!.ctxPayload.Body).not.toContain("parent_user_id");
   });
 });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -399,7 +399,10 @@ export async function prepareSlackMessage(params: {
       GroupSubject: isRoomish ? roomLabel : undefined,
       From: slackFrom,
     }) ?? (isDirectMessage ? senderName : roomLabel);
-  const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}]`;
+  const threadInfo = message.thread_ts
+    ? ` thread_ts: ${message.thread_ts}${message.parent_user_id ? ` parent_user: ${message.parent_user_id}` : ""}`
+    : "";
+  const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}${threadInfo}]`;
   const storePath = resolveStorePath(ctx.cfg.session?.store, {
     agentId: route.agentId,
   });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -399,9 +399,10 @@ export async function prepareSlackMessage(params: {
       GroupSubject: isRoomish ? roomLabel : undefined,
       From: slackFrom,
     }) ?? (isDirectMessage ? senderName : roomLabel);
-  const threadInfo = message.thread_ts
-    ? ` thread_ts: ${message.thread_ts}${message.parent_user_id ? ` parent_user: ${message.parent_user_id}` : ""}`
-    : "";
+  const threadInfo =
+    isThreadReply && threadTs
+      ? ` thread_ts: ${threadTs}${message.parent_user_id ? ` parent_user_id: ${message.parent_user_id}` : ""}`
+      : "";
   const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}${threadInfo}]`;
   const storePath = resolveStorePath(ctx.cfg.session?.store, {
     agentId: route.agentId,


### PR DESCRIPTION
Adds `thread_ts` and `parent_user_id` to the Slack message footer for thread replies, giving agents awareness of thread context. Top-level messages remain unchanged.

**Changes:**
- `prepare.ts`: Appends `thread_ts` and `parent_user_id` to the existing message metadata footer when the message is a thread reply
- `prepare.inbound-contract.test.ts`: Adds 2 new tests verifying thread metadata inclusion/exclusion

**Example footer for thread replies:**
```
[slack message id: 1.002 channel: D123 thread_ts: 1.000 parent_user: U2]
```

**Example footer for top-level messages (unchanged):**
```
[slack message id: 1.000 channel: D123]
```

All 5 tests passing. Clean rebase on latest main.

Supersedes #6534 (rebased cleanly from scratch to avoid accumulated merge noise).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the Slack inbound message footer in `prepareSlackMessage` to include thread metadata for replies by appending `thread_ts` and (optionally) the parent user id, and adds contract tests to verify inclusion/exclusion.

The implementation currently builds the footer directly from the raw Slack event fields (`message.thread_ts` / `message.parent_user_id`) while the rest of the Slack pipeline already centralizes thread semantics in `resolveSlackThreadContext` (used earlier in `prepareSlackMessage` to derive `isThreadReply`, `MessageThreadId`, etc.). Aligning the footer condition and field naming with that existing thread context logic will keep top-level messages unchanged and avoid confusing metadata keys.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a logic mismatch that can change top-level message footers in some Slack event shapes.
- The change is small and well-tested for the common cases, but it gates footer thread metadata on `message.thread_ts` instead of the existing `isThreadReply` logic, which can mislabel root messages that carry `thread_ts`. There is also an inconsistent key name for the parent user field relative to the PR description.
- src/slack/monitor/message-handler/prepare.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->