### PR TITLE
fix: pre-pair CLI operator device during onboarding for non-loopback binds

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -289,6 +289,15 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     const resToken = await authorizeGatewayConnect({ auth, connectAuth: { token } });
     expect(resToken.ok).toBe(true);
 
+    // Verify the CLI operator device was pre-paired during onboarding
+    const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
+    const { getPairedDevice } = await import("../infra/device-pairing.js");
+    const identity = loadOrCreateDeviceIdentity();
+    const paired = await getPairedDevice(identity.deviceId);
+    expect(paired).not.toBeNull();
+    expect(paired?.role).toBe("operator");
+    expect(paired?.roles).toContain("operator");
+
     await fs.rm(stateDir, { recursive: true, force: true });
   }, 60_000);
 });

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -13,6 +13,7 @@ import {
   resolveControlUiLinks,
   waitForGatewayReachable,
 } from "../onboard-helpers.js";
+import { ensureCliOperatorPaired } from "../onboard-pair-cli.js";
 import { inferAuthChoiceFromFlags } from "./local/auth-choice-inference.js";
 import { applyNonInteractiveAuthChoice } from "./local/auth-choice.js";
 import { installGatewayDaemonNonInteractive } from "./local/daemon-install.js";
@@ -96,6 +97,10 @@ export async function runNonInteractiveOnboardingLocal(params: {
   await ensureWorkspaceAndSessions(workspaceDir, runtime, {
     skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
   });
+
+  // Pre-pair the CLI operator device so it can connect to the gateway
+  // immediately, even when binding to a non-loopback address (LAN, custom, etc).
+  await ensureCliOperatorPaired();
 
   await installGatewayDaemonNonInteractive({
     nextConfig,

--- a/src/commands/onboard-pair-cli.test.ts
+++ b/src/commands/onboard-pair-cli.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+describe("ensureCliOperatorPaired", () => {
+  const prev = {
+    home: process.env.HOME,
+    stateDir: process.env.OPENCLAW_STATE_DIR,
+  };
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pair-cli-"));
+    process.env.HOME = tempDir;
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+  });
+
+  afterAll(async () => {
+    process.env.HOME = prev.home;
+    process.env.OPENCLAW_STATE_DIR = prev.stateDir;
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("pairs CLI device on first call and returns created=true", async () => {
+    const { ensureCliOperatorPaired } = await import("./onboard-pair-cli.js");
+    const { getPairedDevice } = await import("../infra/device-pairing.js");
+    const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
+
+    const result = await ensureCliOperatorPaired();
+    expect(result.created).toBe(true);
+    expect(typeof result.deviceId).toBe("string");
+    expect(result.deviceId.length).toBeGreaterThan(0);
+
+    // Verify the device is actually paired
+    const paired = await getPairedDevice(result.deviceId);
+    expect(paired).not.toBeNull();
+    expect(paired?.role).toBe("operator");
+    expect(paired?.roles).toContain("operator");
+    expect(paired?.scopes).toEqual(
+      expect.arrayContaining(["operator.admin", "operator.approvals", "operator.pairing"]),
+    );
+
+    // Verify deviceId matches the local identity
+    const identity = loadOrCreateDeviceIdentity();
+    expect(result.deviceId).toBe(identity.deviceId);
+  });
+
+  test("returns created=false on subsequent calls (idempotent)", async () => {
+    const { ensureCliOperatorPaired } = await import("./onboard-pair-cli.js");
+
+    const first = await ensureCliOperatorPaired();
+    const second = await ensureCliOperatorPaired();
+    expect(second.created).toBe(false);
+    expect(second.deviceId).toBe(first.deviceId);
+  });
+});

--- a/src/commands/onboard-pair-cli.ts
+++ b/src/commands/onboard-pair-cli.ts
@@ -1,0 +1,41 @@
+import os from "node:os";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+} from "../infra/device-identity.js";
+import { addPairedDevice, getPairedDevice } from "../infra/device-pairing.js";
+
+/**
+ * Pre-pair the CLI operator device so it can connect to the gateway immediately
+ * after onboarding, even when the gateway binds to a non-loopback address (LAN,
+ * custom, auto, tailnet).
+ *
+ * When the gateway binds to loopback, the ws-connection handler treats the CLI
+ * as a local client and auto-approves pairing on first connect.  For non-loopback
+ * binds the CLI connects via a non-loopback IP, which makes `isLocalClient` false
+ * and the auto-approve path is skipped.  Pre-pairing here avoids that gap.
+ */
+export async function ensureCliOperatorPaired(): Promise<{
+  deviceId: string;
+  created: boolean;
+}> {
+  const identity = loadOrCreateDeviceIdentity();
+  const publicKeyBase64Url = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
+
+  const existing = await getPairedDevice(identity.deviceId);
+  if (existing) {
+    return { deviceId: identity.deviceId, created: false };
+  }
+
+  const { device, created } = await addPairedDevice({
+    deviceId: identity.deviceId,
+    publicKey: publicKeyBase64Url,
+    displayName: `CLI (${os.hostname()})`,
+    platform: process.platform,
+    role: "operator",
+    roles: ["operator"],
+    scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
+  });
+
+  return { deviceId: device.deviceId, created };
+}

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
+  addPairedDevice,
   approveDevicePairing,
   getPairedDevice,
   requestDevicePairing,
@@ -40,5 +41,89 @@ describe("device pairing tokens", () => {
     });
     paired = await getPairedDevice("device-1", baseDir);
     expect(paired?.tokens?.operator?.scopes).toEqual(["operator.read"]);
+  });
+});
+
+describe("addPairedDevice", () => {
+  test("directly adds a new device as paired", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-add-paired-"));
+    const { addPairedDevice } = await import("./device-pairing.js");
+
+    const result = await addPairedDevice(
+      {
+        deviceId: "direct-device-1",
+        publicKey: "direct-pub-key-1",
+        displayName: "CLI (test)",
+        platform: "linux",
+        role: "operator",
+        roles: ["operator"],
+        scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
+      },
+      baseDir,
+    );
+
+    expect(result.created).toBe(true);
+    expect(result.device.deviceId).toBe("direct-device-1");
+    expect(result.device.publicKey).toBe("direct-pub-key-1");
+    expect(result.device.role).toBe("operator");
+    expect(result.device.roles).toContain("operator");
+    expect(result.device.scopes).toEqual(
+      expect.arrayContaining(["operator.admin", "operator.approvals", "operator.pairing"]),
+    );
+    expect(result.device.tokens).toEqual({});
+    expect(result.device.createdAtMs).toBeGreaterThan(0);
+    expect(result.device.approvedAtMs).toBeGreaterThan(0);
+
+    // Verify retrievable via getPairedDevice
+    const paired = await getPairedDevice("direct-device-1", baseDir);
+    expect(paired).not.toBeNull();
+    expect(paired?.deviceId).toBe("direct-device-1");
+  });
+
+  test("returns existing device without overwriting when already paired", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-add-paired-idempotent-"));
+    const { addPairedDevice } = await import("./device-pairing.js");
+
+    const first = await addPairedDevice(
+      {
+        deviceId: "dup-device",
+        publicKey: "pub-key-dup",
+        displayName: "First",
+        role: "operator",
+        roles: ["operator"],
+        scopes: ["operator.admin"],
+      },
+      baseDir,
+    );
+    expect(first.created).toBe(true);
+
+    const second = await addPairedDevice(
+      {
+        deviceId: "dup-device",
+        publicKey: "pub-key-dup-v2",
+        displayName: "Second",
+        role: "operator",
+        roles: ["operator"],
+        scopes: ["operator.admin", "operator.extra"],
+      },
+      baseDir,
+    );
+    expect(second.created).toBe(false);
+    // Should still be the original data
+    expect(second.device.displayName).toBe("First");
+    expect(second.device.publicKey).toBe("pub-key-dup");
+  });
+
+  test("throws when deviceId is empty", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-add-paired-err-"));
+    const { addPairedDevice } = await import("./device-pairing.js");
+
+    await expect(addPairedDevice({ deviceId: "", publicKey: "key" }, baseDir)).rejects.toThrow(
+      "deviceId required",
+    );
+
+    await expect(addPairedDevice({ deviceId: "  ", publicKey: "key" }, baseDir)).rejects.toThrow(
+      "deviceId required",
+    );
   });
 });

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
-  addPairedDevice,
   approveDevicePairing,
   getPairedDevice,
   requestDevicePairing,

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -29,6 +29,7 @@ import {
   summarizeExistingConfig,
 } from "../commands/onboard-helpers.js";
 import { setupInternalHooks } from "../commands/onboard-hooks.js";
