### PR TITLE
feat(whatsapp): extend markdown conversion with links, headings, and code block cleanup

### DIFF
--- a/src/markdown/whatsapp.test.ts
+++ b/src/markdown/whatsapp.test.ts
@@ -59,4 +59,43 @@ describe("markdownToWhatsApp", () => {
       "Before ```**bold** and ~~strike~~``` after *real bold*",
     );
   });
+
+  it("converts markdown links to text with URL", () => {
+    expect(markdownToWhatsApp("Visit [Google](https://google.com) now")).toBe(
+      "Visit Google (https://google.com) now",
+    );
+  });
+
+  it("converts multiple links", () => {
+    expect(markdownToWhatsApp("[A](https://a.com) and [B](https://b.com)")).toBe(
+      "A (https://a.com) and B (https://b.com)",
+    );
+  });
+
+  it("converts headings to bold", () => {
+    expect(markdownToWhatsApp("# Title")).toBe("*Title*");
+    expect(markdownToWhatsApp("## Subtitle")).toBe("*Subtitle*");
+    expect(markdownToWhatsApp("### Section")).toBe("*Section*");
+  });
+
+  it("converts headings in multiline text", () => {
+    expect(markdownToWhatsApp("# Title\n\nSome text\n\n## Next")).toBe(
+      "*Title*\n\nSome text\n\n*Next*",
+    );
+  });
+
+  it("strips language hints from fenced code blocks", () => {
+    const input = "```javascript\nconst x = 1;\n```";
+    expect(markdownToWhatsApp(input)).toBe("```\nconst x = 1;\n```");
+  });
+
+  it("strips language hints but preserves content", () => {
+    const input = "```python\ndef hello():\n    pass\n```";
+    expect(markdownToWhatsApp(input)).toBe("```\ndef hello():\n    pass\n```");
+  });
+
+  it("leaves fenced code blocks without language hints unchanged", () => {
+    const input = "```\nplain code\n```";
+    expect(markdownToWhatsApp(input)).toBe("```\nplain code\n```");
+  });
 });


### PR DESCRIPTION
#### Summary

Extends `markdownToWhatsApp()` (introduced in #14285) to handle three previously unsupported markdown patterns that were being sent raw to WhatsApp users.

lobster-biscuit

#### Use Cases

1. **Links**: `[Google](https://google.com)` → `Google (https://google.com)` — WhatsApp auto-links plain URLs, so extracting the URL makes it tappable
2. **Headings**: `# Title` → `*Title*` — renders as bold since WhatsApp has no heading syntax
3. **Code block language hints**: ````javascript\n...` `` `` → ````\n...` `` `` — strips useless language identifiers that clutter WhatsApp messages

#### Behavior Changes

| Input | Before | After |
|-------|--------|-------|
| `[link](url)` | `[link](url)` (raw) | `link (url)` |
| `# Heading` | `# Heading` (raw) | `*Heading*` |
| ` ```js\ncode\n``` ` | ` ```js\ncode\n``` ` | ` ```\ncode\n``` ` |

#### Existing Functionality Check

- [x] Searched codebase for existing functionality
  - `markdownToWhatsApp` in `src/markdown/whatsapp.ts` — the function being extended
  - Telegram uses IR-based pipeline (`src/telegram/format.ts`) — different architecture, not applicable here
  - Slack uses prefix-based formatting — different approach

#### Tests

8 new test cases added (20 total, all passing):
- Link conversion (single + multiple)
- Heading conversion (h1-h3 + multiline)
- Language hint stripping (with hint, without hint, content preservation)
- `pnpm build && pnpm check && pnpm test` all green

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: AI-assisted, fully tested
- Agent notes: Minimal regex additions to existing conversion pipeline. No architectural changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends `markdownToWhatsApp()` to transform a few previously-unhandled Markdown constructs into WhatsApp-friendly plain text formatting:

- Converts inline links (`[text](url)`) into `text (url)` to leverage WhatsApp’s URL auto-linking.
- Converts headings (`#`/`##`/`###`) into bold lines (`*Heading*`), since WhatsApp has no heading syntax.
- Removes fenced code block language identifiers (e.g., ```js) while preserving the code block content.

The changes are isolated to `src/markdown/whatsapp.ts` and its unit tests in `src/markdown/whatsapp.test.ts`, extending the existing regex-based conversion pipeline rather than adopting the richer IR-based formatting used in Telegram.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to markdown-to-WhatsApp formatting and are covered by expanded unit tests; no cross-cutting logic or external integrations were modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->