### PR TITLE
fix: fall back to Linux package manager when brew is unavailable in Docker

### DIFF
--- a/src/agents/skills-install.test.ts
+++ b/src/agents/skills-install.test.ts
@@ -112,3 +112,230 @@ describe("installSkill code safety scanning", () => {
     }
   });
 });
+
+const detectLinuxPackageManagerMock = vi.fn();
+const resolveLinuxPackageNameMock = vi.fn();
+const buildLinuxInstallCommandMock = vi.fn();
+
+vi.mock("../infra/linux-package-manager.js", () => ({
+  detectLinuxPackageManager: (...args: unknown[]) => detectLinuxPackageManagerMock(...args),
+  resolveLinuxPackageName: (...args: unknown[]) => resolveLinuxPackageNameMock(...args),
+  buildLinuxInstallCommand: (...args: unknown[]) => buildLinuxInstallCommandMock(...args),
+}));
+
+async function writeBrewSkill(
+  workspaceDir: string,
+  name: string,
+  formula: string,
+  extra?: { apt?: string; apk?: string },
+): Promise<string> {
+  const skillDir = path.join(workspaceDir, "skills", name);
+  await fs.mkdir(skillDir, { recursive: true });
+  const spec: Record<string, unknown> = {
+    id: "brew-dep",
+    kind: "brew",
+    formula,
+    bins: [name],
+    label: `Install ${name} (brew)`,
+  };
+  if (extra?.apt) {
+    spec.apt = extra.apt;
+  }
+  if (extra?.apk) {
+    spec.apk = extra.apk;
+  }
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---
+name: ${name}
+description: test brew skill
+metadata: {"openclaw":{"install":[${JSON.stringify(spec)}]}}
+---
+
+# ${name}
+`,
+    "utf-8",
+  );
+  await fs.writeFile(path.join(skillDir, "runner.js"), "export {};\n", "utf-8");
+  return skillDir;
+}
+
+describe("installSkill brew fallback on Linux", () => {
+  beforeEach(() => {
+    runCommandWithTimeoutMock.mockReset();
+    scanDirectoryWithSummaryMock.mockReset();
+    detectLinuxPackageManagerMock.mockReset();
+    resolveLinuxPackageNameMock.mockReset();
+    buildLinuxInstallCommandMock.mockReset();
+    scanDirectoryWithSummaryMock.mockResolvedValue({
+      scannedFiles: 0,
+      critical: 0,
+      warn: 0,
+      info: 0,
+      findings: [],
+    });
+  });
+
+  it("falls back to apt-get when brew is unavailable on Linux", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-brew-fallback-"));
+    try {
+      await writeBrewSkill(workspaceDir, "ffmpeg-skill", "ffmpeg");
+
+      detectLinuxPackageManagerMock.mockReturnValue("apt-get");
+      resolveLinuxPackageNameMock.mockReturnValue("ffmpeg");
+      buildLinuxInstallCommandMock.mockReturnValue(["apt-get", "install", "-y", "ffmpeg"]);
+      runCommandWithTimeoutMock.mockResolvedValue({
+        code: 0,
+        stdout: "installed ffmpeg",
+        stderr: "",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "ffmpeg-skill",
+        installId: "brew-dep",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toBe("Installed via apt-get");
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+        ["apt-get", "install", "-y", "ffmpeg"],
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("falls back to apk on Alpine when brew is unavailable", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-brew-fallback-"));
+    try {
+      await writeBrewSkill(workspaceDir, "jq-skill", "jq");
+
+      detectLinuxPackageManagerMock.mockReturnValue("apk");
+      resolveLinuxPackageNameMock.mockReturnValue("jq");
+      buildLinuxInstallCommandMock.mockReturnValue(["apk", "add", "--no-cache", "jq"]);
+      runCommandWithTimeoutMock.mockResolvedValue({
+        code: 0,
+        stdout: "installed jq",
+        stderr: "",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "jq-skill",
+        installId: "brew-dep",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toBe("Installed via apk");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("returns helpful error for tap formula with no Linux mapping", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-brew-fallback-"));
+    try {
+      await writeBrewSkill(workspaceDir, "summarize-skill", "steipete/tap/summarize");
+
+      detectLinuxPackageManagerMock.mockReturnValue("apt-get");
+      resolveLinuxPackageNameMock.mockReturnValue(undefined);
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "summarize-skill",
+        installId: "brew-dep",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("no apt-get equivalent");
+      expect(result.message).toContain("steipete/tap/summarize");
+      expect(result.message).toContain("Install Homebrew or the package manually");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("reports failure when Linux package manager install fails", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-brew-fallback-"));
+    try {
+      await writeBrewSkill(workspaceDir, "ffmpeg-skill", "ffmpeg");
+
+      detectLinuxPackageManagerMock.mockReturnValue("apt-get");
+      resolveLinuxPackageNameMock.mockReturnValue("ffmpeg");
+      buildLinuxInstallCommandMock.mockReturnValue(["apt-get", "install", "-y", "ffmpeg"]);
+      runCommandWithTimeoutMock.mockResolvedValue({
+        code: 1,
+        stdout: "",
+        stderr: "E: Unable to locate package ffmpeg",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "ffmpeg-skill",
+        installId: "brew-dep",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("Install failed");
+      expect(result.stderr).toContain("Unable to locate package");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("still returns 'brew not installed' when no Linux package manager is found", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-brew-fallback-"));
+    try {
+      await writeBrewSkill(workspaceDir, "ffmpeg-skill", "ffmpeg");
+
+      detectLinuxPackageManagerMock.mockReturnValue(undefined);
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "ffmpeg-skill",
+        installId: "brew-dep",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("brew not installed");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("uses explicit apt field from spec for brew formula mapping", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-brew-fallback-"));
+    try {
+      await writeBrewSkill(workspaceDir, "custom-skill", "custom/tap/tool", {
+        apt: "custom-tool-apt",
+      });
+
+      detectLinuxPackageManagerMock.mockReturnValue("apt-get");
+      resolveLinuxPackageNameMock.mockReturnValue("custom-tool-apt");
+      buildLinuxInstallCommandMock.mockReturnValue(["apt-get", "install", "-y", "custom-tool-apt"]);
+      runCommandWithTimeoutMock.mockResolvedValue({
+        code: 0,
+        stdout: "installed",
+        stderr: "",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "custom-skill",
+        installId: "brew-dep",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toBe("Installed via apt-get");
+      expect(resolveLinuxPackageNameMock).toHaveBeenCalledWith(
+        "apt-get",
+        "custom/tap/tool",
+        expect.objectContaining({ apt: "custom-tool-apt" }),
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+});

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -82,6 +82,12 @@ function parseInstallSpec(input: unknown): SkillInstallSpec | undefined {
   if (typeof raw.stripComponents === "number") {
     spec.stripComponents = raw.stripComponents;
   }
+  if (typeof raw.apt === "string") {
+    spec.apt = raw.apt;
+  }
+  if (typeof raw.apk === "string") {
+    spec.apk = raw.apk;
+  }
   if (typeof raw.targetDir === "string") {
     spec.targetDir = raw.targetDir;
   }

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -7,6 +7,10 @@ export type SkillInstallSpec = {
   bins?: string[];
   os?: string[];
   formula?: string;
+  /** Explicit apt package name (Debian/Ubuntu) when it differs from the brew formula. */
+  apt?: string;
+  /** Explicit apk package name (Alpine) when it differs from the brew formula. */
+  apk?: string;
   package?: string;
   module?: string;
   url?: string;

--- a/src/infra/linux-package-manager.test.ts
+++ b/src/infra/linux-package-manager.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLinuxInstallCommand,
+  detectLinuxPackageManager,
+  resolveLinuxPackageName,
+} from "./linux-package-manager.js";
+
+describe("detectLinuxPackageManager", () => {
+  it("returns undefined on non-linux platforms", () => {
+    expect(
+      detectLinuxPackageManager({ platform: "darwin", checkBinary: () => true }),
+    ).toBeUndefined();
+    expect(
+      detectLinuxPackageManager({ platform: "win32", checkBinary: () => true }),
+    ).toBeUndefined();
+  });
+
+  it("returns apt-get when available on linux", () => {
+    const available = new Set(["apt-get"]);
+    expect(
+      detectLinuxPackageManager({ platform: "linux", checkBinary: (b) => available.has(b) }),
+    ).toBe("apt-get");
+  });
+
+  it("returns apk when only apk is available", () => {
+    const available = new Set(["apk"]);
+    expect(
+      detectLinuxPackageManager({ platform: "linux", checkBinary: (b) => available.has(b) }),
+    ).toBe("apk");
+  });
+
+  it("prefers apt-get over apk when both are available", () => {
+    const available = new Set(["apt-get", "apk"]);
+    expect(
+      detectLinuxPackageManager({ platform: "linux", checkBinary: (b) => available.has(b) }),
+    ).toBe("apt-get");
+  });
+
+  it("returns dnf when apt-get and apk are absent", () => {
+    const available = new Set(["dnf"]);
+    expect(
+      detectLinuxPackageManager({ platform: "linux", checkBinary: (b) => available.has(b) }),
+    ).toBe("dnf");
+  });
+
+  it("returns undefined when no package manager is found on linux", () => {
+    expect(
+      detectLinuxPackageManager({ platform: "linux", checkBinary: () => false }),
+    ).toBeUndefined();
+  });
+});
+
+describe("buildLinuxInstallCommand", () => {
+  it("builds apt-get command", () => {
+    expect(buildLinuxInstallCommand("apt-get", "ffmpeg")).toEqual([
+      "apt-get",
+      "install",
+      "-y",
+      "ffmpeg",
+    ]);
+  });
+
+  it("builds apk command", () => {
+    expect(buildLinuxInstallCommand("apk", "ffmpeg")).toEqual([
+      "apk",
+      "add",
+      "--no-cache",
+      "ffmpeg",
+    ]);
+  });
+
+  it("builds dnf command", () => {
+    expect(buildLinuxInstallCommand("dnf", "ffmpeg")).toEqual(["dnf", "install", "-y", "ffmpeg"]);
+  });
+
+  it("builds yum command", () => {
+    expect(buildLinuxInstallCommand("yum", "ffmpeg")).toEqual(["yum", "install", "-y", "ffmpeg"]);
+  });
+
+  it("builds pacman command", () => {
+    expect(buildLinuxInstallCommand("pacman", "ffmpeg")).toEqual([
+      "pacman",
+      "-S",
+      "--noconfirm",
+      "ffmpeg",
+    ]);
+  });
+});
+
+describe("resolveLinuxPackageName", () => {
+  it("returns simple formula name as-is", () => {
+    expect(resolveLinuxPackageName("apt-get", "ffmpeg")).toBe("ffmpeg");
+  });
+
+  it("returns undefined for tap formulas without explicit mapping", () => {
+    expect(resolveLinuxPackageName("apt-get", "steipete/tap/summarize")).toBeUndefined();
+  });
+
+  it("uses explicit apt field when provided", () => {
+    expect(resolveLinuxPackageName("apt-get", "some-formula", { apt: "custom-apt-pkg" })).toBe(
+      "custom-apt-pkg",
+    );
+  });
+
+  it("uses explicit apk field for apk manager", () => {
+    expect(resolveLinuxPackageName("apk", "some-formula", { apk: "custom-apk-pkg" })).toBe(
+      "custom-apk-pkg",
+    );
+  });
+
+  it("falls back to apt field for apk when no apk field is set", () => {
+    expect(resolveLinuxPackageName("apk", "some-formula", { apt: "custom-apt-pkg" })).toBe(
+      "custom-apt-pkg",
+    );
+  });
+
+  it("uses explicit apt field even for tap formulas", () => {
+    expect(resolveLinuxPackageName("apt-get", "steipete/tap/summarize", { apt: "summarize" })).toBe(
+      "summarize",
+    );
+  });
+
+  it("prefers apk field over apt field for apk manager", () => {
+    expect(
+      resolveLinuxPackageName("apk", "some-formula", { apt: "apt-name", apk: "apk-name" }),
+    ).toBe("apk-name");
+  });
+
+  it("uses apt field for dnf, yum, and pacman", () => {
+    expect(resolveLinuxPackageName("dnf", "myformula", { apt: "my-pkg" })).toBe("my-pkg");
+    expect(resolveLinuxPackageName("yum", "myformula", { apt: "my-pkg" })).toBe("my-pkg");
+    expect(resolveLinuxPackageName("pacman", "myformula", { apt: "my-pkg" })).toBe("my-pkg");
+  });
+});

--- a/src/infra/linux-package-manager.ts
+++ b/src/infra/linux-package-manager.ts
@@ -1,0 +1,87 @@
+import os from "node:os";
+import { hasBinary } from "../agents/skills/config.js";
+
+export type LinuxPackageManager = "apt-get" | "apk" | "dnf" | "yum" | "pacman";
+
+/**
+ * Detect the available Linux package manager on this system.
+ * Returns `undefined` on non-Linux platforms or when no supported
+ * package manager is found.
+ */
+export function detectLinuxPackageManager(opts?: {
+  platform?: string;
+  checkBinary?: (bin: string) => boolean;
+}): LinuxPackageManager | undefined {
+  const platform = opts?.platform ?? os.platform();
+  const checkBin = opts?.checkBinary ?? hasBinary;
+
+  if (platform !== "linux") {
+    return undefined;
+  }
+
+  // Ordered by popularity in Docker images.
+  const managers: LinuxPackageManager[] = ["apt-get", "apk", "dnf", "yum", "pacman"];
+  for (const mgr of managers) {
+    if (checkBin(mgr)) {
+      return mgr;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build the install command for a given Linux package manager.
+ * Returns `null` when the manager is not supported.
+ */
+export function buildLinuxInstallCommand(
+  manager: LinuxPackageManager,
+  packageName: string,
+): string[] | null {
+  switch (manager) {
+    case "apt-get":
+      return ["apt-get", "install", "-y", packageName];
+    case "apk":
+      return ["apk", "add", "--no-cache", packageName];
+    case "dnf":
+      return ["dnf", "install", "-y", packageName];
+    case "yum":
+      return ["yum", "install", "-y", packageName];
+    case "pacman":
+      return ["pacman", "-S", "--noconfirm", packageName];
+    default:
+      return null;
+  }
+}
+
+/**
+ * Determine the Linux package name for a brew formula.
+ *
+ * Rules:
+ * 1. If the install spec provides an explicit `apt` or `apk` field, use it.
+ * 2. If the formula is a simple name (no `/`), assume the same package name
+ *    works on Linux — this is true for common tools like `ffmpeg`, `jq`, etc.
+ * 3. Tap formulas (containing `/`) have no automatic Linux equivalent.
+ *    Return `undefined` so the caller can show a helpful message.
+ */
+export function resolveLinuxPackageName(
+  manager: LinuxPackageManager,
+  formula: string,
+  spec?: { apt?: string; apk?: string },
+): string | undefined {
+  // Explicit overrides take priority.
+  if (manager === "apk" && spec?.apk?.trim()) {
+    return spec.apk.trim();
+  }
+  // apt-get, dnf, yum, and pacman share similar package names in most cases.
+  if (spec?.apt?.trim()) {
+    return spec.apt.trim();
+  }
+
+  // Tap formulas (e.g. "steipete/tap/summarize") have no automatic mapping.
+  if (formula.includes("/")) {
+    return undefined;
+  }
+
+  // Simple formulas generally share the name across brew and apt/apk.
+  return formula;
+}


### PR DESCRIPTION
## Problem

When running `openclaw onboard` inside the official Docker container (Linux) and selecting a brew-based skill, the install fails with `brew not installed`. The Docker image doesn't ship with Homebrew and there's no fallback.

Fixes #14593

## Solution

Added Linux package manager fallback logic to the skill installer. When `brew` is not found on Linux, the system now:

1. **Detects the available package manager** — supports `apt-get` (Debian/Ubuntu), `apk` (Alpine), `dnf` (Fedora), `yum` (RHEL/CentOS), and `pacman` (Arch)
2. **Maps the brew formula to a Linux package name** — simple formulas (e.g. `ffmpeg`, `jq`) map directly; tap formulas (e.g. `steipete/tap/summarize`) with no mapping produce a helpful error
3. **Supports explicit overrides** — new optional `apt` and `apk` fields on `SkillInstallSpec` let skill authors specify Linux package names when they differ from the brew formula

### Files changed

| File | Change |
|------|--------|
| `src/infra/linux-package-manager.ts` | **New** — Linux package manager detection and command building |
| `src/infra/linux-package-manager.test.ts` | **New** — 19 unit tests for detection, command building, and name resolution |
| `src/agents/skills-install.ts` | Modified — brew fallback to Linux package manager in `installSkill()` |
| `src/agents/skills-install.test.ts` | Modified — 6 new integration tests for the fallback paths |
| `src/agents/skills/types.ts` | Modified — added `apt?` and `apk?` fields to `SkillInstallSpec` |
| `src/agents/skills/frontmatter.ts` | Modified — parse the new `apt`/`apk` fields from skill metadata |

### Testing

- 25 new tests (19 unit + 6 integration), all passing
- All 1904 existing tests pass (1 pre-existing unrelated failure in `bash-tools.test.ts` due to sandbox environment)
- Linter: 0 warnings, 0 errors

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a Linux package-manager fallback for `brew`-based skill installs when Homebrew isn’t available in the official Docker image. It introduces `src/infra/linux-package-manager.ts` (detection of `apt-get`/`apk`/`dnf`/`yum`/`pacman`, command construction, and formula→package name resolution with optional `apt`/`apk` overrides), wires that into `installSkill()` for `brew` specs, and extends skill frontmatter/types to parse the new override fields. Tests were added for both the new module and the `installSkill` fallback paths.

One behavioral issue to address before merging: the fallback currently triggers even when Homebrew is installed but not on `PATH`, because `installSkill()` uses `resolveBrewExecutable()` (which searches common Linuxbrew paths) only as a boolean check, and then proceeds to Linux package-manager install rather than using the discovered brew executable path.


<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the brew fallback condition likely changes behavior in environments where brew exists off-PATH.
- Core logic is straightforward and well-tested, but `installSkill()` can incorrectly prefer Linux package-manager installs even when `resolveBrewExecutable()` found a usable brew binary (common with Linuxbrew installs), which could break existing setups or install the wrong package name/version.
- src/agents/skills-install.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->