### PR TITLE
fix(slack): pass threadId in plugin read action (#14706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/OpenResponses: harden URL-based `input_file`/`input_image` handling with explicit SSRF deny policy, hostname allowlists (`files.urlAllowlist` / `images.urlAllowlist`), per-request URL input caps (`maxUrlParts`), blocked-fetch audit logging, and regression coverage/docs updates.
+- Slack: pass `threadId` in plugin read action so thread replies can be fetched. (#14706)
 - Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
 - Security: remove bundled soul-evil hook. (#14757) Thanks @Imccccc.
 - Security/Audit: add hook session-routing hardening checks (`hooks.defaultSessionKey`, `hooks.allowRequestSessionKey`, and prefix allowlists), and warn when HTTP API endpoints allow explicit session-key routing.

--- a/extensions/slack/src/channel.read-threadid.test.ts
+++ b/extensions/slack/src/channel.read-threadid.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { setSlackRuntime } from "./runtime.js";
+
+// Capture the params passed to handleSlackAction
+const handleSlackAction = vi.fn(async () => ({ ok: true, details: { messages: [] } }));
+
+// Set up a minimal mock runtime before importing channel
+setSlackRuntime({
+  channel: {
+    slack: {
+      handleSlackAction,
+    },
+  },
+  config: { loadConfig: () => ({}) },
+} as any);
+
+// Now import the channel plugin (it will use the mocked runtime)
+const { slackPlugin } = await import("./channel.js");
+
+const cfg = { channels: { slack: { botToken: "xoxb-test" } } } as any;
+
+describe("Slack plugin read action threadId", () => {
+  it("passes threadId to handleSlackAction when provided", async () => {
+    handleSlackAction.mockClear();
+
+    await slackPlugin.actions!.handleAction!({
+      action: "read" as any,
+      params: {
+        to: "C_CHANNEL_123",
+        threadId: "1234567890.123456",
+        limit: 10,
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: undefined,
+    } as any);
+
+    expect(handleSlackAction).toHaveBeenCalledTimes(1);
+    const callArgs = handleSlackAction.mock.calls[0] as unknown[];
+    const params = callArgs[0] as Record<string, unknown>;
+    expect(params.action).toBe("readMessages");
+    expect(params.threadId).toBe("1234567890.123456");
+  });
+
+  it("does not include threadId when not provided", async () => {
+    handleSlackAction.mockClear();
+
+    await slackPlugin.actions!.handleAction!({
+      action: "read" as any,
+      params: {
+        to: "C_CHANNEL_123",
+        limit: 5,
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: undefined,
+    } as any);
+
+    expect(handleSlackAction).toHaveBeenCalledTimes(1);
+    const callArgs = handleSlackAction.mock.calls[0] as unknown[];
+    const params = callArgs[0] as Record<string, unknown>;
+    expect(params.action).toBe("readMessages");
+    expect(params.threadId).toBeUndefined();
+  });
+});

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -355,6 +355,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
 
       if (action === "read") {
         const limit = readNumberParam(params, "limit", { integer: true });
+        const threadId = readStringParam(params, "threadId");
         return await getSlackRuntime().channel.slack.handleSlackAction(
           {
             action: "readMessages",
@@ -362,6 +363,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: threadId ?? undefined,
             accountId: accountId ?? undefined,
           },
           cfg,


### PR DESCRIPTION
## Summary

- **Bug**: Slack plugin's `handleAction` for `action === "read"` silently drops the `threadId` parameter, so thread replies can never be fetched.
- **Root cause**: The `read` branch in `extensions/slack/src/channel.ts` constructs the `handleSlackAction` params without reading `threadId` from the tool params. The core `slack-actions.ts` already supports `threadId` in `readMessages`, but the extension layer never passes it.
- **Fix**: Read `threadId` from params and include it in the `handleSlackAction` call for the `read` action.

Fixes #14706

## Problem

When calling `message(action="read", channel="slack", target="<channel>", threadId="<ts>", limit=N)`, the `threadId` is silently dropped by the Slack plugin extension. The internal `readSlackMessages` function falls through to `conversations.history` (channel-level messages) instead of `conversations.replies` (thread replies).

The bug is in `extensions/slack/src/channel.ts` lines 356-368. The `read` branch reads `limit`, `before`, `after`, and `accountId`, but not `threadId`. Compare with the `send` branch (line 304) which correctly reads `threadId`.

The core code in `src/agents/tools/slack-actions.ts` (line 230) already reads `threadId` and passes it to `readSlackMessages` — the extension layer just never provides it.

**Before fix (reproduced on main via integration test):**
```
pnpm vitest run extensions/slack/src/channel.read-threadid.test.ts

❌ FAIL  passes threadId to handleSlackAction when provided
AssertionError: expected undefined to be '1234567890.123456'
```

The test directly calls `slackPlugin.actions.handleAction` with `threadId: "1234567890.123456"` and asserts the param is passed to `handleSlackAction`. On main, it's `undefined`.

## Changes

- `extensions/slack/src/channel.ts` — Read `threadId` from params via `readStringParam` and pass it as `threadId: threadId ?? undefined` to `handleSlackAction` in the `read` branch (+2 lines)
- `extensions/slack/src/channel.read-threadid.test.ts` — New regression test: imports real `slackPlugin`, mocks `getSlackRuntime`, calls `handleAction` with `action="read"` and asserts `threadId` is forwarded
- `CHANGELOG.md` — Add fix entry

**After fix (verified on fix branch):**
```
pnpm vitest run extensions/slack/src/channel.read-threadid.test.ts

✓ passes threadId to handleSlackAction when provided
✓ does not include threadId when not provided

Test Files  1 passed (1)
Tests       2 passed (2)
```

## Test plan

- [x] New test: `threadId` passed to `handleSlackAction` when provided (integration test calling real extension code)
- [x] New test: `threadId` is `undefined` when not provided (no regression)
- [x] All 22 existing slack-actions tests pass (`pnpm vitest run src/agents/tools/slack-actions.test.ts`)
- [x] Lint passes (`pnpm lint`)
- [x] Bug reproduced on main: test fails with `expected undefined to be '1234567890.123456'`
- [x] Fix verified on fix branch: both tests pass

## Effect on User Experience

**Before:** When an agent calls `message(action="read", threadId="...")` on Slack, it always gets channel-level messages instead of thread replies. Users cannot read Slack thread conversations.

**After:** Thread replies are correctly fetched when `threadId` is provided. Channel-level reads (without `threadId`) continue to work as before (no regression).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Slack extension message reads for threads by passing the `threadId` tool parameter through the Slack plugin’s `handleAction` read branch (`extensions/slack/src/channel.ts`) into the core Slack action handler (`action: "readMessages"`). Core logic in `src/agents/tools/slack-actions.ts` already supports `threadId` and routes to thread replies when present; this change unblocks that behavior by ensuring the extension layer doesn’t drop the parameter.

Also adds a changelog entry for the user-facing behavior fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow parameter pass-through in the Slack extension layer, and it matches the existing core handler contract (`threadId` is already parsed and forwarded to `readSlackMessages`). No behavioral change occurs when `threadId` is absent, and the added changelog line is straightforward.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->