### PR TITLE
fix: retry session lock acquisition with backoff to prevent silent message drops (#14796)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ USER.md
 .agent/*.json
 !.agent/workflows/
 local/
+package-lock.json

--- a/src/auto-reply/reply/dispatch-from-config.lock-timeout.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lock-timeout.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { ReplyPayload } from "../types.js";
+import type { ReplyDispatcher } from "./reply-dispatcher.js";
+import { SessionStoreLockTimeoutError } from "../../config/sessions/store.js";
+import { buildTestCtx } from "./test-ctx.js";
+
+const mocks = vi.hoisted(() => ({
+  routeReply: vi.fn(async () => ({ ok: true, messageId: "mock" })),
+  tryFastAbortFromMessage: vi.fn(async () => ({
+    handled: false,
+    aborted: false,
+  })),
+}));
+const diagnosticMocks = vi.hoisted(() => ({
+  logMessageQueued: vi.fn(),
+  logMessageProcessed: vi.fn(),
+  logSessionStateChange: vi.fn(),
+}));
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => false),
+    runMessageReceived: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("./route-reply.js", () => ({
+  isRoutableChannel: (channel: string | undefined) =>
+    Boolean(
+      channel &&
+      ["telegram", "slack", "discord", "signal", "imessage", "whatsapp"].includes(channel),
+    ),
+  routeReply: mocks.routeReply,
+}));
+
+vi.mock("./abort.js", () => ({
+  tryFastAbortFromMessage: mocks.tryFastAbortFromMessage,
+  formatAbortReplyText: () => "⚙️ Agent was aborted.",
+}));
+
+vi.mock("../../logging/diagnostic.js", () => ({
+  logMessageQueued: diagnosticMocks.logMessageQueued,
+  logMessageProcessed: diagnosticMocks.logMessageProcessed,
+  logSessionStateChange: diagnosticMocks.logSessionStateChange,
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
+const { resetInboundDedupe } = await import("./inbound-dedupe.js");
+
+function createDispatcher(): ReplyDispatcher & {
+  sendFinalReply: ReturnType<typeof vi.fn>;
+  waitForIdle: ReturnType<typeof vi.fn>;
+  getQueuedCounts: ReturnType<typeof vi.fn>;
+} {
+  return {
+    sendToolResult: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => true),
+    sendFinalReply: vi.fn(() => true),
+    waitForIdle: vi.fn(async () => {}),
+    getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+  };
+}
+
+describe("dispatchReplyFromConfig - SessionStoreLockTimeoutError handling", () => {
+  beforeEach(() => {
+    resetInboundDedupe();
+    diagnosticMocks.logMessageQueued.mockReset();
+    diagnosticMocks.logMessageProcessed.mockReset();
+    diagnosticMocks.logSessionStateChange.mockReset();
+    hookMocks.runner.hasHooks.mockReset();
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runMessageReceived.mockReset();
+    mocks.routeReply.mockReset();
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+    mocks.tryFastAbortFromMessage.mockReset();
+    mocks.tryFastAbortFromMessage.mockResolvedValue({ handled: false, aborted: false });
+  });
+
+  it("sends error reply via dispatcher when SessionStoreLockTimeoutError is thrown", async () => {
+    const ctx = buildTestCtx({
+      Body: "hello",
+      From: "telegram:123",
+      To: "telegram:bot",
+      Provider: "telegram",
+      Surface: "telegram",
+      MessageSid: "msg-lock-1",
+    });
+    const cfg = {} as OpenClawConfig;
+    const dispatcher = createDispatcher();
+
+    // Simulate the reply resolver throwing a SessionStoreLockTimeoutError
+    const replyResolver = vi.fn(async () => {
+      throw new SessionStoreLockTimeoutError("/tmp/sessions.json.lock", 30000);
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+    });
+
+    // Should have sent a final reply with the contention error message
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    const sentPayload = dispatcher.sendFinalReply.mock.calls[0][0] as ReplyPayload;
+    expect(sentPayload.text).toContain("could not be processed");
+    expect(sentPayload.text).toContain("contention");
+    expect(result.queuedFinal).toBe(true);
+  });
+
+  it("does not re-throw SessionStoreLockTimeoutError after sending error reply", async () => {
+    const ctx = buildTestCtx({
+      Body: "hello",
+      From: "telegram:123",
+      To: "telegram:bot",
+      Provider: "telegram",
+      Surface: "telegram",
+      MessageSid: "msg-lock-2",
+    });
+    const cfg = {} as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => {
+      throw new SessionStoreLockTimeoutError("/tmp/sessions.json.lock", 30000);
+    });
+
+    // Should NOT throw — the error is caught and a reply is sent instead
+    await expect(
+      dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver }),
+    ).resolves.toBeDefined();
+  });
+
+  it("still throws non-lock-timeout errors", async () => {
+    const ctx = buildTestCtx({
+      Body: "hello",
+      From: "telegram:123",
+      To: "telegram:bot",
+      Provider: "telegram",
+      Surface: "telegram",
+      MessageSid: "msg-lock-3",
+    });
+    const cfg = {} as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => {
+      throw new Error("some other error");
+    });
+
+    await expect(dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver })).rejects.toThrow(
+      "some other error",
+    );
+  });
+
+  it("routes error reply to originating channel when cross-provider", async () => {
+    const ctx = buildTestCtx({
+      Body: "hello",
+      From: "user@slack",
+      To: "bot@slack",
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:chatid",
+      MessageSid: "msg-lock-4",
+    });
+    const cfg = {} as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => {
+      throw new SessionStoreLockTimeoutError("/tmp/sessions.json.lock", 30000);
+    });
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    // Should route via routeReply, not dispatcher.sendFinalReply
+    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
+    const routeCall = mocks.routeReply.mock.calls[0][0] as { payload: ReplyPayload };
+    expect(routeCall.payload.text).toContain("could not be processed");
+  });
+
+  it("records diagnostic event as error", async () => {
+    const ctx = buildTestCtx({
+      Body: "hello",
+      From: "telegram:123",
+      To: "telegram:bot",
+      Provider: "telegram",
+      Surface: "telegram",
+      MessageSid: "msg-lock-5",
+    });
+    const cfg = { diagnostics: { enabled: true } } as unknown as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => {
+      throw new SessionStoreLockTimeoutError("/tmp/sessions.json.lock", 30000);
+    });
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "error",
+      }),
+    );
+  });
+});

--- a/src/config/sessions/store.lock-retry.test.ts
+++ b/src/config/sessions/store.lock-retry.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSessionStoreCacheForTest, SessionStoreLockTimeoutError, __testing } from "./store.js";
+
+const { withSessionStoreLock } = __testing;
+
+// Mock loadConfig so resolveMaintenanceConfig() never reads a real openclaw.json.
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn().mockReturnValue({}),
+}));
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  clearSessionStoreCacheForTest();
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-retry-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("SessionStoreLockTimeoutError", () => {
+  it("is thrown when lock acquisition times out", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const lockPath = `${storePath}.lock`;
+
+    // Create a lock file held by the current process (so it won't be considered stale/dead)
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+      "utf-8",
+    );
+
+    // Use withSessionStoreLock directly with a short timeout
+    await expect(
+      withSessionStoreLock(storePath, async () => "should not reach", {
+        timeoutMs: 500,
+        staleMs: 60_000,
+      }),
+    ).rejects.toThrow(SessionStoreLockTimeoutError);
+
+    // Clean up
+    await fs.unlink(lockPath).catch(() => {});
+  });
+
+  it("has the correct name and properties", () => {
+    const err = new SessionStoreLockTimeoutError("/some/path.lock", 5000);
+    expect(err.name).toBe("SessionStoreLockTimeoutError");
+    expect(err.lockPath).toBe("/some/path.lock");
+    expect(err.timeoutMs).toBe(5000);
+    expect(err.message).toContain("timeout acquiring session store lock");
+    expect(err.message).toContain("/some/path.lock");
+  });
+
+  it("preserves the cause", () => {
+    const cause = new Error("EEXIST");
+    const err = new SessionStoreLockTimeoutError("/some/path.lock", 5000, cause);
+    expect(err.cause).toBe(cause);
+  });
+
+  it("is an instance of Error", () => {
+    const err = new SessionStoreLockTimeoutError("/some/path.lock", 5000);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(SessionStoreLockTimeoutError);
+  });
+});
+
+describe("withSessionStoreLock backoff", () => {
+  it("succeeds when lock is released before timeout", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const lockPath = `${storePath}.lock`;
+
+    // Write initial store
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify({}), "utf-8");
+
+    // Create a lock file held by the current process
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+      "utf-8",
+    );
+
+    // Release the lock after 200ms
+    setTimeout(async () => {
+      await fs.unlink(lockPath).catch(() => {});
+    }, 200);
+
+    // This should succeed after the lock is released
+    const startTime = Date.now();
+    const result = await withSessionStoreLock(storePath, async () => "success", {
+      timeoutMs: 5000,
+      staleMs: 60_000,
+    });
+    const elapsed = Date.now() - startTime;
+
+    expect(result).toBe("success");
+    // Should have waited at least ~200ms for the lock release
+    expect(elapsed).toBeGreaterThanOrEqual(150);
+
+    // Clean up lock if it still exists
+    await fs.unlink(lockPath).catch(() => {});
+  });
+
+  it("uses exponential backoff (delays grow over time)", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const lockPath = `${storePath}.lock`;
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+
+    // Create a lock held by the current process
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+      "utf-8",
+    );
+
+    const startTime = Date.now();
+    try {
+      await withSessionStoreLock(storePath, async () => "should not reach", {
+        timeoutMs: 800,
+        staleMs: 60_000,
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(SessionStoreLockTimeoutError);
+    }
+    const elapsed = Date.now() - startTime;
+
+    // With exponential backoff starting at 50ms and doubling, we should
+    // NOT see hundreds of attempts in 800ms (unlike the old 25ms fixed poll).
+    // The elapsed time should be close to 800ms (the timeout).
+    expect(elapsed).toBeGreaterThanOrEqual(700);
+    expect(elapsed).toBeLessThan(2000);
+
+    await fs.unlink(lockPath).catch(() => {});
+  });
+
+  it("reclaims stale lock files during retry", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const lockPath = `${storePath}.lock`;
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify({}), "utf-8");
+
+    // Create a stale lock file (old mtime)
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: 999999, startedAt: Date.now() - 60_000 }),
+      "utf-8",
+    );
+    // Set mtime to 60 seconds ago to trigger stale eviction
+    const pastTime = new Date(Date.now() - 60_000);
+    await fs.utimes(lockPath, pastTime, pastTime);
+
+    // Should succeed by reclaiming the stale lock
+    const result = await withSessionStoreLock(storePath, async () => "reclaimed", {
+      timeoutMs: 2000,
+      staleMs: 10_000,
+    });
+    expect(result).toBe("reclaimed");
+
+    // Clean up lock if it still exists
+    await fs.unlink(lockPath).catch(() => {});
+  });
+
+  it("concurrent writers eventually succeed (no silent drops)", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify({}), "utf-8");
+
+    // Launch 5 concurrent lock acquisitions — all should succeed
+    const results = await Promise.allSettled(
+      Array.from({ length: 5 }, (_, i) =>
+        withSessionStoreLock(
+          storePath,
+          async () => {
+            // Simulate some work inside the lock
+            await new Promise((r) => setTimeout(r, 20));
+            return `writer-${i}`;
+          },
+          { timeoutMs: 10_000 },
+        ),
+      ),
+    );
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    // All 5 should succeed (no silent drops)
+    expect(fulfilled.length).toBe(5);
+
+    // All should have returned their values
+    const values = fulfilled.map((r) => r.value);
+    for (let i = 0; i < 5; i++) {
+      expect(values).toContain(`writer-${i}`);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

When the session store lock cannot be acquired within the timeout period, incoming messages (e.g. from Telegram) are silently dropped. The user receives no indication their message was lost. Error logs show:

```
timeout acquiring session store lock: .../sessions.json.lock
```

The root causes are:
1. Fixed 25ms polling with only 10s timeout is insufficient under contention
2. The `SessionStoreLockTimeoutError` propagates to `bot.catch()` which only logs — no user notification

## Solution

### 1. Exponential backoff with jitter in `withSessionStoreLock`
- Replace fixed 25ms polling with exponential backoff (50ms base, 2× growth, 2s cap)
- Add ±25% random jitter to reduce lock convoys (synchronized retries)
- Increase default timeout from 10s to 30s for better resilience under load
- Log a warning on first contention detection for observability

### 2. Typed error class for identification
- Add `SessionStoreLockTimeoutError` extending `Error` with `lockPath` and `timeoutMs` properties
- Enables callers to distinguish lock contention from other failures

### 3. User-visible error in dispatch pipeline
- Catch `SessionStoreLockTimeoutError` in `dispatchReplyFromConfig` (common entry for all channels)
- Send a user-visible error reply: *"⚠️ Your message could not be processed due to high contention. Please try again in a moment."*
- Supports cross-provider routing via `routeReply` when `originatingChannel` differs

## Tests (13 new, all pass)

**Lock retry (`store.lock-retry.test.ts`):**
- `SessionStoreLockTimeoutError` class properties and `instanceof` checks
- Lock timeout throws the new error type
- Lock acquired after contention resolves (lock released mid-retry)
- Exponential backoff timing behavior
- Stale lock reclamation during retry
- Concurrent writers all succeed (no silent drops)

**Dispatch error handling (`dispatch-from-config.lock-timeout.test.ts`):**
- Sends error reply via dispatcher on lock timeout
- Does not re-throw after sending error reply
- Non-lock errors still propagate normally
- Cross-provider error routing works correctly
- Diagnostic events recorded as error outcome

## Changed files
- `src/config/sessions/store.ts` — `SessionStoreLockTimeoutError` class, backoff logic, increased timeout
- `src/auto-reply/reply/dispatch-from-config.ts` — catch lock timeout, send user error
- `src/config/sessions/store.lock-retry.test.ts` — new tests
- `src/auto-reply/reply/dispatch-from-config.lock-timeout.test.ts` — new tests

Closes #14796

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves session store locking robustness by replacing fixed-interval polling with exponential backoff + jitter in `withSessionStoreLock`, increasing the default lock acquisition timeout, and introducing a typed `SessionStoreLockTimeoutError` so callers can distinguish lock contention from other failures.

It also updates the central reply dispatch pipeline (`dispatchReplyFromConfig`) to catch `SessionStoreLockTimeoutError` and send a user-visible “try again” message (including cross-provider routing via `routeReply`), preventing silent drops when the sessions.json lock can’t be acquired. Two new Vitest suites cover the new lock behavior and the dispatch error handling path.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but has a couple of correctness/consistency issues to fix first.
- Core locking/backoff changes and typed error plumbing look coherent and are covered by targeted tests. The remaining issues are localized: (1) cross-provider lock-timeout replies bypass the dispatcher but the returned queued counts don’t reflect the routed send, and (2) a now-unused `pollIntervalMs` option remains in the lock options API and will be silently ignored.
- src/auto-reply/reply/dispatch-from-config.ts, src/config/sessions/store.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->