### PR TITLE
fix: recognize cache_creation_input_tokens in toUsage()

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -272,7 +272,8 @@ function toUsage(raw: Record<string, unknown>): CliUsage | undefined {
   const output = pick("output_tokens") ?? pick("outputTokens");
   const cacheRead =
     pick("cache_read_input_tokens") ?? pick("cached_input_tokens") ?? pick("cacheRead");
-  const cacheWrite = pick("cache_write_input_tokens") ?? pick("cacheWrite");
+  const cacheWrite =
+    pick("cache_creation_input_tokens") ?? pick("cache_write_input_tokens") ?? pick("cacheWrite");
   const total = pick("total_tokens") ?? pick("total");
   if (!input && !output && !cacheRead && !cacheWrite && !total) {
     return undefined;


### PR DESCRIPTION
## Summary

- `toUsage()` in `src/agents/cli-runner/helpers.ts` was missing Anthropic's `cache_creation_input_tokens` field
- Only checked `cache_write_input_tokens` and `cacheWrite`, but Anthropic's API returns `cache_creation_input_tokens`
- Added it as first priority in the pick chain, matching the pattern already used in `src/agents/usage.ts`

Fixes #14366

## Changes

```typescript
// Before:
const cacheWrite = pick("cache_write_input_tokens") ?? pick("cacheWrite");

// After:
const cacheWrite =
  pick("cache_creation_input_tokens") ?? pick("cache_write_input_tokens") ?? pick("cacheWrite");
```

## Test plan

- [x] Verified `src/agents/usage.ts` already handles this field correctly (reference implementation)
- [x] Single occurrence of the bug in codebase (this file)
- [ ] Test with Anthropic API response containing `cache_creation_input_tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI runner’s usage parsing (`toUsage()` in `src/agents/cli-runner/helpers.ts`) to recognize Anthropic’s `cache_creation_input_tokens` field when normalizing usage. The new field is checked before the existing `cache_write_input_tokens` / `cacheWrite` fallbacks, aligning the CLI parsing with the existing normalization logic in `src/agents/usage.ts`.

No issues were found that require changes before merge; this is a small, targeted compatibility fix that preserves existing behavior while correctly capturing the Anthropic cache creation token count.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, additive field pick in a usage-normalization helper, and it matches the established normalization behavior already present elsewhere in the repo; no call sites or types are impacted beyond correctly capturing an additional provider field.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->