### PR TITLE
fix(agents): merge agent-level tools.exec config into exec tool creation

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -95,6 +95,42 @@ describe("Agent-specific tool filtering", () => {
     expect(toolNames).toContain("apply_patch");
   });
 
+  it("should allow apply_patch when agent-level applyPatch overrides global", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        allow: ["read", "exec"],
+        exec: {
+          // Global: applyPatch NOT enabled
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "patcher",
+            workspace: "~/openclaw-patcher",
+            tools: {
+              exec: {
+                applyPatch: { enabled: true },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:patcher:main",
+      workspaceDir: "/tmp/test-patcher",
+      agentDir: "/tmp/agent-patcher",
+      modelProvider: "openai",
+      modelId: "gpt-5.2",
+    });
+
+    const toolNames = tools.map((t) => t.name);
+    expect(toolNames).toContain("apply_patch");
+  });
+
   it("should apply agent-specific tool policy", () => {
     const cfg: OpenClawConfig = {
       tools: {

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -519,4 +519,73 @@ describe("Agent-specific tool filtering", () => {
 
     expect(result?.details.status).toBe("completed");
   });
+
+  it("should apply agent-level tools.exec config (host, security, safeBins)", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          host: "sandbox",
+          security: "deny",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "ops",
+            workspace: "~/openclaw-ops",
+            tools: {
+              exec: {
+                host: "gateway",
+                security: "allowlist",
+                ask: "on-miss",
+                safeBins: ["echo", "ls"],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    // The "ops" agent should get agent-level exec config (gateway + allowlist),
+    // not the global config (sandbox + deny).
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:ops:main",
+      workspaceDir: "/tmp/test-ops",
+      agentDir: "/tmp/agent-ops",
+    });
+    const execTool = tools.find((tool) => tool.name === "exec");
+    // If the global "deny" security were applied, exec would be completely blocked.
+    // The presence of the exec tool confirms agent-level config took effect.
+    expect(execTool).toBeDefined();
+  });
+
+  it("should fall back to global tools.exec when agent has no exec config", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "allowlist",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "basic",
+            workspace: "~/openclaw-basic",
+            // No tools.exec override
+          },
+        ],
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:basic:main",
+      workspaceDir: "/tmp/test-basic",
+      agentDir: "/tmp/agent-basic",
+    });
+    const execTool = tools.find((tool) => tool.name === "exec");
+    expect(execTool).toBeDefined();
+  });
 });

--- a/src/agents/pi-tools.safe-bins.test.ts
+++ b/src/agents/pi-tools.safe-bins.test.ts
@@ -36,16 +36,6 @@ vi.mock("../plugins/tools.js", () => ({
   resolvePluginTools: () => [],
 }));
 
