### PR TITLE
fix(cron): prevent list()/status() from silently skipping due jobs (#14356)

### DIFF
--- a/src/cron/service.issue-14356-list-status-skip.test.ts
+++ b/src/cron/service.issue-14356-list-status-skip.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("issue #14356 — list()/status() must not skip due jobs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-12T12:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("list() must not advance a past-due nextRunAtMs without executing the job", async () => {
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "ok" as const,
+      summary: "done",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+
+    const job = await cron.add({
+      name: "isolated every-5m",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 5 * 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Test" },
+      delivery: { mode: "none" },
+    });
+
+    const firstDueAt = job.state.nextRunAtMs!;
+    expect(firstDueAt).toBe(Date.parse("2026-02-12T12:00:00.000Z") + 5 * 60_000);
+
+    // Advance time 1 second past the due time.
+    vi.setSystemTime(new Date(firstDueAt + 1000));
+
+    // Simulate a client calling list() BEFORE the timer fires
+    // (e.g. a TUI refresh or WebSocket poll).
+    const jobsBefore = await cron.list({ includeDisabled: true });
+    const jobBefore = jobsBefore.find((j) => j.id === job.id)!;
+
+    // nextRunAtMs must NOT have been advanced — the job has not been
+    // executed yet. Advancing it here would silently skip the run.
+    expect(jobBefore.state.nextRunAtMs).toBe(firstDueAt);
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("status() must not advance a past-due nextRunAtMs without executing the job", async () => {
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "ok" as const,
+      summary: "done",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+
+    const job = await cron.add({
+      name: "isolated cron-expr",
+      enabled: true,
+      schedule: { kind: "cron", expr: "*/30 * * * *", tz: "UTC" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Test" },
+      delivery: { mode: "none" },
+    });
+
+    const firstDueAt = job.state.nextRunAtMs!;
+
+    // Advance past due.
+    vi.setSystemTime(new Date(firstDueAt + 1000));
+
+    // Status poll — must not advance nextRunAtMs.
+    await cron.status();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const j = jobs.find((j) => j.id === job.id)!;
+    expect(j.state.nextRunAtMs).toBe(firstDueAt);
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("job fires after repeated list() polls around the due time", async () => {
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "ok" as const,
+      summary: "done",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+
+    const job = await cron.add({
+      name: "isolated every-5m",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 5 * 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Test" },
+      delivery: { mode: "none" },
+    });
+
+    const firstDueAt = job.state.nextRunAtMs!;
+
+    // Advance past due.
+    vi.setSystemTime(new Date(firstDueAt + 1000));
+
+    // Simulate repeated list() polls (TUI, WebSocket, CLI, etc.)
+    for (let i = 0; i < 10; i++) {
+      await cron.list();
+    }
+
+    // Now let the timer fire and execute the job.
+    let fired = false;
+    for (let i = 0; i < 30; i++) {
+      await vi.runOnlyPendingTimersAsync();
+      const jobs = await cron.list({ includeDisabled: true });
+      const j = jobs.find((j) => j.id === job.id);
+      if (j?.state.lastStatus === "ok") {
+        fired = true;
+        break;
+      }
+    }
+
+    expect(fired).toBe(true);
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -8,6 +8,7 @@ import {
   isJobDue,
   nextWakeAtMs,
   recomputeNextRuns,
+  recomputeNextRunsForMaintenance,
 } from "./jobs.js";
 import { locked } from "./locked.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
@@ -53,7 +54,7 @@ export async function status(state: CronServiceState) {
   return await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     if (state.store) {
-      const changed = recomputeNextRuns(state);
+      const changed = recomputeNextRunsForMaintenance(state);
       if (changed) {
         await persist(state);
       }
@@ -71,7 +72,7 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
   return await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     if (state.store) {
-      const changed = recomputeNextRuns(state);
+      const changed = recomputeNextRunsForMaintenance(state);
       if (changed) {
         await persist(state);
       }


### PR DESCRIPTION
## Summary

Read-only operations `list()` and `status()` called `recomputeNextRuns()` which advances past-due `nextRunAtMs` values to the next occurrence. When a client (WebSocket, TUI, CLI) polls list/status around the time a job becomes due, this race causes the scheduler to silently skip the execution — the job appears to have "fired" (nextRunAtMs advances) but `runIsolatedAgentJob` is never called.

## Root Cause

`recomputeNextRuns()` treats any past-due `nextRunAtMs` as needing recomputation and advances it to the next schedule occurrence. This is correct **after** a job has been executed (in `onTimer` results processing), but wrong in read-only paths like `list()` and `status()`.

The fix in #14068 / #13992 addressed this for `onTimer`'s "no due jobs" path by introducing `recomputeNextRunsForMaintenance()`, but missed the `list()` and `status()` call sites.

## Fix

Replace `recomputeNextRuns()` with `recomputeNextRunsForMaintenance()` in both `list()` and `status()`. The maintenance variant:
- Fills in missing `nextRunAtMs` for newly enabled jobs ✅
- Clears `nextRunAtMs` for disabled jobs ✅
- Clears stuck running markers (>2h) ✅
- **Does NOT advance past-due values** — leaves them for `onTimer` to execute ✅

## Tests

Three regression tests:
1. `list()` does not advance a past-due `nextRunAtMs`
2. `status()` does not advance a past-due `nextRunAtMs`
3. Jobs still fire correctly after repeated `list()` polls around the due time

All 125 existing cron tests continue to pass.

Fixes #14356

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a scheduler race where read-only `CronService.list()` / `status()` could call `recomputeNextRuns()` and advance a past-due `nextRunAtMs` without executing the job, causing due runs to be silently skipped when clients poll around the due time.

The change swaps those call sites in `src/cron/service/ops.ts` to use `recomputeNextRunsForMaintenance()` instead, preserving past-due `nextRunAtMs` values for `onTimer` to execute while still performing maintenance actions (fill missing `nextRunAtMs`, clear disabled jobs’ `nextRunAtMs`, clear stuck `runningAtMs`).

It adds a regression test file (`src/cron/service.issue-14356-list-status-skip.test.ts`) covering that `list()` and `status()` do not advance a past-due run and that a job still fires after repeated `list()` polling around the due time.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and addresses a real cron scheduling race, with only minor test robustness concerns.
- The functional change is small and targeted (switching list/status to the maintenance recompute path) and aligns with existing onTimer behavior. Added tests cover the reported regression. The main remaining concern is that the new tests perform filesystem cleanup immediately after a synchronous stop, which can become flaky if shutdown ever involves async persistence.
- src/cron/service.issue-14356-list-status-skip.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->