### PR TITLE
fix: use local time in formatConsoleTimestamp (#14699)

### DIFF
--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -86,7 +86,7 @@ describe("enableConsoleCapture", () => {
     console.warn("[EventQueue] Slow listener detected");
     expect(warn).toHaveBeenCalledTimes(1);
     const firstArg = String(warn.mock.calls[0]?.[0] ?? "");
-    expect(firstArg.startsWith("2026-01-17T18:01:02.000Z [EventQueue]")).toBe(true);
+    expect(firstArg.startsWith("2026-01-17T18:01:02.000 [EventQueue]")).toBe(true);
     vi.useRealTimers();
   });
 

--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -86,7 +86,11 @@ describe("enableConsoleCapture", () => {
     console.warn("[EventQueue] Slow listener detected");
     expect(warn).toHaveBeenCalledTimes(1);
     const firstArg = String(warn.mock.calls[0]?.[0] ?? "");
-    expect(firstArg.startsWith("2026-01-17T18:01:02.000 [EventQueue]")).toBe(true);
+    // formatConsoleTimestamp converts to local time via offset subtraction,
+    // so derive the expected prefix the same way to avoid TZ-dependent failures.
+    const offset = now.getTimezoneOffset() * 60000;
+    const localIso = new Date(now.getTime() - offset).toISOString().slice(0, -1);
+    expect(firstArg.startsWith(`${localIso} [EventQueue]`)).toBe(true);
     vi.useRealTimers();
   });
 

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -136,11 +136,12 @@ function isEpipeError(err: unknown): boolean {
 }
 
 function formatConsoleTimestamp(style: ConsoleStyle): string {
-  const now = new Date().toISOString();
+  const now = new Date();
   if (style === "pretty") {
-    return now.slice(11, 19);
+    return now.toLocaleTimeString("en-GB", { hour12: false });
   }
-  return now;
+  const offset = now.getTimezoneOffset() * 60000;
+  return new Date(now.getTime() - offset).toISOString().slice(0, -1);
 }
 
 function hasTimestampPrefix(value: string): boolean {


### PR DESCRIPTION
Fixes #14699

`formatConsoleTimestamp` was using `new Date().toISOString()` which always returns UTC. This made console log timestamps incorrect for users in non-UTC timezones.

**Changes:**
- **Pretty style:** Use `toLocaleTimeString('en-GB', { hour12: false })` to get local `HH:mm:ss`
- **Standard style:** Construct a local ISO string by adjusting for timezone offset (without trailing `Z`)
- Updated test expectation to match the new format (no `Z` suffix)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `formatConsoleTimestamp` (used by `enableConsoleCapture` timestamp prefixes) to use local time rather than UTC: `pretty` style uses `toLocaleTimeString('en-GB', { hour12: false })`, and other styles emit an ISO-like local timestamp by adjusting for the timezone offset and removing the trailing `Z`. The console capture test expectation was updated to match the new no-`Z` format.

Main issue found is test correctness across timezones: the updated assertion still hard-codes the UTC time components, but the implementation now emits local time, so the test will fail when the CI runner isn’t configured for UTC.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but the updated test is likely to fail on non-UTC machines.
- Core code change is small and localized, but the new local-time behavior makes the existing test assertion timezone-dependent, which will cause deterministic failures depending on the runner timezone configuration.
- src/logging/console-capture.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->