### PR TITLE
fix: normalize peer.kind in routing to handle dm/direct variants

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -146,7 +146,9 @@ function matchesPeer(
   if (!kind || !id) {
     return false;
   }
-  return kind === peer.kind && id === peer.id;
+  // Fix #14612: Normalize incoming peer.kind to handle "dm" vs "direct" mismatch
+  const normalizedPeerKind = normalizeChatType(peer.kind);
+  return kind === normalizedPeerKind && id === peer.id;
 }
 
 function matchesGuild(
@@ -171,7 +173,10 @@ function matchesTeam(match: { teamId?: string | undefined } | undefined, teamId:
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
-  const peer = input.peer ? { kind: input.peer.kind, id: normalizeId(input.peer.id) } : null;
+  // Fix #14612: Normalize peer.kind to handle "dm" vs "direct" consistently
+  const peer = input.peer
+    ? { kind: normalizeChatType(input.peer.kind) ?? input.peer.kind, id: normalizeId(input.peer.id) }
+    : null;
   const guildId = normalizeId(input.guildId);
   const teamId = normalizeId(input.teamId);
 
@@ -220,8 +225,12 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   }
 
   // Thread parent inheritance: if peer (thread) didn't match, check parent peer binding
+  // Fix #14612: Normalize parentPeer.kind to handle "dm" vs "direct" consistently
   const parentPeer = input.parentPeer
-    ? { kind: input.parentPeer.kind, id: normalizeId(input.parentPeer.id) }
+    ? {
+        kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
+        id: normalizeId(input.parentPeer.id),
+      }
     : null;
   if (parentPeer && parentPeer.id) {
     const parentPeerMatch = bindings.find((b) => matchesPeer(b.match, parentPeer));


### PR DESCRIPTION
## Summary

- Asymmetric normalization in `resolveAgentRoute()` caused peer-based binding matching to always fail when channel plugins passed `peer.kind = "dm"` instead of `"direct"`
- `matchesPeer()` normalized the config's peer.kind but NOT the incoming peer.kind
- Added `normalizeChatType()` calls to normalize peer.kind, parentPeer.kind, and incoming peer.kind

Fixes #14612

## Root Cause

`matchesPeer()` at line 144 normalized the config match rule's `peer.kind` via `normalizeChatType()` (converting "dm" → "direct"), but the incoming `peer.kind` from channel plugins was compared directly. So `"direct" === "dm"` always failed.

## Changes

Three normalization points (defense in depth):
1. `resolveAgentRoute()`: Normalize `input.peer.kind` when constructing peer object
2. `resolveAgentRoute()`: Normalize `input.parentPeer.kind` when constructing parentPeer object
3. `matchesPeer()`: Normalize incoming `peer.kind` before comparison

## Test plan

- [ ] Channel plugin sending `peer.kind = "dm"` should match binding configured with `"direct"`
- [ ] Channel plugin sending `peer.kind = "direct"` should still match (no regression)
- [ ] Parent peer inheritance should also handle dm/direct normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Change is localized to `src/routing/resolve-route.ts` and addresses an asymmetric comparison in `matchesPeer()` where config `peer.kind` was normalized (`"dm"` → `"direct"`) but the incoming `peer.kind` was not, causing peer bindings to never match when plugins used `"dm"`.

The PR normalizes incoming `peer.kind` inside `matchesPeer()`, and also normalizes `peer.kind` / `parentPeer.kind` during `resolveAgentRoute()` input shaping so the session key and parent-peer inheritance paths use consistent chat type values.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and directly addresses a proven logic bug (asymmetric normalization) without altering routing precedence or widening matching beyond the intended dm/direct normalization. normalizeChatType is already the canonical mapping for dm→direct and the new usages remain within that contract.
- src/routing/resolve-route.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->