### PR TITLE
fix: enforce mediaMaxMb=0 and prevent binary content from entering session

### DIFF
--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -39,7 +39,7 @@ const bluebubblesAccountSchema = z.object({
   dmHistoryLimit: z.number().int().min(0).optional(),
   textChunkLimit: z.number().int().positive().optional(),
   chunkMode: z.enum(["length", "newline"]).optional(),
-  mediaMaxMb: z.number().int().positive().optional(),
+  mediaMaxMb: z.number().int().nonnegative().optional(),
   sendReadReceipts: z.boolean().optional(),
   blockStreaming: z.boolean().optional(),
   groups: z.object({}).catchall(bluebubblesGroupConfigSchema).optional(),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -139,7 +139,7 @@ export const FeishuAccountConfigSchema = z
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema,
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     renderMode: RenderModeSchema,
     tools: FeishuToolsConfigSchema,
@@ -174,7 +174,7 @@ export const FeishuConfigSchema = z
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema,
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     renderMode: RenderModeSchema, // raw = plain text (default), card = interactive card with markdown
     tools: FeishuToolsConfigSchema,

--- a/extensions/irc/src/config-schema.ts
+++ b/extensions/irc/src/config-schema.ts
@@ -70,7 +70,7 @@ export const IrcAccountSchemaBase = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     responsePrefix: z.string().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
   })
   .strict();
 

--- a/extensions/nextcloud-talk/src/config-schema.ts
+++ b/extensions/nextcloud-talk/src/config-schema.ts
@@ -48,7 +48,7 @@ export const NextcloudTalkAccountSchemaBase = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     responsePrefix: z.string().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
   })
   .strict();
 

--- a/src/channels/plugins/media-limits.test.ts
+++ b/src/channels/plugins/media-limits.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveChannelMediaMaxBytes } from "./media-limits.js";
+
+const MB = 1024 * 1024;
+
+function makeCfg(agentMediaMaxMb?: number) {
+  return {
+    agents: agentMediaMaxMb != null ? { defaults: { mediaMaxMb: agentMediaMaxMb } } : undefined,
+  } as Parameters<typeof resolveChannelMediaMaxBytes>[0]["cfg"];
+}
+
+describe("resolveChannelMediaMaxBytes", () => {
+  it("returns channel-specific limit when set", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(10),
+      resolveChannelLimitMb: () => 5,
+    });
+    expect(result).toBe(5 * MB);
+  });
+
+  it("returns agent default when channel limit is undefined", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(3),
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBe(3 * MB);
+  });
+
+  it("returns undefined when no limits are configured", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(),
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns 0 bytes when channel limit is 0 (media disabled)", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(10),
+      resolveChannelLimitMb: () => 0,
+    });
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 bytes when agent default mediaMaxMb is 0", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(0),
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBe(0);
+  });
+});

--- a/src/channels/plugins/media-limits.ts
+++ b/src/channels/plugins/media-limits.ts
@@ -15,10 +15,10 @@ export function resolveChannelMediaMaxBytes(params: {
     cfg: params.cfg,
     accountId,
   });
