### PR TITLE
fix: resolve cron delivery target for Discord channels (#14753)

### DIFF
--- a/src/channels/plugins/outbound/discord.test.ts
+++ b/src/channels/plugins/outbound/discord.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { setActivePluginRegistry } from "../../../plugins/runtime.js";
+import {
+  createOutboundTestPlugin,
+  createTestRegistry,
+} from "../../../test-utils/channel-plugins.js";
+import { discordOutbound } from "./discord.js";
+
+describe("discordOutbound.resolveTarget", () => {
+  const resolveTarget = discordOutbound.resolveTarget!;
+
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          plugin: createOutboundTestPlugin({ id: "discord", outbound: discordOutbound }),
+          source: "test",
+        },
+      ]),
+    );
+  });
+
+  it("normalizes bare numeric channel id to channel: prefix", () => {
+    const result = resolveTarget({ to: "1234567890123456789", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "channel:1234567890123456789" });
+  });
+
+  it("preserves user: prefix targets", () => {
+    const result = resolveTarget({ to: "user:9876543210", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "user:9876543210" });
+  });
+
+  it("preserves channel: prefix targets", () => {
+    const result = resolveTarget({ to: "channel:1234567890", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "channel:1234567890" });
+  });
+
+  it("normalizes discord: prefix to user target", () => {
+    const result = resolveTarget({ to: "discord:9876543210", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "user:9876543210" });
+  });
+
+  it("normalizes mention format", () => {
+    const result = resolveTarget({ to: "<@123456>", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "user:123456" });
+  });
+
+  it("returns error for empty target in explicit mode", () => {
+    const result = resolveTarget({ to: "", mode: "explicit" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error for undefined target in explicit mode", () => {
+    const result = resolveTarget({ to: undefined, mode: "explicit" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("falls back to allowFrom in implicit mode when to is empty", () => {
+    const result = resolveTarget({
+      to: "",
+      allowFrom: ["1234567890"],
+      mode: "implicit",
+    });
+    expect(result).toEqual({ ok: true, to: "channel:1234567890" });
+  });
+
+  it("falls back to allowFrom in heartbeat mode when to is empty", () => {
+    const result = resolveTarget({
+      to: undefined,
+      allowFrom: ["user:5555"],
+      mode: "heartbeat",
+    });
+    expect(result).toEqual({ ok: true, to: "user:5555" });
+  });
+
+  it("returns error when no target and no allowFrom in implicit mode", () => {
+    const result = resolveTarget({ to: "", mode: "implicit" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("normalizes channel name strings to channel: prefix", () => {
+    const result = resolveTarget({ to: "general", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "channel:general" });
+  });
+});

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -1,11 +1,41 @@
 import type { ChannelOutboundAdapter } from "../types.js";
 import { sendMessageDiscord, sendPollDiscord } from "../../../discord/send.js";
+import { missingTargetError } from "../../../infra/outbound/target-errors.js";
+import { normalizeDiscordMessagingTarget } from "../normalize/discord.js";
 
 export const discordOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 2000,
   pollMaxOptions: 10,
+  resolveTarget: ({ to, allowFrom, mode }) => {
+    const trimmed = to?.trim();
+    if (!trimmed) {
+      if (mode === "implicit" || mode === "heartbeat") {
+        const fallback = (allowFrom ?? []).map((e) => String(e).trim()).filter(Boolean)[0];
+        if (fallback) {
+          const normalized = normalizeDiscordMessagingTarget(fallback);
+          if (normalized) {
+            return { ok: true, to: normalized };
+          }
+        }
+      }
+      return {
+        ok: false,
+        error: missingTargetError("Discord", "<channelId|user:ID|channel:ID>"),
+      };
+    }
+    const normalized = normalizeDiscordMessagingTarget(trimmed);
+    if (normalized) {
+      return { ok: true, to: normalized };
+    }
+    return {
+      ok: false,
+      error: new Error(
+        `Invalid Discord target "${trimmed}". Use channel:<id> for channels or user:<id> for DMs.`,
+      ),
+    };
+  },
   sendText: async ({ to, text, accountId, deps, replyToId }) => {
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {

--- a/src/cron/isolated-agent.issue-14753.test.ts
+++ b/src/cron/isolated-agent.issue-14753.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Regression test for #14753: Cron job delivery modes (announce/deliver)
+ * fail to post messages to Discord despite successful execution.
+ *
+ * Root causes:
+ * 1. Bare numeric Discord channel IDs (e.g. "1234567890123456789") were not
+ *    normalized to "channel:1234567890123456789" before reaching
+ *    sendMessageDiscord, causing "Ambiguous Discord recipient" errors that
+ *    were silently swallowed by best-effort delivery.
+ * 2. Discord guild messages don't call updateLastRoute on the main session,
+ *    so resolveDeliveryTarget couldn't find a Discord target when `to` was
+ *    omitted. The session store fallback (from #14646) fixes this.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { CronJob } from "./types.js";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { discordOutbound } from "../channels/plugins/outbound/discord.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+vi.mock("../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn(),
+}));
+
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-cron-14753-" });
+}
+
+function makeCfg(
+  home: string,
+  storePath: string,
+  overrides: Partial<OpenClawConfig> = {},
+): OpenClawConfig {
+  const base: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-opus-4-5",
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+  } as OpenClawConfig;
+  return { ...base, ...overrides };
+}
+
+function makeJob(overrides: Partial<CronJob> = {}): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-1",
+    name: "daily-digest",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "run daily digest" },
+    state: {},
+    ...overrides,
+  };
+}
+
+function makeDeps(): CliDeps {
+  return {
+    sendMessageWhatsApp: vi.fn(),
+    sendMessageTelegram: vi.fn(),
+    sendMessageDiscord: vi.fn().mockResolvedValue({ messageId: "d1", channelId: "ch123" }),
+    sendMessageSignal: vi.fn(),
+    sendMessageIMessage: vi.fn(),
+  };
+}
+
+describe("issue #14753 – cron delivery to Discord", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+    vi.mocked(runSubagentAnnounceFlow).mockReset().mockResolvedValue(true);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          plugin: createOutboundTestPlugin({ id: "discord", outbound: discordOutbound }),
+          source: "test",
+        },
+      ]),
+    );
+  });
+
+  it("normalizes bare numeric Discord channel ID in delivery target", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "discord",
+            lastTo: "user:111222333",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { discord: { token: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "discord", to: "1234567890123456789" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("discord");
+      // Bare ID should be normalized to channel:ID
+      expect(args?.requesterOrigin?.to).toBe("channel:1234567890123456789");
+    });
+  });
+
+  it("preserves channel: prefixed Discord target", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { discord: { token: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "deliver", channel: "discord", to: "channel:9876543210" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.to).toBe("channel:9876543210");
+    });
+  });
+
+  it("finds Discord target from other session entries when main session lastChannel differs", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      // Main session is on webchat, but a Discord DM session exists
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "webchat",
+            lastTo: "web-user-1",
+          },
+          "agent:main:discord:dm:user:555": {
+            sessionId: "discord-dm-session",
+            updatedAt: Date.now(),
+            lastChannel: "discord",
+            lastTo: "user:555",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { discord: { token: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "discord", to: "" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("discord");
+      // Found from the Discord DM session entry, then normalized
+      expect(args?.requesterOrigin?.to).toBe("user:555");
+    });
+  });
+
+  it("still errors when no session entry has a Discord target and to is empty", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      // No session has ever used Discord
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "webchat",
+            lastTo: "web-user-1",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { discord: { token: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "discord", to: "" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("error");
+      expect(res.error).toBe("cron delivery target is missing");
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    });
+  });
+
+  it("normalizes bare ID from session store fallback through resolveTarget", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      // Main session on webchat, Discord session has bare numeric lastTo
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "webchat",
+            lastTo: "web-user-1",
+          },
+          "agent:main:discord:channel:777": {
+            sessionId: "discord-channel-session",
+            updatedAt: Date.now(),
+            lastChannel: "discord",
+            lastTo: "channel:777888999",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { discord: { token: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "discord" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("discord");
+      expect(args?.requesterOrigin?.to).toBe("channel:777888999");
+    });
+  });
+});

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -12,6 +12,43 @@ import {
   resolveOutboundTarget,
   resolveSessionDeliveryTarget,
 } from "../../infra/outbound/targets.js";
