### PR TITLE
fix(agents): classify 'model not found' errors as failover reason

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -35,6 +35,7 @@ export type AuthProfileCredential = ApiKeyCredential | TokenCredential | OAuthCr
 export type AuthProfileFailureReason =
   | "auth"
   | "format"
+  | "not_found"
   | "rate_limit"
   | "billing"
   | "timeout"

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -542,6 +542,14 @@ const ERROR_PATTERNS = {
     "plans & billing",
     "insufficient balance",
   ],
+  notFound: [
+    "does not exist or you do not have access",
+    "model not found",
+    "not_found_error",
+    /\b404\b.*(?:model|not found)/,
+    "no such model",
+    "the model.*does not exist",
+  ],
   auth: [
     /invalid[_ ]?api[_ ]?key/,
     "incorrect api key",
@@ -617,6 +625,10 @@ export function isBillingAssistantError(msg: AssistantMessage | undefined): bool
     return false;
   }
   return isBillingErrorMessage(msg.errorMessage ?? "");
+}
+
+export function isNotFoundErrorMessage(raw: string): boolean {
+  return matchesErrorPatterns(raw, ERROR_PATTERNS.notFound);
 }
 
 export function isAuthErrorMessage(raw: string): boolean {
@@ -718,6 +730,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isAuthErrorMessage(raw)) {
     return "auth";
+  }
+  if (isNotFoundErrorMessage(raw)) {
+    return "not_found";
   }
   return null;
 }

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,3 +1,10 @@
 export type EmbeddedContextFile = { path: string; content: string };
 
-export type FailoverReason = "auth" | "format" | "rate_limit" | "billing" | "timeout" | "unknown";
+export type FailoverReason =
+  | "auth"
+  | "format"
+  | "not_found"
+  | "rate_limit"
+  | "billing"
+  | "timeout"
+  | "unknown";

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -569,6 +569,11 @@ export async function updateSessionStore<T>(
   mutator: (store: Record<string, SessionEntry>) => Promise<T> | T,
   opts?: SaveSessionStoreOptions,
 ): Promise<T> {
+  if (!storePath || typeof storePath !== "string") {
+    throw new TypeError(
+      `updateSessionStore: storePath must be a non-empty string, got ${typeof storePath}`,
+    );
+  }
   return await withSessionStoreLock(storePath, async () => {
     // Always re-read inside the lock to avoid clobbering concurrent writers.
     const store = loadSessionStore(storePath, { skipCache: true });


### PR DESCRIPTION
Fixes #14687

When the API returns `"The model X does not exist or you do not have access to it."`, OpenClaw stopped the run instead of trying the next model in the fallback chain.

Adds `not_found` as a `FailoverReason` and detects common model-not-found patterns:
- `does not exist or you do not have access`
- `model not found`
- `not_found_error`
- `no such model`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change extends the agent failover classification logic to treat common “model not found / no access” API responses as a failover reason. It adds a new `not_found` member to the `FailoverReason` union, introduces corresponding error-message pattern matching in `pi-embedded-helpers/errors.ts`, and wires it into `classifyFailoverReason` so model fallback can continue to the next candidate instead of stopping the run.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but has a correctness bug in the new not-found pattern matching that will miss intended errors.
- Core change is small and localized, but one of the added patterns is written as a string containing regex metacharacters, which will not work with the current `matchesErrorPatterns` implementation and reduces the effectiveness of the fix.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->