### PR TITLE
docs: expand AGENTS.md with architecture, config, and dev guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,93 @@
 - Repo: https://github.com/openclaw/openclaw
 - GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or $'...') for real newlines; never embed "\\n".
 
+## Architecture Overview
+
+OpenClaw is a **multi-channel AI personal assistant** — a gateway that connects messaging platforms (Telegram, Discord, Slack, WhatsApp, Signal, iMessage, etc.) to AI model providers (Claude/Anthropic, OpenAI, Gemini, local via Ollama). It runs as a long-lived gateway process with a WebSocket control plane.
+
+**Core data flow:**
+
+1. **Inbound:** channel webhook/poll → `ChannelMessagingAdapter` normalizes the message
+2. **Routing:** `src/routing/resolve-route.ts` maps inbound message → session key (by channel + account)
+3. **Agent:** PI agent (`src/agents/`) processes the message using configured model providers, tools, and memory
+4. **Memory:** session recorded in SQLite (`memory.db`), compaction triggered as needed
+5. **Outbound:** `ChannelOutboundAdapter` sends the final reply to the originating channel
+
+**Key abstractions:**
+
+- **Dock** (`src/channels/dock.ts`): lightweight channel metadata/behavior registry
+- **Channel plugin interface** (`src/channels/plugins/types.ts`): adapter types for inbound, outbound, auth, status, commands, tools
+- **Plugin SDK** (`src/plugin-sdk/index.ts`): 400+ exports for extension authors; HTTP route registration, tool registration, log transport
+- **Config system** (`src/config/`): YAML/JSON config with Zod validation, env substitution, per-session overrides
+
 ## Project Structure & Module Organization
+
+### Source Code Map (`src/`)
+
+```
+src/
+├── acp/               # ACP (Anthropic Code Platform) integration
+├── agents/            # PI agent execution, tool definitions, sandboxing
+├── auto-reply/        # Reply generation, chunking, templating, memory flush
+├── browser/           # Playwright automation for web browsing
+├── canvas-host/       # Canvas rendering host (A2UI bundle)
+├── channels/          # Core channel logic, dock, registry, allowlists
+│   └── plugins/       # Per-channel adapter implementations + types
+├── cli/               # CLI infrastructure, progress bars (src/cli/progress.ts)
+├── commands/          # CLI commands (gateway, agent, wizard, sandbox, etc.)
+├── config/            # Config loading, 15+ Zod schema files, validation
+├── daemon/            # launchd (macOS) / systemd (Linux) daemon management
+├── discord/           # Discord channel implementation
+├── gateway/           # WebSocket server, control plane, request routing
+│   ├── protocol/      # Core protocol definitions (schema-generated)
+│   └── server-methods/# Config, send, talk, skills, web, wizard handlers
+├── hooks/             # Hook system (bundled + custom hooks)
+├── imessage/          # iMessage channel implementation
+├── infra/             # Binaries, Bonjour, ports, env detection
+├── memory/            # SQLite vector memory (QMD), embeddings, compaction
+├── media/             # Media pipeline (images, audio, PDF processing)
+├── plugin-sdk/        # Public plugin API (400+ exports)
+├── plugins/           # Plugin runtime, HTTP routing, config schemas
+├── providers/         # Model provider implementations (Anthropic, OpenAI, Gemini, Ollama)
+├── routing/           # Session key resolution from inbound messages
+├── security/          # FS audit, skill scanning, Windows ACL
+├── sessions/          # Session overrides, model failover, send policy
+├── signal/            # Signal channel implementation
+├── slack/             # Slack channel implementation
+├── telegram/          # Telegram channel implementation
+├── terminal/          # Terminal UI helpers: table.ts, palette.ts
+├── tui/               # Terminal UI (interactive TUI mode)
+├── web/               # WhatsApp Web channel implementation
+├── wizard/            # Onboarding wizard
+├── entry.ts           # Main entry point (bundled → dist/index.js)
+├── globals.ts         # Global constants
+├── logger.ts          # Logging setup (tslog)
+└── utils.ts           # Shared utilities
+```
+
+### Monorepo Workspace
+
+pnpm workspace (`pnpm-workspace.yaml`) with four package groups:
+
+| Workspace     | Description                                       |
+|---------------|---------------------------------------------------|
+| `.` (root)    | Core CLI + gateway + channels                     |
+| `ui/`         | Control UI (Lit web components + Vite build)      |
+| `packages/*`  | Sibling bots/agents (clawdbot, moltbot)           |
+| `extensions/*`| 37 channel/integration plugins (workspace packages)|
+
+### Other Top-Level Directories
+
+- `apps/` — Native applications: `macos/` (SwiftUI), `ios/` (SwiftUI + xcodegen), `android/` (Kotlin + Gradle)
+- `skills/` — 54 AI skill packages (1Password, GitHub, Google Drive, Coding Agent, etc.)
+- `docs/` — Mintlify-hosted documentation site (docs.openclaw.ai)
+- `test/` — Integration/E2E tests, fixtures, mocks, setup files
+- `scripts/` — Build, test, release, and utility scripts
+- `assets/` — Static assets (icons, sounds)
+- `vendor/` — Vendored dependencies
+- `.agents/` — Agent configuration and skill definitions
+
+### Module Organization Rules
 
 - Source code: `src/` (CLI wiring in `src/cli`, commands in `src/commands`, web provider in `src/provider-web.ts`, infra in `src/infra`, media pipeline in `src/media`).
 - Tests: colocated `*.test.ts`.
