### PR TITLE
fix(browser): clarify stale targetId errors (tab not found)

### DIFF
--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -15,6 +15,21 @@ function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number):
     : `Start (or restart) the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`) and try again.`;
   const msg = String(err);
   const msgLower = msg.toLowerCase();
+
+  // The control service is often healthy, but the targetId/tab becomes stale (e.g., after a
+  // profile restart or transient CDP disconnect). Surface that explicitly to avoid misleading
+  // users with a generic "can't reach the control service" error.
+  const looksLikeMissingTarget =
+    msgLower.includes("tab not found") ||
+    msgLower.includes("target not found") ||
+    msgLower.includes("no such target") ||
+    msgLower.includes("target closed");
+  if (looksLikeMissingTarget) {
+    return new Error(
+      `OpenClaw browser tab/target was not found (stale targetId). Re-open the page to get a new targetId and retry. (${msg})`,
+    );
+  }
+
   const looksLikeTimeout =
     msgLower.includes("timed out") ||
     msgLower.includes("timeout") ||


### PR DESCRIPTION
Fixes error messaging when the underlying failure is a stale targetId/tab (e.g. after profile restart).\n\nInstead of surfacing "Can't reach the OpenClaw browser control service" for messages like "tab not found", return a clearer error advising to re-open the page to obtain a fresh targetId.\n\nRelated: openclaw/openclaw#14503

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `src/browser/client-fetch.ts` to detect common “missing tab/target” error strings (e.g. `tab not found`, `target not found`, `no such target`, `target closed`) and return a clearer, user-directed message indicating the `targetId` is stale and they should re-open the page to obtain a fresh targetId.

The logic sits in the shared error-enhancement layer (`enhanceBrowserFetchError`) used by `fetchBrowserJson`, so it affects both the internal browser control-service dispatcher path and any callers that surface these error messages through this fetch wrapper.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to error-message mapping in a single helper, and the matched strings are consistently used in the codebase for missing/invalid tab/targetId scenarios. No behavior changes to the control path beyond improving the surfaced error message.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->