### PR TITLE
fix(context): key MODEL_CACHE by provider/modelId to prevent collision (#14708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/OpenResponses: harden URL-based `input_file`/`input_image` handling with explicit SSRF deny policy, hostname allowlists (`files.urlAllowlist` / `images.urlAllowlist`), per-request URL input caps (`maxUrlParts`), blocked-fetch audit logging, and regression coverage/docs updates.
+- Context: key `MODEL_CACHE` by `provider/modelId` so same-named models across providers no longer collide. (#14708)
 - Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
 - Security: remove bundled soul-evil hook. (#14757) Thanks @Imccccc.
 - Security/Audit: add hook session-routing hardening checks (`hooks.defaultSessionKey`, `hooks.allowRequestSessionKey`, and prefix allowlists), and warn when HTTP API endpoints allow explicit session-key routing.

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -35,8 +35,8 @@ vi.mock("./pi-model-discovery.js", () => ({
 
 describe("MODEL_CACHE provider-qualified keys (#14708)", () => {
   it("returns correct context window per provider for same model ID", async () => {
-    const { lookupContextTokens } = await import("./context.js");
-    await new Promise((r) => setTimeout(r, 50));
+    const { lookupContextTokens, loadPromise } = await import("./context.js");
+    await loadPromise;
 
     // Provider-qualified lookups return the correct value for each provider
     expect(lookupContextTokens("claude-opus-4-6", "anthropic")).toBe(200_000);
@@ -47,15 +47,16 @@ describe("MODEL_CACHE provider-qualified keys (#14708)", () => {
   });
 
   it("bare model ID fallback uses first-writer-wins", async () => {
-    const { lookupContextTokens } = await import("./context.js");
-    await new Promise((r) => setTimeout(r, 50));
+    const { lookupContextTokens, loadPromise } = await import("./context.js");
+    await loadPromise;
 
     // Without provider, falls back to bare model ID (first-writer-wins: anthropic's 200k)
     expect(lookupContextTokens("claude-opus-4-6")).toBe(200_000);
   });
 
   it("lookupContextTokens accepts optional provider parameter", async () => {
-    const { lookupContextTokens } = await import("./context.js");
+    const { lookupContextTokens, loadPromise } = await import("./context.js");
+    await loadPromise;
     // Function now accepts 2 params: modelId and optional provider
     expect(lookupContextTokens.length).toBeGreaterThanOrEqual(1);
     // Calling without provider still works (backward compatible)

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Test #14708: MODEL_CACHE context window collision across providers
+ *
+ * The real context.ts loads models via discoverModels().getAll() and caches
+ * them keyed by provider/modelId. We mock the discovery layer to return two
+ * models with the same ID but different providers/contextWindows, then call
+ * the real lookupContextTokens to verify provider-qualified lookups work.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// Mock dependencies that context.ts imports at load time
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+vi.mock("./agent-paths.js", () => ({
+  resolveOpenClawAgentDir: () => "/tmp/fake-agent-dir",
+}));
+vi.mock("./models-config.js", () => ({
+  ensureOpenClawModelsJson: async () => {},
+}));
+
+// Two providers have the same model ID but different context windows
+const fakeModels = [
+  { id: "claude-opus-4-6", provider: "anthropic", contextWindow: 200_000 },
+  { id: "claude-opus-4-6", provider: "my-proxy", contextWindow: 128_000 },
+  { id: "gpt-4.1", provider: "openai", contextWindow: 1_047_576 },
+];
+
+vi.mock("./pi-model-discovery.js", () => ({
+  discoverAuthStorage: () => ({}),
+  discoverModels: () => ({
+    getAll: () => fakeModels,
+  }),
+}));
+
+describe("MODEL_CACHE provider-qualified keys (#14708)", () => {
+  it("returns correct context window per provider for same model ID", async () => {
+    const { lookupContextTokens } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Provider-qualified lookups return the correct value for each provider
+    expect(lookupContextTokens("claude-opus-4-6", "anthropic")).toBe(200_000);
+    expect(lookupContextTokens("claude-opus-4-6", "my-proxy")).toBe(128_000);
+
+    // Non-colliding model works fine
+    expect(lookupContextTokens("gpt-4.1", "openai")).toBe(1_047_576);
+  });
+
+  it("bare model ID fallback uses first-writer-wins", async () => {
+    const { lookupContextTokens } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Without provider, falls back to bare model ID (first-writer-wins: anthropic's 200k)
+    expect(lookupContextTokens("claude-opus-4-6")).toBe(200_000);
+  });
+
+  it("lookupContextTokens accepts optional provider parameter", async () => {
+    const { lookupContextTokens } = await import("./context.js");
+    // Function now accepts 2 params: modelId and optional provider
+    expect(lookupContextTokens.length).toBeGreaterThanOrEqual(1);
+    // Calling without provider still works (backward compatible)
+    expect(lookupContextTokens("gpt-4.1")).toBe(1_047_576);
+  });
+});

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -8,7 +8,7 @@ import { ensureOpenClawModelsJson } from "./models-config.js";
 type ModelEntry = { id: string; provider?: string; contextWindow?: number };
 
 const MODEL_CACHE = new Map<string, number>();
-const loadPromise = (async () => {
+export const loadPromise = (async () => {
   try {
     const { discoverAuthStorage, discoverModels } = await import("./pi-model-discovery.js");
     const cfg = loadConfig();

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -69,6 +69,7 @@ export async function runMemoryFlushIfNeeded(params: {
         (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined),
       contextWindowTokens: resolveMemoryFlushContextWindowTokens({
         modelId: params.followupRun.run.model ?? params.defaultModel,
+        provider: params.followupRun.run.provider,
         agentCfgContextTokens: params.agentCfgContextTokens,
       }),
       reserveTokensFloor: memoryFlushSettings.reserveTokensFloor,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -380,7 +380,7 @@ export async function runReplyAgent(params: {
       : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
+      lookupContextTokens(modelUsed, providerUsed) ??
       activeSessionEntry?.contextTokens ??
       DEFAULT_CONTEXT_TOKENS;
 

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -219,7 +219,8 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens:
+      agentCfg?.contextTokens ?? lookupContextTokens(model, provider) ?? DEFAULT_CONTEXT_TOKENS,
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -198,7 +198,7 @@ export function createFollowupRunner(params: {
       const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const contextTokensUsed =
         agentCfgContextTokens ??
-        lookupContextTokens(modelUsed) ??
+        lookupContextTokens(modelUsed, runResult.meta.agentMeta?.provider ?? fallbackProvider) ??
         sessionEntry?.contextTokens ??
         DEFAULT_CONTEXT_TOKENS;
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -401,6 +401,7 @@ export async function resolveReplyDirectives(params: {
   let contextTokens = resolveContextTokens({
     agentCfg,
     model,
+    provider,
   });
 
   const initialModelLabel = `${provider}/${model}`;

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -68,10 +68,13 @@ function ensureNoReplyHint(text: string): string {
 
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;
+  provider?: string;
   agentCfgContextTokens?: number;
 }): number {
   return (
-    lookupContextTokens(params.modelId) ?? params.agentCfgContextTokens ?? DEFAULT_CONTEXT_TOKENS
+    lookupContextTokens(params.modelId, params.provider) ??
+    params.agentCfgContextTokens ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -584,8 +584,11 @@ export function resolveModelDirectiveSelection(params: {
 export function resolveContextTokens(params: {
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
   model: string;
+  provider?: string;
 }): number {
   return (
-    params.agentCfg?.contextTokens ?? lookupContextTokens(params.model) ?? DEFAULT_CONTEXT_TOKENS
+    params.agentCfg?.contextTokens ??
+    lookupContextTokens(params.model, params.provider) ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -323,7 +323,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   let contextTokens =
     entry?.contextTokens ??
     args.agent?.contextTokens ??
-    lookupContextTokens(model) ??
+    lookupContextTokens(model, provider) ??
     DEFAULT_CONTEXT_TOKENS;
 
   let inputTokens = entry?.inputTokens;
@@ -343,7 +343,7 @@ export function buildStatusMessage(args: StatusArgs): string {
         model = logUsage.model ?? model;
       }
       if (!contextTokens && logUsage.model) {
-        contextTokens = lookupContextTokens(logUsage.model) ?? contextTokens;
+        contextTokens = lookupContextTokens(logUsage.model, provider) ?? contextTokens;
       }
       if (!inputTokens || inputTokens === 0) {
         inputTokens = logUsage.input;

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -42,7 +42,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
   const contextTokens =
-    params.contextTokensOverride ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+    params.contextTokensOverride ??
+    lookupContextTokens(modelUsed, providerUsed) ??
+    DEFAULT_CONTEXT_TOKENS;
 
   const entry = sessionStore[sessionKey] ?? {
     sessionId,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -173,7 +173,7 @@ export async function sessionsCommand(
   });
   const configContextTokens =
     cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model) ??
+    lookupContextTokens(resolved.model, resolved.provider) ??
     DEFAULT_CONTEXT_TOKENS;
   const configModel = resolved.model ?? DEFAULT_MODEL;
   const storePath = resolveStorePath(opts.store ?? cfg.session?.store);

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -94,7 +94,7 @@ export async function getStatusSummary(): Promise<StatusSummary> {
   const configModel = resolved.model ?? DEFAULT_MODEL;
   const configContextTokens =
     cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(configModel) ??
+    lookupContextTokens(configModel, resolved.provider) ??
     DEFAULT_CONTEXT_TOKENS;
 
   const now = Date.now();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -460,7 +460,9 @@ export async function runCronIsolatedAgentTurn(params: {
     const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = runResult.meta.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
-      agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      agentCfg?.contextTokens ??
+      lookupContextTokens(modelUsed, providerUsed) ??
+      DEFAULT_CONTEXT_TOKENS;
 
     cronSession.sessionEntry.modelProvider = providerUsed;
     cronSession.sessionEntry.model = modelUsed;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -514,7 +514,7 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
   });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model) ??
+    lookupContextTokens(resolved.model, resolved.provider) ??
     DEFAULT_CONTEXT_TOKENS;
   return {
     modelProvider: resolved.provider ?? null,


### PR DESCRIPTION
## Summary

- **Bug**: `MODEL_CACHE` in `context.ts` keys entries by bare model ID only. When two providers register the same model ID (e.g. `claude-opus-4-6` on both `anthropic` and a proxy), the last-loaded provider silently overwrites the first, returning the wrong context window.
- **Root cause**: `MODEL_CACHE.set(m.id, m.contextWindow)` uses `m.id` as key without provider dimension. `lookupContextTokens(modelId)` has no `provider` parameter, so callers cannot disambiguate.
- **Fix**: Key cache entries by `provider/modelId`, add optional `provider` parameter to `lookupContextTokens`, and pass provider from all 12 call sites where available.

Fixes #14708

## Problem

`context.ts` builds a `MODEL_CACHE` map keyed by bare model ID:

```typescript
MODEL_CACHE.set(m.id, m.contextWindow); // no provider dimension
```

When `discoverModels().getAll()` returns models with the same ID from different providers (e.g. `anthropic/claude-opus-4-6` with 200k and `my-proxy/claude-opus-4-6` with 128k), the second write silently overwrites the first. `lookupContextTokens` only accepts `modelId`, so callers have no way to get the correct value for a specific provider.

This affects session context management (`agent-runner.ts`, `followup-runner.ts`, `cron/run.ts`, etc.) — wrong context window leads to incorrect compaction thresholds and token budgets.

**Before fix (reproduced on main via integration test):**
```
pnpm vitest run src/agents/context.test.ts

✓ lookupContextTokens returns last-writer-wins for same model ID across providers
  → lookupContextTokens("claude-opus-4-6") = 128_000 (my-proxy's value)
  → anthropic's 200_000 is lost
✓ lookupContextTokens has no provider parameter (API limitation)
  → function.length ≤ 1

Test Files  1 passed (1)
Tests       2 passed (2)
```

## Changes

- `src/agents/context.ts` — Key `MODEL_CACHE` by `provider/modelId`; add bare model ID as first-writer-wins fallback; add optional `provider` param to `lookupContextTokens`
- `src/auto-reply/reply/agent-runner.ts` — Pass `providerUsed` to `lookupContextTokens`
- `src/auto-reply/reply/agent-runner-memory.ts` — Pass `provider` to `resolveMemoryFlushContextWindowTokens`
- `src/auto-reply/reply/directive-handling.persist.ts` — Pass `provider` to `lookupContextTokens`
- `src/auto-reply/reply/followup-runner.ts` — Pass `provider` to `lookupContextTokens`
- `src/auto-reply/reply/memory-flush.ts` — Add optional `provider` param to `resolveMemoryFlushContextWindowTokens`
- `src/auto-reply/reply/model-selection.ts` — Add optional `provider` param to `resolveContextTokens`
- `src/auto-reply/reply/get-reply-directives.ts` — Pass `provider` to `resolveContextTokens`
- `src/auto-reply/status.ts` — Pass `provider` to both `lookupContextTokens` calls
- `src/commands/sessions.ts` — Pass `resolved.provider` where available
- `src/commands/status.summary.ts` — Pass `resolved.provider` where available
- `src/commands/agent/session-store.ts` — Pass `providerUsed` to `lookupContextTokens`
- `src/cron/isolated-agent/run.ts` — Pass `providerUsed` to `lookupContextTokens`
- `src/gateway/session-utils.ts` — Pass `resolved.provider` to `lookupContextTokens`
- `src/agents/context.test.ts` — New regression tests
- `CHANGELOG.md` — Add fix entry

**After fix (verified on fix branch):**
```
pnpm vitest run src/agents/context.test.ts

✓ returns correct context window per provider for same model ID
  → lookupContextTokens("claude-opus-4-6", "anthropic") = 200_000
  → lookupContextTokens("claude-opus-4-6", "my-proxy") = 128_000
✓ bare model ID fallback uses first-writer-wins
  → lookupContextTokens("claude-opus-4-6") = 200_000 (first provider wins)
✓ lookupContextTokens accepts optional provider parameter

Test Files  1 passed (1)
Tests       3 passed (3)
```

## Design decisions

- **Backward compatible**: `provider` param is optional. Callers without provider info still get a result via bare model ID fallback (first-writer-wins).
- **First-writer-wins for bare ID**: When no provider is given, the first provider's value is used. This is better than last-writer-wins because it's deterministic and preserves the "primary" provider's value.
- **Not all call sites have provider**: `sessions.ts` row iteration and `status.summary.ts` session rows don't have provider info — these fall back to bare model ID lookup, which is still better than the old behavior.

## Test plan

- [x] Bug reproduced on main: last-writer-wins collision, no provider param (integration test)
- [x] Fix verified: provider-qualified lookups return correct values per provider
- [x] Fix verified: bare model ID fallback uses first-writer-wins
- [x] Fix verified: backward compatible (calling without provider still works)
- [x] All 10 existing memory-flush tests pass
- [x] TypeScript type check passes (`pnpm tsgo` — no errors in changed files)
- [x] Lint passes (`pnpm lint`)

## Effect on User Experience

**Before:** When two providers register the same model ID with different context windows, the wrong context window is silently used. This causes incorrect compaction thresholds, potentially truncating conversation history too aggressively or not aggressively enough.

**After:** Each provider's context window is correctly preserved. Callers with provider info get the exact value; callers without provider info get a deterministic first-writer-wins fallback.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes collisions in `MODEL_CACHE` by qualifying cache keys with `provider/modelId` and extends `lookupContextTokens` to accept an optional `provider` so callers can request the correct context window when different providers expose the same model ID. Call sites across auto-reply/session/cron/gateway paths are updated to pass provider when available, and a new regression test is added to cover provider-qualified lookups and the bare-ID fallback behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but the new regression test is likely to be flaky due to timing-based initialization.
- Core change is localized (cache keying + optional provider parameter) and call sites were updated consistently. The main concern is `src/agents/context.test.ts` using a fixed 50ms sleep to wait for async module initialization, which can fail nondeterministically in CI and block merges.
- src/agents/context.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->