### PR TITLE
fix: increase WhatsApp retry window and surface delivery failures (#14827)

### DIFF
--- a/src/web/auto-reply/deliver-reply.test.ts
+++ b/src/web/auto-reply/deliver-reply.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock all heavy dependencies so we can test sendWithRetry in isolation.
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+  shouldLogVerbose: () => false,
+}));
+vi.mock("../../markdown/tables.js", () => ({
+  convertMarkdownTables: (t: string) => t,
+}));
+vi.mock("../../markdown/whatsapp.js", () => ({
+  markdownToWhatsApp: (t: string) => t,
+}));
+vi.mock("../../auto-reply/chunk.js", () => ({
+  chunkMarkdownTextWithMode: (t: string) => (t ? [t] : []),
+}));
+vi.mock("../media.js", () => ({
+  loadWebMedia: vi.fn(),
+}));
+vi.mock("../reconnect.js", () => ({
+  newConnectionId: () => "conn-test",
+}));
+vi.mock("../session.js", () => ({
+  formatError: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+vi.mock("./loggers.js", () => ({
+  whatsappOutboundLog: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+// Mock sleep to resolve instantly so retry tests don't wait.
+vi.mock("../../utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils.js")>();
+  return {
+    ...actual,
+    sleep: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { sleep } from "../../utils.js";
+import { deliverWebReply } from "./deliver-reply.js";
+
+const mockedSleep = vi.mocked(sleep);
+
+function makeMsg(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    id: "msg-1",
+    from: "+15550001111",
+    to: "+15550002222",
+    reply: vi.fn().mockResolvedValue(undefined),
+    sendMedia: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  return {
+    replyResult: { text: "hello" },
+    msg: makeMsg(),
+    maxMediaBytes: 10_000_000,
+    textLimit: 4096,
+    replyLogger: { info: vi.fn(), warn: vi.fn() },
+    ...overrides,
+  };
+}
+
+describe("deliverWebReply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends a simple text reply", async () => {
+    const params = makeParams();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await deliverWebReply(params as any);
+    expect(params.msg.reply).toHaveBeenCalledWith("hello");
+  });
+
+  it("retries on transient disconnect errors up to 5 times by default", async () => {
+    const msg = makeMsg({
+      reply: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("connection closed"))
+        .mockRejectedValueOnce(new Error("socket reset"))
+        .mockRejectedValueOnce(new Error("connection reset"))
+        .mockRejectedValueOnce(new Error("disconnect"))
+        .mockResolvedValueOnce(undefined),
+    });
+    const params = makeParams({ msg });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await deliverWebReply(params as any);
+    // Should have been called 5 times (4 failures + 1 success)
+    expect(msg.reply).toHaveBeenCalledTimes(5);
+  });
+
+  it("fails after exhausting all 5 retry attempts", async () => {
+    const msg = makeMsg({
+      reply: vi.fn().mockRejectedValue(new Error("connection closed")),
+    });
+    const params = makeParams({ msg });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await expect(deliverWebReply(params as any)).rejects.toThrow("connection closed");
+    expect(msg.reply).toHaveBeenCalledTimes(5);
+  });
+
+  it("does not retry on non-transient errors", async () => {
+    const msg = makeMsg({
+      reply: vi.fn().mockRejectedValue(new Error("permission denied")),
+    });
+    const params = makeParams({ msg });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await expect(deliverWebReply(params as any)).rejects.toThrow("permission denied");
+    // Should fail on first attempt without retrying
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses 1000ms * attempt backoff intervals", async () => {
+    const msg = makeMsg({
+      reply: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("connection closed"))
+        .mockRejectedValueOnce(new Error("connection closed"))
+        .mockResolvedValueOnce(undefined),
+    });
+    const params = makeParams({ msg });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await deliverWebReply(params as any);
+    expect(msg.reply).toHaveBeenCalledTimes(3);
+    // Verify backoff: 1000*1=1000ms, 1000*2=2000ms
+    expect(mockedSleep).toHaveBeenCalledTimes(2);
+    expect(mockedSleep).toHaveBeenNthCalledWith(1, 1000);
+    expect(mockedSleep).toHaveBeenNthCalledWith(2, 2000);
+  });
+});

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -40,7 +40,7 @@ export async function deliverWebReply(params: {
       ? [replyResult.mediaUrl]
       : [];
 
-  const sendWithRetry = async (fn: () => Promise<unknown>, label: string, maxAttempts = 3) => {
+  const sendWithRetry = async (fn: () => Promise<unknown>, label: string, maxAttempts = 5) => {
     let lastErr: unknown;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
@@ -53,7 +53,7 @@ export async function deliverWebReply(params: {
         if (!shouldRetry || isLast) {
           throw err;
         }
-        const backoffMs = 500 * attempt;
+        const backoffMs = 1000 * attempt;
         logVerbose(
           `Retrying ${label} to ${msg.from} after failure (${attempt}/${maxAttempts - 1}) in ${backoffMs}ms: ${errText}`,
         );

--- a/src/web/auto-reply/monitor/process-message.delivery-failure.test.ts
+++ b/src/web/auto-reply/monitor/process-message.delivery-failure.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { resetSystemEventsForTest, drainSystemEvents } from "../../../infra/system-events.js";
+
+// Capture the onError callback from the dispatcher so we can invoke it.
+let capturedOnError: ((err: unknown, info: { kind: string }) => void) | undefined;
+
+vi.mock("../../../auto-reply/reply/provider-dispatcher.js", () => ({
+  dispatchReplyWithBufferedBlockDispatcher: vi.fn(
+    async (params: {
+      ctx: unknown;
+      dispatcherOptions: { onError: (err: unknown, info: { kind: string }) => void };
+    }) => {
+      capturedOnError = params.dispatcherOptions.onError;
+      return { queuedFinal: false };
+    },
+  ),
+}));
+
+import { processMessage } from "./process-message.js";
+
+function callProcessMessage() {
+  return processMessage({
+    // oxlint-disable-next-line typescript/no-explicit-any
+    cfg: { messages: {} } as any,
+    msg: {
+      id: "msg1",
+      from: "+15550001111",
+      to: "+15550002222",
+      chatType: "dm",
+      body: "hello",
+      senderName: "Bob",
+      senderJid: "bob@s.whatsapp.net",
+      senderE164: "+15550001111",
+      groupParticipants: [],
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any,
+    route: {
+      agentId: "main",
+      accountId: "default",
+      sessionKey: "agent:main:whatsapp:dm:15550001111",
+      mainSessionKey: "agent:main",
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any,
+    groupHistoryKey: "+15550001111",
+    groupHistories: new Map(),
+    groupMemberNames: new Map(),
+    connectionId: "conn-1",
+    verbose: false,
+    maxMediaBytes: 1,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    replyResolver: (async () => undefined) as any,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    replyLogger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
+    backgroundTasks: new Set(),
+    rememberSentText: () => {},
+    echoHas: () => false,
+    echoForget: () => {},
+    buildCombinedEchoKey: () => "echo-key",
+    // oxlint-disable-next-line typescript/no-explicit-any
+  } as any);
+}
+
+describe("process-message delivery failure surfacing (#14827)", () => {
+  beforeEach(() => {
+    capturedOnError = undefined;
+    resetSystemEventsForTest();
+  });
+
+  it("enqueues a system event when onError is called for a final reply", async () => {
+    await callProcessMessage();
+    expect(capturedOnError).toBeDefined();
+
+    // Simulate a delivery failure
+    capturedOnError!(new Error("connection closed"), { kind: "final" });
+
+    const events = drainSystemEvents("agent:main:whatsapp:dm:15550001111");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain("WhatsApp delivery failure");
+    expect(events[0]).toContain("+15550001111");
+    expect(events[0]).toContain("connection closed");
+  });
+
+  it("enqueues a system event for tool update failures", async () => {
+    await callProcessMessage();
+    expect(capturedOnError).toBeDefined();
+
+    capturedOnError!(new Error("socket reset"), { kind: "tool" });
+
+    const events = drainSystemEvents("agent:main:whatsapp:dm:15550001111");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain("tool update");
+    expect(events[0]).toContain("socket reset");
+  });
+
+  it("enqueues a system event for block update failures", async () => {
+    await callProcessMessage();
+    expect(capturedOnError).toBeDefined();
+
+    capturedOnError!(new Error("disconnect"), { kind: "block" });
+
+    const events = drainSystemEvents("agent:main:whatsapp:dm:15550001111");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain("block update");
+  });
+});


### PR DESCRIPTION
## Problem

When WhatsApp Web disconnects (408/503), messages sent during the ~3-5s reconnection window are silently dropped. `sendWithRetry()` in `deliver-reply.ts` tried 3 times with 500ms×attempt backoff (total ~3s), but reconnection typically takes 3-5s. After retries exhaust, the `onError` handler in `process-message.ts` only logged without notifying the agent.

## Fix

### 1. Increase retry window (`deliver-reply.ts`)
- **Attempts:** 3 → 5
- **Backoff:** 500ms × attempt → 1000ms × attempt
- **Total window:** ~3s → ~15s (covers the reconnection window)

### 2. Surface delivery failures (`process-message.ts`)
- Call `enqueueSystemEvent()` in the `onError` handler so delivery failures are surfaced as system events to the agent
- The agent will now be aware when a WhatsApp message fails to deliver

## Tests

- `deliver-reply.test.ts`: Tests retry count (5 attempts), backoff intervals (1000ms×attempt), non-transient error handling, and exhaustion behavior
- `process-message.delivery-failure.test.ts`: Tests that system events are enqueued for final reply, tool update, and block update failures

Closes #14827

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends WhatsApp outbound retry behavior and improves visibility of delivery failures.

- `src/web/auto-reply/deliver-reply.ts` increases `sendWithRetry()` defaults from 3→5 attempts and changes backoff from `500ms * attempt` to `1000ms * attempt`, expanding the retry window to better cover WhatsApp Web reconnect gaps.
- `src/web/auto-reply/monitor/process-message.ts` now enqueues a system event in the dispatcher `onError` handler, so final replies/tool updates/block updates that fail to send surface to the agent (instead of only logging).
- Adds unit tests covering retry behavior (`deliver-reply.test.ts`) and system event surfacing on send failures (`process-message.delivery-failure.test.ts`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and covered by new unit tests; the new system-event surfacing uses an existing in-memory queue with session scoping and deduplication, and the retry parameter changes are straightforward.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->