### PR TITLE
fix(gateway): `gateway install --force` now correctly regenerates the service file

### DIFF
--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -123,6 +123,13 @@ export function registerGatewayCli(program: Command) {
     program
       .command("gateway")
       .description("Run the WebSocket Gateway")
+      // The gateway parent command and its subcommands (install, run, etc.)
+      // share option names like --force. Enable positional option parsing so
+      // options after a subcommand name are parsed by the subcommand, not the
+      // parent — e.g. `gateway install --force` uses install's --force, while
+      // `gateway --force` uses the parent's --force.
+      .enablePositionalOptions()
+      .passThroughOptions()
       .addHelpText(
         "after",
         () =>

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -6,6 +6,11 @@ import { registerPreActionHooks } from "./preaction.js";
 
 export function buildProgram() {
   const program = new Command();
+  // Allow subcommands to define options with the same name as parent options
+  // (e.g. gateway --force vs gateway install --force). Without this, Commander
+  // consumes the option at the parent level even when it appears after the
+  // subcommand name.
+  program.enablePositionalOptions();
   const ctx = createProgramContext();
   const argv = process.argv;
 


### PR DESCRIPTION
## Summary

Fixes #14845 — `openclaw gateway install --force` was silently ignoring `--force`, printing *"Gateway service already enabled. Reinstall with: openclaw gateway install --force"* instead of regenerating the systemd/launchd service file.

## Root Cause

The parent `gateway` command (which doubles as `gateway run`) and the `gateway install` subcommand both define a `--force` option with different semantics:

| Command | `--force` meaning |
|---|---|
| `openclaw gateway --force` | Kill existing port listener before starting |
| `openclaw gateway install --force` | Reinstall/overwrite service file |

Commander v14 resolves ambiguous option names at the **parent** level — so `gateway install --force` was consumed by the parent `gateway` command, leaving the `install` subcommand's `force` at its default `false`.

Verified with a minimal reproduction:

```js
const gateway = program.command('gateway')
  .option('--force', 'parent force', false)
  .action(opts => { /* ... */ });

gateway.command('install')
  .option('--force', 'child force', false)
  .action(opts => {
    console.log(opts.force); // ← always false, even with --force!
  });
```

## Fix

Enable Commander's positional option parsing so options after a subcommand name are parsed by the **subcommand**, not the parent:

- `program.enablePositionalOptions()` — on the root program (required by Commander for child `passThroughOptions`)
- `gateway.enablePositionalOptions().passThroughOptions()` — on the gateway command

After the fix:
- `gateway --force` → parent's `--force` (kill port listeners) ✅
- `gateway install --force` → install's `--force` (regenerate service) ✅
- `gateway run --force` → run's `--force` (kill port listeners) ✅

## Tests

- Added test: `gateway install --force` calls `service.install()` when already loaded (the bug scenario)
- Added test: `gateway install` without `--force` skips reinstall when already loaded
- Added test: `daemon install --force` reinstalls when already loaded
- Added test: `daemon install` without `--force` skips when already loaded
- All 343 existing CLI + daemon tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes an option-parsing ambiguity in the CLI where `openclaw gateway install --force` was incorrectly consuming `--force` at the parent `gateway` command level (used for “kill existing listener”) instead of the `install` subcommand (used for “reinstall/overwrite service file”).

The fix enables Commander’s positional option parsing at the root program (`program.enablePositionalOptions()` in `src/cli/program/build-program.ts`) and configures the `gateway` command to both enable positional options and pass through unknown options (`.enablePositionalOptions().passThroughOptions()` in `src/cli/gateway-cli/register.ts`), ensuring options appearing after a subcommand name are parsed by that subcommand.

Coverage tests were expanded to assert the intended behavior for both `gateway install` and `daemon install` when the service is already loaded, with and without `--force`.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are narrowly scoped to Commander option parsing and are backed by coverage tests that exercise the previously broken `gateway install --force` scenario and the non-force behavior. No runtime logic changes beyond CLI parsing configuration were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->