### PR TITLE
fix: coerce string tool args to objects in dispatch pipeline

### DIFF
--- a/src/agents/pi-tool-definition-adapter.coerce-tool-args.test.ts
+++ b/src/agents/pi-tool-definition-adapter.coerce-tool-args.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+// We test the coercion indirectly through toToolDefinitions since
+// coerceToolArgs is not exported.  The key assertion is that a tool
+// whose execute() receives `args` as a JSON *string* still runs
+// correctly after the adapter coerces them.
+
+vi.mock("../logger.js", () => ({
+  logDebug: () => {},
+  logError: () => {},
+  logWarn: () => {},
+}));
+
+vi.mock("./tool-policy.js", () => ({
+  normalizeToolName: (name: string) => name,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => null,
+}));
+
+import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+
+describe("toToolDefinitions – argument coercion", () => {
+  function makeTool(name: string) {
+    const executeFn = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      details: {},
+    });
+    return {
+      name,
+      label: name,
+      description: "test tool",
+      parameters: { type: "object", properties: {} },
+      execute: executeFn,
+      _executeFn: executeFn,
+    };
+  }
+
+  it("passes object args through unchanged", async () => {
+    const tool = makeTool("my_tool");
+    const [def] = toToolDefinitions([tool]);
+    const args = { foo: "bar" };
+    await def.execute("call-1", args, undefined, undefined, undefined);
+    expect(tool._executeFn).toHaveBeenCalledWith("call-1", args, undefined, undefined);
+  });
+
+  it("coerces a JSON string to an object", async () => {
+    const tool = makeTool("my_tool");
+    const [def] = toToolDefinitions([tool]);
+    await def.execute("call-2", '{"kinds":["main"]}' as unknown, undefined, undefined, undefined);
+    expect(tool._executeFn).toHaveBeenCalledWith(
+      "call-2",
+      { kinds: ["main"] },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("coerces an empty JSON string '{}' to an empty object", async () => {
+    const tool = makeTool("sessions_list");
+    const [def] = toToolDefinitions([tool]);
+    await def.execute("call-3", "{}" as unknown, undefined, undefined, undefined);
+    expect(tool._executeFn).toHaveBeenCalledWith("call-3", {}, undefined, undefined);
+  });
+
+  it("leaves a non-JSON string as-is (no crash)", async () => {
+    const tool = makeTool("my_tool");
+    const [def] = toToolDefinitions([tool]);
+    await def.execute("call-4", "not-json" as unknown, undefined, undefined, undefined);
+    expect(tool._executeFn).toHaveBeenCalledWith("call-4", "not-json", undefined, undefined);
+  });
+
+  it("passes undefined/null args through unchanged", async () => {
+    const tool = makeTool("my_tool");
+    const [def] = toToolDefinitions([tool]);
+    await def.execute("call-5", undefined, undefined, undefined, undefined);
+    expect(tool._executeFn).toHaveBeenCalledWith("call-5", undefined, undefined, undefined);
+  });
+});

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -37,7 +37,10 @@ export function createSessionsListTool(opts?: {
     description: "List sessions with optional filters and last messages.",
     parameters: SessionsListToolSchema,
     execute: async (_toolCallId, args) => {
-      const params = args as Record<string, unknown>;
+      const params = (typeof args === "string" ? JSON.parse(args || "{}") : (args ?? {})) as Record<
+        string,
+        unknown
+      >;
       const cfg = loadConfig();
       const { mainKey, alias } = resolveMainSessionAlias(cfg);
       const visibility = resolveSandboxSessionToolsVisibility(cfg);


### PR DESCRIPTION
## Problem

When the LLM calls `sessions_list` with empty arguments `{}`, some code paths deliver the arguments as a JSON **string** (`"{}"`) rather than a parsed object. Tools with all-optional parameters then hit a JSON parsing error because the execute handler expects a plain object.

## Fix

1. **`pi-tool-definition-adapter.ts`** – Add a `coerceToolArgs()` guard that detects string arguments and parses them before forwarding to the tool's execute function. Applied in both `toToolDefinitions()` and `toClientToolDefinitions()`.

2. **`sessions-list-tool.ts`** – Defence-in-depth: handle string/nullish args gracefully at the tool level.

3. **New test file** – 5 tests covering: object passthrough, JSON string coercion, empty `{}` string, non-JSON string fallback, and undefined/null args.

## Testing

All existing tests pass. New test file: `pi-tool-definition-adapter.coerce-tool-args.test.ts`

Fixes #14405

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a dispatch-pipeline inconsistency where tool-call `params` sometimes arrive as a JSON string (e.g. `"{}"`) instead of an object. It adds a coercion guard in `src/agents/pi-tool-definition-adapter.ts` to parse JSON strings into plain objects for both local tools (`toToolDefinitions`) and client tools (`toClientToolDefinitions`), plus a new Vitest file to cover the coercion behavior.

It also updates the built-in `sessions_list` tool to accept string/nullish args, aiming for defense-in-depth.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but `sessions_list` can still crash on invalid string arguments.
- The core adapter-side coercion is small and well-scoped, and the new tests cover the intended string-to-object behavior. The remaining concern is an unguarded `JSON.parse` added in `sessions-list-tool.ts` that can throw if any non-JSON string slips through, which would undermine the goal of making tool execution more robust.
- src/agents/tools/sessions-list-tool.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->