### PR TITLE
fix(whatsapp): use per-account dmPolicy in access control

### DIFF
--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -38,7 +38,7 @@ export async function checkInboundAccessControl(params: {
     cfg,
     accountId: params.accountId,
   });
-  const dmPolicy = cfg.channels?.whatsapp?.dmPolicy ?? "pairing";
+  const dmPolicy = account.dmPolicy ?? "pairing";
   const configuredAllowFrom = account.allowFrom;
   const storeAllowFrom = await readChannelAllowFromStore("whatsapp").catch(() => []);
   // Without user config, default to self-only DM access so the owner can talk to themselves.


### PR DESCRIPTION
Fixes #14789

One-line fix: `checkInboundAccessControl()` read `dmPolicy` from the top-level `channels.whatsapp` config, ignoring per-account overrides. Accounts with `dmPolicy: "allowlist"` fell back to `"pairing"` when no top-level `dmPolicy` was set.

Now uses `account.dmPolicy` from `resolveWhatsAppAccount()`, which already resolves the account → root fallback chain correctly.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes WhatsApp inbound access control to use the per-account `dmPolicy` resolved by `resolveWhatsAppAccount()` instead of reading only the top-level `cfg.channels.whatsapp.dmPolicy`.

This aligns `checkInboundAccessControl()` with the existing account→root fallback chain and fixes cases where an account configured with `dmPolicy: "allowlist"` was incorrectly treated as `"pairing"` when no top-level policy was set. No other behavior changes were introduced in the access-control logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line fix that swaps the dmPolicy source to the already-resolved per-account config, preserving the same default ("pairing") and improving correctness for multi-account setups. No control-flow changes were introduced beyond the policy lookup, and the policy value remains well-defined via existing fallback/defaults.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->