### PR TITLE
fix(security): add --ignore-scripts to skills install commands

### DIFF
--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -147,13 +147,13 @@ function findInstallSpec(entry: SkillEntry, installId: string): SkillInstallSpec
 function buildNodeInstallCommand(packageName: string, prefs: SkillsInstallPreferences): string[] {
   switch (prefs.nodeManager) {
     case "pnpm":
-      return ["pnpm", "add", "-g", packageName];
+      return ["pnpm", "add", "-g", "--ignore-scripts", packageName];
     case "yarn":
-      return ["yarn", "global", "add", packageName];
+      return ["yarn", "global", "add", "--ignore-scripts", packageName];
     case "bun":
-      return ["bun", "add", "-g", packageName];
+      return ["bun", "add", "-g", "--ignore-scripts", packageName];
     default:
-      return ["npm", "install", "-g", packageName];
+      return ["npm", "install", "-g", "--ignore-scripts", packageName];
   }
 }
 


### PR DESCRIPTION
## Summary

- Skills install (`buildNodeInstallCommand`) runs package manager commands (`npm install -g`, `pnpm add -g`, `yarn global add`, `bun add -g`) without `--ignore-scripts`, allowing malicious npm packages to execute arbitrary code via postinstall/preinstall lifecycle scripts during global installation.
- This is inconsistent with commit 92702af7a which added `--ignore-scripts` to both plugin installs (`src/plugins/install.ts:282`) and hook installs (`src/hooks/install.ts:238`). Skills install was overlooked in that change.
- Global install (`-g`) is particularly dangerous as scripts execute with the user's full permissions.
- All four supported package managers (npm, pnpm, yarn, bun) are affected.

## Fix

Add `--ignore-scripts` flag to all four package manager install commands in `buildNodeInstallCommand()`.

## Test plan

- [ ] Verify skill install still works correctly with `--ignore-scripts` flag
- [ ] Verify packages that rely on postinstall scripts for compilation (native modules) are documented as a known limitation, consistent with plugin/hook install behavior

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens skill installation by adding the `--ignore-scripts` flag to global Node package installs performed by `buildNodeInstallCommand()` in `src/agents/skills-install.ts`. This aligns skills installation behavior with the existing plugin and hook installers, which already disable npm lifecycle scripts during dependency installation to prevent arbitrary code execution via `preinstall`/`postinstall` hooks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to adding `--ignore-scripts` to skill install commands, matching existing hardening in plugin/hook installers; no behavioral changes outside suppressing lifecycle scripts during global installs.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->