### PR TITLE
fix: unescape literal \n in write/edit tool content

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -40,6 +40,8 @@ import {
   createSandboxedWriteTool,
   normalizeToolParams,
   patchToolSchemaForClaudeCompatibility,
+  normalizeEditContent,
+  normalizeWriteContent,
   wrapToolParamNormalization,
 } from "./pi-tools.read.js";
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
@@ -262,7 +264,7 @@ export function createOpenClawCodingTools(options?: {
       }
       // Wrap with param normalization for Claude Code compatibility
       return [
-        wrapToolParamNormalization(createWriteTool(workspaceRoot), CLAUDE_PARAM_GROUPS.write),
+        wrapToolParamNormalization(createWriteTool(workspaceRoot), CLAUDE_PARAM_GROUPS.write, normalizeWriteContent),
       ];
     }
     if (tool.name === "edit") {
@@ -270,7 +272,7 @@ export function createOpenClawCodingTools(options?: {
         return [];
       }
       // Wrap with param normalization for Claude Code compatibility
-      return [wrapToolParamNormalization(createEditTool(workspaceRoot), CLAUDE_PARAM_GROUPS.edit)];
+      return [wrapToolParamNormalization(createEditTool(workspaceRoot), CLAUDE_PARAM_GROUPS.edit, normalizeEditContent)];
     }
     return [tool];
   });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -264,7 +264,11 @@ export function createOpenClawCodingTools(options?: {
       }
       // Wrap with param normalization for Claude Code compatibility
       return [
-        wrapToolParamNormalization(createWriteTool(workspaceRoot), CLAUDE_PARAM_GROUPS.write, normalizeWriteContent),
+        wrapToolParamNormalization(
+          createWriteTool(workspaceRoot),
+          CLAUDE_PARAM_GROUPS.write,
+          normalizeWriteContent,
+        ),
       ];
     }
     if (tool.name === "edit") {
@@ -272,7 +276,13 @@ export function createOpenClawCodingTools(options?: {
         return [];
       }
       // Wrap with param normalization for Claude Code compatibility
-      return [wrapToolParamNormalization(createEditTool(workspaceRoot), CLAUDE_PARAM_GROUPS.edit, normalizeEditContent)];
+      return [
+        wrapToolParamNormalization(
+          createEditTool(workspaceRoot),
+          CLAUDE_PARAM_GROUPS.edit,
+          normalizeEditContent,
+        ),
+      ];
     }
     return [tool];
   });

