### PR TITLE
fix(gateway): allow trusted clients to request unredacted config via includeSecrets

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1150,6 +1150,16 @@ public struct SessionsUsageParams: Codable, Sendable {
 }
 
 public struct ConfigGetParams: Codable, Sendable {
+    public let includesecrets: Bool?
+
+    public init(
+        includesecrets: Bool?
+    ) {
+        self.includesecrets = includesecrets
+    }
+    private enum CodingKeys: String, CodingKey {
+        case includesecrets = "includeSecrets"
+    }
 }
 
 public struct ConfigSetParams: Codable, Sendable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1150,6 +1150,16 @@ public struct SessionsUsageParams: Codable, Sendable {
 }
 
 public struct ConfigGetParams: Codable, Sendable {
+    public let includesecrets: Bool?
+
+    public init(
+        includesecrets: Bool?
+    ) {
+        self.includesecrets = includesecrets
+    }
+    private enum CodingKeys: String, CodingKey {
+        case includesecrets = "includeSecrets"
+    }
 }
 
 public struct ConfigSetParams: Codable, Sendable {

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -1,7 +1,12 @@
 import { Type } from "@sinclair/typebox";
 import { NonEmptyString } from "./primitives.js";
 
-export const ConfigGetParamsSchema = Type.Object({}, { additionalProperties: false });
+export const ConfigGetParamsSchema = Type.Object(
+  {
+    includeSecrets: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
 
 export const ConfigSetParamsSchema = Type.Object(
   {

--- a/src/gateway/server-methods/config-get.test.ts
+++ b/src/gateway/server-methods/config-get.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ConnectParams } from "../protocol/index.js";
+import type { GatewayClient, GatewayRequestHandlerOptions } from "./types.js";
+
+const fakeSnapshot = {
+  path: "/test/config.json5",
+  exists: true,
+  raw: '{ "models": { "providers": { "openai": { "apiKey": "sk-real-key" } } } }',
+  parsed: { models: { providers: { openai: { apiKey: "sk-real-key" } } } },
+  valid: true,
+  config: { models: { providers: { openai: { apiKey: "sk-real-key" } } } },
+  hash: "abc123",
+  issues: [],
+  warnings: [],
+  legacyIssues: [],
+};
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    readConfigFileSnapshot: () => Promise.resolve(fakeSnapshot),
+    loadConfig: () => ({}),
+    writeConfigFile: vi.fn(),
+  };
+});
+
+const { configHandlers } = await import("./config.js");
+
+function makeClient(mode: string, id: string): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: id as ConnectParams["client"]["id"],
+        version: "1.0.0",
+        platform: "test",
+        mode: mode as ConnectParams["client"]["mode"],
+      },
+    } as ConnectParams,
+  };
+}
+
+function isWebchatConnect(params: ConnectParams | null | undefined): boolean {
+  return params?.client?.mode === "webchat";
+}
+
+function extractApiKey(payload: unknown): string {
+  const snap = payload as typeof fakeSnapshot;
+  const models = snap.config.models as Record<string, Record<string, Record<string, string>>>;
+  return models.providers.openai.apiKey;
+}
+
+function callConfigGet(
+  params: Record<string, unknown>,
+  client: GatewayClient | null,
+): Promise<{ ok: boolean; payload?: unknown; error?: unknown }> {
+  return new Promise((resolve) => {
+    const respond = (ok: boolean, payload?: unknown, error?: unknown) => {
+      resolve({ ok, payload, error });
+    };
+    void configHandlers["config.get"]({
+      req: { type: "req", id: "test-1", method: "config.get", params },
+      params,
+      client,
+      isWebchatConnect,
+      respond,
+      context: {} as GatewayRequestHandlerOptions["context"],
+    });
+  });
+}
+
+describe("config.get includeSecrets", () => {
+  it("redacts secrets by default", async () => {
+    const result = await callConfigGet({}, makeClient("ui", "openclaw-macos"));
+    expect(result.ok).toBe(true);
+    expect(extractApiKey(result.payload)).toBe("__OPENCLAW_REDACTED__");
+  });
+
+  it("redacts secrets when includeSecrets is false", async () => {
+    const result = await callConfigGet(
+      { includeSecrets: false },
+      makeClient("ui", "openclaw-macos"),
+    );
+    expect(result.ok).toBe(true);
+    expect(extractApiKey(result.payload)).toBe("__OPENCLAW_REDACTED__");
+  });
+
+  it("returns unredacted config when includeSecrets=true for trusted (non-webchat) client", async () => {
+    const result = await callConfigGet(
+      { includeSecrets: true },
+      makeClient("ui", "openclaw-macos"),
+    );
+    expect(result.ok).toBe(true);
+    expect(extractApiKey(result.payload)).toBe("sk-real-key");
+  });
+
+  it("returns unredacted config for CLI client with includeSecrets=true", async () => {
+    const result = await callConfigGet({ includeSecrets: true }, makeClient("cli", "cli"));
+    expect(result.ok).toBe(true);
+    expect(extractApiKey(result.payload)).toBe("sk-real-key");
+  });
+
+  it("still redacts for webchat client even with includeSecrets=true", async () => {
+    const result = await callConfigGet(
+      { includeSecrets: true },
+      makeClient("webchat", "webchat-ui"),
+    );
+    expect(result.ok).toBe(true);
+    expect(extractApiKey(result.payload)).toBe("__OPENCLAW_REDACTED__");
+  });
+
+  it("still redacts when no client is present and includeSecrets=true", async () => {
+    const result = await callConfigGet({ includeSecrets: true }, null);
+    expect(result.ok).toBe(true);
+    expect(extractApiKey(result.payload)).toBe("__OPENCLAW_REDACTED__");
+  });
+});


