### PR TITLE
fix: normalize peer.kind symmetrically in route resolution

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -146,7 +146,8 @@ function matchesPeer(
   if (!kind || !id) {
     return false;
   }
-  return kind === peer.kind && id === peer.id;
+  const peerKind = normalizeChatType(peer.kind);
+  return kind === peerKind && id === peer.id;
 }
 
 function matchesGuild(
@@ -171,7 +172,12 @@ function matchesTeam(match: { teamId?: string | undefined } | undefined, teamId:
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
-  const peer = input.peer ? { kind: input.peer.kind, id: normalizeId(input.peer.id) } : null;
+  const peer = input.peer
+    ? {
+        kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
+        id: normalizeId(input.peer.id),
+      }
+    : null;
   const guildId = normalizeId(input.guildId);
   const teamId = normalizeId(input.teamId);
 
@@ -221,7 +227,10 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   // Thread parent inheritance: if peer (thread) didn't match, check parent peer binding
   const parentPeer = input.parentPeer
-    ? { kind: input.parentPeer.kind, id: normalizeId(input.parentPeer.id) }
+    ? {
+        kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
+        id: normalizeId(input.parentPeer.id),
+      }
     : null;
   if (parentPeer && parentPeer.id) {
     const parentPeerMatch = bindings.find((b) => matchesPeer(b.match, parentPeer));


### PR DESCRIPTION
## Summary

Fixes #14612

`resolveAgentRoute()` did not normalize the incoming `peer.kind` via `normalizeChatType()`, but `matchesPeer()` normalized only the config binding's `peer.kind`. This asymmetric normalization caused peer-based agent routing to always fail when a channel plugin passed a valid alias like `"dm"` instead of the canonical `"direct"`.

## Root Cause

In `matchesPeer()`, the config side `m.kind` was normalized (`"dm"` → `"direct"`), but the incoming `peer.kind` was compared raw. So `"direct" === "dm"` always evaluated to `false`, causing all peer-based bindings to silently fail for plugins using the `"dm"` alias.

## Changes

**`src/routing/resolve-route.ts`:**
- `matchesPeer()`: normalize both the config and incoming `peer.kind` via `normalizeChatType()`
- `resolveAgentRoute()`: normalize `peer.kind` and `parentPeer.kind` at construction time, consistent with how `id` is already normalized via `normalizeId()`

**`src/routing/resolve-route.test.ts`:**
- Added 4 test cases covering the exact bug scenario:
  - Runtime `"dm"` peer matches config `"direct"` binding
  - Runtime `"dm"` peer matches config `"dm"` binding  
  - `parentPeer` with `"dm"` alias is normalized for thread inheritance
  - Verifies messages no longer fall through to the default agent

All 24 existing tests continue to pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes peer-based routing mismatches caused by asymmetric chat-type normalization: config-side `peer.kind` was normalized (e.g. `dm → direct`) but incoming runtime `peer.kind` was compared raw, so bindings would fail when plugins passed the `dm` alias.

Changes update `matchesPeer()` to normalize the incoming `peer.kind`, and `resolveAgentRoute()` to normalize `peer.kind`/`parentPeer.kind` at construction time alongside existing `id` normalization. Tests add cases covering the `dm` alias matching behavior and parentPeer thread inheritance.

One issue to address before merge: the new tests currently assert `"dm" as ChatType`, even though `ChatType` does not include `"dm"` (it’s an alias handled by `normalizeChatType`). This undermines type-safety and can mask regressions at the type boundary; modeling plugin input should not require asserting an invalid value is a `ChatType`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing the test type-safety issue.
- The production change is small and aligns normalization on both sides of the peer.kind comparison, matching the documented intent. The main concern is the new tests’ `"dm" as ChatType` casts, which weaken type guarantees and may conflict with the repo’s preference for strict typing (and could fail CI if unsafe casts are disallowed).
- src/routing/resolve-route.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->