--- a/src/agents/pi-tools.unescape-literal-escapes.test.ts
+++ b/src/agents/pi-tools.unescape-literal-escapes.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeEditContent,
+  normalizeWriteContent,
+  unescapeLiteralEscapes,
+} from "./pi-tools.read.js";
+
+describe("unescapeLiteralEscapes", () => {
+  it("returns text unchanged when no backslashes present", () => {
+    expect(unescapeLiteralEscapes("hello world")).toBe("hello world");
+  });
+
+  it("returns text unchanged when backslash present but no \\n", () => {
+    expect(unescapeLiteralEscapes("path\\to\\file")).toBe("path\\to\\file");
+  });
+
+  it("converts literal \\n to real newlines when no real newlines exist", () => {
+    expect(unescapeLiteralEscapes("Line1\\nLine2\\nLine3")).toBe("Line1\nLine2\nLine3");
+  });
+
+  it("converts literal \\t to real tabs", () => {
+    expect(unescapeLiteralEscapes("col1\\tcol2\\nrow2")).toBe("col1\tcol2\nrow2");
+  });
+
+  it("converts literal \\r to real carriage return", () => {
+    expect(unescapeLiteralEscapes("line1\\r\\nline2")).toBe("line1\r\nline2");
+  });
+
+  it("handles escaped backslashes (\\\\n stays as backslash + newline)", () => {
+    // \\n in source = the model intended a literal backslash followed by n
+    expect(unescapeLiteralEscapes("regex: \\\\n pattern\\n")).toBe("regex: \\n pattern\n");
+  });
+
+  it("leaves text unchanged when real newlines already exist", () => {
+    // Mixed content: model sent some real newlines and some literal \\n.
+    // Assume the literal ones are intentional (e.g. code with escape sequences).
+    const input = "line1\nconst s = 'hello\\nworld';";
+    expect(unescapeLiteralEscapes(input)).toBe(input);
+  });
+
+  it("handles empty string", () => {
+    expect(unescapeLiteralEscapes("")).toBe("");
+  });
+
+  it("handles escaped quotes", () => {
+    expect(unescapeLiteralEscapes('say \\"hello\\"\\nbye')).toBe('say "hello"\nbye');
+  });
+
+  it("handles content that is only \\n", () => {
+    expect(unescapeLiteralEscapes("\\n")).toBe("\n");
+  });
+
+  it("handles multiple consecutive \\n", () => {
+    expect(unescapeLiteralEscapes("a\\n\\n\\nb")).toBe("a\n\n\nb");
+  });
+});
+
+describe("normalizeWriteContent", () => {
+  it("unescapes literal \\n in content field", () => {
+    const params = { path: "test.txt", content: "Line1\\nLine2" };
+    const result = normalizeWriteContent(params);
+    expect(result.content).toBe("Line1\nLine2");
+    expect(result.path).toBe("test.txt");
+  });
+
+  it("returns params unchanged when content has real newlines", () => {
+    const params = { path: "test.txt", content: "Line1\nLine2" };
+    const result = normalizeWriteContent(params);
+    expect(result).toBe(params); // Same reference = no change
+  });
+
+  it("returns params unchanged when content is not a string", () => {
+    const params = { path: "test.txt", content: 42 };
+    const result = normalizeWriteContent(params);
+    expect(result).toBe(params);
+  });
+
+  it("returns params unchanged when content has no escapes", () => {
+    const params = { path: "test.txt", content: "simple text" };
+    const result = normalizeWriteContent(params);
+    expect(result).toBe(params);
+  });
+});
+
+describe("normalizeEditContent", () => {
+  it("unescapes literal \\n in oldText and newText", () => {
+    const params = {
+      path: "test.txt",
+      oldText: "old\\ntext",
+      newText: "new\\ntext",
+    };
+    const result = normalizeEditContent(params);
+    expect(result.oldText).toBe("old\ntext");
+    expect(result.newText).toBe("new\ntext");
+  });
+
+  it("returns params unchanged when both fields have real newlines", () => {
+    const params = {
+      path: "test.txt",
+      oldText: "old\ntext",
+      newText: "new\ntext",
+    };
+    const result = normalizeEditContent(params);
+    expect(result).toBe(params);
+  });
+
+  it("handles only oldText needing fix", () => {
+    const params = {
+      path: "test.txt",
+      oldText: "old\\ntext",
+      newText: "new\ntext",
+    };
+    const result = normalizeEditContent(params);
+    expect(result.oldText).toBe("old\ntext");
+    expect(result.newText).toBe("new\ntext");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #14452

Some models (e.g. XAI/Grok) emit tool-call arguments where string values contain the two-character sequence `\\` `n` instead of a real `0x0a` newline. After `JSON.parse` the string still holds the literal characters, causing all text files written via the `write` tool to contain visible `\n` instead of actual line breaks.

## Changes

- Added `unescapeLiteralEscapes()` — a conservative heuristic that detects literal escape sequences and converts them to real bytes (`\n` → newline, `\t` → tab, `\r` → CR, `\\\\` → backslash, `\\"` → quote)
- Applied to the **write** tool's `content` parameter via `normalizeWriteContent()`
- Applied to the **edit** tool's `oldText`/`newText` parameters via `normalizeEditContent()`
- Both sandbox and non-sandbox code paths are covered

## Safety

The function is intentionally conservative:
- Only activates when text contains literal `\n` but **no** real newlines
- If real newlines exist alongside literal `\n`, assumes the backslash-n is intentional (e.g. code/regex) and skips entirely
- Uses a single-pass regex replacement for correctness with escaped backslashes (`\\n` → `\n`)

## Tests

18 new unit tests covering:
- Basic `\n`/`\t`/`\r` unescaping
- Mixed real + literal newlines (no-op)  
- Escaped backslashes (`\\n`)
- Empty strings, edge cases
- `normalizeWriteContent` and `normalizeEditContent` wrappers

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a conservative content normalizer to the `write` and `edit` tool wrappers to fix cases where some providers emit literal `\\n` sequences (two characters) instead of actual newline bytes in tool-call arguments. The new `unescapeLiteralEscapes()` helper is applied via `normalizeWriteContent()` (for `content`) and `normalizeEditContent()` (for `oldText`/`newText`) in both sandboxed and non-sandboxed tool construction paths, and is covered by a new Vitest suite for the helper and wrappers.

The change fits into the existing tool-compatibility layer in `src/agents/pi-tools.read.ts`, which already normalizes Claude-style parameter aliases (`file_path`, `old_string`, `new_string`) and patches tool schemas for provider compatibility; this PR extends that normalization to handle the specific literal-escape encoding issue before delegating to `pi-coding-agent`’s tool implementations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to tool parameter normalization and guarded by a conservative heuristic that only triggers in the specific failure mode (literal `\\n` present with no real newlines). Both sandbox and non-sandbox wiring paths apply the normalizer, and the new behavior is covered by unit tests for the helper and wrapper functions.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->