### PR TITLE
fix(memory): await sync in search() to prevent stale results

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -273,9 +273,11 @@ export class MemoryIndexManager implements MemorySearchManager {
   ): Promise<MemorySearchResult[]> {
     void this.warmSession(opts?.sessionKey);
     if (this.settings.sync.onSearch && (this.dirty || this.sessionsDirty)) {
-      void this.sync({ reason: "search" }).catch((err) => {
+      try {
+        await this.sync({ reason: "search" });
+      } catch (err) {
         log.warn(`memory sync failed (search): ${String(err)}`);
-      });
+      }
     }
     const cleaned = query.trim();
     if (!cleaned) {


### PR DESCRIPTION
Fixes #14770

The `onSearch` sync was fire-and-forget (`void this.sync()`), so the first `memory_search` after file changes returned stale results.

Now awaits the sync before searching, ensuring the index is up-to-date.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Change makes `MemoryIndexManager.search()` wait for an in-progress or newly triggered `sync({ reason: "search" })` when `sync.onSearch` is enabled and the index is marked dirty. This prevents the first `memory_search` after file/session updates from using stale index data, while preserving the previous behavior of logging (and continuing) on sync failures.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to awaiting an existing sync operation in `search()`, and uses the same failure handling semantics (warn and proceed). No API, schema, or side-effect changes beyond ordering/awaiting were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->