### PR TITLE
fix(browser): improve targetUrl error message for open/navigate actions

### DIFF
--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -364,6 +364,7 @@ export function createBrowserTool(opts?: {
         case "open": {
           const targetUrl = readStringParam(params, "targetUrl", {
             required: true,
+            label: 'targetUrl is required for action "open" — provide the URL to open',
           });
           if (proxyRequest) {
             const result = await proxyRequest({
@@ -546,6 +547,7 @@ export function createBrowserTool(opts?: {
         case "navigate": {
           const targetUrl = readStringParam(params, "targetUrl", {
             required: true,
+            label: 'targetUrl is required for action "navigate" — provide the URL to navigate to',
           });
           const targetId = readStringParam(params, "targetId");
           if (proxyRequest) {


### PR DESCRIPTION
Fixes #14700

The browser tool schema marks `targetUrl` as `Type.Optional()` (correct at the tool level since most actions don't need it), but `open` and `navigate` actions require it. When missing, the error was just `"targetUrl required"` — too vague for models like Gemini Flash, causing infinite retry loops.

Now the error message specifies which action needs `targetUrl` and what to provide.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `browser` tool parameter validation for the `open` and `navigate` actions to emit a more specific error when `targetUrl` is missing. Concretely, it passes action-specific `label` strings into `readStringParam`, so the thrown error includes which action requires `targetUrl` and what value to provide. No tool schema or request/response behavior changes beyond the error message content.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff only changes error message strings by setting `label` on `readStringParam` for `targetUrl` in two actions; the validation logic and control flow are unchanged, and the new strings align with how `readStringParam` formats required-parameter errors.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->