### PR TITLE
fix(agents): add 'do not retry' hint to tool validation errors

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -205,7 +205,9 @@ export function assertRequiredParams(
   toolName: string,
 ): void {
   if (!record || typeof record !== "object") {
-    throw new Error(`Missing parameters for ${toolName}`);
+    throw new Error(
+      `Missing parameters for ${toolName}. This is a validation error — do not retry with the same input.`,
+    );
   }
 
   for (const group of groups) {
@@ -225,7 +227,9 @@ export function assertRequiredParams(
 
     if (!satisfied) {
       const label = group.label ?? group.keys.join(" or ");
-      throw new Error(`Missing required parameter: ${label}`);
+      throw new Error(
+        `Missing required parameter: ${label}. Provide a valid value — do not retry with empty or missing parameters.`,
+      );
     }
   }
 }


### PR DESCRIPTION
Fixes #14729

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `assertRequiredParams` in `src/agents/pi-tools.read.ts` to append explicit “do not retry” guidance to tool parameter validation errors. The change is limited to error message strings and does not alter validation logic or tool execution flow; it should help agents avoid retry loops when required tool inputs are missing/empty.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Only error message text is changed; validation conditions and control flow remain identical, and no new dependencies or side effects are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->