### PR TITLE
fix: increase WebSocket max payload from 512KB to 4MB

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,5 +1,5 @@
-export const MAX_PAYLOAD_BYTES = 512 * 1024; // cap incoming frame size
-export const MAX_BUFFERED_BYTES = 1.5 * 1024 * 1024; // per-connection send buffer limit
+export const MAX_PAYLOAD_BYTES = 4 * 1024 * 1024; // cap incoming frame size (4 MB — accounts for base64-encoded images)
+export const MAX_BUFFERED_BYTES = 8 * 1024 * 1024; // per-connection send buffer limit
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 let maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;


### PR DESCRIPTION
## Problem

When uploading images (~400KB) via WebSocket, the connection is terminated with "Max payload size exceeded". The server hardcodes `MAX_PAYLOAD_BYTES` to 512KB, but base64 encoding adds ~33% overhead, so a 400KB image becomes ~532KB and exceeds the limit.

## Fix

- Increase `MAX_PAYLOAD_BYTES` from 512KB to 4MB to comfortably handle base64-encoded image uploads
- Increase `MAX_BUFFERED_BYTES` from 1.5MB to 8MB to maintain headroom above the new payload limit

The 4MB limit supports images up to ~3MB before base64 encoding, which covers virtually all typical image uploads.

Fixes #14400

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR increases the gateway WebSocket limits by bumping `MAX_PAYLOAD_BYTES` from 512KB to 4MB and `MAX_BUFFERED_BYTES` from 1.5MB to 8MB in `src/gateway/server-constants.ts`. These constants are consumed by the gateway `WebSocketServer` initialization (`src/gateway/server-runtime-state.ts`) and surfaced to clients in the `hello-ok` policy payload (`src/gateway/server/ws-connection/message-handler.ts`), preventing base64-encoded image frames from being rejected with "Max payload size exceeded".

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a straightforward constant bump affecting only WebSocket size limits, and the updated values are consistently used both when constructing the WebSocketServer and when communicating policy to clients. No behavioral logic changes, API shape changes, or cross-module coupling issues were introduced.
- src/gateway/server-constants.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->