### PR TITLE
feat(plugins): allow before_agent_start hook to override model (#14585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - CLI/Plugins: add `openclaw plugins uninstall <id>` with `--dry-run`, `--force`, and `--keep-files` options, including safe uninstall path handling and plugin uninstall docs. (#5985) Thanks @JustasMonkev.
+- Plugins: allow `before_agent_start` hook to override the model for the current turn via a `model` field in the result. (#14585)
 - CLI: add `openclaw logs --local-time` to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
 - Telegram: render blockquotes as native `<blockquote>` tags instead of stripping them. (#14608)
 - Telegram: expose `/compact` in the native command menu. (#10352) Thanks @akramcodez.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2,7 +2,9 @@ import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import {
@@ -194,12 +196,44 @@ export async function runEmbeddedPiAgent(
       }
       const prevCwd = process.cwd();
 
-      const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+      let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+      let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
       const fallbackConfigured =
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
       await ensureOpenClawModelsJson(params.config, agentDir);
+
+      // Run before_agent_start hook to allow plugins to override the model
+      // before session creation. Only the model field is consumed here;
+      // systemPrompt and prependContext are consumed later in attempt.ts.
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("before_agent_start")) {
+        try {
+          const hookAgentId =
+            typeof params.agentId === "string" && params.agentId.trim()
+              ? normalizeAgentId(params.agentId)
+              : undefined;
+          const hookResult = await hookRunner.runBeforeAgentStart(
+            { prompt: params.prompt },
+            {
+              agentId: hookAgentId,
+              sessionKey: params.sessionKey,
+              workspaceDir: params.workspaceDir,
+              messageProvider: params.messageProvider ?? undefined,
+            },
+          );
+          if (hookResult?.model) {
+            const slashIdx = hookResult.model.indexOf("/");
+            if (slashIdx > 0) {
+              provider = hookResult.model.slice(0, slashIdx);
+              modelId = hookResult.model.slice(slashIdx + 1);
+              log.info(`hooks: before_agent_start overrode model to ${provider}/${modelId}`);
+            }
+          }
+        } catch (hookErr) {
+          log.warn(`before_agent_start hook (model phase) failed: ${String(hookErr)}`);
+        }
+      }
 
       const { model, error, authStorage, modelRegistry } = resolveModel(
         provider,

--- a/src/plugins/hooks.test.ts
+++ b/src/plugins/hooks.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { PluginRegistry } from "./registry.js";
+import type { PluginHookBeforeAgentStartResult } from "./types.js";
+import { createHookRunner } from "./hooks.js";
+
+function makeRegistry(
+  hooks: Array<{
+    pluginId: string;
+    priority?: number;
+    handler: (event: unknown, ctx: unknown) => Promise<PluginHookBeforeAgentStartResult>;
+  }>,
+): PluginRegistry {
+  return {
+    plugins: [],
+    tools: [],
+    hooks: [],
+    typedHooks: hooks.map((h) => ({
+      pluginId: h.pluginId,
+      hookName: "before_agent_start" as const,
+      priority: h.priority ?? 0,
+      handler: h.handler,
+      source: "test",
+    })),
+    channels: [],
+    providers: [],
+    gatewayHandlers: {} as PluginRegistry["gatewayHandlers"],
+    httpHandlers: [],
+    httpRoutes: [],
+    cliRegistrars: [],
+    services: [],
+    commands: [],
+    diagnostics: [],
+  };
+}
+
+describe("runBeforeAgentStart", () => {
+  it("returns model from a single hook", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "test-plugin",
+        handler: async () => ({ model: "openrouter/anthropic/claude-sonnet-4" }),
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, { agentId: "main" });
+    expect(result?.model).toBe("openrouter/anthropic/claude-sonnet-4");
+  });
+
+  it("last plugin wins for model override", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "plugin-a",
+        priority: 10,
+        handler: async () => ({ model: "anthropic/claude-opus-4" }),
+      },
+      {
+        pluginId: "plugin-b",
+        priority: 5,
+        handler: async () => ({ model: "openai/gpt-4.1" }),
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, { agentId: "main" });
+    // plugin-a runs first (higher priority), then plugin-b overrides
+    expect(result?.model).toBe("openai/gpt-4.1");
+  });
+
+  it("preserves earlier model when later hook returns no model", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "plugin-a",
+        priority: 10,
+        handler: async () => ({ model: "anthropic/claude-opus-4" }),
+      },
+      {
+        pluginId: "plugin-b",
+        priority: 5,
+        handler: async () => ({ prependContext: "extra context" }),
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, { agentId: "main" });
+    expect(result?.model).toBe("anthropic/claude-opus-4");
+    expect(result?.prependContext).toBe("extra context");
+  });
+
+  it("merges model with systemPrompt and prependContext", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "plugin-a",
+        handler: async () => ({
+          systemPrompt: "You are helpful.",
+          prependContext: "context-a",
+          model: "anthropic/claude-sonnet-4",
+        }),
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, { agentId: "main" });
+    expect(result?.systemPrompt).toBe("You are helpful.");
+    expect(result?.prependContext).toBe("context-a");
+    expect(result?.model).toBe("anthropic/claude-sonnet-4");
+  });
+
+  it("returns undefined when no hooks registered", async () => {
+    const registry = makeRegistry([]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, { agentId: "main" });
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -194,6 +194,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           acc?.prependContext && next.prependContext
             ? `${acc.prependContext}\n\n${next.prependContext}`
             : (next.prependContext ?? acc?.prependContext),
+        model: next.model ?? acc?.model,
       }),
     );
   }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -328,6 +328,8 @@ export type PluginHookBeforeAgentStartEvent = {
 export type PluginHookBeforeAgentStartResult = {
   systemPrompt?: string;
   prependContext?: string;
+  /** Override the model for this turn (e.g. "openrouter/anthropic/claude-sonnet-4.5"). */
+  model?: string;
 };
 
 // agent_end hook


### PR DESCRIPTION
## Summary

Fixes #14585

## Problem

The `before_agent_start` plugin hook can inject `systemPrompt` and `prependContext` into agent turns, but cannot override the model. This prevents plugins from implementing intent-based model routing — e.g., routing simple questions to a cheap model and complex tasks to a powerful one.

**Before:** A plugin returning `{ model: "openai/gpt-4.1" }` from `before_agent_start` is silently ignored. The configured default model is always used.

## Fix

1. **Plugin types** (`src/plugins/types.ts`): Add optional `model?: string` field to `PluginHookBeforeAgentStartResult`.

2. **Hook merge logic** (`src/plugins/hooks.ts`): Add `model` to the merge function — last plugin wins (same semantics as `systemPrompt`).

3. **Run entry point** (`src/agents/pi-embedded-runner/run.ts`): Call `before_agent_start` hook **before** `resolveModel()`. If the hook returns a `model` string (format: `provider/modelId`), override the `provider` and `modelId` variables so the correct model is resolved and used for session creation.

**After:** A plugin can return `{ model: "openai/gpt-4.1" }` and the agent turn will use that model instead of the configured default.

### Design decisions

- **Hook runs twice per turn**: once in `run.ts` (model phase, no messages) and once in `attempt.ts` (prompt phase, with messages). This preserves the existing `systemPrompt`/`prependContext` behavior which needs access to session messages, while allowing model override before session creation.
- **Model format**: `provider/modelId` string, consistent with the existing model reference format used throughout the codebase (e.g., `anthropic/claude-sonnet-4`, `openrouter/anthropic/claude-opus-4`).
- **Graceful degradation**: If the hook fails or returns an invalid model string (no `/`), the original configured model is used.

### Example plugin usage

```typescript
export default {
  hooks: {
    before_agent_start: async (event, ctx) => {
      if (event.prompt.length < 100) {
        return { model: "openai/gpt-4.1-mini" };
      }
      return { model: "anthropic/claude-sonnet-4" };
    },
  },
};
```

## Testing

- ✅ 5 tests pass (`pnpm vitest run src/plugins/hooks.test.ts`) — model merge logic: single hook, last-wins, preserve-on-undefined, merge-with-other-fields, empty-registry
- ✅ Lint passes (`pnpm lint`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `before_agent_start` plugin hook to support per-turn model routing by adding an optional `model` field to the hook result, merging it with “last-wins” semantics in the hook runner, and invoking the hook earlier in `pi-embedded-runner/run.ts` so model selection occurs before session creation.

Key flow change: `runEmbeddedPiAgent` now runs `before_agent_start` (model phase) to potentially override `provider/modelId`, then later `run/attempt.ts` still runs `before_agent_start` (prompt phase) to apply `prependContext`/`systemPrompt` against the live session messages.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with one edge case that can break model override behavior.
- Core type and merge changes are straightforward and tested; the only verified issue is that an invalid-but-plausible hook return like `"provider/"` will override to an empty modelId and then hard-fail instead of degrading to defaults.
- src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->