### PR TITLE
fix: replace hardcoded /tmp/openclaw with os.tmpdir() fallback

### DIFF
--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -1,6 +1,7 @@
 import type { Page } from "playwright-core";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
   ensurePageState,
@@ -20,7 +21,7 @@ import {
 function buildTempDownloadPath(fileName: string): string {
   const id = crypto.randomUUID();
   const safeName = fileName.trim() ? fileName.trim() : "download.bin";
-  return path.join("/tmp/openclaw/downloads", `${id}-${safeName}`);
+  return path.join(os.tmpdir(), "openclaw", "downloads", `${id}-${safeName}`);
 }
 
 function createPageDownloadWaiter(page: Page, timeoutMs: number) {

--- a/src/browser/routes/agent.debug.ts
+++ b/src/browser/routes/agent.debug.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import type { BrowserRouteContext } from "../server-context.js";
 import type { BrowserRouteRegistrar } from "./types.js";
@@ -131,7 +132,7 @@ export function registerBrowserAgentDebugRoutes(
         return;
       }
       const id = crypto.randomUUID();
-      const dir = "/tmp/openclaw";
+      const dir = path.join(os.tmpdir(), "openclaw");
       await fs.mkdir(dir, { recursive: true });
       const tracePath = out.trim() || path.join(dir, `browser-trace-${id}.zip`);
       await pw.traceStopViaPlaywright({

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
 import type { OpenClawConfig } from "../config/types.js";
@@ -8,9 +9,18 @@ import { readLoggingConfig } from "./config.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
 import { loggingState } from "./state.js";
 
-// Pin to /tmp so mac Debug UI and docs match; os.tmpdir() can be a per-user
-// randomized path on macOS which made the “Open log” button a no-op.
-export const DEFAULT_LOG_DIR = "/tmp/openclaw";
+// Prefer /tmp/openclaw so macOS Debug UI and docs match, but fall back to
+// os.tmpdir() on platforms where /tmp is read-only (e.g. Termux/Android).
+function resolveDefaultLogDir(): string {
+  try {
+    fs.mkdirSync("/tmp/openclaw", { recursive: true });
+    return "/tmp/openclaw";
+  } catch {
+    return path.join(os.tmpdir(), "openclaw");
+  }
+}
+
+export const DEFAULT_LOG_DIR = resolveDefaultLogDir();
 export const DEFAULT_LOG_FILE = path.join(DEFAULT_LOG_DIR, "openclaw.log"); // legacy single-file path
 
 const LOG_PREFIX = "openclaw";


### PR DESCRIPTION
Fixes #14802

`/tmp` is read-only on Termux/Android, causing `ENOENT` on startup. The logger now tries `/tmp/openclaw` first (preserving macOS Debug UI compatibility) and falls back to `os.tmpdir()/openclaw`. Browser download and trace paths also use `os.tmpdir()`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes hardcoded `/tmp/openclaw` usage in a few browser-related paths by switching default download/trace outputs to `os.tmpdir()/openclaw/...`, and updates the logger to prefer `/tmp/openclaw` (for macOS debug UI expectations) while falling back to `os.tmpdir()/openclaw` when `/tmp` isn’t writable (e.g., Termux/Android).

Overall this aligns temp file creation with Node’s platform temp directory, but there’s a user-facing CLI help string that still documents `/tmp/openclaw/downloads/...` as the default even though the runtime default changed.

<h3>Confidence Score: 4/5</h3>

- This PR is broadly safe to merge after correcting a small user-facing documentation mismatch.
- The code changes are localized and use standard Node APIs (`os.tmpdir()`), with a defensive fallback for logger directory creation. The only concrete regression found is a CLI help string that no longer reflects the actual default download location, which could confuse users but won’t break runtime behavior.
- src/cli/browser-cli-actions-input/register.files-downloads.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->