### PR TITLE
fix(models): add well-known provider defaults for OpenRouter explicit model routing

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -6,6 +6,7 @@ vi.mock("../pi-model-discovery.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
+import { discoverModels } from "../pi-model-discovery.js";
 import { buildInlineProviderModels, resolveModel } from "./model.js";
 import {
   makeModel,
@@ -433,6 +434,7 @@ describe("resolveModel", () => {
           openrouter: {
             baseUrl: "https://custom-openrouter.example.com/v1",
             api: "anthropic-messages",
+            models: [],
           },
         },
       },

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -23,6 +23,196 @@ type InlineProviderConfig = {
 
 export { buildModelAliasLines };
 
+const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
+const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+
+const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
+
+// Well-known providers with sensible defaults for baseUrl and api type.
+// Allows explicit model IDs like "openrouter/qwen/qwen3-14b" to resolve
+// even without explicit models.providers.openrouter configuration.
+const WELL_KNOWN_PROVIDER_DEFAULTS: Record<string, { baseUrl: string; api: string }> = {
+  openrouter: { baseUrl: "https://openrouter.ai/api/v1", api: "openai-responses" },
+  opencode: { baseUrl: "https://opencode.dev/v1", api: "openai-responses" },
+};
+
+// pi-ai's built-in Anthropic catalog can lag behind OpenClaw's defaults/docs.
+// Add forward-compat fallbacks for known-new IDs by cloning an older template model.
+const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
+const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
+const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"] as const;
+
+function resolveOpenAICodexGpt53FallbackModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  const trimmedModelId = modelId.trim();
+  if (normalizedProvider !== "openai-codex") {
+    return undefined;
+  }
+
+  const lower = trimmedModelId.toLowerCase();
+  const isGpt53 = lower === OPENAI_CODEX_GPT_53_MODEL_ID;
+  const isSpark = lower === OPENAI_CODEX_GPT_53_SPARK_MODEL_ID;
+  if (!isGpt53 && !isSpark) {
+    return undefined;
+  }
+
+  for (const templateId of OPENAI_CODEX_TEMPLATE_MODEL_IDS) {
+    const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
+    if (!template) {
+      continue;
+    }
+    return normalizeModelCompat({
+      ...template,
+      id: trimmedModelId,
+      name: trimmedModelId,
+      // Spark is a low-latency variant; keep api/baseUrl from template.
+      ...(isSpark ? { reasoning: true } : {}),
+    } as Model<Api>);
+  }
+
+  return normalizeModelCompat({
+    id: trimmedModelId,
+    name: trimmedModelId,
+    api: "openai-codex-responses",
+    provider: normalizedProvider,
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_TOKENS,
+    maxTokens: DEFAULT_CONTEXT_TOKENS,
+  } as Model<Api>);
+}
+
+function resolveAnthropicOpus46ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (normalizedProvider !== "anthropic") {
+    return undefined;
+  }
+
+  const trimmedModelId = modelId.trim();
+  const lower = trimmedModelId.toLowerCase();
+  const isOpus46 =
+    lower === ANTHROPIC_OPUS_46_MODEL_ID ||
+    lower === ANTHROPIC_OPUS_46_DOT_MODEL_ID ||
+    lower.startsWith(`${ANTHROPIC_OPUS_46_MODEL_ID}-`) ||
+    lower.startsWith(`${ANTHROPIC_OPUS_46_DOT_MODEL_ID}-`);
+  if (!isOpus46) {
+    return undefined;
+  }
+
+  const templateIds: string[] = [];
+  if (lower.startsWith(ANTHROPIC_OPUS_46_MODEL_ID)) {
+    templateIds.push(lower.replace(ANTHROPIC_OPUS_46_MODEL_ID, "claude-opus-4-5"));
+  }
+  if (lower.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID)) {
+    templateIds.push(lower.replace(ANTHROPIC_OPUS_46_DOT_MODEL_ID, "claude-opus-4.5"));
+  }
+  templateIds.push(...ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS);
+
+  for (const templateId of [...new Set(templateIds)].filter(Boolean)) {
+    const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
+    if (!template) {
+      continue;
+    }
+    return normalizeModelCompat({
+      ...template,
+      id: trimmedModelId,
+      name: trimmedModelId,
+    } as Model<Api>);
+  }
+
+  return undefined;
+}
+
+// Z.ai's GLM-5 may not be present in pi-ai's built-in model catalog yet.
+// When a user configures zai/glm-5 without a models.json entry, clone glm-4.7 as a forward-compat fallback.
+const ZAI_GLM5_MODEL_ID = "glm-5";
+const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
+
+function resolveZaiGlm5ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  if (normalizeProviderId(provider) !== "zai") {
+    return undefined;
+  }
+  const trimmed = modelId.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower !== ZAI_GLM5_MODEL_ID && !lower.startsWith(`${ZAI_GLM5_MODEL_ID}-`)) {
+    return undefined;
+  }
+
+  for (const templateId of ZAI_GLM5_TEMPLATE_MODEL_IDS) {
+    const template = modelRegistry.find("zai", templateId) as Model<Api> | null;
+    if (!template) {
+      continue;
+    }
+    return normalizeModelCompat({
+      ...template,
+      id: trimmed,
+      name: trimmed,
+      reasoning: true,
+    } as Model<Api>);
+  }
+
+  return normalizeModelCompat({
+    id: trimmed,
+    name: trimmed,
+    api: "openai-completions",
+    provider: "zai",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_TOKENS,
+    maxTokens: DEFAULT_CONTEXT_TOKENS,
+  } as Model<Api>);
+}
+
+// google-antigravity's model catalog in pi-ai can lag behind the actual platform.
+// When a google-antigravity model ID contains "opus-4-6" (or "opus-4.6") but isn't
+// in the registry yet, clone the opus-4-5 template so the correct api
+// ("google-gemini-cli") and baseUrl are preserved.
+const ANTIGRAVITY_OPUS_46_STEMS = ["claude-opus-4-6", "claude-opus-4.6"] as const;
+const ANTIGRAVITY_OPUS_45_TEMPLATES = ["claude-opus-4-5-thinking", "claude-opus-4-5"] as const;
+
+function resolveAntigravityOpus46ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  if (normalizeProviderId(provider) !== "google-antigravity") {
+    return undefined;
+  }
+  const lower = modelId.trim().toLowerCase();
+  const isOpus46 = ANTIGRAVITY_OPUS_46_STEMS.some(
+    (stem) => lower === stem || lower.startsWith(`${stem}-`),
+  );
+  if (!isOpus46) {
+    return undefined;
+  }
+  for (const templateId of ANTIGRAVITY_OPUS_45_TEMPLATES) {
+    const template = modelRegistry.find("google-antigravity", templateId) as Model<Api> | null;
+    if (template) {
+      return normalizeModelCompat({
+        ...template,
+        id: modelId.trim(),
+        name: modelId.trim(),
+      } as Model<Api>);
+    }
+  }
+  return undefined;
+}
+
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
 ): InlineModelEntry[] {
@@ -77,13 +267,14 @@ export function resolveModel(
       return { model: forwardCompat, authStorage, modelRegistry };
     }
     const providerCfg = providers[provider];
-    if (providerCfg || modelId.startsWith("mock-")) {
+    const wellKnownDefaults = WELL_KNOWN_PROVIDER_DEFAULTS[normalizedProvider];
+    if (providerCfg || wellKnownDefaults || modelId.startsWith("mock-")) {
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
         name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
+        api: providerCfg?.api ?? wellKnownDefaults?.api ?? "openai-responses",
         provider,
-        baseUrl: providerCfg?.baseUrl,
+        baseUrl: providerCfg?.baseUrl ?? wellKnownDefaults?.baseUrl,
         reasoning: false,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -266,7 +266,12 @@ export function resolveModel(
     if (forwardCompat) {
       return { model: forwardCompat, authStorage, modelRegistry };
     }
-    const providerCfg = providers[provider];
+    // Lookup provider config using normalized comparison to handle casing differences
+    // (e.g., config has "OpenRouter" but model string has "openrouter")
+    const providerCfgKey = Object.keys(providers).find(
+      (key) => normalizeProviderId(key) === normalizedProvider,
+    );
+    const providerCfg = providerCfgKey ? providers[providerCfgKey] : undefined;
     const wellKnownDefaults = WELL_KNOWN_PROVIDER_DEFAULTS[normalizedProvider];
     if (providerCfg || wellKnownDefaults || modelId.startsWith("mock-")) {
       const fallbackModel: Model<Api> = normalizeModelCompat({


### PR DESCRIPTION
Fixes #14641

## What
Add fallback defaults for well-known providers (OpenRouter, OpenCode) so explicit model IDs resolve correctly.

## Why
When users configure `openrouter/qwen/qwen3-14b`, model resolution fails because:
- The model isn't in pi-ai's built-in registry (unlike `openrouter/auto`)
- Without explicit `models.providers.openrouter` config, no fallback model is created
- Silent failure results in falling back to expensive default models

## How
Added `WELL_KNOWN_PROVIDER_DEFAULTS` map with baseUrl and api type for OpenRouter/OpenCode. The fallback model creation now checks this map when no explicit provider config exists.

## Testing
- [x] Added unit test for OpenRouter explicit model resolution
- [x] `pnpm check` passes
- [x] `pnpm vitest run src/agents/pi-embedded-runner/model.test.ts` passes (14 tests)

## AI-Assisted
This PR was built with AI assistance (Claude via OpenClaw). The code has been reviewed, tested, and I understand what it does.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `WELL_KNOWN_PROVIDER_DEFAULTS` to `resolveModel()` so explicit model IDs (e.g. `openrouter/qwen/qwen3-14b`) can resolve even when the provider isn’t present in pi-ai’s registry and the user hasn’t configured `models.providers.<provider>`. It also adds unit coverage for OpenRouter/OpenCode fallback resolution and for ensuring explicit provider config overrides these defaults.

The change fits into the existing model-resolution flow in `src/agents/pi-embedded-runner/model.ts` by extending the existing “generic fallback model” branch (used when a model isn’t found in the discovered registry and/or inline provider models) to consider well-known providers before emitting `Unknown model`.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a real config lookup mismatch that can cause provider settings to be ignored in some cases.
- Core logic change is small and covered by new unit tests, but `resolveModel()` still indexes `cfg.models.providers` with an unnormalized provider key while other logic uses `normalizeProviderId`, which can lead to incorrect fallback `api/baseUrl` when users configure providers using different casing or aliases.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->