### PR TITLE
feat(hooks): add channel:connected hook event

### DIFF
--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -6,9 +6,10 @@
  */
 
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
+import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "channel";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message" | "channel";
 
 export type ChannelConnectedHookContext = {
   /** Channel identifier (e.g., "whatsapp", "telegram", "discord") */
@@ -23,6 +24,7 @@ export type ChannelConnectedHookEvent = InternalHookEvent & {
   context: ChannelConnectedHookContext;
 };
 
+
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
   bootstrapFiles: WorkspaceBootstrapFile[];
@@ -36,6 +38,72 @@ export type AgentBootstrapHookEvent = InternalHookEvent & {
   type: "agent";
   action: "bootstrap";
   context: AgentBootstrapHookContext;
+};
+
+export type GatewayStartupHookContext = {
+  cfg?: OpenClawConfig;
+  deps?: CliDeps;
+  workspaceDir?: string;
+};
+
+export type GatewayStartupHookEvent = InternalHookEvent & {
+  type: "gateway";
+  action: "startup";
+  context: GatewayStartupHookContext;
+};
+
+// ============================================================================
+// Message Hook Events
+// ============================================================================
+
+export type MessageReceivedHookContext = {
+  /** Sender identifier (e.g., phone number, user ID) */
+  from: string;
+  /** Message content */
+  content: string;
+  /** Unix timestamp when the message was received */
+  timestamp?: number;
+  /** Channel identifier (e.g., "telegram", "whatsapp") */
+  channelId: string;
+  /** Provider account ID for multi-account setups */
+  accountId?: string;
+  /** Conversation/chat ID */
+  conversationId?: string;
+  /** Message ID from the provider */
+  messageId?: string;
+  /** Additional provider-specific metadata */
+  metadata?: Record<string, unknown>;
+};
+
+export type MessageReceivedHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "received";
+  context: MessageReceivedHookContext;
+};
+
+export type MessageSentHookContext = {
+  /** Recipient identifier */
+  to: string;
+  /** Message content */
+  content: string;
+  /** Whether the message was sent successfully */
+  success: boolean;
+  /** Error message if sending failed */
+  error?: string;
+  /** Channel identifier (e.g., "telegram", "whatsapp") */
+  channelId: string;
+  /** Provider account ID for multi-account setups */
+  accountId?: string;
+  /** Conversation/chat ID */
+  conversationId?: string;
+  /** Message ID returned by the provider */
+  messageId?: string;
+};
+
+export type MessageSentHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "sent";
+  context: MessageSentHookContext;
 };
 
 export interface InternalHookEvent {
@@ -191,6 +259,42 @@ export function isAgentBootstrapEvent(event: InternalHookEvent): event is AgentB
     return false;
   }
   return Array.isArray(context.bootstrapFiles);
+}
+
+export function isGatewayStartupEvent(event: InternalHookEvent): event is GatewayStartupHookEvent {
+  if (event.type !== "gateway" || event.action !== "startup") {
+    return false;
+  }
+  const context = event.context as GatewayStartupHookContext | null;
+  return Boolean(context && typeof context === "object");
+}
+
+export function isMessageReceivedEvent(
+  event: InternalHookEvent,
+): event is MessageReceivedHookEvent {
+  if (event.type !== "message" || event.action !== "received") {
+    return false;
+  }
+  const context = event.context as Partial<MessageReceivedHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.from === "string" && typeof context.channelId === "string";
+}
+
+export function isMessageSentEvent(event: InternalHookEvent): event is MessageSentHookEvent {
+  if (event.type !== "message" || event.action !== "sent") {
+    return false;
+  }
+  const context = event.context as Partial<MessageSentHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return (
+    typeof context.to === "string" &&
+    typeof context.channelId === "string" &&
+    typeof context.success === "boolean"
+  );
 }
 
 export function isChannelConnectedEvent(

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,20 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "channel";
+
+export type ChannelConnectedHookContext = {
+  /** Channel identifier (e.g., "whatsapp", "telegram", "discord") */
+  channel: string;
+  /** Account identifier within the channel */
+  accountId: string;
+};
+
+export type ChannelConnectedHookEvent = InternalHookEvent & {
+  type: "channel";
+  action: "connected";
+  context: ChannelConnectedHookContext;
+};
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -178,4 +191,17 @@ export function isAgentBootstrapEvent(event: InternalHookEvent): event is AgentB
     return false;
   }
   return Array.isArray(context.bootstrapFiles);
