### PR TITLE
fix(agents): reduce billing error false positives for '402'

### DIFF
--- a/src/agents/live-auth-keys.ts
+++ b/src/agents/live-auth-keys.ts
@@ -90,7 +90,13 @@ export function isAnthropicBillingError(message: string): boolean {
   if (lower.includes("billing") && lower.includes("disabled")) {
     return true;
   }
-  if (lower.includes("402")) {
+  if (
+    lower.includes("402") &&
+    (lower.includes("payment") ||
+      lower.includes("billing") ||
+      lower.includes("credit") ||
+      /(?:status|code|error|http )[:\s]+\b402\b/.test(lower))
+  ) {
     return true;
   }
   return false;

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -22,6 +22,24 @@ describe("isBillingErrorMessage", () => {
       expect(isBillingErrorMessage(sample)).toBe(true);
     }
   });
+  it("ignores conversational text containing numbers (False Positives)", () => {
+    const samples = [
+      "Hi Robbie, testing the 402 text sanitizer bug fix",
+      "My address is 402 Main Street",
+      "Room 402 is available",
+      "Bug 402 has been fixed",
+      "Port 402 is open",
+      "There are 402 items in the list",
+      "Call me at 402-555-1234",
+      "Section 402 of the tax code",
+      "Flight 402 departs at 3pm",
+    ];
+    for (const sample of samples) {
+      expect(isBillingErrorMessage(sample), `Expected '${sample}' NOT to be a billing error`).toBe(
+        false,
+      );
+    }
+  });
   it("ignores unrelated errors", () => {
     expect(isBillingErrorMessage("rate limit exceeded")).toBe(false);
     expect(isBillingErrorMessage("invalid api key")).toBe(false);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -525,7 +525,7 @@ type ErrorPattern = RegExp | string;
 
 const ERROR_PATTERNS = {
   rateLimit: [
-    /rate[_ ]limit|too many requests|429/,
+    /rate[_ ]limit|too many requests|\b429\b/,
     "exceeded your current quota",
     "resource has been exhausted",
     "quota exceeded",
@@ -535,7 +535,10 @@ const ERROR_PATTERNS = {
   overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
   timeout: ["timeout", "timed out", "deadline exceeded", "context deadline exceeded"],
   billing: [
-    /\b402\b/,
+    /(?:^|[\s:])402\s+payment\s+required/i,
+    /(?:status|code|error|http )[:\s]+\b402\b/i,
+    /\b402\b.*(?:credits?|billing|payment|balance|subscription|quota)/i,
+    /(?:credits?|billing|payment|balance|subscription|quota).*\b402\b/i,
     "payment required",
     "insufficient credits",
     "credit balance",
@@ -554,8 +557,8 @@ const ERROR_PATTERNS = {
     "access denied",
     "expired",
     "token has expired",
-    /\b401\b/,
-    /\b403\b/,
+    /(?:status|code|error|http )[:\s]+\b401\b/i, // Unauthorized
+    /(?:status|code|error|http )[:\s]+\b403\b/i, // Forbidden
     "no credentials found",
     "no api key found",
   ],


### PR DESCRIPTION
This PR fixes an issue where conversational text containing the number "402" was being incorrectly identified as a billing error, causing the assistant's actual reply to be replaced with a warning message.

**Root Cause:**
The `ERROR_PATTERNS.billing` array in `src/agents/pi-embedded-helpers/errors.ts` and the `isAnthropicBillingError` function in `src/agents/live-auth-keys.ts` used overly broad patterns (`/\b402\b/` and `.includes("402")`) that matched the number "402" in any context.

**Changes:**
- Replaced the broad patterns with more specific, context-aware regular expressions that require billing-related keywords (e.g., "payment", "credit", "status code") to be present alongside the number "402".
- Updated the unit tests for `isBillingErrorMessage` to include cases that were previously false positives, ensuring they are now correctly ignored.
- As a bonus, similar broad patterns for HTTP status codes `401`, `403` (auth), and `429` (rate limit) have also been improved to prevent similar future issues.

This change significantly reduces false positives and improves the user experience on messaging channels like Telegram, preventing normal conversations from being interrupted by incorrect error warnings.

Fixes #14680

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens error detection heuristics to avoid treating plain conversational mentions of status codes (notably `402`) as billing errors. It replaces broad `402`/`401`/`403`/`429` patterns in `pi-embedded-helpers/errors.ts` with more context-aware regexes and adds unit tests covering prior false positives (e.g., addresses/room numbers containing `402`).

These helpers feed into user-facing error rewriting (`formatAssistantErrorText` / `sanitizeUserFacingText`) so more precise patterns prevent legitimate assistant text from being replaced with generic billing warnings.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one remaining false-positive path can still misclassify messages containing "429" as rate-limit errors.
- The core change (tightening billing/auth/rate-limit regexes in pi-embedded error helpers and adding regression tests) is low risk and directly addresses the reported bug. The main concern is that Anthropic-specific rate limit detection still matches any "429" substring, which can trigger incorrect retry behavior in the live model profile tests, partially undermining the PR’s stated goal of reducing status-code false positives.
- src/agents/live-auth-keys.ts (rate limit detection); verify downstream behavior in src/agents/models.profiles.live.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->