### PR TITLE
feat(agent-autonomy): add runtime behavioral health monitor

### DIFF
--- a/extensions/agent-autonomy/src/behavioral-health-monitor.test.ts
+++ b/extensions/agent-autonomy/src/behavioral-health-monitor.test.ts
@@ -1,0 +1,429 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createBehavioralHealthMonitor,
+  type BehavioralHealthMonitor,
+  type HealthEvent,
+} from "./behavioral-health-monitor.js";
+
+describe("BehavioralHealthMonitor", () => {
+  let monitor: BehavioralHealthMonitor;
+
+  beforeEach(() => {
+    monitor = createBehavioralHealthMonitor();
+  });
+
+  describe("initial state", () => {
+    it("should start healthy with no events", () => {
+      const assessment = monitor.assess();
+      expect(assessment.status).toBe("healthy");
+      expect(assessment.score).toBe(100);
+      expect(assessment.degradations).toHaveLength(0);
+      expect(assessment.suggestedAction).toBe("none");
+    });
+
+    it("should report zero event count initially", () => {
+      expect(monitor.getEventCount()).toBe(0);
+    });
+
+    it("should have healthy status on quick check", () => {
+      expect(monitor.getStatus()).toBe("healthy");
+    });
+  });
+
+  describe("recording events", () => {
+    it("should track event count", () => {
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "write", success: true }));
+      expect(monitor.getEventCount()).toBe(2);
+    });
+
+    it("should remain healthy with successful events", () => {
+      // Use varying tool names and params to avoid loop detection
+      const tools = ["read", "write", "exec", "edit", "search"];
+      for (let i = 0; i < 10; i++) {
+        monitor.recordEvent(
+          makeEvent({
+            toolName: tools[i % tools.length],
+            success: true,
+            params: { id: i },
+          }),
+        );
+      }
+      const assessment = monitor.assess();
+      expect(assessment.status).toBe("healthy");
+      expect(assessment.score).toBe(100);
+    });
+
+    it("should bound event buffer to 2x window size", () => {
+      const m = createBehavioralHealthMonitor({ windowSize: 5 });
+      for (let i = 0; i < 20; i++) {
+        m.recordEvent(makeEvent({ toolName: "read", success: true }));
+      }
+      // Buffer should be capped at 2 * 5 = 10
+      expect(m.getEventCount()).toBe(10);
+    });
+  });
+
+  describe("failure streak detection", () => {
+    it("should detect 3 consecutive failures (default threshold)", () => {
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "write", success: false }));
+
+      const assessment = monitor.assess();
+      const streakReport = assessment.degradations.find((d) => d.signal === "failure_streak");
+      expect(streakReport).toBeDefined();
+      expect(streakReport!.affectedTools).toContain("exec");
+      expect(streakReport!.affectedTools).toContain("read");
+      expect(streakReport!.affectedTools).toContain("write");
+    });
+
+    it("should not trigger for 2 failures (below threshold)", () => {
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: false }));
+
+      const assessment = monitor.assess();
+      const streakReport = assessment.degradations.find((d) => d.signal === "failure_streak");
+      expect(streakReport).toBeUndefined();
+    });
+
+    it("should reset streak on success", () => {
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true })); // resets
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+
+      const assessment = monitor.assess();
+      const streakReport = assessment.degradations.find((d) => d.signal === "failure_streak");
+      expect(streakReport).toBeUndefined();
+    });
+
+    it("should use custom threshold", () => {
+      const m = createBehavioralHealthMonitor({ failureStreakThreshold: 5 });
+      for (let i = 0; i < 4; i++) {
+        m.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      }
+      expect(m.assess().degradations.find((d) => d.signal === "failure_streak")).toBeUndefined();
+
+      m.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      expect(m.assess().degradations.find((d) => d.signal === "failure_streak")).toBeDefined();
+    });
+  });
+
+  describe("execution loop detection", () => {
+    it("should detect 3 identical consecutive calls", () => {
+      const params = { path: "/test/file.ts" };
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true, params }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true, params }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true, params }));
+
+      const assessment = monitor.assess();
+      const loopReport = assessment.degradations.find((d) => d.signal === "execution_loop");
+      expect(loopReport).toBeDefined();
+      expect(loopReport!.affectedTools).toContain("read");
+      expect(loopReport!.detail).toContain("3 times");
+    });
+
+    it("should not trigger for different params", () => {
+      monitor.recordEvent(
+        makeEvent({ toolName: "read", success: true, params: { path: "/a.ts" } }),
+      );
+      monitor.recordEvent(
+        makeEvent({ toolName: "read", success: true, params: { path: "/b.ts" } }),
+      );
+      monitor.recordEvent(
+        makeEvent({ toolName: "read", success: true, params: { path: "/c.ts" } }),
+      );
+
+      const assessment = monitor.assess();
+      expect(assessment.degradations.find((d) => d.signal === "execution_loop")).toBeUndefined();
+    });
+
+    it("should not trigger for different tools", () => {
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "write", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+
+      const assessment = monitor.assess();
+      expect(assessment.degradations.find((d) => d.signal === "execution_loop")).toBeUndefined();
+    });
+
+    it("should handle param key ordering consistently", () => {
+      monitor.recordEvent(makeEvent({ toolName: "edit", success: true, params: { a: 1, b: 2 } }));
+      monitor.recordEvent(makeEvent({ toolName: "edit", success: true, params: { b: 2, a: 1 } }));
+      monitor.recordEvent(makeEvent({ toolName: "edit", success: true, params: { a: 1, b: 2 } }));
+
+      const assessment = monitor.assess();
+      const loopReport = assessment.degradations.find((d) => d.signal === "execution_loop");
+      expect(loopReport).toBeDefined();
+    });
+  });
+
+  describe("rising error rate detection", () => {
+    it("should detect high error rate in window", () => {
+      // 4 failures out of 5 = 80% > 60% threshold
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "write", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+
+      const assessment = monitor.assess();
+      const errorReport = assessment.degradations.find((d) => d.signal === "rising_error_rate");
+      expect(errorReport).toBeDefined();
+      expect(errorReport!.detail).toContain("80%");
+    });
+
+    it("should not trigger with low error rate", () => {
+      // 1 failure out of 5 = 20% < 60% threshold
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "write", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+
+      const assessment = monitor.assess();
+      expect(assessment.degradations.find((d) => d.signal === "rising_error_rate")).toBeUndefined();
+    });
+
+    it("should not trigger with fewer than 5 events", () => {
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+
+      const assessment = monitor.assess();
+      expect(assessment.degradations.find((d) => d.signal === "rising_error_rate")).toBeUndefined();
+    });
+
+    it("should rank affected tools by failure count", () => {
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: false }));
+
+      const assessment = monitor.assess();
+      const errorReport = assessment.degradations.find((d) => d.signal === "rising_error_rate");
+      expect(errorReport).toBeDefined();
+      expect(errorReport!.affectedTools[0]).toBe("exec"); // More failures
+      expect(errorReport!.affectedTools[1]).toBe("read");
+    });
+  });
+
+  describe("context exhaustion detection", () => {
+    it("should detect critical context usage (>= 90%)", () => {
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true, contextUsagePercent: 92 }));
+
+      const assessment = monitor.assess();
+      const contextReport = assessment.degradations.find((d) => d.signal === "context_exhaustion");
+      expect(contextReport).toBeDefined();
+      expect(contextReport!.severity).toBe(1);
+      expect(contextReport!.suggestedAction).toBe("compact_context");
+    });
+
+    it("should detect warning-level context usage (>= 70%, < 90%)", () => {
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true, contextUsagePercent: 78 }));
+
+      const assessment = monitor.assess();
+      const contextReport = assessment.degradations.find((d) => d.signal === "context_exhaustion");
+      expect(contextReport).toBeDefined();
+      expect(contextReport!.severity).toBeLessThan(1);
+      expect(contextReport!.suggestedAction).toBe("warn");
+    });
+
+    it("should not trigger below warning threshold", () => {
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true, contextUsagePercent: 50 }));
+
+      const assessment = monitor.assess();
+      expect(
+        assessment.degradations.find((d) => d.signal === "context_exhaustion"),
+      ).toBeUndefined();
+    });
+
+    it("should use most recent context usage", () => {
+      monitor.recordEvent(makeEvent({ toolName: "read", success: true, contextUsagePercent: 95 }));
+      monitor.recordEvent(makeEvent({ toolName: "write", success: true, contextUsagePercent: 50 }));
+
+      const assessment = monitor.assess();
+      // Most recent is 50%, which is below warning threshold
+      expect(
+        assessment.degradations.find((d) => d.signal === "context_exhaustion"),
+      ).toBeUndefined();
+    });
+
+    it("should use custom thresholds", () => {
+      const m = createBehavioralHealthMonitor({
+        contextWarningThreshold: 50,
+        contextCriticalThreshold: 80,
+      });
+      m.recordEvent(makeEvent({ toolName: "read", success: true, contextUsagePercent: 55 }));
+
+      const assessment = m.assess();
+      expect(assessment.degradations.find((d) => d.signal === "context_exhaustion")).toBeDefined();
+    });
+  });
+
+  describe("stalled progress detection", () => {
+    it("should detect stalled progress after threshold failures", () => {
+      for (let i = 0; i < 8; i++) {
+        monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      }
+
+      const assessment = monitor.assess();
+      const stalledReport = assessment.degradations.find((d) => d.signal === "stalled_progress");
+      expect(stalledReport).toBeDefined();
+      expect(stalledReport!.detail).toContain("8");
+    });
+
+    it("should not trigger if recent success exists", () => {
+      for (let i = 0; i < 6; i++) {
+        monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      }
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true })); // breaks the stall
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+
+      const assessment = monitor.assess();
+      expect(assessment.degradations.find((d) => d.signal === "stalled_progress")).toBeUndefined();
+    });
+  });
+
+  describe("overall health assessment", () => {
+    it("should combine multiple degradation signals", () => {
+      // Create a scenario with both failure streak and rising error rate
+      for (let i = 0; i < 5; i++) {
+        monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      }
+
+      const assessment = monitor.assess();
+      expect(assessment.degradations.length).toBeGreaterThanOrEqual(2);
+      expect(assessment.status).not.toBe("healthy");
+    });
+
+    it("should compute degraded status for moderate issues", () => {
+      // 3 consecutive failures (just above threshold)
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "write", success: false }));
+
+      const assessment = monitor.assess();
+      // Should be degraded but not necessarily critical
+      expect(assessment.score).toBeLessThan(100);
+    });
+
+    it("should reach critical status with severe degradation", () => {
+      // Many failures + context exhaustion
+      for (let i = 0; i < 10; i++) {
+        monitor.recordEvent(
+          makeEvent({
+            toolName: "exec",
+            success: false,
+            contextUsagePercent: 95,
+          }),
+        );
+      }
+
+      const assessment = monitor.assess();
+      expect(assessment.status).toBe("critical");
+      expect(assessment.score).toBeLessThan(40);
+    });
+
+    it("should pick the highest-priority intervention", () => {
+      // Context exhaustion should suggest compact_context
+      monitor.recordEvent(
+        makeEvent({
+          toolName: "read",
+          success: false,
+          contextUsagePercent: 95,
+        }),
+      );
+      monitor.recordEvent(makeEvent({ toolName: "read", success: false }));
+      monitor.recordEvent(makeEvent({ toolName: "read", success: false }));
+
+      const assessment = monitor.assess();
+      // compact_context should be present among degradations
+      const hasCompact = assessment.degradations.some(
+        (d) => d.suggestedAction === "compact_context",
+      );
+      expect(hasCompact).toBe(true);
+    });
+
+    it("should produce meaningful summaries", () => {
+      const healthyAssessment = monitor.assess();
+      expect(healthyAssessment.summary).toBe("Agent is operating normally.");
+
+      // Create degraded state
+      for (let i = 0; i < 5; i++) {
+        monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      }
+
+      const degradedAssessment = monitor.assess();
+      expect(degradedAssessment.summary).not.toBe("Agent is operating normally.");
+      expect(degradedAssessment.summary.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("reset", () => {
+    it("should clear all events and restore healthy state", () => {
+      for (let i = 0; i < 10; i++) {
+        monitor.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      }
+
+      expect(monitor.getStatus()).not.toBe("healthy");
+
+      monitor.reset();
+
+      expect(monitor.getEventCount()).toBe(0);
+      expect(monitor.getStatus()).toBe("healthy");
+      expect(monitor.assess().score).toBe(100);
+    });
+  });
+
+  describe("custom configuration", () => {
+    it("should respect custom window size", () => {
+      // Use a window of 5 (minimum for rising_error_rate detection)
+      const m = createBehavioralHealthMonitor({ windowSize: 5, errorRateThreshold: 0.5 });
+
+      // Fill with successes then failures so the window slides
+      m.recordEvent(makeEvent({ toolName: "exec", success: true }));
+      m.recordEvent(makeEvent({ toolName: "read", success: true }));
+      m.recordEvent(makeEvent({ toolName: "write", success: false }));
+      m.recordEvent(makeEvent({ toolName: "exec", success: false }));
+      m.recordEvent(makeEvent({ toolName: "read", success: false }));
+      // Window is [success, success, fail, fail, fail] — 60% error rate >= 50%
+
+      const assessment = m.assess();
+      const errorReport = assessment.degradations.find((d) => d.signal === "rising_error_rate");
+      expect(errorReport).toBeDefined();
+    });
+
+    it("should respect custom loop detection threshold", () => {
+      const m = createBehavioralHealthMonitor({ loopDetectionThreshold: 2 });
+
+      const params = { path: "/test" };
+      m.recordEvent(makeEvent({ toolName: "read", success: true, params }));
+      m.recordEvent(makeEvent({ toolName: "read", success: true, params }));
+
+      const assessment = m.assess();
+      expect(assessment.degradations.find((d) => d.signal === "execution_loop")).toBeDefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(
+  overrides: Partial<HealthEvent> & { toolName: string; success: boolean },
+): HealthEvent {
+  return {
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}

--- a/extensions/agent-autonomy/src/behavioral-health-monitor.ts
+++ b/extensions/agent-autonomy/src/behavioral-health-monitor.ts
@@ -1,0 +1,493 @@
+/**
+ * Runtime Behavioral Health Monitor (VIGIL-Inspired)
+ *
+ * Tracks aggregate tool call patterns during agent execution to detect
+ * degradation signals in real-time:
+ * - Repeated failures on the same tool (failure streaks)
+ * - Execution loops (same tool+params called repeatedly)
+ * - Rising error rates within a sliding window
+ * - Context budget exhaustion trends
+ * - Stalled progress (no successful actions over time)
+ *
+ * Unlike individual error classifiers, this monitors the overall "health"
+ * of an agent session and triggers adaptive interventions before the agent
+ * enters a terminal failure state.
+ *
+ * Inspired by: VIGIL: A Reflective Runtime for Self-Healing Agents
+ * https://arxiv.org/abs/2512.07094
+ */
+
+import type { ToolErrorCategory } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type HealthStatus = "healthy" | "degraded" | "critical";
+
+export type DegradationSignal =
+  | "failure_streak"
+  | "execution_loop"
+  | "rising_error_rate"
+  | "context_exhaustion"
+  | "stalled_progress";
+
+export type InterventionAction =
+  | "none"
+  | "warn"
+  | "switch_strategy"
+  | "compact_context"
+  | "escalate_to_human";
+
+export type HealthEvent = {
+  toolName: string;
+  toolCallId?: string;
+  success: boolean;
+  params?: Record<string, unknown>;
+  errorCategory?: ToolErrorCategory;
+  contextUsagePercent?: number;
+  timestamp: number;
+};
+
+export type DegradationReport = {
+  signal: DegradationSignal;
+  severity: number; // 0-1
+  detail: string;
+  suggestedAction: InterventionAction;
+  affectedTools: string[];
+};
+
+export type HealthAssessment = {
+  status: HealthStatus;
+  score: number; // 0-100, higher = healthier
+  degradations: DegradationReport[];
+  suggestedAction: InterventionAction;
+  summary: string;
+  assessedAt: number;
+};
+
+export type BehavioralHealthConfig = {
+  /** Size of the sliding window for event analysis */
+  windowSize?: number;
+  /** Number of consecutive failures to trigger failure_streak */
+  failureStreakThreshold?: number;
+  /** Number of identical calls to trigger execution_loop */
+  loopDetectionThreshold?: number;
+  /** Error rate (0-1) within window to trigger rising_error_rate */
+  errorRateThreshold?: number;
+  /** Context usage percent (0-100) to trigger context_exhaustion warning */
+  contextWarningThreshold?: number;
+  /** Context usage percent (0-100) to trigger critical context_exhaustion */
+  contextCriticalThreshold?: number;
+  /** Number of events without success to trigger stalled_progress */
+  stalledProgressThreshold?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONFIG: Required<BehavioralHealthConfig> = {
+  windowSize: 20,
+  failureStreakThreshold: 3,
+  loopDetectionThreshold: 3,
+  errorRateThreshold: 0.6,
+  contextWarningThreshold: 70,
+  contextCriticalThreshold: 90,
+  stalledProgressThreshold: 8,
+};
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export type BehavioralHealthMonitor = {
+  /** Record a tool execution event */
+  recordEvent(event: HealthEvent): void;
+
+  /** Get the current health assessment */
+  assess(): HealthAssessment;
+
+  /** Get the current health status (quick check, no full report) */
+  getStatus(): HealthStatus;
+
+  /** Get the event count in the current window */
+  getEventCount(): number;
+
+  /** Reset the monitor (e.g., after a strategy switch) */
+  reset(): void;
+};
+
+/**
+ * Create a behavioral health monitor for an agent session.
+ */
+export function createBehavioralHealthMonitor(
+  userConfig?: BehavioralHealthConfig,
+): BehavioralHealthMonitor {
+  const config = { ...DEFAULT_CONFIG, ...userConfig };
+  const events: HealthEvent[] = [];
+
+  function getWindow(): HealthEvent[] {
+    return events.slice(-config.windowSize);
+  }
+
+  /**
+   * Detect consecutive failures on any tool.
+   */
+  function detectFailureStreak(): DegradationReport | undefined {
+    const window = getWindow();
+    if (window.length < config.failureStreakThreshold) {
+      return undefined;
+    }
+
+    // Check from the end of the window for consecutive failures
+    let streak = 0;
+    const failedTools = new Set<string>();
+    for (let i = window.length - 1; i >= 0; i--) {
+      const event = window[i];
+      if (!event.success) {
+        streak++;
+        failedTools.add(event.toolName);
+      } else {
+        break;
+      }
+    }
+
+    if (streak >= config.failureStreakThreshold) {
+      const severity = Math.min(streak / (config.failureStreakThreshold * 2), 1);
+      return {
+        signal: "failure_streak",
+        severity,
+        detail: `${streak} consecutive failures detected across tools: ${[...failedTools].join(", ")}`,
+        suggestedAction: severity > 0.7 ? "switch_strategy" : "warn",
+        affectedTools: [...failedTools],
+      };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Detect repeated identical tool calls (same tool + similar params).
+   */
+  function detectExecutionLoop(): DegradationReport | undefined {
+    const window = getWindow();
+    if (window.length < config.loopDetectionThreshold) {
+      return undefined;
+    }
+
+    // Build a fingerprint for each event
+    const fingerprints: string[] = window.map(
+      (e) => `${e.toolName}:${e.params ? stableStringify(e.params) : ""}`,
+    );
+
+    // Check for repeated consecutive fingerprints
+    let maxRepeat = 1;
+    let currentRepeat = 1;
+    let repeatedFingerprint = "";
+
+    for (let i = 1; i < fingerprints.length; i++) {
+      if (fingerprints[i] === fingerprints[i - 1]) {
+        currentRepeat++;
+        if (currentRepeat > maxRepeat) {
+          maxRepeat = currentRepeat;
+          repeatedFingerprint = fingerprints[i]!;
+        }
+      } else {
+        currentRepeat = 1;
+      }
+    }
+
+    if (maxRepeat >= config.loopDetectionThreshold) {
+      const toolName = repeatedFingerprint.split(":")[0] ?? "unknown";
+      const severity = Math.min(maxRepeat / (config.loopDetectionThreshold * 2), 1);
+      return {
+        signal: "execution_loop",
+        severity,
+        detail: `Tool "${toolName}" called ${maxRepeat} times with identical parameters — possible infinite loop`,
+        suggestedAction: severity > 0.7 ? "escalate_to_human" : "switch_strategy",
+        affectedTools: [toolName],
+      };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Detect rising error rates within the sliding window.
+   */
+  function detectRisingErrorRate(): DegradationReport | undefined {
+    const window = getWindow();
+    // Need minimum events for meaningful rate
+    if (window.length < 5) {
+      return undefined;
+    }
+
+    const failures = window.filter((e) => !e.success).length;
+    const errorRate = failures / window.length;
+
+    if (errorRate >= config.errorRateThreshold) {
+      // Identify which tools are failing
+      const toolFailures = new Map<string, number>();
+      for (const event of window) {
+        if (!event.success) {
+          toolFailures.set(event.toolName, (toolFailures.get(event.toolName) ?? 0) + 1);
+        }
+      }
+
+      const affectedTools = [...toolFailures.entries()]
+        .toSorted((a, b) => b[1] - a[1])
+        .map(([name]) => name);
+
+      const severity = Math.min(errorRate / 1, 1); // Cap at 1
+      return {
+        signal: "rising_error_rate",
+        severity,
+        detail: `Error rate at ${(errorRate * 100).toFixed(0)}% (${failures}/${window.length}) — degraded performance`,
+        suggestedAction: severity > 0.8 ? "switch_strategy" : "warn",
+        affectedTools,
+      };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Detect context budget exhaustion based on reported context usage.
+   */
+  function detectContextExhaustion(): DegradationReport | undefined {
+    // Find the most recent event with context usage data
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      if (event.contextUsagePercent != null) {
+        if (event.contextUsagePercent >= config.contextCriticalThreshold) {
+          return {
+            signal: "context_exhaustion",
+            severity: 1,
+            detail: `Context usage at ${event.contextUsagePercent.toFixed(0)}% — critical, compaction needed immediately`,
+            suggestedAction: "compact_context",
+            affectedTools: [],
+          };
+        }
+        if (event.contextUsagePercent >= config.contextWarningThreshold) {
+          const severity =
+            (event.contextUsagePercent - config.contextWarningThreshold) /
+            (config.contextCriticalThreshold - config.contextWarningThreshold);
+          return {
+            signal: "context_exhaustion",
+            severity: Math.min(severity, 0.9),
+            detail: `Context usage at ${event.contextUsagePercent.toFixed(0)}% — approaching limit`,
+            suggestedAction: "warn",
+            affectedTools: [],
+          };
+        }
+        break; // Only check the most recent context usage report
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Detect stalled progress (too many events without a success).
+   */
+  function detectStalledProgress(): DegradationReport | undefined {
+    if (events.length < config.stalledProgressThreshold) {
+      return undefined;
+    }
+
+    // Count consecutive non-success events from the end
+    let stalledCount = 0;
+    for (let i = events.length - 1; i >= 0; i--) {
+      if (!events[i].success) {
+        stalledCount++;
+      } else {
+        break;
+      }
+    }
+
+    if (stalledCount >= config.stalledProgressThreshold) {
+      const affectedTools = new Set<string>();
+      for (let i = events.length - stalledCount; i < events.length; i++) {
+        affectedTools.add(events[i].toolName);
+      }
+
+      const severity = Math.min(stalledCount / (config.stalledProgressThreshold * 2), 1);
+      return {
+        signal: "stalled_progress",
+        severity,
+        detail: `No successful tool calls in last ${stalledCount} attempts — agent may be stuck`,
+        suggestedAction: severity > 0.7 ? "escalate_to_human" : "switch_strategy",
+        affectedTools: [...affectedTools],
+      };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Compute an overall health score from degradation reports.
+   */
+  function computeHealthScore(degradations: DegradationReport[]): number {
+    if (degradations.length === 0) {
+      return 100;
+    }
+
+    // Each degradation reduces the score proportional to its severity
+    let score = 100;
+    for (const d of degradations) {
+      // Weight different signals differently
+      const weight = SIGNAL_WEIGHTS[d.signal] ?? 1;
+      score -= d.severity * weight * 20;
+    }
+
+    return Math.max(0, Math.min(100, score));
+  }
+
+  function deriveStatus(score: number): HealthStatus {
+    if (score >= 70) {
+      return "healthy";
+    }
+    if (score >= 40) {
+      return "degraded";
+    }
+    return "critical";
+  }
+
+  function deriveAction(degradations: DegradationReport[]): InterventionAction {
+    if (degradations.length === 0) {
+      return "none";
+    }
+
+    // Use the most severe action from all degradations
+    const actionPriority: InterventionAction[] = [
+      "none",
+      "warn",
+      "switch_strategy",
+      "compact_context",
+      "escalate_to_human",
+    ];
+
+    let maxPriority = 0;
+    for (const d of degradations) {
+      const priority = actionPriority.indexOf(d.suggestedAction);
+      if (priority > maxPriority) {
+        maxPriority = priority;
+      }
+    }
+
+    return actionPriority[maxPriority] ?? "none";
+  }
+
+  function buildSummary(status: HealthStatus, degradations: DegradationReport[]): string {
+    if (status === "healthy") {
+      return "Agent is operating normally.";
+    }
+
+    const signals = degradations.map((d) => d.detail).join("; ");
+    if (status === "critical") {
+      return `CRITICAL: ${signals}`;
+    }
+    return `Degraded: ${signals}`;
+  }
+
+  return {
+    recordEvent(event: HealthEvent): void {
+      events.push(event);
+
+      // Keep events bounded to 2x window size for efficiency
+      const maxEvents = config.windowSize * 2;
+      if (events.length > maxEvents) {
+        events.splice(0, events.length - maxEvents);
+      }
+    },
+
+    assess(): HealthAssessment {
+      const degradations: DegradationReport[] = [];
+
+      const failureStreak = detectFailureStreak();
+      if (failureStreak) {
+        degradations.push(failureStreak);
+      }
+
+      const executionLoop = detectExecutionLoop();
+      if (executionLoop) {
+        degradations.push(executionLoop);
+      }
+
+      const risingErrorRate = detectRisingErrorRate();
+      if (risingErrorRate) {
+        degradations.push(risingErrorRate);
+      }
+
+      const contextExhaustion = detectContextExhaustion();
+      if (contextExhaustion) {
+        degradations.push(contextExhaustion);
+      }
+
+      const stalledProgress = detectStalledProgress();
+      if (stalledProgress) {
+        degradations.push(stalledProgress);
+      }
+
+      const score = computeHealthScore(degradations);
+      const status = deriveStatus(score);
+      const suggestedAction = deriveAction(degradations);
+      const summary = buildSummary(status, degradations);
+
+      return {
+        status,
+        score,
+        degradations,
+        suggestedAction,
+        summary,
+        assessedAt: Date.now(),
+      };
+    },
+
+    getStatus(): HealthStatus {
+      // Quick assessment without full report
+      const assessment = this.assess();
+      return assessment.status;
+    },
+
+    getEventCount(): number {
+      return events.length;
+    },
+
+    reset(): void {
+      events.length = 0;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Weights for each degradation signal type (higher = more impactful) */
+const SIGNAL_WEIGHTS: Record<DegradationSignal, number> = {
+  failure_streak: 1.0,
+  execution_loop: 1.5, // Loops are particularly wasteful
+  rising_error_rate: 1.0,
+  context_exhaustion: 1.2, // Context is a precious resource
+  stalled_progress: 1.3, // Stalled = nothing useful happening
+};
+
+/**
+ * Produce a stable JSON string for parameter comparison.
+ * Keys are sorted so that { a: 1, b: 2 } === { b: 2, a: 1 }.
+ */
+function stableStringify(obj: Record<string, unknown>): string {
+  const keys = Object.keys(obj).toSorted();
+  const parts: string[] = [];
+  for (const key of keys) {
+    const val = obj[key];
+    if (val !== undefined) {
+      parts.push(
+        `${key}:${typeof val === "object" && val !== null ? JSON.stringify(val) : JSON.stringify(val)}`,
+      );
+    }
+  }
+  return parts.join("|");
+}

--- a/extensions/agent-autonomy/src/behavioral-health-monitor.ts
+++ b/extensions/agent-autonomy/src/behavioral-health-monitor.ts
@@ -17,11 +17,16 @@
  * https://arxiv.org/abs/2512.07094
  */
 
-import type { ToolErrorCategory } from "./types.js";
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+export type ToolErrorCategory =
+  | "transient"
+  | "resource"
+  | "semantic"
+  | "permanent"
+  | "context_limit";
 
 export type HealthStatus = "healthy" | "degraded" | "critical";
 


### PR DESCRIPTION
## Summary
- Add a VIGIL-inspired runtime behavioral health monitor for agent sessions
- Detects degradation patterns in real-time: failure streaks, execution loops, rising error rates, context budget exhaustion, and stalled progress
- Each signal produces severity score, suggested intervention, and affected tool list; overall assessment computes a 0–100 health score (healthy/degraded/critical)

## Changes
- `extensions/agent-autonomy/src/behavioral-health-monitor.ts` — monitor implementation (493 lines)
- `extensions/agent-autonomy/src/behavioral-health-monitor.test.ts` — comprehensive test suite (429 lines)

## Test plan
- [x] Unit tests included covering all 5 signal types
- [ ] CI pass on this branch

Ref: [VIGIL paper](https://arxiv.org/abs/2512.07094)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `BehavioralHealthMonitor` to the `agent-autonomy` extension that records tool-call events and computes a health assessment based on five degradation signals (failure streak, execution loop, rising error rate, context exhaustion, stalled progress). It also introduces a comprehensive Vitest suite that exercises each signal and the combined scoring/action derivation.

The monitor is currently self-contained within `extensions/agent-autonomy/src/` and is intended to be consumed by agent session/runtime logic to detect real-time degradation and suggest interventions.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a build-breaking missing import/module.
- The new monitor file imports `./types.js`, but that module does not exist in this extension in the provided changeset/HEAD tree, which should break TypeScript resolution and CI. There is also an API/doc mismatch in `getEventCount()` semantics that can mislead consumers.
- extensions/agent-autonomy/src/behavioral-health-monitor.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->