@@ -17,6 +103,58 @@
   - Extensions (channel plugins): `extensions/*` (e.g. `extensions/msteams`, `extensions/matrix`, `extensions/zalo`, `extensions/zalouser`, `extensions/voice-call`)
 - When adding channels/extensions/apps/docs, update `.github/labeler.yml` and create matching GitHub labels (use existing channel/extension label colors).
 
+## Configuration System
+
+### Config Hierarchy (highest to lowest priority)
+
+```
+process env vars              (highest)
+  ↓
+./.env                        (local dev)
+  ↓
+~/.openclaw/.env              (daemon)
+  ↓
+openclaw.json keys            (channels/agents/sandbox)
+  ↓
+src/config/defaults.ts        (lowest)
+```
+
+### Storage Paths
+
+```
+~/.openclaw/
+  openclaw.json         # Main config file
+  workspace/            # Agent workspace (per-agent isolated)
+  skills/               # Installed skill packages (npm)
+  sessions.json         # Session metadata + encryption key (JSON5)
+  memory.db             # SQLite vector memory database
+  credentials/          # Web provider credentials
+  agents/<id>/sessions/ # Pi session transcripts (*.jsonl)
+```
+
+### Config Validation
+
+- 15+ Zod schema files in `src/config/zod-schema*.ts`
+- Supports channel-specific, agent-specific, sandbox, and cron configs
+- Per-session overrides and model failover chains
+
+## Database & Storage
+
+- **SQLite 3** via Node.js built-in `node:sqlite` module + `sqlite-vec` (0.1.7-alpha.2) for vector operations
+  - Location: `~/.openclaw/memory.db`
+  - Features: vector memory (embeddings), async embedding batches, atomic reindexing, deduplication, compaction/session pruning
+- **Session transcripts** use `parentId` chain/DAG in JSONL files; never append raw entries — always go through `SessionManager.appendMessage(...)` to maintain the leaf path
+- **JSON5** for `sessions.json` (but `JSON.parse` used where possible for 35x speed)
+
+## Gateway API
+
+- **Protocol:** WebSocket (native) + Express HTTP (fallback)
+- **Default port:** 18789 (bridge: 18790)
+- **Bind:** loopback (127.0.0.1) by default; LAN/WAN configurable
+- **Auth:** token-based or password auth
+- **Protocol models:** `src/gateway/protocol/` — generated Swift models in `apps/macos/Sources/OpenClawProtocol/`; validate with `pnpm protocol:check`
+- **RPC mode:** `openclaw agent --mode rpc --json` (JSON-RPC streaming)
+
 ## Docs Linking (Mintlify)
 
 - Docs are hosted on Mintlify (docs.openclaw.ai).