-vi.mock("../infra/shell-env.js", async (importOriginal) => {
-  const mod = await importOriginal<typeof import("../infra/shell-env.js")>();
-  return { ...mod, getShellPathFromLoginShell: () => null };
-});
-
-vi.mock("../plugins/tools.js", () => ({
-  resolvePluginTools: () => [],
-  getPluginToolMeta: () => undefined,
-}));
-
 vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
   const mod = await importOriginal<typeof import("../infra/exec-approvals.js")>();
   const approvals: ExecApprovalsResolved = {

--- a/src/agents/pi-tools.safe-bins.test.ts
+++ b/src/agents/pi-tools.safe-bins.test.ts
@@ -130,4 +130,62 @@ describe("createOpenClawCodingTools safeBins", () => {
     expect(result.details.status).toBe("completed");
     expect(text).toContain(marker);
   });
+
+  it("threads agent-level tools.exec.safeBins into exec allowlist checks", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const { createOpenClawCodingTools } = await import("./pi-tools.js");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-safe-bins-"));
+    const cfg: OpenClawConfig = {
+      // No global safeBins configured
+      agents: {
+        list: [
+          {
+            id: "ops",
+            tools: {
+              exec: {
+                host: "gateway",
+                security: "allowlist",
+                ask: "off",
+                safeBins: ["echo"],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:ops:main",
+      workspaceDir: tmpDir,
+      agentDir: path.join(tmpDir, "agent"),
+    });
+    const execTool = tools.find((tool) => tool.name === "exec");
+    expect(execTool).toBeDefined();
+
+    const marker = `agent-safe-bins-${Date.now()}`;
+    const prevShellEnvTimeoutMs = process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS;
+    process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS = "1000";
+    const result = await (async () => {
+      try {
+        return await execTool!.execute("call1", {
+          command: `echo ${marker}`,
+          workdir: tmpDir,
+        });
+      } finally {
+        if (prevShellEnvTimeoutMs === undefined) {
+          delete process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS;
+        } else {
+          process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS = prevShellEnvTimeoutMs;
+        }
+      }
+    })();
+    const text = result.content.find((content) => content.type === "text")?.text ?? "";
+
+    expect(result.details.status).toBe("completed");
+    expect(text).toContain(marker);
+  });
 });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -238,7 +238,7 @@ export function createOpenClawCodingTools(options?: {
   const sandboxRoot = sandbox?.workspaceDir;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = options?.workspaceDir ?? process.cwd();
-  const applyPatchConfig = options?.config?.tools?.exec?.applyPatch;
+  const applyPatchConfig = execConfig.applyPatch;
   const applyPatchEnabled =
     !!applyPatchConfig?.enabled &&
     isOpenAIProvider(options?.modelProvider) &&

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -13,6 +13,7 @@ import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import {
   createExecTool,
@@ -86,21 +87,23 @@ function isApplyPatchAllowedForModel(params: {
   });
 }
 
-function resolveExecConfig(cfg: OpenClawConfig | undefined) {
+function resolveExecConfig(cfg: OpenClawConfig | undefined, agentId?: string) {
   const globalExec = cfg?.tools?.exec;
+  const agentExec = cfg && agentId ? resolveAgentConfig(cfg, agentId)?.tools?.exec : undefined;
   return {
-    host: globalExec?.host,
-    security: globalExec?.security,
-    ask: globalExec?.ask,
-    node: globalExec?.node,
-    pathPrepend: globalExec?.pathPrepend,
-    safeBins: globalExec?.safeBins,
-    backgroundMs: globalExec?.backgroundMs,
-    timeoutSec: globalExec?.timeoutSec,
-    approvalRunningNoticeMs: globalExec?.approvalRunningNoticeMs,
-    cleanupMs: globalExec?.cleanupMs,
-    notifyOnExit: globalExec?.notifyOnExit,
-    applyPatch: globalExec?.applyPatch,
+    host: agentExec?.host ?? globalExec?.host,
+    security: agentExec?.security ?? globalExec?.security,
+    ask: agentExec?.ask ?? globalExec?.ask,
+    node: agentExec?.node ?? globalExec?.node,
+    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
+    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    backgroundMs: agentExec?.backgroundMs ?? globalExec?.backgroundMs,
+    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    approvalRunningNoticeMs:
+      agentExec?.approvalRunningNoticeMs ?? globalExec?.approvalRunningNoticeMs,
+    cleanupMs: agentExec?.cleanupMs ?? globalExec?.cleanupMs,
+    notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
+    applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
   };
 }
 
@@ -231,7 +234,7 @@ export function createOpenClawCodingTools(options?: {
     sandbox?.tools,
     subagentPolicy,
   ]);
-  const execConfig = resolveExecConfig(options?.config);
+  const execConfig = resolveExecConfig(options?.config, agentId);
   const sandboxRoot = sandbox?.workspaceDir;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = options?.workspaceDir ?? process.cwd();


### PR DESCRIPTION
#### Summary

`resolveExecConfig()` in `pi-tools.ts` only read global `tools.exec` config, ignoring per-agent config in `agents.list[].tools.exec`. Agent-specific `host`, `security`, `ask`, `safeBins`, and other exec settings had no effect — agents intended to run with restricted exec permissions silently inherited global defaults.

Fixes #11832

#### Repro Steps

1. Configure an agent with restricted exec settings:
```json
{
  "agents": {
    "list": [{
      "id": "ops",
      "tools": {
        "exec": {
          "host": "gateway",
          "security": "allowlist",
          "safeBins": ["echo"]
        }
      }
    }]
  }
}
```
2. Run commands as the `ops` agent
3. Observe that exec uses global defaults instead of agent-level config

#### Root Cause

`resolveExecConfig()` (line 89) only reads `cfg?.tools?.exec` (global). It never calls `resolveAgentConfig()` to check `agents.list[].tools.exec`, even though `agentId` is available in scope at the call site.

The correct merge pattern already exists in `directive-handling.impl.ts:resolveExecDefaults()` (line 32-58), which properly merges agent-level config with precedence: `agentExec ?? globalExec ?? default`.

#### Behavior Changes

- Agent-level `tools.exec` config (`host`, `security`, `ask`, `node`, `pathPrepend`, `safeBins`, `backgroundMs`, `timeoutSec`, `approvalRunningNoticeMs`, `cleanupMs`, `notifyOnExit`, `applyPatch`) now takes precedence over global `tools.exec` when set
- No change when agent has no `tools.exec` override (falls back to global as before)

#### Codebase and GitHub Search

- Searched for existing pattern: `resolveExecDefaults` in `directive-handling.impl.ts` already implements correct merge logic
- Searched for `resolveAgentConfig` usage: used in 18 files for other agent config resolution
- Reviewed open PRs: #4825 (host defaulting) and #11185 (schema default) are related but orthogonal

#### Tests

- `pnpm test -- --run src/agents/pi-tools-agent-config.test.ts` — 17 tests pass (2 new: agent-level exec config applied, fallback to global)
- `pnpm test -- --run src/agents/pi-tools.safe-bins.test.ts` — 2 tests pass (1 new: agent-level safeBins threaded through)
- `pnpm build` — clean
- `pnpm check` — clean (format + lint + typecheck)

#### Manual Testing

N/A — covered by unit tests

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: AI-assisted with human review and direction
- Agent notes: lobster-biscuit. The fix is a minimal, focused change (3 files, ~145 lines added) that aligns `resolveExecConfig()` with the established pattern in `resolveExecDefaults()`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `createOpenClawCodingTools()` to merge per-agent `tools.exec` settings (from `agents.list[].tools.exec`) with the global `tools.exec` config when constructing the `exec` tool, so agent-level exec settings take precedence.

It also adds unit coverage to verify agent-level exec settings are respected and that `safeBins` is correctly threaded into allowlist checks.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but there are a couple of correctness issues to address before merging.
- Core change (merging agent-level exec config) is small and aligns with an existing pattern, but (1) apply_patch gating still reads only global exec config so agent-level applyPatch overrides won’t work, and (2) the new safe-bins test file has duplicate `vi.mock()` registrations that can make the tests brittle/misleading.
- src/agents/pi-tools.ts, src/agents/pi-tools.safe-bins.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->