### PR TITLE
fix(security): restrict canvas IP-based auth to private networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security/Canvas: serve A2UI assets via the shared safe-open path (`openFileWithinRoot`) to close traversal/TOCTOU gaps, with traversal and symlink regression coverage. (#10525) Thanks @abdelsfane.
+- Security/Gateway: breaking default-behavior change - canvas IP-based auth fallback now only accepts machine-scoped addresses (RFC1918, link-local, ULA IPv6, CGNAT); public-source IP matches now require bearer token auth. (#14661) Thanks @sumleo.
 - Security/WhatsApp: enforce `0o600` on `creds.json` and `creds.json.bak` on save/backup/restore paths to reduce credential file exposure. (#10529) Thanks @abdelsfane.
 - Security/Gateway + ACP: block high-risk tools (`sessions_spawn`, `sessions_send`, `gateway`, `whatsapp_login`) from HTTP `/tools/invoke` by default with `gateway.tools.{allow,deny}` overrides, and harden ACP permission selection to fail closed when tool identity/options are ambiguous while supporting `allow_always`/`reject_always`. (#15390) Thanks @aether-ai-agent.
 - Gateway/Tools Invoke: sanitize `/tools/invoke` execution failures while preserving `400` for tool input errors and returning `500` for unexpected runtime failures, with regression coverage and docs updates. (#13185) Thanks @davidrudduck.

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { pickPrimaryLanIPv4, resolveGatewayListenHosts } from "./net.js";
+import { isPrivateOrLoopbackAddress, pickPrimaryLanIPv4, resolveGatewayListenHosts } from "./net.js";
 
 describe("resolveGatewayListenHosts", () => {
   it("returns the input host when not loopback", async () => {
@@ -75,5 +75,37 @@ describe("pickPrimaryLanIPv4", () => {
       ] as unknown as os.NetworkInterfaceInfo[],
     });
     expect(pickPrimaryLanIPv4()).toBeUndefined();
+  });
+});
+
+describe("isPrivateOrLoopbackAddress", () => {
+  it("accepts loopback, private, link-local, and cgnat ranges", () => {
+    const accepted = [
+      "127.0.0.1",
+      "::1",
+      "10.1.2.3",
+      "172.16.0.1",
+      "172.31.255.254",
+      "192.168.0.1",
+      "169.254.10.20",
+      "100.64.0.1",
+      "100.127.255.254",
+      "::ffff:100.100.100.100",
+      "fc00::1",
+      "fd12:3456:789a::1",
+      "fe80::1",
+      "fe9a::1",
+      "febb::1",
+    ];
+    for (const ip of accepted) {
+      expect(isPrivateOrLoopbackAddress(ip)).toBe(true);
+    }
+  });
+
+  it("rejects public addresses", () => {
+    const rejected = ["1.1.1.1", "8.8.8.8", "172.32.0.1", "203.0.113.10", "2001:4860:4860::8888"];
+    for (const ip of rejected) {
+      expect(isPrivateOrLoopbackAddress(ip)).toBe(false);
+    }
   });
 });

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,6 +1,10 @@
 import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isPrivateOrLoopbackAddress, pickPrimaryLanIPv4, resolveGatewayListenHosts } from "./net.js";
+import {
+  isPrivateOrLoopbackAddress,
+  pickPrimaryLanIPv4,
+  resolveGatewayListenHosts,
+} from "./net.js";
 
 describe("resolveGatewayListenHosts", () => {
   it("returns the input host when not loopback", async () => {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -51,7 +51,7 @@ import {
 } from "./hooks.js";
 import { sendGatewayAuthFailure } from "./http-common.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
-import { resolveGatewayClientIp } from "./net.js";
+import { isPrivateOrLoopbackAddress, resolveGatewayClientIp } from "./net.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
@@ -141,6 +141,17 @@ async function authorizeCanvasRequest(params: {
     trustedProxies,
   });
   if (!clientIp) {
+    return lastAuthFailure ?? { ok: false, reason: "unauthorized" };
+  }
+  if (hasAuthorizedWsClientForIp(clients, clientIp)) {
+    return { ok: true };
+  }
+  return lastAuthFailure ?? { ok: false, reason: "unauthorized" };
+
+  // IP-based fallback is only safe for machine-scoped addresses.
+  // Only allow IP-based fallback for private/loopback addresses to prevent
+  // cross-session access in shared-IP environments (corporate NAT, cloud).
+  if (!isPrivateOrLoopbackAddress(clientIp)) {
     return lastAuthFailure ?? { ok: false, reason: "unauthorized" };
   }
   if (hasAuthorizedWsClientForIp(clients, clientIp)) {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -143,10 +143,6 @@ async function authorizeCanvasRequest(params: {
   if (!clientIp) {
     return lastAuthFailure ?? { ok: false, reason: "unauthorized" };
   }
-  if (hasAuthorizedWsClientForIp(clients, clientIp)) {
-    return { ok: true };
-  }
-  return lastAuthFailure ?? { ok: false, reason: "unauthorized" };
 
   // IP-based fallback is only safe for machine-scoped addresses.
   // Only allow IP-based fallback for private/loopback addresses to prevent

--- a/src/gateway/server.canvas-auth.e2e.test.ts
+++ b/src/gateway/server.canvas-auth.e2e.test.ts
@@ -81,7 +81,7 @@ async function expectWsRejected(
 }
 
 describe("gateway canvas host auth", () => {
-  test("authorizes canvas/a2ui HTTP and canvas WS by matching an authenticated gateway ws client ip", async () => {
+  test("allows canvas IP fallback for private/CGNAT addresses and denies public fallback", async () => {
     const resolvedAuth: ResolvedGatewayAuth = {
       mode: "token",
       token: "test-token",
@@ -149,35 +149,37 @@ describe("gateway canvas host auth", () => {
 
         const listener = await listen(httpServer);
         try {
-          const ipA = "203.0.113.10";
-          const ipB = "203.0.113.11";
+          const privateIpA = "192.168.1.10";
+          const privateIpB = "192.168.1.11";
+          const publicIp = "203.0.113.10";
+          const cgnatIp = "100.100.100.100";
 
           const unauthCanvas = await fetch(
             `http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`,
             {
-              headers: { "x-forwarded-for": ipA },
+              headers: { "x-forwarded-for": privateIpA },
             },
           );
           expect(unauthCanvas.status).toBe(401);
 
           const unauthA2ui = await fetch(`http://127.0.0.1:${listener.port}${A2UI_PATH}/`, {
-            headers: { "x-forwarded-for": ipA },
+            headers: { "x-forwarded-for": privateIpA },
           });
           expect(unauthA2ui.status).toBe(401);
 
           await expectWsRejected(`ws://127.0.0.1:${listener.port}${CANVAS_WS_PATH}`, {
-            "x-forwarded-for": ipA,
+            "x-forwarded-for": privateIpA,
           });
 
           clients.add({
             socket: {} as unknown as WebSocket,
             connect: {} as never,
             connId: "c1",
-            clientIp: ipA,
+            clientIp: privateIpA,
           });
 
           const authCanvas = await fetch(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`, {
-            headers: { "x-forwarded-for": ipA },
+            headers: { "x-forwarded-for": privateIpA },
           });
           expect(authCanvas.status).toBe(200);
           expect(await authCanvas.text()).toBe("ok");
@@ -185,14 +187,42 @@ describe("gateway canvas host auth", () => {
           const otherIpStillBlocked = await fetch(
             `http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`,
             {
-              headers: { "x-forwarded-for": ipB },
+              headers: { "x-forwarded-for": privateIpB },
             },
           );
           expect(otherIpStillBlocked.status).toBe(401);
 
+          clients.add({
+            socket: {} as unknown as WebSocket,
+            connect: {} as never,
+            connId: "c-public",
+            clientIp: publicIp,
+          });
+          const publicIpStillBlocked = await fetch(
+            `http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`,
+            {
+              headers: { "x-forwarded-for": publicIp },
+            },
+          );
+          expect(publicIpStillBlocked.status).toBe(401);
+          await expectWsRejected(`ws://127.0.0.1:${listener.port}${CANVAS_WS_PATH}`, {
+            "x-forwarded-for": publicIp,
+          });
+
+          clients.add({
+            socket: {} as unknown as WebSocket,
+            connect: {} as never,
+            connId: "c-cgnat",
+            clientIp: cgnatIp,
+          });
+          const cgnatAllowed = await fetch(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`, {
+            headers: { "x-forwarded-for": cgnatIp },
+          });
+          expect(cgnatAllowed.status).toBe(200);
+
           await new Promise<void>((resolve, reject) => {
             const ws = new WebSocket(`ws://127.0.0.1:${listener.port}${CANVAS_WS_PATH}`, {
-              headers: { "x-forwarded-for": ipA },
+              headers: { "x-forwarded-for": privateIpA },
             });
             const timer = setTimeout(() => reject(new Error("timeout")), 10_000);
             ws.once("open", () => {

--- a/src/gateway/server.canvas-auth.e2e.test.ts
+++ b/src/gateway/server.canvas-auth.e2e.test.ts
@@ -215,9 +215,12 @@ describe("gateway canvas host auth", () => {
             connId: "c-cgnat",
             clientIp: cgnatIp,
           });
-          const cgnatAllowed = await fetch(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`, {
-            headers: { "x-forwarded-for": cgnatIp },
-          });
+          const cgnatAllowed = await fetch(
+            `http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`,
+            {
+              headers: { "x-forwarded-for": cgnatIp },
+            },
+          );
           expect(cgnatAllowed.status).toBe(200);
 
           await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary

- Canvas endpoint authorization (`authorizeCanvasRequest`) falls back to IP-based matching when no bearer token is present, checking if the client IP matches any existing authenticated WebSocket client's IP via `hasAuthorizedWsClientForIp`.
- In shared-IP environments (corporate NAT, cloud instances), this allows an unauthorized user sharing the same external IP as an authenticated user to access canvas endpoints without any token.
- Canvas access grants ability to present A2UI content, evaluate JavaScript, and take snapshots.

## Fix

- Add `isPrivateOrLoopbackAddress()` helper to `net.ts` covering RFC1918 (10/8, 172.16/12, 192.168/16), IPv6 unique local (fc00::/7), link-local (169.254/16, fe80::/10), and loopback ranges.
- Restrict IP-based canvas auth fallback to only accept private/loopback IPs, where addresses are unique per-machine on a local network.
- Public IP matches now require explicit bearer token authentication.

## Test plan

- [ ] Verify canvas access still works on loopback (127.0.0.1) without token
- [ ] Verify canvas access works on LAN (192.168.x.x) with authenticated WS client from same IP
- [ ] Verify canvas access is denied for public IPs without bearer token even if an authenticated WS client shares the IP

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens canvas endpoint authorization by limiting the “no bearer token” fallback path (matching an HTTP client IP to an already-authenticated WebSocket client IP) to only private/loopback addresses. This addresses the shared-public-IP/NAT scenario where an unauthenticated user could otherwise gain canvas access.

Implementation-wise, it introduces `isPrivateOrLoopbackAddress()` in `src/gateway/net.ts` and uses it inside `authorizeCanvasRequest()` in `src/gateway/server-http.ts` before `hasAuthorizedWsClientForIp()` is consulted.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and meaningfully improves security, with a couple of correctness edge cases in IP range checks to address.
- The authorization change is straightforward and scoped, but the new helper misclassifies parts of IPv6 link-local space (`fe80::/10`) and doesn’t validate that inputs are actually IPs before applying prefix logic, which can lead to unexpected behavior at the auth boundary.
- src/gateway/net.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->