### PR TITLE
fix: normalize peer.kind in resolveAgentRoute for symmetric matching

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -171,7 +171,12 @@ function matchesTeam(match: { teamId?: string | undefined } | undefined, teamId:
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
-  const peer = input.peer ? { kind: input.peer.kind, id: normalizeId(input.peer.id) } : null;
+  const peer = input.peer
+    ? {
+        kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
+        id: normalizeId(input.peer.id),
+      }
+    : null;
   const guildId = normalizeId(input.guildId);
   const teamId = normalizeId(input.teamId);
 
@@ -221,7 +226,10 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   // Thread parent inheritance: if peer (thread) didn't match, check parent peer binding
   const parentPeer = input.parentPeer
-    ? { kind: input.parentPeer.kind, id: normalizeId(input.parentPeer.id) }
+    ? {
+        kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
+        id: normalizeId(input.parentPeer.id),
+      }
     : null;
   if (parentPeer && parentPeer.id) {
     const parentPeerMatch = bindings.find((b) => matchesPeer(b.match, parentPeer));


### PR DESCRIPTION
## Summary

Fixes #14612 — Asymmetric normalization in `resolveAgentRoute` causes peer-based binding matching to always fail.

## Problem

`matchesPeer()` normalizes `"dm" → "direct"` on the **config side** via `normalizeChatType()`, but `resolveAgentRoute()` leaves the incoming `peer.kind` raw (`"dm"`). This means the comparison always fails when the runtime peer kind is `"dm"` and the config binding uses `"direct"` (or vice versa).

## Fix

Apply `normalizeChatType()` to `peer.kind` and `parentPeer.kind` in `resolveAgentRoute()` when constructing the normalized peer objects, ensuring symmetric normalization on both sides of the comparison.

This is a 2-line change in `src/routing/resolve-route.ts`.

## Tests

Added 3 test cases covering:
- Runtime `"dm"` peer matching config `"direct"` binding
- Runtime `"dm"` parentPeer matching config `"direct"` binding  
- Both config and runtime using `"dm"` (symmetric normalization)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveAgentRoute` to normalize incoming `peer.kind` and `parentPeer.kind` via `normalizeChatType()`, making peer-binding matching symmetric with the existing config-side normalization in `matchesPeer()`.

It also adds three regression tests covering runtime `"dm"` vs config `"direct"` matching for both `peer` and `parentPeer`, plus a `"dm"`/`"dm"` symmetric case.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge once the new tests avoid invalid type casting.
- The production change is small and scoped (normalizing `peer.kind`/`parentPeer.kind` before matching) and aligns with existing config-side normalization. The main concern is test quality/type-safety: the added tests currently rely on `as unknown as ChatType` to inject an impossible `ChatType` value ("dm"), which can mask real typing issues and reduce confidence in the test suite’s signal.
- src/routing/resolve-route.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->