### PR TITLE
feat(telegram): render blockquotes as native <blockquote> tags (#14608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Telegram: render blockquotes as native `<blockquote>` tags instead of stripping them. (#14608)
 - Version alignment: bump manifests and package versions to `2026.2.10`; keep `appcast.xml` unchanged until the next macOS release cut.
 - CLI: add `openclaw logs --local-time` to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
 - Config: avoid redacting `maxTokens`-like fields during config snapshot redaction, preventing round-trip validation failures in `/config`. (#14006) Thanks @constansino.

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -24,7 +24,14 @@ type MarkdownToken = {
   attrGet?: (name: string) => string | null;
 };
 
-export type MarkdownStyle = "bold" | "italic" | "strikethrough" | "code" | "code_block" | "spoiler";
+export type MarkdownStyle =
+  | "bold"
+  | "italic"
+  | "strikethrough"
+  | "code"
+  | "code_block"
+  | "spoiler"
+  | "blockquote";
 
 export type MarkdownStyleSpan = {
   start: number;
@@ -578,8 +585,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         if (state.blockquotePrefix) {
           state.text += state.blockquotePrefix;
         }
+        openStyle(state, "blockquote");
         break;
       case "blockquote_close":
+        closeStyle(state, "blockquote");
         state.text += "\n";
         break;
       case "bullet_list_open":

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -21,6 +21,7 @@ export type RenderOptions = {
 };
 
 const STYLE_ORDER: MarkdownStyle[] = [
+  "blockquote",
   "code_block",
   "code",
   "bold",

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -37,9 +37,23 @@ describe("markdownToTelegramHtml", () => {
     expect(res).toBe("2. two\n3. three");
   });
 
-  it("flattens headings and blockquotes", () => {
-    const res = markdownToTelegramHtml("# Title\n\n> Quote");
-    expect(res).toBe("Title\n\nQuote");
+  it("flattens headings", () => {
+    const res = markdownToTelegramHtml("# Title");
+    expect(res).toBe("Title");
+  });
+
+  it("renders blockquotes as native Telegram blockquote tags", () => {
+    const res = markdownToTelegramHtml("> Quote");
+    expect(res).toContain("<blockquote>");
+    expect(res).toContain("Quote");
+    expect(res).toContain("</blockquote>");
+  });
+
+  it("renders blockquotes with inline formatting", () => {
+    const res = markdownToTelegramHtml("> **bold** quote");
+    expect(res).toContain("<blockquote>");
+    expect(res).toContain("<b>bold</b>");
+    expect(res).toContain("</blockquote>");
   });
 
   it("renders fenced code blocks", () => {

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -56,6 +56,18 @@ describe("markdownToTelegramHtml", () => {
     expect(res).toContain("</blockquote>");
   });
 
+  it("renders multiline blockquotes as a single Telegram blockquote", () => {
+    const res = markdownToTelegramHtml("> first\n> second");
+    expect(res).toBe("<blockquote>first\nsecond</blockquote>");
+  });
+
+  it("renders separated quoted paragraphs as distinct blockquotes", () => {
+    const res = markdownToTelegramHtml("> first\n\n> second");
+    expect(res).toContain("<blockquote>first");
+    expect(res).toContain("<blockquote>second</blockquote>");
+    expect(res.match(/<blockquote>/g)).toHaveLength(2);
+  });
+
   it("renders fenced code blocks", () => {
     const res = markdownToTelegramHtml("```js\nconst x = 1;\n```");
     expect(res).toBe("<pre><code>const x = 1;\n</code></pre>");

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -46,6 +46,7 @@ function renderTelegramHtml(ir: MarkdownIR): string {
       code: { open: "<code>", close: "</code>" },
       code_block: { open: "<pre><code>", close: "</code></pre>" },
       spoiler: { open: "<tg-spoiler>", close: "</tg-spoiler>" },
+      blockquote: { open: "<blockquote>", close: "</blockquote>" },
     },
     escapeText: escapeHtml,
     buildLink: buildTelegramLink,


### PR DESCRIPTION
## Summary

Fixes #14608

## Problem

The Telegram message formatter strips blockquote markers by setting `blockquotePrefix: ""` in the markdown-to-IR conversion. This means any blockquoted text (`> Quote`) loses its visual distinction when sent to Telegram — it renders as plain `Quote` with no formatting.

Telegram Bot API 7.0 (January 2024) added native support for the `<blockquote>` HTML tag, but OpenClaw does not use it.

**Before fix:**
```
Input:  "> This is a quote"
Output: "This is a quote"     (blockquote stripped)
```

## Fix

1. Add `"blockquote"` to the `MarkdownStyle` union type in `src/markdown/ir.ts`
2. Track blockquote content as style spans using `openStyle`/`closeStyle` in the IR token processor (same pattern as headings using bold)
3. Add `"blockquote"` to `STYLE_ORDER` in `src/markdown/render.ts` (outermost priority)
4. Add `blockquote: { open: "<blockquote>", close: "</blockquote>" }` to Telegram HTML style markers

**After fix:**
```
Input:  "> This is a quote"
Output: "<blockquote>This is a quote</blockquote>"
```

Other channels (Slack, Signal, Line, WhatsApp) are unaffected — they don't include `blockquote` in their `styleMarkers`, so the blockquote style span is simply ignored during rendering.

## Testing

- ✅ 17 tests pass (`pnpm vitest run src/telegram/format.test.ts`)
- ✅ 25 markdown IR tests pass (`pnpm vitest run src/markdown/`)
- ✅ 56 Slack + Line format tests pass (no regressions)
- ✅ Lint passes (`pnpm lint`)

## Effect on User Experience

**Before:** Blockquoted text in AI responses sent to Telegram loses all visual distinction — users cannot tell what was quoted vs. original text.

**After:** Blockquotes render as native Telegram blockquotes with the characteristic left-border visual, matching how Telegram displays `<blockquote>` content.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds first-class support for Markdown blockquotes in the shared Markdown IR/rendering pipeline, then enables Telegram to emit native `<blockquote>...</blockquote>` HTML for quoted text. Concretely:

- Extends the `MarkdownStyle` union with a new `blockquote` style and emits it as a style span when encountering `blockquote_open/close` tokens during Markdown → IR conversion.
- Updates the shared renderer’s `STYLE_ORDER` to treat `blockquote` as the outermost style for tag nesting.
- Adds Telegram HTML style markers for `blockquote`, and updates Telegram formatter tests to assert blockquote output (including inline formatting within quotes).
- Adds a changelog entry for the user-facing Telegram behavior change.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized and consistent across the IR type, IR token processing, renderer ordering, Telegram style markers, and tests. The renderer already ignores unknown styles per-channel via `styleMarkers`, so adding a new style is low-risk for other channels.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->