### PR TITLE
fix: stop isolated cron job summaries leaking as system events to user chat

### DIFF
--- a/src/cron/service.delivery-plan.test.ts
+++ b/src/cron/service.delivery-plan.test.ts
@@ -84,7 +84,9 @@ describe("CronService delivery plan consistency", () => {
 
     const result = await cron.run(job.id, "force");
     expect(result).toEqual({ ok: true, ran: true });
-    expect(enqueueSystemEvent).toHaveBeenCalledWith("Cron: done", { agentId: undefined });
+    // Delivery is handled inside runIsolatedAgentJob (via the announce flow).
+    // The summary must NOT be re-posted as a system event (#14605).
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
 
     cron.stop();
     await store.cleanup();


### PR DESCRIPTION
## Summary

When an isolated cron job completes, `executeJobCore()` in `timer.ts` posted the summary as a system event to the main agent session **and** triggered a heartbeat. This was redundant because `runCronIsolatedAgentTurn()` already delivers results to the user via `runSubagentAnnounceFlow()` (or `deliverOutboundPayloads` for structured/media content).

The duplicate system event caused the cron summary to appear **twice** in the user's Telegram chat — once from the announce flow and once from the heartbeat processing the system event — often in the wrong order, breaking natural conversation flow.

## Root Cause

In `src/cron/service/timer.ts`, `executeJobCore()` had a block after the isolated agent run that:
1. Called `enqueueSystemEvent()` with `Cron: <summary>` → injected into the main session
2. Called `requestHeartbeatNow()` → triggered the main agent to process the event
3. The main agent then generated a response → delivered to Telegram

This was a **legacy delivery mechanism** that predated the proper `runSubagentAnnounceFlow` path. Both paths were active simultaneously, causing duplicate messages.

## Fix

- **Removed** the redundant `enqueueSystemEvent` + `requestHeartbeatNow` calls for isolated jobs in `executeJobCore()`
- **Removed** the now-unused `resolveCronDeliveryPlan` import from `timer.ts`
- **Updated** 3 existing tests that asserted the old (buggy) behavior
- **Added** 3 new regression tests covering:
  - Isolated job with `delivery.mode=announce` does not leak system events
  - Isolated job with `delivery.mode=none` does not leak system events
  - Isolated job errors do not leak as system events

## Testing

All 125 cron tests pass (`pnpm vitest run src/cron/`).

Closes #14605

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change removes the legacy “post cron summary back to main session” path for *isolated* cron jobs in `src/cron/service/timer.ts`, which previously enqueued a `Cron: …` system event and triggered a heartbeat. Isolated cron job delivery is already handled inside `runIsolatedAgentJob` (announce flow for text via `runSubagentAnnounceFlow`, or direct `deliverOutboundPayloads` for structured/media), so the old path caused duplicate/out-of-order user messages in chat channels (notably Telegram).

Tests were updated to stop asserting the old behavior, and new regression coverage was added to ensure isolated cron runs (including `delivery.mode=announce`, `delivery.mode=none`, and error cases) do not enqueue system events or request heartbeats as a side-effect.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrowly-scoped removal of redundant delivery logic for isolated cron jobs, and the new/updated tests directly assert the intended behavior (no system-event/heartbeat leak). The isolated delivery path is already implemented in `src/cron/isolated-agent/run.ts`, so removing the duplicate enqueue/heartbeat calls reduces user-facing duplication without affecting main-session cron jobs.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->