### PR TITLE
fix(security): escape < in inline JSON to prevent script tag XSS

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -166,15 +166,22 @@ interface ControlUiInjectionOpts {
   assistantAvatar?: string;
 }
 
+function safeInlineJson(value: unknown): string {
+  // Escape < to \u003c to prevent </script> injection in inline script tags.
+  // JSON.stringify does not escape <, so a value containing "</script>" would
+  // prematurely close the script element and allow arbitrary HTML injection.
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
 function injectControlUiConfig(html: string, opts: ControlUiInjectionOpts): string {
   const { basePath, assistantName, assistantAvatar } = opts;
   const script =
     `<script>` +
-    `window.__OPENCLAW_CONTROL_UI_BASE_PATH__=${JSON.stringify(basePath)};` +
-    `window.__OPENCLAW_ASSISTANT_NAME__=${JSON.stringify(
+    `window.__OPENCLAW_CONTROL_UI_BASE_PATH__=${safeInlineJson(basePath)};` +
+    `window.__OPENCLAW_ASSISTANT_NAME__=${safeInlineJson(
       assistantName ?? DEFAULT_ASSISTANT_IDENTITY.name,
     )};` +
-    `window.__OPENCLAW_ASSISTANT_AVATAR__=${JSON.stringify(
+    `window.__OPENCLAW_ASSISTANT_AVATAR__=${safeInlineJson(
       assistantAvatar ?? DEFAULT_ASSISTANT_IDENTITY.avatar,
     )};` +
     `</script>`;


### PR DESCRIPTION
## Summary

- \`injectControlUiConfig\` injects config values into HTML via \`JSON.stringify\` inside a \`<script>\` tag.
- \`JSON.stringify\` does not escape \`<\` characters, so a config value containing \`</script><script>alert(1)//\` would prematurely close the script tag and allow arbitrary JavaScript execution.
- The values (assistantName, assistantAvatar) primarily come from admin config, limiting practical exploitability, but this is a well-known XSS pattern (OWASP recommends escaping \`<\` as \`\\u003c\` in inline JSON).
- The codebase already applies security headers (X-Frame-Options, CSP), making this omission a defense-in-depth gap.

## Fix

Add \`safeInlineJson()\` helper that wraps \`JSON.stringify\` and escapes \`<\` as \`\\u003c\`, then use it for all inline script injections.

## Test plan

- [ ] Verify control UI still renders correctly with the escaped output
- [ ] Verify a config value containing \`</script>\` does not break the page

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change introduces a `safeInlineJson()` helper in `src/gateway/control-ui.ts` to safely embed configuration values into an inline `<script>` tag.

Previously, `injectControlUiConfig()` used `JSON.stringify(...)` directly. Since `JSON.stringify` doesn’t escape `<`, a value containing `</script>` could terminate the script block early and inject HTML/JS. The helper wraps `JSON.stringify` and replaces `<` with `\\u003c`, and the injected globals now use `safeInlineJson(...)` for `basePath`, `assistantName`, and `assistantAvatar`.

This is consistent with the existing pattern of server-side HTML injection for the control UI and closes an inline-script XSS vector in a defense-in-depth way.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to escaping `<` in JSON embedded in an inline `<script>` tag, addressing a real XSS class without altering control flow. Current call sites only pass strings, so the helper cannot throw in practice.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->