### PR TITLE
fix: prefer runtime model config for contextTokens over persisted session value

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -321,9 +321,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   const provider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
   let model = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
   let contextTokens =
-    entry?.contextTokens ??
     args.agent?.contextTokens ??
     lookupContextTokens(model) ??
+    entry?.contextTokens ??
     DEFAULT_CONTEXT_TOKENS;
 
   let inputTokens = entry?.inputTokens;


### PR DESCRIPTION
## Summary

`session_status` was showing 200k context window instead of the configured 1M because `contextTokens` gets baked into `sessions.json` at session creation time using `DEFAULT_CONTEXT_TOKENS` (200,000), and the nullish coalescing chain in `buildStatusMessage` always picked the persisted value first:

```js
// Before (persisted value always wins)
let contextTokens =
    entry?.contextTokens ??        // 200000 from store — always truthy
    args.agent?.contextTokens ??   // never reached
    lookupContextTokens(model) ??
    DEFAULT_CONTEXT_TOKENS;
```

## Fix

Reorder the resolution chain so runtime config takes priority over the stale persisted value:

```js
// After (runtime config wins)
let contextTokens =
    args.agent?.contextTokens ??   // from current openclaw.json
    lookupContextTokens(model) ??  // model-specific lookup
    entry?.contextTokens ??        // fallback to persisted
    DEFAULT_CONTEXT_TOKENS;
```

## Tests

Added test `prefers runtime agent contextTokens over persisted session value` that verifies when agent config has 1M context but session store has 200k, the status output shows 1M.

Fixes #14332

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `buildStatusMessage` to resolve `contextTokens` from the *runtime* agent config first, then fall back to model-based lookup, then to the persisted session value, and finally to `DEFAULT_CONTEXT_TOKENS`. A new unit test asserts the status output prefers a 1M runtime context window over a stale 200k persisted value.

This fits into the auto-reply `/status` output generation path (`src/auto-reply/status.ts`) by making the reported context window reflect the current `openclaw.json` configuration rather than what was captured at session creation time in `sessions.json`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized precedence fix in `buildStatusMessage` plus a targeted regression test that covers the reported bug. No other behavior changes were found in the reviewed code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->