+import { ensureCliOperatorPaired } from "../commands/onboard-pair-cli.js";
 import { promptRemoteGatewayConfig } from "../commands/onboard-remote.js";
 import { setupSkills } from "../commands/onboard-skills.js";
 import {
@@ -466,6 +467,10 @@ export async function runOnboardingWizard(
 
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
   await writeConfigFile(nextConfig);
+
+  // Pre-pair the CLI operator device so it can connect to the gateway
+  // immediately, even when binding to a non-loopback address (LAN, custom, etc).
+  await ensureCliOperatorPaired();
 
   const { launchedTui } = await finalizeOnboardingWizard({
     flow,


### PR DESCRIPTION
## Summary

Fixes #14774

When OpenClaw is configured to bind to LAN during onboarding (`--gateway-bind lan`), the gateway fails to automatically pair and authenticate the CLI operator. This makes subsequent CLI configuration impossible without manual intervention.

## Root Cause

The gateway's ws-connection handler auto-approves device pairing only for loopback clients (`isLocalClient=true` → `silent=true` → auto-approve). When binding to LAN/custom/auto/tailnet, the CLI connects via a non-loopback IP, so `isLocalClient` is `false`, `silent` is `false`, and the pairing request is broadcast instead of auto-approved — causing the connection to be rejected.

## Fix

Pre-pair the CLI operator device during onboarding by writing it directly to the paired devices store. This makes the device immediately recognized when the gateway starts, regardless of bind mode.

### Changes

- **`src/infra/device-pairing.ts`**: Add `addPairedDevice()` — directly adds a device as paired without going through the pending→approve flow. Idempotent (no-ops if device already exists).
- **`src/commands/onboard-pair-cli.ts`**: New helper `ensureCliOperatorPaired()` — loads the CLI device identity and pre-pairs it with operator role and scopes (`operator.admin`, `operator.approvals`, `operator.pairing`).
- **`src/commands/onboard-non-interactive/local.ts`**: Call `ensureCliOperatorPaired()` after config is written and workspace is set up, before daemon install.
- **`src/wizard/onboarding.ts`**: Call `ensureCliOperatorPaired()` after final config write, before finalize wizard.

### Tests

- `src/infra/device-pairing.test.ts`: Tests for `addPairedDevice` (creation, idempotency, empty deviceId error)
- `src/commands/onboard-pair-cli.test.ts`: Tests for `ensureCliOperatorPaired` (creation, idempotency, identity match)
- `src/commands/onboard-non-interactive.gateway.test.ts`: Enhanced existing LAN onboarding test to verify CLI operator is paired after onboard

All existing tests continue to pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes LAN/non-loopback onboarding by pre-pairing the local CLI operator device during onboarding.

Key changes:
- Adds `addPairedDevice()` in `src/infra/device-pairing.ts` to directly persist a paired device entry (idempotent).
- Introduces `ensureCliOperatorPaired()` in `src/commands/onboard-pair-cli.ts` to load the CLI’s device identity and pre-pair it with operator role/scopes.
- Calls `ensureCliOperatorPaired()` from both the non-interactive local onboarding path and the interactive onboarding wizard, ensuring the gateway recognizes the CLI regardless of bind mode.
- Extends tests to validate pairing occurs during LAN onboarding and covers new helper behavior.

This integrates cleanly with existing device identity/pairing storage: it writes the paired device record into the same paired-devices state used by the gateway connection/auth flows, so subsequent CLI connections are recognized without relying on loopback-only auto-approval.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to onboarding, add an idempotent pairing helper that writes into existing pairing state, and are covered by targeted unit/integration tests. No definite runtime or security regressions were identified in the modified paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->