### PR TITLE
fix: distinguish OAuth tokens from API keys in models status

### DIFF
--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -2,7 +2,9 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   type AuthProfileCredential,
   type AuthProfileStore,
+  classifyTokenKind,
   resolveAuthProfileDisplayLabel,
+  type TokenKind,
 } from "./auth-profiles.js";
 
 export type AuthProfileSource = "store";
@@ -13,6 +15,14 @@ export type AuthProfileHealth = {
   profileId: string;
   provider: string;
   type: "oauth" | "token" | "api_key";
+  /**
+   * Refined token classification based on prefix analysis.
+   * Only set when `type === "token"`:
+   * - `"oauth"` — Anthropic OAuth token (`sk-ant-oat01-`), subscription billing
+   * - `"api_key"` — Anthropic API key (`sk-ant-api03-`), credits billing
+   * - `"token"` — Unknown/unrecognised prefix
+   */
+  tokenKind?: TokenKind;
   status: AuthProfileHealthStatus;
   expiresAt?: number;
   remainingMs?: number;
@@ -113,6 +123,7 @@ function buildProfileHealth(params: {
         profileId,
         provider: credential.provider,
         type: "token",
+        tokenKind: classifyTokenKind(credential.token),
         status: "static",
         source,
         label,
@@ -123,6 +134,7 @@ function buildProfileHealth(params: {
       profileId,
       provider: credential.provider,
       type: "token",
+      tokenKind: classifyTokenKind(credential.token),
       status,
       expiresAt,
       remainingMs,

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -38,3 +38,4 @@ export {
   markAuthProfileUsed,
   resolveProfileUnusableUntilForDisplay,
 } from "./auth-profiles/usage.js";
+export { classifyTokenKind, type TokenKind } from "./auth-profiles/token-classify.js";

--- a/src/agents/auth-profiles/token-classify.test.ts
+++ b/src/agents/auth-profiles/token-classify.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { classifyTokenKind } from "./token-classify.js";
+
+describe("classifyTokenKind", () => {
+  it("classifies sk-ant-oat01- prefix as oauth", () => {
+    expect(classifyTokenKind("sk-ant-oat01-ACCESS-TOKEN-1234567890")).toBe("oauth");
+  });
+
+  it("classifies sk-ant-api03- prefix as api_key", () => {
+    expect(classifyTokenKind("sk-ant-api03-0123456789abcdefghijklmnopqrstuvwxyz")).toBe("api_key");
+  });
+
+  it("classifies other sk-ant- prefixes as generic token", () => {
+    expect(classifyTokenKind("sk-ant-sid01-SOMETHING")).toBe("token");
+  });
+
+  it("classifies non-Anthropic tokens as generic token", () => {
+    expect(classifyTokenKind("eyJhbGciOi-ACCESS-TOKEN")).toBe("token");
+    expect(classifyTokenKind("oai-some-token")).toBe("token");
+  });
+
+  it("classifies empty string as generic token", () => {
+    expect(classifyTokenKind("")).toBe("token");
+  });
+
+  it("handles exact prefix match (no trailing content)", () => {
+    expect(classifyTokenKind("sk-ant-oat01-")).toBe("oauth");
+    expect(classifyTokenKind("sk-ant-api03-")).toBe("api_key");
+  });
+
+  it("does not match partial prefixes", () => {
+    expect(classifyTokenKind("sk-ant-oat01")).toBe("token");
+    expect(classifyTokenKind("sk-ant-api03")).toBe("token");
+    expect(classifyTokenKind("sk-ant-oat0")).toBe("token");
+  });
+});

--- a/src/agents/auth-profiles/token-classify.ts
+++ b/src/agents/auth-profiles/token-classify.ts
@@ -1,0 +1,26 @@
+/**
+ * Refined classification of a static bearer token based on known prefixes.
+ *
+ * - `"oauth"` — Anthropic OAuth access token (`sk-ant-oat01-`), billed
+ *   through a Max/Pro subscription.
+ * - `"api_key"` — Anthropic API key (`sk-ant-api03-`), billed against
+ *   console.anthropic.com credits.
+ * - `"token"` — Unknown/unrecognised prefix; keep the generic label.
+ */
+export type TokenKind = "oauth" | "api_key" | "token";
+
+/**
+ * Classify a bearer token string by its prefix.
+ *
+ * Currently recognises Anthropic-specific prefixes; all other tokens
+ * fall through as `"token"`.
+ */
+export function classifyTokenKind(token: string): TokenKind {
+  if (token.startsWith("sk-ant-oat01-")) {
+    return "oauth";
+  }
+  if (token.startsWith("sk-ant-api03-")) {
+    return "api_key";
+  }
+  return "token";
+}

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import { resolveProviderAuthOverview } from "./list.auth-overview.js";
+
+vi.mock("../../agents/auth-profiles/paths.js", () => ({
+  resolveAuthStorePathForDisplay: vi.fn().mockReturnValue("/tmp/auth-profiles.json"),
+}));
+
+vi.mock("../../agents/model-auth.js", () => ({
+  resolveEnvApiKey: vi.fn().mockReturnValue(null),
+  getCustomProviderApiKey: vi.fn().mockReturnValue(undefined),
+}));
+
+function makeStore(profiles: AuthProfileStore["profiles"]): AuthProfileStore {
+  return { version: 1, profiles };
+}
+
+describe("resolveProviderAuthOverview token classification", () => {
+  it("classifies sk-ant-oat01- token as oauth in counts", () => {
+    const store = makeStore({
+      "anthropic:oauth-tok": {
+        type: "token",
+        provider: "anthropic",
+        token: "sk-ant-oat01-ACCESS-TOKEN-1234567890",
+      },
+    });
+    const overview = resolveProviderAuthOverview({
+      provider: "anthropic",
+      cfg: {} as never,
+      store,
+      modelsPath: "/tmp/models.json",
+    });
+    expect(overview.profiles.oauth).toBe(1);
+    expect(overview.profiles.token).toBe(0);
+    expect(overview.profiles.apiKey).toBe(0);
+    expect(overview.profiles.labels[0]).toContain("oauth_token:");
+  });
+
+  it("classifies sk-ant-api03- token as api_key in counts", () => {
+    const store = makeStore({
+      "anthropic:api-tok": {
+        type: "token",
+        provider: "anthropic",
+        token: "sk-ant-api03-0123456789abcdef",
+      },
+    });
+    const overview = resolveProviderAuthOverview({
+      provider: "anthropic",
+      cfg: {} as never,
+      store,
+      modelsPath: "/tmp/models.json",
+    });
+    expect(overview.profiles.oauth).toBe(0);
+    expect(overview.profiles.token).toBe(0);
+    expect(overview.profiles.apiKey).toBe(1);
+    expect(overview.profiles.labels[0]).toContain("api_key:");
+  });
+
+  it("keeps unrecognised tokens as generic token", () => {
+    const store = makeStore({
+      "anthropic:unknown": {
+        type: "token",
+        provider: "anthropic",
+        token: "eyJhbGciOi-SOMETHING",
+      },
+    });
+    const overview = resolveProviderAuthOverview({
+      provider: "anthropic",
+      cfg: {} as never,
+      store,
+      modelsPath: "/tmp/models.json",
+    });
+    expect(overview.profiles.oauth).toBe(0);
+    expect(overview.profiles.token).toBe(1);
+    expect(overview.profiles.apiKey).toBe(0);
+    expect(overview.profiles.labels[0]).toMatch(/^anthropic:unknown=token:/);
+  });
+
+  it("combines real oauth, reclassified oauth-token, and api_key correctly", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        type: "oauth",
+        provider: "anthropic",
+        access: "sk-ant-oat01-ACCESS",
+        refresh: "sk-ant-ort01-REFRESH",
+        expires: Date.now() + 60_000,
+      } as never,
+      "anthropic:token-oauth": {
+        type: "token",
+        provider: "anthropic",
+        token: "sk-ant-oat01-STATIC-TOKEN",
+      },
+      "anthropic:work": {
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-ant-api03-KEY",
+      },
+    });
+    const overview = resolveProviderAuthOverview({
+      provider: "anthropic",
+      cfg: {} as never,
+      store,
+      modelsPath: "/tmp/models.json",
+    });
+    // 1 real oauth + 1 reclassified token-as-oauth
+    expect(overview.profiles.oauth).toBe(2);
+    expect(overview.profiles.token).toBe(0);
+    // 1 real api_key
+    expect(overview.profiles.apiKey).toBe(1);
+    expect(overview.profiles.count).toBe(3);
+  });
+});

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -618,13 +618,21 @@ export async function modelsStatusCommand(
         const labelText = profile.label || profile.profileId;
         const label = colorize(rich, theme.accent, labelText);
         const status = formatStatus(profile.status);
+        const kindSuffix =
+          profile.tokenKind && profile.tokenKind !== "token"
+            ? colorize(
+                rich,
+                theme.muted,
+                profile.tokenKind === "oauth" ? " (oauth_token)" : " (api_key)",
+              )
+            : "";
         const expiry =
           profile.status === "static"
             ? ""
             : profile.expiresAt
               ? ` expires in ${formatRemainingShort(profile.remainingMs)}`
               : " expires unknown";
-        runtime.log(`  - ${label} ${status}${expiry}`);
+        runtime.log(`  - ${label} ${status}${kindSuffix}${expiry}`);
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #14805

`openclaw models status` now parses Anthropic token prefixes to distinguish OAuth tokens from API keys, instead of classifying all static tokens as generic "token".

## Token prefix detection

| Prefix | Classification | Billing |
|--------|---------------|---------|
| `sk-ant-oat01-` | `oauth` | Max/Pro subscription |
| `sk-ant-api03-` | `api_key` | console.anthropic.com credits |
| Other `sk-ant-` | `token` | Unknown |

## Changes

- **New:** `classifyTokenKind()` utility (`src/agents/auth-profiles/token-classify.ts`)
- **Auth overview:** Token credentials are reclassified by prefix in both counts and labels
  - Labels now show `oauth_token:sk-ant...` or `api_key:sk-ant...` instead of `token:sk-ant...`
  - Counts fold recognised tokens into `oauth` / `api_key` buckets
- **Auth health:** `AuthProfileHealth` gains an optional `tokenKind` field for token-type profiles
- **Status display:** Shows `(oauth_token)` or `(api_key)` suffix in the OAuth/token status section
- **Tests:** 11 new tests covering token classification, auth overview reclassification, and combined scenarios

## Example output change

Before:
```
profiles=2 (oauth=1, token=1, api_key=0)
  - anthropic:token-profile static
```

After:
```
profiles=2 (oauth=2, token=0, api_key=0)
  - anthropic:token-profile static (oauth_token)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds prefix-based classification for Anthropic `sk-ant-*` static tokens so `openclaw models status` can distinguish OAuth access tokens (`sk-ant-oat01-`) from API keys (`sk-ant-api03-`).

Key changes:
- Introduces `classifyTokenKind()` (`src/agents/auth-profiles/token-classify.ts`) and exports it via `src/agents/auth-profiles.ts`.
- Extends `AuthProfileHealth` with an optional `tokenKind` (set only for `type: "token"`) and surfaces it in the status output as `(oauth_token)` / `(api_key)`.
- Updates the auth overview (`src/commands/models/list.auth-overview.ts`) to relabel token profiles and to fold recognized token prefixes into the `oauth` / `api_key` count buckets.
- Adds unit tests covering token classification and overview bucketing/labels.

No must-fix issues were found in the changed code paths based on static review.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and covered by targeted unit tests.
- Reviewed all changed files and traced the new `tokenKind` field through `buildAuthHealthSummary` to status rendering. The new classification only affects display/counting logic and does not alter credential resolution. Unit tests cover the new classifier and the overview bucketing. I was not able to execute the full test suite in this environment due to missing package manager tooling/modules, so confidence is reduced slightly.
- src/commands/models/list.auth-overview.ts (count bucketing + labels), src/agents/auth-health.ts (new tokenKind field)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->