### PR TITLE
fix(gateway): guard against undefined path in recordSessionMetaFromInbound

### DIFF
--- a/src/config/sessions/store.record-meta.test.ts
+++ b/src/config/sessions/store.record-meta.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { recordSessionMetaFromInbound } from "./store.js";
+
+describe("recordSessionMetaFromInbound", () => {
+  it("returns null when storePath is undefined", async () => {
+    const result = await recordSessionMetaFromInbound({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      storePath: undefined as any,
+      sessionKey: "agent:main:telegram:default:direct:12345",
+      ctx: { Provider: "telegram", From: "12345" },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when storePath is empty string", async () => {
+    const result = await recordSessionMetaFromInbound({
+      storePath: "",
+      sessionKey: "agent:main:telegram:default:direct:12345",
+      ctx: { Provider: "telegram", From: "12345" },
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -687,6 +687,9 @@ export async function recordSessionMetaFromInbound(params: {
   createIfMissing?: boolean;
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, ctx } = params;
+  if (!storePath) {
+    return null;
+  }
   const createIfMissing = params.createIfMissing ?? true;
   return await updateSessionStore(
     storePath,


### PR DESCRIPTION
## Problem

`recordSessionMetaFromInbound` passes `storePath` directly to `updateSessionStore`, which calls `path.dirname(storePath)`. When `storePath` is `undefined` (e.g. a plugin caller does not resolve the store path), `path.dirname(undefined)` throws a `TypeError`, crashing the gateway.

## Fix

Add an early guard in `recordSessionMetaFromInbound`: if `storePath` is falsy, return `null` immediately. This matches the function's existing return type (`SessionEntry | null`) and prevents the crash without changing behavior for valid paths.

## Tests

Added `store.record-meta.test.ts` covering both `undefined` and empty-string cases.

Closes #14717

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a defensive guard in `recordSessionMetaFromInbound` to return `null` when `storePath` is falsy, preventing crashes when downstream code calls `path.dirname(storePath)` with `undefined`.

It also adds a focused vitest file (`src/config/sessions/store.record-meta.test.ts`) that asserts the function returns `null` for both `undefined` and empty-string `storePath`, matching the function’s existing `Promise<SessionEntry | null>` contract.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, localized guard that prevents a real runtime TypeError, and the added tests align with existing test import conventions in this codebase (e.g., importing from ./store.js). No behavior changes occur for valid store paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->