@@ -27,7 +165,7 @@
 - When Peter asks for links, reply with full `https://docs.openclaw.ai/...` URLs (not root-relative).
 - When you touch docs, end the reply with the `https://docs.openclaw.ai/...` URLs you referenced.
 - README (GitHub): keep absolute docs URLs (`https://docs.openclaw.ai/...`) so links work on GitHub.
-- Docs content must be generic: no personal device names/hostnames/paths; use placeholders like `user@gateway-host` and “gateway host”.
+- Docs content must be generic: no personal device names/hostnames/paths; use placeholders like `user@gateway-host` and "gateway host".
 
 ## Docs i18n (zh-CN)
 
@@ -35,7 +173,7 @@
 - Pipeline: update English docs → adjust glossary (`docs/.i18n/glossary.zh-CN.json`) → run `scripts/docs-i18n` → apply targeted fixes only if instructed.
 - Translation memory: `docs/.i18n/zh-CN.tm.jsonl` (generated).
 - See `docs/.i18n/README.md`.
-- The pipeline can be slow/inefficient; if it’s dragging, ping @jospalmbier on Discord instead of hacking around it.
+- The pipeline can be slow/inefficient; if it's dragging, ping @jospalmbier on Discord instead of hacking around it.
 
 ## exe.dev VM ops (general)
 
@@ -51,6 +189,7 @@
 ## Build, Test, and Development Commands
 
 - Runtime baseline: Node **22+** (keep Node + Bun paths working).
+- Package manager: **pnpm 10.23.0** (enforced via corepack; `packageManager` field in `package.json`).
 - Install deps: `pnpm install`
 - Pre-commit hooks: `prek install` (runs same checks as CI)
 - Also supported: `bun install` (keep `pnpm-lock.yaml` + Bun patching in sync when touching deps/patches).
@@ -58,21 +197,77 @@
 - Run CLI in dev: `pnpm openclaw ...` (bun) or `pnpm dev`.
 - Node remains supported for running built output (`dist/*`) and production installs.
 - Mac packaging (dev): `scripts/package-mac-app.sh` defaults to current arch. Release checklist: `docs/platforms/mac/release.md`.
-- Type-check/build: `pnpm build`
-- TypeScript checks: `pnpm tsgo`
-- Lint/format: `pnpm check`
-- Format check: `pnpm format` (oxfmt --check)
-- Format fix: `pnpm format:fix` (oxfmt --write)
-- Tests: `pnpm test` (vitest); coverage: `pnpm test:coverage`
+
+### Key Build Commands
+
+| Command              | Description                                           |
+|----------------------|-------------------------------------------------------|
+| `pnpm build`         | Full build (canvas bundle, tsdown, plugin SDK DTS, build info, CLI compat) |
+| `pnpm tsgo`          | TypeScript type checking (tsgo native preview)        |
+| `pnpm check`         | Full static checks (format + tsgo + lint)             |
+| `pnpm lint`          | oxlint with type-aware rules                          |
+| `pnpm lint:fix`      | Auto-fix lint + format                                |
+| `pnpm format`        | oxfmt --write (format source)                         |
+| `pnpm format:check`  | oxfmt --check (verify formatting)                     |
+| `pnpm ui:build`      | Build control UI (Vite + Lit)                         |
+
+### Test Commands
+
+| Command                       | Description                                  |
+|-------------------------------|----------------------------------------------|
+| `pnpm test`                   | All unit tests (parallel via test-parallel.mjs) |
+| `pnpm test:watch`             | Watch mode (vitest)                          |
+| `pnpm test:coverage`          | Coverage report (70% lines/functions, 55% branches) |
+| `pnpm test:e2e`               | End-to-end tests                             |
+| `OPENCLAW_LIVE_TEST=1 pnpm test:live` | Live API tests (requires real keys)  |
+| `pnpm test:docker:all`        | Full Docker integration suite                |
+
+### Build Tooling
+
+- **tsdown** — primary TypeScript bundler (entry: `src/entry.ts` → `dist/index.js`)
+- **tsc** — plugin SDK `.d.ts` generation (`tsconfig.plugin-sdk.dts.json`)
+- **tsx** — TypeScript execution for scripts
+- **Vite** — UI build (`ui/vite.config.ts`)
+- **tsgo** — Native TypeScript type checker (`@typescript/native-preview`)
 
 ## Coding Style & Naming Conventions
 
 - Language: TypeScript (ESM). Prefer strict typing; avoid `any`.
 - Formatting/linting via Oxlint and Oxfmt; run `pnpm check` before commits.
 - Add brief code comments for tricky or non-obvious logic.
-- Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
+- Keep files concise; extract helpers instead of "V2" copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
 - Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
 - Naming: use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, and config keys.
+
+## Linting & Formatting Details
+
+- **Linter:** oxlint 1.46.0 (Rust-based, type-aware). Config: `.oxlintrc.json`. Plugins: unicorn, typescript, oxc. All categories (correctness, perf, suspicious) → error.
+- **Formatter:** oxfmt 0.31.0. Config: `.oxfmtrc.jsonc`.
+- **Swift:** swiftlint (`.swiftlint.yml`) + swiftformat (`.swiftformat`). Run: `pnpm lint:swift`, `pnpm format:swift`.
+- **Markdown:** markdownlint-cli2 (`.markdownlint-cli2.jsonc`). Run: `pnpm lint:docs`.
+- **Pre-commit hooks** (`.pre-commit-config.yaml`): trailing-whitespace, detect-secrets, shellcheck, actionlint, zizmor, oxlint, oxfmt, swiftlint.
+
+## CI/CD Pipeline
+
+Main workflow: `.github/workflows/ci.yml` (GitHub Actions).
+
+**Jobs:**
+
+1. **docs-scope** — detect docs-only changes (skip heavy jobs)
+2. **changed-scope** — detect macOS/Android/Node changes for PR optimization
+3. **lint** (always runs) — oxlint, oxfmt, Swift, Markdown, secret detection
+4. **format-check** — code formatting consistency
+5. **node-test** — unit + E2E + live tests
+6. **build** — tsdown, UI, plugin SDK
+7. **docker-test** — multi-container integration tests
+8. **formal-conformance** — protocol schema validation
+9. **macOS** — build .app, code signing, DMG packaging
+10. **Android** — Gradle build, APK generation
+11. **iOS** — xcodegen, build archive
+
+**Other workflows:** `docker-release.yml` (multi-arch Docker images), `install-smoke.yml`, `formal-conformance.yml`, `auto-response.yml`, `stale.yml`, `labeler.yml`.
+
+**Concurrency:** groups by PR number; cancels previous runs. If scope detection fails, runs everything.
 
 ## Release Channels (Naming)
 
@@ -87,9 +282,18 @@
 - Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
 - Do not set test workers above 16; tried already.
 - Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
-- Full kit + what’s covered: `docs/testing.md`.
+- Full kit + what's covered: `docs/testing.md`.
 - Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
 - Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
+
+### Test Configuration
+
+- **Pool:** forks (process isolation)
+- **Timeout:** 120s default (180s on Windows hooks)
+- **Workers:** 4–16 local, 2–3 CI
+- **Setup:** `test/setup.ts`, `test/global-setup.ts`
+- **Fixtures:** `test/fixtures/`, `test/mocks/`
+- **Configs:** `vitest.config.ts` (main), `vitest.unit.config.ts`, `vitest.e2e.config.ts`, `vitest.live.config.ts`, `vitest.gateway.config.ts`, `vitest.extensions.config.ts`
 
 ## Commit & Pull Request Guidelines
 
