### PR TITLE
fix: respect explicit empty fallbacks in model-fallback

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-
 import type { OpenClawConfig } from "../config/config.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1,4 +1,10 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { FailoverReason } from "./pi-embedded-helpers.js";
+import {
+  ensureAuthProfileStore,
+  isProfileInCooldown,
+  resolveAuthProfileOrder,
+} from "./auth-profiles.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
   coerceToFailoverError,
@@ -13,12 +19,6 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "./model-selection.js";
-import type { FailoverReason } from "./pi-embedded-helpers.js";
-import {
-  ensureAuthProfileStore,
-  isProfileInCooldown,
-  resolveAuthProfileOrder,
-} from "./auth-profiles.js";
 
 type ModelCandidate = {
   provider: string;
@@ -219,7 +219,12 @@ function resolveFallbackCandidates(params: {
     const model = params.cfg?.agents?.defaults?.model;
     return model && typeof model === "object" && "fallbacks" in model;
   })();
-  if (params.fallbacksOverride === undefined && !hasExplicitModelConfig && primary?.provider && primary.model) {
+  if (
+    params.fallbacksOverride === undefined &&
+    !hasExplicitModelConfig &&
+    primary?.provider &&
+    primary.model
+  ) {
     addCandidate({ provider: primary.provider, model: primary.model }, false);
   }
 


### PR DESCRIPTION
See commit for details

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts model fallback candidate resolution so that an explicitly configured empty `agents.defaults.model.fallbacks: []` is respected (i.e., it disables adding the configured primary as a final implicit fallback). It also refactors allowlist key generation to use `parseModelRef` directly, and updates tests to cover the explicit-empty-fallbacks behavior plus the string-model configuration case.

The change is localized to `runWithModelFallback`’s candidate building logic in `src/agents/model-fallback.ts`, and the corresponding test coverage in `src/agents/model-fallback.test.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to fallback candidate selection and include targeted tests for the new explicit-empty-fallbacks behavior. Refactors (allowlist key building and abort error helper rename) preserve prior semantics as verified against existing helpers.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->