### PR DESCRIPTION
## Problem

The `config.get` RPC always redacts sensitive fields (`apiKey`, `token`, etc.) with `__OPENCLAW_REDACTED__` before returning the config snapshot. The macOS Companion App calls `config.get` to read ElevenLabs API keys for talk mode, but receives the sentinel string instead of the real key — which is then sent as the actual API key in POST requests to ElevenLabs, causing authentication failures.

Closes #14586

## Solution

Add an optional `includeSecrets` boolean parameter to the `config.get` RPC (Option A from the issue discussion).

When `includeSecrets: true` is requested by a **trusted** (non-webchat) client, the handler returns the unredacted config snapshot. Webchat clients and unauthenticated requests always receive the redacted version, preserving the existing security model.

### Trust model
- **Trusted:** CLI, macOS app, iOS app, Android app, node-host, control-ui — these connect via local WebSocket and are already authenticated through the gateway's auth flow (token/password/device pairing)
- **Untrusted:** Webchat clients (public-facing embed) — always redacted regardless of `includeSecrets`
- **No client:** Always redacted (safety default)

## Changes

| File | Change |
|------|--------|
| `src/gateway/protocol/schema/config.ts` | Add optional `includeSecrets: boolean` to `ConfigGetParamsSchema` |
| `src/gateway/server-methods/config.ts` | Check `includeSecrets` + client trust in `config.get` handler |
| `src/gateway/server-methods/config-get.test.ts` | 6 unit tests covering all trust/param combinations |

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run` — 1021 passed, 1 pre-existing failure (unrelated `bash-tools.test.ts` env issue)
- New tests verify: default redaction, explicit false, trusted + includeSecrets, CLI + includeSecrets, webchat denied, null client denied

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `includeSecrets` flag to the `config.get` RPC params schema, and updates the `config.get` handler to optionally return an unredacted config snapshot when that flag is set and the caller is considered “trusted”; otherwise it preserves the existing redacted response behavior. It also adds unit tests covering default redaction and the `includeSecrets` behavior across different client types.


<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but the current trust check broadens secret exposure to the browser-based Control UI.
- Core behavior change is small and well-tested, but the implementation defines “trusted” as any non-webchat client, which includes Control UI; that likely violates the intended trust boundary for returning unredacted secrets.
- src/gateway/server-methods/config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->