### PR TITLE
fix(sessions): guard withSessionStoreLock against undefined storePath (#14717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/OpenResponses: harden URL-based `input_file`/`input_image` handling with explicit SSRF deny policy, hostname allowlists (`files.urlAllowlist` / `images.urlAllowlist`), per-request URL input caps (`maxUrlParts`), blocked-fetch audit logging, and regression coverage/docs updates.
+- Sessions: guard `withSessionStoreLock` against undefined `storePath` to prevent `path.dirname` crash. (#14717)
 - Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
 - Security: remove bundled soul-evil hook. (#14757) Thanks @Imccccc.
 - Security/Audit: add hook session-routing hardening checks (`hooks.defaultSessionKey`, `hooks.allowRequestSessionKey`, and prefix allowlists), and warn when HTTP API endpoints allow explicit session-key routing.

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -716,7 +716,7 @@ async function withSessionStoreLock<T>(
 ): Promise<T> {
   if (!storePath || typeof storePath !== "string") {
     throw new Error(
-      `withSessionStoreLock: storePath must be a non-empty string, got ${typeof storePath}`,
+      `withSessionStoreLock: storePath must be a non-empty string, got ${JSON.stringify(storePath)}`,
     );
   }
   const timeoutMs = opts.timeoutMs ?? 10_000;

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -714,6 +714,11 @@ async function withSessionStoreLock<T>(
   fn: () => Promise<T>,
   opts: SessionStoreLockOptions = {},
 ): Promise<T> {
+  if (!storePath || typeof storePath !== "string") {
+    throw new Error(
+      `withSessionStoreLock: storePath must be a non-empty string, got ${typeof storePath}`,
+    );
+  }
   const timeoutMs = opts.timeoutMs ?? 10_000;
   const staleMs = opts.staleMs ?? 30_000;
   // `pollIntervalMs` is retained for API compatibility with older lock options.

--- a/src/config/sessions/store.undefined-path.test.ts
+++ b/src/config/sessions/store.undefined-path.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression test for #14717: path.dirname(undefined) crash in withSessionStoreLock
+ *
+ * When a channel plugin passes undefined as storePath to recordSessionMetaFromInbound,
+ * the call chain reaches withSessionStoreLock → path.dirname(undefined) → TypeError crash.
+ * After fix, a clear Error is thrown instead of an unhandled TypeError.
+ */
+import { describe, expect, it } from "vitest";
+import { updateSessionStore } from "./store.js";
+
+describe("withSessionStoreLock storePath guard (#14717)", () => {
+  it("throws descriptive error when storePath is undefined", async () => {
+    await expect(
+      updateSessionStore(undefined as unknown as string, (store) => store),
+    ).rejects.toThrow("withSessionStoreLock: storePath must be a non-empty string");
+  });
+
+  it("throws descriptive error when storePath is empty string", async () => {
+    await expect(updateSessionStore("", (store) => store)).rejects.toThrow(
+      "withSessionStoreLock: storePath must be a non-empty string",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: `withSessionStoreLock` calls `path.dirname(storePath)` without validating `storePath`, causing an unhandled `TypeError` crash when a channel plugin passes `undefined`.
- **Root cause**: `withSessionStoreLock` in `store.ts` trusts that `storePath` is always a valid string. Channel plugins call `recordInboundSession` → `recordSessionMetaFromInbound` → `updateSessionStore` → `withSessionStoreLock`, and if the plugin fails to resolve a store path, `undefined` reaches `path.dirname`.
- **Fix**: Add a guard at the top of `withSessionStoreLock` that throws a descriptive `Error` instead of letting `path.dirname(undefined)` crash with an unhandled `TypeError`.

Fixes #14717

## Problem

`withSessionStoreLock` in `src/config/sessions/store.ts` calls `path.dirname(storePath)` at line 598 without checking if `storePath` is valid:

```typescript
async function withSessionStoreLock(storePath: string, ...) {
  // No validation — if storePath is undefined, path.dirname crashes
  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
```

Channel plugins receive `recordInboundSession` via the plugin runtime (`src/plugins/runtime/index.ts`). If a plugin fails to resolve the session store path (e.g. missing config), `undefined` propagates through the call chain and crashes the gateway with an unhandled promise rejection.

**Before fix (reproduced on main via integration test):**
```
pnpm vitest run src/config/sessions/store.undefined-path.test.ts

✓ updateSessionStore crashes with TypeError when storePath is undefined
  → TypeError: The "path" argument must be of type string. Received undefined

Test Files  1 passed (1)
Tests       1 passed (1)
```

## Changes

- `src/config/sessions/store.ts` — Add guard at top of `withSessionStoreLock`: throw descriptive `Error` when `storePath` is falsy or not a string
- `src/config/sessions/store.undefined-path.test.ts` — New regression tests: verify descriptive error for `undefined` and empty string `storePath`
- `CHANGELOG.md` — Add fix entry

**After fix (verified on fix branch):**
```
pnpm vitest run src/config/sessions/store.undefined-path.test.ts

✓ throws descriptive error when storePath is undefined
✓ throws descriptive error when storePath is empty string

Test Files  1 passed (1)
Tests       2 passed (2)
```

## Test plan

- [x] Bug reproduced on main: `updateSessionStore(undefined)` crashes with `TypeError`
- [x] Fix verified: throws descriptive `Error("withSessionStoreLock: storePath must be a non-empty string, got undefined")`
- [x] Edge case: empty string also throws descriptive error
- [x] Lint passes (`pnpm lint`)

## Effect on User Experience

**Before:** Gateway crashes with unhandled `TypeError` when a channel plugin passes undefined `storePath`. The triggering message is lost and the gateway must be restarted by systemd.

**After:** A clear `Error` is thrown with a message identifying the problem (`storePath must be a non-empty string, got undefined`). The error is catchable by the plugin's `onRecordError` handler, preventing a gateway crash.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a defensive guard in `src/config/sessions/store.ts` so `withSessionStoreLock` fails fast with a descriptive error when `storePath` is invalid, preventing a `path.dirname(undefined)` crash that can be triggered via plugin-driven session recording. It also adds a regression test for undefined/empty `storePath` and records the fix in the changelog.

The change fits into the sessions persistence layer by protecting the lock+write path (`withSessionStoreLock` → mkdir/lock file creation) against invalid inputs coming from channel plugins via `recordInboundSession`/`recordSessionMetaFromInbound`.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one small but user-visible diagnostic bug in the new error message.
- Core behavior change (guarding against undefined storePath) is sound and covered by a regression test, but the thrown error message currently reports `typeof storePath`, which is misleading for the empty-string case and reduces debuggability.
- src/config/sessions/store.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->