### PR TITLE
fix: exempt wake reason from empty heartbeat skip (#14527)

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -427,10 +427,11 @@ export async function runHeartbeatOnce(opts: {
 
   // Skip heartbeat if HEARTBEAT.md exists but has no actionable content.
   // This saves API calls/costs when the file is effectively empty (only comments/headers).
-  // EXCEPTION: Don't skip for exec events or cron events - they have pending system events
-  // to process regardless of HEARTBEAT.md content.
+  // EXCEPTION: Don't skip for exec events, cron events, or wake events - they have pending
+  // system events to process regardless of HEARTBEAT.md content.
   const isExecEventReason = opts.reason === "exec-event";
   const isCronEventReason = Boolean(opts.reason?.startsWith("cron:"));
+  const isWakeEventReason = opts.reason === "wake";
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
@@ -438,7 +439,8 @@ export async function runHeartbeatOnce(opts: {
     if (
       isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) &&
       !isExecEventReason &&
-      !isCronEventReason
+      !isCronEventReason &&
+      !isWakeEventReason
     ) {
       emitHeartbeatEvent({
         status: "skipped",

--- a/src/infra/heartbeat-runner.wake-reason-bypass.test.ts
+++ b/src/infra/heartbeat-runner.wake-reason-bypass.test.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
+import { setTelegramRuntime } from "../../extensions/telegram/src/runtime.js";
+import { whatsappPlugin } from "../../extensions/whatsapp/src/channel.js";
+import { setWhatsAppRuntime } from "../../extensions/whatsapp/src/runtime.js";
+import * as replyModule from "../auto-reply/reply.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+beforeEach(() => {
+  const runtime = createPluginRuntime();
+  setTelegramRuntime(runtime);
+  setWhatsAppRuntime(runtime);
+  setActivePluginRegistry(
+    createTestRegistry([
+      { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+      { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+    ]),
+  );
+});
+
+/**
+ * Helpers to reduce boilerplate across tests in this file.
+ */
+async function setupEmptyHeartbeat() {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-wake-"));
+  const storePath = path.join(tmpDir, "sessions.json");
+  const workspaceDir = path.join(tmpDir, "workspace");
+  await fs.mkdir(workspaceDir, { recursive: true });
+
+  // Create an effectively empty HEARTBEAT.md (only headers)
+  await fs.writeFile(
+    path.join(workspaceDir, "HEARTBEAT.md"),
+    "# HEARTBEAT.md\n\n## Tasks\n\n",
+    "utf-8",
+  );
+
+  const cfg: OpenClawConfig = {
+    agents: {
+      defaults: {
+        workspace: workspaceDir,
+        heartbeat: { every: "5m", target: "whatsapp" },
+      },
+    },
+    channels: { whatsapp: { allowFrom: ["*"] } },
+    session: { store: storePath },
+  };
+  const sessionKey = resolveMainSessionKey(cfg);
+
+  await fs.writeFile(
+    storePath,
+    JSON.stringify(
+      {
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "+1555",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const sendWhatsApp = vi.fn().mockResolvedValue({
+    messageId: "m1",
+    toJid: "jid",
+  });
+
+  return { cfg, tmpDir, storePath, workspaceDir, sendWhatsApp };
+}
+
+const baseDeps = (sendWhatsApp: ReturnType<typeof vi.fn>) => ({
+  sendWhatsApp,
+  getQueueSize: () => 0,
+  nowMs: () => 0,
+  webAuthExists: async () => true,
+  hasActiveWebListener: () => true,
+});
+
+describe("runHeartbeatOnce – empty heartbeat exemptions (#14527)", () => {
+  it("skips regular heartbeat when HEARTBEAT.md is effectively empty", async () => {
+    const { cfg, tmpDir, sendWhatsApp } = await setupEmptyHeartbeat();
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        deps: baseDeps(sendWhatsApp),
+      });
+
+      expect(res.status).toBe("skipped");
+      if (res.status === "skipped") {
+        expect(res.reason).toBe("empty-heartbeat-file");
+      }
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(sendWhatsApp).not.toHaveBeenCalled();
+    } finally {
+      replySpy.mockRestore();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs heartbeat with reason 'wake' even when HEARTBEAT.md is empty", async () => {
+    const { cfg, tmpDir, sendWhatsApp } = await setupEmptyHeartbeat();
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      replySpy.mockResolvedValue([{ text: "Wake event processed" }]);
+
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "wake",
+        deps: baseDeps(sendWhatsApp),
+      });
+
+      // Should NOT be skipped – wake is exempted from empty heartbeat check
+      expect(res.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalled();
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    } finally {
+      replySpy.mockRestore();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs heartbeat with reason 'exec-event' even when HEARTBEAT.md is empty", async () => {
+    const { cfg, tmpDir, sendWhatsApp } = await setupEmptyHeartbeat();
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      replySpy.mockResolvedValue([{ text: "Exec event processed" }]);
+
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "exec-event",
+        deps: baseDeps(sendWhatsApp),
+      });
+
+      expect(res.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalled();
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    } finally {
+      replySpy.mockRestore();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs heartbeat with reason 'cron:daily' even when HEARTBEAT.md is empty", async () => {
+    const { cfg, tmpDir, sendWhatsApp } = await setupEmptyHeartbeat();
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      replySpy.mockResolvedValue([{ text: "Cron event processed" }]);
+
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "cron:daily",
+        deps: baseDeps(sendWhatsApp),
+      });
+
+      expect(res.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalled();
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    } finally {
+      replySpy.mockRestore();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`openclaw system event --mode now` is silently skipped when `HEARTBEAT.md` is empty.

In `runHeartbeatOnce()`, the `isHeartbeatContentEffectivelyEmpty` check only exempted `"exec-event"` and `"cron:*"` reasons. When a system event uses `reason: "wake"`, it was incorrectly being skipped if `HEARTBEAT.md` had no actionable content.

## Fix

Add `"wake"` to the exemption list alongside `"exec-event"` and `"cron:*"`, so system events with the wake reason are always processed regardless of `HEARTBEAT.md` content.

## Tests

Added `heartbeat-runner.wake-reason-bypass.test.ts` covering:
- Regular heartbeat is still skipped when `HEARTBEAT.md` is empty (existing behavior preserved)
- `wake` reason bypasses the empty heartbeat check (**the fix**)
- `exec-event` reason still bypasses the check (existing behavior)
- `cron:*` reason still bypasses the check (existing behavior)

Closes #14527