### PR TITLE
fix(gateway): use timing-safe comparison for hook token auth

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1,6 +1,6 @@
-import { timingSafeEqual } from "node:crypto";
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
+import { timingSafeEqual } from "node:crypto";
 import {
   createServer as createHttpServer,
   type Server as HttpServer,
@@ -162,7 +162,11 @@ export function createHooksRequestHandler(
     }
 
     const token = extractHookToken(req);
-    if (!token || token.length !== hooksConfig.token.length || !timingSafeEqual(Buffer.from(token), Buffer.from(hooksConfig.token))) {
+    if (
+      !token ||
+      token.length !== hooksConfig.token.length ||
+      !timingSafeEqual(Buffer.from(token), Buffer.from(hooksConfig.token))
+    ) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
 import {
@@ -161,7 +162,7 @@ export function createHooksRequestHandler(
     }
 
     const token = extractHookToken(req);
-    if (!token || token !== hooksConfig.token) {
+    if (!token || token.length !== hooksConfig.token.length || !timingSafeEqual(Buffer.from(token), Buffer.from(hooksConfig.token))) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");


### PR DESCRIPTION
## Summary

The hook token check in `server-http.ts` currently uses `!==`, while
gateway authentication in `auth.ts` already relies on
`crypto.timingSafeEqual`. This change aligns both paths.

## Changes

- Import `timingSafeEqual` from `node:crypto`
- Replace `token !== hooksConfig.token` with a length check +
  `timingSafeEqual`, mirroring the existing helper in `auth.ts`.

Diff is minimal (2 insertions, 1 deletion) and there is no behavior
change for valid or invalid tokens.

## Context

Risk is low under OpenClaw's local-first model and hook endpoints are
usually not internet-facing. The main benefit is consistency across
authentication surfaces.

## Test plan

Existing tests pass unchanged:
- valid tokens are accepted
- invalid tokens return 401

No new dependencies.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates hook token authentication in `src/gateway/server-http.ts` to use a timing-safe comparison (`crypto.timingSafeEqual`) instead of a direct string inequality check. The new logic mirrors the existing `safeEqual` helper already used in `src/gateway/auth.ts`, reducing timing side-channel differences between gateway auth surfaces while keeping the same accept/reject behavior for valid and invalid tokens.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and localized to hook token auth, and it follows an already-established pattern in `src/gateway/auth.ts` (length check + `timingSafeEqual`). `hooksConfig.token` is guaranteed non-empty when hooks are enabled, so the new code avoids the common `timingSafeEqual` length-throw pitfall and should not alter accept/reject behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->