### PR TITLE
fix: include scripts/ directory in npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "openclaw.mjs",
     "README-header.png",
     "README.md",
+    "scripts/",
     "skills/"
   ],
   "type": "module",


### PR DESCRIPTION
## Problem

The npm package (v2026.2.9) is missing the `scripts/` directory, which breaks `ui:build` and other npm scripts that reference files like `scripts/ui.js` and `scripts/run-node.mjs`.

## Root Cause

The `scripts/` directory was not listed in the `files` field of `package.json`, so npm excludes it from the published tarball.

## Fix

Add `"scripts/"` to the `files` array in `package.json`.

Fixes #14416

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the root `package.json` `files` whitelist to include the `scripts/` directory in the published npm tarball. That matches the current npm scripts (e.g. `ui:build`, `dev`, `gateway:watch`) which invoke entrypoints under `scripts/`, and should prevent published installs from failing due to missing script files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, targeted adjustment to the npm publish file whitelist (adds `scripts/`), aligning the published package contents with existing npm scripts that already depend on those files. No runtime logic changes, and no new dependencies or behaviors introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->