### PR TITLE
fix: allow mediaMaxMb=0 to disable media and prevent binary content from entering session

### DIFF
--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -39,7 +39,7 @@ const bluebubblesAccountSchema = z.object({
   dmHistoryLimit: z.number().int().min(0).optional(),
   textChunkLimit: z.number().int().positive().optional(),
   chunkMode: z.enum(["length", "newline"]).optional(),
-  mediaMaxMb: z.number().int().positive().optional(),
+  mediaMaxMb: z.number().int().nonnegative().optional(),
   sendReadReceipts: z.boolean().optional(),
   blockStreaming: z.boolean().optional(),
   groups: z.object({}).catchall(bluebubblesGroupConfigSchema).optional(),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -139,7 +139,7 @@ export const FeishuAccountConfigSchema = z
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema,
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     renderMode: RenderModeSchema,
     tools: FeishuToolsConfigSchema,
@@ -174,7 +174,7 @@ export const FeishuConfigSchema = z
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema,
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     renderMode: RenderModeSchema, // raw = plain text (default), card = interactive card with markdown
     tools: FeishuToolsConfigSchema,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -774,7 +774,7 @@ async function downloadAttachment(
   if (!resourceName) {
     return null;
   }
-  const maxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
+  const maxBytes = mediaMaxMb * 1024 * 1024;
   const downloaded = await downloadGoogleChatMedia({ account, resourceName, maxBytes });
   const saved = await core.channel.media.saveMediaBuffer(
     downloaded.buffer,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -770,6 +770,9 @@ async function downloadAttachment(
   mediaMaxMb: number,
   core: GoogleChatCoreRuntime,
 ): Promise<{ path: string; contentType?: string } | null> {
+  if (mediaMaxMb <= 0) {
+    return null;
+  }
   const resourceName = attachment.attachmentDataRef?.resourceName;
   if (!resourceName) {
     return null;

--- a/extensions/irc/src/config-schema.ts
+++ b/extensions/irc/src/config-schema.ts
@@ -70,7 +70,7 @@ export const IrcAccountSchemaBase = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     responsePrefix: z.string().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
   })
   .strict();
 

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -330,7 +330,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           : undefined;
       const contentType = contentInfo?.mimetype;
       const contentSize = typeof contentInfo?.size === "number" ? contentInfo.size : undefined;
-      if (mediaUrl?.startsWith("mxc://")) {
+      if (mediaUrl?.startsWith("mxc://") && mediaMaxBytes > 0) {
         try {
           media = await downloadMatrixMedia({
             client,

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -248,7 +248,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const dmPolicy = allowlistOnly && dmPolicyRaw !== "disabled" ? "allowlist" : dmPolicyRaw;
   const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "matrix");
   const mediaMaxMb = opts.mediaMaxMb ?? cfg.channels?.matrix?.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
-  const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
+  const mediaMaxBytes = mediaMaxMb * 1024 * 1024;
   const startupMs = Date.now();
   const startupGraceMs = 0;
   const directTracker = createDirectRoomTracker(client, { log: logVerboseMessage });

--- a/extensions/nextcloud-talk/src/config-schema.ts
+++ b/extensions/nextcloud-talk/src/config-schema.ts
@@ -48,7 +48,7 @@ export const NextcloudTalkAccountSchemaBase = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     responsePrefix: z.string().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
   })
   .strict();
 

--- a/src/channels/plugins/media-limits.test.ts
+++ b/src/channels/plugins/media-limits.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveChannelMediaMaxBytes } from "./media-limits.js";
+
+const MB = 1024 * 1024;
+
+function makeCfg(globalMediaMaxMb?: number): OpenClawConfig {
+  return {
+    agents: globalMediaMaxMb != null ? { defaults: { mediaMaxMb: globalMediaMaxMb } } : undefined,
+  } as OpenClawConfig;
+}
+
+describe("resolveChannelMediaMaxBytes", () => {
+  it("returns channel limit when set", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(10),
+      resolveChannelLimitMb: () => 5,
+    });
+    expect(result).toBe(5 * MB);
+  });
+
+  it("falls back to global mediaMaxMb when channel limit is undefined", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(3),
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBe(3 * MB);
+  });
+
+  it("returns undefined when neither is set", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(),
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns 0 when channel limit is 0 (media disabled)", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(10),
+      resolveChannelLimitMb: () => 0,
+    });
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 when global mediaMaxMb is 0 (media disabled)", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(0),
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBe(0);
+  });
+
+  it("channel limit of 0 takes precedence over global limit", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(5),
+      resolveChannelLimitMb: () => 0,
+    });
+    expect(result).toBe(0);
+  });
+});