+import { deliveryContextFromSession } from "../../utils/delivery-context.js";
+import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
+
+/**
+ * When the main session's lastChannel doesn't match the requested channel,
+ * scan all session entries for the same agent to find one whose lastChannel
+ * matches. This handles the common case where the user configured a cron to
+ * deliver on a specific channel (e.g. Discord or Telegram) but their main
+ * session's lastChannel has since changed to another channel (e.g. webchat),
+ * or was never set for that channel (e.g. Discord guild messages don't update
+ * lastRoute on the main session).
+ *
+ * See: https://github.com/openclaw/openclaw/issues/14646
+ * See: https://github.com/openclaw/openclaw/issues/14753
+ */
+function findDeliveryTargetFromStore(
+  store: Record<string, unknown>,
+  requestedChannel: string,
+  excludeKey?: string,
+): { to: string; accountId?: string; threadId?: string | number } | undefined {
+  for (const [key, entry] of Object.entries(store)) {
+    if (key === excludeKey || !entry || typeof entry !== "object") {
+      continue;
+    }
+    const ctx = deliveryContextFromSession(
+      entry as Parameters<typeof deliveryContextFromSession>[0],
+    );
+    if (
+      ctx?.channel === requestedChannel &&
+      typeof ctx.to === "string" &&
+      ctx.to.trim().length > 0
+    ) {
+      return { to: ctx.to, accountId: ctx.accountId, threadId: ctx.threadId };
+    }
+  }
+  return undefined;
+}
 
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
@@ -68,7 +105,26 @@ export async function resolveDeliveryTarget(
 
   const channel = resolved.channel ?? fallbackChannel ?? DEFAULT_CHAT_CHANNEL;
   const mode = resolved.mode as "explicit" | "implicit";
-  const toCandidate = resolved.to;
+  let toCandidate = resolved.to;
+  let accountId = resolved.accountId;
+
+  // #14646 / #14753: When an explicit channel is requested but the main
+  // session's lastChannel doesn't match (e.g. user interacts via Discord
+  // guilds where updateLastRoute is skipped, or switched from Telegram to
+  // webchat), the initial resolution can't find a `to`. Fall back to scanning
+  // the session store for ANY entry that was last used on the requested channel.
+  if (
+    !toCandidate &&
+    !explicitTo &&
+    requestedChannel !== "last" &&
+    isDeliverableMessageChannel(channel)
+  ) {
+    const storeHit = findDeliveryTargetFromStore(store, channel, mainSessionKey);
+    if (storeHit) {
+      toCandidate = storeHit.to;
+      accountId = storeHit.accountId ?? accountId;
+    }
+  }
 
   // Only carry threadId when delivering to the same recipient as the session's
   // last conversation. This prevents stale thread IDs (e.g. from a Telegram
@@ -83,7 +139,7 @@ export async function resolveDeliveryTarget(
     return {
       channel,
       to: undefined,
-      accountId: resolved.accountId,
+      accountId,
       threadId,
       mode,
     };
@@ -93,13 +149,13 @@ export async function resolveDeliveryTarget(
     channel,
     to: toCandidate,
     cfg,
-    accountId: resolved.accountId,
+    accountId,
     mode,
   });
   return {
     channel,
     to: docked.ok ? docked.to : undefined,
-    accountId: resolved.accountId,
+    accountId,
     threadId,
     mode,
     error: docked.ok ? undefined : docked.error,


### PR DESCRIPTION
## Problem

Cron jobs with `delivery: { mode: "announce", channel: "discord", to: "1234567890123456789" }` fail to deliver messages to Discord. The cron completes successfully but no message appears in Discord, and no errors are visible in cron run logs.

### Root Causes

**1. Bare numeric Discord IDs cause silent "Ambiguous recipient" errors**

When `resolveDeliveryTarget` passes a bare numeric channel ID (e.g. `"1234567890123456789"`) through `resolveOutboundTarget`, it returns successfully because the Discord plugin had no `resolveTarget` function (just returns the trimmed string). But downstream, `sendMessageDiscord` → `parseAndResolveRecipient` → `parseDiscordTarget` throws "Ambiguous Discord recipient" because it cannot determine if the ID is a user or channel.

This error is silently swallowed because:
- The announce flow uses `callGateway({ method: "agent" })` which spawns an async agent run
- The gateway sets `bestEffortDeliver = true` for main session runs
- `deliverOutboundPayloads` catches the error via `bestEffort`, logs it to `runtime.error` (not cron run logs)
- The cron run reports "ok" since the announce call itself succeeded

**2. Discord guild messages never update `lastRoute` on the main session**

The Discord monitor only calls `updateLastRoute` for DMs, not guild/channel messages:
```typescript
updateLastRoute: isDirectMessage
  ? { sessionKey: route.mainSessionKey, channel: "discord", to: \`user:\${author.id}\` }
  : undefined,
```

This means when a cron job has `delivery: { channel: "discord" }` with empty `to`, `resolveDeliveryTarget` cannot find a Discord target from the main session's `lastChannel`/`lastTo` (they're never set for Discord guild interactions).

### Fix

**Fix 1: Add `resolveTarget` to Discord outbound adapter**

Normalizes Discord targets before they reach `sendMessageDiscord`:
- Bare numeric IDs → `channel:<id>` (using `normalizeDiscordMessagingTarget` which defaults bare IDs to channels)
- Already-prefixed targets (`user:`, `channel:`, `discord:`) → preserved/normalized
- Empty targets in implicit/heartbeat mode → falls back to `allowFrom[0]`

This is the same pattern WhatsApp uses (WhatsApp already has `resolveTarget`).

**Fix 2: Session store fallback for channel mismatch (port from #14693)**

When the main session's `lastChannel` doesn't match the requested delivery channel, scan all session entries for one whose `lastChannel` matches. This is the same fix as PR #14693 (for Telegram), applied here for all channels including Discord.

### Tests

**11 unit tests** for `discordOutbound.resolveTarget`:
- Bare numeric ID normalization → `channel:<id>`
- Prefixed targets preserved (`user:`, `channel:`, `discord:`)
- Mention format normalization (`<@123>` → `user:123`)
- Empty/undefined target error handling
- `allowFrom` fallback in implicit/heartbeat modes
- Channel name string normalization

**5 integration tests** for cron Discord delivery:
- Bare numeric ID in `delivery.to` → normalized to `channel:<id>` in announce origin
- `channel:` prefixed target preserved through delivery pipeline
- Session store fallback when main session `lastChannel` differs
- Proper error when no session has Discord target and `to` is empty
- Combined session store fallback + resolveTarget normalization

Fixes #14753

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Discord cron delivery by adding a `resolveTarget` normalizer for Discord outbound targets (so bare numeric IDs and mentions are normalized before sending), and by adding a session-store fallback in `resolveDeliveryTarget` to find a matching `lastChannel`/`lastTo` when the main session’s `lastChannel` doesn’t match the requested delivery channel.

The changes integrate into the existing outbound docking flow via `resolveOutboundTarget` (which prefers `plugin.outbound.resolveTarget`) and into cron isolated-agent delivery via `resolveDeliveryTarget` so cron announcements get a fully-normalized `{channel,to}` origin.

One blocking issue: the new regression test introduces an invalid cron `delivery.mode` value (`"deliver"`) that doesn’t match the declared `CronDeliveryMode` union (`"none" | "announce"`), which should fail type-checking and/or misrepresent the supported config.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a test/type mismatch that should be fixed first.
- Core logic changes (Discord target normalization + session-store fallback) are consistent with existing outbound docking and session context code, and are covered by new unit/integration tests. However, one newly-added regression test uses an unsupported `delivery.mode` value ("deliver") that contradicts `CronDeliveryMode` ("none" | "announce"), which should fail type-checking and needs correction before merging.
- src/cron/isolated-agent.issue-14753.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->