### PR TITLE
fix(browser): add targetUrl description and improve error messages (#14700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/OpenResponses: harden URL-based `input_file`/`input_image` handling with explicit SSRF deny policy, hostname allowlists (`files.urlAllowlist` / `images.urlAllowlist`), per-request URL input caps (`maxUrlParts`), blocked-fetch audit logging, and regression coverage/docs updates.
+- Browser: add `targetUrl` description to schema and improve error messages for `open`/`navigate` actions to prevent model tool-call loops. (#14700)
 - Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
 - Security: remove bundled soul-evil hook. (#14757) Thanks @Imccccc.
 - Security/Audit: add hook session-routing hardening checks (`hooks.defaultSessionKey`, `hooks.allowRequestSessionKey`, and prefix allowlists), and warn when HTTP API endpoints allow explicit session-key routing.

--- a/src/agents/tools/browser-tool.schema.ts
+++ b/src/agents/tools/browser-tool.schema.ts
@@ -85,7 +85,11 @@ export const BrowserToolSchema = Type.Object({
   target: optionalStringEnum(BROWSER_TARGETS),
   node: Type.Optional(Type.String()),
   profile: Type.Optional(Type.String()),
-  targetUrl: Type.Optional(Type.String()),
+  targetUrl: Type.Optional(
+    Type.String({
+      description: "URL to open or navigate to. Required for open and navigate actions.",
+    }),
+  ),
   targetId: Type.Optional(Type.String()),
   limit: Type.Optional(Type.Number()),
   maxChars: Type.Optional(Type.Number()),

--- a/src/agents/tools/browser-tool.targeturl-schema.test.ts
+++ b/src/agents/tools/browser-tool.targeturl-schema.test.ts
@@ -57,7 +57,7 @@ describe("BrowserToolSchema targetUrl consistency (#14700)", () => {
       .map((s) => s.description as string | undefined)
       .filter(Boolean);
     expect(descriptions.length).toBeGreaterThan(0);
-    expect(descriptions[0]).toMatch(/required.*open|open.*required/i);
+    expect(descriptions[0]).toMatch(/required.*open.*navigate|open.*navigate.*required/i);
   });
 
   it("execute(action:'open') error mentions the action name", async () => {

--- a/src/agents/tools/browser-tool.targeturl-schema.test.ts
+++ b/src/agents/tools/browser-tool.targeturl-schema.test.ts
@@ -1,6 +1,49 @@
-import { describe, expect, it } from "vitest";
+/**
+ * Regression test for #14700: Browser tool targetUrl schema/runtime mismatch
+ *
+ * Uses the same mock pattern as browser-tool.test.ts to isolate external deps,
+ * but calls the REAL createBrowserTool().execute() to walk the actual code path.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// Same mocks as browser-tool.test.ts — isolate external deps only
+vi.mock("../../browser/client.js", () => ({
+  browserCloseTab: vi.fn(async () => ({})),
+  browserFocusTab: vi.fn(async () => ({})),
+  browserOpenTab: vi.fn(async () => ({})),
+  browserProfiles: vi.fn(async () => []),
+  browserSnapshot: vi.fn(async () => ({ ok: true })),
+  browserStart: vi.fn(async () => ({})),
+  browserStatus: vi.fn(async () => ({
+    ok: true,
+    running: true,
+    pid: 1,
+    cdpPort: 18792,
+    cdpUrl: "http://127.0.0.1:18792",
+  })),
+  browserStop: vi.fn(async () => ({})),
+  browserTabs: vi.fn(async () => []),
+}));
+vi.mock("../../browser/config.js", () => ({
+  resolveBrowserConfig: vi.fn(() => ({ enabled: true, controlPort: 18791 })),
+}));
+vi.mock("./nodes-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("./nodes-utils.js")>("./nodes-utils.js");
+  return { ...actual, listNodes: vi.fn(async () => []) };
+});
+vi.mock("./gateway.js", () => ({
+  callGatewayTool: vi.fn(async () => ({ ok: true, payload: { result: { ok: true } } })),
+}));
+vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({ browser: {} })),
+}));
+vi.mock("./common.js", async () => {
+  const actual = await vi.importActual<typeof import("./common.js")>("./common.js");
+  return { ...actual, imageResultFromFile: vi.fn() };
+});
+
+import { createBrowserTool } from "./browser-tool.js";
 import { BrowserToolSchema } from "./browser-tool.schema.js";
-import { readStringParam } from "./common.js";
 
 describe("BrowserToolSchema targetUrl consistency (#14700)", () => {
   it("schema targetUrl has description guiding the model", () => {
@@ -9,7 +52,6 @@ describe("BrowserToolSchema targetUrl consistency (#14700)", () => {
       Record<string, unknown>
     >;
     const targetUrlProp = props.targetUrl;
-    // TypeBox Optional wraps in anyOf; check inner schema for description
     const innerSchemas = (targetUrlProp.anyOf as Record<string, unknown>[]) ?? [targetUrlProp];
     const descriptions = innerSchemas
       .map((s) => s.description as string | undefined)
@@ -18,21 +60,15 @@ describe("BrowserToolSchema targetUrl consistency (#14700)", () => {
     expect(descriptions[0]).toMatch(/required.*open|open.*required/i);
   });
 
-  it("runtime error for open action mentions the action name", () => {
-    expect(() =>
-      readStringParam({}, "targetUrl", {
-        required: true,
-        label: "targetUrl is required for the open action — provide the URL to open",
-      }),
-    ).toThrow(/open action/);
+  it("execute(action:'open') error mentions the action name", async () => {
+    const tool = createBrowserTool();
+    await expect(tool.execute?.("call-1", { action: "open" })).rejects.toThrow(/open action/);
   });
 
-  it("runtime error for navigate action mentions the action name", () => {
-    expect(() =>
-      readStringParam({}, "targetUrl", {
-        required: true,
-        label: "targetUrl is required for the navigate action — provide the URL to navigate to",
-      }),
-    ).toThrow(/navigate action/);
+  it("execute(action:'navigate') error mentions the action name", async () => {
+    const tool = createBrowserTool();
+    await expect(tool.execute?.("call-2", { action: "navigate" })).rejects.toThrow(
+      /navigate action/,
+    );
   });
 });

--- a/src/agents/tools/browser-tool.targeturl-schema.test.ts
+++ b/src/agents/tools/browser-tool.targeturl-schema.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { BrowserToolSchema } from "./browser-tool.schema.js";
+import { readStringParam } from "./common.js";
+
+describe("BrowserToolSchema targetUrl consistency (#14700)", () => {
+  it("schema targetUrl has description guiding the model", () => {
+    const props = (BrowserToolSchema as Record<string, unknown>).properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const targetUrlProp = props.targetUrl;
+    // TypeBox Optional wraps in anyOf; check inner schema for description
+    const innerSchemas = (targetUrlProp.anyOf as Record<string, unknown>[]) ?? [targetUrlProp];
+    const descriptions = innerSchemas
+      .map((s) => s.description as string | undefined)
+      .filter(Boolean);
+    expect(descriptions.length).toBeGreaterThan(0);
+    expect(descriptions[0]).toMatch(/required.*open|open.*required/i);
+  });
+
+  it("runtime error for open action mentions the action name", () => {
+    expect(() =>
+      readStringParam({}, "targetUrl", {
+        required: true,
+        label: "targetUrl is required for the open action — provide the URL to open",
+      }),
+    ).toThrow(/open action/);
+  });
+
+  it("runtime error for navigate action mentions the action name", () => {
+    expect(() =>
+      readStringParam({}, "targetUrl", {
+        required: true,
+        label: "targetUrl is required for the navigate action — provide the URL to navigate to",
+      }),
+    ).toThrow(/navigate action/);
+  });
+});

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -408,6 +408,7 @@ export function createBrowserTool(opts?: {
         case "open": {
           const targetUrl = readStringParam(params, "targetUrl", {
             required: true,
+            label: "targetUrl is required for the open action — provide the URL to open",
           });
           if (proxyRequest) {
             const result = await proxyRequest({
@@ -638,6 +639,7 @@ export function createBrowserTool(opts?: {
         case "navigate": {
           const targetUrl = readStringParam(params, "targetUrl", {
             required: true,
+            label: "targetUrl is required for the navigate action — provide the URL to navigate to",
           });
           const targetId = readStringParam(params, "targetId");
           if (proxyRequest) {


### PR DESCRIPTION
## Summary

- **Bug**: Browser tool schema marks `targetUrl` as `Optional`, but runtime requires it for `open`/`navigate` actions. Models (especially Gemini 3 Flash) omit it, get a generic `"targetUrl required"` error, and enter infinite tool-call loops lasting up to 10 minutes.
- **Root cause**: `browser-tool.schema.ts` defines `targetUrl: Type.Optional(Type.String())` with no description. `browser-tool.ts` reads it with `{ required: true }` for `open`/`navigate`. The model sees optional in schema, omits it, gets unhelpful error, retries identically.
- **Fix**: Add a description to the schema field explaining `targetUrl` is required for `open`/`navigate`, and improve runtime error messages to include the action name.

Fixes #14700

## Problem

The browser tool uses a flat schema (all actions share one `Type.Object`). `targetUrl` is `Type.Optional` because most actions don't need it, but `open` and `navigate` require it at runtime via `readStringParam(params, "targetUrl", { required: true })`.

When a model calls `browser(action="open")` without `targetUrl`, the error is just `"targetUrl required"` — no mention of which action or what to provide. The model sees the schema says optional, doesn't understand the error, and retries with the same params indefinitely.

**Before fix (reproduced on main via integration test):**
```
pnpm vitest run src/agents/tools/_repro-14700.test.ts

✓ schema has no description on targetUrl to guide the model
  → descriptions = [] (length 0)
✓ runtime throws generic 'targetUrl required' without mentioning the action
  → Error: "targetUrl required" (no mention of open/navigate)

Test Files  1 passed (1)
Tests       2 passed (2)
```

## Changes

- `src/agents/tools/browser-tool.schema.ts` — Add `description: "URL to open or navigate to. Required for open and navigate actions."` to the `targetUrl` field
- `src/agents/tools/browser-tool.ts` — Use descriptive `label` in `readStringParam` for `open` and `navigate` actions so error messages include the action name (e.g. `"targetUrl is required for the open action — provide the URL to open"`)
- `src/agents/tools/browser-tool.targeturl-schema.test.ts` — New regression tests: verify schema description exists and runtime errors mention action names
- `CHANGELOG.md` — Add fix entry

**After fix (verified on fix branch):**
```
pnpm vitest run src/agents/tools/browser-tool.targeturl-schema.test.ts

✓ schema targetUrl has description guiding the model
✓ runtime error for open action mentions the action name
✓ runtime error for navigate action mentions the action name

Test Files  1 passed (1)
Tests       3 passed (3)
```

## Design decisions

- **Keep `targetUrl` as Optional in schema**: The flat schema is shared across all actions. Making it required would force `status`, `tabs`, `snapshot` etc. to also provide a URL. Instead, the description tells the model when it's needed.
- **Description + better error message (dual approach)**: Description prevents the model from omitting `targetUrl` in the first place. Improved error message helps recovery if it still does.

## Test plan

- [x] New test: schema `targetUrl` has description mentioning `open`/`navigate`
- [x] New test: runtime error for `open` action includes action name
- [x] New test: runtime error for `navigate` action includes action name
- [x] All 12 existing browser-tool tests pass (`pnpm vitest run src/agents/tools/browser-tool.test.ts`)
- [x] Lint passes (`pnpm lint`)
- [x] Bug reproduced on main: no description, generic error message (integration test)
- [x] Fix verified on fix branch: description present, descriptive errors (integration test)

## Effect on User Experience

**Before:** Models (especially Gemini 3 Flash) enter infinite tool-call loops when using browser `open`/`navigate` without `targetUrl`. Agent becomes unresponsive for up to 10 minutes, wastes API quota.

**After:** Schema description guides models to include `targetUrl` for `open`/`navigate`. If still omitted, the error message clearly states which action requires it and what to provide, enabling model self-correction.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves the browser tool’s guidance and error surfaces around `targetUrl` by (1) adding a schema description indicating it’s required for the `open` and `navigate` actions, and (2) providing more descriptive `readStringParam` labels so missing-parameter errors include the relevant action. It also adds a small Vitest regression suite to prevent the schema/behavior mismatch from reappearing and records the fix in the changelog.

Within the codebase, `BrowserToolSchema` (TypeBox) remains intentionally flattened to satisfy tool-schema constraints, while `browser-tool.ts` continues to enforce per-action runtime requirements; these changes make that runtime contract clearer to both models and developers.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; it primarily adds schema metadata, clearer errors, and a regression test.
- Reviewed the changed schema, runtime usage, and the shared `readStringParam` implementation. The runtime change is localized and low-risk. The only actionable issue found is that one new regression assertion doesn’t actually protect the stated requirement for both `open` and `navigate`, reducing the test’s value.
- src/agents/tools/browser-tool.targeturl-schema.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->