### PR TITLE
fix: skip duplicate skill commands from bundled skills across agents

### DIFF
--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -62,8 +62,13 @@ export function listSkillCommandsForAgents(params: {
       reservedNames: used,
     });
     for (const command of commands) {
-      used.add(command.name.toLowerCase());
-      entries.push(command);
+      const key = command.name.toLowerCase();
+      // Skip duplicate commands from bundled skills loaded by different agents
+      // rather than appending _2 suffixes (#14721).
+      if (!used.has(key)) {
+        used.add(key);
+        entries.push(command);
+      }
     }
   }
   return entries;


### PR DESCRIPTION
Fixes #14721

When multiple agents with different workspace directories load the same bundled skills, the second agent's commands got `_2` suffixes (e.g. `/gog_2`). Now commands already registered by a previous agent are silently skipped instead of being renamed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `listSkillCommandsForAgents` to skip adding a skill command if another agent already registered the same command name, aiming to prevent auto-renaming to `_2` when bundled skills are loaded across different agent workspaces.

The skill command list is built by calling `buildWorkspaceSkillCommandSpecs` per agent/workspace and aggregating results while tracking reserved/used names.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to dedupe logic not achieving intended behavior.
- The new skip check runs after command names have already been forced unique by the workspace builder using the same `used` set, so duplicate bundled skills can still appear with `_2` suffixes (the issue this PR claims to fix).
- src/auto-reply/skill-commands.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->