### PR TITLE
fix(slack): pass threadId through in read action

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -355,6 +355,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
 
       if (action === "read") {
         const limit = readNumberParam(params, "limit", { integer: true });
+        const threadId = readStringParam(params, "threadId");
         return await getSlackRuntime().channel.slack.handleSlackAction(
           {
             action: "readMessages",
@@ -362,6 +363,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: threadId ?? undefined,
             accountId: accountId ?? undefined,
           },
           cfg,


### PR DESCRIPTION
Fixes #14706

The Slack channel plugin's `read` action handler did not forward the `threadId` parameter to `handleSlackAction`, so `message(action="read", threadId="..."` could never fetch thread replies. The `threadId` is now passed through, matching how the `send` action already handles it.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Slack channel plugin’s `read` action handler to forward the `threadId` parameter into the `readMessages` payload passed to `handleSlackAction`. This aligns the extension plugin behavior with the core Slack actions adapter (`src/channels/plugins/slack.actions.ts`), enabling the message tool to fetch thread replies when `threadId` is provided (fixes #14706).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted parameter pass-through in the Slack extension plugin, and it matches the existing contract used elsewhere in the codebase for `readMessages` (which already accepts `threadId`). No behavior changes occur unless `threadId` is supplied, and the new field is forwarded without altering existing defaults.
- extensions/slack/src/channel.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->