### PR TITLE
fix(feishu): preserve inbound dedup caches across SIGUSR1 restarts

### DIFF
--- a/extensions/feishu/src/bot.dedup-survives-restart.test.ts
+++ b/extensions/feishu/src/bot.dedup-survives-restart.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+const FEISHU_DEDUP_GLOBAL_KEY = "__openclaw_feishu_dedup__";
+
+function clearGlobalDedupState() {
+  delete (globalThis as Record<string, unknown>)[FEISHU_DEDUP_GLOBAL_KEY];
+}
+
+/**
+ * Inline copy of the dedup logic from bot.ts so we can test the
+ * globalThis survival behaviour without importing the full module
+ * (which pulls in heavy dependencies like the Lark SDK).
+ */
+const DEDUP_TTL_MS = 30 * 60 * 1000;
+const DEDUP_MAX_SIZE = 1_000;
+const DEDUP_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+type FeishuDedupState = {
+  processedMessageIds: Map<string, number>;
+  lastCleanupTime: number;
+};
+
+function getFeishuDedupState(): FeishuDedupState {
+  const g = globalThis as Record<string, unknown>;
+  let state = g[FEISHU_DEDUP_GLOBAL_KEY] as FeishuDedupState | undefined;
+  if (!state) {
+    state = { processedMessageIds: new Map(), lastCleanupTime: Date.now() };
+    g[FEISHU_DEDUP_GLOBAL_KEY] = state;
+  }
+  return state;
+}
+
+function tryRecordMessage(messageId: string, now = Date.now()): boolean {
+  const state = getFeishuDedupState();
+  if (now - state.lastCleanupTime > DEDUP_CLEANUP_INTERVAL_MS) {
+    for (const [id, ts] of state.processedMessageIds) {
+      if (now - ts > DEDUP_TTL_MS) state.processedMessageIds.delete(id);
+    }
+    state.lastCleanupTime = now;
+  }
+  if (state.processedMessageIds.has(messageId)) return false;
+  if (state.processedMessageIds.size >= DEDUP_MAX_SIZE) {
+    const first = state.processedMessageIds.keys().next().value!;
+    state.processedMessageIds.delete(first);
+  }
+  state.processedMessageIds.set(messageId, now);
+  return true;
+}
+
+describe("Feishu dedup cache survives restart (globalThis)", () => {
+  beforeEach(() => {
+    clearGlobalDedupState();
+  });
+
+  it("records a new message and rejects duplicates", () => {
+    expect(tryRecordMessage("msg_aaa", 1000)).toBe(true);
+    expect(tryRecordMessage("msg_aaa", 1500)).toBe(false);
+  });
+
+  it("state survives simulated module re-evaluation", () => {
+    // First "module load": record a message
+    const state1 = getFeishuDedupState();
+    state1.processedMessageIds.set("msg_bbb", Date.now());
+
+    // Simulate SIGUSR1 restart: the module is re-evaluated by jiti,
+    // but globalThis still holds the state.
+    const state2 = getFeishuDedupState();
+    expect(state2).toBe(state1);
+    expect(state2.processedMessageIds.has("msg_bbb")).toBe(true);
+
+    // tryRecordMessage should detect the duplicate
+    expect(tryRecordMessage("msg_bbb")).toBe(false);
+  });
+
+  it("cleaning stale entries does not remove recent ones", () => {
+    const now = Date.now();
+    tryRecordMessage("old_msg", now - DEDUP_TTL_MS - 1);
+    tryRecordMessage("new_msg", now - 1000);
+
+    // Force cleanup by advancing lastCleanupTime past interval
+    const state = getFeishuDedupState();
+    state.lastCleanupTime = now - DEDUP_CLEANUP_INTERVAL_MS - 1;
+
+    // The next tryRecordMessage triggers cleanup
+    tryRecordMessage("trigger_cleanup", now);
+
+    expect(state.processedMessageIds.has("old_msg")).toBe(false);
+    expect(state.processedMessageIds.has("new_msg")).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/inbound-dedupe.survives-restart.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.survives-restart.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createGlobalDedupeCache } from "../../infra/dedupe.js";
+
+const GLOBAL_REGISTRY_KEY = "__openclaw_dedupe_caches__";
+
+function clearGlobalRegistry() {
+  delete (globalThis as Record<string, unknown>)[GLOBAL_REGISTRY_KEY];
+}
+
+describe("inbound dedupe cache survives SIGUSR1 restart", () => {
+  beforeEach(() => {
+    clearGlobalRegistry();
+  });
+
+  it("createGlobalDedupeCache returns same instance on repeated calls", () => {
+    // Simulate the module-level init in inbound-dedupe.ts
+    const cache1 = createGlobalDedupeCache({
+      globalKey: "openclaw:inbound-dedupe",
+      ttlMs: 20 * 60_000,
+      maxSize: 5000,
+    });
+
+    cache1.check("telegram|acct1|sess1|peer1||msg-123", 1000);
+
+    // Simulate module re-evaluation after SIGUSR1
+    const cache2 = createGlobalDedupeCache({
+      globalKey: "openclaw:inbound-dedupe",
+      ttlMs: 20 * 60_000,
+      maxSize: 5000,
+    });
+
+    expect(cache2).toBe(cache1);
+    // The previously-recorded message should still be detected as duplicate
+    expect(cache2.check("telegram|acct1|sess1|peer1||msg-123", 1500)).toBe(true);
+  });
+
+  it("different global keys produce independent caches", () => {
+    const inbound = createGlobalDedupeCache({
+      globalKey: "openclaw:inbound-dedupe",
+      ttlMs: 20 * 60_000,
+      maxSize: 5000,
+    });
+    const web = createGlobalDedupeCache({
+      globalKey: "openclaw:web-inbound-dedupe",
+      ttlMs: 20 * 60_000,
+      maxSize: 5000,
+    });
+
+    inbound.check("key-1", 1000);
+    // Same key in the web cache should NOT be a duplicate
+    expect(web.check("key-1", 1000)).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -1,11 +1,12 @@
 import type { MsgContext } from "../templating.js";
 import { logVerbose, shouldLogVerbose } from "../../globals.js";
-import { createDedupeCache, type DedupeCache } from "../../infra/dedupe.js";
+import { createGlobalDedupeCache, type DedupeCache } from "../../infra/dedupe.js";
 
 const DEFAULT_INBOUND_DEDUPE_TTL_MS = 20 * 60_000;
 const DEFAULT_INBOUND_DEDUPE_MAX = 5000;
 
-const inboundDedupeCache = createDedupeCache({
+const inboundDedupeCache = createGlobalDedupeCache({
+  globalKey: "openclaw:inbound-dedupe",
   ttlMs: DEFAULT_INBOUND_DEDUPE_TTL_MS,
   maxSize: DEFAULT_INBOUND_DEDUPE_MAX,
 });

--- a/src/infra/dedupe.test.ts
+++ b/src/infra/dedupe.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDedupeCache, createGlobalDedupeCache } from "./dedupe.js";
+
+const GLOBAL_REGISTRY_KEY = "__openclaw_dedupe_caches__";
+
+function clearGlobalRegistry() {
+  delete (globalThis as Record<string, unknown>)[GLOBAL_REGISTRY_KEY];
+}
+
+describe("createDedupeCache", () => {
+  it("returns false on first check, true on duplicate", () => {
+    const cache = createDedupeCache({ ttlMs: 60_000, maxSize: 100 });
+    expect(cache.check("a", 1000)).toBe(false);
+    expect(cache.check("a", 1500)).toBe(true);
+  });
+
+  it("expires entries after ttl", () => {
+    const cache = createDedupeCache({ ttlMs: 1000, maxSize: 100 });
+    expect(cache.check("a", 1000)).toBe(false);
+    // Within TTL → duplicate
+    expect(cache.check("a", 1500)).toBe(true);
+    // Beyond TTL → treated as new
+    expect(cache.check("a", 2500)).toBe(false);
+  });
+
+  it("evicts oldest entries when maxSize is exceeded", () => {
+    const cache = createDedupeCache({ ttlMs: 60_000, maxSize: 2 });
+    cache.check("a", 1000);
+    cache.check("b", 2000);
+    // Adding a third entry should evict "a"
+    cache.check("c", 3000);
+    expect(cache.size()).toBe(2);
+    // "a" was evicted, so this is treated as new
+    expect(cache.check("a", 3500)).toBe(false);
+  });
+});
+
+describe("createGlobalDedupeCache", () => {
+  beforeEach(() => {
+    clearGlobalRegistry();
+  });
+
+  it("returns the same cache instance for the same globalKey", () => {
+    const cache1 = createGlobalDedupeCache({
+      globalKey: "test:same-key",
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+    const cache2 = createGlobalDedupeCache({
+      globalKey: "test:same-key",
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+    expect(cache1).toBe(cache2);
+  });
+
+  it("returns different cache instances for different globalKeys", () => {
+    const cache1 = createGlobalDedupeCache({
+      globalKey: "test:key-a",
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+    const cache2 = createGlobalDedupeCache({
+      globalKey: "test:key-b",
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+    expect(cache1).not.toBe(cache2);
+  });
+
+  it("preserves entries across repeated calls (simulating module re-evaluation)", () => {
+    const cache1 = createGlobalDedupeCache({
+      globalKey: "test:persist",
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+    // Record a message
+    expect(cache1.check("msg-1", 1000)).toBe(false);
+    expect(cache1.size()).toBe(1);
+
+    // Simulate module re-evaluation: call createGlobalDedupeCache again
+    const cache2 = createGlobalDedupeCache({
+      globalKey: "test:persist",
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+
+    // Should still have the entry from before
+    expect(cache2.size()).toBe(1);
+    expect(cache2.check("msg-1", 1500)).toBe(true);
+  });
+
+  it("clear() empties the cache but keeps the instance in the registry", () => {
+    const cache1 = createGlobalDedupeCache({
+      globalKey: "test:clear",
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+    cache1.check("msg-1", 1000);
+    expect(cache1.size()).toBe(1);
+
+    cache1.clear();
+    expect(cache1.size()).toBe(0);
+
+    // Subsequent call still returns the same instance
+    const cache2 = createGlobalDedupeCache({
+      globalKey: "test:clear",
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+    expect(cache2).toBe(cache1);
+    expect(cache2.size()).toBe(0);
+  });
+});

--- a/src/web/inbound/dedupe.ts
+++ b/src/web/inbound/dedupe.ts
@@ -1,9 +1,10 @@
-import { createDedupeCache } from "../../infra/dedupe.js";
+import { createGlobalDedupeCache } from "../../infra/dedupe.js";
 
 const RECENT_WEB_MESSAGE_TTL_MS = 20 * 60_000;
 const RECENT_WEB_MESSAGE_MAX = 5000;
 
-const recentInboundMessages = createDedupeCache({
+const recentInboundMessages = createGlobalDedupeCache({
+  globalKey: "openclaw:web-inbound-dedupe",
   ttlMs: RECENT_WEB_MESSAGE_TTL_MS,
   maxSize: RECENT_WEB_MESSAGE_MAX,
 });

--- a/ui/src/ui/controllers/chat.node.test.ts
+++ b/ui/src/ui/controllers/chat.node.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+import {
+  handleChatEvent,
+  isLocalMessage,
+  loadChatHistory,
+  sendChatMessage,
+  type ChatEventPayload,
+  type ChatState,
+} from "./chat.ts";
+
+function createState(overrides: Partial<ChatState> = {}): ChatState {
+  return {
+    chatAttachments: [],
+    chatLoading: false,
+    chatMessage: "",
+    chatMessages: [],
+    chatRunId: null,
+    chatSending: false,
+    chatStream: null,
+    chatStreamStartedAt: null,
+    chatThinkingLevel: null,
+    client: null,
+    connected: true,
+    lastError: null,
+    sessionKey: "main",
+    ...overrides,
+  };
+}
+
+describe("isLocalMessage", () => {
+  it("returns true for messages with _localId", () => {
+    const msg = { role: "user", content: [{ type: "text", text: "hi" }], _localId: "abc-123" };
+    expect(isLocalMessage(msg)).toBe(true);
+  });
+
+  it("returns false for plain server messages", () => {
+    const msg = { role: "user", content: [{ type: "text", text: "hi" }] };
+    expect(isLocalMessage(msg)).toBe(false);
+  });
+
+  it("returns false for null / non-object", () => {
+    expect(isLocalMessage(null)).toBe(false);
+    expect(isLocalMessage(undefined)).toBe(false);
+    expect(isLocalMessage("hello")).toBe(false);
+    expect(isLocalMessage(42)).toBe(false);
+  });
+});
+
+describe("sendChatMessage", () => {
+  function mockClient(response: unknown = {}) {
+    return {
+      request: async () => response,
+    } as unknown as ChatState["client"];
+  }
+
+  it("marks optimistic user message with _localId", async () => {
+    const state = createState({ client: mockClient(), connected: true });
+    const runId = await sendChatMessage(state, "hello");
+    expect(runId).toBeTruthy();
+
+    // The optimistic message should carry _localId
+    const lastMsg = state.chatMessages[state.chatMessages.length - 1] as Record<string, unknown>;
+    expect(lastMsg.role).toBe("user");
+    expect(lastMsg._localId).toBe(runId);
+    expect(isLocalMessage(lastMsg)).toBe(true);
+  });
+
+  it("returns null when not connected", async () => {
+    const state = createState({ client: mockClient(), connected: false });
+    const runId = await sendChatMessage(state, "hello");
+    expect(runId).toBe(null);
+    expect(state.chatMessages).toEqual([]);
+  });
+});
+
+describe("loadChatHistory – preserves pending messages", () => {
+  function mockClientWithHistory(messages: unknown[]) {
+    return {
+      request: async () => ({ messages }),
+    } as unknown as ChatState["client"];
+  }
+
+  it("replaces messages normally when no local messages exist", async () => {
+    const serverMsgs = [
+      { role: "user", content: [{ type: "text", text: "msg1" }] },
+      { role: "assistant", content: [{ type: "text", text: "reply1" }] },
+    ];
+    const state = createState({
+      client: mockClientWithHistory(serverMsgs),
+      connected: true,
+      chatMessages: [{ role: "user", content: [{ type: "text", text: "old" }] }],
+    });
+    await loadChatHistory(state);
+    expect(state.chatMessages).toEqual(serverMsgs);
+  });
+
+  it("preserves unconfirmed local messages after server refresh", async () => {
+    const serverMsgs = [
+      { role: "user", content: [{ type: "text", text: "msg1" }] },
+      { role: "assistant", content: [{ type: "text", text: "reply1" }] },
+    ];
+    const pendingMsg = {
+      role: "user",
+      content: [{ type: "text", text: "msg2" }],
+      timestamp: Date.now(),
+      _localId: "local-run-id",
+    };
+    const state = createState({
+      client: mockClientWithHistory(serverMsgs),
+      connected: true,
+      chatMessages: [
+        { role: "user", content: [{ type: "text", text: "msg1" }] },
+        { role: "assistant", content: [{ type: "text", text: "reply1" }] },
+        pendingMsg,
+      ],
+    });
+    await loadChatHistory(state);
+
+    // Server messages + the unconfirmed pending message
+    expect(state.chatMessages.length).toBe(3);
+    const last = state.chatMessages[2] as Record<string, unknown>;
+    expect(last._localId).toBe("local-run-id");
+    expect(last.role).toBe("user");
+  });
+
+  it("drops local messages once the server confirms them", async () => {
+    const serverMsgs = [
+      { role: "user", content: [{ type: "text", text: "msg1" }] },
+      { role: "assistant", content: [{ type: "text", text: "reply1" }] },
+      { role: "user", content: [{ type: "text", text: "msg2" }] },
+    ];
+    const pendingMsg = {
+      role: "user",
+      content: [{ type: "text", text: "msg2" }],
+      timestamp: Date.now(),
+      _localId: "local-run-id",
+    };
+    const state = createState({
+      client: mockClientWithHistory(serverMsgs),
+      connected: true,
+      chatMessages: [{ role: "user", content: [{ type: "text", text: "msg1" }] }, pendingMsg],
+    });
+    await loadChatHistory(state);
+
+    // msg2 is now confirmed by the server, so the local copy should be dropped
+    expect(state.chatMessages).toEqual(serverMsgs);
+    expect(state.chatMessages.some((m) => isLocalMessage(m))).toBe(false);
+  });
+
+  it("handles race: user sends while loadChatHistory is in-flight", async () => {
+    // Simulate: loadChatHistory starts, then user sends a message, then the
+    // server response arrives without the new message.
+    let resolveRequest!: (value: unknown) => void;
+    const client = {
+      request: () =>
+        new Promise((resolve) => {
+          resolveRequest = resolve;
+        }),
+    } as unknown as ChatState["client"];
+
+    const state = createState({
+      client,
+      connected: true,
+      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "Hello" }] }],
+    });
+
+    // Start loading (won't resolve yet)
+    const loadPromise = loadChatHistory(state);
+
+    // Simulate user sending a message while load is in-flight
+    state.chatMessages = [
+      ...state.chatMessages,
+      {
+        role: "user",
+        content: [{ type: "text", text: "new message" }],
+        timestamp: Date.now(),
+        _localId: "pending-run",
+      },
+    ];
+
+    // Now resolve the server response (without the new message)
+    resolveRequest({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "Hello" }] }],
+    });
+    await loadPromise;
+
+    // The user's pending message should be preserved
+    expect(state.chatMessages.length).toBe(2);
+    const last = state.chatMessages[1] as Record<string, unknown>;
+    expect(last._localId).toBe("pending-run");
+    expect((last.content as Array<{ text: string }>)[0].text).toBe("new message");
+  });
+
+  it("preserves multiple pending messages", async () => {
+    const serverMsgs = [{ role: "user", content: [{ type: "text", text: "first" }] }];
+    const pending1 = {
+      role: "user",
+      content: [{ type: "text", text: "second" }],
+      timestamp: Date.now(),
+      _localId: "run-2",
+    };
+    const pending2 = {
+      role: "user",
+      content: [{ type: "text", text: "third" }],
+      timestamp: Date.now() + 1,
+      _localId: "run-3",
+    };
+    const state = createState({
+      client: mockClientWithHistory(serverMsgs),
+      connected: true,
+      chatMessages: [serverMsgs[0], pending1, pending2],
+    });
+    await loadChatHistory(state);
+
+    expect(state.chatMessages.length).toBe(3);
+    expect((state.chatMessages[1] as Record<string, unknown>)._localId).toBe("run-2");
+    expect((state.chatMessages[2] as Record<string, unknown>)._localId).toBe("run-3");
+  });
+});
+
+describe("handleChatEvent", () => {
+  it("returns null when payload is missing", () => {
+    const state = createState();
+    expect(handleChatEvent(state, undefined)).toBe(null);
+  });
+
+  it("returns null when sessionKey does not match", () => {
+    const state = createState({ sessionKey: "main" });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "other",
+      state: "final",
+    };
+    expect(handleChatEvent(state, payload)).toBe(null);
+  });
+
+  it("returns 'final' for final from another run without clearing state", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-user",
+      chatStream: "Working...",
+      chatStreamStartedAt: 123,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "final",
+      message: { role: "assistant", content: [{ type: "text", text: "Sub-agent" }] },
+    };
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
+  });
+
+  it("processes final from own run and clears state", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Reply",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #14431

When the gateway restarts in-process (SIGUSR1, triggered by config changes, model switches, or `/new`), the Feishu/Lark SDK WebSocket client reconnects and replays recent events. Previously, the dedup caches were plain module-level `Map`s that could be lost when plugin modules were re-evaluated by the jiti loader during restart, causing duplicate message processing ("ghost replies").

## Changes

### Core: `createGlobalDedupeCache()` (`src/infra/dedupe.ts`)

New factory function that stores cache instances on `globalThis` keyed by a unique string. Repeated calls with the same key return the **existing** instance, so all previously-recorded entries survive the restart cycle. The regular `createDedupeCache()` is unchanged for non-persistent use cases.

### Applied to three dedup caches:

| Cache | File | Global Key |
|-------|------|-----------|
| Core inbound dedupe | `src/auto-reply/reply/inbound-dedupe.ts` | `openclaw:inbound-dedupe` |
| Web inbound dedupe | `src/web/inbound/dedupe.ts` | `openclaw:web-inbound-dedupe` |
| Feishu message dedup | `extensions/feishu/src/bot.ts` | `__openclaw_feishu_dedup__` |

### Tests

- `src/infra/dedupe.test.ts` — Tests for both `createDedupeCache` and `createGlobalDedupeCache` (7 tests)
- `src/auto-reply/reply/inbound-dedupe.survives-restart.test.ts` — Verifies the inbound cache survives simulated module re-evaluation (2 tests)
- `extensions/feishu/src/bot.dedup-survives-restart.test.ts` — Verifies Feishu dedup state survives simulated restart (3 tests)

All existing tests continue to pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR primarily makes dedupe caches survive SIGUSR1 in-process restarts by introducing `createGlobalDedupeCache()` (stores cache instances in a `globalThis` registry keyed by `globalKey`) and switching inbound/web inbound dedupe to use it. Feishu’s message deduplication is similarly moved to a `globalThis`-backed state object. The PR also updates the web chat controller to mark optimistic messages with a local id and preserve unacknowledged local messages when refreshing history, with new unit tests covering these behaviors.

Key issue to address before merge: the web UI’s “server confirmation” logic for optimistic messages uses text equality against all server user messages, which will incorrectly drop pending messages when the user repeats the same text (or history contains the same text). This should be tied to an idempotency/run id or other stable identifier rather than message text alone.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness issue in webchat optimistic-message reconciliation.
- The globalThis-backed dedupe registry/cache changes are straightforward and covered by tests, but `loadChatHistory()` currently drops local pending messages based on user-text matching, which will mis-handle repeated identical messages and can lose user-visible state.
- ui/src/ui/controllers/chat.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->