### PR TITLE
fix: clean up stale session write locks on in-process restart

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,5 +1,6 @@
 import type { startGatewayServer } from "../../gateway/server.js";
 import type { defaultRuntime } from "../../runtime.js";
+import { invalidateSessionWriteLocks } from "../../agents/session-write-lock.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import {
   consumeGatewaySigusr1RestartAuthorization,
@@ -53,6 +54,7 @@ export async function runGatewayLoop(params: {
         clearTimeout(forceExitTimer);
         server = null;
         if (isRestart) {
+          invalidateSessionWriteLocks();
           shuttingDown = false;
           restartResolver?.();
         } else {


### PR DESCRIPTION
## Summary

After an in-process restart via SIGUSR1, on-disk session write lock files (`.lock`) persist and block session access for up to 30 minutes. In PID 1 containers the lock's PID check still passes (same process) and `createdAt` is recent, so the lock is never considered stale.

## Root Cause

- Session write locks store `{ pid, createdAt }` on disk
- On SIGUSR1, gateway restarts in-place — same process, same PID
- `isAlive(1)` returns true → lock not reclaimed → session blocked

## Fix

Add a unique **boot ID** (UUID) to each lock file payload. On SIGUSR1 restart:

1. `invalidateSessionWriteLocks()` releases all held in-memory locks and removes their lock files
2. A new `bootId` is generated for the new boot cycle
3. Any surviving lock file from a previous boot cycle is detected via `bootId` mismatch and immediately reclaimed — regardless of PID liveness or age

The fix is **backwards-compatible**: lock files without a `bootId` field (from older versions) fall through to the existing PID/staleness checks.

## Changes

- **`src/agents/session-write-lock.ts`**: Add `bootId` to lock payload, `invalidateSessionWriteLocks()` export, boot mismatch detection in stale check
- **`src/cli/gateway-cli/run-loop.ts`**: Call `invalidateSessionWriteLocks()` after server close during SIGUSR1 restart
- **`src/agents/session-write-lock.test.ts`**: 3 new tests covering boot mismatch reclaim, invalidation, and backwards compatibility

Closes #4043

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a per-process `bootId` to on-disk session write lock files and introduces `invalidateSessionWriteLocks()` so an in-process gateway restart (SIGUSR1) can release any held locks and ensure surviving `.lock` files from the previous boot cycle are immediately reclaimed. The gateway run loop now calls `invalidateSessionWriteLocks()` after closing the server during a restart, and new tests cover boot mismatch reclamation, invalidation behavior, and backwards compatibility with legacy lock payloads missing `bootId`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized and consistent: lock payload adds an optional field with a compatibility path, reclaim logic is gated on bootId presence, and the gateway restart path explicitly invalidates held locks. Tests cover the new behaviors (boot mismatch reclaim, invalidation, legacy payload handling). Repository Node engine (>=22.12.0) supports crypto.randomUUID, so the new bootId generation is compatible.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->