### PR TITLE
fix: persist session metadata to sessions.json after context pruning

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -393,6 +393,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
+        sessionKey: params.sessionKey,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -394,6 +394,7 @@ export async function compactEmbeddedPiSessionDirect(
         modelId,
         model,
         sessionKey: params.sessionKey,
+        agentId: sessionAgentId,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -44,6 +44,7 @@ function buildContextPruningExtension(params: {
   model: Model<Api> | undefined;
   sessionKey?: string;
   storePath?: string;
+  agentId?: string;
 }): { additionalExtensionPaths?: string[] } {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
   if (raw?.mode !== "cache-ttl") {
@@ -58,7 +59,8 @@ function buildContextPruningExtension(params: {
     return {};
   }
 
-  const effectiveStorePath = params.storePath ?? resolveStorePath();
+  const effectiveStorePath =
+    params.storePath ?? resolveStorePath(undefined, { agentId: params.agentId });
 
   setContextPruningRuntime(params.sessionManager, {
     settings,
@@ -86,6 +88,7 @@ export function buildEmbeddedExtensionPaths(params: {
   model: Model<Api> | undefined;
   sessionKey?: string;
   storePath?: string;
+  agentId?: string;
 }): string[] {
   const paths: string[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -453,6 +453,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        sessionKey: params.sessionKey,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -454,6 +454,7 @@ export async function runEmbeddedAttempt(
         modelId: params.modelId,
         model: params.model,
         sessionKey: params.sessionKey,
+        agentId: params.agentId,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-extensions/context-pruning/extension.test.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { setContextPruningRuntime, getContextPruningRuntime } from "./runtime.js";
+import type { ContextPruningRuntimeValue } from "./runtime.js";
+import { CHARS_PER_TOKEN_ESTIMATE, estimateContextChars } from "./pruner.js";
+import type { EffectiveContextPruningSettings } from "./settings.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock updateSessionStoreEntry so the extension can import it without
+// touching the real filesystem.
+const mockUpdateSessionStoreEntry = vi.fn().mockResolvedValue(null);
+vi.mock("../../../config/sessions.js", () => ({
+  updateSessionStoreEntry: (...args: unknown[]) => mockUpdateSessionStoreEntry(...args),
+}));
+
+// Mock pruneContextMessages to control pruning behavior
+const mockPruneContextMessages = vi.fn();
+vi.mock("./pruner.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./pruner.js")>();
+  return {
+    ...original,
+    pruneContextMessages: (...args: unknown[]) => mockPruneContextMessages(...args),
+  };
+});
+
+// Dynamic import so mocks are in place first
+const { default: contextPruningExtension } = await import("./extension.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSettings(overrides?: Partial<EffectiveContextPruningSettings>): EffectiveContextPruningSettings {
+  return {
+    mode: "cache-ttl",
+    ttlMs: 300_000,
+    softTrimRatio: 0.7,
+    hardClearRatio: 0.9,
+    keepLastAssistants: 3,
+    minPrunableToolChars: 0,
+    softTrim: { maxChars: 4000, headChars: 500, tailChars: 500 },
+    hardClear: { enabled: true, placeholder: "[pruned]" },
+    tools: { prunable: [], protected: [] },
+    ...overrides,
+  };
+}
+
+function makeSessionManager(): object {
+  return {};
+}
+
+function makeMessages(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    role: "user" as const,
+    content: `message ${i} ${"x".repeat(100)}`,
+  }));
+}
+
+function makePrunedMessages(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    role: "user" as const,
+    content: `pruned ${i}`,
+  }));
+}
+
+function buildExtensionAndCapture(): {
+  handler: (event: ContextEvent, ctx: ExtensionContext) => unknown;
+} {
+  let captured: ((event: ContextEvent, ctx: ExtensionContext) => unknown) | null = null;
+  const api: ExtensionAPI = {
+    on: (eventName: string, handler: unknown) => {
+      if (eventName === "context") {
+        captured = handler as typeof captured;
+      }
+    },
+  } as unknown as ExtensionAPI;
+
+  contextPruningExtension(api);
+  if (!captured) throw new Error("context handler not registered");
+  return { handler: captured };
+}
+
+function makeCtx(sessionManager: object): ExtensionContext {
+  return {
+    sessionManager,
+    model: { contextWindow: 200_000 },
+  } as unknown as ExtensionContext;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("contextPruningExtension", () => {
+  const sessionManager = makeSessionManager();
+  const ctx = makeCtx(sessionManager);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset runtime state
+    setContextPruningRuntime(sessionManager, null);
+  });
+
+  afterEach(() => {
+    setContextPruningRuntime(sessionManager, null);
+  });
+
+  // -- Basic behavior -------------------------------------------------------
+
+  it("does nothing when no runtime is registered", () => {
+    const { handler } = buildExtensionAndCapture();
+    const event = { messages: makeMessages(5) } as unknown as ContextEvent;
+    const result = handler(event, ctx);
+    expect(result).toBeUndefined();
+    expect(mockPruneContextMessages).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when TTL has not expired", () => {
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now(), // Just touched
+    });
+    const { handler } = buildExtensionAndCapture();
+    const event = { messages: makeMessages(5) } as unknown as ContextEvent;
+    const result = handler(event, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("does nothing when pruning returns the same messages array", () => {
+    const originalMessages = makeMessages(5);
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+    });
+    mockPruneContextMessages.mockReturnValue(originalMessages);
+
+    const { handler } = buildExtensionAndCapture();
+    const event = { messages: originalMessages } as unknown as ContextEvent;
+    const result = handler(event, ctx);
+    expect(result).toBeUndefined();
+    expect(mockUpdateSessionStoreEntry).not.toHaveBeenCalled();
+  });
+
+  // -- Persistence after pruning -------------------------------------------
+
+  it("persists token count after successful pruning when sessionKey and storePath are set", () => {
+    const originalMessages = makeMessages(10);
+    const prunedMessages = makePrunedMessages(3);
+
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+      sessionKey: "test-session",
+      storePath: "/tmp/sessions.json",
+    });
+    mockPruneContextMessages.mockReturnValue(prunedMessages);
+
+    const { handler } = buildExtensionAndCapture();
+    const event = { messages: originalMessages } as unknown as ContextEvent;
+    const result = handler(event, ctx);
+
+    expect(result).toEqual({ messages: prunedMessages });
+    expect(mockUpdateSessionStoreEntry).toHaveBeenCalledTimes(1);
+
+    const callArgs = mockUpdateSessionStoreEntry.mock.calls[0]![0];
+    expect(callArgs.storePath).toBe("/tmp/sessions.json");
+    expect(callArgs.sessionKey).toBe("test-session");
+    expect(typeof callArgs.update).toBe("function");
+  });
+
+  it("does NOT persist when sessionKey is missing", () => {
+    const originalMessages = makeMessages(10);
+    const prunedMessages = makePrunedMessages(3);
+
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+      storePath: "/tmp/sessions.json",
+      // sessionKey intentionally omitted
+    });
+    mockPruneContextMessages.mockReturnValue(prunedMessages);
+
+    const { handler } = buildExtensionAndCapture();
+    const event = { messages: originalMessages } as unknown as ContextEvent;
+    handler(event, ctx);
+
+    expect(mockUpdateSessionStoreEntry).not.toHaveBeenCalled();
+  });
+
+  it("does NOT persist when storePath is missing", () => {
+    const originalMessages = makeMessages(10);
+    const prunedMessages = makePrunedMessages(3);
+
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+      sessionKey: "test-session",
+      // storePath intentionally omitted
+    });
+    mockPruneContextMessages.mockReturnValue(prunedMessages);
+
+    const { handler } = buildExtensionAndCapture();
+    const event = { messages: originalMessages } as unknown as ContextEvent;
+    handler(event, ctx);
+
+    expect(mockUpdateSessionStoreEntry).not.toHaveBeenCalled();
+  });
+
+  it("swallows persistence errors without throwing", async () => {
+    const originalMessages = makeMessages(10);
+    const prunedMessages = makePrunedMessages(3);
+
+    mockUpdateSessionStoreEntry.mockRejectedValueOnce(new Error("disk full"));
+
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+      sessionKey: "test-session",
+      storePath: "/tmp/sessions.json",
+    });
+    mockPruneContextMessages.mockReturnValue(prunedMessages);
+
+    const { handler } = buildExtensionAndCapture();
+    const event = { messages: originalMessages } as unknown as ContextEvent;
+
+    // Should not throw
+    const result = handler(event, ctx);
+    expect(result).toEqual({ messages: prunedMessages });
+
+    // Wait for the fire-and-forget promise to settle
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockUpdateSessionStoreEntry).toHaveBeenCalledTimes(1);
+  });
+
+  // -- Update callback verification ----------------------------------------
+
+  it("update callback computes correct estimated tokens from pruned messages", async () => {
+    const prunedMessages = makePrunedMessages(3);
+    const expectedChars = estimateContextChars(prunedMessages as any);
+    const expectedTokens = Math.round(expectedChars / CHARS_PER_TOKEN_ESTIMATE);
+
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+      sessionKey: "test-session",
+      storePath: "/tmp/sessions.json",
+    });
+    mockPruneContextMessages.mockReturnValue(prunedMessages);
+
+    const { handler } = buildExtensionAndCapture();
+    handler({ messages: makeMessages(10) } as unknown as ContextEvent, ctx);
+
+    const callArgs = mockUpdateSessionStoreEntry.mock.calls[0]![0];
+    const patch = await callArgs.update({
+      sessionId: "sid",
+      updatedAt: 0,
+      inputTokens: 1000,
+      outputTokens: 500,
+      contextTokens: 200_000,
+    });
+
+    expect(patch.contextTokens).toBe(expectedTokens);
+    expect(patch.totalTokens).toBe(Math.max(expectedTokens, 1000 + 500));
+    expect(typeof patch.updatedAt).toBe("number");
+  });
+
+  it("totalTokens is at least the estimated token count", async () => {
+    const prunedMessages = [{ role: "user" as const, content: "x".repeat(40_000) }];
+    const expectedChars = estimateContextChars(prunedMessages as any);
+    const expectedTokens = Math.round(expectedChars / CHARS_PER_TOKEN_ESTIMATE);
+
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+      sessionKey: "s",
+      storePath: "/tmp/s.json",
+    });
+    mockPruneContextMessages.mockReturnValue(prunedMessages);
+
+    const { handler } = buildExtensionAndCapture();
+    handler({ messages: makeMessages(20) } as unknown as ContextEvent, ctx);
+
+    const callArgs = mockUpdateSessionStoreEntry.mock.calls[0]![0];
+    // Entry with very low input/output tokens
+    const patch = await callArgs.update({
+      sessionId: "sid",
+      updatedAt: 0,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+
+    expect(patch.totalTokens).toBe(expectedTokens);
+  });
+
+  // -- TTL behavior ---------------------------------------------------------
+
+  it("updates lastCacheTouchAt after pruning", () => {
+    const originalMessages = makeMessages(10);
+    const prunedMessages = makePrunedMessages(3);
+
+    const runtime: ContextPruningRuntimeValue = {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+      sessionKey: "s",
+      storePath: "/tmp/s.json",
+    };
+    setContextPruningRuntime(sessionManager, runtime);
+    mockPruneContextMessages.mockReturnValue(prunedMessages);
+
+    const before = Date.now();
+    const { handler } = buildExtensionAndCapture();
+    handler({ messages: originalMessages } as unknown as ContextEvent, ctx);
+
+    expect(runtime.lastCacheTouchAt).toBeGreaterThanOrEqual(before);
+    expect(runtime.lastCacheTouchAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("does nothing when TTL is zero", () => {
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings({ ttlMs: 0 }),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: Date.now() - 600_000,
+    });
+
+    const { handler } = buildExtensionAndCapture();
+    const result = handler({ messages: makeMessages(5) } as unknown as ContextEvent, ctx);
+    expect(result).toBeUndefined();
+    expect(mockPruneContextMessages).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no lastCacheTouchAt is set", () => {
+    setContextPruningRuntime(sessionManager, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      lastCacheTouchAt: null,
+    });
+
+    const { handler } = buildExtensionAndCapture();
+    const result = handler({ messages: makeMessages(5) } as unknown as ContextEvent, ctx);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/agents/pi-extensions/context-pruning/extension.test.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { setContextPruningRuntime, getContextPruningRuntime } from "./runtime.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContextPruningRuntimeValue } from "./runtime.js";
-import { CHARS_PER_TOKEN_ESTIMATE, estimateContextChars } from "./pruner.js";
 import type { EffectiveContextPruningSettings } from "./settings.js";
+import { CHARS_PER_TOKEN_ESTIMATE, estimateContextChars } from "./pruner.js";
+import { setContextPruningRuntime, getContextPruningRuntime } from "./runtime.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -33,7 +33,9 @@ const { default: contextPruningExtension } = await import("./extension.js");
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeSettings(overrides?: Partial<EffectiveContextPruningSettings>): EffectiveContextPruningSettings {
+function makeSettings(
+  overrides?: Partial<EffectiveContextPruningSettings>,
+): EffectiveContextPruningSettings {
   return {
     mode: "cache-ttl",
     ttlMs: 300_000,

--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -1,6 +1,37 @@
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { pruneContextMessages } from "./pruner.js";
+import { updateSessionStoreEntry } from "../../../config/sessions.js";
+import { CHARS_PER_TOKEN_ESTIMATE, estimateContextChars, pruneContextMessages } from "./pruner.js";
 import { getContextPruningRuntime } from "./runtime.js";
+
+/**
+ * Persist the post-pruning token estimate to `sessions.json` so that
+ * dashboards and monitoring tools see up-to-date `contextTokens`
+ * immediately — not only after the next message arrives.
+ *
+ * Runs fire-and-forget: a failure here must never block the agent run.
+ */
+function persistPrunedTokenCount(params: {
+  storePath: string;
+  sessionKey: string;
+  estimatedTokens: number;
+}): void {
+  const { storePath, sessionKey, estimatedTokens } = params;
+  updateSessionStoreEntry({
+    storePath,
+    sessionKey,
+    update: async (entry) => ({
+      contextTokens: estimatedTokens,
+      totalTokens: Math.max(
+        estimatedTokens,
+        (entry.inputTokens ?? 0) + (entry.outputTokens ?? 0),
+      ),
+      updatedAt: Date.now(),
+    }),
+  }).catch(() => {
+    // Swallow — best-effort persistence; the next agent run will
+    // re-sync anyway.
+  });
+}
 
 export default function contextPruningExtension(api: ExtensionAPI): void {
   api.on("context", (event: ContextEvent, ctx: ExtensionContext) => {
@@ -34,6 +65,19 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
 
     if (runtime.settings.mode === "cache-ttl") {
       runtime.lastCacheTouchAt = Date.now();
+    }
+
+    // Persist the reduced token count to sessions.json immediately
+    // so dashboards reflect the post-pruning state.  (#14857)
+    if (runtime.sessionKey && runtime.storePath) {
+      const estimatedTokens = Math.round(
+        estimateContextChars(next) / CHARS_PER_TOKEN_ESTIMATE,
+      );
+      persistPrunedTokenCount({
+        storePath: runtime.storePath,
+        sessionKey: runtime.sessionKey,
+        estimatedTokens,
+      });
     }
 
     return { messages: next };

--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -21,10 +21,7 @@ function persistPrunedTokenCount(params: {
     sessionKey,
     update: async (entry) => ({
       contextTokens: estimatedTokens,
-      totalTokens: Math.max(
-        estimatedTokens,
-        (entry.inputTokens ?? 0) + (entry.outputTokens ?? 0),
-      ),
+      totalTokens: Math.max(estimatedTokens, (entry.inputTokens ?? 0) + (entry.outputTokens ?? 0)),
       updatedAt: Date.now(),
     }),
   }).catch(() => {
@@ -70,9 +67,7 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
     // Persist the reduced token count to sessions.json immediately
     // so dashboards reflect the post-pruning state.  (#14857)
     if (runtime.sessionKey && runtime.storePath) {
-      const estimatedTokens = Math.round(
-        estimateContextChars(next) / CHARS_PER_TOKEN_ESTIMATE,
-      );
+      const estimatedTokens = Math.round(estimateContextChars(next) / CHARS_PER_TOKEN_ESTIMATE);
       persistPrunedTokenCount({
         storePath: runtime.storePath,
         sessionKey: runtime.sessionKey,

--- a/src/agents/pi-extensions/context-pruning/pruner-exports.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner-exports.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { CHARS_PER_TOKEN_ESTIMATE, estimateContextChars } from "./pruner.js";
+
+describe("pruner exports", () => {
+  describe("CHARS_PER_TOKEN_ESTIMATE", () => {
+    it("is exported and equals 4", () => {
+      expect(CHARS_PER_TOKEN_ESTIMATE).toBe(4);
+    });
+
+    it("is a positive integer", () => {
+      expect(Number.isInteger(CHARS_PER_TOKEN_ESTIMATE)).toBe(true);
+      expect(CHARS_PER_TOKEN_ESTIMATE).toBeGreaterThan(0);
+    });
+  });
+
+  describe("estimateContextChars", () => {
+    it("is exported as a function", () => {
+      expect(typeof estimateContextChars).toBe("function");
+    });
+
+    it("returns 0 for empty messages array", () => {
+      expect(estimateContextChars([])).toBe(0);
+    });
+
+    it("estimates character count for user string messages", () => {
+      const messages = [
+        { role: "user" as const, content: "hello world" },
+      ];
+      expect(estimateContextChars(messages as any)).toBe(11);
+    });
+
+    it("estimates character count for multiple messages", () => {
+      const messages = [
+        { role: "user" as const, content: "hello" },
+        { role: "user" as const, content: "world" },
+      ];
+      expect(estimateContextChars(messages as any)).toBe(10);
+    });
+
+    it("estimates assistant text content blocks", () => {
+      const messages = [
+        {
+          role: "assistant" as const,
+          content: [{ type: "text" as const, text: "response text here" }],
+        },
+      ];
+      expect(estimateContextChars(messages as any)).toBe(18);
+    });
+
+    it("token estimate from chars is consistent with CHARS_PER_TOKEN_ESTIMATE", () => {
+      const messages = [
+        { role: "user" as const, content: "x".repeat(4000) },
+      ];
+      const chars = estimateContextChars(messages as any);
+      const tokens = Math.round(chars / CHARS_PER_TOKEN_ESTIMATE);
+      expect(tokens).toBe(1000);
+    });
+
+    it("handles mixed message roles", () => {
+      const messages = [
+        { role: "user" as const, content: "question" },
+        {
+          role: "assistant" as const,
+          content: [{ type: "text" as const, text: "answer" }],
+        },
+        {
+          role: "toolResult" as const,
+          toolName: "search",
+          toolCallId: "tc1",
+          content: [{ type: "text" as const, text: "result data" }],
+        },
+      ];
+      const chars = estimateContextChars(messages as any);
+      // "question" = 8, "answer" = 6, "result data" = 11
+      expect(chars).toBe(25);
+    });
+  });
+});

--- a/src/agents/pi-extensions/context-pruning/pruner-exports.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner-exports.test.ts
@@ -23,9 +23,7 @@ describe("pruner exports", () => {
     });
 
     it("estimates character count for user string messages", () => {
-      const messages = [
-        { role: "user" as const, content: "hello world" },
-      ];
+      const messages = [{ role: "user" as const, content: "hello world" }];
       expect(estimateContextChars(messages as any)).toBe(11);
     });
 
@@ -48,9 +46,7 @@ describe("pruner exports", () => {
     });
 
     it("token estimate from chars is consistent with CHARS_PER_TOKEN_ESTIMATE", () => {
-      const messages = [
-        { role: "user" as const, content: "x".repeat(4000) },
-      ];
+      const messages = [{ role: "user" as const, content: "x".repeat(4000) }];
       const chars = estimateContextChars(messages as any);
       const tokens = Math.round(chars / CHARS_PER_TOKEN_ESTIMATE);
       expect(tokens).toBe(1000);

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -4,7 +4,7 @@ import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { EffectiveContextPruningSettings } from "./settings.js";
 import { makeToolPrunablePredicate } from "./tools.js";
 
-const CHARS_PER_TOKEN_ESTIMATE = 4;
+export const CHARS_PER_TOKEN_ESTIMATE = 4;
 // We currently skip pruning tool results that contain images. Still, we count them (approx.) so
 // we start trimming prunable tool results earlier when image-heavy context is consuming the window.
 const IMAGE_CHAR_ESTIMATE = 8_000;
@@ -150,7 +150,7 @@ function estimateMessageChars(message: AgentMessage): number {
   return 256;
 }
 
-function estimateContextChars(messages: AgentMessage[]): number {
+export function estimateContextChars(messages: AgentMessage[]): number {
   return messages.reduce((sum, m) => sum + estimateMessageChars(m), 0);
 }
 

--- a/src/agents/pi-extensions/context-pruning/runtime.test.ts
+++ b/src/agents/pi-extensions/context-pruning/runtime.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  setContextPruningRuntime,
+  getContextPruningRuntime,
+  type ContextPruningRuntimeValue,
+} from "./runtime.js";
+import type { EffectiveContextPruningSettings } from "./settings.js";
+
+function makeSettings(): EffectiveContextPruningSettings {
+  return {
+    mode: "cache-ttl",
+    ttlMs: 300_000,
+    softTrimRatio: 0.7,
+    hardClearRatio: 0.9,
+    keepLastAssistants: 3,
+    minPrunableToolChars: 0,
+    softTrim: { maxChars: 4000, headChars: 500, tailChars: 500 },
+    hardClear: { enabled: true, placeholder: "[pruned]" },
+    tools: { prunable: [], protected: [] },
+  };
+}
+
+describe("ContextPruningRuntime", () => {
+  it("stores and retrieves runtime value by session manager identity", () => {
+    const sm = {};
+    const value: ContextPruningRuntimeValue = {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+    };
+    setContextPruningRuntime(sm, value);
+    expect(getContextPruningRuntime(sm)).toBe(value);
+  });
+
+  it("returns null when no runtime is set", () => {
+    expect(getContextPruningRuntime({})).toBeNull();
+  });
+
+  it("deletes runtime when set to null", () => {
+    const sm = {};
+    setContextPruningRuntime(sm, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+    });
+    expect(getContextPruningRuntime(sm)).not.toBeNull();
+    setContextPruningRuntime(sm, null);
+    expect(getContextPruningRuntime(sm)).toBeNull();
+  });
+
+  it("ignores non-object session managers", () => {
+    setContextPruningRuntime(null, { settings: makeSettings(), isToolPrunable: () => true });
+    expect(getContextPruningRuntime(null)).toBeNull();
+
+    setContextPruningRuntime(undefined, { settings: makeSettings(), isToolPrunable: () => true });
+    expect(getContextPruningRuntime(undefined)).toBeNull();
+
+    setContextPruningRuntime("string" as any, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+    });
+    expect(getContextPruningRuntime("string" as any)).toBeNull();
+  });
+
+  it("stores sessionKey in runtime value", () => {
+    const sm = {};
+    const value: ContextPruningRuntimeValue = {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      sessionKey: "agent:main:slack:channel:C123",
+    };
+    setContextPruningRuntime(sm, value);
+    expect(getContextPruningRuntime(sm)?.sessionKey).toBe("agent:main:slack:channel:C123");
+  });
+
+  it("stores storePath in runtime value", () => {
+    const sm = {};
+    const value: ContextPruningRuntimeValue = {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      storePath: "/home/user/.openclaw/agents/main/sessions/sessions.json",
+    };
+    setContextPruningRuntime(sm, value);
+    expect(getContextPruningRuntime(sm)?.storePath).toBe(
+      "/home/user/.openclaw/agents/main/sessions/sessions.json",
+    );
+  });
+
+  it("stores both sessionKey and storePath together", () => {
+    const sm = {};
+    const value: ContextPruningRuntimeValue = {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      sessionKey: "test-key",
+      storePath: "/tmp/sessions.json",
+      contextWindowTokens: 200_000,
+      lastCacheTouchAt: Date.now(),
+    };
+    setContextPruningRuntime(sm, value);
+    const retrieved = getContextPruningRuntime(sm);
+    expect(retrieved?.sessionKey).toBe("test-key");
+    expect(retrieved?.storePath).toBe("/tmp/sessions.json");
+    expect(retrieved?.contextWindowTokens).toBe(200_000);
+  });
+
+  it("keeps separate runtimes for different session managers", () => {
+    const sm1 = {};
+    const sm2 = {};
+    setContextPruningRuntime(sm1, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      sessionKey: "key1",
+    });
+    setContextPruningRuntime(sm2, {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+      sessionKey: "key2",
+    });
+    expect(getContextPruningRuntime(sm1)?.sessionKey).toBe("key1");
+    expect(getContextPruningRuntime(sm2)?.sessionKey).toBe("key2");
+  });
+
+  it("sessionKey and storePath are optional (backward compatible)", () => {
+    const sm = {};
+    const value: ContextPruningRuntimeValue = {
+      settings: makeSettings(),
+      isToolPrunable: () => true,
+    };
+    setContextPruningRuntime(sm, value);
+    const retrieved = getContextPruningRuntime(sm);
+    expect(retrieved?.sessionKey).toBeUndefined();
+    expect(retrieved?.storePath).toBeUndefined();
+  });
+});

--- a/src/agents/pi-extensions/context-pruning/runtime.test.ts
+++ b/src/agents/pi-extensions/context-pruning/runtime.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
+import type { EffectiveContextPruningSettings } from "./settings.js";
 import {
   setContextPruningRuntime,
   getContextPruningRuntime,
   type ContextPruningRuntimeValue,
 } from "./runtime.js";
-import type { EffectiveContextPruningSettings } from "./settings.js";
 
 function makeSettings(): EffectiveContextPruningSettings {
   return {

--- a/src/agents/pi-extensions/context-pruning/runtime.ts
+++ b/src/agents/pi-extensions/context-pruning/runtime.ts
@@ -5,6 +5,10 @@ export type ContextPruningRuntimeValue = {
   contextWindowTokens?: number | null;
   isToolPrunable: (toolName: string) => boolean;
   lastCacheTouchAt?: number | null;
+  /** Session key used to persist metadata after pruning. */
+  sessionKey?: string;
+  /** Path to sessions.json — used to persist metadata after pruning. */
+  storePath?: string;
 };
 
 // Session-scoped runtime registry keyed by object identity.


### PR DESCRIPTION
## Summary

Fixes #14857

After context pruning runs (cache-ttl mode), `sessions.json` retains stale `contextTokens` values until the next inbound message triggers a usage update. This causes Mission Control dashboards and monitoring systems to show incorrect context usage (e.g. 200k/200k when actual is much lower post-pruning).

**Root cause:** The pruning extension modifies messages in-flight during the Pi context event but never writes the reduced token estimate back to the session store. The store only updates when `persistSessionUsageUpdate` runs after the next agent reply.

**Fix:** After a successful prune, fire-and-forget persist the new estimated token count to `sessions.json` via `updateSessionStoreEntry`. This is best-effort -- a failure here never blocks the agent run.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-extensions/context-pruning/runtime.ts` | Add `sessionKey` and `storePath` to `ContextPruningRuntimeValue` type |
| `src/agents/pi-extensions/context-pruning/pruner.ts` | Export `estimateContextChars` and `CHARS_PER_TOKEN_ESTIMATE` for reuse |
| `src/agents/pi-extensions/context-pruning/extension.ts` | After pruning, calculate new token estimate and persist to sessions.json |
| `src/agents/pi-embedded-runner/extensions.ts` | Accept `sessionKey`/`storePath` params, resolve `storePath` from config, thread to runtime |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Pass `sessionKey` to `buildEmbeddedExtensionPaths` |
| `src/agents/pi-embedded-runner/compact.ts` | Pass `sessionKey` to `buildEmbeddedExtensionPaths` |

## Tests (30 new tests across 3 files)

| Test File | Tests | Coverage |
|-----------|-------|----------|
| `extension.test.ts` | 12 | Persistence after pruning, no-persist when session info missing, error swallowing, update callback token calculation, TTL behavior |
| `runtime.test.ts` | 9 | Store/retrieve runtime, sessionKey/storePath storage, deletion, non-object guards, isolation between sessions, backward compatibility |
| `pruner-exports.test.ts` | 9 | CHARS_PER_TOKEN_ESTIMATE value/type, estimateContextChars for empty/single/multiple/mixed messages, token consistency |

## Test plan

- [x] No persist when no runtime registered
- [x] No persist when TTL not expired
- [x] No persist when messages unchanged (no pruning occurred)
- [x] Persist fires after successful pruning with sessionKey + storePath
- [x] No persist when sessionKey missing
- [x] No persist when storePath missing
- [x] Persistence errors swallowed (fire-and-forget)
- [x] Update callback computes correct estimated tokens
- [x] totalTokens is at least the estimated context tokens
- [x] lastCacheTouchAt updated after pruning
- [x] Runtime stores/retrieves sessionKey and storePath
- [x] Backward compatible -- sessionKey/storePath are optional
- [x] Existing session and pruning config tests still pass
- [x] All 30 new tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires `sessionKey`/`storePath` into the context-pruning runtime and, after a successful prune in cache-TTL mode, fire-and-forget persists an updated `contextTokens` estimate to the session store so monitoring dashboards reflect post-pruning usage immediately.

The main new flow is: embedded runner builds extension paths → initializes context-pruning runtime → extension prunes messages on the `context` event → computes an estimated token count from the pruned messages and calls `updateSessionStoreEntry` to patch `contextTokens`/`totalTokens`.

Issue found: the embedded runner currently resolves `storePath` via `resolveStorePath()` without passing the active agent id/config store, which defaults to the *default agent* sessions store; this can cause writes to the wrong `sessions.json` when running under a non-default agent.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness issue in multi-agent setups that can write pruning metadata to the wrong sessions store.
- Core pruning/persistence logic is straightforward and best-effort, but `storePath` resolution currently falls back to `DEFAULT_AGENT_ID` (via `resolveStorePath()` with no opts), so embedded runs for non-default agents can fail to persist or update the wrong `sessions.json` entry.
- src/agents/pi-embedded-runner/extensions.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->