### PR TITLE
fix: parse inline MEDIA: tokens in agent replies

### DIFF
--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -116,13 +116,6 @@ export function splitMediaFromOutput(raw: string): {
       continue;
     }
 
-    const trimmedStart = line.trimStart();
-    if (!trimmedStart.startsWith("MEDIA:")) {
-      keptLines.push(line);
-      lineOffset += line.length + 1; // +1 for newline
-      continue;
-    }
-
     const matches = Array.from(line.matchAll(MEDIA_TOKEN_RE));
     if (matches.length === 0) {
       keptLines.push(line);

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -153,8 +153,13 @@ export function splitMediaFromOutput(raw: string): {
       const trimmedPayload = payloadValue.trim();
       const looksLikeLocalPath =
         isLikelyLocalPath(trimmedPayload) || trimmedPayload.startsWith("file://");
+      // Only apply the "path with spaces" fallback when MEDIA: is at line start.
+      // When MEDIA: appears inline (preceded by other text), trailing words are
+      // likely prose, not part of the file path.
+      const isInlineToken = start > 0 && line.slice(0, start).trim().length > 0;
       if (
         !unwrapped &&
+        !isInlineToken &&
         validCount === 1 &&
         invalidParts.length > 0 &&
         /\s/.test(payloadValue) &&

--- a/src/media/reproduce_issue.test.ts
+++ b/src/media/reproduce_issue.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { splitMediaFromOutput } from "./parse.js";
+
+describe("splitMediaFromOutput - Reproduction of #13790", () => {
+  it("should extract MEDIA from text even when preceded by text", () => {
+    const input = "Here is your audio:\nMEDIA:/tmp/tts-123/voice.opus";
+    const result = splitMediaFromOutput(input);
+    expect(result.mediaUrls).toEqual(["/tmp/tts-123/voice.opus"]);
+    expect(result.text).toBe("Here is your audio:");
+  });
+
+  it("should extract inline MEDIA tokens in the same line", () => {
+    const input = "Here is your audio: MEDIA:/tmp/tts-123/voice.opus";
+    const result = splitMediaFromOutput(input);
+    expect(result.mediaUrls).toEqual(["/tmp/tts-123/voice.opus"]);
+    expect(result.text).toBe("Here is your audio:");
+  });
+
+  it("should handle MEDIA with a space after the colon", () => {
+    const input = "MEDIA: /tmp/tts-123/voice.opus";
+    const result = splitMediaFromOutput(input);
+    expect(result.mediaUrls).toEqual(["/tmp/tts-123/voice.opus"]);
+  });
+
+  it("should NOT extract MEDIA from inside code fences (baseline check)", () => {
+    const input = "```txt\nMEDIA:/tmp/tts-123/voice.opus\n```";
+    const result = splitMediaFromOutput(input);
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toContain("MEDIA:/tmp/tts-123/voice.opus");
+  });
+});

--- a/src/media/reproduce_issue.test.ts
+++ b/src/media/reproduce_issue.test.ts
@@ -22,6 +22,22 @@ describe("splitMediaFromOutput - Reproduction of #13790", () => {
     expect(result.mediaUrls).toEqual(["/tmp/tts-123/voice.opus"]);
   });
 
+  it("should not capture trailing text after an inline MEDIA path", () => {
+    const input = "Here is your audio: MEDIA:/tmp/voice.opus and enjoy";
+    const result = splitMediaFromOutput(input);
+    // The parser splits payload by whitespace and validates each part.
+    // "/tmp/voice.opus" is valid media, "and" and "enjoy" are not.
+    expect(result.mediaUrls).toEqual(["/tmp/voice.opus"]);
+    // Trailing non-media words should be preserved in text output
+    expect(result.text).toMatch(/and enjoy/);
+  });
+
+  it("should support backtick-quoted paths with spaces", () => {
+    const input = "MEDIA:`/tmp/file with spaces.opus`";
+    const result = splitMediaFromOutput(input);
+    expect(result.mediaUrls).toEqual(["/tmp/file with spaces.opus"]);
+  });
+
   it("should NOT extract MEDIA from inside code fences (baseline check)", () => {
     const input = "```txt\nMEDIA:/tmp/tts-123/voice.opus\n```";
     const result = splitMediaFromOutput(input);

--- a/src/media/reproduce_issue.test.ts
+++ b/src/media/reproduce_issue.test.ts
@@ -38,6 +38,15 @@ describe("splitMediaFromOutput - Reproduction of #13790", () => {
     expect(result.mediaUrls).toEqual(["/tmp/file with spaces.opus"]);
   });
 
+  it("should handle prose containing MEDIA: mid-sentence", () => {
+    const input = "Docs: MEDIA:/tmp/foo.png is used for thumbnails";
+    const result = splitMediaFromOutput(input);
+    // The inline MEDIA: token should extract the valid path but preserve surrounding prose
+    expect(result.mediaUrls).toEqual(["/tmp/foo.png"]);
+    expect(result.text).toMatch(/Docs:/);
+    expect(result.text).toMatch(/is used for thumbnails/);
+  });
+
   it("should NOT extract MEDIA from inside code fences (baseline check)", () => {
     const input = "```txt\nMEDIA:/tmp/tts-123/voice.opus\n```";
     const result = splitMediaFromOutput(input);

--- a/src/media/reproduce_issue.test.ts
+++ b/src/media/reproduce_issue.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { splitMediaFromOutput } from "./parse.js";
 
 describe("splitMediaFromOutput - Reproduction of #13790", () => {


### PR DESCRIPTION
## Problem

Fixes #13790

When an agent reply contains an inline `MEDIA:` tag (e.g. `Here is your audio: MEDIA:/tmp/voice.opus`), it was not detected and delivered as an attachment on Telegram. The literal text path was sent instead.

## Root Cause

`splitMediaFromOutput` in `src/media/parse.ts` had an early-return guard that skipped any line where `MEDIA:` didn't appear at the start of the line (after trimming). This meant inline `MEDIA:` tokens were never matched by the regex.

## Fix

Removed the `trimmedStart.startsWith("MEDIA:")` guard so the `MEDIA_TOKEN_RE` regex runs on every line, catching both line-start and inline tokens.

## Tests

- Added regression test in `src/media/reproduce_issue.test.ts` covering inline MEDIA tokens
- Test fails on `main` (confirms it catches the bug), passes with the fix
- All 59 existing media tests continue to pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes update `splitMediaFromOutput` to scan every line for `MEDIA:` tokens (not just lines that start with `MEDIA:`), enabling inline tokens like `Here is your audio: MEDIA:/tmp/voice.opus` to be extracted into `mediaUrls` and removed from the rendered text. A small guard was also added to avoid the "path with spaces" fallback when the token is inline (to reduce accidental capture of trailing prose).

A new regression test file exercises inline tokens, spacing after the colon, quoted paths with spaces, and confirms fenced code blocks are not parsed for media tokens.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and appears to fix the reported Telegram attachment parsing issue.
- The change is localized to media token parsing, includes targeted regression tests (including inline-token coverage), and existing behavior around fenced code blocks and audio tags remains intact based on code review. The only notable risk area is the semantics of extracting inline `MEDIA:` sequences in prose, but that concern is already tracked in prior review threads for this PR.
- src/media/parse.ts (token syntax/edge-case semantics)

<sub>Last reviewed commit: 2a9824d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->