### PR TITLE
fix: increase lane wait diagnostic threshold for cron lane

### DIFF
--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -112,7 +112,10 @@ export function enqueueCommandInLane<T>(
   },
 ): Promise<T> {
   const cleaned = lane.trim() || CommandLane.Main;
-  const warnAfterMs = opts?.warnAfterMs ?? 2_000;
+  // Cron jobs legitimately take 60-120s (external CLI tools, API polling).
+  // Use a higher default to avoid flooding logs with non-actionable warnings (#14747).
+  const defaultWarnMs = cleaned === "cron" ? 120_000 : 2_000;
+  const warnAfterMs = opts?.warnAfterMs ?? defaultWarnMs;
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {
     state.queue.push({


### PR DESCRIPTION
Fixes #14747

Cron jobs legitimately take 60-120s (external CLI tools, API polling), but the hardcoded 2s `warnAfterMs` threshold floods logs with hundreds of non-actionable warnings per day.

Increases default to 120s for the `cron` lane while keeping 2s for all other lanes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the default `warnAfterMs` used by `enqueueCommandInLane` so that the `cron` lane uses a 120s warning threshold instead of the global 2s default, while leaving all other lanes at 2s. Callers can still override the threshold via `opts.warnAfterMs`, and lane selection continues to be based on the trimmed lane string (defaulting to `CommandLane.Main`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to default diagnostics behavior for a single lane (`cron`), preserves the existing override path via `opts.warnAfterMs`, and matches the lane identifier defined in `CommandLane.Cron` ("cron"). No behavioral changes to queueing, concurrency, or task execution semantics.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->