### PR TITLE
feat: per-model recursive fallbacks

### DIFF
--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -39,6 +39,8 @@ export const AgentDefaultsSchema = z
             params: z.record(z.string(), z.unknown()).optional(),
             /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
             streaming: z.boolean().optional(),
+            /** Per-model fallback chain. When this model fails, try these before the global fallbacks. Recursive. */
+            fallbacks: z.array(z.string()).optional(),
           })
           .strict(),
       )


### PR DESCRIPTION
## Summary

Add per-model fallback chains via agents.defaults.models[key].fallbacks.

When a model fails, its per-model fallbacks are tried first (recursively, depth-first) before the global chain.

## Changes

- zod-schema.agent-defaults.ts: Added fallbacks field
- model-fallback.ts: Recursive depth-first expansion
- model-fallback.test.ts: 4 new tests, all 23 pass

Zero breaking changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds per-model fallback chains via `agents.defaults.models[provider/model].fallbacks` and updates the fallback resolution logic to expand those fallbacks recursively (depth-first) before applying the existing global `agents.defaults.model.fallbacks` chain. Tests were extended to cover ordering, recursion, cycle protection, and merging per-model + global fallbacks.

The main integration point is `runWithModelFallback()` / `resolveFallbackCandidates()` in `src/agents/model-fallback.ts`, which now builds a candidate list by expanding the requested model’s per-model chain and then doing the same for each global fallback.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple correctness/type integration issues that should be fixed first.
- Core idea and tests look solid, but per-model fallbacks can be skipped in real configs due to provider/model normalization mismatch during lookup, and TS config types weren’t updated to match the new schema field.
- src/agents/model-fallback.ts, src/config/types.agent-defaults.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->