### PR TITLE
fix: await memory sync in search() to prevent stale results (#14770)

### DIFF
--- a/src/memory/manager.async-search.test.ts
+++ b/src/memory/manager.async-search.test.ts
@@ -24,7 +24,7 @@ vi.mock("./embeddings.js", () => ({
   }),
 }));
 
-describe("memory search async sync", () => {
+describe("memory search awaits sync", () => {
   let workspaceDir: string;
   let indexPath: string;
   let manager: MemoryIndexManager | null = null;
@@ -45,7 +45,7 @@ describe("memory search async sync", () => {
     await fs.rm(workspaceDir, { recursive: true, force: true });
   });
 
-  it("does not await sync when searching", async () => {
+  it("awaits sync before returning search results", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -70,13 +70,120 @@ describe("memory search async sync", () => {
     }
     manager = result.manager;
 
-    const pending = new Promise<void>(() => {});
-    (manager as unknown as { sync: () => Promise<void> }).sync = vi.fn(async () => pending);
+    // Track sync call order relative to search completion
+    let syncStarted = false;
+    let syncFinished = false;
+    let searchReturnedWhileSyncPending = false;
 
-    const resolved = await Promise.race([
-      manager.search("hello").then(() => true),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 1000)),
-    ]);
-    expect(resolved).toBe(true);
+    const originalSync = manager.sync.bind(manager);
+    const syncSpy = vi.fn(async (...args: Parameters<typeof manager.sync>) => {
+      syncStarted = true;
+      await originalSync(...args);
+      syncFinished = true;
+    });
+    (manager as unknown as { sync: typeof syncSpy }).sync = syncSpy;
+
+    // Mark manager as dirty so sync triggers on search
+    (manager as unknown as { dirty: boolean }).dirty = true;
+
+    const results = await manager.search("hello");
+    // After search returns, sync should have finished (because we now await it)
+    if (syncStarted && !syncFinished) {
+      searchReturnedWhileSyncPending = true;
+    }
+
+    expect(searchReturnedWhileSyncPending).toBe(false);
+    // sync must have been called since dirty was true and onSearch is enabled
+    expect(syncSpy).toHaveBeenCalled();
+    expect(Array.isArray(results)).toBe(true);
+  });
+
+  it("blocks search until sync resolves when dirty", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "text-embedding-3-small",
+            store: { path: indexPath },
+            sync: { watch: false, onSessionStart: false, onSearch: true },
+            query: { minScore: 0 },
+            remote: { batch: { enabled: true, wait: true } },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    };
+
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    expect(result.manager).not.toBeNull();
+    if (!result.manager) {
+      throw new Error("manager missing");
+    }
+    manager = result.manager;
+
+    // Replace sync with a controlled deferred promise
+    let resolveSync!: () => void;
+    const syncPromise = new Promise<void>((r) => {
+      resolveSync = r;
+    });
+    const syncMock = vi.fn(async () => syncPromise);
+    (manager as unknown as { sync: typeof syncMock }).sync = syncMock;
+    (manager as unknown as { dirty: boolean }).dirty = true;
+
+    let searchResolved = false;
+    const searchPromise = manager.search("hello").then((r) => {
+      searchResolved = true;
+      return r;
+    });
+
+    // Give event loop a chance to proceed
+    await new Promise((r) => setTimeout(r, 50));
+    // search should NOT have resolved because sync is still pending
+    expect(searchResolved).toBe(false);
+
+    // Now resolve sync
+    resolveSync();
+    await searchPromise;
+    expect(searchResolved).toBe(true);
+    expect(syncMock).toHaveBeenCalled();
+  });
+
+  it("does not block search when not dirty", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "text-embedding-3-small",
+            store: { path: indexPath },
+            sync: { watch: false, onSessionStart: false, onSearch: true },
+            query: { minScore: 0 },
+            remote: { batch: { enabled: true, wait: true } },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    };
+
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    expect(result.manager).not.toBeNull();
+    if (!result.manager) {
+      throw new Error("manager missing");
+    }
+    manager = result.manager;
+
+    // sync should not be called when not dirty
+    const syncMock = vi.fn(async () => {});
+    (manager as unknown as { sync: typeof syncMock }).sync = syncMock;
+    // dirty defaults to false after initial sync, but ensure it
+    (manager as unknown as { dirty: boolean }).dirty = false;
+    (manager as unknown as { sessionsDirty: boolean }).sessionsDirty = false;
+
+    const results = await manager.search("hello");
+    expect(syncMock).not.toHaveBeenCalled();
+    expect(Array.isArray(results)).toBe(true);
   });
 });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -273,7 +273,7 @@ export class MemoryIndexManager implements MemorySearchManager {
   ): Promise<MemorySearchResult[]> {
     void this.warmSession(opts?.sessionKey);
     if (this.settings.sync.onSearch && (this.dirty || this.sessionsDirty)) {
-      void this.sync({ reason: "search" }).catch((err) => {
+      await this.sync({ reason: "search" }).catch((err) => {
         log.warn(`memory sync failed (search): ${String(err)}`);
       });
     }


### PR DESCRIPTION
## Problem

`MemoryIndexManager.search()` called `this.sync()` with `void` (fire-and-forget) when the index was dirty. This meant the first `memory_search` call after file changes returned stale results while re-indexing happened in the background. Only a second call would get fresh results.

## Fix

Replace `void this.sync({ reason: "search" })` with `await this.sync({ reason: "search" })` so the index is fully updated before the search query runs. The `.catch()` handler is preserved so sync errors are logged but don't crash the search.

## Tests

Updated `manager.async-search.test.ts` with three tests:
- **blocks search until sync resolves when dirty** — mocks sync with a deferred promise, verifies search doesn't resolve until sync completes
- **awaits sync before returning search results** — verifies sync has finished by the time search returns
- **does not block search when not dirty** — verifies sync is not called when index is clean

Closes #14770

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `MemoryIndexManager.search()` to `await` `sync({ reason: "search" })` when the index is marked dirty, ensuring the first `memory_search` call after filesystem/session changes sees up-to-date index state instead of racing a background sync. Tests in `src/memory/manager.async-search.test.ts` were expanded to assert that search blocks on an in-flight sync when dirty and skips sync when clean.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; behavior change is small and well-targeted.
- The core change (awaiting `sync()` during search when dirty) is straightforward and uses the existing sync de-duping (`this.syncing`) and error logging behavior, so functional risk is low. Tests cover the new blocking behavior, though the async-search test file uses module-scoped mocks that aren’t reset, which can make tests order-dependent if additional assertions are added later.
- src/memory/manager.async-search.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->