### PR TITLE
fix: display local timezone in console logs

### DIFF
--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -139,13 +139,14 @@ function formatConsoleTimestamp(style: ConsoleStyle): string {
   const now = new Date();
 
   if (style === "pretty") {
-    return now.toLocaleTimeString('en-GB', { 
+    return now.toLocaleTimeString("en-GB", {
       hour12: false,
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit'
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
     });
   }
+
   return now.toISOString();
 }
 

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -137,6 +137,7 @@ function isEpipeError(err: unknown): boolean {
 
 function formatConsoleTimestamp(style: ConsoleStyle): string {
   const now = new Date();
+
   if (style === "pretty") {
     return now.toLocaleTimeString('en-GB', { 
       hour12: false,
@@ -145,9 +146,7 @@ function formatConsoleTimestamp(style: ConsoleStyle): string {
       second: '2-digit'
     });
   }
-  
-  const offset = now.getTimezoneOffset() * 60000;
-  return new Date(now.getTime() - offset).toISOString().slice(0, -1);
+  return now.toISOString();
 }
 
 function hasTimestampPrefix(value: string): boolean {

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -136,11 +136,18 @@ function isEpipeError(err: unknown): boolean {
 }
 
 function formatConsoleTimestamp(style: ConsoleStyle): string {
-  const now = new Date().toISOString();
+  const now = new Date();
   if (style === "pretty") {
-    return now.slice(11, 19);
+    return now.toLocaleTimeString('en-GB', { 
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    });
   }
-  return now;
+  
+  const offset = now.getTimezoneOffset() * 60000;
+  return new Date(now.getTime() - offset).toISOString().slice(0, -1);
 }
 
 function hasTimestampPrefix(value: string): boolean {


### PR DESCRIPTION
### Description
Fixes #14699

This PR addresses the issue where console logs were hardcoded to UTC time using `toISOString()`. It updates the formatting to respect the user's local system timezone.

### Changes
- Updated `formatConsoleTimestamp` in `src/logging/console.ts`.
- Uses `toLocaleTimeString` with `en-GB` locale to ensure a consistent 24-hour format (HH:mm:ss) across different environments.
- Adjusted standard style to reflect the local timezone offset.

### Test Configuration
- System Timezone: Asia/Shanghai (UTC+8)
- Result: Logs now correctly match the system clock instead of being 8 hours behind.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `formatConsoleTimestamp()` in `src/logging/console.ts` so console-captured output uses local time instead of `toISOString()`’s UTC.

Main concern is the new “compact/json” timestamp prefix format: it’s now an ISO-like string without any timezone designator, which is ambiguous and breaks an existing test expectation. Also, other console logging paths (notably `src/logging/subsystem.ts`’s `formatConsoleLine()` and JSON console output) still use `toISOString()`, so many console timestamps will remain UTC despite the PR’s stated intent.

<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge after fixing timestamp format consistency and covering remaining UTC console paths.
- The change is localized, but it introduces an ambiguous ISO-like timestamp (no timezone designator) and appears to leave other console timestamp codepaths still emitting UTC, conflicting with the PR’s stated goal and breaking existing test expectations.
- src/logging/console.ts; src/logging/subsystem.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->