### PR TITLE
fix: prefer Bedrock inference profile IDs over foundation model IDs

### DIFF
--- a/src/agents/bedrock-discovery.test.ts
+++ b/src/agents/bedrock-discovery.test.ts
@@ -4,6 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const sendMock = vi.fn();
 const clientFactory = () => ({ send: sendMock }) as unknown as BedrockClient;
 
+/** Helper: queue a foundation-models response followed by an inference-profiles response. */
+function mockBedrockResponses(modelSummaries: unknown[], inferenceProfiles: unknown[] = []) {
+  sendMock
+    .mockResolvedValueOnce({ modelSummaries })
+    .mockResolvedValueOnce({ inferenceProfileSummaries: inferenceProfiles });
+}
+
 describe("bedrock discovery", () => {
   beforeEach(() => {
     sendMock.mockReset();
@@ -14,46 +21,44 @@ describe("bedrock discovery", () => {
       await import("./bedrock-discovery.js");
     resetBedrockDiscoveryCacheForTest();
 
-    sendMock.mockResolvedValueOnce({
-      modelSummaries: [
-        {
-          modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          modelName: "Claude 3.7 Sonnet",
-          providerName: "anthropic",
-          inputModalities: ["TEXT", "IMAGE"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-        {
-          modelId: "anthropic.claude-3-haiku-20240307-v1:0",
-          modelName: "Claude 3 Haiku",
-          providerName: "anthropic",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: false,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-        {
-          modelId: "meta.llama3-8b-instruct-v1:0",
-          modelName: "Llama 3 8B",
-          providerName: "meta",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "INACTIVE" },
-        },
-        {
-          modelId: "amazon.titan-embed-text-v1",
-          modelName: "Titan Embed",
-          providerName: "amazon",
-          inputModalities: ["TEXT"],
-          outputModalities: ["EMBEDDING"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-      ],
-    });
+    mockBedrockResponses([
+      {
+        modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        modelName: "Claude 3.7 Sonnet",
+        providerName: "anthropic",
+        inputModalities: ["TEXT", "IMAGE"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+      {
+        modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+        modelName: "Claude 3 Haiku",
+        providerName: "anthropic",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: false,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+      {
+        modelId: "meta.llama3-8b-instruct-v1:0",
+        modelName: "Llama 3 8B",
+        providerName: "meta",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "INACTIVE" },
+      },
+      {
+        modelId: "amazon.titan-embed-text-v1",
+        modelName: "Titan Embed",
+        providerName: "amazon",
+        inputModalities: ["TEXT"],
+        outputModalities: ["EMBEDDING"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+    ]);
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
     expect(models).toHaveLength(1);
@@ -72,19 +77,17 @@ describe("bedrock discovery", () => {
       await import("./bedrock-discovery.js");
     resetBedrockDiscoveryCacheForTest();
 
-    sendMock.mockResolvedValueOnce({
-      modelSummaries: [
-        {
-          modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          modelName: "Claude 3.7 Sonnet",
-          providerName: "anthropic",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-      ],
-    });
+    mockBedrockResponses([
+      {
+        modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        modelName: "Claude 3.7 Sonnet",
+        providerName: "anthropic",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+    ]);
 
     const models = await discoverBedrockModels({
       region: "us-east-1",
@@ -99,19 +102,17 @@ describe("bedrock discovery", () => {
       await import("./bedrock-discovery.js");
     resetBedrockDiscoveryCacheForTest();
 
-    sendMock.mockResolvedValueOnce({
-      modelSummaries: [
-        {
-          modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          modelName: "Claude 3.7 Sonnet",
-          providerName: "anthropic",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-      ],
-    });
+    mockBedrockResponses([
+      {
+        modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        modelName: "Claude 3.7 Sonnet",
+        providerName: "anthropic",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+    ]);
 
     const models = await discoverBedrockModels({
       region: "us-east-1",
@@ -126,8 +127,82 @@ describe("bedrock discovery", () => {
       await import("./bedrock-discovery.js");
     resetBedrockDiscoveryCacheForTest();
 
-    sendMock.mockResolvedValueOnce({
-      modelSummaries: [
+    mockBedrockResponses([
+      {
+        modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        modelName: "Claude 3.7 Sonnet",
+        providerName: "anthropic",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+    ]);
+
+    await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    // Two sends per discovery (foundation models + inference profiles), but only one discovery call
+    expect(sendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips cache when refreshInterval is 0", async () => {
+    const { discoverBedrockModels, resetBedrockDiscoveryCacheForTest } =
+      await import("./bedrock-discovery.js");
+    resetBedrockDiscoveryCacheForTest();
+
+    mockBedrockResponses([
+      {
+        modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        modelName: "Claude 3.7 Sonnet",
+        providerName: "anthropic",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+    ]);
+    mockBedrockResponses([
+      {
+        modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        modelName: "Claude 3.7 Sonnet",
+        providerName: "anthropic",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+    ]);
+
+    await discoverBedrockModels({
+      region: "us-east-1",
+      config: { refreshInterval: 0 },
+      clientFactory,
+    });
+    await discoverBedrockModels({
+      region: "us-east-1",
+      config: { refreshInterval: 0 },
+      clientFactory,
+    });
+    // Two discovery calls × 2 sends each = 4
+    expect(sendMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("prefers inference profile IDs over foundation model IDs", async () => {
+    const { discoverBedrockModels, resetBedrockDiscoveryCacheForTest } =
+      await import("./bedrock-discovery.js");
+    resetBedrockDiscoveryCacheForTest();
+
+    mockBedrockResponses(
+      [
+        {
+          modelId: "amazon.nova-2-lite-v1:0",
+          modelName: "Amazon Nova 2 Lite",
+          providerName: "amazon",
+          inputModalities: ["TEXT"],
+          outputModalities: ["TEXT"],
+          responseStreamingSupported: true,
+          modelLifecycle: { status: "ACTIVE" },
+        },
         {
           modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
           modelName: "Claude 3.7 Sonnet",
@@ -138,14 +213,97 @@ describe("bedrock discovery", () => {
           modelLifecycle: { status: "ACTIVE" },
         },
       ],
-    });
+      [
+        {
+          inferenceProfileId: "us.amazon.nova-2-lite-v1:0",
+          inferenceProfileName: "US Amazon Nova 2 Lite",
+          inferenceProfileArn:
+            "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.amazon.nova-2-lite-v1:0",
+          status: "ACTIVE",
+          type: "SYSTEM_DEFINED",
+          models: [{ modelArn: "arn:aws:bedrock:*::foundation-model/amazon.nova-2-lite-v1:0" }],
+        },
+      ],
+    );
 
-    await discoverBedrockModels({ region: "us-east-1", clientFactory });
-    await discoverBedrockModels({ region: "us-east-1", clientFactory });
-    expect(sendMock).toHaveBeenCalledTimes(1);
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    expect(models).toHaveLength(2);
+    const nova = models.find((m) => m.name === "Amazon Nova 2 Lite");
+    const claude = models.find((m) => m.name === "Claude 3.7 Sonnet");
+    // Nova should use the inference profile ID
+    expect(nova?.id).toBe("us.amazon.nova-2-lite-v1:0");
+    // Claude has no inference profile, keeps foundation model ID
+    expect(claude?.id).toBe("anthropic.claude-3-7-sonnet-20250219-v1:0");
   });
 
-  it("skips cache when refreshInterval is 0", async () => {
+  it("ignores non-SYSTEM_DEFINED inference profiles", async () => {
+    const { discoverBedrockModels, resetBedrockDiscoveryCacheForTest } =
+      await import("./bedrock-discovery.js");
+    resetBedrockDiscoveryCacheForTest();
+
+    mockBedrockResponses(
+      [
+        {
+          modelId: "amazon.nova-2-lite-v1:0",
+          modelName: "Amazon Nova 2 Lite",
+          providerName: "amazon",
+          inputModalities: ["TEXT"],
+          outputModalities: ["TEXT"],
+          responseStreamingSupported: true,
+          modelLifecycle: { status: "ACTIVE" },
+        },
+      ],
+      [
+        {
+          inferenceProfileId: "custom.amazon.nova-2-lite-v1:0",
+          inferenceProfileName: "Custom Nova 2 Lite",
+          inferenceProfileArn: "arn:aws:bedrock:us-east-1:123456789012:inference-profile/custom",
+          status: "ACTIVE",
+          type: "APPLICATION",
+          models: [{ modelArn: "arn:aws:bedrock:*::foundation-model/amazon.nova-2-lite-v1:0" }],
+        },
+      ],
+    );
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    expect(models[0]?.id).toBe("amazon.nova-2-lite-v1:0");
+  });
+
+  it("ignores inactive inference profiles", async () => {
+    const { discoverBedrockModels, resetBedrockDiscoveryCacheForTest } =
+      await import("./bedrock-discovery.js");
+    resetBedrockDiscoveryCacheForTest();
+
+    mockBedrockResponses(
+      [
+        {
+          modelId: "amazon.nova-2-lite-v1:0",
+          modelName: "Amazon Nova 2 Lite",
+          providerName: "amazon",
+          inputModalities: ["TEXT"],
+          outputModalities: ["TEXT"],
+          responseStreamingSupported: true,
+          modelLifecycle: { status: "ACTIVE" },
+        },
+      ],
+      [
+        {
+          inferenceProfileId: "us.amazon.nova-2-lite-v1:0",
+          inferenceProfileName: "US Amazon Nova 2 Lite",
+          inferenceProfileArn:
+            "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.amazon.nova-2-lite-v1:0",
+          status: "DEPRECATED",
+          type: "SYSTEM_DEFINED",
+          models: [{ modelArn: "arn:aws:bedrock:*::foundation-model/amazon.nova-2-lite-v1:0" }],
+        },
+      ],
+    );
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    expect(models[0]?.id).toBe("amazon.nova-2-lite-v1:0");
+  });
+
+  it("falls back to foundation model IDs when ListInferenceProfiles fails", async () => {
     const { discoverBedrockModels, resetBedrockDiscoveryCacheForTest } =
       await import("./bedrock-discovery.js");
     resetBedrockDiscoveryCacheForTest();
@@ -154,9 +312,9 @@ describe("bedrock discovery", () => {
       .mockResolvedValueOnce({
         modelSummaries: [
           {
-            modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            modelName: "Claude 3.7 Sonnet",
-            providerName: "anthropic",
+            modelId: "amazon.nova-2-lite-v1:0",
+            modelName: "Amazon Nova 2 Lite",
+            providerName: "amazon",
             inputModalities: ["TEXT"],
             outputModalities: ["TEXT"],
             responseStreamingSupported: true,
@@ -164,30 +322,10 @@ describe("bedrock discovery", () => {
           },
         ],
       })
-      .mockResolvedValueOnce({
-        modelSummaries: [
-          {
-            modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            modelName: "Claude 3.7 Sonnet",
-            providerName: "anthropic",
-            inputModalities: ["TEXT"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
-          },
-        ],
-      });
+      .mockRejectedValueOnce(new Error("AccessDeniedException"));
 
-    await discoverBedrockModels({
-      region: "us-east-1",
-      config: { refreshInterval: 0 },
-      clientFactory,
-    });
-    await discoverBedrockModels({
-      region: "us-east-1",
-      config: { refreshInterval: 0 },
-      clientFactory,
-    });
-    expect(sendMock).toHaveBeenCalledTimes(2);
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    expect(models).toHaveLength(1);
+    expect(models[0]?.id).toBe("amazon.nova-2-lite-v1:0");
   });
 });

--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -215,7 +215,7 @@ export async function discoverBedrockModels(params: {
       client.send(new ListInferenceProfilesCommand({})).catch(() => {
         // ListInferenceProfiles may fail if the caller lacks permissions.
         // Fall back gracefully to foundation model IDs only.
-        return { inferenceProfileSummaries: [] } as ListInferenceProfilesCommandOutput;
+        return { inferenceProfileSummaries: [] } as unknown as ListInferenceProfilesCommandOutput;
       }),
     ]);
     const inferenceProfileMap = buildInferenceProfileMap(


### PR DESCRIPTION
## Summary

Fixes #14566

When using AWS Bedrock models like Amazon Nova 2 and Claude Opus 4.6, OpenClaw only discovers foundation model IDs (e.g. `amazon.nova-2-lite-v1:0`), but these models require inference profile IDs (e.g. `us.amazon.nova-2-lite-v1:0`). This causes the error:

> Invocation of model ID amazon.nova-2-lite-v1:0 with on-demand throughput isn't supported.

## Changes

- **`src/agents/bedrock-discovery.ts`**: Call `ListInferenceProfiles` alongside `ListFoundationModels` during Bedrock model discovery. Build a mapping from foundation model IDs to SYSTEM_DEFINED inference profile IDs, and prefer profile IDs when available. Falls back gracefully if `ListInferenceProfiles` fails (e.g. insufficient permissions).
- **`src/agents/bedrock-discovery.test.ts`**: Added 4 new tests covering inference profile preference, filtering of non-SYSTEM_DEFINED/inactive profiles, and graceful fallback on API failure.

## How it works

1. Both `ListFoundationModels` and `ListInferenceProfiles` are called in parallel
2. A map is built: foundation model ID → inference profile ID (only for ACTIVE, SYSTEM_DEFINED profiles)
3. When converting foundation model summaries to model definitions, the inference profile ID is used if available
4. If `ListInferenceProfiles` fails, discovery continues with foundation model IDs only (backward compatible)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates Bedrock model discovery to prefer AWS **inference profile IDs** (from `ListInferenceProfiles`) over **foundation model IDs** (from `ListFoundationModels`) when a SYSTEM_DEFINED + ACTIVE profile exists for a given foundation model. The discovery logic now queries both endpoints in parallel, builds a foundation-id → profile-id map, and uses the profile ID as the model `id` when available, while gracefully falling back to foundation IDs if `ListInferenceProfiles` errors (e.g., missing IAM permissions).

Tests were expanded to cover the new preference behavior, filtering out non-SYSTEM_DEFINED and inactive profiles, and validating the fallback behavior when `ListInferenceProfiles` fails, as well as updating cache-related expectations to account for the additional API call.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is localized to Bedrock discovery, maintains backward compatibility by falling back when inference profile listing fails, and includes focused tests for the new mapping/filtering behavior and caching expectations.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->