### PR TITLE
fix: resolve cron delivery target from session store when lastChannel mismatches (#14646)

### DIFF
--- a/src/cron/isolated-agent.issue-14646.test.ts
+++ b/src/cron/isolated-agent.issue-14646.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Regression test for #14646: Isolated session + delivery announce not sending
+ * messages to Telegram when delivery.to is empty but the main session has a
+ * valid Telegram lastChannel / lastTo.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { CronJob } from "./types.js";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { telegramOutbound } from "../channels/plugins/outbound/telegram.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+vi.mock("../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn(),
+}));
+
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-cron-14646-" });
+}
+
+function makeCfg(
+  home: string,
+  storePath: string,
+  overrides: Partial<OpenClawConfig> = {},
+): OpenClawConfig {
+  const base: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-opus-4-5",
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+  } as OpenClawConfig;
+  return { ...base, ...overrides };
+}
+
+function makeJob(overrides: Partial<CronJob> = {}): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-1",
+    name: "daily-digest",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "run daily digest" },
+    state: {},
+    ...overrides,
+  };
+}
+
+function makeDeps(): CliDeps {
+  return {
+    sendMessageWhatsApp: vi.fn(),
+    sendMessageTelegram: vi.fn().mockResolvedValue({ messageId: "t1", chatId: "99887766" }),
+    sendMessageDiscord: vi.fn(),
+    sendMessageSignal: vi.fn(),
+    sendMessageIMessage: vi.fn(),
+  };
+}
+
+describe("issue #14646 – isolated session + delivery announce to Telegram", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+    vi.mocked(runSubagentAnnounceFlow).mockReset().mockResolvedValue(true);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          plugin: createOutboundTestPlugin({ id: "telegram", outbound: telegramOutbound }),
+          source: "test",
+        },
+      ]),
+    );
+  });
+
+  it("resolves delivery target from main session when delivery.to is empty string", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "99887766",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Daily digest: all clear" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, { channels: { telegram: { botToken: "t-1" } } }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram", to: "" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("telegram");
+      expect(args?.requesterOrigin?.to).toBe("99887766");
+    });
+  });
+
+  it("resolves delivery target from main session when delivery.to is undefined", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "99887766",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Daily digest: all clear" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, { channels: { telegram: { botToken: "t-1" } } }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("telegram");
+      expect(args?.requesterOrigin?.to).toBe("99887766");
+    });
+  });
+
+  it("resolves Telegram target from main session with lastProvider migration", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastProvider: "telegram",
+            lastTo: "99887766",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Daily digest: all clear" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, { channels: { telegram: { botToken: "t-1" } } }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram", to: "" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("telegram");
+      expect(args?.requesterOrigin?.to).toBe("99887766");
+    });
+  });
+
+  it("finds Telegram target from other session entries when main session lastChannel differs", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      // Main session is on webchat, but a Telegram group session exists
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "webchat",
+            lastTo: "web-user-1",
+          },
+          "agent:main:telegram:group:-100123": {
+            sessionId: "tg-group-session",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-100123",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Daily digest: all clear" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, { channels: { telegram: { botToken: "t-1" } } }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram", to: "" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("telegram");
+      expect(args?.requesterOrigin?.to).toBe("telegram:-100123");
+    });
+  });
+
+  it("still errors when no session entry has the requested channel target", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      // No session has ever used Telegram
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "webchat",
+            lastTo: "web-user-1",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Daily digest: all clear" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, { channels: { telegram: { botToken: "t-1" } } }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram", to: "" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("error");
+      expect(res.error).toBe("cron delivery target is missing");
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -12,6 +12,40 @@ import {
   resolveOutboundTarget,
   resolveSessionDeliveryTarget,
 } from "../../infra/outbound/targets.js";
+import { deliveryContextFromSession } from "../../utils/delivery-context.js";
+import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
+
+/**
+ * When the main session's lastChannel doesn't match the requested channel,
+ * scan all session entries for the same agent to find one whose lastChannel
+ * matches. This handles the common case where the user configured a cron to
+ * deliver on Telegram but their main session's lastChannel has since changed
+ * to another channel (e.g. webchat).
+ *
+ * See: https://github.com/openclaw/openclaw/issues/14646
+ */
+function findDeliveryTargetFromStore(
+  store: Record<string, unknown>,
+  requestedChannel: string,
+  excludeKey?: string,
+): { to: string; accountId?: string; threadId?: string | number } | undefined {
+  for (const [key, entry] of Object.entries(store)) {
+    if (key === excludeKey || !entry || typeof entry !== "object") {
+      continue;
+    }
+    const ctx = deliveryContextFromSession(
+      entry as Parameters<typeof deliveryContextFromSession>[0],
+    );
+    if (
+      ctx?.channel === requestedChannel &&
+      typeof ctx.to === "string" &&
+      ctx.to.trim().length > 0
+    ) {
+      return { to: ctx.to, accountId: ctx.accountId, threadId: ctx.threadId };
+    }
+  }
+  return undefined;
+}
 
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
@@ -68,7 +102,25 @@ export async function resolveDeliveryTarget(
 
   const channel = resolved.channel ?? fallbackChannel ?? DEFAULT_CHAT_CHANNEL;
   const mode = resolved.mode as "explicit" | "implicit";
-  const toCandidate = resolved.to;
+  let toCandidate = resolved.to;
+  let accountId = resolved.accountId;
+
+  // #14646: When an explicit channel is requested but the main session's
+  // lastChannel doesn't match (e.g. user switched from Telegram to webchat),
+  // the initial resolution can't find a `to`. Fall back to scanning the
+  // session store for ANY entry that was last used on the requested channel.
+  if (
+    !toCandidate &&
+    !explicitTo &&
+    requestedChannel !== "last" &&
+    isDeliverableMessageChannel(channel)
+  ) {
+    const storeHit = findDeliveryTargetFromStore(store, channel, mainSessionKey);
+    if (storeHit) {
+      toCandidate = storeHit.to;
+      accountId = storeHit.accountId ?? accountId;
+    }
+  }
 
   // Only carry threadId when delivering to the same recipient as the session's
   // last conversation. This prevents stale thread IDs (e.g. from a Telegram
@@ -83,7 +135,7 @@ export async function resolveDeliveryTarget(
     return {
       channel,
       to: undefined,
-      accountId: resolved.accountId,
+      accountId,
       threadId,
       mode,
     };
@@ -93,13 +145,13 @@ export async function resolveDeliveryTarget(
     channel,
     to: toCandidate,
     cfg,
-    accountId: resolved.accountId,
+    accountId,
     mode,
   });
   return {
     channel,
     to: docked.ok ? docked.to : undefined,
-    accountId: resolved.accountId,
+    accountId,
     threadId,
     mode,
     error: docked.ok ? undefined : docked.error,


### PR DESCRIPTION
## Problem

Isolated session cron jobs with `delivery: {mode: "announce", channel: "telegram", to: ""}` fail to deliver messages to Telegram. The cron completes successfully but the delivery is silently skipped with `cron delivery target is missing`.

### Root Cause

When `resolveDeliveryTarget` processes an explicit channel (e.g. `telegram`) with no explicit `to`, it falls back to the main session's `lastTo`. However, `resolveSessionDeliveryTarget` only uses `lastTo` when `channel === lastChannel`. If the main session's `lastChannel` has changed (e.g. the user switched to webchat, or only uses Telegram groups where `updateLastRoute` is skipped), the `to` stays `undefined` and delivery fails.

### Fix

After the initial target resolution fails to find a `to`, scan the session store for **any** entry whose `lastChannel` matches the requested channel and use its delivery target as a fallback. This handles:

1. Main session `lastChannel` changed from telegram → webchat
2. User only interacts via Telegram groups (main session never gets Telegram delivery context because `updateLastRoute` is skipped for groups)
3. Multi-session setups where the Telegram target exists on a different session entry

### Tests

Added 5 regression tests covering:
- Empty string `to` with matching `lastChannel` (existing behavior, still works)  
- Undefined `to` with matching `lastChannel` (existing behavior, still works)
- `lastProvider` → `lastChannel` migration (existing behavior, still works)
- **Channel mismatch fallback**: main session on webchat, Telegram target found from another session entry (**new fix**)
- **No target available**: properly errors when no session has the requested channel

Fixes #14646

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cron delivery for isolated-session jobs when `delivery.channel` is explicitly set (e.g. `telegram`) but `delivery.to` is empty/omitted and the *main* session’s `lastChannel` has since changed. The change adds a fallback in `src/cron/isolated-agent/delivery-target.ts` that, when initial resolution yields no `to`, scans the session store for another entry whose last delivery context matches the requested channel and uses that target.

It also adds a dedicated regression test suite (`src/cron/isolated-agent.issue-14646.test.ts`) covering empty/undefined `to`, `lastProvider` migration behavior, the new mismatch fallback, and the error case when no suitable target exists.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but the new fallback can select a delivery target from the wrong agent when using a shared session store path.
- Core logic and regression coverage for the reported issue look sound, but `findDeliveryTargetFromStore()` currently scans the entire store without filtering by `agentId`, which can misroute deliveries if multiple agents share the same sessions.json via `cfg.session.store`. Fixing that scoping should make the change low-risk.
- src/cron/isolated-agent/delivery-target.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->