### PR TITLE
fix(providers): include provider name in billing error messages

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -7,11 +7,30 @@ import {
 } from "./pi-embedded-helpers.js";
 
 describe("formatAssistantErrorText", () => {
-  const makeAssistantError = (errorMessage: string): AssistantMessage =>
-    ({
-      stopReason: "error",
-      errorMessage,
-    }) as AssistantMessage;
+  const makeAssistantError = (errorMessage: string): AssistantMessage => ({
+    role: "assistant",
+    api: "openai-responses",
+    provider: "openai",
+    model: "test-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "error",
+    errorMessage,
+    content: [{ type: "text", text: errorMessage }],
+    timestamp: 0,
+  });
 
   it("returns a friendly message for context overflow", () => {
     const msg = makeAssistantError("request_too_large");

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -1,6 +1,10 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { BILLING_ERROR_USER_MESSAGE, formatAssistantErrorText } from "./pi-embedded-helpers.js";
+import {
+  BILLING_ERROR_USER_MESSAGE,
+  formatBillingErrorMessage,
+  formatAssistantErrorText,
+} from "./pi-embedded-helpers.js";
 
 describe("formatAssistantErrorText", () => {
   const makeAssistantError = (errorMessage: string): AssistantMessage =>
@@ -66,6 +70,19 @@ describe("formatAssistantErrorText", () => {
   it("returns a friendly billing message for insufficient credits", () => {
     const msg = makeAssistantError("insufficient credits");
     const result = formatAssistantErrorText(msg);
+    expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
+  });
+  it("includes provider name in billing message when provider is given", () => {
+    const msg = makeAssistantError("insufficient credits");
+    const result = formatAssistantErrorText(msg, { provider: "Anthropic" });
+    expect(result).toBe(formatBillingErrorMessage("Anthropic"));
+    expect(result).toContain("Anthropic");
+    expect(result).not.toContain("API provider");
+  });
+  it("returns generic billing message when provider is not given", () => {
+    const msg = makeAssistantError("insufficient credits");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("API provider");
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -7,6 +7,7 @@ export {
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,
+  formatBillingErrorMessage,
   classifyFailoverReason,
   formatRawAssistantErrorForUi,
   formatAssistantErrorText,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -3,8 +3,14 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { FailoverReason } from "./types.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 
-export const BILLING_ERROR_USER_MESSAGE =
-  "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
+export function formatBillingErrorMessage(provider?: string): string {
+  if (provider) {
+    return `⚠️ ${provider} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${provider} billing dashboard and top up or switch to a different API key.`;
+  }
+  return "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
+}
+
+export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
@@ -388,7 +394,7 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
 
 export function formatAssistantErrorText(
   msg: AssistantMessage,
-  opts?: { cfg?: OpenClawConfig; sessionKey?: string },
+  opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string },
 ): string | undefined {
   // Also format errors if errorMessage is present, even if stopReason isn't "error"
   const raw = (msg.errorMessage ?? "").trim();
@@ -450,7 +456,7 @@ export function formatAssistantErrorText(
   }
 
   if (isBillingErrorMessage(raw)) {
-    return BILLING_ERROR_USER_MESSAGE;
+    return formatBillingErrorMessage(opts?.provider);
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -4,8 +4,9 @@ import type { FailoverReason } from "./types.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 
 export function formatBillingErrorMessage(provider?: string): string {
-  if (provider) {
-    return `⚠️ ${provider} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${provider} billing dashboard and top up or switch to a different API key.`;
+  const providerName = provider?.trim();
+  if (providerName) {
+    return `⚠️ ${providerName} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${providerName} billing dashboard and top up or switch to a different API key.`;
   }
   return "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -28,7 +28,7 @@ import {
 import { normalizeProviderId } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
-  BILLING_ERROR_USER_MESSAGE,
+  formatBillingErrorMessage,
   classifyFailoverReason,
   formatAssistantErrorText,
   isAuthAssistantError,
@@ -484,6 +484,7 @@ export async function runEmbeddedPiAgent(
             ? formatAssistantErrorText(lastAssistant, {
                 cfg: params.config,
                 sessionKey: params.sessionKey ?? params.sessionId,
+                provider,
               })
             : undefined;
           const assistantErrorText =
@@ -792,6 +793,7 @@ export async function runEmbeddedPiAgent(
                   ? formatAssistantErrorText(lastAssistant, {
                       cfg: params.config,
                       sessionKey: params.sessionKey ?? params.sessionId,
+                      provider,
                     })
                   : undefined) ||
                 lastAssistant?.errorMessage?.trim() ||
@@ -800,7 +802,7 @@ export async function runEmbeddedPiAgent(
                   : rateLimitFailure
                     ? "LLM request rate limited."
                     : billingFailure
-                      ? BILLING_ERROR_USER_MESSAGE
+                      ? formatBillingErrorMessage(provider)
                       : authFailure
                         ? "LLM request unauthorized."
                         : "LLM request failed.");
@@ -833,6 +835,7 @@ export async function runEmbeddedPiAgent(
             lastToolError: attempt.lastToolError,
             config: params.config,
             sessionKey: params.sessionKey ?? params.sessionId,
+            provider,
             verboseLevel: params.verboseLevel,
             reasoningLevel: params.reasoningLevel,
             toolResultFormat: resolvedToolResultFormat,

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -6,6 +6,7 @@ import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
 import {
+  BILLING_ERROR_USER_MESSAGE,
   formatAssistantErrorText,
   formatRawAssistantErrorForUi,
   getApiErrorPayloadFingerprint,
@@ -77,6 +78,7 @@ export function buildEmbeddedRunPayloads(params: {
     ? normalizeTextForComparison(rawErrorMessage)
     : null;
   const normalizedErrorText = errorText ? normalizeTextForComparison(errorText) : null;
+  const normalizedGenericBillingErrorText = normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE);
   const genericErrorText = "The AI service returned an error. Please try again.";
   if (errorText) {
     replyItems.push({ text: errorText, isError: true });
@@ -133,6 +135,13 @@ export function buildEmbeddedRunPayloads(params: {
         return true;
       }
       if (trimmed === genericErrorText) {
+        return true;
+      }
+      if (
+        normalized &&
+        normalizedGenericBillingErrorText &&
+        normalized === normalizedGenericBillingErrorText
+      ) {
         return true;
       }
     }

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -27,6 +27,7 @@ export function buildEmbeddedRunPayloads(params: {
   lastToolError?: { toolName: string; meta?: string; error?: string };
   config?: OpenClawConfig;
   sessionKey: string;
+  provider?: string;
   verboseLevel?: VerboseLevel;
   reasoningLevel?: ReasoningLevel;
   toolResultFormat?: ToolResultFormat;
@@ -57,6 +58,7 @@ export function buildEmbeddedRunPayloads(params: {
     ? formatAssistantErrorText(params.lastAssistant, {
         cfg: params.config,
         sessionKey: params.sessionKey,
+        provider: params.provider,
       })
     : undefined;
   const rawErrorMessage = lastAssistantErrored


### PR DESCRIPTION
#### Summary

Closes #14630. Billing/quota errors now include the provider name (e.g. "Anthropic returned a billing error") instead of the generic "API provider". When multiple providers are configured, this tells users exactly which key/account needs attention.

lobster-biscuit

#### Root Cause

`formatAssistantErrorText()` returned a hardcoded `BILLING_ERROR_USER_MESSAGE` constant with no provider context, even though the provider name was already available at every call site.

#### Behavior Changes

- **With provider context** (all normal chat/failover paths): `"⚠️ Anthropic returned a billing error — your API key has run out of credits or has an insufficient balance. Check your Anthropic billing dashboard and top up or switch to a different API key."`
- **Without provider context** (fallback/sanitization paths): unchanged generic message

#### Codebase and GitHub Search

- Searched all call sites of `formatAssistantErrorText` (3 production, 1 test file) and `BILLING_ERROR_USER_MESSAGE` (6 references)
- Confirmed `provider` variable is available at all production call sites in `run.ts`
- `sanitizeUserFacingText` has no provider context — left using generic message (text-sanitization fallback, not primary error path)

#### Tests

- 2 new tests in `formatassistanterrortext.test.ts`: with provider → includes name, without → generic
- All 269 existing tests pass, zero regressions
- `pnpm build && pnpm check && pnpm test` all green

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: AI-assisted, fully tested
- Agent notes: Minimal change — added `formatBillingErrorMessage(provider?)` function, threaded `provider` through existing opts. No architectural changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads an optional `provider` string through the embedded agent error-formatting path so billing/quota errors can say which provider failed (e.g., "Anthropic returned a billing error") instead of the generic "API provider".

Concretely:
- Adds `formatBillingErrorMessage(provider?)` in `src/agents/pi-embedded-helpers/errors.ts` and uses it from `formatAssistantErrorText()` when classifying billing errors.
- Updates embedded runner call sites (`src/agents/pi-embedded-runner/run.ts` and `src/agents/pi-embedded-runner/run/payloads.ts`) to pass the currently selected provider into `formatAssistantErrorText()`, and uses the new formatter for a fallback billing message.
- Re-exports the helper from `src/agents/pi-embedded-helpers.ts` and adds tests verifying provider-present vs provider-absent behavior.

The change is localized to user-facing error messaging and keeps the sanitize-only fallback path returning the existing generic billing text.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to formatting of billing error messages and threading an optional provider string through existing call sites; no control flow, provider selection, or error classification logic was altered beyond substituting the billing message generator. Call sites compile (types updated), tests were added for the new behavior, and the existing generic fallback message remains unchanged where provider context is unavailable.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->