### PR TITLE
fix: add garbage collection for cron session records (#14773)

### DIFF
--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -8,4 +8,9 @@ export type CronConfig = {
    * Default: "24h".
    */
   sessionRetention?: string | false;
+  /**
+   * Maximum number of completed cron run sessions to retain in the store.
+   * Older entries (by updatedAt) are pruned first. Default: 50.
+   */
+  maxCronRunSessions?: number;
 };


### PR DESCRIPTION
Closes #14773

## Problem

Cron run records in `agents/*/sessions/sessions.json` accumulated indefinitely. Each cron run left ~15KB. The file grew to 14MB (960 entries), exceeding the context window and causing a cascading cooldown and system lockout.

The existing timer-based session reaper couldn't break the death spiral because it only runs during cron timer ticks — which themselves fail when the context overflows.

## Solution

Add automatic garbage collection for cron session records that runs **unconditionally during every session store save**, regardless of maintenance mode (`warn` vs `enforce`). This breaks the death spiral by pruning cron sessions as a side-effect of normal save operations.

Two complementary strategies:

1. **TTL-based pruning** — remove cron run sessions older than the retention period (default 24h, configurable via `cron.sessionRetention`)
2. **Cap-based pruning** — keep at most N most-recent cron run sessions (default 50, configurable via new `cron.maxCronRunSessions` config)

## Changes

- **`src/config/sessions/store.ts`** — Add `pruneCronRunSessions()` with TTL + cap logic; call it in `saveSessionStoreUnlocked` before general maintenance
- **`src/config/types.cron.ts`** — Add `maxCronRunSessions` config field
- **`src/cron/session-reaper.ts`** — Update timer-based reaper to also enforce the max cap
- **`src/config/sessions/store.pruning.test.ts`** — Add 9 new tests (7 unit + 2 integration)
- **`src/cron/session-reaper.test.ts`** — Add 2 new tests for cap enforcement

All 54 new + existing tests pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds automatic garbage collection for cron run session records (`agent:*:cron:<job>:run:<id>`) to prevent `sessions.json` from growing without bound and causing context-window lockouts. The new `pruneCronRunSessions()` runs during every session store save (even in `session.maintenance.mode: "warn"`) and prunes cron runs by TTL (`cron.sessionRetention`, default 24h) and by a new cap (`cron.maxCronRunSessions`, default 50). The existing timer-based cron session reaper is also updated to enforce the same max-cap behavior, and the test suite is extended to cover TTL + cap interactions and warn-mode behavior.

One functional inconsistency remains: in the timer reaper path, disabling TTL (`sessionRetention: false`) currently skips cap enforcement as well, which undermines the “TTL + cap are complementary” intent and differs from the save-path GC implementation.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix the timer reaper cap/TTL interaction first.
- Core change is localized and well-tested, but `sweepCronRunSessions` currently bypasses the new `maxCronRunSessions` cap when `sessionRetention` is disabled, which can allow unbounded cron session growth in that configuration.
- src/cron/session-reaper.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->