### PR TITLE
feat(compaction): configurable auto-compaction notifications with optional metrics

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -375,7 +375,7 @@ export async function runReplyAgent(params: {
     }
 
     const { runResult, fallbackProvider, fallbackModel, directlySentBlockKeys } = runOutcome;
-    let { didLogHeartbeatStrip, autoCompactionCompleted } = runOutcome;
+    let { didLogHeartbeatStrip, autoCompactionCompleted, compactionStats } = runOutcome;
 
     if (
       shouldInjectGroupIntro &&
@@ -577,7 +577,16 @@ export async function runReplyAgent(params: {
       }
 
       if (shouldEmitCompactionNotice({ cfg: followupRun.run.config, verboseEnabled })) {
-        finalPayloads = [{ text: formatCompactionNotice(count) }, ...finalPayloads];
+        finalPayloads = [
+          {
+            text: formatCompactionNotice(count, {
+              tokensBefore: compactionStats?.tokensBefore,
+              tokensAfter: compactionStats?.tokensAfter,
+              contextTokens: contextTokensUsed,
+            }),
+          },
+          ...finalPayloads,
+        ];
       }
     }
     if (verboseEnabled && activeIsNewSession) {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -561,9 +561,10 @@ export async function runReplyAgent(params: {
         sessionKey,
         storePath,
         tokensAfter: compactionStats?.tokensAfter,
-        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,        contextTokensUsed,
+        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
+        contextTokensUsed,
       });
-// Inject post-compaction workspace context for the next agent turn
+      // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
         const workspaceDir = process.cwd();
         readPostCompactionContext(workspaceDir)

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -560,8 +560,8 @@ export async function runReplyAgent(params: {
         sessionStore: activeSessionStore,
         sessionKey,
         storePath,
-        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
-        contextTokensUsed,
+        tokensAfter: compactionStats?.tokensAfter,
+        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,        contextTokensUsed,
       });
 // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -229,7 +229,6 @@ describe("createFollowupRunner compaction", () => {
     expect(notice).toContain("window 50.0%→20.0%");
   });
 
-
   it("adds verbose full compaction summary block", async () => {
     const onBlockReply = vi.fn(async () => {});
     runEmbeddedPiAgentMock.mockImplementationOnce(
@@ -253,7 +252,9 @@ describe("createFollowupRunner compaction", () => {
 
     const queued = baseQueuedRun();
     queued.run.verboseLevel = "full";
-    queued.run.config = { agents: { defaults: { contextTokens: 240_000, compaction: { notify: "always" } } } };
+    queued.run.config = {
+      agents: { defaults: { contextTokens: 240_000, compaction: { notify: "always" } } },
+    };
 
     await runner(queued);
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -301,7 +301,8 @@ export function createFollowupRunner(params: {
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
           contextTokensUsed,
         });
-        const verboseEnabled = queued.run.verboseLevel && queued.run.verboseLevel !== "off";
+        const verboseEnabled =
+          queued.run.verboseLevel !== undefined && queued.run.verboseLevel !== "off";
         const contextTokensUsed =
           agentCfgContextTokens ??
           lookupContextTokens(fallbackModel ?? defaultModel) ??

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -123,6 +123,7 @@ export function createFollowupRunner(params: {
         });
       }
       let autoCompactionCompleted = false;
+      let compactionStats: { tokensBefore?: number; tokensAfter?: number } | undefined;
       let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
       let fallbackProvider = queued.run.provider;
       let fallbackModel = queued.run.model;
@@ -180,6 +181,24 @@ export function createFollowupRunner(params: {
                 const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
                 if (phase === "end") {
                   autoCompactionCompleted = true;
+                  const data = evt.data as {
+                    tokensBefore?: unknown;
+                    tokensAfter?: unknown;
+                    result?: { tokensBefore?: unknown; tokensAfter?: unknown };
+                  };
+                  const rawBefore = data.tokensBefore ?? data.result?.tokensBefore;
+                  const rawAfter = data.tokensAfter ?? data.result?.tokensAfter;
+                  const tokensBefore =
+                    typeof rawBefore === "number" && Number.isFinite(rawBefore) && rawBefore > 0
+                      ? rawBefore
+                      : undefined;
+                  const tokensAfter =
+                    typeof rawAfter === "number" && Number.isFinite(rawAfter) && rawAfter > 0
+                      ? rawAfter
+                      : undefined;
+                  if (tokensBefore != null || tokensAfter != null) {
+                    compactionStats = { tokensBefore, tokensAfter };
+                  }
                 }
               },
             });
@@ -280,7 +299,18 @@ export function createFollowupRunner(params: {
         });
         const verboseEnabled = queued.run.verboseLevel && queued.run.verboseLevel !== "off";
         if (shouldEmitCompactionNotice({ cfg: queued.run.config, verboseEnabled })) {
-          finalPayloads.unshift({ text: formatCompactionNotice(count) });
+          const contextTokensUsed =
+            agentCfgContextTokens ??
+            lookupContextTokens(fallbackModel ?? defaultModel) ??
+            sessionEntry?.contextTokens ??
+            DEFAULT_CONTEXT_TOKENS;
+          finalPayloads.unshift({
+            text: formatCompactionNotice(count, {
+              tokensBefore: compactionStats?.tokensBefore,
+              tokensAfter: compactionStats?.tokensAfter,
+              contextTokens: contextTokensUsed,
+            }),
+          });
         }
       }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -298,8 +298,9 @@ export function createFollowupRunner(params: {
           sessionStore,
           sessionKey,
           storePath,
-        tokensAfter: compactionStats?.tokensAfter,
-        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,          contextTokensUsed,
+          tokensAfter: compactionStats?.tokensAfter,
+          lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
+          contextTokensUsed,
         });
         const verboseEnabled =
           queued.run.verboseLevel !== undefined && queued.run.verboseLevel !== "off";

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -298,16 +298,11 @@ export function createFollowupRunner(params: {
           sessionStore,
           sessionKey,
           storePath,
-          lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
-          contextTokensUsed,
+        tokensAfter: compactionStats?.tokensAfter,
+        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,          contextTokensUsed,
         });
         const verboseEnabled =
           queued.run.verboseLevel !== undefined && queued.run.verboseLevel !== "off";
-        const contextTokensUsed =
-          agentCfgContextTokens ??
-          lookupContextTokens(fallbackModel ?? defaultModel) ??
-          sessionEntry?.contextTokens ??
-          DEFAULT_CONTEXT_TOKENS;
         const compactionNoticeStats = {
           tokensBefore: compactionStats?.tokensBefore,
           tokensAfter: compactionStats?.tokensAfter,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -24,6 +24,7 @@ import {
 import { resolveReplyToMode } from "./reply-threading.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
+import { formatCompactionNotice, shouldEmitCompactionNotice } from "./session-updates.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
@@ -277,11 +278,9 @@ export function createFollowupRunner(params: {
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
           contextTokensUsed,
         });
-        if (queued.run.verboseLevel && queued.run.verboseLevel !== "off") {
-          const suffix = typeof count === "number" ? ` (count ${count})` : "";
-          finalPayloads.unshift({
-            text: `🧹 Auto-compaction complete${suffix}.`,
-          });
+        const verboseEnabled = queued.run.verboseLevel && queued.run.verboseLevel !== "off";
+        if (shouldEmitCompactionNotice({ cfg: queued.run.config, verboseEnabled })) {
+          finalPayloads.unshift({ text: formatCompactionNotice(count) });
         }
       }
 

--- a/src/auto-reply/reply/session-run-accounting.ts
+++ b/src/auto-reply/reply/session-run-accounting.ts
@@ -8,6 +8,7 @@ type IncrementRunCompactionCountParams = Omit<
   Parameters<typeof incrementCompactionCount>[0],
   "tokensAfter"
 > & {
+  tokensAfter?: number;
   lastCallUsage?: NormalizedUsage;
   contextTokensUsed?: number;
 };
@@ -31,12 +32,14 @@ export async function persistRunSessionUsage(params: PersistRunSessionUsageParam
 export async function incrementRunCompactionCount(
   params: IncrementRunCompactionCountParams,
 ): Promise<number | undefined> {
-  const tokensAfterCompaction = params.lastCallUsage
-    ? deriveSessionTotalTokens({
-        usage: params.lastCallUsage,
-        contextTokens: params.contextTokensUsed,
-      })
-    : undefined;
+  const tokensAfterCompaction =
+    params.tokensAfter ??
+    (params.lastCallUsage
+      ? deriveSessionTotalTokens({
+          usage: params.lastCallUsage,
+          contextTokens: params.contextTokensUsed,
+        })
+      : undefined);
   return incrementCompactionCount({
     sessionEntry: params.sessionEntry,
     sessionStore: params.sessionStore,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -316,14 +316,17 @@ export function shouldEmitCompactionNotice(params: {
   return params.verboseEnabled;
 }
 
-
 export function formatCompactionVerboseSummary(stats?: CompactionNoticeStats): string | undefined {
   const before =
-    typeof stats?.tokensBefore === "number" && stats.tokensBefore > 0 ? stats.tokensBefore : undefined;
+    typeof stats?.tokensBefore === "number" && stats.tokensBefore > 0
+      ? stats.tokensBefore
+      : undefined;
   const after =
     typeof stats?.tokensAfter === "number" && stats.tokensAfter > 0 ? stats.tokensAfter : undefined;
   const context =
-    typeof stats?.contextTokens === "number" && stats.contextTokens > 0 ? stats.contextTokens : undefined;
+    typeof stats?.contextTokens === "number" && stats.contextTokens > 0
+      ? stats.contextTokens
+      : undefined;
 
   if (typeof before !== "number" || typeof after !== "number") {
     return undefined;
@@ -339,7 +342,9 @@ export function formatCompactionVerboseSummary(stats?: CompactionNoticeStats): s
   if (typeof context === "number") {
     const beforeWindowPct = (before / context) * 100;
     const afterWindowPct = (after / context) * 100;
-    lines.push(`- Context window: ${beforeWindowPct.toFixed(1)}% → ${afterWindowPct.toFixed(1)}% of ${formatTokenCount(context)}`);
+    lines.push(
+      `- Context window: ${beforeWindowPct.toFixed(1)}% → ${afterWindowPct.toFixed(1)}% of ${formatTokenCount(context)}`,
+    );
   }
 
   return lines.join("\n");
@@ -351,16 +356,22 @@ export function formatCompactionNotice(count?: number, stats?: CompactionNoticeS
   }
 
   const before =
-    typeof stats?.tokensBefore === "number" && stats.tokensBefore > 0 ? stats.tokensBefore : undefined;
+    typeof stats?.tokensBefore === "number" && stats.tokensBefore > 0
+      ? stats.tokensBefore
+      : undefined;
   const after =
     typeof stats?.tokensAfter === "number" && stats.tokensAfter > 0 ? stats.tokensAfter : undefined;
   const context =
-    typeof stats?.contextTokens === "number" && stats.contextTokens > 0 ? stats.contextTokens : undefined;
+    typeof stats?.contextTokens === "number" && stats.contextTokens > 0
+      ? stats.contextTokens
+      : undefined;
 
   if (typeof before === "number" && typeof after === "number") {
     const reducedTokens = Math.max(0, before - after);
     const reducedPct = before > 0 ? (reducedTokens / before) * 100 : 0;
-    parts.push(`${formatTokenCount(before)}→${formatTokenCount(after)} (-${reducedPct.toFixed(1)}%)`);
+    parts.push(
+      `${formatTokenCount(before)}→${formatTokenCount(after)} (-${reducedPct.toFixed(1)}%)`,
+    );
 
     if (typeof context === "number") {
       const beforeWindowPct = (before / context) * 100;

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -284,3 +284,32 @@ export async function incrementCompactionCount(params: {
   }
   return nextCount;
 }
+
+export type CompactionNotifyMode = "verbose" | "always" | "off";
+
+export function resolveCompactionNotifyMode(cfg?: OpenClawConfig): CompactionNotifyMode {
+  const mode = cfg?.agents?.defaults?.compaction?.notify;
+  if (mode === "always" || mode === "off" || mode === "verbose") {
+    return mode;
+  }
+  return "verbose";
+}
+
+export function shouldEmitCompactionNotice(params: {
+  cfg?: OpenClawConfig;
+  verboseEnabled: boolean;
+}): boolean {
+  const mode = resolveCompactionNotifyMode(params.cfg);
+  if (mode === "off") {
+    return false;
+  }
+  if (mode === "always") {
+    return true;
+  }
+  return params.verboseEnabled;
+}
+
+export function formatCompactionNotice(count?: number): string {
+  const suffix = typeof count === "number" ? ` (count ${count})` : "";
+  return `🧹 Context auto-compacted to keep this chat responsive${suffix}.`;
+}

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -316,6 +316,34 @@ export function shouldEmitCompactionNotice(params: {
   return params.verboseEnabled;
 }
 
+
+export function formatCompactionVerboseSummary(stats?: CompactionNoticeStats): string | undefined {
+  const before =
+    typeof stats?.tokensBefore === "number" && stats.tokensBefore > 0 ? stats.tokensBefore : undefined;
+  const after =
+    typeof stats?.tokensAfter === "number" && stats.tokensAfter > 0 ? stats.tokensAfter : undefined;
+  const context =
+    typeof stats?.contextTokens === "number" && stats.contextTokens > 0 ? stats.contextTokens : undefined;
+
+  if (typeof before !== "number" || typeof after !== "number") {
+    return undefined;
+  }
+
+  const reducedTokens = Math.max(0, before - after);
+  const reducedPct = before > 0 ? (reducedTokens / before) * 100 : 0;
+  const lines = [
+    "📉 Compaction summary",
+    `- Tokens: ${formatTokenCount(before)} → ${formatTokenCount(after)} (${formatTokenCount(reducedTokens)} saved, ${reducedPct.toFixed(1)}%)`,
+  ];
+
+  if (typeof context === "number") {
+    const beforeWindowPct = (before / context) * 100;
+    const afterWindowPct = (after / context) * 100;
+    lines.push(`- Context window: ${beforeWindowPct.toFixed(1)}% → ${afterWindowPct.toFixed(1)}% of ${formatTokenCount(context)}`);
+  }
+
+  return lines.join("\n");
+}
 export function formatCompactionNotice(count?: number, stats?: CompactionNoticeStats): string {
   const parts: string[] = [];
   if (typeof count === "number") {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -286,6 +286,8 @@ export type AgentDefaultsConfig = {
 
 export type AgentCompactionMode = "default" | "safeguard";
 
+export type AgentCompactionNotifyMode = "verbose" | "always" | "off";
+
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
@@ -293,6 +295,13 @@ export type AgentCompactionConfig = {
   reserveTokensFloor?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */
   maxHistoryShare?: number;
+  /**
+   * Compaction notice behavior.
+   * - "verbose" (default): only show in verbose mode
+   * - "always": always show compaction notice
+   * - "off": never show compaction notice
+   */
+  notify?: AgentCompactionNotifyMode;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
 };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -93,6 +93,7 @@ export const AgentDefaultsSchema = z
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
         maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
+        notify: z.union([z.literal("verbose"), z.literal("always"), z.literal("off")]).optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

This PR improves visibility and operator control for **auto-compaction notifications** in OpenClaw reply flows.

### What’s included

- Adds config: `agents.defaults.compaction.notify`
  - `verbose` (default): show auto-compaction notice in verbose modes
  - `always`: always show auto-compaction notice when compaction completes
  - `off`: suppress auto-compaction notice
- Standardizes auto-compaction notice formatting across:
  - main reply path
  - followup runner path
- Adds adaptive metric display in notices:
  - when available: token reduction + context window occupancy
  - when unavailable: clean fallback notice text (no noisy placeholders)

## Motivation

Auto-compaction can materially change context state, but users/operators may not clearly see when it happened or how much reduction occurred.

This change keeps behavior backward-compatible while improving observability and making notification policy explicit and configurable.

## Scope / Non-goals

### In scope
- Notification policy (`verbose | always | off`)
- Notification text/formatting consistency in auto-compaction reply paths
- Optional stats rendering when engine event data exists

### Out of scope
- Compaction trigger thresholds
- Compaction algorithm/selection logic
- Manual `/compact` command formatting path

## Config

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "notify": "verbose"
      }
    }
  }
}
```

Allowed values: `"verbose" | "always" | "off"`.

## Testing

### 1) Targeted unit tests (auto-compaction notice behavior)

```bash
npx -y pnpm@10.23.0 vitest run \
  src/auto-reply/reply/followup-runner.test.ts \
  src/auto-reply/reply/agent-runner.heartbeat-typing.runreplyagent-typing-heartbeat.signals-typing-block-replies.test.ts
```

Result: **13 passed**

Covers:
- verbose notice emission
- notify=always behavior even when verbose is off
- metrics-present formatting
- metrics-absent fallback path

### 2) Additional verification (isolated forced-injection path)

To validate both branches safely without affecting a live gateway, I verified behavior in an isolated workspace (`/tmp/openclaw-upstream`) using mock/forced compaction event injection.

- **stats-present path**
  - notice includes reduction metrics (e.g. `100k→40k`, window occupancy)
- **stats-absent path**
  - notice still appears with clean fallback text

### 3) E2E command-path check

```bash
npx -y pnpm@10.23.0 vitest --config vitest.e2e.config.ts run \
  src/auto-reply/reply.triggers.trigger-handling.runs-compact-as-gated-command.e2e.test.ts
```

Result: **3 passed**

## Manual `/compact` vs auto-compaction (important distinction)

- Manual `/compact` output (`⚙️ Compacted ...`) is an existing upstream command-path UI.
- This PR targets **auto-compaction notification delivery** in agent/reply flows.
- Different strings between these two paths are expected and intentional.

## Notes for stable users (`v2026.2.9`)

- Upstream source can support `agents.defaults.compaction.notify` with schema/type updates in this PR.
- Current stable `v2026.2.9` has strict schema and rejects this key until a release containing these changes is published.

## Backward compatibility

- Default mode remains `verbose`.
- If compaction metric fields are missing from engine events, behavior degrades gracefully to text-only notices.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a configurable notification policy for auto-compaction (`agents.defaults.compaction.notify`), standardizes the auto-compaction notice text across the main reply runner and followup runner, and optionally includes compaction metrics (tokens before/after and context window occupancy) when engines emit them via compaction events. It also adds a verbose-full “Compaction summary” block.

Most changes are localized to the reply/followup runners and `session-updates.ts` helpers for deciding whether to emit the notice and formatting the notice/summary text, plus schema/type updates to accept the new config key.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but should fix one correctness issue around session token totals after auto-compaction.
- Notification policy, formatting, and schema updates are straightforward and covered by tests, but the new compaction stats plumbing isn’t used to persist post-compaction token totals (unlike the manual /compact path), which can leave session usage metadata stale.
- src/auto-reply/reply/agent-runner.ts, src/auto-reply/reply/followup-runner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->