### PR TITLE
fix(gateway): support timezone offset in usage date range queries

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1126,19 +1126,22 @@ public struct SessionsUsageParams: Codable, Sendable {
     public let enddate: String?
     public let limit: Int?
     public let includecontextweight: Bool?
+    public let tzoffsetminutes: Double?
 
     public init(
         key: String?,
         startdate: String?,
         enddate: String?,
         limit: Int?,
-        includecontextweight: Bool?
+        includecontextweight: Bool?,
+        tzoffsetminutes: Double?
     ) {
         self.key = key
         self.startdate = startdate
         self.enddate = enddate
         self.limit = limit
         self.includecontextweight = includecontextweight
+        self.tzoffsetminutes = tzoffsetminutes
     }
     private enum CodingKeys: String, CodingKey {
         case key
@@ -1146,6 +1149,7 @@ public struct SessionsUsageParams: Codable, Sendable {
         case enddate = "endDate"
         case limit
         case includecontextweight = "includeContextWeight"
+        case tzoffsetminutes = "tzOffsetMinutes"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1126,19 +1126,22 @@ public struct SessionsUsageParams: Codable, Sendable {
     public let enddate: String?
     public let limit: Int?
     public let includecontextweight: Bool?
+    public let tzoffsetminutes: Double?
 
     public init(
         key: String?,
         startdate: String?,
         enddate: String?,
         limit: Int?,
-        includecontextweight: Bool?
+        includecontextweight: Bool?,
+        tzoffsetminutes: Double?
     ) {
         self.key = key
         self.startdate = startdate
         self.enddate = enddate
         self.limit = limit
         self.includecontextweight = includecontextweight
+        self.tzoffsetminutes = tzoffsetminutes
     }
     private enum CodingKeys: String, CodingKey {
         case key
@@ -1146,6 +1149,7 @@ public struct SessionsUsageParams: Codable, Sendable {
         case enddate = "endDate"
         case limit
         case includecontextweight = "includeContextWeight"
+        case tzoffsetminutes = "tzOffsetMinutes"
     }
 }
 

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -114,6 +114,8 @@ export const SessionsUsageParamsSchema = Type.Object(
     limit: Type.Optional(Type.Integer({ minimum: 1 })),
     /** Include context weight breakdown (systemPromptReport). */
     includeContextWeight: Type.Optional(Type.Boolean()),
+    /** Timezone offset in minutes (same as Date.getTimezoneOffset(), e.g. -480 for UTC+8). */
+    tzOffsetMinutes: Type.Optional(Type.Number()),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
Fixes #14750

Usage date boundaries were always UTC, causing evening/morning activity to appear under the wrong day for non-UTC users.

Adds optional `tzOffsetMinutes` parameter to `usage.cost` and `usage.sessions` endpoints. Follows `Date.getTimezoneOffset()` convention (e.g. UTC+8 = -480).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway usage endpoints to support user-local day boundaries by accepting an optional `tzOffsetMinutes` parameter (matching `Date.getTimezoneOffset()` semantics). The offset is incorporated into usage date-range calculations so that cost/session aggregation for a given “day” aligns with the caller’s local timezone rather than UTC, fixing mis-attribution of morning/evening activity for non‑UTC users.

The change is localized to `src/gateway/server-methods/usage.ts`, which is the server-method layer that parses request parameters and builds the date range used by the underlying usage query/aggregation logic.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- The change is narrowly scoped to parameter parsing and date-range computation for usage endpoints, and it aligns behavior with a documented timezone offset convention; no other subsystems or storage formats are modified.
- src/gateway/server-methods/usage.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->