### PR TITLE
fix: skip SSE chunks with empty/missing choices array

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,6 +211,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch"
+    }
   }
 }

--- a/patches/@mariozechner__pi-ai.patch
+++ b/patches/@mariozechner__pi-ai.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/providers/openai-completions.js b/dist/providers/openai-completions.js
+index 3b57cd261f37b7075445866a2b7b68a77c0b09e6..fa658e7cfa3e57c57ec475960dd9528fdd545fed 100644
+--- a/dist/providers/openai-completions.js
++++ b/dist/providers/openai-completions.js
+@@ -127,7 +127,7 @@ export const streamOpenAICompletions = (model, context, options) => {
+                     };
+                     calculateCost(model, output.usage);
+                 }
+-                const choice = chunk.choices[0];
++                const choice = chunk.choices?.[0];
+                 if (!choice)
+                     continue;
+                 if (choice.finish_reason) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,11 @@ overrides:
   tar: 7.5.7
   tough-cookie: 4.1.3
 
+patchedDependencies:
+  '@mariozechner/pi-ai':
+    hash: 9026d10f413461ec324dba45f66947a4af785ea88ecf42b2ca6b6c8304480d9d
+    path: patches/@mariozechner__pi-ai.patch
+
 importers:
 
   .:
@@ -51,7 +56,7 @@ importers:
         version: 0.52.9(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.52.9
-        version: 0.52.9(ws@8.19.0)(zod@4.3.6)
+        version: 0.52.9(patch_hash=9026d10f413461ec324dba45f66947a4af785ea88ecf42b2ca6b6c8304480d9d)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.52.9
         version: 0.52.9(ws@8.19.0)(zod@4.3.6)
@@ -6872,7 +6877,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.52.9(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.52.9(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.52.9(patch_hash=9026d10f413461ec324dba45f66947a4af785ea88ecf42b2ca6b6c8304480d9d)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6882,7 +6887,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.52.9(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.52.9(patch_hash=9026d10f413461ec324dba45f66947a4af785ea88ecf42b2ca6b6c8304480d9d)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.988.0
@@ -6910,7 +6915,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.52.9(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.52.9(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.52.9(patch_hash=9026d10f413461ec324dba45f66947a4af785ea88ecf42b2ca6b6c8304480d9d)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.52.9
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2

--- a/src/agents/openai-empty-choices.test.ts
+++ b/src/agents/openai-empty-choices.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test for #14442: Some OpenAI-compatible providers (vLLM, LocalAI)
+ * send an extra SSE chunk with an empty `choices` array (or no `choices` field)
+ * after the `finish_reason: "stop"` chunk. The streaming parser must tolerate
+ * these chunks without throwing.
+ *
+ * The fix is a pnpm patch on @mariozechner/pi-ai that uses optional chaining
+ * (`chunk.choices?.[0]`) instead of direct indexing (`chunk.choices[0]`).
+ */
+describe("openai-completions empty-choices guard (#14442)", () => {
+  it("should use optional chaining on chunk.choices access", async () => {
+    // Read the compiled openai-completions.js to verify the patch is applied
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const modulePath = path.join(
+      process.cwd(),
+      "node_modules",
+      "@mariozechner",
+      "pi-ai",
+      "dist",
+      "providers",
+      "openai-completions.js",
+    );
+    const source = await fs.readFile(modulePath, "utf-8");
+
+    // The patched line should use optional chaining
+    expect(source).toContain("chunk.choices?.[0]");
+    // The unpatched line should NOT be present
+    expect(source).not.toMatch(/chunk\.choices\[0\]/);
+  });
+
+  it("should safely handle a chunk with empty choices array", () => {
+    // Simulate the exact scenario from the issue: a chunk with choices: []
+    const chunk = {
+      id: "endpoint_common_4876945",
+      choices: [] as Array<{
+        delta: { content: string };
+        finish_reason: string | null;
+        index: number;
+      }>,
+      created: 1770861149,
+      model: "test-75b",
+      object: "chat.completion.chunk",
+      usage: { completion_tokens: 41, prompt_tokens: 1431, total_tokens: 1472 },
+    };
+
+    // This is the patched expression — must not throw
+    const choice = chunk.choices?.[0];
+    expect(choice).toBeUndefined();
+  });
+
+  it("should safely handle a chunk with missing choices field", () => {
+    // Some providers may omit `choices` entirely in the final usage-only chunk
+    const chunk = {
+      id: "endpoint_common_4876945",
+      created: 1770861149,
+      model: "test-75b",
+      object: "chat.completion.chunk",
+      usage: { completion_tokens: 41, prompt_tokens: 1431, total_tokens: 1472 },
+    } as {
+      choices?: Array<{ delta: { content: string }; finish_reason: string | null; index: number }>;
+      [key: string]: unknown;
+    };
+
+    // With optional chaining this is safe; without it, TypeError is thrown
+    const choice = chunk.choices?.[0];
+    expect(choice).toBeUndefined();
+  });
+
+  it("should still extract choice from a normal chunk", () => {
+    const chunk = {
+      id: "test",
+      choices: [
+        {
+          index: 0,
+          delta: { content: "hello" },
+          finish_reason: null,
+        },
+      ],
+      created: 123,
+      model: "test",
+      object: "chat.completion.chunk",
+    };
+
+    const choice = chunk.choices?.[0];
+    expect(choice).toBeDefined();
+    expect(choice.delta.content).toBe("hello");
+  });
+});


### PR DESCRIPTION
## Problem

Some OpenAI-compatible providers (vLLM, LocalAI, and others) send an extra SSE chunk with an empty `choices` array (`choices: []`) after the final chunk containing `finish_reason: "stop"`. This causes a `TypeError` because the streaming parser in `@mariozechner/pi-ai` accesses `chunk.choices[0]` without checking whether `choices` exists or is empty.

### Failing chunk example (from issue):
```
ChatCompletionChunk(choices=[], usage=CompletionUsage(completion_tokens=41, prompt_tokens=1431, total_tokens=1472))
```

## Fix

Applied a pnpm patch to `@mariozechner/pi-ai@0.52.9` that changes:
```diff
- const choice = chunk.choices[0];
+ const choice = chunk.choices?.[0];
```

The existing `if (!choice) continue;` guard then safely skips these chunks.

## Tests

Added `src/agents/openai-empty-choices.test.ts` with 4 tests verifying:
- The patch is correctly applied (source code check)
- Empty choices array (`choices: []`) is handled safely
- Missing choices field is handled safely
- Normal chunks with choices still work correctly

Closes #14442

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR applies a pnpm patch to `@mariozechner/pi-ai@0.52.9` so the OpenAI-compatible streaming parser tolerates providers that emit a trailing SSE chunk with `choices: []` or no `choices` field. The patch changes `chunk.choices[0]` to `chunk.choices?.[0]` in the compiled `openai-completions.js`, allowing the existing `if (!choice) continue;` guard to safely skip these chunks.

It also updates `pnpm-lock.yaml` to include the patch hash, and adds a Vitest regression test (`src/agents/openai-empty-choices.test.ts`) that asserts the patched code is present and that optional-chaining semantics handle empty/missing `choices` without throwing, while still working for normal chunks.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it is a minimal defensive fix plus regression coverage.
- The change is narrowly scoped to an optional-chaining guard in a patched dependency and does not alter local code paths beyond preventing a TypeError on provider-specific trailing chunks. Dependency version is pinned exactly (required for patched deps) and lockfile is updated accordingly. I could not run tests in this environment due to missing pnpm, so confidence is not 5/5.
- src/agents/openai-empty-choices.test.ts (ensure it passes in CI/test runner environment)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->