### PR TITLE
[Feature]: Extend before_agent_start hook context with Model, Tools, and Identity fields

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -8,7 +8,7 @@ import {
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
+import type { PluginHookAgentContext } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
@@ -311,9 +311,8 @@ export async function runEmbeddedPiAgent(
       // Legacy compatibility: before_agent_start is also checked for override
       // fields if present. New hook takes precedence when both are set.
       let modelResolveOverride: { providerOverride?: string; modelOverride?: string } | undefined;
-      let legacyBeforeAgentStartResult: PluginHookBeforeAgentStartResult | undefined;
       const hookRunner = getGlobalHookRunner();
-      const hookCtx = {
+      const hookCtx: PluginHookAgentContext = {
         agentId: workspaceResolution.agentId,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
@@ -321,6 +320,12 @@ export async function runEmbeddedPiAgent(
         messageProvider: params.messageProvider ?? undefined,
         trigger: params.trigger,
         channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+        accountId: params.agentAccountId ?? undefined,
+        senderId: params.senderId ?? undefined,
+        senderName: params.senderName ?? undefined,
+        senderUsername: params.senderUsername ?? undefined,
+        senderE164: params.senderE164 ?? undefined,
+        runId: params.runId,
       };
       if (hookRunner?.hasHooks("before_model_resolve")) {
         try {
@@ -330,25 +335,6 @@ export async function runEmbeddedPiAgent(
           );
         } catch (hookErr) {
           log.warn(`before_model_resolve hook failed: ${String(hookErr)}`);
-        }
-      }
-      if (hookRunner?.hasHooks("before_agent_start")) {
-        try {
-          legacyBeforeAgentStartResult = await hookRunner.runBeforeAgentStart(
-            { prompt: params.prompt },
-            hookCtx,
-          );
-          modelResolveOverride = {
-            providerOverride:
-              modelResolveOverride?.providerOverride ??
-              legacyBeforeAgentStartResult?.providerOverride,
-            modelOverride:
-              modelResolveOverride?.modelOverride ?? legacyBeforeAgentStartResult?.modelOverride,
-          };
-        } catch (hookErr) {
-          log.warn(
-            `before_agent_start hook (legacy model resolve path) failed: ${String(hookErr)}`,
-          );
         }
       }
       if (modelResolveOverride?.providerOverride) {
@@ -373,6 +359,9 @@ export async function runEmbeddedPiAgent(
           model: modelId,
         });
       }
+
+      hookCtx.model = model;
+      hookCtx.modelRegistry = modelRegistry;
 
       const ctxInfo = resolveContextWindowInfo({
         cfg: params.config,
@@ -888,7 +877,7 @@ export async function runEmbeddedPiAgent(
             authStorage,
             modelRegistry,
             agentId: workspaceResolution.agentId,
-            legacyBeforeAgentStartResult,
+            legacyBeforeAgentStartResult: undefined,
             thinkLevel,
             verboseLevel: params.verboseLevel,
             reasoningLevel: params.reasoningLevel,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1632,6 +1632,17 @@ export async function runEmbeddedAttempt(
         // Run before_prompt_build hooks to allow plugins to inject prompt context.
         // Legacy compatibility: before_agent_start is also checked for context fields.
         let effectivePrompt = params.prompt;
+        const hookTools =
+          tools.length > 0
+            ? tools.map((tool) => ({
+                name: tool.name || "tool",
+                description: tool.description ?? "",
+                parameters:
+                  tool.parameters && typeof tool.parameters === "object"
+                    ? (tool.parameters as Record<string, unknown>)
+                    : undefined,
+              }))
+            : undefined;
         const hookCtx = {
           agentId: hookAgentId,
           sessionKey: params.sessionKey,
@@ -1640,6 +1651,14 @@ export async function runEmbeddedAttempt(
           messageProvider: params.messageProvider ?? undefined,
           trigger: params.trigger,
           channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+          accountId: params.agentAccountId,
+          senderId: params.senderId ?? undefined,
+          senderName: params.senderName ?? undefined,
+          senderUsername: params.senderUsername ?? undefined,
+          senderE164: params.senderE164 ?? undefined,
+          runId: params.runId,
+          model: params.model,
+          modelRegistry: params.modelRegistry,
         };
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1634,14 +1634,16 @@ export async function runEmbeddedAttempt(
         let effectivePrompt = params.prompt;
         const hookTools =
           tools.length > 0
-            ? tools.map((tool) => ({
-                name: tool.name || "tool",
-                description: tool.description ?? "",
-                parameters:
-                  tool.parameters && typeof tool.parameters === "object"
-                    ? (tool.parameters as Record<string, unknown>)
-                    : undefined,
-              }))
+            ? tools
+                .filter((tool) => tool.name)
+                .map((tool) => ({
+                  name: tool.name,
+                  description: tool.description ?? "",
+                  parameters:
+                    tool.parameters && typeof tool.parameters === "object"
+                      ? (tool.parameters as Record<string, unknown>)
+                      : undefined,
+                }))
             : undefined;
         const hookCtx = {
           agentId: hookAgentId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -140,7 +140,11 @@ type PromptBuildHookRunner = {
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
-    event: { prompt: string; messages: unknown[] },
+    event: {
+      prompt: string;
+      messages: unknown[];
+      tools?: Array<{ name: string; description?: string; parameters?: Record<string, unknown> }>;
+    },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | undefined>;
 };
@@ -540,6 +544,7 @@ function wrapStreamFnDecodeXaiToolCallArguments(baseFn: StreamFn): StreamFn {
 export async function resolvePromptBuildHookResult(params: {
   prompt: string;
   messages: unknown[];
+  tools?: Array<{ name: string; description?: string; parameters?: Record<string, unknown> }>;
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
@@ -566,6 +571,7 @@ export async function resolvePromptBuildHookResult(params: {
             {
               prompt: params.prompt,
               messages: params.messages,
+              tools: params.tools,
             },
             params.hookCtx,
           )
@@ -1632,19 +1638,6 @@ export async function runEmbeddedAttempt(
         // Run before_prompt_build hooks to allow plugins to inject prompt context.
         // Legacy compatibility: before_agent_start is also checked for context fields.
         let effectivePrompt = params.prompt;
-        const hookTools =
-          tools.length > 0
-            ? tools
-                .filter((tool) => tool.name)
-                .map((tool) => ({
-                  name: tool.name,
-                  description: tool.description ?? "",
-                  parameters:
-                    tool.parameters && typeof tool.parameters === "object"
-                      ? (tool.parameters as Record<string, unknown>)
-                      : undefined,
-                }))
-            : undefined;
         const hookCtx = {
           agentId: hookAgentId,
           sessionKey: params.sessionKey,
@@ -1665,6 +1658,11 @@ export async function runEmbeddedAttempt(
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
+          tools: tools.map((t) => ({
+            name: t.name ?? "",
+            description: t.description,
+            parameters: t.parameters as Record<string, unknown> | undefined,
+          })),
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -13,6 +13,11 @@ export type HookContext = {
   sessionId?: string;
   runId?: string;
   loopDetection?: ToolLoopDetectionConfig;
+  senderId?: string;
+  senderName?: string;
+  senderUsername?: string;
+  senderE164?: string;
+  runId?: string;
 };
 
 type HookOutcome = { blocked: true; reason: string } | { blocked: false; params: unknown };
@@ -169,7 +174,13 @@ export async function runBeforeToolCallHook(args: {
         ...(args.ctx?.runId ? { runId: args.ctx.runId } : {}),
         ...(args.toolCallId ? { toolCallId: args.toolCallId } : {}),
       },
-      toolContext,
+      {
+        ...toolContext,
+        senderId: args.ctx?.senderId,
+        senderName: args.ctx?.senderName,
+        senderUsername: args.ctx?.senderUsername,
+        senderE164: args.ctx?.senderE164,
+      },
     );
 
     if (hookResult?.block) {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -17,7 +17,6 @@ export type HookContext = {
   senderName?: string;
   senderUsername?: string;
   senderE164?: string;
-  runId?: string;
 };
 
 type HookOutcome = { blocked: true; reason: string } | { blocked: false; params: unknown };

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -599,21 +599,25 @@ export function createOpenClawCodingTools(options?: {
       modelId: options?.modelId,
     }),
   );
-  const withHooks = normalized.map((tool) =>
+  const withAbort = options?.abortSignal
+    ? normalized.map((tool) => wrapToolWithAbortSignal(tool, options.abortSignal))
+    : normalized;
+  const withHooks = withAbort.map((tool) =>
     wrapToolWithBeforeToolCallHook(tool, {
       agentId,
       sessionKey: options?.sessionKey,
       sessionId: options?.sessionId,
       runId: options?.runId,
       loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
+      senderId: options?.senderId ?? undefined,
+      senderName: options?.senderName ?? undefined,
+      senderUsername: options?.senderUsername ?? undefined,
+      senderE164: options?.senderE164 ?? undefined,
     }),
   );
-  const withAbort = options?.abortSignal
-    ? withHooks.map((tool) => wrapToolWithAbortSignal(tool, options.abortSignal))
-    : withHooks;
 
   // NOTE: Keep canonical (lowercase) tool names here.
   // pi-ai's Anthropic OAuth transport remaps tool names to Claude Code-style names
   // on the wire and maps them back for tool dispatch.
-  return withAbort;
+  return withHooks;
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { Command } from "commander";
 import type { AuthProfileCredential, OAuthCredential } from "../agents/auth-profiles/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
@@ -404,6 +406,14 @@ export type PluginHookAgentContext = {
   trigger?: string;
   /** Channel identifier (e.g. "telegram", "discord", "whatsapp"). */
   channelId?: string;
+  accountId?: string;
+  senderId?: string;
+  senderName?: string;
+  senderUsername?: string;
+  senderE164?: string;
+  runId?: string;
+  model?: Model<Api>;
+  modelRegistry?: ModelRegistry;
 };
 
 // before_model_resolve hook
@@ -462,6 +472,11 @@ export type PluginHookBeforeAgentStartEvent = {
   prompt: string;
   /** Optional because legacy hook can run in pre-session phase. */
   messages?: unknown[];
+  tools?: Array<{
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  }>;
 };
 
 export type PluginHookBeforeAgentStartResult = PluginHookBeforePromptBuildResult &

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,7 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { Api, Model } from "@mariozechner/pi-ai";
-import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { Command } from "commander";
 import type { AuthProfileCredential, OAuthCredential } from "../agents/auth-profiles/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
@@ -412,8 +410,8 @@ export type PluginHookAgentContext = {
   senderUsername?: string;
   senderE164?: string;
   runId?: string;
-  model?: Model<Api>;
-  modelRegistry?: ModelRegistry;
+  model?: unknown;
+  modelRegistry?: unknown;
 };
 
 // before_model_resolve hook

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -614,6 +614,12 @@ export type PluginHookToolContext = {
   toolName: string;
   /** Provider-specific tool call ID when available. */
   toolCallId?: string;
+  senderId?: string;
+  senderName?: string;
+  senderUsername?: string;
+  senderE164?: string;
+  intentTokenRaw?: string;
+  csrgPath?: string;
 };
 
 // before_tool_call hook


### PR DESCRIPTION
## Summary

The current before_agent_start plugin hook provides a sanitized context (prompt, messages), which is insufficient for plugins that require "Agentic" capabilities. Specifically, external plugins cannot access the LLM instance to perform intent planning, nor can they see the tools available to the agent, or robustly identify the user (missing senderId, senderE164). This prevents the creation of advanced security and governance plugins that need to verify intent before execution.

## Proposed solution

Extend PluginHookAgentContext and PluginHookBeforeAgentStartEvent to expose the following fields, which are already available in attempt.ts:

In ctx (PluginHookAgentContext):

Model: The Model instance (enables the plugin to call the LLM for planning/verification).
modelRegistry: For model configuration access.

runId: To correlate the start event with subsequent tool calls (for caching plans).
senderId, senderE164, senderUsername: For identity verification and audit logging.
messageChannel

accountId: For full context awareness.
In event (PluginHookBeforeAgentStartEvent):

Tools: The list of tools available for this run (crucial for verifying if a user's intent matches allowed tools).

## Alternatives considered

Building a custom agent: This bypasses the plugin system entirely and fragments the ecosystem.

Using before_tool_call only: This is too late for "Intent Planning". By the time a tool is called, the "plan" has already been decided by the LLM. Security plugins need to verify the plan against policy before any tool is even attempted.

## Additional context

I have a working implementation in a fork that successfully powers an "ArmorIQ" security plugin. This plugin uses the exposed ctx.model to generate a secure execution plan and event.tools to validate it, preventing prompt injection and unauthorized actions.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `before_agent_start` plugin hook payload so plugins can do richer pre-run governance/intent checks. Specifically:

- `src/agents/pi-embedded-runner/run/attempt.ts` now passes a `tools` summary on the event and adds additional fields (run/account/sender identity, channel, model, modelRegistry) on the hook context when running `runBeforeAgentStart`.
- `src/plugins/types.ts` updates the public hook type definitions to include these new fields.

These changes integrate with the existing hook runner in `src/plugins/hooks.ts` (sequential modifying hook for `before_agent_start`) and are surfaced to external plugins via the re-export in `src/plugin-sdk/index.ts`.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing the plugin-SDK type dependency and tool naming ambiguity.
- Core runtime behavior changes are limited to passing additional context into an existing hook call, but the hook type exports are part of the public plugin SDK and may break external plugin builds if the new pi-* types aren’t resolvable. Additionally, the emitted tool list may be unreliable due to duplicate fallback names.
- src/plugins/types.ts, src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->