### PR TITLE
New files from Fly.io Launch

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,34 +1,23 @@
-# OpenClaw Fly.io deployment configuration
-# See https://fly.io/docs/reference/configuration/
+# fly.toml app configuration file generated for app-muddy-snow-1764 on 2026-02-12T14:28:04Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
-app = "openclaw"
-primary_region = "iad" # change to your closest region
+app = 'app-muddy-snow-1764'
+primary_region = 'iad'
 
 [build]
-dockerfile = "Dockerfile"
-
-[env]
-NODE_ENV = "production"
-# Fly uses x86, but keep this for consistency
-OPENCLAW_PREFER_PNPM = "1"
-OPENCLAW_STATE_DIR = "/data"
-NODE_OPTIONS = "--max-old-space-size=1536"
-
-[processes]
-app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
 
 [http_service]
-internal_port = 3000
-force_https = true
-auto_stop_machines = false # Keep running for persistent connections
-auto_start_machines = true
-min_machines_running = 1
-processes = ["app"]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
 
 [[vm]]
-size = "shared-cpu-2x"
-memory = "2048mb"
-
-[mounts]
-source = "openclaw_data"
-destination = "/data"
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 256


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR replaces the existing OpenClaw Fly.io deployment configuration (`fly.toml`) with a generated Fly Launch template.

In doing so, it changes the app name, switches the service port to 8080, and removes the repository’s documented Fly settings (Dockerfile build, environment variables, explicit gateway process command, and persistent `/data` volume mount). The current repo deployment guide (`docs/install/fly.md`) and the private template (`fly.private.toml`) assume a gateway process bound to LAN on port 3000 with state persisted under `/data`; without those settings, Fly health checks/ingress and persistence won’t match how OpenClaw is intended to run.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge: the Fly.io config will likely break deployments and persistence.
- The only changed file is fly.toml, and it no longer matches the repo’s documented Fly deployment requirements (port/process/env/mount), plus it contains conflicting VM memory settings. These are high-impact configuration errors for anyone deploying via Fly.
- fly.toml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->