### PR TITLE
fix: strengthen CRON_EVENT_PROMPT to ensure agents execute tasks

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -100,8 +100,9 @@ const EXEC_EVENT_PROMPT =
 // This overrides the standard heartbeat prompt so the model relays the scheduled
 // reminder instead of responding with "HEARTBEAT_OK".
 const CRON_EVENT_PROMPT =
-  "A scheduled reminder has been triggered. The reminder message is shown in the system messages above. " +
-  "Please relay this reminder to the user in a helpful and friendly way.";
+  "A scheduled cron job has fired. The task instructions are in the system messages above. " +
+  "Execute the requested task fully — do NOT reply with HEARTBEAT_OK. " +
+  "Complete the work described, then report the results.";
 
 type HeartbeatAgentState = {
   agentId: string;


### PR DESCRIPTION
## Problem

The existing CRON_EVENT_PROMPT is too passive:
> *A scheduled reminder has been triggered. Please relay this reminder to the user in a helpful and friendly way.*

Agents interpret 'relay' as informational acknowledgment and dismiss cron systemEvent tasks without executing the actual work.

## Fix

Strengthen the prompt to be explicit:
> *A scheduled cron job has fired. The task instructions are in the system messages above. Execute the requested task fully — do NOT reply with HEARTBEAT_OK. Complete the work described, then report the results.*

Matches the assertive tone of EXEC_EVENT_PROMPT which works reliably for exec completions.

## Notes
- The cron detection wiring (reason prefix, peekSystemEvents, empty-heartbeat-file bypass) is already correct on main
- Only the prompt text needs changing — 3 lines