### PR TITLE
fix: support apt-get as fallback package manager on Linux

### DIFF
--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -39,7 +39,14 @@ function parseInstallSpec(input: unknown): SkillInstallSpec | undefined {
   const kindRaw =
     typeof raw.kind === "string" ? raw.kind : typeof raw.type === "string" ? raw.type : "";
   const kind = kindRaw.trim().toLowerCase();
-  if (kind !== "brew" && kind !== "node" && kind !== "go" && kind !== "uv" && kind !== "download") {
+  if (
+    kind !== "brew" &&
+    kind !== "apt" &&
+    kind !== "node" &&
+    kind !== "go" &&
+    kind !== "uv" &&
+    kind !== "download"
+  ) {
     return undefined;
   }
 
@@ -63,6 +70,9 @@ function parseInstallSpec(input: unknown): SkillInstallSpec | undefined {
   }
   if (typeof raw.formula === "string") {
     spec.formula = raw.formula;
+  }
+  if (typeof raw.aptPackage === "string") {
+    spec.aptPackage = raw.aptPackage;
   }
   if (typeof raw.package === "string") {
     spec.package = raw.package;

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -2,11 +2,12 @@ import type { Skill } from "@mariozechner/pi-coding-agent";
 
 export type SkillInstallSpec = {
   id?: string;
-  kind: "brew" | "node" | "go" | "uv" | "download";
+  kind: "brew" | "apt" | "node" | "go" | "uv" | "download";
   label?: string;
   bins?: string[];
   os?: string[];
   formula?: string;
+  aptPackage?: string;
   package?: string;
   module?: string;
   url?: string;

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -114,25 +114,37 @@ export async function setupSkills(
       !(await detectBinary("brew"));
 
     if (needsBrewPrompt) {
-      await prompter.note(
-        [
-          "Many skill dependencies are shipped via Homebrew.",
-          "Without brew, you'll need to build from source or download releases manually.",
-        ].join("\n"),
-        "Homebrew recommended",
-      );
-      const showBrewInstall = await prompter.confirm({
-        message: "Show Homebrew install command?",
-        initialValue: true,
-      });
-      if (showBrewInstall) {
+      const hasApt = process.platform === "linux" && (await detectBinary("apt-get"));
+      if (hasApt) {
         await prompter.note(
           [
-            "Run:",
-            '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"',
+            "Some skill dependencies are shipped via Homebrew, but apt-get was detected.",
+            "Skills with apt package mappings will be installed via apt-get automatically.",
+            "For others, you may need to install Homebrew or install dependencies manually.",
           ].join("\n"),
-          "Homebrew install",
+          "Package manager: apt-get",
         );
+      } else {
+        await prompter.note(
+          [
+            "Many skill dependencies are shipped via Homebrew.",
+            "Without brew, you'll need to build from source or download releases manually.",
+          ].join("\n"),
+          "Homebrew recommended",
+        );
+        const showBrewInstall = await prompter.confirm({
+          message: "Show Homebrew install command?",
+          initialValue: true,
+        });
+        if (showBrewInstall) {
+          await prompter.note(
+            [
+              "Run:",
+              '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"',
+            ].join("\n"),
+            "Homebrew install",
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

Skills installation assumes `brew` (Homebrew) is available, which fails in Docker containers and other Linux environments that only have `apt`. When a skill tries to install dependencies, it fails with `brew not installed`.

Closes #14593

## Solution

- **New `apt` install kind** — skills can now define `kind: "apt"` install specs directly
- **`aptPackage` field on brew specs** — brew install specs can include an `aptPackage` field as a fallback package name for apt-based systems
- **Automatic OS detection** — `detectSystemPackageManager()` checks `process.platform` and binary availability to choose between `apt-get` (Linux) and `brew` (macOS)
- **Graceful fallback** — when brew is unavailable on Linux, the installer automatically uses `sudo apt-get install -y <package>` if `aptPackage` is defined
- **Better error messages** — instead of just `brew not installed`, errors now indicate whether apt-get is unavailable or the skill lacks an apt package mapping
- **Onboard wizard updated** — detects apt-get on Linux and informs users that compatible skills will install via apt automatically
- **`uv` and `go` fallbacks** — these dependency installers also try apt when brew is unavailable

## Skill Frontmatter Example

```yaml
metadata:
  openclaw:
    install:
      - id: deps
        kind: brew
        formula: ripgrep
        aptPackage: ripgrep   # Used on Linux when brew unavailable
```

Or as a dedicated apt spec:
```yaml
      - id: deps
        kind: apt
        aptPackage: ffmpeg
```

## Testing

- Added tests for `apt` kind installation via apt-get
- Added tests for descriptive errors when brew-only skills lack apt fallback
- All existing tests continue to pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `apt-get` support to skill dependency installation on Linux by introducing an `apt` install kind, allowing `brew` install specs to include an `aptPackage` fallback, and updating the install flow to fall back to `sudo apt-get install -y …` when `brew` isn’t available. It also updates the onboarding wizard to mention `apt-get` when detected, and extends the special-case installers for `uv` and `go` to try `apt` when `brew` is missing.

Main issue found: the newly added apt/brew fallback tests include an environment-dependent assertion that will fail on CI runners where Homebrew is present (or discoverable via `HOMEBREW_*` env / default paths).

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the new tests are non-deterministic on environments with Homebrew present.
- Core logic changes are straightforward and localized, but the added unit test relies on the real machine’s brew availability (and `resolveBrewExecutable` heuristics), which can make CI results flaky until the test environment is controlled via mocking.
- src/agents/skills-install.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->