### PR TITLE
fix(routing): normalize peer.kind in matchesPeer for symmetric comparison

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -140,13 +140,13 @@ function matchesPeer(
   if (!m) {
     return false;
   }
-  // Backward compat: normalize "dm" to "direct" in config match rules
+  // Normalize both sides: "dm" → "direct", etc.
   const kind = normalizeChatType(m.kind);
   const id = normalizeId(m.id);
   if (!kind || !id) {
     return false;
   }
-  return kind === peer.kind && id === peer.id;
+  return kind === normalizeChatType(peer.kind) && id === peer.id;
 }
 
 function matchesGuild(


### PR DESCRIPTION
## Summary

Fixes asymmetric normalization in `matchesPeer()` that caused peer-based agent routing to always fail when a channel plugin passes `"dm"` instead of the canonical `"direct"`.

## Problem

`matchesPeer()` normalized the config binding\'s `peer.kind` via `normalizeChatType()` but compared it against the raw (unnormalized) incoming `peer.kind`. This meant:

- Config `"direct"` (normalized to `"direct"`) vs plugin `"dm"` (raw) → `"direct" === "dm"` → **always false**
- All peer-based routing silently fell through to the default agent

## Fix

Normalize `peer.kind` on **both sides** of the comparison in `matchesPeer()`:

```typescript
return kind === normalizeChatType(peer.kind) && id === peer.id;
```

This ensures `"dm"` and `"direct"` are treated as equivalent regardless of which side uses the alias.

## Tests

Added 3 test cases:
- Plugin passes `"dm"`, config uses `"direct"` → matches
- Config uses `"dm"`, plugin passes `"direct"` → matches  
- `parentPeer` with `"dm"` alias → matches

All 23 tests pass.

Closes #14612

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes peer-based routing matching by normalizing `peer.kind` on both sides of the `matchesPeer()` comparison so aliases like `"dm"` and the canonical `"direct"` compare symmetrically. It also adds unit tests covering config/runtime combinations (`dm`↔`direct`) and parent-thread inheritance behavior.

The change is localized to `src/routing/resolve-route.ts` and affects how bindings with `match.peer.kind` are selected during `resolveAgentRoute`, ensuring peer bindings no longer silently fall back to the default agent when an integration uses an alias.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and fixes a real routing mismatch, with one concern around test typing correctness.
- The production change is a minimal, targeted fix (normalizing runtime `peer.kind` during comparison) and is consistent with existing `normalizeChatType()` behavior. The added tests improve coverage, but they currently pass `kind: 'dm'` into an API typed as `ChatType`, which may break compilation if tests are type-checked or may mask type-contract drift.
- src/routing/resolve-route.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->