### PR TITLE
fix(mattermost): use createReplyPrefixContext to avoid missing SDK export

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { createReplyPrefixOptions } from "openclaw/plugin-sdk";
+import { createReplyPrefixContext } from "openclaw/plugin-sdk";
 import { describe, expect, it } from "vitest";
 import { mattermostPlugin } from "./channel.js";
 
@@ -59,7 +59,7 @@ describe("mattermostPlugin", () => {
         },
       };
 
-      const prefixContext = createReplyPrefixOptions({
+      const prefixContext = createReplyPrefixContext({
         cfg,
         agentId: "main",
         channel: "mattermost",

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -6,7 +6,7 @@ import type {
   RuntimeEnv,
 } from "openclaw/plugin-sdk";
 import {
-  createReplyPrefixOptions,
+  createReplyPrefixContext,
   createTypingCallbacks,
   logInboundDrop,
   logTypingFailure,
@@ -771,12 +771,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       accountId: account.accountId,
     });
 
-    const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
-      cfg,
-      agentId: route.agentId,
-      channel: "mattermost",
-      accountId: account.accountId,
-    });
+    const { onModelSelected, responsePrefix, responsePrefixContextProvider } =
+      createReplyPrefixContext({
+        cfg,
+        agentId: route.agentId,
+        channel: "mattermost",
+        accountId: account.accountId,
+      });
 
     const typingCallbacks = createTypingCallbacks({
       start: () => sendTypingIndicator(channelId, threadRootId),
@@ -791,7 +792,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     });
     const { dispatcher, replyOptions, markDispatchIdle } =
       core.channel.reply.createReplyDispatcherWithTyping({
-        ...prefixOptions,
+        responsePrefix,
+        responsePrefixContextProvider,
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         deliver: async (payload: ReplyPayload) => {
           const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);

--- a/src/plugin-sdk/index.test.ts
+++ b/src/plugin-sdk/index.test.ts
@@ -47,3 +47,13 @@ describe("plugin-sdk exports", () => {
     }
   });
 });
+
+describe("plugin-sdk reply-prefix exports", () => {
+  it("exports createReplyPrefixContext as a function", () => {
+    expect(typeof sdk.createReplyPrefixContext).toBe("function");
+  });
+
+  it("exports createReplyPrefixOptions as a function", () => {
+    expect(typeof sdk.createReplyPrefixOptions).toBe("function");
+  });
+});

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -165,6 +165,7 @@ export {
 } from "../channels/ack-reactions.js";
 export { createTypingCallbacks } from "../channels/typing.js";
 export { createReplyPrefixContext, createReplyPrefixOptions } from "../channels/reply-prefix.js";
+export type { ReplyPrefixContextBundle, ReplyPrefixOptions } from "../channels/reply-prefix.js";
 export { logAckFailure, logInboundDrop, logTypingFailure } from "../channels/logging.js";
 export { resolveChannelMediaMaxBytes } from "../channels/plugins/media-limits.js";
 export type { NormalizedLocation } from "../channels/location.js";


### PR DESCRIPTION
## Summary

Fixes #14492

The Mattermost plugin handler crashes at runtime with:
```
TypeError: (0 , _pluginSdk.createReplyPrefixOptions) is not a function
```

### Root Cause

`createReplyPrefixOptions` was added to the plugin SDK after `createReplyPrefixContext`. When the Mattermost extension is loaded by jiti at runtime, the SDK alias resolution may fall back to an older installed `openclaw` package (< 2026.2.6) that lacks this export, causing the crash.

### Changes

1. **`extensions/mattermost/src/mattermost/monitor.ts`** — Replace `createReplyPrefixOptions` with `createReplyPrefixContext` (universally available) and destructure the needed properties (`responsePrefix`, `responsePrefixContextProvider`, `onModelSelected`) explicitly.

2. **`extensions/mattermost/src/channel.test.ts`** — Update test to use `createReplyPrefixContext`.

3. **`src/plugin-sdk/index.ts`** — Export the `ReplyPrefixOptions` and `ReplyPrefixContextBundle` types so external consumers can type their code against the SDK.

4. **`src/plugin-sdk/index.test.ts`** — Add tests asserting both `createReplyPrefixContext` and `createReplyPrefixOptions` remain exported as functions.

### Testing

All existing + new tests pass:
- `extensions/mattermost/src/channel.test.ts` (5 tests ✓)
- `src/plugin-sdk/index.test.ts` (3 tests ✓)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Mattermost extension to use `createReplyPrefixContext` instead of `createReplyPrefixOptions`, avoiding a runtime crash when the extension is loaded against an older installed `openclaw/plugin-sdk` that doesn’t export `createReplyPrefixOptions`. It also re-exports the `ReplyPrefixOptions` and `ReplyPrefixContextBundle` types from the plugin SDK and adds tests asserting both reply-prefix helpers remain exported.

Within the codebase, the Mattermost monitor builds reply dispatch options via the plugin SDK and feeds them into `core.channel.reply.createReplyDispatcherWithTyping`, while passing `onModelSelected` into `dispatchReplyFromConfig`; switching to `createReplyPrefixContext` preserves the same fields and semantics because `createReplyPrefixOptions` is just a wrapper around it.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped, swaps to an equivalent helper (`createReplyPrefixContext`) that returns the same fields used downstream, and adds targeted tests and type re-exports without altering runtime behavior in core reply dispatching.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->