### PR TITLE
fix:sandbox file path Inconsistency

### DIFF
--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -1,5 +1,5 @@
-import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { SandboxWorkspaceInfo } from "../../agents/sandbox/types.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { GroupToolPolicyConfig } from "../../config/types.tools.js";
 import type { OutboundDeliveryResult, OutboundSendDeps } from "../../infra/outbound/deliver.js";

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -1,4 +1,5 @@
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { SandboxWorkspaceInfo } from "../../agents/sandbox/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { GroupToolPolicyConfig } from "../../config/types.tools.js";
 import type { OutboundDeliveryResult, OutboundSendDeps } from "../../infra/outbound/deliver.js";
@@ -80,6 +81,12 @@ export type ChannelOutboundContext = {
   threadId?: string | number | null;
   accountId?: string | null;
   deps?: OutboundSendDeps;
+  /**
+   * Sandbox workspace info for automatic path resolution.
+   * When present, file paths in container format (/workspace/file.txt)
+   * will be automatically converted to host paths.
+   */
+  sandboxWorkspace?: SandboxWorkspaceInfo | null;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1,21 +1,17 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import type { SandboxWorkspaceInfo } from "../../agents/sandbox/types.js";
 import type {
   ChannelId,
   ChannelMessageActionName,
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.js";
-import type { SandboxWorkspaceInfo } from "../../agents/sandbox/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { OutboundSendDeps } from "./deliver.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { assertMediaNotDataUrl, resolveSandboxedMediaSource } from "../../agents/sandbox-paths.js";
-import {
-  getSandboxContextForSession,
-  resolveFilePathsInParams,
-} from "./sandbox-path-resolver.js";
 import {
   readNumberParam,
   readStringArrayParam,
@@ -49,6 +45,7 @@ import {
 } from "./outbound-policy.js";
 import { executePollAction, executeSendAction } from "./outbound-send-service.js";
 import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
+import { getSandboxContextForSession, resolveFilePathsInParams } from "./sandbox-path-resolver.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
 
 export type MessageActionRunnerGateway = {

--- a/src/infra/outbound/sandbox-path-resolver.test.ts
+++ b/src/infra/outbound/sandbox-path-resolver.test.ts
@@ -34,10 +34,7 @@ describe("resolveSandboxFilePath", () => {
   });
 
   it("should handle paths with special characters", () => {
-    const result = resolveSandboxFilePath(
-      "/workspace/my file (1).txt",
-      mockSandboxWorkspace,
-    );
+    const result = resolveSandboxFilePath("/workspace/my file (1).txt", mockSandboxWorkspace);
     expect(result).toBe("/opt/openclaw/sandboxes/agent-test-123/my file (1).txt");
   });
 
@@ -166,7 +163,7 @@ describe("getSandboxContextForSession", () => {
   it("should return null for missing sessionKey", async () => {
     const result = await import("./sandbox-path-resolver.js").then((m) =>
       m.getSandboxContextForSession({
-        cfg: {} as any,
+        cfg: {} as unknown as import("../../config/config.js").OpenClawConfig,
         sessionKey: undefined,
       }),
     );
@@ -176,7 +173,7 @@ describe("getSandboxContextForSession", () => {
   it("should return null for empty sessionKey", async () => {
     const result = await import("./sandbox-path-resolver.js").then((m) =>
       m.getSandboxContextForSession({
-        cfg: {} as any,
+        cfg: {} as unknown as import("../../config/config.js").OpenClawConfig,
         sessionKey: "",
       }),
     );

--- a/src/infra/outbound/sandbox-path-resolver.test.ts
+++ b/src/infra/outbound/sandbox-path-resolver.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import type { SandboxWorkspaceInfo } from "../../agents/sandbox/types.js";
+import {
+  resolveSandboxFilePath,
+  resolveFilePathsInParams,
+  clearSandboxContextCache,
+} from "./sandbox-path-resolver.js";
+
+describe("resolveSandboxFilePath", () => {
+  const mockSandboxWorkspace: SandboxWorkspaceInfo = {
+    workspaceDir: "/opt/openclaw/sandboxes/agent-test-123",
+    containerWorkdir: "/workspace",
+    workspaceAccess: "rw",
+  };
+
+  it("should resolve container path to host path", () => {
+    const result = resolveSandboxFilePath("/workspace/file.txt", mockSandboxWorkspace);
+    expect(result).toBe("/opt/openclaw/sandboxes/agent-test-123/file.txt");
+  });
+
+  it("should handle nested container paths", () => {
+    const result = resolveSandboxFilePath("/workspace/subdir/file.pdf", mockSandboxWorkspace);
+    expect(result).toBe("/opt/openclaw/sandboxes/agent-test-123/subdir/file.pdf");
+  });
+
+  it("should return original path for non-sandbox environment", () => {
+    const result = resolveSandboxFilePath("/home/user/file.txt", null);
+    expect(result).toBe("/home/user/file.txt");
+  });
+
+  it("should return original path if not in container workdir", () => {
+    const result = resolveSandboxFilePath("/opt/openclaw/file.txt", mockSandboxWorkspace);
+    expect(result).toBe("/opt/openclaw/file.txt");
+  });
+
+  it("should handle paths with special characters", () => {
+    const result = resolveSandboxFilePath(
+      "/workspace/my file (1).txt",
+      mockSandboxWorkspace,
+    );
+    expect(result).toBe("/opt/openclaw/sandboxes/agent-test-123/my file (1).txt");
+  });
+
+  it("should handle root workspace path", () => {
+    const result = resolveSandboxFilePath("/workspace", mockSandboxWorkspace);
+    expect(result).toBe("/opt/openclaw/sandboxes/agent-test-123");
+  });
+
+  it("should handle workspace path with trailing slash", () => {
+    const result = resolveSandboxFilePath("/workspace/", mockSandboxWorkspace);
+    expect(result).toBe("/opt/openclaw/sandboxes/agent-test-123/");
+  });
+});
+
+describe("resolveFilePathsInParams", () => {
+  const mockSandboxWorkspace: SandboxWorkspaceInfo = {
+    workspaceDir: "/opt/openclaw/sandboxes/agent-test-123",
+    containerWorkdir: "/workspace",
+    workspaceAccess: "rw",
+  };
+
+  beforeEach(() => {
+    clearSandboxContextCache();
+  });
+
+  it("should resolve filePath parameter", () => {
+    const params = {
+      filePath: "/workspace/file.txt",
+      message: "Hello",
+    };
+
+    const result = resolveFilePathsInParams(params, mockSandboxWorkspace);
+
+    expect(result.filePath).toBe("/opt/openclaw/sandboxes/agent-test-123/file.txt");
+    expect(result.message).toBe("Hello");
+  });
+
+  it("should resolve multiple file path parameters", () => {
+    const params = {
+      filePath: "/workspace/file1.txt",
+      path: "/workspace/file2.pdf",
+      media: "/workspace/image.png",
+    };
+
+    const result = resolveFilePathsInParams(params, mockSandboxWorkspace);
+
+    expect(result.filePath).toBe("/opt/openclaw/sandboxes/agent-test-123/file1.txt");
+    expect(result.path).toBe("/opt/openclaw/sandboxes/agent-test-123/file2.pdf");
+    expect(result.media).toBe("/opt/openclaw/sandboxes/agent-test-123/image.png");
+  });
+
+  it("should not modify non-path parameters", () => {
+    const params = {
+      filePath: "/workspace/file.txt",
+      count: 42,
+      flag: true,
+      url: "http://example.com/file.txt",
+    };
+
+    const result = resolveFilePathsInParams(params, mockSandboxWorkspace);
+
+    expect(result.count).toBe(42);
+    expect(result.flag).toBe(true);
+    expect(result.url).toBe("http://example.com/file.txt");
+  });
+
+  it("should not modify relative paths", () => {
+    const params = {
+      filePath: "./relative/file.txt",
+      path: "relative/file2.txt",
+    };
+
+    const result = resolveFilePathsInParams(params, mockSandboxWorkspace);
+
+    expect(result.filePath).toBe("./relative/file.txt");
+    expect(result.path).toBe("relative/file2.txt");
+  });
+
+  it("should handle non-sandbox environment", () => {
+    const params = {
+      filePath: "/workspace/file.txt",
+      message: "Hello",
+    };
+
+    const result = resolveFilePathsInParams(params, null);
+
+    expect(result.filePath).toBe("/workspace/file.txt");
+    expect(result.message).toBe("Hello");
+  });
+
+  it("should support custom file keys", () => {
+    const params = {
+      customPath: "/workspace/file.txt",
+      anotherPath: "/workspace/file2.txt",
+      message: "Hello",
+    };
+
+    const result = resolveFilePathsInParams(params, mockSandboxWorkspace, [
+      "customPath",
+      "anotherPath",
+    ]);
+
+    expect(result.customPath).toBe("/opt/openclaw/sandboxes/agent-test-123/file.txt");
+    expect(result.anotherPath).toBe("/opt/openclaw/sandboxes/agent-test-123/file2.txt");
+    expect(result.message).toBe("Hello");
+  });
+
+  it("should not mutate original params object", () => {
+    const params = {
+      filePath: "/workspace/file.txt",
+      message: "Hello",
+    };
+
+    const result = resolveFilePathsInParams(params, mockSandboxWorkspace);
+
+    expect(params.filePath).toBe("/workspace/file.txt");
+    expect(result).not.toBe(params);
+  });
+});
+
+describe("getSandboxContextForSession", () => {
+  beforeEach(() => {
+    clearSandboxContextCache();
+  });
+
+  it("should return null for missing sessionKey", async () => {
+    const result = await import("./sandbox-path-resolver.js").then((m) =>
+      m.getSandboxContextForSession({
+        cfg: {} as any,
+        sessionKey: undefined,
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("should return null for empty sessionKey", async () => {
+    const result = await import("./sandbox-path-resolver.js").then((m) =>
+      m.getSandboxContextForSession({
+        cfg: {} as any,
+        sessionKey: "",
+      }),
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/infra/outbound/sandbox-path-resolver.ts
+++ b/src/infra/outbound/sandbox-path-resolver.ts
@@ -1,7 +1,7 @@
-import type { OpenClawConfig } from "../../config/config.js";
-import type { SandboxWorkspaceInfo } from "../../agents/sandbox/types.js";
-import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import path from "node:path";
+import type { SandboxWorkspaceInfo } from "../../agents/sandbox/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 
 /**
  * Generic sandbox path resolver
@@ -14,8 +14,8 @@ import path from "node:path";
  * @returns Resolved host path
  */
 export function resolveSandboxFilePath(
-    filePath: string,
-    sandboxWorkspace: SandboxWorkspaceInfo | null,
+  filePath: string,
+  sandboxWorkspace: SandboxWorkspaceInfo | null,
 ): string {
   // Non-sandbox environment, return directly
   if (!sandboxWorkspace) {
@@ -90,9 +90,9 @@ export async function getSandboxContextForSession(params: {
  * @returns Converted parameters object
  */
 export function resolveFilePathsInParams(
-    params: Record<string, unknown>,
-    sandboxWorkspace: SandboxWorkspaceInfo | null,
-    fileKeys: string[] = ["filePath", "path", "media"],
+  params: Record<string, unknown>,
+  sandboxWorkspace: SandboxWorkspaceInfo | null,
+  fileKeys: string[] = ["filePath", "path", "media"],
 ): Record<string, unknown> {
   if (!sandboxWorkspace) {
     return params;

--- a/src/infra/outbound/sandbox-path-resolver.ts
+++ b/src/infra/outbound/sandbox-path-resolver.ts
@@ -1,0 +1,118 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SandboxWorkspaceInfo } from "../../agents/sandbox/types.js";
+import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
+import path from "node:path";
+
+/**
+ * Generic sandbox path resolver
+ *
+ * Converts container paths (/workspace/file.txt) to host paths
+ * (/opt/openclaw/sandboxes/agent-xxx/file.txt)
+ *
+ * @param filePath - Original file path (container path or host path)
+ * @param sandboxWorkspace - Sandbox workspace info (null means non-sandbox environment)
+ * @returns Resolved host path
+ */
+export function resolveSandboxFilePath(
+    filePath: string,
+    sandboxWorkspace: SandboxWorkspaceInfo | null,
+): string {
+  // Non-sandbox environment, return directly
+  if (!sandboxWorkspace) {
+    return filePath;
+  }
+
+  // If path starts with container workdir, convert to host path
+  if (filePath.startsWith(sandboxWorkspace.containerWorkdir)) {
+    const relativePath = filePath.slice(sandboxWorkspace.containerWorkdir.length);
+    return path.join(sandboxWorkspace.workspaceDir, relativePath);
+  }
+
+  // Otherwise return original path (may already be host path)
+  return filePath;
+}
+
+/**
+ * Sandbox context cache
+ * Key: sessionKey
+ * Value: SandboxWorkspaceInfo | null
+ */
+const sandboxContextCache = new Map<string, SandboxWorkspaceInfo | null>();
+
+/**
+ * Cache TTL (5 minutes)
+ */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Get sandbox context for session (with caching)
+ *
+ * @param params - Configuration and session key
+ * @returns Sandbox workspace info (null means non-sandbox environment)
+ */
+export async function getSandboxContextForSession(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+}): Promise<SandboxWorkspaceInfo | null> {
+  if (!params.sessionKey) {
+    return null;
+  }
+
+  // Try to get from cache
+  const cached = sandboxContextCache.get(params.sessionKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  // Get sandbox context
+  const context = await ensureSandboxWorkspaceForSession({
+    config: params.cfg,
+    sessionKey: params.sessionKey,
+  });
+
+  // Cache result
+  sandboxContextCache.set(params.sessionKey, context);
+
+  // Set expiration cleanup
+  setTimeout(() => {
+    sandboxContextCache.delete(params.sessionKey!);
+  }, CACHE_TTL_MS);
+
+  return context;
+}
+
+/**
+ * Batch convert file paths in parameters
+ *
+ * @param params - Original parameters object
+ * @param sandboxWorkspace - Sandbox workspace info
+ * @param fileKeys - List of parameter names to convert
+ * @returns Converted parameters object
+ */
+export function resolveFilePathsInParams(
+    params: Record<string, unknown>,
+    sandboxWorkspace: SandboxWorkspaceInfo | null,
+    fileKeys: string[] = ["filePath", "path", "media"],
+): Record<string, unknown> {
+  if (!sandboxWorkspace) {
+    return params;
+  }
+
+  const resolved = { ...params };
+
+  for (const key of fileKeys) {
+    const value = resolved[key];
+    if (typeof value === "string" && value.startsWith("/")) {
+      resolved[key] = resolveSandboxFilePath(value, sandboxWorkspace);
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Clear sandbox context cache (for testing or manual cleanup)
+ */
+export function clearSandboxContextCache(): void {
+  sandboxContextCache.clear();
+}

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -4,6 +4,14 @@ export {
   BLUEBUBBLES_ACTION_NAMES,
   BLUEBUBBLES_GROUP_ACTIONS,
 } from "../channels/plugins/bluebubbles-actions.js";
+export { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+export { ensureSandboxWorkspaceForSession } from "../agents/sandbox/context.js";
+export type { SandboxWorkspaceInfo } from "../agents/sandbox/types.js";
+export {
+  resolveSandboxFilePath,
+  getSandboxContextForSession,
+  resolveFilePathsInParams,
+} from "../infra/outbound/sandbox-path-resolver.js";
 export type {
   ChannelAccountSnapshot,
   ChannelAccountState,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a sandbox path resolver to translate container paths (e.g. `/workspace/...`) into host workspace paths, and wires it into `runMessageAction` so outbound actions can accept sandbox-style file parameters (`filePath`, `path`, `media`). It also exports the new resolver utilities via the plugin SDK and adds unit tests for the resolver behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has at least one definite TypeScript test failure and a concrete path-resolution logic bug that can mis-rewrite certain absolute paths.
- Core change is small and localized, but the new test file uses an invalid `SandboxWorkspaceInfo` shape (will not typecheck) and the resolver’s `startsWith` check will incorrectly rewrite paths that share a prefix with the container workdir (e.g. `/workspace2/...`).
- src/infra/outbound/sandbox-path-resolver.ts, src/infra/outbound/sandbox-path-resolver.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->