@@ -117,6 +321,24 @@
 
 - Rebrand/migration issues or legacy config/service warnings: run `openclaw doctor` (see `docs/gateway/doctor.md`).
 
+## Key Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `@mariozechner/pi-*` | PI agent framework (core, AI, coding agent, TUI) |
+| `grammy` | Telegram bot framework |
+| `@slack/bolt` | Slack app framework |
+| `@buape/carbon` | Discord bot framework (do **not** update) |
+| `@whiskeysockets/baileys` | WhatsApp Web client |
+| `@larksuiteoapi/node-sdk` | Feishu/Lark integration |
+| `@line/bot-sdk` | LINE messaging |
+| `sharp` | Image processing |
+| `playwright-core` | Browser automation |
+| `sqlite-vec` | SQLite vector search |
+| `zod` | Schema validation (config) |
+| `commander` | CLI framework |
+| `express` + `ws` | Gateway HTTP + WebSocket server |
+
 ## Agent-Specific Notes
 
 - Vocabulary: "makeup" = "mac app".
@@ -128,16 +350,16 @@
 - Never update the Carbon dependency.
 - Any dependency with `pnpm.patchedDependencies` must use an exact version (no `^`/`~`).
 - Patching dependencies (pnpm patches, overrides, or vendored changes) requires explicit approval; do not do this by default.
-- CLI progress: use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner); don’t hand-roll spinners/bars.
+- CLI progress: use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner); don't hand-roll spinners/bars.
 - Status output: keep tables + ANSI-safe wrapping (`src/terminal/table.ts`); `status --all` = read-only/pasteable, `status --deep` = probes.
 - Gateway currently runs only as the menubar app; there is no separate LaunchAgent/helper label installed. Restart via the OpenClaw Mac app or `scripts/restart-mac.sh`; to verify/kill use `launchctl print gui/$UID | grep openclaw` rather than assuming a fixed label. **When debugging on macOS, start/stop the gateway via the app, not ad-hoc tmux sessions; kill any temporary tunnels before handoff.**
 - macOS logs: use `./scripts/clawlog.sh` to query unified logs for the OpenClaw subsystem; it supports follow/tail/category filters and expects passwordless sudo for `/usr/bin/log`.
 - If shared guardrails are available locally, review them; otherwise follow this repo's guidance.
-- SwiftUI state management (iOS/macOS): prefer the `Observation` framework (`@Observable`, `@Bindable`) over `ObservableObject`/`@StateObject`; don’t introduce new `ObservableObject` unless required for compatibility, and migrate existing usages when touching related code.
+- SwiftUI state management (iOS/macOS): prefer the `Observation` framework (`@Observable`, `@Bindable`) over `ObservableObject`/`@StateObject`; don't introduce new `ObservableObject` unless required for compatibility, and migrate existing usages when touching related code.
 - Connection providers: when adding a new connection, update every UI surface and docs (macOS app, web UI, mobile if applicable, onboarding/overview docs) and add matching status + configuration forms so provider lists and settings stay in sync.
 - Version locations: `package.json` (CLI), `apps/android/app/build.gradle.kts` (versionName/versionCode), `apps/ios/Sources/Info.plist` + `apps/ios/Tests/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `apps/macos/Sources/OpenClaw/Resources/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `docs/install/updating.md` (pinned npm version), `docs/platforms/mac/release.md` (APP_VERSION/APP_BUILD examples), Peekaboo Xcode projects/Info.plists (MARKETING_VERSION/CURRENT_PROJECT_VERSION).
 - "Bump version everywhere" means all version locations above **except** `appcast.xml` (only touch appcast when cutting a new macOS Sparkle release).
