### PR TITLE
fix: respect session model override in agent runtime (#14783)

### DIFF
--- a/src/auto-reply/reply/model-selection.override-respected.test.ts
+++ b/src/auto-reply/reply/model-selection.override-respected.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createModelSelectionState } from "./model-selection.js";
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(async () => [
+    { provider: "inferencer", id: "deepseek-v3-4bit-mlx", name: "DeepSeek V3" },
+    { provider: "kimi-coding", id: "k2p5", name: "Kimi K2.5" },
+    { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+  ]),
+}));
+
+const defaultProvider = "inferencer";
+const defaultModel = "deepseek-v3-4bit-mlx";
+
+const makeEntry = (overrides: Record<string, unknown> = {}) => ({
+  sessionId: "session-id",
+  updatedAt: Date.now(),
+  ...overrides,
+});
+
+describe("createModelSelectionState respects session model override", () => {
+  it("applies session modelOverride when set", async () => {
+    const cfg = {} as OpenClawConfig;
+    const sessionKey = "agent:main:main";
+    const sessionEntry = makeEntry({
+      providerOverride: "kimi-coding",
+      modelOverride: "k2p5",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("kimi-coding");
+    expect(state.model).toBe("k2p5");
+  });
+
+  it("falls back to default when no modelOverride is set", async () => {
+    const cfg = {} as OpenClawConfig;
+    const sessionKey = "agent:main:main";
+    const sessionEntry = makeEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+  });
+
+  it("respects modelOverride even when session model field differs", async () => {
+    // This tests the scenario from issue #14783: user switches model via /model,
+    // the override is stored, but session.model still reflects the last-used
+    // fallback model. The override should take precedence.
+    const cfg = {} as OpenClawConfig;
+    const sessionKey = "agent:main:main";
+    const sessionEntry = makeEntry({
+      // Last-used model (from fallback) - should NOT be used for selection
+      model: "k2p5",
+      modelProvider: "kimi-coding",
+      contextTokens: 262_000,
+      // User's explicit override - SHOULD be used
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-5",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    // Should use the override, not the last-used model
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-opus-4-5");
+  });
+
+  it("uses default provider when providerOverride is not set but modelOverride is", async () => {
+    const cfg = {} as OpenClawConfig;
+    const sessionKey = "agent:main:main";
+    const sessionEntry = makeEntry({
+      modelOverride: "deepseek-v3-4bit-mlx",
+      // no providerOverride
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe("deepseek-v3-4bit-mlx");
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -247,6 +247,28 @@ export async function runCronIsolatedAgentTurn(params: {
     cronSession.sessionEntry.label = `Cron: ${labelSuffix}`;
   }
 
+  // Respect session model override — check session.modelOverride before falling
+  // back to the default config model. This ensures /model and /switch changes
+  // are honoured by cron and isolated agent runs.
+  if (!modelOverride) {
+    const sessionModelOverride = cronSession.sessionEntry.modelOverride?.trim();
+    if (sessionModelOverride) {
+      const sessionProviderOverride =
+        cronSession.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
+      const resolvedSessionOverride = resolveAllowedModelRef({
+        cfg: cfgWithAgentDefaults,
+        catalog: await loadCatalog(),
+        raw: `${sessionProviderOverride}/${sessionModelOverride}`,
+        defaultProvider: resolvedDefault.provider,
+        defaultModel: resolvedDefault.model,
+      });
+      if (!("error" in resolvedSessionOverride)) {
+        provider = resolvedSessionOverride.ref.provider;
+        model = resolvedSessionOverride.ref.model;
+      }
+    }
+  }
+
   // Resolve thinking level - job thinking > hooks.gmail.thinking > agent default
   const hooksGmailThinking = isGmailHook
     ? normalizeThinkLevel(params.cfg.hooks?.gmail?.thinking)

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(),
+  resolveStorePath: vi.fn().mockReturnValue("/tmp/test-store.json"),
+}));
+
+import { loadSessionStore } from "../../config/sessions.js";
+import { resolveCronSession } from "./session.js";
+
+describe("resolveCronSession", () => {
+  it("preserves modelOverride and providerOverride from existing session entry", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main:cron:test-job": {
+        sessionId: "old-session-id",
+        updatedAt: 1000,
+        modelOverride: "deepseek-v3-4bit-mlx",
+        providerOverride: "inferencer",
+        thinkingLevel: "high",
+        model: "k2p5",
+      },
+    });
+
+    const result = resolveCronSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:main:cron:test-job",
+      agentId: "main",
+      nowMs: Date.now(),
+    });
+
+    expect(result.sessionEntry.modelOverride).toBe("deepseek-v3-4bit-mlx");
+    expect(result.sessionEntry.providerOverride).toBe("inferencer");
+    expect(result.sessionEntry.thinkingLevel).toBe("high");
+    // The model field (last-used model) should also be preserved
+    expect(result.sessionEntry.model).toBe("k2p5");
+  });
+
+  it("handles missing modelOverride gracefully", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main:cron:test-job": {
+        sessionId: "old-session-id",
+        updatedAt: 1000,
+        model: "claude-opus-4-5",
+      },
+    });
+
+    const result = resolveCronSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:main:cron:test-job",
+      agentId: "main",
+      nowMs: Date.now(),
+    });
+
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+  });
+
+  it("handles no existing session entry", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({});
+
+    const result = resolveCronSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:main:cron:new-job",
+      agentId: "main",
+      nowMs: Date.now(),
+    });
+
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    expect(result.sessionEntry.model).toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -23,6 +23,8 @@ export function resolveCronSession(params: {
     thinkingLevel: entry?.thinkingLevel,
     verboseLevel: entry?.verboseLevel,
     model: entry?.model,
+    modelOverride: entry?.modelOverride,
+    providerOverride: entry?.providerOverride,
     contextTokens: entry?.contextTokens,
     sendPolicy: entry?.sendPolicy,
     lastChannel: entry?.lastChannel,


### PR DESCRIPTION
## Problem

After executing `/model` or `/switch` to change the model, the session reports success but continues using the previous model. The `session.modelOverride` field was not being checked by the cron/isolated agent runtime before falling back to the default config model.

Fixes #14783

## Root Cause

Two issues in the cron/isolated agent path:

1. **`resolveCronSession()`** did not copy `modelOverride` and `providerOverride` from the existing session entry when constructing the cron session. These fields were silently dropped, so any model override set via `/model` or `/switch` was lost for cron-triggered and isolated agent runs.

2. **`runCronIsolatedAgentTurn()`** only checked for job-level model overrides (from the cron payload) but never checked the session-level `modelOverride` / `providerOverride`. When no job-level override was present, it fell back directly to the default config model, ignoring the user's explicit model choice.

## Fix

- **`resolveCronSession`**: Now copies `modelOverride` and `providerOverride` from the existing session entry.
- **`runCronIsolatedAgentTurn`**: After checking job-level model overrides, now checks `session.modelOverride` / `session.providerOverride` before falling back to the default config model. Job-level overrides still take precedence.

## Tests

- Added `src/cron/isolated-agent/session.test.ts` — verifies `resolveCronSession` preserves model override fields, handles missing overrides, and handles missing session entries.
- Added `src/auto-reply/reply/model-selection.override-respected.test.ts` — verifies `createModelSelectionState` respects stored model overrides, falls back correctly when none is set, and prioritises overrides over the last-used fallback model.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cron/isolated agent runs ignoring a user’s `/model` or `/switch` selection by (1) preserving `modelOverride`/`providerOverride` when constructing cron sessions in `resolveCronSession`, and (2) teaching `runCronIsolatedAgentTurn` to consult the session-level overrides when no job-level model override is provided. It also adds focused unit tests around cron session resolution and model-selection override precedence.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but has a correctness edge case around inherited (parent) model overrides not being reset when disallowed.
- Core runtime changes are small and well-scoped, and the cron session override preservation looks correct. However, the model-selection reset logic uses only the current session’s override fields even though stored overrides can come from a parent session; this can leave a disallowed parent override in place without being cleared.
- src/auto-reply/reply/model-selection.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->