### PR TITLE
feat(telegram): support configurable apiRoot for Bot API proxy

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -101,6 +101,8 @@ export type TelegramAccountConfig = {
   mediaMaxMb?: number;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
+  /** Custom Telegram Bot API root URL (e.g. for a local Bot API server). */
+  apiRoot?: string;
   /** Retry policy for outbound Telegram API calls. */
   retry?: OutboundRetryConfig;
   /** Network transport overrides for Telegram. */

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -135,11 +135,16 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+  const apiRoot =
+    typeof telegramCfg?.apiRoot === "string" && telegramCfg.apiRoot
+      ? telegramCfg.apiRoot
+      : undefined;
   const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
+    shouldProvideFetch || timeoutSeconds || apiRoot
       ? {
           ...(shouldProvideFetch && fetchImpl ? { fetch: fetchForClient } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
 


### PR DESCRIPTION
Fixes #14657

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change introduces an `apiRoot` option for Telegram accounts and wires it into the grammY `ApiClientOptions` when creating a bot, enabling use of a custom Telegram Bot API root (e.g. a local Bot API proxy/server).

However, the repository’s config validation uses strict Zod schemas for provider configs. The new `apiRoot` setting was added to TypeScript types and bot creation, but not to the Telegram Zod schema, so configurations that set `channels.telegram.apiRoot` (or per-account `channels.telegram.accounts.*.apiRoot`) will be rejected during validation and won’t work as intended.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because the new config key will be rejected by strict config validation.
- The core functional bug is that `apiRoot` is added to TypeScript config types and used at runtime, but is missing from the strict Zod schema (`TelegramAccountSchemaBase`). In deployments that validate config (expected in this repo), users won’t be able to set the new option, so the feature effectively doesn’t work via config.
- src/config/zod-schema.providers-core.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->