### PR TITLE
fix: prevent heartbeat scheduler death when runOnce throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Cron: prevent duplicate fires when multiple jobs trigger simultaneously. (#14256) Thanks @xinhuagu.
 - Cron: isolate scheduler errors so one bad job does not break all jobs. (#14385) Thanks @MarvinDontPanic.
 - Cron: prevent one-shot `at` jobs from re-firing on restart after skipped/errored runs. (#13878) Thanks @lailoo.
+- Heartbeat: prevent scheduler stalls on unexpected run errors and avoid immediate rerun loops after `requests-in-flight` skips. (#14901) Thanks @joeykrug.
 - WhatsApp: convert Markdown bold/strikethrough to WhatsApp formatting. (#14285) Thanks @Raikan10.
 - WhatsApp: allow media-only sends and normalize leading blank payloads. (#14408) Thanks @karimnaguib.
 - WhatsApp: default MIME type for voice messages when Baileys omits it. (#14444) Thanks @mcaxtr.

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -797,6 +797,11 @@ export function startHeartbeatRunner(opts: {
     return now + intervalMs;
   };
 
+  const advanceAgentSchedule = (agent: HeartbeatAgentState, now: number) => {
+    agent.lastRunMs = now;
+    agent.nextDueMs = now + agent.intervalMs;
+  };
+
   const scheduleNext = () => {
     if (state.stopped) {
       return;
@@ -911,19 +916,16 @@ export function startHeartbeatRunner(opts: {
         // advance the timer and call scheduleNext so heartbeats keep firing.
         const errMsg = formatErrorMessage(err);
         log.error(`heartbeat runner: runOnce threw unexpectedly: ${errMsg}`, { error: errMsg });
-        agent.lastRunMs = now;
-        agent.nextDueMs = now + agent.intervalMs;
+        advanceAgentSchedule(agent, now);
         continue;
       }
       if (res.status === "skipped" && res.reason === "requests-in-flight") {
-        agent.lastRunMs = now;
-        agent.nextDueMs = now + agent.intervalMs;
+        advanceAgentSchedule(agent, now);
         scheduleNext();
         return res;
       }
       if (res.status !== "skipped" || res.reason !== "disabled") {
-        agent.lastRunMs = now;
-        agent.nextDueMs = now + agent.intervalMs;
+        advanceAgentSchedule(agent, now);
       }
       if (res.status === "ran") {
         ran = true;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -916,6 +916,8 @@ export function startHeartbeatRunner(opts: {
         continue;
       }
       if (res.status === "skipped" && res.reason === "requests-in-flight") {
+        agent.lastRunMs = now;
+        agent.nextDueMs = now + agent.intervalMs;
         scheduleNext();
         return res;
       }

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadWakeModule() {
+  vi.resetModules();
+  return import("./heartbeat-wake.js");
+}
+
+describe("heartbeat-wake", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("coalesces multiple wake requests into one run", async () => {
+    vi.useFakeTimers();
+    const wake = await loadWakeModule();
+    const handler = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" });
+    wake.setHeartbeatWakeHandler(handler);
+
+    wake.requestHeartbeatNow({ reason: "interval", coalesceMs: 200 });
+    wake.requestHeartbeatNow({ reason: "exec-event", coalesceMs: 200 });
+    wake.requestHeartbeatNow({ reason: "retry", coalesceMs: 200 });
+
+    expect(wake.hasPendingHeartbeatWake()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(199);
+    expect(handler).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ reason: "retry" });
+    expect(wake.hasPendingHeartbeatWake()).toBe(false);
+  });
+
+  it("retries requests-in-flight after the default retry delay", async () => {
+    vi.useFakeTimers();
+    const wake = await loadWakeModule();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "skipped", reason: "requests-in-flight" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    wake.setHeartbeatWakeHandler(handler);
+
+    wake.requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1]?.[0]).toEqual({ reason: "interval" });
+  });
+
+  it("retries thrown handler errors after the default retry delay", async () => {
+    vi.useFakeTimers();
+    const wake = await loadWakeModule();
+    const handler = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ status: "skipped", reason: "disabled" });
+    wake.setHeartbeatWakeHandler(handler);
+
+    wake.requestHeartbeatNow({ reason: "exec-event", coalesceMs: 0 });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1]?.[0]).toEqual({ reason: "exec-event" });
+  });
+
+  it("drains pending wake once a handler is registered", async () => {
+    vi.useFakeTimers();
+    const wake = await loadWakeModule();
+
+    wake.requestHeartbeatNow({ reason: "manual", coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(wake.hasPendingHeartbeatWake()).toBe(true);
+
+    const handler = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" });
+    wake.setHeartbeatWakeHandler(handler);
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(handler).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ reason: "manual" });
+    expect(wake.hasPendingHeartbeatWake()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #14892

The heartbeat scheduler's `run()` function had no try/catch around `runOnce()`. If `runOnce()` threw an unhandled exception (observed during session compaction), `scheduleNext()` was never reached and the timer was never rescheduled — causing **heartbeats to silently stop forever** until a gateway restart.

## Changes

### `src/infra/heartbeat-runner.ts`
- Wrap `runOnce()` in try/catch that logs the error, advances the timer, and continues to the next agent
- Call `scheduleNext()` before the early return on `requests-in-flight` (previously skipped, could strand the timer)

### `src/infra/heartbeat-runner.scheduler.test.ts`
- Add test: scheduler continues firing after `runOnce` throws
- Add test: timer is rescheduled when `runOnce` returns `requests-in-flight`

## Root Cause

When a heartbeat session accumulates enough context to trigger compaction, the embedded agent run (`getReplyFromConfig`) can throw an unhandled exception that escapes `runHeartbeatOnce`'s try/catch. The `run()` function in `startHeartbeatRunner` propagates this, skipping `scheduleNext()`. Since `scheduleNext()` is the only thing that reschedules the `setTimeout`, heartbeats die permanently.

## Observed Impact

In our deployment, heartbeats stopped for 34+ hours after a session compaction. The only recovery was a full gateway restart. This went undetected because no error was logged (the exception was an unhandled promise rejection in the wake handler).

## Testing

The two new tests verify:
1. After a throw, the scheduler advances the agent timer and the next interval fires normally
2. The `requests-in-flight` early return now calls `scheduleNext()` before returning

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the heartbeat scheduler so it can’t permanently stop scheduling when `runOnce()` throws. In `src/infra/heartbeat-runner.ts`, `runOnce()` is now wrapped in a `try/catch` that logs the error and advances the agent’s `lastRunMs/nextDueMs` so future intervals keep firing. It also ensures the timer is rescheduled even when `runOnce()` returns `skipped: requests-in-flight` by calling `scheduleNext()` before returning.

`src/infra/heartbeat-runner.scheduler.test.ts` adds coverage for both behaviors: (1) subsequent intervals still fire after an exception, and (2) the timer continues to reschedule when the runner reports `requests-in-flight`.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and addresses a real scheduler-stall failure mode.
- Changes are localized to the heartbeat runner’s scheduling loop and add defensive handling for exceptions and an early-return path. Behavior aligns with the wake-handler retry semantics. I couldn’t execute the test suite in this environment (npm unavailable), so confidence is slightly reduced despite the logic looking correct by inspection.
- src/infra/heartbeat-runner.scheduler.test.ts (ensure timer expectations pass in CI)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->