-  if (channelLimit) {
+  if (channelLimit != null) {
     return channelLimit * MB;
   }
-  if (params.cfg.agents?.defaults?.mediaMaxMb) {
+  if (params.cfg.agents?.defaults?.mediaMaxMb != null) {
     return params.cfg.agents.defaults.mediaMaxMb * MB;
   }
   return undefined;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -125,7 +125,7 @@ export const AgentDefaultsSchema = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     humanDelay: HumanDelaySchema.optional(),
     timeoutSeconds: z.number().int().positive().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: z
       .union([

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -113,7 +113,7 @@ export const TelegramAccountSchemaBase = z
     draftChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     streamMode: z.enum(["off", "partial", "block"]).optional().default("partial"),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z
@@ -272,7 +272,7 @@ export const DiscordAccountSchema = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     maxLinesPerMessage: z.number().int().positive().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     retry: RetryConfigSchema,
     actions: z
       .object({
@@ -387,7 +387,7 @@ export const GoogleChatAccountSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     replyToMode: ReplyToModeSchema.optional(),
     actions: z
       .object({
@@ -481,7 +481,7 @@ export const SlackAccountSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     replyToMode: ReplyToModeSchema.optional(),
@@ -585,7 +585,7 @@ export const SignalAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     actions: z
@@ -675,7 +675,7 @@ export const IrcAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     responsePrefix: z.string().optional(),
   })
@@ -737,7 +737,7 @@ export const IMessageAccountSchemaBase = z
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     includeAttachments: z.boolean().optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
@@ -830,7 +830,7 @@ export const BlueBubblesAccountSchemaBase = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     sendReadReceipts: z.boolean().optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
@@ -915,7 +915,7 @@ export const MSTeamsConfigSchema = z
     replyStyle: MSTeamsReplyStyleSchema.optional(),
     teams: z.record(z.string(), MSTeamsTeamSchema.optional()).optional(),
     /** Max media size in MB (default: 100MB for OneDrive upload support). */
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     /** SharePoint site ID for file uploads in group chats/channels (e.g., "contoso.sharepoint.com,guid1,guid2") */
     sharePointSiteId: z.string().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -33,7 +33,7 @@ export const WhatsAppAccountSchema = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     groups: z
@@ -95,7 +95,7 @@ export const WhatsAppConfigSchema = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
-    mediaMaxMb: z.number().int().positive().optional().default(50),
+    mediaMaxMb: z.number().int().nonnegative().optional().default(50),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     actions: z

--- a/src/media-understanding/apply.binary-detection.test.ts
+++ b/src/media-understanding/apply.binary-detection.test.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveApiKeyForProvider: vi.fn(async () => ({
+    apiKey: "test-key",
+    source: "test",
+    mode: "api-key",
+  })),
+  requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+    if (auth?.apiKey) {
+      return auth.apiKey;
+    }
+    throw new Error(`No API key resolved for provider "${provider}".`);
+  },
+}));
+
+vi.mock("../media/fetch.js", () => ({
+  fetchRemoteMedia: vi.fn(),
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runExec: vi.fn(),
+}));
+
+async function loadApply() {
+  return await import("./apply.js");
+}
+
+describe("applyMediaUnderstanding – binary file detection", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "binary-detect-"));
+    process.env.HOME = tmpDir;
+    process.env.USERPROFILE = tmpDir;
+    const mediaDir = path.join(tmpDir, ".openclaw", "media", "inbound");
+    await fs.mkdir(mediaDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const baseCfg = {} as OpenClawConfig;
+
+  function buildCtx(overrides: Partial<MsgContext>): MsgContext {
+    return {
+      Body: "test",
+      From: "user",
+      To: "bot",
+      ...overrides,
+    } as MsgContext;
+  }
+
+  it("skips .docx files (ZIP-based binary) and does not inject content into Body", async () => {
+    // Create a minimal ZIP/docx-like file (ZIP magic bytes + binary content)
+    const zipHeader = Buffer.from([
+      0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x06, 0x00, 0x08, 0x00, 0x00, 0x00, 0x21, 0x00,
+    ]);
+    const binaryPadding = Buffer.alloc(4096, 0xab);
+    const docxBuffer = Buffer.concat([zipHeader, binaryPadding]);
+    const filePath = path.join(tmpDir, ".openclaw", "media", "inbound", "report.docx");
+    await fs.writeFile(filePath, docxBuffer);
+
+    const ctx = buildCtx({
+      MediaPath: filePath,
+      MediaPaths: [filePath],
+      MediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      MediaTypes: ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+    });
+
+    const { applyMediaUnderstanding } = await loadApply();
+    const result = await applyMediaUnderstanding({ ctx, cfg: baseCfg });
+
+    // The .docx should NOT be extracted as a file block
+    expect(result.appliedFile).toBe(false);
+    // Body should not contain <file> blocks with binary content
+    expect(ctx.Body).not.toContain("<file");
+  });
+
+  it("skips executable binary files and does not inject content into Body", async () => {
+    // ELF binary header
+    const elfHeader = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00]);
+    const binaryContent = Buffer.alloc(4096, 0x00);
+    const elfBuffer = Buffer.concat([elfHeader, binaryContent]);
+    const filePath = path.join(tmpDir, ".openclaw", "media", "inbound", "program.bin");
+    await fs.writeFile(filePath, elfBuffer);
+
+    const ctx = buildCtx({
+      MediaPath: filePath,
+      MediaPaths: [filePath],
+      MediaType: "application/octet-stream",
+      MediaTypes: ["application/octet-stream"],
+    });
+
+    const { applyMediaUnderstanding } = await loadApply();
+    const result = await applyMediaUnderstanding({ ctx, cfg: baseCfg });
+
+    expect(result.appliedFile).toBe(false);
+    expect(ctx.Body).not.toContain("<file");
+  });
+
+  it("still extracts legitimate text files", async () => {
+    const textContent = "Hello, this is a perfectly normal text file.\nLine 2.\n";
+    const filePath = path.join(tmpDir, ".openclaw", "media", "inbound", "readme.txt");
+    await fs.writeFile(filePath, textContent, "utf-8");
+
+    const ctx = buildCtx({
+      MediaPath: filePath,
+      MediaPaths: [filePath],
+      MediaType: "text/plain",
+      MediaTypes: ["text/plain"],
+    });
+
+    const { applyMediaUnderstanding } = await loadApply();
+    const result = await applyMediaUnderstanding({ ctx, cfg: baseCfg });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("<file");
+    expect(ctx.Body).toContain("Hello, this is a perfectly normal text file.");
+  });
+
+  it("skips files with high null-byte density (binary indicator)", async () => {
+    // Binary file with lots of null bytes interspersed with ASCII
+    const content = Buffer.alloc(4096);
+    for (let i = 0; i < content.length; i += 2) {
+      content[i] = 0x41; // 'A'
+      content[i + 1] = 0x00; // null
+    }
+    const filePath = path.join(tmpDir, ".openclaw", "media", "inbound", "data.bin");
+    await fs.writeFile(filePath, content);
+
+    const ctx = buildCtx({
+      MediaPath: filePath,
+      MediaPaths: [filePath],
+      MediaType: "application/octet-stream",
+      MediaTypes: ["application/octet-stream"],
+    });
+
+    const { applyMediaUnderstanding } = await loadApply();
+    const result = await applyMediaUnderstanding({ ctx, cfg: baseCfg });
+
+    expect(result.appliedFile).toBe(false);
+    expect(ctx.Body).not.toContain("<file");
+  });
+});

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -92,6 +92,24 @@ describe("media store", () => {
     });
   });
 
