### PR TITLE
fix(slack): pass threadId through in read action

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -362,6 +362,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: readStringParam(params, "threadId"),
             accountId: accountId ?? undefined,
           },
           cfg,


### PR DESCRIPTION
Fixes #14706

The Slack channel plugin's `read` action did not forward the `threadId` parameter, so thread replies could never be fetched.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Slack channel plugin message reads by forwarding the `threadId` parameter when invoking the Slack runtime `readMessages` action (`extensions/slack/src/channel.ts`). This aligns the plugin’s `read` action behavior with the core Slack actions adapter, allowing thread replies to be fetched via `conversations.replies` when `threadId` is provided.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a one-line parameter passthrough; verification shows downstream Slack read implementation already supports `threadId` for `readMessages` and routes it to `conversations.replies` when present. No behavior changes for non-thread reads.
- extensions/slack/src/channel.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->