### PR TITLE
fix(tts): use configured ElevenLabs voiceId for [[tts]] tags

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -603,8 +603,17 @@ function parseTtsDirectives(
   let cleanedText = text;
   let hasDirective = false;
 
-  const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
-  cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
+  const textBlockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
+  cleanedText = cleanedText.replace(textBlockRegex, (_match, inner: string) => {
+    hasDirective = true;
+    if (policy.allowText && overrides.ttsText == null) {
+      overrides.ttsText = inner.trim();
+    }
+    return "";
+  });
+
+  const genericBlockRegex = /\[\[tts\]\]([\s\S]*?)\[\[\/tts\]\]/gi;
+  cleanedText = cleanedText.replace(genericBlockRegex, (_match, inner: string) => {
     hasDirective = true;
     if (policy.allowText && overrides.ttsText == null) {
       overrides.ttsText = inner.trim();


### PR DESCRIPTION
## Summary
Fixes #14651 — `[[tts]]` tags ignore the configured ElevenLabs `voiceId`, falling back to a default voice instead.

## Problem
Same root cause as #14652: the TTS parser didn't recognize the legacy `[[tts]]...[[/tts]]` format. Because these blocks weren't parsed as TTS directives, they bypassed the normal config-backed ElevenLabs flow — meaning the user's configured `messages.tts.elevenlabs.voiceId` was never used.

## Solution
Extended `parseTtsDirectives()` in `src/tts/tts.ts` to handle `[[tts]]...[[/tts]]` blocks. Once parsed correctly, the content flows through the standard ElevenLabs TTS path which reads the configured `voiceId`.

## Changes
- `src/tts/tts.ts` — Added legacy tag support in parser
- `src/tts/tts.test.ts` — Added regression test verifying fetch URL includes configured voiceId (`aviXFY7Zd7b9DnCUwaCh`)

## Testing
- `pnpm -s vitest run src/tts/tts.test.ts` — 34 tests passing
- Lightly tested (unit tests, no local OpenClaw instance run)

## AI Disclosure
AI-assisted (Codex). Code reviewed and understood by contributor.

## Related
- #14652 / PR #14668 (same root cause, different symptom)
