### PR TITLE
fix: omit message_thread_id for private Telegram chats

### DIFF
--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -138,7 +138,7 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("keeps message_thread_id=1 when allowed", async () => {
+  it("omits message_thread_id for dm threads (private chats don't support threads)", async () => {
     const runtime = { error: vi.fn(), log: vi.fn() };
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 4,
@@ -157,13 +157,17 @@ describe("deliverReplies", () => {
       thread: { id: 1, scope: "dm" },
     });
 
+    // Private chats don't support threads, so message_thread_id should be omitted
     expect(sendMessage).toHaveBeenCalledWith(
       "123",
       expect.any(String),
       expect.objectContaining({
-        message_thread_id: 1,
+        parse_mode: "HTML",
       }),
     );
+    // Verify message_thread_id is NOT in the params
+    const callArgs = sendMessage.mock.calls[0];
+    expect(callArgs[2]).not.toHaveProperty("message_thread_id");
   });
 
   it("does not include link_preview_options when linkPreview is true", async () => {

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,10 +43,9 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("keeps thread id=1 for dm threads", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
-      message_thread_id: 1,
-    });
+  it("omits thread id for dm chats (private chats don't support threads)", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: 99, scope: "dm" })).toBeUndefined();
   });
 
   it("normalizes thread ids to integers", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -58,12 +58,17 @@ export function resolveTelegramThreadSpec(params: {
  * Build thread params for Telegram API calls (messages, media).
  * General forum topic (id=1) must be treated like a regular supergroup send:
  * Telegram rejects sendMessage/sendMedia with message_thread_id=1 ("thread not found").
+ * Private/DM chats do not support message_thread_id and will error if it's included.
  */
 export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
   if (!thread?.id) {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);
+  // Private chats don't support threads - omit message_thread_id
+  if (thread.scope === "dm") {
+    return undefined;
+  }
   if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
     return undefined;
   }

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -34,7 +34,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
   });
 
-  it("keeps message_thread_id for dm threads", () => {
+  it("omits message_thread_id for dm threads (private chats don't support threads)", () => {
     const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
     const stream = createTelegramDraftStream({
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -46,8 +46,6 @@ describe("createTelegramDraftStream", () => {
 
     stream.update("Hello");
 
-    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
-      message_thread_id: 1,
-    });
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
   });
 });


### PR DESCRIPTION
## Summary

- Cron jobs delivering to private Telegram chats failed with `400: Bad Request: message thread not found`
- OpenClaw was incorrectly injecting `message_thread_id` into API calls for private/dm chats
- Private chats don't support threads — the parameter must be omitted

Fixes #14742

## Root Cause

`buildTelegramThreadParams()` in `src/telegram/bot/helpers.ts` returned thread parameters for all chat types, including DMs. Private Telegram chats don't support `message_thread_id`, causing the Telegram API to reject the request.

## Changes

- Modified `buildTelegramThreadParams()` to return `undefined` when `scope === "dm"`
- Updated tests to verify thread params are NOT included for dm scope

## Test plan

- [x] All 423 Telegram tests pass
- [ ] Cron job delivering to private Telegram chat should succeed
- [ ] Cron job delivering to group/forum chats should still include thread ID (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `buildTelegramThreadParams()` to omit `message_thread_id` when the resolved thread scope is `dm`, because Telegram private chats don’t support topics/threads and will reject requests that include `message_thread_id` (observed as `400: Bad Request: message thread not found`). Tests were updated across the bot delivery and draft-stream paths to assert thread params are excluded for DM scope while preserving existing behavior for forum topics (including omitting General topic ID=1 for message sends).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped (only affects thread param construction), aligns with Telegram Bot API constraints for private chats, and is exercised by updated unit tests across key call sites (delivery and draft stream). No regressions observed in forum/general-topic logic, and other call sites build thread specs with non-dm scopes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->