### PR TITLE
fix(macos): align minimum Node.js version with runtime guard (22.12.0)

### DIFF
--- a/apps/macos/Sources/OpenClaw/AboutSettings.swift
+++ b/apps/macos/Sources/OpenClaw/AboutSettings.swift
@@ -110,8 +110,8 @@ struct AboutSettings: View {
     private var buildTimestamp: String? {
         guard
             let raw =
-                (Bundle.main.object(forInfoDictionaryKey: "OpenClawBuildTimestamp") as? String) ??
-                (Bundle.main.object(forInfoDictionaryKey: "OpenClawBuildTimestamp") as? String)
+            (Bundle.main.object(forInfoDictionaryKey: "OpenClawBuildTimestamp") as? String) ??
+            (Bundle.main.object(forInfoDictionaryKey: "OpenClawBuildTimestamp") as? String)
         else { return nil }
         let parser = ISO8601DateFormatter()
         parser.formatOptions = [.withInternetDateTime]

--- a/apps/macos/Sources/OpenClaw/AgeFormatting.swift
+++ b/apps/macos/Sources/OpenClaw/AgeFormatting.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// Human-friendly age string (e.g., "2m ago").
+/// Human-friendly age string (e.g., "2m ago").
 func age(from date: Date, now: Date = .init()) -> String {
     let seconds = max(0, Int(now.timeIntervalSince(date)))
     let minutes = seconds / 60

--- a/apps/macos/Sources/OpenClaw/AgentWorkspace.swift
+++ b/apps/macos/Sources/OpenClaw/AgentWorkspace.swift
@@ -19,7 +19,7 @@ enum AgentWorkspace {
     ]
     enum BootstrapSafety: Equatable {
         case safe
-        case unsafe(reason: String)
+        case unsafe (reason: String)
     }
 
     static func displayPath(for url: URL) -> String {
@@ -72,7 +72,7 @@ enum AgentWorkspace {
             return .safe
         }
         if !isDir.boolValue {
-            return .unsafe(reason: "Workspace path points to a file.")
+            return .unsafe (reason: "Workspace path points to a file.")
         }
         let agentsURL = self.agentsURL(workspaceURL: workspaceURL)
         if fm.fileExists(atPath: agentsURL.path) {
@@ -82,9 +82,9 @@ enum AgentWorkspace {
             let entries = try self.workspaceEntries(workspaceURL: workspaceURL)
             return entries.isEmpty
                 ? .safe
-                : .unsafe(reason: "Folder isn't empty. Choose a new folder or add AGENTS.md first.")
+                : .unsafe (reason: "Folder isn't empty. Choose a new folder or add AGENTS.md first.")
         } catch {
-            return .unsafe(reason: "Couldn't inspect the workspace folder.")
+            return .unsafe (reason: "Couldn't inspect the workspace folder.")
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/AnthropicOAuth.swift
+++ b/apps/macos/Sources/OpenClaw/AnthropicOAuth.swift
@@ -234,9 +234,8 @@ enum OpenClawOAuthStore {
             return URL(fileURLWithPath: expanded, isDirectory: true)
         }
         let home = FileManager().homeDirectoryForCurrentUser
-        let preferred = home.appendingPathComponent(".openclaw", isDirectory: true)
+        return home.appendingPathComponent(".openclaw", isDirectory: true)
             .appendingPathComponent("credentials", isDirectory: true)
-        return preferred
     }
 
     static func oauthURL() -> URL {

--- a/apps/macos/Sources/OpenClaw/AnyCodable+Helpers.swift
+++ b/apps/macos/Sources/OpenClaw/AnyCodable+Helpers.swift
@@ -1,18 +1,35 @@
+import Foundation
 import OpenClawKit
 import OpenClawProtocol
-import Foundation
 
 // Prefer the OpenClawKit wrapper to keep gateway request payloads consistent.
 typealias AnyCodable = OpenClawKit.AnyCodable
 typealias InstanceIdentity = OpenClawKit.InstanceIdentity
 
 extension AnyCodable {
-    var stringValue: String? { self.value as? String }
-    var boolValue: Bool? { self.value as? Bool }
-    var intValue: Int? { self.value as? Int }
-    var doubleValue: Double? { self.value as? Double }
-    var dictionaryValue: [String: AnyCodable]? { self.value as? [String: AnyCodable] }
-    var arrayValue: [AnyCodable]? { self.value as? [AnyCodable] }
+    var stringValue: String? {
+        self.value as? String
+    }
+
+    var boolValue: Bool? {
+        self.value as? Bool
+    }
+
+    var intValue: Int? {
+        self.value as? Int
+    }
+
+    var doubleValue: Double? {
+        self.value as? Double
+    }
+
+    var dictionaryValue: [String: AnyCodable]? {
+        self.value as? [String: AnyCodable]
+    }
+
+    var arrayValue: [AnyCodable]? {
+        self.value as? [AnyCodable]
+    }
 
     var foundationValue: Any {
         switch self.value {
@@ -27,12 +44,29 @@ extension AnyCodable {
 }
 
 extension OpenClawProtocol.AnyCodable {
-    var stringValue: String? { self.value as? String }
-    var boolValue: Bool? { self.value as? Bool }
-    var intValue: Int? { self.value as? Int }
-    var doubleValue: Double? { self.value as? Double }
-    var dictionaryValue: [String: OpenClawProtocol.AnyCodable]? { self.value as? [String: OpenClawProtocol.AnyCodable] }
-    var arrayValue: [OpenClawProtocol.AnyCodable]? { self.value as? [OpenClawProtocol.AnyCodable] }
+    var stringValue: String? {
+        self.value as? String
+    }
+
+    var boolValue: Bool? {
+        self.value as? Bool
+    }
+
+    var intValue: Int? {
+        self.value as? Int
+    }
+
+    var doubleValue: Double? {
+        self.value as? Double
+    }
+
+    var dictionaryValue: [String: OpenClawProtocol.AnyCodable]? {
+        self.value as? [String: OpenClawProtocol.AnyCodable]
+    }
+
+    var arrayValue: [OpenClawProtocol.AnyCodable]? {
+        self.value as? [OpenClawProtocol.AnyCodable]
+    }
 
     var foundationValue: Any {
         switch self.value {

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -422,11 +422,10 @@ final class AppState {
         let trimmedUser = parsed.user?.trimmingCharacters(in: .whitespacesAndNewlines)
         let user = (trimmedUser?.isEmpty ?? true) ? nil : trimmedUser
         let port = parsed.port
-        let assembled: String
-        if let user {
-            assembled = port == 22 ? "\(user)@\(host)" : "\(user)@\(host):\(port)"
+        let assembled: String = if let user {
+            port == 22 ? "\(user)@\(host)" : "\(user)@\(host):\(port)"
         } else {
-            assembled = port == 22 ? host : "\(host):\(port)"
+            port == 22 ? host : "\(host):\(port)"
         }
         if assembled != self.remoteTarget {
             self.remoteTarget = assembled
@@ -698,7 +697,9 @@ extension AppState {
 @MainActor
 enum AppStateStore {
     static let shared = AppState()
-    static var isPausedFlag: Bool { UserDefaults.standard.bool(forKey: pauseDefaultsKey) }
+    static var isPausedFlag: Bool {
+        UserDefaults.standard.bool(forKey: pauseDefaultsKey)
+    }
 
     static func updateLaunchAtLogin(enabled: Bool) {
         Task.detached(priority: .utility) {

--- a/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
+++ b/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
@@ -1,8 +1,8 @@
 import AVFoundation
-import OpenClawIPC
-import OpenClawKit
 import CoreGraphics
 import Foundation
+import OpenClawIPC
+import OpenClawKit
 import OSLog
 
 actor CameraCaptureService {

--- a/apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift
@@ -1,7 +1,7 @@
 import AppKit
+import Foundation
 import OpenClawIPC
 import OpenClawKit
-import Foundation
 import WebKit
 
 final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {

--- a/apps/macos/Sources/OpenClaw/CanvasChromeContainerView.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasChromeContainerView.swift
@@ -39,7 +39,9 @@ final class HoverChromeContainerView: NSView {
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
@@ -60,14 +62,18 @@ final class HoverChromeContainerView: NSView {
             self.window?.performDrag(with: event)
         }
 
-        override func acceptsFirstMouse(for _: NSEvent?) -> Bool { true }
+        override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+            true
+        }
     }
 
     private final class CanvasResizeHandleView: NSView {
         private var startPoint: NSPoint = .zero
         private var startFrame: NSRect = .zero
 
-        override func acceptsFirstMouse(for _: NSEvent?) -> Bool { true }
+        override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+            true
+        }
 
         override func mouseDown(with event: NSEvent) {
             guard let window else { return }
@@ -102,7 +108,9 @@ final class HoverChromeContainerView: NSView {
         private let resizeHandle = CanvasResizeHandleView(frame: .zero)
 
         private final class PassthroughVisualEffectView: NSVisualEffectView {
-            override func hitTest(_: NSPoint) -> NSView? { nil }
+            override func hitTest(_: NSPoint) -> NSView? {
+                nil
+            }
         }
 
         private let closeBackground: NSVisualEffectView = {
@@ -190,7 +198,9 @@ final class HoverChromeContainerView: NSView {
         }
 
         @available(*, unavailable)
-        required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) is not supported")
+        }
 
         override func hitTest(_ point: NSPoint) -> NSView? {
             // When the chrome is hidden, do not intercept any mouse events (let the WKWebView receive them).

--- a/apps/macos/Sources/OpenClaw/CanvasManager.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasManager.swift
@@ -1,7 +1,7 @@
 import AppKit
+import Foundation
 import OpenClawIPC
 import OpenClawKit
-import Foundation
 import OSLog
 
 @MainActor

--- a/apps/macos/Sources/OpenClaw/CanvasSchemeHandler.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasSchemeHandler.swift
@@ -1,5 +1,5 @@
-import OpenClawKit
 import Foundation
+import OpenClawKit
 import OSLog
 import WebKit
 

--- a/apps/macos/Sources/OpenClaw/CanvasWindow.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindow.swift
@@ -11,8 +11,13 @@ enum CanvasLayout {
 }
 
 final class CanvasPanel: NSPanel {
-    override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { true }
+    override var canBecomeKey: Bool {
+        true
+    }
+
+    override var canBecomeMain: Bool {
+        true
+    }
 }
 
 enum CanvasPresentation {

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Navigation.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Navigation.swift
@@ -19,7 +19,8 @@ extension CanvasWindowController {
         // Deep links: allow local Canvas content to invoke the agent without bouncing through NSWorkspace.
         if scheme == "openclaw" {
             if let currentScheme = self.webView.url?.scheme,
-               CanvasScheme.allSchemes.contains(currentScheme) {
+               CanvasScheme.allSchemes.contains(currentScheme)
+            {
                 Task { await DeepLinkHandler.shared.handle(url: url) }
             } else {
                 canvasWindowLogger

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -1,7 +1,7 @@
 import AppKit
+import Foundation
 import OpenClawIPC
 import OpenClawKit
-import Foundation
 import WebKit
 
 @MainActor
@@ -183,7 +183,9 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
 
     @MainActor deinit {
         for name in CanvasA2UIActionMessageHandler.allMessageNames {

--- a/apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift
@@ -10,7 +10,6 @@ extension ChannelsSettings {
         }
     }
 
-    @ViewBuilder
     func channelHeaderActions(_ channel: ChannelItem) -> some View {
         HStack(spacing: 8) {
             if channel.id == "whatsapp" {
@@ -88,7 +87,6 @@ extension ChannelsSettings {
         }
     }
 
-    @ViewBuilder
     func genericChannelSection(_ channel: ChannelItem) -> some View {
         VStack(alignment: .leading, spacing: 16) {
             self.configEditorSection(channelId: channel.id)

--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Foundation
+import OpenClawProtocol
 
 extension ChannelsStore {
     func loadConfigSchema() async {

--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Foundation
+import OpenClawProtocol
 
 extension ChannelsStore {
     func start() {

--- a/apps/macos/Sources/OpenClaw/ChannelsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore.swift
@@ -1,6 +1,6 @@
-import OpenClawProtocol
 import Foundation
 import Observation
+import OpenClawProtocol
 
 struct ChannelsStatusSnapshot: Codable {
     struct WhatsAppSelf: Codable {

--- a/apps/macos/Sources/OpenClaw/ConfigSchemaSupport.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigSchemaSupport.swift
@@ -39,11 +39,26 @@ struct ConfigSchemaNode {
         self.raw = dict
     }
 
-    var title: String? { self.raw["title"] as? String }
-    var description: String? { self.raw["description"] as? String }
-    var enumValues: [Any]? { self.raw["enum"] as? [Any] }
-    var constValue: Any? { self.raw["const"] }
-    var explicitDefault: Any? { self.raw["default"] }
+    var title: String? {
+        self.raw["title"] as? String
+    }
+
+    var description: String? {
+        self.raw["description"] as? String
+    }
+
+    var enumValues: [Any]? {
+        self.raw["enum"] as? [Any]
+    }
+
+    var constValue: Any? {
+        self.raw["const"]
+    }
+
+    var explicitDefault: Any? {
+        self.raw["default"]
+    }
+
     var requiredKeys: Set<String> {
         Set((self.raw["required"] as? [String]) ?? [])
     }

--- a/apps/macos/Sources/OpenClaw/ConfigSettings.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigSettings.swift
@@ -45,7 +45,9 @@ extension ConfigSettings {
         let help: String?
         let node: ConfigSchemaNode
 
-        var id: String { self.key }
+        var id: String {
+            self.key
+        }
     }
 
     private struct ConfigSubsection: Identifiable {
@@ -55,7 +57,9 @@ extension ConfigSettings {
         let node: ConfigSchemaNode
         let path: ConfigPath
 
-        var id: String { self.key }
+        var id: String {
+            self.key
+        }
     }
 
     private var sections: [ConfigSection] {

--- a/apps/macos/Sources/OpenClaw/ConfigStore.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigStore.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Foundation
+import OpenClawProtocol
 
 enum ConfigStore {
     struct Overrides: Sendable {

--- a/apps/macos/Sources/OpenClaw/ContextMenuCardView.swift
+++ b/apps/macos/Sources/OpenClaw/ContextMenuCardView.swift
@@ -70,7 +70,6 @@ struct ContextMenuCardView: View {
         return "\(count) sessions · 24h"
     }
 
-    @ViewBuilder
     private func sessionRow(_ row: SessionRow) -> some View {
         VStack(alignment: .leading, spacing: 5) {
             ContextUsageBar(

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -1,7 +1,7 @@
-import OpenClawKit
-import OpenClawProtocol
 import Foundation
 import Observation
+import OpenClawKit
+import OpenClawProtocol
 import SwiftUI
 
 struct ControlHeartbeatEvent: Codable {
@@ -15,7 +15,10 @@ struct ControlHeartbeatEvent: Codable {
 }
 
 struct ControlAgentEvent: Codable, Sendable, Identifiable {
-    var id: String { "\(self.runId)-\(self.seq)" }
+    var id: String {
+        "\(self.runId)-\(self.seq)"
+    }
+
     let runId: String
     let seq: Int
     let stream: String

--- a/apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Foundation
+import OpenClawProtocol
 import SwiftUI
 
 extension CronJobEditor {

--- a/apps/macos/Sources/OpenClaw/CronJobEditor.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobEditor.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Observation
+import OpenClawProtocol
 import SwiftUI
 
 struct CronJobEditor: View {
@@ -32,18 +32,24 @@ struct CronJobEditor: View {
     @State var wakeMode: CronWakeMode = .now
     @State var deleteAfterRun: Bool = false
 
-    enum ScheduleKind: String, CaseIterable, Identifiable { case at, every, cron; var id: String { rawValue } }
+    enum ScheduleKind: String, CaseIterable, Identifiable { case at, every, cron; var id: String {
+        rawValue
+    } }
     @State var scheduleKind: ScheduleKind = .every
     @State var atDate: Date = .init().addingTimeInterval(60 * 5)
     @State var everyText: String = "1h"
     @State var cronExpr: String = "0 9 * * 3"
     @State var cronTz: String = ""
 
-    enum PayloadKind: String, CaseIterable, Identifiable { case systemEvent, agentTurn; var id: String { rawValue } }
+    enum PayloadKind: String, CaseIterable, Identifiable { case systemEvent, agentTurn; var id: String {
+        rawValue
+    } }
     @State var payloadKind: PayloadKind = .systemEvent
     @State var systemEventText: String = ""
     @State var agentMessage: String = ""
-    enum DeliveryChoice: String, CaseIterable, Identifiable { case announce, none; var id: String { rawValue } }
+    enum DeliveryChoice: String, CaseIterable, Identifiable { case announce, none; var id: String {
+        rawValue
+    } }
     @State var deliveryMode: DeliveryChoice = .announce
     @State var channel: String = "last"
     @State var to: String = ""
@@ -244,7 +250,6 @@ struct CronJobEditor: View {
                             }
                         }
                     }
-
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 2)

--- a/apps/macos/Sources/OpenClaw/CronJobsStore.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobsStore.swift
@@ -1,7 +1,7 @@
-import OpenClawKit
-import OpenClawProtocol
 import Foundation
 import Observation
+import OpenClawKit
+import OpenClawProtocol
 import OSLog
 
 @MainActor

--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -4,21 +4,27 @@ enum CronSessionTarget: String, CaseIterable, Identifiable, Codable {
     case main
     case isolated
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 }
 
 enum CronWakeMode: String, CaseIterable, Identifiable, Codable {
     case now
     case nextHeartbeat = "next-heartbeat"
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 }
 
 enum CronDeliveryMode: String, CaseIterable, Identifiable, Codable {
     case none
     case announce
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 }
 
 struct CronDelivery: Codable, Equatable {
@@ -98,11 +104,11 @@ enum CronSchedule: Codable, Equatable {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return nil }
         if let date = makeIsoFormatter(withFractional: true).date(from: trimmed) { return date }
-        return makeIsoFormatter(withFractional: false).date(from: trimmed)
+        return self.makeIsoFormatter(withFractional: false).date(from: trimmed)
     }
 
     static func formatIsoDate(_ date: Date) -> String {
-        makeIsoFormatter(withFractional: false).string(from: date)
+        self.makeIsoFormatter(withFractional: false).string(from: date)
     }
 
     private static func makeIsoFormatter(withFractional: Bool) -> ISO8601DateFormatter {
@@ -231,7 +237,9 @@ struct CronEvent: Codable, Sendable {
 }
 
 struct CronRunLogEntry: Codable, Identifiable, Sendable {
-    var id: String { "\(self.jobId)-\(self.ts)" }
+    var id: String {
+        "\(self.jobId)-\(self.ts)"
+    }
 
     let ts: Int
     let jobId: String
@@ -243,7 +251,10 @@ struct CronRunLogEntry: Codable, Identifiable, Sendable {
     let durationMs: Int?
     let nextRunAtMs: Int?
 
-    var date: Date { Date(timeIntervalSince1970: TimeInterval(self.ts) / 1000) }
+    var date: Date {
+        Date(timeIntervalSince1970: TimeInterval(self.ts) / 1000)
+    }
+
     var runDate: Date? {
         guard let runAtMs else { return nil }
         return Date(timeIntervalSince1970: TimeInterval(runAtMs) / 1000)

--- a/apps/macos/Sources/OpenClaw/CronSettings+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Actions.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Foundation
+import OpenClawProtocol
 
 extension CronSettings {
     func save(payload: [String: AnyCodable]) async {

--- a/apps/macos/Sources/OpenClaw/DeepLinks.swift
+++ b/apps/macos/Sources/OpenClaw/DeepLinks.swift
@@ -1,6 +1,6 @@
 import AppKit
-import OpenClawKit
 import Foundation
+import OpenClawKit
 import OSLog
 import Security
 
@@ -12,9 +12,9 @@ final class DeepLinkHandler {
 
     private var lastPromptAt: Date = .distantPast
 
-    // Ephemeral, in-memory key used for unattended deep links originating from the in-app Canvas.
-    // This avoids blocking Canvas init on UserDefaults and doesn't weaken the external deep-link prompt:
-    // outside callers can't know this randomly generated key.
+    /// Ephemeral, in-memory key used for unattended deep links originating from the in-app Canvas.
+    /// This avoids blocking Canvas init on UserDefaults and doesn't weaken the external deep-link prompt:
+    /// outside callers can't know this randomly generated key.
     private nonisolated static let canvasUnattendedKey: String = DeepLinkHandler.generateRandomKey()
 
     func handle(url: URL) async {

--- a/apps/macos/Sources/OpenClaw/DevicePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/DevicePairingApprovalPrompter.swift
@@ -1,8 +1,8 @@
 import AppKit
-import OpenClawKit
-import OpenClawProtocol
 import Foundation
 import Observation
+import OpenClawKit
+import OpenClawProtocol
 import OSLog
 
 @MainActor
@@ -23,8 +23,13 @@ final class DevicePairingApprovalPrompter {
     private var resolvedByRequestId: Set<String> = []
 
     private final class AlertHostWindow: NSWindow {
-        override var canBecomeKey: Bool { true }
-        override var canBecomeMain: Bool { true }
+        override var canBecomeKey: Bool {
+            true
+        }
+
+        override var canBecomeMain: Bool {
+            true
+        }
     }
 
     private struct PairingList: Codable {
@@ -55,7 +60,9 @@ final class DevicePairingApprovalPrompter {
         let isRepair: Bool?
         let ts: Double
 
-        var id: String { self.requestId }
+        var id: String {
+            self.requestId
+        }
     }
 
     private struct PairingResolvedEvent: Codable {

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -8,7 +8,9 @@ enum ExecSecurity: String, CaseIterable, Codable, Identifiable {
     case allowlist
     case full
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var title: String {
         switch self {
@@ -24,7 +26,9 @@ enum ExecApprovalQuickMode: String, CaseIterable, Identifiable {
     case ask
     case allow
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var title: String {
         switch self {
@@ -67,7 +71,9 @@ enum ExecAsk: String, CaseIterable, Codable, Identifiable {
     case onMiss = "on-miss"
     case always
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var title: String {
         switch self {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -1,7 +1,7 @@
-import OpenClawKit
-import OpenClawProtocol
 import CoreGraphics
 import Foundation
+import OpenClawKit
+import OpenClawProtocol
 import OSLog
 
 @MainActor

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -1,8 +1,8 @@
 import AppKit
-import OpenClawKit
 import CryptoKit
 import Darwin
 import Foundation
+import OpenClawKit
 import OSLog
 
 struct ExecApprovalPromptRequest: Codable, Sendable {
@@ -76,7 +76,9 @@ private struct ExecHostResponse: Codable {
 enum ExecApprovalsSocketClient {
     private struct TimeoutError: LocalizedError {
         var message: String
-        var errorDescription: String? { self.message }
+        var errorDescription: String? {
+            self.message
+        }
     }
 
     static func requestDecision(

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1,7 +1,7 @@
+import Foundation
 import OpenClawChatUI
 import OpenClawKit
 import OpenClawProtocol
-import Foundation
 import OSLog
 
 private let gatewayConnectionLogger = Logger(subsystem: "ai.openclaw", category: "gateway.connection")
@@ -24,9 +24,13 @@ enum GatewayAgentChannel: String, Codable, CaseIterable, Sendable {
         self = GatewayAgentChannel(rawValue: normalized) ?? .last
     }
 
-    var isDeliverable: Bool { self != .webchat }
+    var isDeliverable: Bool {
+        self != .webchat
+    }
 
-    func shouldDeliver(_ deliver: Bool) -> Bool { deliver && self.isDeliverable }
+    func shouldDeliver(_ deliver: Bool) -> Bool {
+        deliver && self.isDeliverable
+    }
 }
 
 struct GatewayAgentInvocation: Sendable {

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift
@@ -1,5 +1,5 @@
-import OpenClawDiscovery
 import Foundation
+import OpenClawDiscovery
 
 enum GatewayDiscoveryHelpers {
     static func sshTarget(for gateway: GatewayDiscoveryModel.DiscoveredGateway) -> String? {

--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -1,14 +1,16 @@
-import OpenClawIPC
 import Foundation
+import OpenClawIPC
 import OSLog
 
-// Lightweight SemVer helper (major.minor.patch only) for gateway compatibility checks.
+/// Lightweight SemVer helper (major.minor.patch only) for gateway compatibility checks.
 struct Semver: Comparable, CustomStringConvertible, Sendable {
     let major: Int
     let minor: Int
     let patch: Int
 
-    var description: String { "\(self.major).\(self.minor).\(self.patch)" }
+    var description: String {
+        "\(self.major).\(self.minor).\(self.patch)"
+    }
 
     static func < (lhs: Semver, rhs: Semver) -> Bool {
         if lhs.major != rhs.major { return lhs.major < rhs.major }
@@ -93,7 +95,7 @@ enum GatewayEnvironment {
         return (trimmed?.isEmpty == false) ? trimmed : nil
     }
 
-    // Exposed for tests so we can inject fake version checks without rewriting bundle metadata.
+    /// Exposed for tests so we can inject fake version checks without rewriting bundle metadata.
     static func expectedGatewayVersion(from versionString: String?) -> Semver? {
         Semver.parse(versionString)
     }

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -1,8 +1,8 @@
 import AppKit
+import Observation
 import OpenClawDiscovery
 import OpenClawIPC
 import OpenClawKit
-import Observation
 import SwiftUI
 
 struct GeneralSettings: View {
@@ -16,8 +16,13 @@ struct GeneralSettings: View {
     @State private var remoteStatus: RemoteStatus = .idle
     @State private var showRemoteAdvanced = false
     private let isPreview = ProcessInfo.processInfo.isPreview
-    private var isNixMode: Bool { ProcessInfo.processInfo.isNixMode }
-    private var remoteLabelWidth: CGFloat { 88 }
+    private var isNixMode: Bool {
+        ProcessInfo.processInfo.isNixMode
+    }
+
+    private var remoteLabelWidth: CGFloat {
+        88
+    }
 
     var body: some View {
         ScrollView(.vertical) {

--- a/apps/macos/Sources/OpenClaw/HealthStore.swift
+++ b/apps/macos/Sources/OpenClaw/HealthStore.swift
@@ -89,8 +89,8 @@ final class HealthStore {
         }
     }
 
-    // Test-only escape hatch: the HealthStore is a process-wide singleton but
-    // state derivation is pure from `snapshot` + `lastError`.
+    /// Test-only escape hatch: the HealthStore is a process-wide singleton but
+    /// state derivation is pure from `snapshot` + `lastError`.
     func __setSnapshotForTest(_ snapshot: HealthSnapshot?, lastError: String? = nil) {
         self.snapshot = snapshot
         self.lastError = lastError

--- a/apps/macos/Sources/OpenClaw/IconState.swift
+++ b/apps/macos/Sources/OpenClaw/IconState.swift
@@ -72,7 +72,9 @@ enum IconOverrideSelection: String, CaseIterable, Identifiable {
     case mainBash, mainRead, mainWrite, mainEdit, mainOther
     case otherBash, otherRead, otherWrite, otherEdit, otherOther
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var label: String {
         switch self {

--- a/apps/macos/Sources/OpenClaw/InstancesStore.swift
+++ b/apps/macos/Sources/OpenClaw/InstancesStore.swift
@@ -1,8 +1,8 @@
-import OpenClawKit
-import OpenClawProtocol
 import Cocoa
 import Foundation
 import Observation
+import OpenClawKit
+import OpenClawProtocol
 import OSLog
 
 struct InstanceInfo: Identifiable, Codable {

--- a/apps/macos/Sources/OpenClaw/LogLocator.swift
+++ b/apps/macos/Sources/OpenClaw/LogLocator.swift
@@ -7,8 +7,7 @@ enum LogLocator {
         {
             return URL(fileURLWithPath: override)
         }
-        let preferred = URL(fileURLWithPath: "/tmp/openclaw")
-        return preferred
+        return URL(fileURLWithPath: "/tmp/openclaw")
     }
 
     private static var stdoutLog: URL {

--- a/apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift
+++ b/apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift
@@ -37,7 +37,9 @@ enum AppLogLevel: String, CaseIterable, Identifiable {
 
     static let `default`: AppLogLevel = .info
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var title: String {
         switch self {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -345,7 +345,7 @@ protocol UpdaterProviding: AnyObject {
     func checkForUpdates(_ sender: Any?)
 }
 
-// No-op updater used for debug/dev runs to suppress Sparkle dialogs.
+/// No-op updater used for debug/dev runs to suppress Sparkle dialogs.
 final class DisabledUpdaterController: UpdaterProviding {
     var automaticallyChecksForUpdates: Bool = false
     var automaticallyDownloadsUpdates: Bool = false
@@ -394,7 +394,9 @@ final class SparkleUpdaterController: NSObject, UpdaterProviding {
         set { self.controller.updater.automaticallyDownloadsUpdates = newValue }
     }
 
-    var isAvailable: Bool { true }
+    var isAvailable: Bool {
+        true
+    }
 
     func checkForUpdates(_ sender: Any?) {
         self.controller.checkForUpdates(sender)

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -400,7 +400,6 @@ struct MenuContent: View {
         }
     }
 
-    @ViewBuilder
     private func statusLine(label: String, color: Color) -> some View {
         HStack(spacing: 6) {
             Circle()
@@ -590,6 +589,8 @@ struct MenuContent: View {
     private struct AudioInputDevice: Identifiable, Equatable {
         let uid: String
         let name: String
-        var id: String { self.uid }
+        var id: String {
+            self.uid
+        }
     }
 }

--- a/apps/macos/Sources/OpenClaw/MenuHighlightedHostView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuHighlightedHostView.swift
@@ -22,7 +22,9 @@ final class HighlightedMenuItemHostView: NSView {
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override var intrinsicContentSize: NSSize {
         let size = self.hosting.fittingSize

--- a/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
+++ b/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
@@ -159,7 +159,9 @@ final class MenuSessionsInjector: NSObject, NSMenuDelegate {
 extension MenuSessionsInjector {
     // MARK: - Injection
 
-    private var mainSessionKey: String { WorkActivityStore.shared.mainSessionKey }
+    private var mainSessionKey: String {
+        WorkActivityStore.shared.mainSessionKey
+    }
 
     private func inject(into menu: NSMenu) {
         self.cancelPreviewTasks()
@@ -1175,8 +1177,7 @@ extension MenuSessionsInjector {
 
     private func makeHostedView(rootView: AnyView, width: CGFloat, highlighted: Bool) -> NSView {
         if highlighted {
-            let container = HighlightedMenuItemHostView(rootView: rootView, width: width)
-            return container
+            return HighlightedMenuItemHostView(rootView: rootView, width: width)
         }
 
         let hosting = NSHostingView(rootView: rootView)

--- a/apps/macos/Sources/OpenClaw/MicLevelMonitor.swift
+++ b/apps/macos/Sources/OpenClaw/MicLevelMonitor.swift
@@ -64,8 +64,7 @@ actor MicLevelMonitor {
         }
         let rms = sqrt(sum / Float(frameCount) + 1e-12)
         let db = 20 * log10(Double(rms))
-        let normalized = max(0, min(1, (db + 50) / 50))
-        return normalized
+        return max(0, min(1, (db + 50) / 50))
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/ModelCatalogLoader.swift
+++ b/apps/macos/Sources/OpenClaw/ModelCatalogLoader.swift
@@ -2,7 +2,10 @@ import Foundation
 import JavaScriptCore
 
 enum ModelCatalogLoader {
-    static var defaultPath: String { self.resolveDefaultPath() }
+    static var defaultPath: String {
+        self.resolveDefaultPath()
+    }
+
     private static let logger = Logger(subsystem: "ai.openclaw", category: "models")
     private nonisolated static let appSupportDir: URL = {
         let base = FileManager().urls(for: .applicationSupportDirectory, in: .userDomainMask).first!

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeLocationService.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeLocationService.swift
@@ -1,6 +1,6 @@
-import OpenClawKit
 import CoreLocation
 import Foundation
+import OpenClawKit
 
 @MainActor
 final class MacNodeLocationService: NSObject, CLLocationManagerDelegate {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -1,5 +1,5 @@
-import OpenClawKit
 import Foundation
+import OpenClawKit
 import OSLog
 
 @MainActor

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -1,7 +1,7 @@
 import AppKit
+import Foundation
 import OpenClawIPC
 import OpenClawKit
-import Foundation
 
 actor MacNodeRuntime {
     private let cameraCapture = CameraCaptureService()

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntimeMainActorServices.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntimeMainActorServices.swift
@@ -1,6 +1,6 @@
-import OpenClawKit
 import CoreLocation
 import Foundation
+import OpenClawKit
 
 @MainActor
 protocol MacNodeRuntimeMainActorServices: Sendable {

--- a/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
@@ -1,10 +1,10 @@
 import AppKit
+import Foundation
+import Observation
 import OpenClawDiscovery
 import OpenClawIPC
 import OpenClawKit
 import OpenClawProtocol
-import Foundation
-import Observation
 import OSLog
 import UserNotifications
 
@@ -39,8 +39,13 @@ final class NodePairingApprovalPrompter {
     private var autoApproveAttempts: Set<String> = []
 
     private final class AlertHostWindow: NSWindow {
-        override var canBecomeKey: Bool { true }
-        override var canBecomeMain: Bool { true }
+        override var canBecomeKey: Bool {
+            true
+        }
+
+        override var canBecomeMain: Bool {
+            true
+        }
     }
 
     private struct PairingList: Codable {
@@ -68,7 +73,9 @@ final class NodePairingApprovalPrompter {
         let silent: Bool?
         let ts: Double
 
-        var id: String { self.requestId }
+        var id: String {
+            self.requestId
+        }
     }
 
     private struct PairingResolvedEvent: Codable {

--- a/apps/macos/Sources/OpenClaw/NodesStore.swift
+++ b/apps/macos/Sources/OpenClaw/NodesStore.swift
@@ -18,9 +18,17 @@ struct NodeInfo: Identifiable, Codable {
     let paired: Bool?
     let connected: Bool?
 
-    var id: String { self.nodeId }
-    var isConnected: Bool { self.connected ?? false }
-    var isPaired: Bool { self.paired ?? false }
+    var id: String {
+        self.nodeId
+    }
+
+    var isConnected: Bool {
+        self.connected ?? false
+    }
+
+    var isPaired: Bool {
+        self.paired ?? false
+    }
 }
 
 private struct NodeListResponse: Codable {

--- a/apps/macos/Sources/OpenClaw/NotificationManager.swift
+++ b/apps/macos/Sources/OpenClaw/NotificationManager.swift
@@ -1,5 +1,5 @@
-import OpenClawIPC
 import Foundation
+import OpenClawIPC
 import Security
 import UserNotifications
 

--- a/apps/macos/Sources/OpenClaw/NotifyOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/NotifyOverlay.swift
@@ -10,7 +10,9 @@ final class NotifyOverlayController {
     static let shared = NotifyOverlayController()
 
     private(set) var model = Model()
-    var isVisible: Bool { self.model.isVisible }
+    var isVisible: Bool {
+        self.model.isVisible
+    }
 
     struct Model {
         var title: String = ""

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -1,9 +1,9 @@
 import AppKit
+import Combine
+import Observation
 import OpenClawChatUI
 import OpenClawDiscovery
 import OpenClawIPC
-import Combine
-import Observation
 import SwiftUI
 
 enum UIStrings {
@@ -142,18 +142,30 @@ struct OnboardingView: View {
         Self.pageOrder(for: self.state.connectionMode, showOnboardingChat: self.showOnboardingChat)
     }
 
-    var pageCount: Int { self.pageOrder.count }
+    var pageCount: Int {
+        self.pageOrder.count
+    }
+
     var activePageIndex: Int {
         self.activePageIndex(for: self.currentPage)
     }
 
-    var buttonTitle: String { self.currentPage == self.pageCount - 1 ? "Finish" : "Next" }
-    var wizardPageOrderIndex: Int? { self.pageOrder.firstIndex(of: self.wizardPageIndex) }
+    var buttonTitle: String {
+        self.currentPage == self.pageCount - 1 ? "Finish" : "Next"
+    }
+
+    var wizardPageOrderIndex: Int? {
+        self.pageOrder.firstIndex(of: self.wizardPageIndex)
+    }
+
     var isWizardBlocking: Bool {
         self.activePageIndex == self.wizardPageIndex && !self.onboardingWizard.isComplete
     }
 
-    var canAdvance: Bool { !self.isWizardBlocking }
+    var canAdvance: Bool {
+        !self.isWizardBlocking
+    }
+
     var devLinkCommand: String {
         let version = GatewayEnvironment.expectedGatewayVersionString() ?? "latest"
         return "npm install -g openclaw@\(version)"

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -1,7 +1,7 @@
 import AppKit
+import Foundation
 import OpenClawDiscovery
 import OpenClawIPC
-import Foundation
 import SwiftUI
 
 extension OnboardingView {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -1,5 +1,5 @@
-import OpenClawIPC
 import Foundation
+import OpenClawIPC
 
 extension OnboardingView {
     @MainActor

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -206,7 +206,9 @@ extension OnboardingView {
                                             .textFieldStyle(.roundedBorder)
                                             .frame(width: fieldWidth)
                                     }
-                                    if let message = CommandResolver.sshTargetValidationMessage(self.state.remoteTarget) {
+                                    if let message = CommandResolver
+                                        .sshTargetValidationMessage(self.state.remoteTarget)
+                                    {
                                         GridRow {
                                             Text("")
                                                 .frame(width: labelWidth, alignment: .leading)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Wizard.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Wizard.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Observation
+import OpenClawProtocol
 import SwiftUI
 
 extension OnboardingView {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Workspace.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Workspace.swift
@@ -23,7 +23,7 @@ extension OnboardingView {
             } catch {
                 self.workspaceStatus = "Failed to create workspace: \(error.localizedDescription)"
             }
-        case let .unsafe(reason):
+        case let .unsafe (reason):
             self.workspaceStatus = "Workspace not touched: \(reason)"
         }
         self.refreshBootstrapStatus()
@@ -54,7 +54,7 @@ extension OnboardingView {
 
         do {
             let url = AgentWorkspace.resolveWorkspaceURL(from: self.workspacePath)
-            if case let .unsafe(reason) = AgentWorkspace.bootstrapSafety(for: url) {
+            if case let .unsafe (reason) = AgentWorkspace.bootstrapSafety(for: url) {
                 self.workspaceStatus = "Workspace not created: \(reason)"
                 return
             }

--- a/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
@@ -1,7 +1,7 @@
-import OpenClawKit
-import OpenClawProtocol
 import Foundation
 import Observation
+import OpenClawKit
+import OpenClawProtocol
 import OSLog
 import SwiftUI
 
@@ -41,8 +41,13 @@ final class OnboardingWizardModel {
     private var restartAttempts = 0
     private let maxRestartAttempts = 1
 
-    var isComplete: Bool { self.status == "done" }
-    var isRunning: Bool { self.status == "running" }
+    var isComplete: Bool {
+        self.status == "done"
+    }
+
+    var isRunning: Bool {
+        self.status == "running"
+    }
 
     func reset() {
         self.sessionId = nil
@@ -408,5 +413,7 @@ private struct WizardOptionItem: Identifiable {
     let index: Int
     let option: WizardOption
 
-    var id: Int { self.index }
+    var id: Int {
+        self.index
+    }
 }

--- a/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Foundation
+import OpenClawProtocol
 
 enum OpenClawConfigFile {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "config")

--- a/apps/macos/Sources/OpenClaw/OpenClawPaths.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawPaths.swift
@@ -24,8 +24,7 @@ enum OpenClawPaths {
             }
         }
         let home = FileManager().homeDirectoryForCurrentUser
-        let preferred = home.appendingPathComponent(".openclaw", isDirectory: true)
-        return preferred
+        return home.appendingPathComponent(".openclaw", isDirectory: true)
     }
 
     private static func resolveConfigCandidate(in dir: URL) -> URL? {

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -1,11 +1,11 @@
 import AppKit
 import ApplicationServices
 import AVFoundation
-import OpenClawIPC
 import CoreGraphics
 import CoreLocation
 import Foundation
 import Observation
+import OpenClawIPC
 import Speech
 import UserNotifications
 
@@ -336,7 +336,7 @@ final class LocationPermissionRequester: NSObject, CLLocationManagerDelegate {
         cont.resume(returning: status)
     }
 
-    // nonisolated for Swift 6 strict concurrency compatibility
+    /// nonisolated for Swift 6 strict concurrency compatibility
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
         Task { @MainActor in
@@ -344,7 +344,7 @@ final class LocationPermissionRequester: NSObject, CLLocationManagerDelegate {
         }
     }
 
-    // Legacy callback (still used on some macOS versions / configurations).
+    /// Legacy callback (still used on some macOS versions / configurations).
     nonisolated func locationManager(
         _ manager: CLLocationManager,
         didChangeAuthorization status: CLAuthorizationStatus)

--- a/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
@@ -1,6 +1,6 @@
+import CoreLocation
 import OpenClawIPC
 import OpenClawKit
-import CoreLocation
 import SwiftUI
 
 struct PermissionsSettings: View {
@@ -164,7 +164,9 @@ struct PermissionRow: View {
         .padding(.vertical, self.compact ? 4 : 6)
     }
 
-    private var iconSize: CGFloat { self.compact ? 28 : 32 }
+    private var iconSize: CGFloat {
+        self.compact ? 28 : 32
+    }
 
     private var title: String {
         switch self.capability {

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -103,7 +103,9 @@ actor PortGuardian {
         let status: Status
         let listeners: [ReportListener]
 
-        var id: Int { self.port }
+        var id: Int {
+            self.port
+        }
 
         var offenders: [ReportListener] {
             if case let .interference(_, offenders) = self.status { return offenders }
@@ -141,7 +143,9 @@ actor PortGuardian {
         let user: String?
         let expected: Bool
 
-        var id: Int32 { self.pid }
+        var id: Int32 {
+            self.pid
+        }
     }
 
     func diagnose(mode: AppState.ConnectionMode) async -> [PortReport] {

--- a/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
+++ b/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
@@ -12,8 +12,8 @@ extension ProcessInfo {
         environment: [String: String],
         standard: UserDefaults,
         stableSuite: UserDefaults?,
-        isAppBundle: Bool
-    ) -> Bool {
+        isAppBundle: Bool) -> Bool
+    {
         if environment["OPENCLAW_NIX_MODE"] == "1" { return true }
         if standard.bool(forKey: "openclaw.nixMode") { return true }
 

--- a/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
+++ b/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
@@ -10,7 +10,9 @@ struct RuntimeVersion: Comparable, CustomStringConvertible {
     let minor: Int
     let patch: Int
 
-    var description: String { "\(self.major).\(self.minor).\(self.patch)" }
+    var description: String {
+        "\(self.major).\(self.minor).\(self.patch)"
+    }
 
     static func < (lhs: RuntimeVersion, rhs: RuntimeVersion) -> Bool {
         if lhs.major != rhs.major { return lhs.major < rhs.major }
@@ -163,5 +165,7 @@ enum RuntimeLocator {
 }
 
 extension RuntimeKind {
-    fileprivate var binaryName: String { "node" }
+    fileprivate var binaryName: String {
+        "node"
+    }
 }

--- a/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
+++ b/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
@@ -52,7 +52,7 @@ enum RuntimeResolutionError: Error {
 
 enum RuntimeLocator {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "runtime")
-    private static let minNode = RuntimeVersion(major: 22, minor: 0, patch: 0)
+    private static let minNode = RuntimeVersion(major: 22, minor: 12, patch: 0)
 
     static func resolve(
         searchPaths: [String] = CommandResolver.preferredPaths()) -> Result<RuntimeResolution, RuntimeResolutionError>
@@ -89,7 +89,7 @@ enum RuntimeLocator {
         switch error {
         case let .notFound(searchPaths):
             [
-                "openclaw needs Node >=22.0.0 but found no runtime.",
+                "openclaw needs Node >=22.12.0 but found no runtime.",
                 "PATH searched: \(searchPaths.joined(separator: ":"))",
                 "Install Node: https://nodejs.org/en/download",
             ].joined(separator: "\n")
@@ -103,7 +103,7 @@ enum RuntimeLocator {
             [
                 "Could not parse \(kind.rawValue) version output \"\(raw)\" from \(path).",
                 "PATH searched: \(searchPaths.joined(separator: ":"))",
-                "Try reinstalling or pinning a supported version (Node >=22.0.0).",
+                "Try reinstalling or pinning a supported version (Node >=22.12.0).",
             ].joined(separator: "\n")
         }
     }

--- a/apps/macos/Sources/OpenClaw/SessionData.swift
+++ b/apps/macos/Sources/OpenClaw/SessionData.swift
@@ -84,8 +84,13 @@ struct SessionRow: Identifiable {
     let tokens: SessionTokenStats
     let model: String?
 
-    var ageText: String { relativeAge(from: self.updatedAt) }
-    var label: String { self.displayName ?? self.key }
+    var ageText: String {
+        relativeAge(from: self.updatedAt)
+    }
+
+    var label: String {
+        self.displayName ?? self.key
+    }
 
     var flagLabels: [String] {
         var flags: [String] = []

--- a/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
+++ b/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
@@ -1,14 +1,7 @@
 import SwiftUI
 
-private struct MenuItemHighlightedKey: EnvironmentKey {
-    static let defaultValue = false
-}
-
 extension EnvironmentValues {
-    var menuItemHighlighted: Bool {
-        get { self[MenuItemHighlightedKey.self] }
-        set { self[MenuItemHighlightedKey.self] = newValue }
-    }
+    @Entry var menuItemHighlighted: Bool = false
 }
 
 struct SessionMenuLabelView: View {

--- a/apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift
+++ b/apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift
@@ -183,7 +183,6 @@ struct SessionMenuPreviewView: View {
         .frame(width: max(1, self.width), alignment: .leading)
     }
 
-    @ViewBuilder
     private func previewRow(_ item: SessionPreviewItem) -> some View {
         HStack(alignment: .top, spacing: 4) {
             Text(item.role.label)
@@ -212,7 +211,6 @@ struct SessionMenuPreviewView: View {
         }
     }
 
-    @ViewBuilder
     private func placeholder(_ text: String) -> some View {
         Text(text)
             .font(.caption)
@@ -227,7 +225,9 @@ enum SessionMenuPreviewLoader {
     private static let previewMaxChars = 240
 
     private struct PreviewTimeoutError: LocalizedError {
-        var errorDescription: String? { "preview timeout" }
+        var errorDescription: String? {
+            "preview timeout"
+        }
     }
 
     static func prewarm(sessionKeys: [String], maxItems: Int) async {

--- a/apps/macos/Sources/OpenClaw/SessionsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SessionsSettings.swift
@@ -85,7 +85,6 @@ struct SessionsSettings: View {
         }
     }
 
-    @ViewBuilder
     private func sessionRow(_ row: SessionRow) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {

--- a/apps/macos/Sources/OpenClaw/ShellExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ShellExecutor.swift
@@ -1,5 +1,5 @@
-import OpenClawIPC
 import Foundation
+import OpenClawIPC
 
 enum ShellExecutor {
     struct ShellResult {
@@ -69,7 +69,7 @@ enum ShellExecutor {
 
         if let timeout, timeout > 0 {
             let nanos = UInt64(timeout * 1_000_000_000)
-            let result = await withTaskGroup(of: ShellResult.self) { group in
+            return await withTaskGroup(of: ShellResult.self) { group in
                 group.addTask { await waitTask.value }
                 group.addTask {
                     try? await Task.sleep(nanoseconds: nanos)
@@ -87,7 +87,6 @@ enum ShellExecutor {
                 group.cancelAll()
                 return first
             }
-            return result
         }
 
         return await waitTask.value

--- a/apps/macos/Sources/OpenClaw/SkillsModels.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsModels.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Foundation
+import OpenClawProtocol
 
 struct SkillsStatusReport: Codable {
     let workspaceDir: String
@@ -25,7 +25,9 @@ struct SkillStatus: Codable, Identifiable {
     let configChecks: [SkillStatusConfigCheck]
     let install: [SkillInstallOption]
 
-    var id: String { self.name }
+    var id: String {
+        self.name
+    }
 }
 
 struct SkillRequirements: Codable {
@@ -45,7 +47,9 @@ struct SkillStatusConfigCheck: Codable, Identifiable {
     let value: AnyCodable?
     let satisfied: Bool
 
-    var id: String { self.path }
+    var id: String {
+        self.path
+    }
 }
 
 struct SkillInstallOption: Codable, Identifiable {

--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -1,5 +1,5 @@
-import OpenClawProtocol
 import Observation
+import OpenClawProtocol
 import SwiftUI
 
 struct SkillsSettings: View {
@@ -142,7 +142,9 @@ private enum SkillsFilter: String, CaseIterable, Identifiable {
     case needsSetup
     case disabled
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var title: String {
         switch self {
@@ -171,24 +173,16 @@ private struct SkillRow: View {
     let onInstall: (SkillInstallOption, InstallTarget) -> Void
     let onSetEnv: (String, Bool) -> Void
 
-    private var missingBins: [String] { self.skill.missing.bins }
-    private var missingEnv: [String] { self.skill.missing.env }
-    private var missingConfig: [String] { self.skill.missing.config }
+    private var missingBins: [String] {
+        self.skill.missing.bins
+    }
 
-    init(
-        skill: SkillStatus,
-        isBusy: Bool,
-        connectionMode: AppState.ConnectionMode,
-        onToggleEnabled: @escaping (Bool) -> Void,
-        onInstall: @escaping (SkillInstallOption, InstallTarget) -> Void,
-        onSetEnv: @escaping (String, Bool) -> Void)
-    {
-        self.skill = skill
-        self.isBusy = isBusy
-        self.connectionMode = connectionMode
-        self.onToggleEnabled = onToggleEnabled
-        self.onInstall = onInstall
-        self.onSetEnv = onSetEnv
+    private var missingEnv: [String] {
+        self.skill.missing.env
+    }
+
+    private var missingConfig: [String] {
+        self.skill.missing.config
     }
 
     var body: some View {
@@ -274,7 +268,6 @@ private struct SkillRow: View {
             set: { self.onToggleEnabled($0) })
     }
 
-    @ViewBuilder
     private var missingSummary: some View {
         VStack(alignment: .leading, spacing: 4) {
             if self.shouldShowMissingBins {
@@ -295,7 +288,6 @@ private struct SkillRow: View {
         }
     }
 
-    @ViewBuilder
     private var configChecksView: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(self.skill.configChecks) { check in
@@ -326,7 +318,6 @@ private struct SkillRow: View {
         }
     }
 
-    @ViewBuilder
     private var trailingActions: some View {
         VStack(alignment: .trailing, spacing: 8) {
             if !self.installOptions.isEmpty {
@@ -438,7 +429,9 @@ private struct EnvEditorState: Identifiable {
     let envKey: String
     let isPrimary: Bool
 
-    var id: String { "\(self.skillKey)::\(self.envKey)" }
+    var id: String {
+        "\(self.skillKey)::\(self.envKey)"
+    }
 }
 
 private struct EnvEditorView: View {

--- a/apps/macos/Sources/OpenClaw/SoundEffects.swift
+++ b/apps/macos/Sources/OpenClaw/SoundEffects.swift
@@ -10,7 +10,9 @@ enum SoundEffectCatalog {
         return ["Glass"] + sorted
     }
 
-    static func displayName(for raw: String) -> String { raw }
+    static func displayName(for raw: String) -> String {
+        raw
+    }
 
     static func url(for name: String) -> URL? {
         self.discoveredSoundMap[name]

--- a/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
+++ b/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
@@ -150,7 +150,9 @@ private enum ExecApprovalsSettingsTab: String, CaseIterable, Identifiable {
     case policy
     case allowlist
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var title: String {
         switch self {

--- a/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
+++ b/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
@@ -5,7 +5,9 @@ private enum GatewayTailscaleMode: String, CaseIterable, Identifiable {
     case serve
     case funnel
 
-    var id: String { self.rawValue }
+    var id: String {
+        self.rawValue
+    }
 
     var label: String {
         switch self {

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -1,7 +1,7 @@
 import AVFoundation
+import Foundation
 import OpenClawChatUI
 import OpenClawKit
-import Foundation
 import OSLog
 import Speech
 

--- a/apps/macos/Sources/OpenClaw/TalkOverlayView.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlayView.swift
@@ -99,8 +99,13 @@ private final class OrbInteractionNSView: NSView {
     private var didDrag = false
     private var suppressSingleClick = false
 
-    override var acceptsFirstResponder: Bool { true }
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+    override var acceptsFirstResponder: Bool {
+        true
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
 
     override func mouseDown(with event: NSEvent) {
         self.mouseDownEvent = event

--- a/apps/macos/Sources/OpenClaw/UsageData.swift
+++ b/apps/macos/Sources/OpenClaw/UsageData.swift
@@ -41,8 +41,7 @@ struct UsageRow: Identifiable {
 
     var remainingPercent: Int? {
         guard let usedPercent, usedPercent.isFinite else { return nil }
-        let remaining = max(0, min(100, Int(round(100 - usedPercent))))
-        return remaining
+        return max(0, min(100, Int(round(100 - usedPercent))))
     }
 
     func detailText(now: Date = .init()) -> String {

--- a/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
+++ b/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
@@ -122,7 +122,7 @@ actor VoicePushToTalk {
     private var recognitionTask: SFSpeechRecognitionTask?
     private var tapInstalled = false
 
-    // Session token used to drop stale callbacks when a new capture starts.
+    /// Session token used to drop stale callbacks when a new capture starts.
     private var sessionID = UUID()
 
     private var committed: String = ""

--- a/apps/macos/Sources/OpenClaw/VoiceWakeChime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeChime.swift
@@ -28,7 +28,9 @@ enum VoiceWakeChime: Codable, Equatable, Sendable {
 
 enum VoiceWakeChimeCatalog {
     /// Options shown in the picker.
-    static var systemOptions: [String] { SoundEffectCatalog.systemOptions }
+    static var systemOptions: [String] {
+        SoundEffectCatalog.systemOptions
+    }
 
     static func displayName(for raw: String) -> String {
         SoundEffectCatalog.displayName(for: raw)

--- a/apps/macos/Sources/OpenClaw/VoiceWakeGlobalSettingsSync.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeGlobalSettingsSync.swift
@@ -1,5 +1,5 @@
-import OpenClawKit
 import Foundation
+import OpenClawKit
 import OSLog
 
 @MainActor

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlay.swift
@@ -18,7 +18,9 @@ final class VoiceWakeOverlayController {
     enum Source: String { case wakeWord, pushToTalk }
 
     var model = Model()
-    var isVisible: Bool { self.model.isVisible }
+    var isVisible: Bool {
+        self.model.isVisible
+    }
 
     struct Model {
         var text: String = ""

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayTextViews.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayTextViews.swift
@@ -11,7 +11,9 @@ struct TranscriptTextView: NSViewRepresentable {
     var onEndEditing: () -> Void
     var onSend: () -> Void
 
-    func makeCoordinator() -> Coordinator { Coordinator(self) }
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
 
     func makeNSView(context: Context) -> NSScrollView {
         let textView = TranscriptNSTextView()
@@ -77,7 +79,9 @@ struct TranscriptTextView: NSViewRepresentable {
         var parent: TranscriptTextView
         var isProgrammaticUpdate = false
 
-        init(_ parent: TranscriptTextView) { self.parent = parent }
+        init(_ parent: TranscriptTextView) {
+            self.parent = parent
+        }
 
         func textDidBeginEditing(_ notification: Notification) {
             self.parent.onBeginEditing()
@@ -147,7 +151,9 @@ private final class ClickCatcher: NSView {
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func mouseDown(with event: NSEvent) {
         super.mouseDown(with: event)

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift
@@ -131,7 +131,9 @@ private struct OverlayBackground: View {
 }
 
 extension OverlayBackground: @MainActor Equatable {
-    static func == (lhs: Self, rhs: Self) -> Bool { true }
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        true
+    }
 }
 
 struct CloseHoverButton: View {

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -48,10 +48,10 @@ actor VoiceWakeRuntime {
     private var isStarting: Bool = false
     private var triggerOnlyTask: Task<Void, Never>?
 
-    // Tunables
-    // Silence threshold once we've captured user speech (post-trigger).
+    /// Tunables
+    /// Silence threshold once we've captured user speech (post-trigger).
     private let silenceWindow: TimeInterval = 2.0
-    // Silence threshold when we only heard the trigger but no post-trigger speech yet.
+    /// Silence threshold when we only heard the trigger but no post-trigger speech yet.
     private let triggerOnlySilenceWindow: TimeInterval = 5.0
     // Maximum capture duration from trigger until we force-send, to avoid runaway sessions.
     private let captureHardStop: TimeInterval = 120.0

--- a/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
@@ -29,7 +29,9 @@ struct VoiceWakeSettings: View {
     private struct AudioInputDevice: Identifiable, Equatable {
         let uid: String
         let name: String
-        var id: String { self.uid }
+        var id: String {
+            self.uid
+        }
     }
 
     private struct TriggerEntry: Identifiable {

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -3,8 +3,13 @@ import Foundation
 
 /// A borderless panel that can still accept key focus (needed for typing).
 final class WebChatPanel: NSPanel {
-    override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { true }
+    override var canBecomeKey: Bool {
+        true
+    }
+
+    override var canBecomeMain: Bool {
+        true
+    }
 }
 
 enum WebChatPresentation {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -1,8 +1,8 @@
 import AppKit
+import Foundation
 import OpenClawChatUI
 import OpenClawKit
 import OpenClawProtocol
-import Foundation
 import OSLog
 import QuartzCore
 import SwiftUI

--- a/apps/macos/Sources/OpenClaw/WorkActivityStore.swift
+++ b/apps/macos/Sources/OpenClaw/WorkActivityStore.swift
@@ -1,7 +1,7 @@
-import OpenClawKit
-import OpenClawProtocol
 import Foundation
 import Observation
+import OpenClawKit
+import OpenClawProtocol
 import SwiftUI
 
 @MainActor
@@ -31,7 +31,9 @@ final class WorkActivityStore {
     private var mainSessionKeyStorage = "main"
     private let toolResultGrace: TimeInterval = 2.0
 
-    var mainSessionKey: String { self.mainSessionKeyStorage }
+    var mainSessionKey: String {
+        self.mainSessionKeyStorage
+    }
 
     func handleJob(sessionKey: String, state: String) {
         let isStart = state.lowercased() == "started" || state.lowercased() == "streaming"

--- a/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
@@ -1,7 +1,7 @@
-import OpenClawKit
 import Foundation
 import Network
 import Observation
+import OpenClawKit
 import OSLog
 
 @MainActor
@@ -18,7 +18,10 @@ public final class GatewayDiscoveryModel {
     }
 
     public struct DiscoveredGateway: Identifiable, Equatable, Sendable {
-        public var id: String { self.stableID }
+        public var id: String {
+            self.stableID
+        }
+
         public var displayName: String
         public var lanHost: String?
         public var tailnetDns: String?

--- a/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
@@ -1,5 +1,5 @@
-import OpenClawKit
 import Foundation
+import OpenClawKit
 
 struct WideAreaGatewayBeacon: Sendable, Equatable {
     var instanceName: String
@@ -117,13 +117,12 @@ enum WideAreaGatewayDiscovery {
         }
 
         var seen = Set<String>()
-        let ordered = ips.filter { value in
+        return ips.filter { value in
             guard self.isTailnetIPv4(value) else { return false }
             if seen.contains(value) { return false }
             seen.insert(value)
             return true
         }
-        return ordered
     }
 
     private static func readTailscaleStatus() -> String? {
@@ -370,5 +369,7 @@ private struct TailscaleStatus: Decodable {
 }
 
 extension Collection {
-    fileprivate var nonEmpty: Self? { isEmpty ? nil : self }
+    fileprivate var nonEmpty: Self? {
+        isEmpty ? nil : self
+    }
 }

--- a/apps/macos/Sources/OpenClawIPC/IPC.swift
+++ b/apps/macos/Sources/OpenClawIPC/IPC.swift
@@ -407,11 +407,10 @@ extension Request: Codable {
     }
 }
 
-// Shared transport settings
+/// Shared transport settings
 public let controlSocketPath: String = {
     let home = FileManager().homeDirectoryForCurrentUser
-    let preferred = home
+    return home
         .appendingPathComponent("Library/Application Support/OpenClaw/control.sock")
         .path
-    return preferred
 }()

--- a/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
@@ -1,6 +1,6 @@
+import Foundation
 import OpenClawKit
 import OpenClawProtocol
-import Foundation
 #if canImport(Darwin)
 import Darwin
 #endif

--- a/apps/macos/Sources/OpenClawMacCLI/DiscoverCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/DiscoverCommand.swift
@@ -1,5 +1,5 @@
-import OpenClawDiscovery
 import Foundation
+import OpenClawDiscovery
 
 struct DiscoveryOptions {
     var timeoutMs: Int = 2000

--- a/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
@@ -1,7 +1,7 @@
-import OpenClawKit
-import OpenClawProtocol
 import Darwin
 import Foundation
+import OpenClawKit
+import OpenClawProtocol
 
 struct WizardCliOptions {
     var url: String?

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -40,8 +40,8 @@ public struct ConnectParams: Codable, Sendable {
         device: [String: AnyCodable]?,
         auth: [String: AnyCodable]?,
         locale: String?,
-        useragent: String?
-    ) {
+        useragent: String?)
+    {
         self.minprotocol = minprotocol
         self.maxprotocol = maxprotocol
         self.client = client
@@ -56,6 +56,7 @@ public struct ConnectParams: Codable, Sendable {
         self.locale = locale
         self.useragent = useragent
     }
+
     private enum CodingKeys: String, CodingKey {
         case minprotocol = "minProtocol"
         case maxprotocol = "maxProtocol"
@@ -91,8 +92,8 @@ public struct HelloOk: Codable, Sendable {
         snapshot: Snapshot,
         canvashosturl: String?,
         auth: [String: AnyCodable]?,
-        policy: [String: AnyCodable]
-    ) {
+        policy: [String: AnyCodable])
+    {
         self.type = type
         self._protocol = _protocol
         self.server = server
@@ -102,6 +103,7 @@ public struct HelloOk: Codable, Sendable {
         self.auth = auth
         self.policy = policy
     }
+
     private enum CodingKeys: String, CodingKey {
         case type
         case _protocol = "protocol"
@@ -124,13 +126,14 @@ public struct RequestFrame: Codable, Sendable {
         type: String,
         id: String,
         method: String,
-        params: AnyCodable?
-    ) {
+        params: AnyCodable?)
+    {
         self.type = type
         self.id = id
         self.method = method
         self.params = params
     }
+
     private enum CodingKeys: String, CodingKey {
         case type
         case id
@@ -151,14 +154,15 @@ public struct ResponseFrame: Codable, Sendable {
         id: String,
         ok: Bool,
         payload: AnyCodable?,
-        error: [String: AnyCodable]?
-    ) {
+        error: [String: AnyCodable]?)
+    {
         self.type = type
         self.id = id
         self.ok = ok
         self.payload = payload
         self.error = error
     }
+
     private enum CodingKeys: String, CodingKey {
         case type
         case id
@@ -180,14 +184,15 @@ public struct EventFrame: Codable, Sendable {
         event: String,
         payload: AnyCodable?,
         seq: Int?,
-        stateversion: [String: AnyCodable]?
-    ) {
+        stateversion: [String: AnyCodable]?)
+    {
         self.type = type
         self.event = event
         self.payload = payload
         self.seq = seq
         self.stateversion = stateversion
     }
+
     private enum CodingKeys: String, CodingKey {
         case type
         case event
@@ -231,8 +236,8 @@ public struct PresenceEntry: Codable, Sendable {
         deviceid: String?,
         roles: [String]?,
         scopes: [String]?,
-        instanceid: String?
-    ) {
+        instanceid: String?)
+    {
         self.host = host
         self.ip = ip
         self.version = version
@@ -250,6 +255,7 @@ public struct PresenceEntry: Codable, Sendable {
         self.scopes = scopes
         self.instanceid = instanceid
     }
+
     private enum CodingKeys: String, CodingKey {
         case host
         case ip
@@ -276,11 +282,12 @@ public struct StateVersion: Codable, Sendable {
 
     public init(
         presence: Int,
-        health: Int
-    ) {
+        health: Int)
+    {
         self.presence = presence
         self.health = health
     }
+
     private enum CodingKeys: String, CodingKey {
         case presence
         case health
@@ -303,8 +310,8 @@ public struct Snapshot: Codable, Sendable {
         uptimems: Int,
         configpath: String?,
         statedir: String?,
-        sessiondefaults: [String: AnyCodable]?
-    ) {
+        sessiondefaults: [String: AnyCodable]?)
+    {
         self.presence = presence
         self.health = health
         self.stateversion = stateversion
@@ -313,6 +320,7 @@ public struct Snapshot: Codable, Sendable {
         self.statedir = statedir
         self.sessiondefaults = sessiondefaults
     }
+
     private enum CodingKeys: String, CodingKey {
         case presence
         case health
@@ -336,14 +344,15 @@ public struct ErrorShape: Codable, Sendable {
         message: String,
         details: AnyCodable?,
         retryable: Bool?,
-        retryafterms: Int?
-    ) {
+        retryafterms: Int?)
+    {
         self.code = code
         self.message = message
         self.details = details
         self.retryable = retryable
         self.retryafterms = retryafterms
     }
+
     private enum CodingKeys: String, CodingKey {
         case code
         case message
@@ -365,14 +374,15 @@ public struct AgentEvent: Codable, Sendable {
         seq: Int,
         stream: String,
         ts: Int,
-        data: [String: AnyCodable]
-    ) {
+        data: [String: AnyCodable])
+    {
         self.runid = runid
         self.seq = seq
         self.stream = stream
         self.ts = ts
         self.data = data
     }
+
     private enum CodingKeys: String, CodingKey {
         case runid = "runId"
         case seq
@@ -402,8 +412,8 @@ public struct SendParams: Codable, Sendable {
         channel: String?,
         accountid: String?,
         sessionkey: String?,
-        idempotencykey: String
-    ) {
+        idempotencykey: String)
+    {
         self.to = to
         self.message = message
         self.mediaurl = mediaurl
@@ -414,6 +424,7 @@ public struct SendParams: Codable, Sendable {
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
+
     private enum CodingKeys: String, CodingKey {
         case to
         case message
@@ -445,8 +456,8 @@ public struct PollParams: Codable, Sendable {
         durationhours: Int?,
         channel: String?,
         accountid: String?,
-        idempotencykey: String
-    ) {
+        idempotencykey: String)
+    {
         self.to = to
         self.question = question
         self.options = options
@@ -456,6 +467,7 @@ public struct PollParams: Codable, Sendable {
         self.accountid = accountid
         self.idempotencykey = idempotencykey
     }
+
     private enum CodingKeys: String, CodingKey {
         case to
         case question
@@ -516,8 +528,8 @@ public struct AgentParams: Codable, Sendable {
         extrasystemprompt: String?,
         idempotencykey: String,
         label: String?,
-        spawnedby: String?
-    ) {
+        spawnedby: String?)
+    {
         self.message = message
         self.agentid = agentid
         self.to = to
@@ -542,6 +554,7 @@ public struct AgentParams: Codable, Sendable {
         self.label = label
         self.spawnedby = spawnedby
     }
+
     private enum CodingKeys: String, CodingKey {
         case message
         case agentid = "agentId"
@@ -575,11 +588,12 @@ public struct AgentIdentityParams: Codable, Sendable {
 
     public init(
         agentid: String?,
-        sessionkey: String?
-    ) {
+        sessionkey: String?)
+    {
         self.agentid = agentid
         self.sessionkey = sessionkey
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case sessionkey = "sessionKey"
@@ -596,13 +610,14 @@ public struct AgentIdentityResult: Codable, Sendable {
         agentid: String,
         name: String?,
         avatar: String?,
-        emoji: String?
-    ) {
+        emoji: String?)
+    {
         self.agentid = agentid
         self.name = name
         self.avatar = avatar
         self.emoji = emoji
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case name
@@ -617,11 +632,12 @@ public struct AgentWaitParams: Codable, Sendable {
 
     public init(
         runid: String,
-        timeoutms: Int?
-    ) {
+        timeoutms: Int?)
+    {
         self.runid = runid
         self.timeoutms = timeoutms
     }
+
     private enum CodingKeys: String, CodingKey {
         case runid = "runId"
         case timeoutms = "timeoutMs"
@@ -634,11 +650,12 @@ public struct WakeParams: Codable, Sendable {
 
     public init(
         mode: AnyCodable,
-        text: String
-    ) {
+        text: String)
+    {
         self.mode = mode
         self.text = text
     }
+
     private enum CodingKeys: String, CodingKey {
         case mode
         case text
@@ -671,8 +688,8 @@ public struct NodePairRequestParams: Codable, Sendable {
         caps: [String]?,
         commands: [String]?,
         remoteip: String?,
-        silent: Bool?
-    ) {
+        silent: Bool?)
+    {
         self.nodeid = nodeid
         self.displayname = displayname
         self.platform = platform
@@ -686,6 +703,7 @@ public struct NodePairRequestParams: Codable, Sendable {
         self.remoteip = remoteip
         self.silent = silent
     }
+
     private enum CodingKeys: String, CodingKey {
         case nodeid = "nodeId"
         case displayname = "displayName"
@@ -702,17 +720,17 @@ public struct NodePairRequestParams: Codable, Sendable {
     }
 }
 
-public struct NodePairListParams: Codable, Sendable {
-}
+public struct NodePairListParams: Codable, Sendable {}
 
 public struct NodePairApproveParams: Codable, Sendable {
     public let requestid: String
 
     public init(
-        requestid: String
-    ) {
+        requestid: String)
+    {
         self.requestid = requestid
     }
+
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
     }
@@ -722,10 +740,11 @@ public struct NodePairRejectParams: Codable, Sendable {
     public let requestid: String
 
     public init(
-        requestid: String
-    ) {
+        requestid: String)
+    {
         self.requestid = requestid
     }
+
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
     }
@@ -737,11 +756,12 @@ public struct NodePairVerifyParams: Codable, Sendable {
 
     public init(
         nodeid: String,
-        token: String
-    ) {
+        token: String)
+    {
         self.nodeid = nodeid
         self.token = token
     }
+
     private enum CodingKeys: String, CodingKey {
         case nodeid = "nodeId"
         case token
@@ -754,28 +774,29 @@ public struct NodeRenameParams: Codable, Sendable {
 
     public init(
         nodeid: String,
-        displayname: String
-    ) {
+        displayname: String)
+    {
         self.nodeid = nodeid
         self.displayname = displayname
     }
+
     private enum CodingKeys: String, CodingKey {
         case nodeid = "nodeId"
         case displayname = "displayName"
     }
 }
 
-public struct NodeListParams: Codable, Sendable {
-}
+public struct NodeListParams: Codable, Sendable {}
 
 public struct NodeDescribeParams: Codable, Sendable {
     public let nodeid: String
 
     public init(
-        nodeid: String
-    ) {
+        nodeid: String)
+    {
         self.nodeid = nodeid
     }
+
     private enum CodingKeys: String, CodingKey {
         case nodeid = "nodeId"
     }
@@ -793,14 +814,15 @@ public struct NodeInvokeParams: Codable, Sendable {
         command: String,
         params: AnyCodable?,
         timeoutms: Int?,
-        idempotencykey: String
-    ) {
+        idempotencykey: String)
+    {
         self.nodeid = nodeid
         self.command = command
         self.params = params
         self.timeoutms = timeoutms
         self.idempotencykey = idempotencykey
     }
+
     private enum CodingKeys: String, CodingKey {
         case nodeid = "nodeId"
         case command
@@ -824,8 +846,8 @@ public struct NodeInvokeResultParams: Codable, Sendable {
         ok: Bool,
         payload: AnyCodable?,
         payloadjson: String?,
-        error: [String: AnyCodable]?
-    ) {
+        error: [String: AnyCodable]?)
+    {
         self.id = id
         self.nodeid = nodeid
         self.ok = ok
@@ -833,6 +855,7 @@ public struct NodeInvokeResultParams: Codable, Sendable {
         self.payloadjson = payloadjson
         self.error = error
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case nodeid = "nodeId"
@@ -851,12 +874,13 @@ public struct NodeEventParams: Codable, Sendable {
     public init(
         event: String,
         payload: AnyCodable?,
-        payloadjson: String?
-    ) {
+        payloadjson: String?)
+    {
         self.event = event
         self.payload = payload
         self.payloadjson = payloadjson
     }
+
     private enum CodingKeys: String, CodingKey {
         case event
         case payload
@@ -878,8 +902,8 @@ public struct NodeInvokeRequestEvent: Codable, Sendable {
         command: String,
         paramsjson: String?,
         timeoutms: Int?,
-        idempotencykey: String?
-    ) {
+        idempotencykey: String?)
+    {
         self.id = id
         self.nodeid = nodeid
         self.command = command
@@ -887,6 +911,7 @@ public struct NodeInvokeRequestEvent: Codable, Sendable {
         self.timeoutms = timeoutms
         self.idempotencykey = idempotencykey
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case nodeid = "nodeId"
@@ -919,8 +944,8 @@ public struct SessionsListParams: Codable, Sendable {
         label: String?,
         spawnedby: String?,
         agentid: String?,
-        search: String?
-    ) {
+        search: String?)
+    {
         self.limit = limit
         self.activeminutes = activeminutes
         self.includeglobal = includeglobal
@@ -932,6 +957,7 @@ public struct SessionsListParams: Codable, Sendable {
         self.agentid = agentid
         self.search = search
     }
+
     private enum CodingKeys: String, CodingKey {
         case limit
         case activeminutes = "activeMinutes"
@@ -954,12 +980,13 @@ public struct SessionsPreviewParams: Codable, Sendable {
     public init(
         keys: [String],
         limit: Int?,
-        maxchars: Int?
-    ) {
+        maxchars: Int?)
+    {
         self.keys = keys
         self.limit = limit
         self.maxchars = maxchars
     }
+
     private enum CodingKeys: String, CodingKey {
         case keys
         case limit
@@ -983,8 +1010,8 @@ public struct SessionsResolveParams: Codable, Sendable {
         agentid: String?,
         spawnedby: String?,
         includeglobal: Bool?,
-        includeunknown: Bool?
-    ) {
+        includeunknown: Bool?)
+    {
         self.key = key
         self.sessionid = sessionid
         self.label = label
@@ -993,6 +1020,7 @@ public struct SessionsResolveParams: Codable, Sendable {
         self.includeglobal = includeglobal
         self.includeunknown = includeunknown
     }
+
     private enum CodingKeys: String, CodingKey {
         case key
         case sessionid = "sessionId"
@@ -1036,8 +1064,8 @@ public struct SessionsPatchParams: Codable, Sendable {
         model: AnyCodable?,
         spawnedby: AnyCodable?,
         sendpolicy: AnyCodable?,
-        groupactivation: AnyCodable?
-    ) {
+        groupactivation: AnyCodable?)
+    {
         self.key = key
         self.label = label
         self.thinkinglevel = thinkinglevel
@@ -1054,6 +1082,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.sendpolicy = sendpolicy
         self.groupactivation = groupactivation
     }
+
     private enum CodingKeys: String, CodingKey {
         case key
         case label
@@ -1077,10 +1106,11 @@ public struct SessionsResetParams: Codable, Sendable {
     public let key: String
 
     public init(
-        key: String
-    ) {
+        key: String)
+    {
         self.key = key
     }
+
     private enum CodingKeys: String, CodingKey {
         case key
     }
@@ -1092,11 +1122,12 @@ public struct SessionsDeleteParams: Codable, Sendable {
 
     public init(
         key: String,
-        deletetranscript: Bool?
-    ) {
+        deletetranscript: Bool?)
+    {
         self.key = key
         self.deletetranscript = deletetranscript
     }
+
     private enum CodingKeys: String, CodingKey {
         case key
         case deletetranscript = "deleteTranscript"
@@ -1109,11 +1140,12 @@ public struct SessionsCompactParams: Codable, Sendable {
 
     public init(
         key: String,
-        maxlines: Int?
-    ) {
+        maxlines: Int?)
+    {
         self.key = key
         self.maxlines = maxlines
     }
+
     private enum CodingKeys: String, CodingKey {
         case key
         case maxlines = "maxLines"
@@ -1132,14 +1164,15 @@ public struct SessionsUsageParams: Codable, Sendable {
         startdate: String?,
         enddate: String?,
         limit: Int?,
-        includecontextweight: Bool?
-    ) {
+        includecontextweight: Bool?)
+    {
         self.key = key
         self.startdate = startdate
         self.enddate = enddate
         self.limit = limit
         self.includecontextweight = includecontextweight
     }
+
     private enum CodingKeys: String, CodingKey {
         case key
         case startdate = "startDate"
@@ -1149,8 +1182,7 @@ public struct SessionsUsageParams: Codable, Sendable {
     }
 }
 
-public struct ConfigGetParams: Codable, Sendable {
-}
+public struct ConfigGetParams: Codable, Sendable {}
 
 public struct ConfigSetParams: Codable, Sendable {
     public let raw: String
@@ -1158,11 +1190,12 @@ public struct ConfigSetParams: Codable, Sendable {
 
     public init(
         raw: String,
-        basehash: String?
-    ) {
+        basehash: String?)
+    {
         self.raw = raw
         self.basehash = basehash
     }
+
     private enum CodingKeys: String, CodingKey {
         case raw
         case basehash = "baseHash"
@@ -1181,14 +1214,15 @@ public struct ConfigApplyParams: Codable, Sendable {
         basehash: String?,
         sessionkey: String?,
         note: String?,
-        restartdelayms: Int?
-    ) {
+        restartdelayms: Int?)
+    {
         self.raw = raw
         self.basehash = basehash
         self.sessionkey = sessionkey
         self.note = note
         self.restartdelayms = restartdelayms
     }
+
     private enum CodingKeys: String, CodingKey {
         case raw
         case basehash = "baseHash"
@@ -1210,14 +1244,15 @@ public struct ConfigPatchParams: Codable, Sendable {
         basehash: String?,
         sessionkey: String?,
         note: String?,
-        restartdelayms: Int?
-    ) {
+        restartdelayms: Int?)
+    {
         self.raw = raw
         self.basehash = basehash
         self.sessionkey = sessionkey
         self.note = note
         self.restartdelayms = restartdelayms
     }
+
     private enum CodingKeys: String, CodingKey {
         case raw
         case basehash = "baseHash"
@@ -1227,8 +1262,7 @@ public struct ConfigPatchParams: Codable, Sendable {
     }
 }
 
-public struct ConfigSchemaParams: Codable, Sendable {
-}
+public struct ConfigSchemaParams: Codable, Sendable {}
 
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
@@ -1240,13 +1274,14 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         schema: AnyCodable,
         uihints: [String: AnyCodable],
         version: String,
-        generatedat: String
-    ) {
+        generatedat: String)
+    {
         self.schema = schema
         self.uihints = uihints
         self.version = version
         self.generatedat = generatedat
     }
+
     private enum CodingKeys: String, CodingKey {
         case schema
         case uihints = "uiHints"
@@ -1261,11 +1296,12 @@ public struct WizardStartParams: Codable, Sendable {
 
     public init(
         mode: AnyCodable?,
-        workspace: String?
-    ) {
+        workspace: String?)
+    {
         self.mode = mode
         self.workspace = workspace
     }
+
     private enum CodingKeys: String, CodingKey {
         case mode
         case workspace
@@ -1278,11 +1314,12 @@ public struct WizardNextParams: Codable, Sendable {
 
     public init(
         sessionid: String,
-        answer: [String: AnyCodable]?
-    ) {
+        answer: [String: AnyCodable]?)
+    {
         self.sessionid = sessionid
         self.answer = answer
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionid = "sessionId"
         case answer
@@ -1293,10 +1330,11 @@ public struct WizardCancelParams: Codable, Sendable {
     public let sessionid: String
 
     public init(
-        sessionid: String
-    ) {
+        sessionid: String)
+    {
         self.sessionid = sessionid
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionid = "sessionId"
     }
@@ -1306,10 +1344,11 @@ public struct WizardStatusParams: Codable, Sendable {
     public let sessionid: String
 
     public init(
-        sessionid: String
-    ) {
+        sessionid: String)
+    {
         self.sessionid = sessionid
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionid = "sessionId"
     }
@@ -1335,8 +1374,8 @@ public struct WizardStep: Codable, Sendable {
         initialvalue: AnyCodable?,
         placeholder: String?,
         sensitive: Bool?,
-        executor: AnyCodable?
-    ) {
+        executor: AnyCodable?)
+    {
         self.id = id
         self.type = type
         self.title = title
@@ -1347,6 +1386,7 @@ public struct WizardStep: Codable, Sendable {
         self.sensitive = sensitive
         self.executor = executor
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case type
@@ -1370,13 +1410,14 @@ public struct WizardNextResult: Codable, Sendable {
         done: Bool,
         step: [String: AnyCodable]?,
         status: AnyCodable?,
-        error: String?
-    ) {
+        error: String?)
+    {
         self.done = done
         self.step = step
         self.status = status
         self.error = error
     }
+
     private enum CodingKeys: String, CodingKey {
         case done
         case step
@@ -1397,14 +1438,15 @@ public struct WizardStartResult: Codable, Sendable {
         done: Bool,
         step: [String: AnyCodable]?,
         status: AnyCodable?,
-        error: String?
-    ) {
+        error: String?)
+    {
         self.sessionid = sessionid
         self.done = done
         self.step = step
         self.status = status
         self.error = error
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionid = "sessionId"
         case done
@@ -1420,11 +1462,12 @@ public struct WizardStatusResult: Codable, Sendable {
 
     public init(
         status: AnyCodable,
-        error: String?
-    ) {
+        error: String?)
+    {
         self.status = status
         self.error = error
     }
+
     private enum CodingKeys: String, CodingKey {
         case status
         case error
@@ -1437,11 +1480,12 @@ public struct TalkModeParams: Codable, Sendable {
 
     public init(
         enabled: Bool,
-        phase: String?
-    ) {
+        phase: String?)
+    {
         self.enabled = enabled
         self.phase = phase
     }
+
     private enum CodingKeys: String, CodingKey {
         case enabled
         case phase
@@ -1454,11 +1498,12 @@ public struct ChannelsStatusParams: Codable, Sendable {
 
     public init(
         probe: Bool?,
-        timeoutms: Int?
-    ) {
+        timeoutms: Int?)
+    {
         self.probe = probe
         self.timeoutms = timeoutms
     }
+
     private enum CodingKeys: String, CodingKey {
         case probe
         case timeoutms = "timeoutMs"
@@ -1485,8 +1530,8 @@ public struct ChannelsStatusResult: Codable, Sendable {
         channelmeta: [[String: AnyCodable]]?,
         channels: [String: AnyCodable],
         channelaccounts: [String: AnyCodable],
-        channeldefaultaccountid: [String: AnyCodable]
-    ) {
+        channeldefaultaccountid: [String: AnyCodable])
+    {
         self.ts = ts
         self.channelorder = channelorder
         self.channellabels = channellabels
@@ -1497,6 +1542,7 @@ public struct ChannelsStatusResult: Codable, Sendable {
         self.channelaccounts = channelaccounts
         self.channeldefaultaccountid = channeldefaultaccountid
     }
+
     private enum CodingKeys: String, CodingKey {
         case ts
         case channelorder = "channelOrder"
@@ -1516,11 +1562,12 @@ public struct ChannelsLogoutParams: Codable, Sendable {
 
     public init(
         channel: String,
-        accountid: String?
-    ) {
+        accountid: String?)
+    {
         self.channel = channel
         self.accountid = accountid
     }
+
     private enum CodingKeys: String, CodingKey {
         case channel
         case accountid = "accountId"
@@ -1537,13 +1584,14 @@ public struct WebLoginStartParams: Codable, Sendable {
         force: Bool?,
         timeoutms: Int?,
         verbose: Bool?,
-        accountid: String?
-    ) {
+        accountid: String?)
+    {
         self.force = force
         self.timeoutms = timeoutms
         self.verbose = verbose
         self.accountid = accountid
     }
+
     private enum CodingKeys: String, CodingKey {
         case force
         case timeoutms = "timeoutMs"
@@ -1558,11 +1606,12 @@ public struct WebLoginWaitParams: Codable, Sendable {
 
     public init(
         timeoutms: Int?,
-        accountid: String?
-    ) {
+        accountid: String?)
+    {
         self.timeoutms = timeoutms
         self.accountid = accountid
     }
+
     private enum CodingKeys: String, CodingKey {
         case timeoutms = "timeoutMs"
         case accountid = "accountId"
@@ -1577,12 +1626,13 @@ public struct AgentSummary: Codable, Sendable {
     public init(
         id: String,
         name: String?,
-        identity: [String: AnyCodable]?
-    ) {
+        identity: [String: AnyCodable]?)
+    {
         self.id = id
         self.name = name
         self.identity = identity
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case name
@@ -1600,13 +1650,14 @@ public struct AgentsCreateParams: Codable, Sendable {
         name: String,
         workspace: String,
         emoji: String?,
-        avatar: String?
-    ) {
+        avatar: String?)
+    {
         self.name = name
         self.workspace = workspace
         self.emoji = emoji
         self.avatar = avatar
     }
+
     private enum CodingKeys: String, CodingKey {
         case name
         case workspace
@@ -1625,13 +1676,14 @@ public struct AgentsCreateResult: Codable, Sendable {
         ok: Bool,
         agentid: String,
         name: String,
-        workspace: String
-    ) {
+        workspace: String)
+    {
         self.ok = ok
         self.agentid = agentid
         self.name = name
         self.workspace = workspace
     }
+
     private enum CodingKeys: String, CodingKey {
         case ok
         case agentid = "agentId"
@@ -1652,14 +1704,15 @@ public struct AgentsUpdateParams: Codable, Sendable {
         name: String?,
         workspace: String?,
         model: String?,
-        avatar: String?
-    ) {
+        avatar: String?)
+    {
         self.agentid = agentid
         self.name = name
         self.workspace = workspace
         self.model = model
         self.avatar = avatar
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case name
@@ -1675,11 +1728,12 @@ public struct AgentsUpdateResult: Codable, Sendable {
 
     public init(
         ok: Bool,
-        agentid: String
-    ) {
+        agentid: String)
+    {
         self.ok = ok
         self.agentid = agentid
     }
+
     private enum CodingKeys: String, CodingKey {
         case ok
         case agentid = "agentId"
@@ -1692,11 +1746,12 @@ public struct AgentsDeleteParams: Codable, Sendable {
 
     public init(
         agentid: String,
-        deletefiles: Bool?
-    ) {
+        deletefiles: Bool?)
+    {
         self.agentid = agentid
         self.deletefiles = deletefiles
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case deletefiles = "deleteFiles"
@@ -1711,12 +1766,13 @@ public struct AgentsDeleteResult: Codable, Sendable {
     public init(
         ok: Bool,
         agentid: String,
-        removedbindings: Int
-    ) {
+        removedbindings: Int)
+    {
         self.ok = ok
         self.agentid = agentid
         self.removedbindings = removedbindings
     }
+
     private enum CodingKeys: String, CodingKey {
         case ok
         case agentid = "agentId"
@@ -1738,8 +1794,8 @@ public struct AgentsFileEntry: Codable, Sendable {
         missing: Bool,
         size: Int?,
         updatedatms: Int?,
-        content: String?
-    ) {
+        content: String?)
+    {
         self.name = name
         self.path = path
         self.missing = missing
@@ -1747,6 +1803,7 @@ public struct AgentsFileEntry: Codable, Sendable {
         self.updatedatms = updatedatms
         self.content = content
     }
+
     private enum CodingKeys: String, CodingKey {
         case name
         case path
@@ -1761,10 +1818,11 @@ public struct AgentsFilesListParams: Codable, Sendable {
     public let agentid: String
 
     public init(
-        agentid: String
-    ) {
+        agentid: String)
+    {
         self.agentid = agentid
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
     }
@@ -1778,12 +1836,13 @@ public struct AgentsFilesListResult: Codable, Sendable {
     public init(
         agentid: String,
         workspace: String,
-        files: [AgentsFileEntry]
-    ) {
+        files: [AgentsFileEntry])
+    {
         self.agentid = agentid
         self.workspace = workspace
         self.files = files
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case workspace
@@ -1797,11 +1856,12 @@ public struct AgentsFilesGetParams: Codable, Sendable {
 
     public init(
         agentid: String,
-        name: String
-    ) {
+        name: String)
+    {
         self.agentid = agentid
         self.name = name
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case name
@@ -1816,12 +1876,13 @@ public struct AgentsFilesGetResult: Codable, Sendable {
     public init(
         agentid: String,
         workspace: String,
-        file: AgentsFileEntry
-    ) {
+        file: AgentsFileEntry)
+    {
         self.agentid = agentid
         self.workspace = workspace
         self.file = file
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case workspace
@@ -1837,12 +1898,13 @@ public struct AgentsFilesSetParams: Codable, Sendable {
     public init(
         agentid: String,
         name: String,
-        content: String
-    ) {
+        content: String)
+    {
         self.agentid = agentid
         self.name = name
         self.content = content
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case name
@@ -1860,13 +1922,14 @@ public struct AgentsFilesSetResult: Codable, Sendable {
         ok: Bool,
         agentid: String,
         workspace: String,
-        file: AgentsFileEntry
-    ) {
+        file: AgentsFileEntry)
+    {
         self.ok = ok
         self.agentid = agentid
         self.workspace = workspace
         self.file = file
     }
+
     private enum CodingKeys: String, CodingKey {
         case ok
         case agentid = "agentId"
@@ -1875,8 +1938,7 @@ public struct AgentsFilesSetResult: Codable, Sendable {
     }
 }
 
-public struct AgentsListParams: Codable, Sendable {
-}
+public struct AgentsListParams: Codable, Sendable {}
 
 public struct AgentsListResult: Codable, Sendable {
     public let defaultid: String
@@ -1888,13 +1950,14 @@ public struct AgentsListResult: Codable, Sendable {
         defaultid: String,
         mainkey: String,
         scope: AnyCodable,
-        agents: [AgentSummary]
-    ) {
+        agents: [AgentSummary])
+    {
         self.defaultid = defaultid
         self.mainkey = mainkey
         self.scope = scope
         self.agents = agents
     }
+
     private enum CodingKeys: String, CodingKey {
         case defaultid = "defaultId"
         case mainkey = "mainKey"
@@ -1915,14 +1978,15 @@ public struct ModelChoice: Codable, Sendable {
         name: String,
         provider: String,
         contextwindow: Int?,
-        reasoning: Bool?
-    ) {
+        reasoning: Bool?)
+    {
         self.id = id
         self.name = name
         self.provider = provider
         self.contextwindow = contextwindow
         self.reasoning = reasoning
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case name
@@ -1932,17 +1996,17 @@ public struct ModelChoice: Codable, Sendable {
     }
 }
 
-public struct ModelsListParams: Codable, Sendable {
-}
+public struct ModelsListParams: Codable, Sendable {}
 
 public struct ModelsListResult: Codable, Sendable {
     public let models: [ModelChoice]
 
     public init(
-        models: [ModelChoice]
-    ) {
+        models: [ModelChoice])
+    {
         self.models = models
     }
+
     private enum CodingKeys: String, CodingKey {
         case models
     }
@@ -1952,26 +2016,27 @@ public struct SkillsStatusParams: Codable, Sendable {
     public let agentid: String?
 
     public init(
-        agentid: String?
-    ) {
+        agentid: String?)
+    {
         self.agentid = agentid
     }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
     }
 }
 
-public struct SkillsBinsParams: Codable, Sendable {
-}
+public struct SkillsBinsParams: Codable, Sendable {}
 
 public struct SkillsBinsResult: Codable, Sendable {
     public let bins: [String]
 
     public init(
-        bins: [String]
-    ) {
+        bins: [String])
+    {
         self.bins = bins
     }
+
     private enum CodingKeys: String, CodingKey {
         case bins
     }
@@ -1985,12 +2050,13 @@ public struct SkillsInstallParams: Codable, Sendable {
     public init(
         name: String,
         installid: String,
-        timeoutms: Int?
-    ) {
+        timeoutms: Int?)
+    {
         self.name = name
         self.installid = installid
         self.timeoutms = timeoutms
     }
+
     private enum CodingKeys: String, CodingKey {
         case name
         case installid = "installId"
@@ -2008,13 +2074,14 @@ public struct SkillsUpdateParams: Codable, Sendable {
         skillkey: String,
         enabled: Bool?,
         apikey: String?,
-        env: [String: AnyCodable]?
-    ) {
+        env: [String: AnyCodable]?)
+    {
         self.skillkey = skillkey
         self.enabled = enabled
         self.apikey = apikey
         self.env = env
     }
+
     private enum CodingKeys: String, CodingKey {
         case skillkey = "skillKey"
         case enabled
@@ -2053,8 +2120,8 @@ public struct CronJob: Codable, Sendable {
         wakemode: AnyCodable,
         payload: AnyCodable,
         delivery: [String: AnyCodable]?,
-        state: [String: AnyCodable]
-    ) {
+        state: [String: AnyCodable])
+    {
         self.id = id
         self.agentid = agentid
         self.name = name
@@ -2070,6 +2137,7 @@ public struct CronJob: Codable, Sendable {
         self.delivery = delivery
         self.state = state
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case agentid = "agentId"
@@ -2092,17 +2160,17 @@ public struct CronListParams: Codable, Sendable {
     public let includedisabled: Bool?
 
     public init(
-        includedisabled: Bool?
-    ) {
+        includedisabled: Bool?)
+    {
         self.includedisabled = includedisabled
     }
+
     private enum CodingKeys: String, CodingKey {
         case includedisabled = "includeDisabled"
     }
 }
 
-public struct CronStatusParams: Codable, Sendable {
-}
+public struct CronStatusParams: Codable, Sendable {}
 
 public struct CronAddParams: Codable, Sendable {
     public let name: String
@@ -2126,8 +2194,8 @@ public struct CronAddParams: Codable, Sendable {
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
         payload: AnyCodable,
-        delivery: [String: AnyCodable]?
-    ) {
+        delivery: [String: AnyCodable]?)
+    {
         self.name = name
         self.agentid = agentid
         self.description = description
@@ -2139,6 +2207,7 @@ public struct CronAddParams: Codable, Sendable {
         self.payload = payload
         self.delivery = delivery
     }
+
     private enum CodingKeys: String, CodingKey {
         case name
         case agentid = "agentId"
@@ -2177,8 +2246,8 @@ public struct CronRunLogEntry: Codable, Sendable {
         sessionkey: String?,
         runatms: Int?,
         durationms: Int?,
-        nextrunatms: Int?
-    ) {
+        nextrunatms: Int?)
+    {
         self.ts = ts
         self.jobid = jobid
         self.action = action
@@ -2191,6 +2260,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.durationms = durationms
         self.nextrunatms = nextrunatms
     }
+
     private enum CodingKeys: String, CodingKey {
         case ts
         case jobid = "jobId"
@@ -2214,12 +2284,13 @@ public struct LogsTailParams: Codable, Sendable {
     public init(
         cursor: Int?,
         limit: Int?,
-        maxbytes: Int?
-    ) {
+        maxbytes: Int?)
+    {
         self.cursor = cursor
         self.limit = limit
         self.maxbytes = maxbytes
     }
+
     private enum CodingKeys: String, CodingKey {
         case cursor
         case limit
@@ -2241,8 +2312,8 @@ public struct LogsTailResult: Codable, Sendable {
         size: Int,
         lines: [String],
         truncated: Bool?,
-        reset: Bool?
-    ) {
+        reset: Bool?)
+    {
         self.file = file
         self.cursor = cursor
         self.size = size
@@ -2250,6 +2321,7 @@ public struct LogsTailResult: Codable, Sendable {
         self.truncated = truncated
         self.reset = reset
     }
+
     private enum CodingKeys: String, CodingKey {
         case file
         case cursor
@@ -2260,8 +2332,7 @@ public struct LogsTailResult: Codable, Sendable {
     }
 }
 
-public struct ExecApprovalsGetParams: Codable, Sendable {
-}
+public struct ExecApprovalsGetParams: Codable, Sendable {}
 
 public struct ExecApprovalsSetParams: Codable, Sendable {
     public let file: [String: AnyCodable]
@@ -2269,11 +2340,12 @@ public struct ExecApprovalsSetParams: Codable, Sendable {
 
     public init(
         file: [String: AnyCodable],
-        basehash: String?
-    ) {
+        basehash: String?)
+    {
         self.file = file
         self.basehash = basehash
     }
+
     private enum CodingKeys: String, CodingKey {
         case file
         case basehash = "baseHash"
@@ -2284,10 +2356,11 @@ public struct ExecApprovalsNodeGetParams: Codable, Sendable {
     public let nodeid: String
 
     public init(
-        nodeid: String
-    ) {
+        nodeid: String)
+    {
         self.nodeid = nodeid
     }
+
     private enum CodingKeys: String, CodingKey {
         case nodeid = "nodeId"
     }
@@ -2301,12 +2374,13 @@ public struct ExecApprovalsNodeSetParams: Codable, Sendable {
     public init(
         nodeid: String,
         file: [String: AnyCodable],
-        basehash: String?
-    ) {
+        basehash: String?)
+    {
         self.nodeid = nodeid
         self.file = file
         self.basehash = basehash
     }
+
     private enum CodingKeys: String, CodingKey {
         case nodeid = "nodeId"
         case file
@@ -2324,13 +2398,14 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
         path: String,
         exists: Bool,
         hash: String,
-        file: [String: AnyCodable]
-    ) {
+        file: [String: AnyCodable])
+    {
         self.path = path
         self.exists = exists
         self.hash = hash
         self.file = file
     }
+
     private enum CodingKeys: String, CodingKey {
         case path
         case exists
@@ -2361,8 +2436,8 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         agentid: AnyCodable?,
         resolvedpath: AnyCodable?,
         sessionkey: AnyCodable?,
-        timeoutms: Int?
-    ) {
+        timeoutms: Int?)
+    {
         self.id = id
         self.command = command
         self.cwd = cwd
@@ -2374,6 +2449,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.sessionkey = sessionkey
         self.timeoutms = timeoutms
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case command
@@ -2394,28 +2470,29 @@ public struct ExecApprovalResolveParams: Codable, Sendable {
 
     public init(
         id: String,
-        decision: String
-    ) {
+        decision: String)
+    {
         self.id = id
         self.decision = decision
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case decision
     }
 }
 
-public struct DevicePairListParams: Codable, Sendable {
-}
+public struct DevicePairListParams: Codable, Sendable {}
 
 public struct DevicePairApproveParams: Codable, Sendable {
     public let requestid: String
 
     public init(
-        requestid: String
-    ) {
+        requestid: String)
+    {
         self.requestid = requestid
     }
+
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
     }
@@ -2425,10 +2502,11 @@ public struct DevicePairRejectParams: Codable, Sendable {
     public let requestid: String
 
     public init(
-        requestid: String
-    ) {
+        requestid: String)
+    {
         self.requestid = requestid
     }
+
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
     }
@@ -2442,12 +2520,13 @@ public struct DeviceTokenRotateParams: Codable, Sendable {
     public init(
         deviceid: String,
         role: String,
-        scopes: [String]?
-    ) {
+        scopes: [String]?)
+    {
         self.deviceid = deviceid
         self.role = role
         self.scopes = scopes
     }
+
     private enum CodingKeys: String, CodingKey {
         case deviceid = "deviceId"
         case role
@@ -2461,11 +2540,12 @@ public struct DeviceTokenRevokeParams: Codable, Sendable {
 
     public init(
         deviceid: String,
-        role: String
-    ) {
+        role: String)
+    {
         self.deviceid = deviceid
         self.role = role
     }
+
     private enum CodingKeys: String, CodingKey {
         case deviceid = "deviceId"
         case role
@@ -2502,8 +2582,8 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         remoteip: String?,
         silent: Bool?,
         isrepair: Bool?,
-        ts: Int
-    ) {
+        ts: Int)
+    {
         self.requestid = requestid
         self.deviceid = deviceid
         self.publickey = publickey
@@ -2519,6 +2599,7 @@ public struct DevicePairRequestedEvent: Codable, Sendable {
         self.isrepair = isrepair
         self.ts = ts
     }
+
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
         case deviceid = "deviceId"
@@ -2547,13 +2628,14 @@ public struct DevicePairResolvedEvent: Codable, Sendable {
         requestid: String,
         deviceid: String,
         decision: String,
-        ts: Int
-    ) {
+        ts: Int)
+    {
         self.requestid = requestid
         self.deviceid = deviceid
         self.decision = decision
         self.ts = ts
     }
+
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
         case deviceid = "deviceId"
@@ -2568,11 +2650,12 @@ public struct ChatHistoryParams: Codable, Sendable {
 
     public init(
         sessionkey: String,
-        limit: Int?
-    ) {
+        limit: Int?)
+    {
         self.sessionkey = sessionkey
         self.limit = limit
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case limit
@@ -2595,8 +2678,8 @@ public struct ChatSendParams: Codable, Sendable {
         deliver: Bool?,
         attachments: [AnyCodable]?,
         timeoutms: Int?,
-        idempotencykey: String
-    ) {
+        idempotencykey: String)
+    {
         self.sessionkey = sessionkey
         self.message = message
         self.thinking = thinking
@@ -2605,6 +2688,7 @@ public struct ChatSendParams: Codable, Sendable {
         self.timeoutms = timeoutms
         self.idempotencykey = idempotencykey
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case message
@@ -2622,11 +2706,12 @@ public struct ChatAbortParams: Codable, Sendable {
 
     public init(
         sessionkey: String,
-        runid: String?
-    ) {
+        runid: String?)
+    {
         self.sessionkey = sessionkey
         self.runid = runid
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case runid = "runId"
@@ -2641,12 +2726,13 @@ public struct ChatInjectParams: Codable, Sendable {
     public init(
         sessionkey: String,
         message: String,
-        label: String?
-    ) {
+        label: String?)
+    {
         self.sessionkey = sessionkey
         self.message = message
         self.label = label
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case message
@@ -2672,8 +2758,8 @@ public struct ChatEvent: Codable, Sendable {
         message: AnyCodable?,
         errormessage: String?,
         usage: AnyCodable?,
-        stopreason: String?
-    ) {
+        stopreason: String?)
+    {
         self.runid = runid
         self.sessionkey = sessionkey
         self.seq = seq
@@ -2683,6 +2769,7 @@ public struct ChatEvent: Codable, Sendable {
         self.usage = usage
         self.stopreason = stopreason
     }
+
     private enum CodingKeys: String, CodingKey {
         case runid = "runId"
         case sessionkey = "sessionKey"
@@ -2705,13 +2792,14 @@ public struct UpdateRunParams: Codable, Sendable {
         sessionkey: String?,
         note: String?,
         restartdelayms: Int?,
-        timeoutms: Int?
-    ) {
+        timeoutms: Int?)
+    {
         self.sessionkey = sessionkey
         self.note = note
         self.restartdelayms = restartdelayms
         self.timeoutms = timeoutms
     }
+
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case note
@@ -2724,10 +2812,11 @@ public struct TickEvent: Codable, Sendable {
     public let ts: Int
 
     public init(
-        ts: Int
-    ) {
+        ts: Int)
+    {
         self.ts = ts
     }
+
     private enum CodingKeys: String, CodingKey {
         case ts
     }
@@ -2739,11 +2828,12 @@ public struct ShutdownEvent: Codable, Sendable {
 
     public init(
         reason: String,
-        restartexpectedms: Int?
-    ) {
+        restartexpectedms: Int?)
+    {
         self.reason = reason
         self.restartexpectedms = restartexpectedms
     }
+
     private enum CodingKeys: String, CodingKey {
         case reason
         case restartexpectedms = "restartExpectedMs"
@@ -2765,11 +2855,11 @@ public enum GatewayFrame: Codable, Sendable {
         let type = try typeContainer.decode(String.self, forKey: .type)
         switch type {
         case "req":
-            self = .req(try RequestFrame(from: decoder))
+            self = try .req(RequestFrame(from: decoder))
         case "res":
-            self = .res(try ResponseFrame(from: decoder))
+            self = try .res(ResponseFrame(from: decoder))
         case "event":
-            self = .event(try EventFrame(from: decoder))
+            self = try .event(EventFrame(from: decoder))
         default:
             let container = try decoder.singleValueContainer()
             let raw = try container.decode([String: AnyCodable].self)
@@ -2779,13 +2869,12 @@ public enum GatewayFrame: Codable, Sendable {
 
     public func encode(to encoder: Encoder) throws {
         switch self {
-        case .req(let v): try v.encode(to: encoder)
-        case .res(let v): try v.encode(to: encoder)
-        case .event(let v): try v.encode(to: encoder)
-        case .unknown(_, let raw):
+        case let .req(v): try v.encode(to: encoder)
+        case let .res(v): try v.encode(to: encoder)
+        case let .event(v): try v.encode(to: encoder)
+        case let .unknown(_, raw):
             var container = encoder.singleValueContainer()
             try container.encode(raw)
         }
     }
-
 }


### PR DESCRIPTION
## Summary

- macOS `RuntimeLocator.swift` uses `minNode = RuntimeVersion(major: 22, minor: 0, patch: 0)` while the actual minimum enforced by `runtime-guard.ts` and `package.json` engines field is `>=22.12.0`.
- Error messages also reference `>=22.0.0` instead of `>=22.12.0`.
- Users with Node 22.0.0–22.11.x see the macOS message, believe they have a compatible version, then encounter a different failure from the runtime guard.

## Fix

- Update `minNode` to `RuntimeVersion(major: 22, minor: 12, patch: 0)`
- Update error messages from `>=22.0.0` to `>=22.12.0`

## Test plan

- [ ] Verify macOS app correctly rejects Node versions below 22.12.0
- [ ] Verify macOS app accepts Node 22.12.0 and above
- [ ] Verify error messages display the correct minimum version

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the macOS runtime locator to require Node.js `>=22.12.0` (instead of `>=22.0.0`) and adjusts the user-facing error strings to match. The change makes the macOS app’s preflight check consistent with the repository’s runtime guard / engines constraints, preventing users on Node `22.0.0–22.11.x` from getting a misleading “supported” message before failing later.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a straightforward constant and string update in a single macOS Swift file, and it makes the minimum Node version check consistent with the repository’s enforced runtime requirements. No behavioral changes beyond earlier rejection + corrected messaging are introduced.
- apps/macos/Sources/OpenClaw/RuntimeLocator.swift

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->