### PR TITLE
onboard: set per-channel DM scope by default for multi-channel setups

### DIFF
--- a/src/commands/onboard-channels.test.ts
+++ b/src/commands/onboard-channels.test.ts
@@ -9,6 +9,7 @@ import { slackPlugin } from "../../extensions/slack/src/channel.js";
 import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
 import { whatsappPlugin } from "../../extensions/whatsapp/src/channel.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { setupChannels } from "./onboard-channels.js";
 
@@ -27,6 +28,45 @@ vi.mock("../channel-web.js", () => ({
 vi.mock("./onboard-helpers.js", () => ({
   detectBinary: vi.fn(async () => false),
 }));
+
+function createDirectOnboardingPlugin(params: { id: string; multiAccount: boolean }) {
+  const { id, multiAccount } = params;
+  return {
+    id,
+    meta: {
+      id,
+      label: id,
+      selectionLabel: id,
+      docsPath: `/channels/${id}`,
+      blurb: "test stub.",
+    },
+    capabilities: {
+      chatTypes: ["direct"],
+    },
+    onboarding: {
+      channel: id,
+      getStatus: async () => ({
+        channel: id,
+        configured: false,
+        statusLines: [`${id}: not configured`],
+        selectionHint: "not configured",
+        quickstartScore: 1,
+      }),
+      configure: async ({ cfg }: { cfg: OpenClawConfig }) => ({ cfg }),
+    },
+    config: {
+      listAccountIds: () => [DEFAULT_ACCOUNT_ID],
+      resolveAccount: (_cfg: OpenClawConfig, accountId?: string | null) => ({
+        accountId: multiAccount ? accountId?.trim() || DEFAULT_ACCOUNT_ID : DEFAULT_ACCOUNT_ID,
+      }),
+    },
+    setup: {
+      resolveAccountId: ({ accountId }: { accountId?: string }) =>
+        multiAccount ? accountId?.trim() || DEFAULT_ACCOUNT_ID : DEFAULT_ACCOUNT_ID,
+      applyAccountConfig: ({ cfg }: { cfg: OpenClawConfig }) => cfg,
+    },
+  };
+}
 
 describe("setupChannels", () => {
   beforeEach(() => {
@@ -204,5 +244,109 @@ describe("setupChannels", () => {
 
     expect(select).toHaveBeenCalledWith(expect.objectContaining({ message: "Select a channel" }));
     expect(multiselect).not.toHaveBeenCalled();
+  });
+
+  it("defaults DM isolation to per-account-channel-peer when selected channels support multiple accounts", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "alpha",
+          plugin: createDirectOnboardingPlugin({ id: "alpha", multiAccount: true }),
+          source: "test",
+        },
+        {
+          pluginId: "beta",
+          plugin: createDirectOnboardingPlugin({ id: "beta", multiAccount: true }),
+          source: "test",
+        },
+      ]),
+    );
+
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("alpha")
+      .mockResolvedValueOnce("beta")
+      .mockResolvedValueOnce("__done__");
+    const note = vi.fn(async () => {});
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note,
+      select,
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    const result = await setupChannels({} as OpenClawConfig, runtime, prompter, {
+      skipConfirm: true,
+      skipDmPolicyPrompt: true,
+    });
+
+    expect(result.session?.dmScope).toBe("per-account-channel-peer");
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining('session.dmScope="per-account-channel-peer"'),
+      "DM session scope",
+    );
+  });
+
+  it("defaults DM isolation to per-channel-peer when selected channels are single-account", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "alpha",
+          plugin: createDirectOnboardingPlugin({ id: "alpha", multiAccount: false }),
+          source: "test",
+        },
+        {
+          pluginId: "beta",
+          plugin: createDirectOnboardingPlugin({ id: "beta", multiAccount: false }),
+          source: "test",
+        },
+      ]),
+    );
+
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("alpha")
+      .mockResolvedValueOnce("beta")
+      .mockResolvedValueOnce("__done__");
+    const note = vi.fn(async () => {});
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note,
+      select,
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    const result = await setupChannels({} as OpenClawConfig, runtime, prompter, {
+      skipConfirm: true,
+      skipDmPolicyPrompt: true,
+    });
+
+    expect(result.session?.dmScope).toBe("per-channel-peer");
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining('session.dmScope="per-channel-peer"'),
+      "DM session scope",
+    );
   });
 });

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -282,6 +282,52 @@ async function maybeConfigureDmPolicies(params: {
   return cfg;
 }
 
+async function maybeConfigureDmScopeIsolation(params: {
+  cfg: OpenClawConfig;
+  selection: ChannelChoice[];
+  prompter: WizardPrompter;
+  skipConfirm?: boolean;
+}): Promise<OpenClawConfig> {
+  if (params.cfg.session?.dmScope) {
+    return params.cfg;
+  }
+
+  const dmCapableSelection = params.selection.filter((channel) =>
+    Boolean(getChannelOnboardingAdapter(channel)?.dmPolicy),
+  );
+  if (dmCapableSelection.length < 2) {
+    return params.cfg;
+  }
+
+  const shouldSet = params.skipConfirm
+    ? true
+    : await params.prompter.confirm({
+        message:
+          'Enable safe DM session isolation now? (recommended for multi-channel DM setups)',
+        initialValue: true,
+      });
+  if (!shouldSet) {
+    await params.prompter.note(
+      'Skipped. To prevent cross-channel DM context mixing, set session.dmScope="per-channel-peer" later.',
+      'DM session scope',
+    );
+    return params.cfg;
+  }
+
+  const next: OpenClawConfig = {
+    ...params.cfg,
+    session: {
+      ...(params.cfg.session ?? {}),
+      dmScope: 'per-channel-peer',
+    },
+  };
+  await params.prompter.note(
+    'Set session.dmScope="per-channel-peer" to isolate DM context by channel+sender.',
+    'DM session scope',
+  );
+  return next;
+}
+
 // Channel-specific prompts moved into onboarding adapters.
 
 export async function setupChannels(
@@ -670,6 +716,13 @@ export async function setupChannels(
       accountIdsByChannel,
     });
   }
