### PR TITLE
feat(zai): auto-detect endpoint + default glm-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 - Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
 - Onboarding/Providers: add Z.AI endpoint-specific auth choices (`zai-coding-global`, `zai-coding-cn`, `zai-global`, `zai-cn`) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.
-- Onboarding/Providers: auto-detect the correct Z.AI endpoint for your API key (prefer general API + `zai/glm-5`; fall back to Coding Plan + `zai/glm-4.7`) and add GLM-5 forward-compat resolution when provider catalogs lag. (#14786) Thanks @steipete.
 - Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
 - Voice Call: pass Twilio stream auth token via `<Parameter>` instead of query string. (#14029) Thanks @mcwigglesmcgee.
 - Feishu: pass `Buffer` directly to the Feishu SDK upload APIs instead of `Readable.from(...)` to avoid form-data upload failures. (#10345) Thanks @youngerstyle.
@@ -1714,3 +1713,5 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Discord: avoid duplicate replies when OpenAI emits repeated `message_end` events.
 - Commands: unify /status (inline) and command auth across providers; group bypass for authorized control commands; remove Discord /clawd slash handler.
 - CLI: run `openclaw agent` via the Gateway by default; use `--local` to force embedded mode.
+
+- Onboarding/Providers: auto-detect the correct Z.AI endpoint for your API key (prefer general API + `zai/glm-5`; fall back to Coding Plan + `zai/glm-4.7`) and add GLM-5 forward-compat resolution when provider catalogs lag. (#14786) Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,18 @@ Docs: https://docs.openclaw.ai
 - Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
 - Security: remove bundled soul-evil hook. (#14757) Thanks @Imccccc.
 - Gateway: raise WS payload/buffer limits so 5,000,000-byte image attachments work reliably. (#14486) Thanks @0xRaini.
+- Logging/CLI: use local timezone timestamps for console prefixing, and include `±HH:MM` offsets when using `openclaw logs --local-time` to avoid ambiguity. (#14771) Thanks @0xRaini.
 - Gateway: drain active turns before restart to prevent message loss. (#13931) Thanks @0xRaini.
 - Gateway: auto-generate auth token during install to prevent launchd restart loops. (#13813) Thanks @cathrynlavery.
 - Gateway: prevent `undefined`/missing token in auth config. (#13809) Thanks @asklee-klawd.
 - Gateway: handle async `EPIPE` on stdout/stderr during shutdown. (#13414) Thanks @keshav55.
+- Cron: use requested `agentId` for isolated job auth resolution. (#13983) Thanks @0xRaini.
+- Cron: prevent cron jobs from skipping execution when `nextRunAtMs` advances. (#14068) Thanks @WalterSumbon.
+- Cron: pass `agentId` to `runHeartbeatOnce` for main-session jobs. (#14140) Thanks @ishikawa-pro.
+- Cron: re-arm timers when `onTimer` fires while a job is still executing. (#14233) Thanks @tomron87.
+- Cron: prevent duplicate fires when multiple jobs trigger simultaneously. (#14256) Thanks @xinhuagu.
+- Cron: isolate scheduler errors so one bad job does not break all jobs. (#14385) Thanks @MarvinDontPanic.
+- Cron: prevent one-shot `at` jobs from re-firing on restart after skipped/errored runs. (#13878) Thanks @lailoo.
 - WhatsApp: convert Markdown bold/strikethrough to WhatsApp formatting. (#14285) Thanks @Raikan10.
 - WhatsApp: allow media-only sends and normalize leading blank payloads. (#14408) Thanks @karimnaguib.
 - WhatsApp: default MIME type for voice messages when Baileys omits it. (#14444) Thanks @mcaxtr.
@@ -1713,5 +1721,3 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Discord: avoid duplicate replies when OpenAI emits repeated `message_end` events.
 - Commands: unify /status (inline) and command auth across providers; group bypass for authorized control commands; remove Discord /clawd slash handler.
 - CLI: run `openclaw agent` via the Gateway by default; use `--local` to force embedded mode.
-
-- Onboarding/Providers: auto-detect the correct Z.AI endpoint for your API key (prefer general API + `zai/glm-5`; fall back to Coding Plan + `zai/glm-4.7`) and add GLM-5 forward-compat resolution when provider catalogs lag. (#14786) Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: raise WS payload/buffer limits so 5,000,000-byte image attachments work reliably. (#14486) Thanks @0xRaini.
 - Cron: use requested `agentId` for isolated job auth resolution. (#13983) Thanks @0xRaini.
 - Cron: prevent cron jobs from skipping execution when `nextRunAtMs` advances. (#14068) Thanks @WalterSumbon.
 - Cron: pass `agentId` to `runHeartbeatOnce` for main-session jobs. (#14140) Thanks @ishikawa-pro.
@@ -28,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Discord tests: use a partial @buape/carbon mock in slash command coverage. (#13262) Thanks @arosstale.
 - CLI/Wizard: exit with code 1 when `configure`, `agents add`, or interactive `onboard` wizards are canceled, so `set -e` automation stops correctly. (#14156) Thanks @0xRaini.
 - Onboarding/Providers: add Z.AI endpoint-specific auth choices (`zai-coding-global`, `zai-coding-cn`, `zai-global`, `zai-cn`) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.
+- Onboarding/Providers: auto-detect the correct Z.AI endpoint for your API key (prefer general API + `zai/glm-5`; fall back to Coding Plan + `zai/glm-4.7`) and add GLM-5 forward-compat resolution when provider catalogs lag. (#14786) Thanks @steipete.
 - Feishu: pass `Buffer` directly to the Feishu SDK upload APIs instead of `Readable.from(...)` to avoid form-data upload failures. (#10345) Thanks @youngerstyle.
 - Feishu: trigger mention-gated group handling only when the bot itself is mentioned (not just any mention). (#11088) Thanks @openperf.
 - Feishu: probe status uses the resolved account context for multi-account credential checks. (#11233) Thanks @onevcat.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,58 +2,58 @@
 
 Docs: https://docs.openclaw.ai
 
-## 2026.2.10
+## 2026.2.12
 
 ### Changes
 
-- Telegram: render blockquotes as native `<blockquote>` tags instead of stripping them. (#14608)
-- Version alignment: bump manifests and package versions to `2026.2.10`; keep `appcast.xml` unchanged until the next macOS release cut.
 - CLI: add `openclaw logs --local-time` to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
+- Telegram: render blockquotes as native `<blockquote>` tags instead of stripping them. (#14608)
 - Config: avoid redacting `maxTokens`-like fields during config snapshot redaction, preventing round-trip validation failures in `/config`. (#14006) Thanks @constansino.
 
 ### Fixes
 
+- Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
+- Security: remove bundled soul-evil hook. (#14757) Thanks @Imccccc.
 - Gateway: raise WS payload/buffer limits so 5,000,000-byte image attachments work reliably. (#14486) Thanks @0xRaini.
-- Cron: use requested `agentId` for isolated job auth resolution. (#13983) Thanks @0xRaini.
-- Cron: prevent cron jobs from skipping execution when `nextRunAtMs` advances. (#14068) Thanks @WalterSumbon.
-- Cron: pass `agentId` to `runHeartbeatOnce` for main-session jobs. (#14140) Thanks @ishikawa-pro.
-- Cron: re-arm timers when `onTimer` fires while a job is still executing. (#14233) Thanks @tomron87.
-- Cron: prevent duplicate fires when multiple jobs trigger simultaneously. (#14256) Thanks @xinhuagu.
-- Cron: isolate scheduler errors so one bad job does not break all jobs. (#14385) Thanks @MarvinDontPanic.
-- Cron: prevent one-shot `at` jobs from re-firing on restart after skipped/errored runs. (#13878) Thanks @lailoo.
+- Gateway: drain active turns before restart to prevent message loss. (#13931) Thanks @0xRaini.
+- Gateway: auto-generate auth token during install to prevent launchd restart loops. (#13813) Thanks @cathrynlavery.
+- Gateway: prevent `undefined`/missing token in auth config. (#13809) Thanks @asklee-klawd.
+- Gateway: handle async `EPIPE` on stdout/stderr during shutdown. (#13414) Thanks @keshav55.
 - WhatsApp: convert Markdown bold/strikethrough to WhatsApp formatting. (#14285) Thanks @Raikan10.
 - WhatsApp: allow media-only sends and normalize leading blank payloads. (#14408) Thanks @karimnaguib.
 - WhatsApp: default MIME type for voice messages when Baileys omits it. (#14444) Thanks @mcaxtr.
-- Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
+- Telegram: handle no-text message in model picker editMessageText. (#14397) Thanks @0xRaini.
+- Telegram: surface REACTION_INVALID as non-fatal warning. (#14340) Thanks @0xRaini.
+- BlueBubbles: fix webhook auth bypass via loopback proxy trust. (#13787) Thanks @coygeek.
+- Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
-- Discord tests: use a partial @buape/carbon mock in slash command coverage. (#13262) Thanks @arosstale.
-- CLI/Wizard: exit with code 1 when `configure`, `agents add`, or interactive `onboard` wizards are canceled, so `set -e` automation stops correctly. (#14156) Thanks @0xRaini.
 - Onboarding/Providers: add Z.AI endpoint-specific auth choices (`zai-coding-global`, `zai-coding-cn`, `zai-global`, `zai-cn`) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.
 - Onboarding/Providers: auto-detect the correct Z.AI endpoint for your API key (prefer general API + `zai/glm-5`; fall back to Coding Plan + `zai/glm-4.7`) and add GLM-5 forward-compat resolution when provider catalogs lag. (#14786) Thanks @steipete.
+- Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
+- Voice Call: pass Twilio stream auth token via `<Parameter>` instead of query string. (#14029) Thanks @mcwigglesmcgee.
 - Feishu: pass `Buffer` directly to the Feishu SDK upload APIs instead of `Readable.from(...)` to avoid form-data upload failures. (#10345) Thanks @youngerstyle.
 - Feishu: trigger mention-gated group handling only when the bot itself is mentioned (not just any mention). (#11088) Thanks @openperf.
 - Feishu: probe status uses the resolved account context for multi-account credential checks. (#11233) Thanks @onevcat.
 - Feishu DocX: preserve top-level converted block order using `firstLevelBlockIds` when writing/appending documents. (#13994) Thanks @Cynosure159.
 - Feishu plugin packaging: remove `workspace:*` `openclaw` dependency from `extensions/feishu` and sync lockfile for install compatibility. (#14423) Thanks @jackcooper2015.
-- Telegram: handle no-text message in model picker editMessageText. (#14397) Thanks @0xRaini.
-- Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.
-- Tests: update thread ID handling in Slack message collection tests. (#14108) Thanks @swizzmagik.
-- Telegram: surface REACTION_INVALID as non-fatal warning. (#14340) Thanks @0xRaini.
-- BlueBubbles: fix webhook auth bypass via loopback proxy trust. (#13787) Thanks @coygeek.
-- Gateway: auto-generate auth token during install to prevent launchd restart loops. (#13813) Thanks @cathrynlavery.
+- CLI/Wizard: exit with code 1 when `configure`, `agents add`, or interactive `onboard` wizards are canceled, so `set -e` automation stops correctly. (#14156) Thanks @0xRaini.
 - Media: strip `MEDIA:` lines with local paths instead of leaking as visible text. (#14399) Thanks @0xRaini.
-- Gateway: handle async `EPIPE` on stdout/stderr during shutdown. (#13414) Thanks @keshav55.
-- Gateway: prevent `undefined`/missing token in auth config. (#13809) Thanks @asklee-klawd.
-- Voice Call: pass Twilio stream auth token via `<Parameter>` instead of query string. (#14029) Thanks @mcwigglesmcgee.
 - Config/Cron: exclude `maxTokens` from config redaction and honor `deleteAfterRun` on skipped cron jobs. (#13342) Thanks @niceysam.
-- Gateway: drain active turns before restart to prevent message loss. (#13931) Thanks @0xRaini.
-- Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
 - Config: ignore `meta` field changes in config file watcher. (#13460) Thanks @brandonwise.
+- Cron: use requested `agentId` for isolated job auth resolution. (#13983) Thanks @0xRaini.
+- Cron: pass `agentId` to `runHeartbeatOnce` for main-session jobs. (#14140) Thanks @ishikawa-pro.
+- Cron: prevent cron jobs from skipping execution when `nextRunAtMs` advances. (#14068) Thanks @WalterSumbon.
+- Cron: re-arm timers when `onTimer` fires while a job is still executing. (#14233) Thanks @tomron87.
+- Cron: prevent duplicate fires when multiple jobs trigger simultaneously. (#14256) Thanks @xinhuagu.
+- Cron: isolate scheduler errors so one bad job does not break all jobs. (#14385) Thanks @MarvinDontPanic.
+- Cron: prevent one-shot `at` jobs from re-firing on restart after skipped/errored runs. (#13878) Thanks @lailoo.
 - Daemon: suppress `EPIPE` error when restarting LaunchAgent. (#14343) Thanks @0xRaini.
-- Agents: prevent double compaction caused by cache TTL bypassing guard. (#13514) Thanks @taw0002.
 - Antigravity: add opus 4.6 forward-compat model and bypass thinking signature sanitization. (#14218) Thanks @jg-noncelogic.
 - Agents: prevent file descriptor leaks in child process cleanup. (#13565) Thanks @KyleChen26.
+- Agents: prevent double compaction caused by cache TTL bypassing guard. (#13514) Thanks @taw0002.
 - Agents: use last API call's cache tokens for context display instead of accumulated sum. (#13805) Thanks @akari-musubi.
+- Discord tests: use a partial @buape/carbon mock in slash command coverage. (#13262) Thanks @arosstale.
+- Tests: update thread ID handling in Slack message collection tests. (#14108) Thanks @swizzmagik.
 
 ## 2026.2.9
 

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -41,6 +41,9 @@ openclaw onboard --non-interactive \
 
 Non-interactive Z.AI endpoint choices:
 
+Note: `--auth-choice zai-api-key` now auto-detects the best Z.AI endpoint for your key (prefers the general API with `zai/glm-5`).
+If you specifically want the GLM Coding Plan endpoints, pick `zai-coding-global` or `zai-coding-cn`.
+
 ```bash
 # Promptless endpoint selection
 openclaw onboard --non-interactive \

--- a/docs/providers/glm.md
+++ b/docs/providers/glm.md
@@ -9,7 +9,7 @@ title: "GLM Models"
 # GLM models
 
 GLM is a **model family** (not a company) available through the Z.AI platform. In OpenClaw, GLM
-models are accessed via the `zai` provider and model IDs like `zai/glm-4.7`.
+models are accessed via the `zai` provider and model IDs like `zai/glm-5`.
 
 ## CLI setup
 
@@ -22,12 +22,12 @@ openclaw onboard --auth-choice zai-api-key
 ```json5
 {
   env: { ZAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "zai/glm-4.7" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5" } } },
 }
 ```
 
 ## Notes
 
 - GLM versions and availability can change; check Z.AI's docs for the latest.
-- Example model IDs include `glm-4.7` and `glm-4.6`.
+- Example model IDs include `glm-5`, `glm-4.7`, and `glm-4.6`.
 - For provider details, see [/providers/zai](/providers/zai).

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -25,12 +25,12 @@ openclaw onboard --zai-api-key "$ZAI_API_KEY"
 ```json5
 {
   env: { ZAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "zai/glm-4.7" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5" } } },
 }
 ```
 
 ## Notes
 
-- GLM models are available as `zai/<model>` (example: `zai/glm-4.7`).
+- GLM models are available as `zai/<model>` (example: `zai/glm-5`).
 - See [/providers/glm](/providers/glm) for the model family overview.
 - Z.AI uses Bearer auth with your API key.

--- a/src/agents/pi-embedded-runner.test.ts
+++ b/src/agents/pi-embedded-runner.test.ts
@@ -104,7 +104,7 @@ beforeAll(async () => {
   workspaceDir = path.join(tempRoot, "workspace");
   await fs.mkdir(agentDir, { recursive: true });
   await fs.mkdir(workspaceDir, { recursive: true });
-}, 20_000);
+}, 60_000);
 
 afterAll(async () => {
   if (!tempRoot) {

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -241,10 +241,10 @@ describe("applyAuthChoice", () => {
     });
 
     expect(select).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Select Z.AI endpoint", initialValue: "coding-global" }),
+      expect.objectContaining({ message: "Select Z.AI endpoint", initialValue: "global" }),
     );
     expect(result.config.models?.providers?.zai?.baseUrl).toBe(ZAI_CODING_CN_BASE_URL);
-    expect(result.config.agents?.defaults?.model?.primary).toBe("zai/glm-4.7");
+    expect(result.config.agents?.defaults?.model?.primary).toBe("zai/glm-5");
 
     const authProfilePath = authProfilePathFor(requireAgentDir());
     const raw = await fs.readFile(authProfilePath, "utf8");

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -115,7 +115,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
   });
 }
 
-export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
+export const ZAI_DEFAULT_MODEL_REF = "zai/glm-5";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 export const TOGETHER_DEFAULT_MODEL_REF = "together/moonshotai/Kimi-K2.5";

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -24,7 +24,7 @@ export const ZAI_CODING_GLOBAL_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 export const ZAI_CODING_CN_BASE_URL = "https://open.bigmodel.cn/api/coding/paas/v4";
 export const ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4";
 export const ZAI_CN_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
-export const ZAI_DEFAULT_MODEL_ID = "glm-4.7";
+export const ZAI_DEFAULT_MODEL_ID = "glm-5";
 
 export function resolveZaiBaseUrl(endpoint?: string): string {
   switch (endpoint) {
@@ -35,8 +35,9 @@ export function resolveZaiBaseUrl(endpoint?: string): string {
     case "cn":
       return ZAI_CN_BASE_URL;
     case "coding-global":
-    default:
       return ZAI_CODING_GLOBAL_BASE_URL;
+    default:
+      return ZAI_GLOBAL_BASE_URL;
   }
 }
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -27,7 +27,7 @@ import {
   setMinimaxApiKey,
   writeOAuthCredentials,
   ZAI_CODING_CN_BASE_URL,
-  ZAI_CODING_GLOBAL_BASE_URL,
+  ZAI_GLOBAL_BASE_URL,
 } from "./onboard-auth.js";
 
 const authProfilePathFor = (agentDir: string) => path.join(agentDir, "auth-profiles.json");
@@ -311,7 +311,8 @@ describe("applyZaiConfig", () => {
   it("adds zai provider with correct settings", () => {
     const cfg = applyZaiConfig({});
     expect(cfg.models?.providers?.zai).toMatchObject({
-      baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
+      // Default: general (non-coding) endpoint. Coding Plan endpoint is detected during onboarding.
+      baseUrl: ZAI_GLOBAL_BASE_URL,
       api: "openai-completions",
     });
     const ids = cfg.models?.providers?.zai?.models?.map((m) => m.id);

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -139,7 +139,7 @@ async function expectApiKeyProfile(params: {
 }
 
 describe("onboard (non-interactive): provider auth", () => {
-  it("stores Z.AI API key and uses coding-global baseUrl by default", async () => {
+  it("stores Z.AI API key and uses global baseUrl by default", async () => {
     await withOnboardEnv("openclaw-onboard-zai-", async ({ configPath, runtime }) => {
       await runNonInteractive(
         {
@@ -162,8 +162,8 @@ describe("onboard (non-interactive): provider auth", () => {
 
       expect(cfg.auth?.profiles?.["zai:default"]?.provider).toBe("zai");
       expect(cfg.auth?.profiles?.["zai:default"]?.mode).toBe("api_key");
-      expect(cfg.models?.providers?.zai?.baseUrl).toBe("https://api.z.ai/api/coding/paas/v4");
-      expect(cfg.agents?.defaults?.model?.primary).toBe("zai/glm-4.7");
+      expect(cfg.models?.providers?.zai?.baseUrl).toBe("https://api.z.ai/api/paas/v4");
+      expect(cfg.agents?.defaults?.model?.primary).toBe("zai/glm-5");
       await expectApiKeyProfile({ profileId: "zai:default", provider: "zai", key: "zai-test-key" });
     });
   }, 60_000);

--- a/src/commands/zai-endpoint-detect.test.ts
+++ b/src/commands/zai-endpoint-detect.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { detectZaiEndpoint } from "./zai-endpoint-detect.js";
+
+function makeFetch(map: Record<string, { status: number; body?: unknown }>) {
+  return (async (url: string) => {
+    const entry = map[url];
+    if (!entry) {
+      throw new Error(`unexpected url: ${url}`);
+    }
+    const json = entry.body ?? {};
+    return new Response(JSON.stringify(json), {
+      status: entry.status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+describe("detectZaiEndpoint", () => {
+  it("prefers global glm-5 when it works", async () => {
+    const fetchFn = makeFetch({
+      "https://api.z.ai/api/paas/v4/chat/completions": { status: 200 },
+    });
+
+    const detected = await detectZaiEndpoint({ apiKey: "sk-test", fetchFn });
+    expect(detected?.endpoint).toBe("global");
+    expect(detected?.modelId).toBe("glm-5");
+  });
+
+  it("falls back to cn glm-5 when global fails", async () => {
+    const fetchFn = makeFetch({
+      "https://api.z.ai/api/paas/v4/chat/completions": {
+        status: 404,
+        body: { error: { message: "not found" } },
+      },
+      "https://open.bigmodel.cn/api/paas/v4/chat/completions": { status: 200 },
+    });
+
+    const detected = await detectZaiEndpoint({ apiKey: "sk-test", fetchFn });
+    expect(detected?.endpoint).toBe("cn");
+    expect(detected?.modelId).toBe("glm-5");
+  });
+
+  it("falls back to coding endpoint with glm-4.7", async () => {
+    const fetchFn = makeFetch({
+      "https://api.z.ai/api/paas/v4/chat/completions": { status: 404 },
+      "https://open.bigmodel.cn/api/paas/v4/chat/completions": { status: 404 },
+      "https://api.z.ai/api/coding/paas/v4/chat/completions": { status: 200 },
+    });
+
+    const detected = await detectZaiEndpoint({ apiKey: "sk-test", fetchFn });
+    expect(detected?.endpoint).toBe("coding-global");
+    expect(detected?.modelId).toBe("glm-4.7");
+  });
+
+  it("returns null when nothing works", async () => {
+    const fetchFn = makeFetch({
+      "https://api.z.ai/api/paas/v4/chat/completions": { status: 401 },
+      "https://open.bigmodel.cn/api/paas/v4/chat/completions": { status: 401 },
+      "https://api.z.ai/api/coding/paas/v4/chat/completions": { status: 401 },
+      "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions": { status: 401 },
+    });
+
+    const detected = await detectZaiEndpoint({ apiKey: "sk-test", fetchFn });
+    expect(detected).toBe(null);
+  });
+});

--- a/src/commands/zai-endpoint-detect.ts
+++ b/src/commands/zai-endpoint-detect.ts
@@ -1,0 +1,148 @@
+import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+import {
+  ZAI_CN_BASE_URL,
+  ZAI_CODING_CN_BASE_URL,
+  ZAI_CODING_GLOBAL_BASE_URL,
+  ZAI_GLOBAL_BASE_URL,
+} from "./onboard-auth.models.js";
+
+export type ZaiEndpointId = "global" | "cn" | "coding-global" | "coding-cn";
+
+export type ZaiDetectedEndpoint = {
+  endpoint: ZaiEndpointId;
+  /** Provider baseUrl to store in config. */
+  baseUrl: string;
+  /** Recommended default model id for that endpoint. */
+  modelId: string;
+  /** Human-readable note explaining the choice. */
+  note: string;
+};
+
+type ProbeResult =
+  | { ok: true }
+  | {
+      ok: false;
+      status?: number;
+      errorCode?: string;
+      errorMessage?: string;
+    };
+
+async function probeZaiChatCompletions(params: {
+  baseUrl: string;
+  apiKey: string;
+  modelId: string;
+  timeoutMs: number;
+  fetchFn?: typeof fetch;
+}): Promise<ProbeResult> {
+  try {
+    const res = await fetchWithTimeout(
+      `${params.baseUrl}/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${params.apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: params.modelId,
+          stream: false,
+          max_tokens: 1,
+          messages: [{ role: "user", content: "ping" }],
+        }),
+      },
+      params.timeoutMs,
+      params.fetchFn,
+    );
+
+    if (res.ok) {
+      return { ok: true };
+    }
+
+    let errorCode: string | undefined;
+    let errorMessage: string | undefined;
+    try {
+      const json = (await res.json()) as {
+        error?: { code?: unknown; message?: unknown };
+        msg?: unknown;
+        message?: unknown;
+      };
+      const code = json?.error?.code;
+      const msg = json?.error?.message ?? json?.msg ?? json?.message;
+      if (typeof code === "string") {
+        errorCode = code;
+      } else if (typeof code === "number") {
+        errorCode = String(code);
+      }
+      if (typeof msg === "string") {
+        errorMessage = msg;
+      }
+    } catch {
+      // ignore
+    }
+
+    return { ok: false, status: res.status, errorCode, errorMessage };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export async function detectZaiEndpoint(params: {
+  apiKey: string;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+}): Promise<ZaiDetectedEndpoint | null> {
+  // Never auto-probe in vitest; it would create flaky network behavior.
+  if (process.env.VITEST && !params.fetchFn) {
+    return null;
+  }
+
+  const timeoutMs = params.timeoutMs ?? 5_000;
+
+  // Prefer GLM-5 on the general API endpoints.
+  const glm5: Array<{ endpoint: ZaiEndpointId; baseUrl: string }> = [
+    { endpoint: "global", baseUrl: ZAI_GLOBAL_BASE_URL },
+    { endpoint: "cn", baseUrl: ZAI_CN_BASE_URL },
+  ];
+  for (const candidate of glm5) {
+    const result = await probeZaiChatCompletions({
+      baseUrl: candidate.baseUrl,
+      apiKey: params.apiKey,
+      modelId: "glm-5",
+      timeoutMs,
+      fetchFn: params.fetchFn,
+    });
+    if (result.ok) {
+      return {
+        endpoint: candidate.endpoint,
+        baseUrl: candidate.baseUrl,
+        modelId: "glm-5",
+        note: `Verified GLM-5 on ${candidate.endpoint} endpoint.`,
+      };
+    }
+  }
+
+  // Fallback: Coding Plan endpoint (GLM-5 not available there).
+  const coding: Array<{ endpoint: ZaiEndpointId; baseUrl: string }> = [
+    { endpoint: "coding-global", baseUrl: ZAI_CODING_GLOBAL_BASE_URL },
+    { endpoint: "coding-cn", baseUrl: ZAI_CODING_CN_BASE_URL },
+  ];
+  for (const candidate of coding) {
+    const result = await probeZaiChatCompletions({
+      baseUrl: candidate.baseUrl,
+      apiKey: params.apiKey,
+      modelId: "glm-4.7",
+      timeoutMs,
+      fetchFn: params.fetchFn,
+    });
+    if (result.ok) {
+      return {
+        endpoint: candidate.endpoint,
+        baseUrl: candidate.baseUrl,
+        modelId: "glm-4.7",
+        note: "Coding Plan endpoint detected; GLM-5 is not available there. Defaulting to GLM-4.7.",
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
What
- Make `zai-api-key` onboarding auto-detect the correct Z.AI endpoint by probing `glm-5` on the general API, then falling back to the Coding Plan endpoint + `glm-4.7`.
- Default Z.AI provider to the general API baseUrl + `zai/glm-5`.
- Add forward-compat fallback so `zai/glm-5` works even when the underlying pi-ai catalog lags.

Why
- Coding Plan endpoints don't currently support GLM-5; auto-detection keeps onboarding working for both key types with minimal user input.

Tests
- `pnpm test src/commands/zai-endpoint-detect.test.ts src/agents/pi-embedded-runner/model.test.ts src/commands/auth-choice.test.ts src/commands/onboard-non-interactive.provider-auth.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes Z.AI onboarding defaults to prefer the general Z.AI API base URL and `zai/glm-5`, and adds an auto-detection step for `--auth-choice zai-api-key` that probes `/chat/completions` to pick a working endpoint/model (GLM-5 on general endpoints, fallback to Coding Plan endpoints with GLM-4.7). It also adds a forward-compat model-resolution fallback so `zai/glm-5` can work even if the embedded pi-ai model catalog doesn’t include GLM-5 yet, by cloning the `glm-4.7` template.

The changes mainly touch onboarding/auth config application, add a new `detectZaiEndpoint` helper with tests, and update docs/tests to reflect the new default model and baseUrl behavior.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there are a couple of behavioral footguns in the Z.AI onboarding/detection flow that should be addressed first.
- Core logic is straightforward and covered by targeted tests, and the forward-compat model fallback is isolated. Remaining concerns are around subtle state handling in the interactive Z.AI key flow (`hasCredential` not updated after prompt) and a too-broad `process.env.VITEST` guard that can disable endpoint detection in non-test runs if that env var is present.
- src/commands/auth-choice.apply.api-providers.ts, src/commands/zai-endpoint-detect.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->