-- **Restart apps:** “restart iOS/Android apps” means rebuild (recompile/install) and relaunch, not just kill/launch.
+- **Restart apps:** "restart iOS/Android apps" means rebuild (recompile/install) and relaunch, not just kill/launch.
 - **Device checks:** before testing, verify connected real devices (iOS/Android) before reaching for simulators/emulators.
 - iOS Team ID lookup: `security find-identity -p codesigning -v` → use Apple Development (…) TEAMID. Fallback: `defaults read com.apple.dt.Xcode IDEProvisioningTeamIdentifiers`.
 - A2UI bundle hash: `src/canvas-host/a2ui/.bundle.hash` is auto-generated; ignore unexpected changes, and only regenerate via `pnpm canvas:a2ui:bundle` (or `scripts/bundle-a2ui.sh`) when needed. Commit the hash as a separate commit.
@@ -154,19 +376,19 @@
   - If commit/push already requested, auto-stage and include formatting-only follow-ups in the same commit (or a tiny follow-up commit if needed), no extra confirmation.
   - Only ask when changes are semantic (logic/data/behavior).
 - Lobster seam: use the shared CLI palette in `src/terminal/palette.ts` (no hardcoded colors); apply palette to onboarding/config prompts and other TTY UI output as needed.
-- **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
+- **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief "other files present" note only if relevant.
 - Bug investigations: read source code of relevant npm dependencies and all related local code before concluding; aim for high-confidence root cause.
 - Code style: add brief comments for tricky logic; keep files under ~500 LOC when feasible (split/refactor as needed).
 - Tool schema guardrails (google-antigravity): avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`. Use `stringEnum`/`optionalStringEnum` (Type.Unsafe enum) for string lists, and `Type.Optional(...)` instead of `... | null`. Keep top-level tool schema as `type: "object"` with `properties`.
 - Tool schema guardrails: avoid raw `format` property names in tool schemas; some validators treat `format` as a reserved keyword and reject the schema.
-- When asked to open a “session” file, open the Pi session logs under `~/.openclaw/agents/<agentId>/sessions/*.jsonl` (use the `agent=<id>` value in the Runtime line of the system prompt; newest unless a specific ID is given), not the default `sessions.json`. If logs are needed from another machine, SSH via Tailscale and read the same path there.
+- When asked to open a "session" file, open the Pi session logs under `~/.openclaw/agents/<agentId>/sessions/*.jsonl` (use the `agent=<id>` value in the Runtime line of the system prompt; newest unless a specific ID is given), not the default `sessions.json`. If logs are needed from another machine, SSH via Tailscale and read the same path there.
 - Do not rebuild the macOS app over SSH; rebuilds must be run directly on the Mac.
 - Never send streaming/partial replies to external messaging surfaces (WhatsApp, Telegram); only final replies should be delivered there. Streaming/tool events may still go to internal UIs/control channel.
 - Voice wake forwarding tips:
-  - Command template should stay `openclaw-mac agent --message "${text}" --thinking low`; `VoiceWakeForwarder` already shell-escapes `${text}`. Don’t add extra quotes.
-  - launchd PATH is minimal; ensure the app’s launch agent PATH includes standard system paths plus your pnpm bin (typically `$HOME/Library/pnpm`) so `pnpm`/`openclaw` binaries resolve when invoked via `openclaw-mac`.
-- For manual `openclaw message send` messages that include `!`, use the heredoc pattern noted below to avoid the Bash tool’s escaping.
-- Release guardrails: do not change version numbers without operator’s explicit consent; always ask permission before running any npm publish/release step.
+  - Command template should stay `openclaw-mac agent --message "${text}" --thinking low`; `VoiceWakeForwarder` already shell-escapes `${text}`. Don't add extra quotes.
+  - launchd PATH is minimal; ensure the app's launch agent PATH includes standard system paths plus your pnpm bin (typically `$HOME/Library/pnpm`) so `pnpm`/`openclaw` binaries resolve when invoked via `openclaw-mac`.
+- For manual `openclaw message send` messages that include `!`, use the heredoc pattern noted below to avoid the Bash tool's escaping.
+- Release guardrails: do not change version numbers without operator's explicit consent; always ask permission before running any npm publish/release step.
 
 ## NPM + 1Password (publish/verify)
 


### PR DESCRIPTION
## Summary

Significantly expanded `AGENTS.md` with comprehensive documentation covering OpenClaw's architecture, project structure, configuration system, database/storage, gateway API, build tooling, CI/CD pipeline, testing setup, and key dependencies. This serves as a central reference guide for contributors and maintainers.

## Key Changes

- **Architecture Overview**: Added high-level data flow diagram (inbound → routing → agent → memory → outbound) and key abstractions (Dock, Channel plugin interface, Plugin SDK, Config system)

- **Project Structure**: 
  - Detailed source code map (`src/`) with all major modules and their purposes
  - Monorepo workspace layout (root, `ui/`, `packages/`, `extensions/`)
  - Top-level directories overview (`apps/`, `skills/`, `docs/`, `test/`, `scripts/`, `assets/`, `vendor/`, `.agents/`)
  - Module organization rules

- **Configuration System**:
  - Config hierarchy (env vars → .env → ~/.openclaw/.env → openclaw.json → defaults)
  - Storage paths under `~/.openclaw/`
  - Config validation approach (15+ Zod schemas)

- **Database & Storage**:
  - SQLite 3 with sqlite-vec for vector operations
  - Session transcript structure (parentId chain/DAG in JSONL)
  - JSON5 format for sessions.json

- **Gateway API**:
  - Protocol details (WebSocket + Express HTTP fallback)
  - Default port (18789), binding, auth, and RPC mode

- **Build & Test Commands**:
  - Organized build commands in table format (build, tsgo, check, lint, format, ui:build)
  - Test commands table (unit, watch, coverage, E2E, live, Docker)
  - Build tooling overview (tsdown, tsc, tsx, Vite, tsgo)

- **Linting & Formatting Details**:
  - oxlint 1.46.0 and oxfmt 0.31.0 configuration
  - Swift, Markdown, and pre-commit hook setup

- **CI/CD Pipeline**:
  - 11 main GitHub Actions jobs with descriptions
  - Other workflows (docker-release, install-smoke, etc.)
  - Concurrency strategy

- **Test Configuration**:
  - Pool, timeout, worker settings
  - Setup files and fixtures
  - Multiple vitest configs for different test suites

- **Key Dependencies**:
  - Added table of critical packages (PI agent, Telegram, Slack, Discord, WhatsApp, image processing, browser automation, database, validation, CLI, server)

## Notable Details

- Clarified pnpm 10.23.0 as enforced package manager via corepack
- Emphasized tsdown as primary TypeScript bundler
- Documented vector memory features (embeddings, batching, reindexing, deduplication, compaction)
- Included protocol validation and Swift model generation workflow
- Preserved all existing guidance on coding style, naming, agent-specific notes, and release procedures

https://claude.ai/code/session_01MhS5NPD3DwLXLZnJLdzCGi

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands `AGENTS.md` into a more comprehensive contributor/maintainer guide covering architecture, repo structure, configuration, storage, gateway protocol, build/test commands, CI, and dependencies.

Review focus was factual correctness of new concrete claims (counts, commands, env vars, and operational guidance). A few of the newly added hard-coded numbers and setup instructions don’t match the current repository state (skills/extensions counts, pre-commit install command, live-test env var guidance), and one operational statement about macOS LaunchAgents contradicts the codebase (the app manages a LaunchAgent plist). These should be corrected to avoid misleading contributors.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but it contains several factual inaccuracies that will mislead contributors.
- Changes are documentation-only, but multiple new statements are objectively incorrect relative to the repo (counts, commands, env vars, and macOS LaunchAgent behavior). Fixing these before merge avoids sending contributors down broken paths.
- AGENTS.md (setup commands, hard-coded counts, and macOS gateway/LaunchAgent guidance)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->