+
+  next = await maybeConfigureDmScopeIsolation({
+    cfg: next,
+    selection,
+    prompter,
+    skipConfirm: options?.skipConfirm,
+  });
 
   return next;
 }

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -1,6 +1,6 @@
 import type { ChannelMeta } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
-import type { DmPolicy } from "../config/types.js";
+import type { DmPolicy, DmScope } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter, WizardSelectOption } from "../wizard/prompts.js";
 import type { ChannelChoice } from "./onboard-types.js";
@@ -218,6 +218,57 @@ function resolveQuickstartDefault(
   return best?.channel;
 }
 
+function channelSupportsDirectMessages(channel: ChannelChoice): boolean {
+  return getChannelPlugin(channel)?.capabilities.chatTypes.includes("direct") ?? false;
+}
+
+function channelSupportsMultipleAccounts(channel: ChannelChoice, cfg: OpenClawConfig): boolean {
+  const plugin = getChannelPlugin(channel);
+  if (!plugin) {
+    return false;
+  }
+
+  const probeAccountId = "openclaw-dm-scope-probe";
+  const normalizedProbeAccountId = normalizeAccountId(probeAccountId);
+  try {
+    const setupResolvedAccountId = plugin.setup?.resolveAccountId?.({
+      cfg,
+      accountId: probeAccountId,
+    });
+    if (normalizeAccountId(setupResolvedAccountId) === normalizedProbeAccountId) {
+      return true;
+    }
+
+    const resolvedAccount = plugin.config.resolveAccount(cfg, probeAccountId) as
+      | { accountId?: string | null }
+      | undefined;
+    return normalizeAccountId(resolvedAccount?.accountId) === normalizedProbeAccountId;
+  } catch {
+    return false;
+  }
+}
+
+function resolveRecommendedDmScope(params: {
+  cfg: OpenClawConfig;
+  selection: ChannelChoice[];
+}): DmScope | null {
+  const dmCapableSelection = params.selection.filter((channel) =>
+    channelSupportsDirectMessages(channel),
+  );
+  if (dmCapableSelection.length < 2) {
+    return null;
+  }
+  return dmCapableSelection.some((channel) => channelSupportsMultipleAccounts(channel, params.cfg))
+    ? "per-account-channel-peer"
+    : "per-channel-peer";
+}
+
+function formatDmScopeSummary(dmScope: DmScope): string {
+  return dmScope === "per-account-channel-peer"
+    ? 'session.dmScope="per-account-channel-peer" to isolate DM context by account + channel + sender'
+    : 'session.dmScope="per-channel-peer" to isolate DM context by channel + sender';
+}
+
 async function maybeConfigureDmPolicies(params: {
   cfg: OpenClawConfig;
   selection: ChannelChoice[];
@@ -292,24 +343,24 @@ async function maybeConfigureDmScopeIsolation(params: {
     return params.cfg;
   }
 
-  const dmCapableSelection = params.selection.filter((channel) =>
-    Boolean(getChannelOnboardingAdapter(channel)?.dmPolicy),
-  );
-  if (dmCapableSelection.length < 2) {
+  const recommendedDmScope = resolveRecommendedDmScope({
+    cfg: params.cfg,
+    selection: params.selection,
+  });
+  if (!recommendedDmScope) {
     return params.cfg;
   }
 
   const shouldSet = params.skipConfirm
     ? true
     : await params.prompter.confirm({
-        message:
-          'Enable safe DM session isolation now? (recommended for multi-channel DM setups)',
+        message: "Enable safe DM session isolation now? (recommended for multi-channel DM setups)",
         initialValue: true,
       });
   if (!shouldSet) {
     await params.prompter.note(
-      'Skipped. To prevent cross-channel DM context mixing, set session.dmScope="per-channel-peer" later.',
-      'DM session scope',
+      `Skipped. To prevent DM context mixing, set ${formatDmScopeSummary(recommendedDmScope)} later.`,
+      "DM session scope",
     );
     return params.cfg;
   }
@@ -317,13 +368,13 @@ async function maybeConfigureDmScopeIsolation(params: {
   const next: OpenClawConfig = {
     ...params.cfg,
     session: {
-      ...(params.cfg.session ?? {}),
-      dmScope: 'per-channel-peer',
+      ...params.cfg.session,
+      dmScope: recommendedDmScope,
     },
   };
   await params.prompter.note(
-    'Set session.dmScope="per-channel-peer" to isolate DM context by channel+sender.',
-    'DM session scope',
+    `Set ${formatDmScopeSummary(recommendedDmScope)}.`,
+    "DM session scope",
   );
   return next;
 }


### PR DESCRIPTION
## What
This PR makes channel onboarding safer for shared inbox scenarios by setting a DM-isolated session scope during setup.

### Change
In `setupChannels` (`src/commands/onboard-channels.ts`):
- If `session.dmScope` is **unset**
- and user selected **2+ DM-capable channels**
- onboarding now sets `session.dmScope = "per-channel-peer"`
  - interactive mode: asks for confirmation (default: yes)
  - non-interactive/skip-confirm mode: applies automatically

## Why
Many first-time multi-channel setups leave `dmScope` unset and later run into DM context bleed/cross-channel continuity surprises.

The core behavior (`dmScope=main` when unset) is documented, but onboarding currently only warns; it does not apply a safe default.

This PR keeps backward compatibility for existing configs and only affects onboarding-generated config when `dmScope` is not explicitly set.

## Scope and compatibility
- ✅ No change for users who already set `session.dmScope`
- ✅ No change for single-channel DM onboarding
- ✅ No core routing behavior change
- ✅ Existing deployments remain untouched

## Validation
- Ran targeted test suite:
  - `corepack pnpm -s vitest src/commands/onboard-channels.test.ts`

## Related
- Closes #14688
- Related context: #10172, #7861, #14117

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change introduces a new onboarding step in `setupChannels` that, when `session.dmScope` is unset and the user selects 2+ DM-capable channels, prompts (or auto-applies in `skipConfirm` mode) setting `session.dmScope` to `"per-channel-peer"` to isolate DM session history per channel+sender.

The logic is implemented as `maybeConfigureDmScopeIsolation()` and is invoked at the end of channel selection, after optional DM policy configuration. This keeps core routing behavior unchanged and only affects onboarding-generated config defaults.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe, but it may apply an incorrect dmScope default for multi-account channels during onboarding.
- The change is localized and preserves existing behavior when dmScope is already set, but the onboarding default is hard-coded to per-channel-peer despite the codebase recommending per-account-channel-peer for multi-account channels, which can lead to account-level DM context mixing.
- src/commands/onboard-channels.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->