### PR TITLE
fix(msteams): remove redundant authorizeJWT middleware blocking webhooks

### DIFF
--- a/extensions/msteams/src/monitor.test.ts
+++ b/extensions/msteams/src/monitor.test.ts
@@ -1,0 +1,136 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Mock the runtime before imports
+vi.mock("./runtime.js", () => ({
+  getMSTeamsRuntime: () => ({
+    logging: {
+      getChildLogger: () => ({
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      }),
+    },
+    channel: {
+      text: {
+        resolveTextChunkLimit: () => 4000,
+      },
+    },
+  }),
+  setMSTeamsRuntime: vi.fn(),
+}));
+
+// Track whether authorizeJWT was called
+const authorizeJWTSpy = vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next());
+
+vi.mock("@microsoft/agents-hosting", () => ({
+  getAuthConfigWithDefaults: (cfg: unknown) => cfg,
+  MsalTokenProvider: class {
+    async getAccessToken() {
+      return "mock-token";
+    }
+  },
+  ActivityHandler: class {
+    onMessage() {}
+    onMembersAdded() {}
+    onConversationUpdate() {}
+    async run(_context: unknown) {}
+  },
+  CloudAdapter: class {
+    async process(
+      _req: unknown,
+      res: { status: (n: number) => { end: () => void } },
+      _handler: unknown,
+    ) {
+      res.status(200).end();
+    }
+  },
+  authorizeJWT: authorizeJWTSpy,
+}));
+
+vi.mock("./monitor-handler.js", () => ({
+  registerMSTeamsHandlers: (_handler: unknown) => ({
+    run: async () => {},
+  }),
+}));
+
+vi.mock("./conversation-store-fs.js", () => ({
+  createMSTeamsConversationStoreFs: () => ({}),
+}));
+
+vi.mock("./polls.js", () => ({
+  createMSTeamsPollStoreFs: () => ({}),
+}));
+
+vi.mock("./resolve-allowlist.js", () => ({
+  resolveMSTeamsUserAllowlist: async () => [],
+  resolveMSTeamsChannelAllowlist: async () => [],
+}));
+
+import { monitorMSTeamsProvider } from "./monitor.js";
+
+describe("msteams monitor", () => {
+  describe("JWT middleware bypass", () => {
+    let result: { app: unknown; shutdown: () => Promise<void> };
+
+    const cfg: OpenClawConfig = {
+      channels: {
+        msteams: {
+          enabled: true,
+          appId: "test-app-id",
+          appPassword: "test-password",
+          tenantId: "test-tenant",
+          webhook: { port: 0 }, // port 0 = random available port
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    beforeAll(async () => {
+      result = await monitorMSTeamsProvider({
+        cfg,
+        runtime: {
+          log: vi.fn(),
+          error: vi.fn(),
+          exit: vi.fn() as never,
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await result?.shutdown();
+    });
+
+    it("does not apply the SDK authorizeJWT middleware globally", () => {
+      // authorizeJWT should NOT have been called to create middleware
+      // because CloudAdapter.process() handles JWT validation internally
+      expect(authorizeJWTSpy).not.toHaveBeenCalled();
+    });
+
+    it("starts the Express server successfully", () => {
+      expect(result.app).toBeTruthy();
+    });
+
+    it("accepts POST requests to /api/messages without Authorization header", async () => {
+      const app = result.app as import("express").Express;
+      // Use supertest-like approach - make a real HTTP request
+      const { createServer } = await import("node:http");
+      const server = app.listen(0);
+      const port = (server.address() as { port: number }).port;
+
+      try {
+        const response = await fetch(`http://localhost:${port}/api/messages`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ type: "message", text: "hello" }),
+        });
+        // Should NOT get 401 jwt-auth-error
+        expect(response.status).not.toBe(401);
+        const body = await response.text();
+        expect(body).not.toContain("jwt-auth-error");
+      } finally {
+        server.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The msteams plugin's Express server applies the SDK's `authorizeJWT` middleware globally via `expressApp.use(authorizeJWT(authConfig))`. This middleware intercepts **all** incoming requests and rejects any without a valid `Authorization` header with:

```json
{"jwt-auth-error": "authorization header not found"}
```

Bot Framework webhook requests are rejected before `CloudAdapter.process()` can handle them.

## Root Cause

The `authorizeJWT` middleware from `@microsoft/agents-hosting` validates JWT tokens at the Express middleware layer. However, `CloudAdapter.process()` already performs Bot Framework JWT validation internally as part of its processing pipeline. The explicit middleware is redundant and causes requests to be rejected prematurely.

## Fix

Remove the global `authorizeJWT` middleware from the msteams Express server. `CloudAdapter.process()` handles authentication internally, consistent with how other channel plugins (telegram, slack, etc.) handle webhook auth — they rely on the channel adapter's built-in validation rather than applying global JWT middleware.

## Changes

- **`extensions/msteams/src/monitor.ts`**: Remove `authorizeJWT` import and global middleware application. Added explanatory comment.
- **`extensions/msteams/src/monitor.test.ts`**: New test verifying `authorizeJWT` is not applied and webhook requests without `Authorization` headers are not rejected with 401.

## Testing

- All 87 extension test files pass (939 tests)
- New monitor test verifies the JWT middleware bypass

Fixes #14436

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the global `authorizeJWT(authConfig)` Express middleware from the MS Teams provider (`extensions/msteams/src/monitor.ts`) so Bot Framework webhook requests reach `CloudAdapter.process()`, which already performs JWT validation internally.

It also adds a new Vitest (`extensions/msteams/src/monitor.test.ts`) that mocks the MS Teams SDK to assert `authorizeJWT` is not invoked and that `/api/messages` accepts a POST without an `Authorization` header (i.e., it is not rejected by the removed middleware).

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; the functional change is small and targeted, with one test hygiene issue to fix.
- The core change only removes a redundant global middleware call and adds a regression test. The only definite pre-merge issue found is an unused import/variable in the new test file that is likely to fail lint/typecheck depending on repo settings. I could not execute the test suite in this environment (missing Node/pnpm), so confidence is slightly reduced.
- extensions/msteams/src/monitor.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->