--- a/src/channels/plugins/media-limits.ts
+++ b/src/channels/plugins/media-limits.ts
@@ -15,11 +15,12 @@ export function resolveChannelMediaMaxBytes(params: {
     cfg: params.cfg,
     accountId,
   });
-  if (channelLimit) {
+  if (channelLimit != null) {
     return channelLimit * MB;
   }
-  if (params.cfg.agents?.defaults?.mediaMaxMb) {
-    return params.cfg.agents.defaults.mediaMaxMb * MB;
+  const globalLimit = params.cfg.agents?.defaults?.mediaMaxMb;
+  if (globalLimit != null) {
+    return globalLimit * MB;
   }
   return undefined;
 }

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -125,7 +125,7 @@ export const AgentDefaultsSchema = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     humanDelay: HumanDelaySchema.optional(),
     timeoutSeconds: z.number().int().positive().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: z
       .union([

--- a/src/config/zod-schema.media-max-mb.test.ts
+++ b/src/config/zod-schema.media-max-mb.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
+
+describe("mediaMaxMb schema validation", () => {
+  it("accepts mediaMaxMb=0", () => {
+    const result = AgentDefaultsSchema.safeParse({ mediaMaxMb: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts mediaMaxMb=1", () => {
+    const result = AgentDefaultsSchema.safeParse({ mediaMaxMb: 1 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts mediaMaxMb=50", () => {
+    const result = AgentDefaultsSchema.safeParse({ mediaMaxMb: 50 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects negative mediaMaxMb", () => {
+    const result = AgentDefaultsSchema.safeParse({ mediaMaxMb: -1 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -113,7 +113,7 @@ export const TelegramAccountSchemaBase = z
     draftChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     streamMode: z.enum(["off", "partial", "block"]).optional().default("partial"),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z
@@ -272,7 +272,7 @@ export const DiscordAccountSchema = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     maxLinesPerMessage: z.number().int().positive().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     retry: RetryConfigSchema,
     actions: z
       .object({
@@ -387,7 +387,7 @@ export const GoogleChatAccountSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     replyToMode: ReplyToModeSchema.optional(),
     actions: z
       .object({
@@ -481,7 +481,7 @@ export const SlackAccountSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     replyToMode: ReplyToModeSchema.optional(),
@@ -585,7 +585,7 @@ export const SignalAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     actions: z
@@ -675,7 +675,7 @@ export const IrcAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     responsePrefix: z.string().optional(),
   })
@@ -737,7 +737,7 @@ export const IMessageAccountSchemaBase = z
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     includeAttachments: z.boolean().optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
@@ -830,7 +830,7 @@ export const BlueBubblesAccountSchemaBase = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     sendReadReceipts: z.boolean().optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
@@ -915,7 +915,7 @@ export const MSTeamsConfigSchema = z
     replyStyle: MSTeamsReplyStyleSchema.optional(),
     teams: z.record(z.string(), MSTeamsTeamSchema.optional()).optional(),
     /** Max media size in MB (default: 100MB for OneDrive upload support). */
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     /** SharePoint site ID for file uploads in group chats/channels (e.g., "contoso.sharepoint.com,guid1,guid2") */
     sharePointSiteId: z.string().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -33,7 +33,7 @@ export const WhatsAppAccountSchema = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     groups: z
@@ -95,7 +95,7 @@ export const WhatsAppConfigSchema = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
-    mediaMaxMb: z.number().int().positive().optional().default(50),
+    mediaMaxMb: z.number().int().nonnegative().optional().default(50),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     actions: z

--- a/src/media-understanding/apply.binary-mime-filter.test.ts
+++ b/src/media-understanding/apply.binary-mime-filter.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveApiKeyForProvider: vi.fn(async () => ({
+    apiKey: "test-key",
+    source: "test",
+    mode: "api-key",
+  })),
+  requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+    if (auth?.apiKey) {
+      return auth.apiKey;
+    }
+    throw new Error(`No API key for "${provider}"`);
+  },
+}));
+
+vi.mock("../media/fetch.js", () => ({
+  fetchRemoteMedia: vi.fn(),
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runExec: vi.fn(),
+}));
+
+const NO_MEDIA_CFG: OpenClawConfig = {
+  tools: {
+    media: {
+      audio: { enabled: false },
+      image: { enabled: false },
+      video: { enabled: false },
+    },
+  },
+};
+
+async function loadApply() {
+  return await import("./apply.js");
+}
+
+describe("extractFileBlocks binary MIME filtering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips .docx file with specific binary MIME type", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
+    // Create a fake .docx file (ZIP header + some data that might look text-like in parts)
+    const zipHeader = Buffer.from("PK\x03\x04");
+    const padding = Buffer.alloc(200, 0x41); // 'A' bytes — text-like
+    const filePath = path.join(dir, "report.docx");
+    await fs.writeFile(filePath, Buffer.concat([zipHeader, padding]));
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg: NO_MEDIA_CFG });
+
+    expect(result.appliedFile).toBe(false);
+    expect(ctx.Body).not.toContain("<file");
+    expect(ctx.Body).toBe("<media:document>");
+  });
+
+  it("skips .xlsx file with specific binary MIME type", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
+    const filePath = path.join(dir, "data.xlsx");
+    const zipHeader = Buffer.from("PK\x03\x04");
+    const padding = Buffer.alloc(200, 0x41);
+    await fs.writeFile(filePath, Buffer.concat([zipHeader, padding]));
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg: NO_MEDIA_CFG });
+
+    expect(result.appliedFile).toBe(false);
+    expect(ctx.Body).not.toContain("<file");
+  });
+
+  it("skips application/zip even if byte content looks text-like", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
+    const filePath = path.join(dir, "archive.zip");
+    // Fill with mostly printable ASCII chars to trick text detection
+    const textLikeContent = Buffer.from("Hello world this is all ASCII text ".repeat(100));
+    await fs.writeFile(filePath, textLikeContent);
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "application/zip",
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg: NO_MEDIA_CFG });
+
+    expect(result.appliedFile).toBe(false);
+    expect(ctx.Body).not.toContain("<file");
+  });
+
+  it("still allows application/json files through", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
+    const filePath = path.join(dir, "data.json");
+    await fs.writeFile(filePath, JSON.stringify({ hello: "world" }));
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "application/json",
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg: NO_MEDIA_CFG });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("<file");
+    expect(ctx.Body).toContain("hello");
+  });
+
+  it("still allows text/plain files through", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
+    const filePath = path.join(dir, "readme.txt");
+    await fs.writeFile(filePath, "Important information here");
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "text/plain",
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg: NO_MEDIA_CFG });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("<file");
+    expect(ctx.Body).toContain("Important information here");
+  });
+
+  it("still allows application/octet-stream with text-like content through", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-"));
+    const filePath = path.join(dir, "unknown.bin");
+    await fs.writeFile(filePath, "This is actually plain text content");
+
+    const ctx: MsgContext = {
+      Body: "<media:document>",
+      MediaPath: filePath,
+      MediaType: "application/octet-stream",
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg: NO_MEDIA_CFG });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("<file");
+    expect(ctx.Body).toContain("This is actually plain text");
+  });
+});

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -885,11 +885,15 @@ export const registerTelegramHandlers = ({
         const errMsg = String(mediaErr);
         if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {
           const limitMb = Math.round(mediaMaxBytes / (1024 * 1024));
+          const userMessage =
+            limitMb === 0
+              ? "⚠️ Media uploads are disabled."
+              : `⚠️ File too large. Maximum size is ${limitMb}MB.`;
           await withTelegramApiErrorLogging({
             operation: "sendMessage",
             runtime,
             fn: () =>
-              bot.api.sendMessage(chatId, `⚠️ File too large. Maximum size is ${limitMb}MB.`, {
+              bot.api.sendMessage(chatId, userMessage, {
                 reply_to_message_id: msg.message_id,
               }),
           }).catch(() => {});

--- a/src/telegram/bot/delivery.resolve-media-zero-limit.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-zero-limit.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveMedia } from "./delivery.js";
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+  shouldLogVerbose: () => false,
+}));
+
+vi.mock("../../media/fetch.js", () => ({
+  fetchRemoteMedia: vi.fn(),
+}));
+
+vi.mock("../../media/store.js", () => ({
+  saveMediaBuffer: vi.fn(),
+}));
+
+vi.mock("../sticker-cache.js", () => ({
+  getCachedSticker: vi.fn(),
+  cacheSticker: vi.fn(),
+}));
+
+vi.mock("../api-logging.js", () => ({
+  withTelegramApiErrorLogging: vi.fn(({ fn }) => fn()),
+}));
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    message: {
+      sticker: null,
+      photo: null,
+      video: null,
+      video_note: null,
+      document: null,
+      audio: null,
+      voice: null,
+      ...overrides,
+    },
+    me: { username: "testbot" },
+    getFile: vi.fn(),
+  };
+}
+
+describe("resolveMedia with maxBytes=0", () => {
+  it("throws when document is present and maxBytes is 0", async () => {
+    const ctx = makeCtx({
+      document: { file_id: "abc123", file_unique_id: "u1" },
+    });
+
+    await expect(resolveMedia(ctx as never, 0, "tok")).rejects.toThrow("Media exceeds 0MB limit");
+  });
+
+  it("throws when photo is present and maxBytes is 0", async () => {
+    const ctx = makeCtx({
+      photo: [{ file_id: "abc123", file_unique_id: "u1", width: 100, height: 100 }],
+    });
+
+    await expect(resolveMedia(ctx as never, 0, "tok")).rejects.toThrow("Media exceeds 0MB limit");
+  });
+
+  it("throws when sticker is present and maxBytes is 0", async () => {
+    const ctx = makeCtx({
+      sticker: {
+        file_id: "abc123",
+        file_unique_id: "u1",
+        is_animated: false,
+        is_video: false,
+        type: "regular",
+        width: 100,
+        height: 100,
+      },
+    });
+
+    await expect(resolveMedia(ctx as never, 0, "tok")).rejects.toThrow("Media exceeds 0MB limit");
+  });
+
+  it("throws when audio is present and maxBytes is 0", async () => {
+    const ctx = makeCtx({
+      audio: { file_id: "abc123", file_unique_id: "u1" },
+    });
+
+    await expect(resolveMedia(ctx as never, 0, "tok")).rejects.toThrow("Media exceeds 0MB limit");
+  });
+
+  it("returns null for text-only messages when maxBytes is 0", async () => {
+    const ctx = makeCtx();
+    const result = await resolveMedia(ctx as never, 0, "tok");
+    expect(result).toBeNull();
+  });
+});

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -303,6 +303,22 @@ export async function resolveMedia(
 } | null> {
   const msg = ctx.message;
 
+  // When media limit is 0, reject all media before downloading.
+  if (maxBytes <= 0) {
+    const hasMedia =
+      msg.sticker ||
+      msg.photo ||
+      msg.video ||
+      msg.video_note ||
+      msg.document ||
+      msg.audio ||
+      msg.voice;
+    if (hasMedia) {
+      throw new Error("Media exceeds 0MB limit");
+    }
+    return null;
+  }
+
   // Handle stickers separately - only static stickers (WEBP) are supported
   if (msg.sticker) {
     const sticker = msg.sticker;


### PR DESCRIPTION
## Summary

Closes #14609

When a user sends a binary file (e.g. `.docx`) through Telegram, the content could enter the AI session even with `mediaMaxMb` configured. Setting `mediaMaxMb=0` was rejected by schema validation (required a positive number, minimum 1).

## Root Causes

1. **Schema validation**: All `mediaMaxMb` Zod schemas used `.positive()`, rejecting `0`
2. **Truthiness bug**: `resolveChannelMediaMaxBytes` used `if (channelLimit)` / `if (cfg.agents?.defaults?.mediaMaxMb)` — `0` is falsy in JS, so it was treated as "unset" and fell through to defaults
3. **Late size check**: Telegram's `resolveMedia` downloaded files via the Bot API before checking the size limit, wasting bandwidth when the limit is 0
4. **Binary text detection**: `extractFileBlocks` could force-decode binary files as `text/plain` when their byte content happened to pass the text-like heuristic, even if the detected MIME was a specific binary format (e.g. `application/vnd.openxmlformats-officedocument.wordprocessingml.document`)

## Changes

### Schema (all channels + agent defaults)
- `.positive()` → `.nonnegative()` for `mediaMaxMb` across 16 schema definitions in core config and channel extensions (telegram, slack, discord, signal, line, web, whatsapp, IRC, feishu, bluebubbles, nextcloud-talk)

### `resolveChannelMediaMaxBytes` (media-limits.ts)
- Use `!= null` checks instead of truthiness so `0` is properly propagated as "media disabled"

### Telegram `resolveMedia` (delivery.ts)
- Short-circuit with an error **before downloading** when `maxBytes <= 0`, avoiding unnecessary Telegram Bot API calls and bandwidth

### Telegram handler (bot-handlers.ts)
- Show "⚠️ Media uploads are disabled." when limit is 0MB instead of the confusing "Maximum size is 0MB"

### `extractFileBlocks` (apply.ts)
- Skip files whose detected MIME is a specific non-text binary format not in the allowed list, preventing binary formats from being force-decoded as `text/plain` via byte-content heuristics
- Only guess `text/plain` from byte content when the raw MIME is missing or generic (`application/octet-stream`)

### Extensions (googlechat, matrix)
- Remove `Math.max(1, mediaMaxMb)` guards that clamped the limit to ≥1MB, preventing `0` from working

## Tests Added
- **`media-limits.test.ts`** (6 tests): Validates `resolveChannelMediaMaxBytes` handles 0 correctly at both channel and global levels
- **`zod-schema.media-max-mb.test.ts`** (4 tests): Schema accepts 0, 1, 50; rejects negative
- **`delivery.resolve-media-zero-limit.test.ts`** (5 tests): `resolveMedia` throws for documents/photos/stickers/audio when maxBytes=0, returns null for text-only
- **`apply.binary-mime-filter.test.ts`** (6 tests): Binary MIME types (.docx, .xlsx, .zip) are rejected even with text-like byte content; JSON, text/plain, and octet-stream with text content still pass through

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `mediaMaxMb=0` a valid configuration to fully disable inbound media processing across multiple channels.

Key changes:
- Config validation: updates many Zod schemas from `.positive()` to `.nonnegative()` so `mediaMaxMb` can be `0`.
- Limit resolution: fixes a falsy/truthiness bug in `resolveChannelMediaMaxBytes` so `0` is treated as an explicit limit rather than “unset”.
- Telegram: adds an early guard in `resolveMedia` to reject media before download when `maxBytes <= 0`, and improves the user-facing error message for 0MB.
- Media understanding: tightens `extractFileBlocks` so specific non-text/binary MIME types don’t get force-decoded into `<file>` blocks via text-like heuristics.
- Extensions: removes clamping guards (`Math.max(1, mediaMaxMb)`) in Google Chat and Matrix so `0` can propagate.

Merge readiness: core intent looks sound, but a couple of channel paths now propagate `0` into download functions in ways that can cause errors or still perform full downloads before rejecting (see comments).

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but has a couple of 0-limit handling bugs in non-Telegram channels that can break message processing or still download media when disabled.
- The schema and core limit-resolution changes are consistent and covered by tests, and the Telegram early-exit path correctly avoids downloads. However, Google Chat and Matrix now propagate `mediaMaxMb=0` into their download code paths without consistent early short-circuiting, which can either throw unexpectedly (Google Chat) or still download/decrypt before rejecting (Matrix).
- extensions/googlechat/src/monitor.ts, extensions/matrix/src/matrix/monitor/media.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->