+  it("rejects any buffer when maxBytes is 0 (mediaMaxMb=0)", async () => {
+    await withTempStore(async (store) => {
+      const small = Buffer.from("hello");
+      await expect(store.saveMediaBuffer(small, "text/plain", "inbound", 0)).rejects.toThrow(
+        "Media is disabled",
+      );
+    });
+  });
+
+  it("rejects buffer exceeding custom maxBytes limit", async () => {
+    await withTempStore(async (store) => {
+      const buf = Buffer.alloc(2 * 1024 * 1024); // 2MB
+      await expect(
+        store.saveMediaBuffer(buf, "text/plain", "inbound", 1 * 1024 * 1024),
+      ).rejects.toThrow("Media exceeds 1MB limit");
+    });
+  });
+
   it("copies local files and cleans old media", async () => {
     await withTempStore(async (store, home) => {
       const srcFile = path.join(home, "tmp-src.txt");

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -215,8 +215,12 @@ export async function saveMediaBuffer(
   maxBytes = MAX_BYTES,
   originalFilename?: string,
 ): Promise<SavedMedia> {
-  if (buffer.byteLength > maxBytes) {
-    throw new Error(`Media exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit`);
+  if (maxBytes <= 0 || buffer.byteLength > maxBytes) {
+    const limitLabel =
+      maxBytes <= 0
+        ? "Media is disabled (mediaMaxMb=0)"
+        : `Media exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit`;
+    throw new Error(limitLabel);
   }
   const dir = path.join(resolveMediaDir(), subdir);
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -89,9 +89,7 @@ export async function monitorWebChannel(
 
   const configuredMaxMb = cfg.agents?.defaults?.mediaMaxMb;
   const maxMediaBytes =
-    typeof configuredMaxMb === "number" && configuredMaxMb > 0
-      ? configuredMaxMb * 1024 * 1024
-      : DEFAULT_WEB_MEDIA_BYTES;
+    typeof configuredMaxMb === "number" ? configuredMaxMb * 1024 * 1024 : DEFAULT_WEB_MEDIA_BYTES;
   const heartbeatSeconds = resolveHeartbeatSeconds(cfg, tuning.heartbeatSeconds);
   const reconnectPolicy = resolveReconnectPolicy(cfg, tuning.reconnect);
   const baseMentionConfig = buildMentionConfig(cfg);

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -254,27 +254,30 @@ export async function monitorWebInbox(options: {
       let mediaPath: string | undefined;
       let mediaType: string | undefined;
       let mediaFileName: string | undefined;
-      try {
-        const inboundMedia = await downloadInboundMedia(msg as proto.IWebMessageInfo, sock);
-        if (inboundMedia) {
-          const maxMb =
-            typeof options.mediaMaxMb === "number" && options.mediaMaxMb > 0
-              ? options.mediaMaxMb
-              : 50;
-          const maxBytes = maxMb * 1024 * 1024;
-          const saved = await saveMediaBuffer(
-            inboundMedia.buffer,
-            inboundMedia.mimetype,
-            "inbound",
-            maxBytes,
-            inboundMedia.fileName,
-          );
-          mediaPath = saved.path;
-          mediaType = inboundMedia.mimetype;
-          mediaFileName = inboundMedia.fileName;
+      const mediaDisabled = options.mediaMaxMb === 0;
+      if (!mediaDisabled) {
+        try {
+          const inboundMedia = await downloadInboundMedia(msg as proto.IWebMessageInfo, sock);
+          if (inboundMedia) {
+            const maxMb =
+              typeof options.mediaMaxMb === "number" && options.mediaMaxMb > 0
+                ? options.mediaMaxMb
+                : 50;
+            const maxBytes = maxMb * 1024 * 1024;
+            const saved = await saveMediaBuffer(
+              inboundMedia.buffer,
+              inboundMedia.mimetype,
+              "inbound",
+              maxBytes,
+              inboundMedia.fileName,
+            );
+            mediaPath = saved.path;
+            mediaType = inboundMedia.mimetype;
+            mediaFileName = inboundMedia.fileName;
+          }
+        } catch (err) {
+          logVerbose(`Inbound media download failed: ${String(err)}`);
         }
-      } catch (err) {
-        logVerbose(`Inbound media download failed: ${String(err)}`);
       }
 
       const chatJid = remoteJid;


### PR DESCRIPTION
## Summary

Fixes #14609 — `mediaMaxMb` didn't prevent binary file content from entering the session.

## Root Causes

1. **Schema rejected `mediaMaxMb=0`** — All schemas used `z.number().positive()`, so users couldn't set `0` to disable media entirely
2. **Truthy check for 0** — `resolveChannelMediaMaxBytes` used `if (channelLimit)` which treated `0` as falsy, falling through to defaults
3. **Binary misclassification** — `extractFileBlocks` could misclassify binary files (ZIP/.docx, executables, archives) as text via heuristics, injecting raw binary into sessions

## Changes

### Config schema
- `.positive()` → `.nonnegative()` for all `mediaMaxMb` fields across core config and extension schemas

### Media limits resolution
- `resolveChannelMediaMaxBytes`: use `!= null` instead of truthy checks so `0` propagates correctly

### Media storage
- `saveMediaBuffer`: when `maxBytes ≤ 0`, reject immediately with clear `Media is disabled` message

### Binary detection (main fix for session pollution)
- Expanded `isBinaryMediaMime` to cover known binary MIME types: ZIP, Office documents (.docx/.xlsx/.pptx), executables, archives, protobuf, etc.
- Added `hasHighNullDensity` guard to prevent binary files with embedded null bytes from being misclassified as text by the legacy text heuristic

### Telegram handler
- Media groups now catch size/disabled errors per-item (previously only caught for single messages)
- User-friendly messages for both `too large` and `disabled` cases

## Tests Added
- `resolveChannelMediaMaxBytes`: verifies 0 propagation for channel and agent defaults
- `saveMediaBuffer`: rejects on `maxBytes=0` and custom limits  
- Binary detection: .docx (ZIP-based), ELF binaries, null-dense files are skipped; legitimate text files still extracted correctly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates config schemas to allow `mediaMaxMb=0`, fixes media limit resolution to treat `0` as a valid value, makes `saveMediaBuffer` reject immediately when media is disabled, and hardens file extraction in media-understanding to avoid misclassifying common binary formats (ZIP/Office/executables/etc.) as text (including a null-byte density guard). It also adjusts Telegram bot handlers to handle per-item failures in media groups and provide clearer user-facing messages when media is disabled or too large.

Overall, the change fits into the existing media pipeline by ensuring limits propagate from config → channel handlers/downloaders → media store → session content extraction, reducing the chance of raw binary entering sessions.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but one inbound path still bypasses mediaMaxMb=0 semantics and Telegram error handling is fragile.
- Core schema/limit/store changes are coherent and covered by tests, but `src/web/inbound/monitor.ts` still falls back to 50MB when `mediaMaxMb=0`, which undermines the main fix for at least one channel path. Telegram handlers also depend on substring matching error messages, which is likely to regress behavior on future message changes.
- src/web/inbound/monitor.ts, src/telegram/bot-handlers.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->