### PR TITLE
feat(gateway): route chat/agent events per-connection instead of glob…

### DIFF
--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -20,6 +20,12 @@ export function startGatewayMaintenanceTimers(params: {
       stateVersion?: { presence?: number; health?: number };
     },
   ) => void;
+  broadcastToConnIds?: (
+    event: string,
+    payload: unknown,
+    connIds: ReadonlySet<string>,
+    opts?: { dropIfSlow?: boolean },
+  ) => void;
   nodeSendToAllSubscribed: (event: string, payload: unknown) => void;
   getPresenceVersion: () => number;
   getHealthVersion: () => number;
@@ -37,6 +43,7 @@ export function startGatewayMaintenanceTimers(params: {
   ) => ChatRunEntry | undefined;
   agentRunSeq: Map<string, number>;
   nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
+  getRunRecipients?: (runId: string) => ReadonlySet<string> | undefined;
 }): {
   tickInterval: ReturnType<typeof setInterval>;
   healthInterval: ReturnType<typeof setInterval>;
@@ -100,6 +107,8 @@ export function startGatewayMaintenanceTimers(params: {
           agentRunSeq: params.agentRunSeq,
           broadcast: params.broadcast,
           nodeSendToSession: params.nodeSendToSession,
+          broadcastToConnIds: params.broadcastToConnIds,
+          getRunRecipients: params.getRunRecipients,
         },
         { runId, sessionKey: entry.sessionKey, stopReason: "timeout" },
       );

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -71,6 +71,7 @@ export type GatewayRequestContext = {
     sessionKey?: string,
   ) => { sessionKey: string; clientRunId: string } | undefined;
   registerToolEventRecipient: (runId: string, connId: string) => void;
+  getRunRecipients: (runId: string) => ReadonlySet<string> | undefined;
   dedupe: Map<string, DedupeEntry>;
   wizardSessions: Map<string, WizardSession>;
   findRunningWizard: () => string | null;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -425,6 +425,7 @@ export async function startGatewayServer(
 
   const { tickInterval, healthInterval, dedupeCleanup } = startGatewayMaintenanceTimers({
     broadcast,
+    broadcastToConnIds,
     nodeSendToAllSubscribed,
     getPresenceVersion,
     getHealthVersion,
@@ -438,6 +439,7 @@ export async function startGatewayServer(
     removeChatRun,
     agentRunSeq,
     nodeSendToSession,
+    getRunRecipients: toolEventRecipients.get,
   });
 
   const agentUnsub = onAgentEvent(
@@ -515,6 +517,7 @@ export async function startGatewayServer(
       addChatRun,
       removeChatRun,
       registerToolEventRecipient: toolEventRecipients.add,
+      getRunRecipients: toolEventRecipients.get,
       dedupe,
       wizardSessions,
       findRunningWizard,


### PR DESCRIPTION
…al broadcast

The existing toolEventRecipientRegistry already maps runId → connId for tool events via broadcastToConnIds(). This change extends that pattern to chat and agent events so that in multi-user deployments each WebSocket client only receives events for its own session.

Changes:
- Always register connId in toolEventRecipientRegistry (remove wantsToolEvents gate)
- Add optional runId parameter to emitChatDelta/emitChatFinal to look up registered recipients and route via broadcastToConnIds
- Extend ChatAbortOps with optional broadcastToConnIds/getRunRecipients so aborted events are also routed per-connection
- Expose getRunRecipients on GatewayRequestContext and thread it through server-maintenance → chat-abort
- All new fields are optional; every call site falls back to global broadcast() when no connId is registered, preserving full backward compatibility for single-user deployments

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change extends the existing `ToolEventRecipientRegistry` (runId → connIds) routing pattern beyond tool events to cover `chat` deltas/finals, `agent` events, and `chat aborted` events. The gateway now registers a websocket connection id for each agent run and, when recipients exist for a run, emits `chat`/`agent` via `broadcastToConnIds` instead of global `broadcast`, while still forwarding to the node session bus.

Notable wiring includes threading `getRunRecipients` through `GatewayRequestContext` into maintenance timeouts and chat abort operations, plus new tests validating that `chat` and non-tool `agent` events are targeted when a connId is registered and fall back to global broadcast otherwise.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has at least one concrete routing regression for `/stop` aborts and a likely runtime-footgun around unconditional `broadcastToConnIds` usage in chat methods.
- Core routing logic in `createAgentEventHandler` and maintenance abort wiring appears consistent and is covered by added tests, but the stop-command abort path still omits the new per-connection ops and will continue globally broadcasting aborted events. Also, `broadcastChatFinal`/`broadcastChatError` call `broadcastToConnIds` without guarding its presence, which can break callers that construct a minimal `GatewayRequestContext`.
- src/gateway/server-methods/chat.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->