+}
+
+export function isChannelConnectedEvent(
+  event: InternalHookEvent,
+): event is ChannelConnectedHookEvent {
+  if (event.type !== "channel" || event.action !== "connected") {
+    return false;
+  }
+  const context = event.context as Partial<ChannelConnectedHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.channel === "string" && typeof context.accountId === "string";
 }

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -1,4 +1,3 @@
-import type { WebChannelStatus, WebInboundMsg, WebMonitorTuning } from "./types.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { resolveInboundDebounceMs } from "../../auto-reply/inbound-debounce.js";
 import { getReplyFromConfig } from "../../auto-reply/reply.js";
@@ -30,6 +29,7 @@ import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
 import { createEchoTracker } from "./monitor/echo.js";
 import { createWebOnMessageHandler } from "./monitor/on-message.js";
+import type { WebChannelStatus, WebInboundMsg, WebMonitorTuning } from "./types.js";
 import { isLikelyWhatsAppCryptoError } from "./util.js";
 
 export async function monitorWebChannel(
@@ -340,6 +340,7 @@ export async function monitorWebChannel(
 
     if (!keepAlive) {
       await closeListener();
+      process.removeListener("SIGINT", handleSigint);
       return;
     }
 

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -7,6 +7,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import { waitForever } from "../../cli/wait.js";
 import { loadConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { registerUnhandledRejectionHandler } from "../../infra/unhandled-rejections.js";
@@ -224,6 +225,14 @@ export async function monitorWebChannel(
     enqueueSystemEvent(`WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`, {
       sessionKey: connectRoute.sessionKey,
     });
+
+    // Fire channel:connected hook for custom automation (e.g., boot notifications).
+    void triggerInternalHook(
+      createInternalHookEvent("channel", "connected", connectRoute.sessionKey, {
+        channel: "whatsapp",
+        accountId: account.accountId,
+      }),
+    );
 
     setActiveWebListener(account.accountId, listener);
     unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {


### PR DESCRIPTION
## Summary

Adds a `channel:connected` internal hook event that fires when a channel successfully connects or reconnects. Currently implemented for WhatsApp; other channels can adopt the same pattern.

## Motivation

There is currently no way for custom hooks to react to channel connection events. This makes it impossible to build automations like:

- Sending a "bot is online" notification when WhatsApp reconnects
- Updating status dashboards when channels come online
- Logging connection events for monitoring

The hook system already supports `command`, `session`, `agent`, and `gateway` events, but channel lifecycle events are missing.

## Changes

### `src/hooks/internal-hooks.ts`
- Added `"channel"` to `InternalHookEventType` union
- Added `ChannelConnectedHookContext` type with `channel` and `accountId` fields
- Added `ChannelConnectedHookEvent` type
- Added `isChannelConnectedEvent()` type guard

### `src/web/auto-reply/monitor.ts`
- Fire `channel:connected` hook after successful WhatsApp connection (alongside existing `enqueueSystemEvent`)
- Hook is fired with `void` (fire-and-forget) to avoid blocking the connection flow

## Example Usage

```ts
// In a custom hook (hooks/boot-notify/handler.js)
const handler = async (event) => {
  if (event.type === "channel" && event.action === "connected") {
    event.messages.push("Bot is online! 🤖");
  }
};
export default handler;
```

## Notes

- Follows the same pattern as existing hook events (`agent:bootstrap`, `gateway:startup`)
- Other channel plugins (Telegram, Discord, Slack, etc.) can adopt this by adding a similar `triggerInternalHook` call at their connection success point
- Minimal change: 2 files, ~36 lines added

---

*Generated by [OpenClaw](https://github.com/openclaw/openclaw) (Chappie 🤖)*

My work runs on caffeine ☕. Help me keep the lights on!

[![Buy me a coffee](https://img.shields.io/badge/☕-Buy%20me%20a%20coffee-orange.svg)](https://paypal.me/JunyeobBaek)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the internal hook system by adding a new `channel:connected` event type/action and a corresponding typed context (`{ channel, accountId }`) plus a type guard (`isChannelConnectedEvent`). It then emits this hook from the WhatsApp web monitor immediately after a successful connection (alongside the existing `enqueueSystemEvent`), using a fire-and-forget `void triggerInternalHook(...)` call so hook execution doesn’t block the connection flow.

The change integrates cleanly with the existing hook registry (`registerInternalHook` / `triggerInternalHook`) which already keys handlers by `type` and `type:action` strings, and uses the same `sessionKey` routing already used for the WhatsApp connection system event.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized (type union expansion, new event/type guard, and a single new hook emission). The hook triggering mechanism already tolerates handler errors internally, and the new event uses the same sessionKey routing already used for WhatsApp connection system events.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->