### PR TITLE
fix(whatsapp): replies silently dropped during reconnection window

### DIFF
--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -41,7 +41,7 @@ export async function deliverWebReply(params: {
       ? [replyResult.mediaUrl]
       : [];
 
-  const sendWithRetry = async (fn: () => Promise<unknown>, label: string, maxAttempts = 3) => {
+  const sendWithRetry = async (fn: () => Promise<unknown>, label: string, maxAttempts = 5) => {
     let lastErr: unknown;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
@@ -54,7 +54,7 @@ export async function deliverWebReply(params: {
         if (!shouldRetry || isLast) {
           throw err;
         }
-        const backoffMs = 500 * attempt;
+        const backoffMs = 1000 * attempt;
         logVerbose(
           `Retrying ${label} to ${msg.from} after failure (${attempt}/${maxAttempts - 1}) in ${backoffMs}ms: ${errText}`,
         );


### PR DESCRIPTION
## Summary

Fixes #14827

Messages sent while WhatsApp Web is reconnecting (after a 408/503 disconnect) are silently dropped because `sendWithRetry()` exhausts all attempts before the connection is restored.

## Changes

In `src/web/auto-reply/deliver-reply.ts`:

- **`maxAttempts`**: 3 → 5
- **`backoffMs`**: `500 × attempt` → `1000 × attempt`

| | Before | After |
|---|---|---|
| Retry attempts | 3 | 5 |
| Backoff per attempt | 500ms, 1000ms, 1500ms | 1000ms, 2000ms, 3000ms, 4000ms, 5000ms |
| Total retry window | ~1.5s (sleep before attempts 2-3) | ~10s (sleep before attempts 2-5) |
| Covers reconnection? | ❌ (3-5s typical) | ✅ |

Note: the total backoff is 1000+2000+3000+4000 = 10s (no sleep after the final attempt).

## Root cause

WhatsApp Web reconnection typically takes 3-5 seconds. The previous retry budget of ~1.5s was too short — all retries were exhausted before the connection was restored, and the `onError` callback only logged the failure without surfacing it to the agent or user.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Verified retry math: sleep before attempts 2-5 = 1000+2000+3000+4000 = 10s total window
- [x] No behavioral change for non-connection errors (only `closed|reset|timed out|disconnect` patterns trigger retry)