### PR TITLE
fix(agents): guard against undefined path in context file entries

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -301,6 +301,23 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Bravo");
   });
 
+  it("ignores context files with missing or blank paths", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        { path: undefined as unknown as string, content: "Missing path" },
+        { path: "   ", content: "Blank path" },
+        { path: "AGENTS.md", content: "Alpha" },
+      ],
+    });
+
+    expect(prompt).toContain("# Project Context");
+    expect(prompt).toContain("## AGENTS.md");
+    expect(prompt).toContain("Alpha");
+    expect(prompt).not.toContain("Missing path");
+    expect(prompt).not.toContain("Blank path");
+  });
+
   it("adds SOUL guidance when a soul file is present", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -550,8 +550,11 @@ export function buildAgentSystemPrompt(params: {
   }
 
   const contextFiles = params.contextFiles ?? [];
-  if (contextFiles.length > 0) {
-    const hasSoulFile = contextFiles.some((file) => {
+  const validContextFiles = contextFiles.filter(
+    (file) => typeof file.path === "string" && file.path.trim(),
+  );
+  if (validContextFiles.length > 0) {
+    const hasSoulFile = validContextFiles.some((file) => {
       const normalizedPath = file.path.trim().replace(/\\/g, "/");
       const baseName = normalizedPath.split("/").pop() ?? normalizedPath;
       return baseName.toLowerCase() === "soul.md";
@@ -563,7 +566,7 @@ export function buildAgentSystemPrompt(params: {
       );
     }
     lines.push("");
-    for (const file of contextFiles) {
+    for (const file of validContextFiles) {
       lines.push(`## ${file.path}`, "", file.content, "");
     }
   }

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -551,7 +551,7 @@ export function buildAgentSystemPrompt(params: {
 
   const contextFiles = params.contextFiles ?? [];
   const validContextFiles = contextFiles.filter(
-    (file) => typeof file.path === "string" && file.path.trim(),
+    (file) => typeof file.path === "string" && file.path.trim().length > 0,
   );
   if (validContextFiles.length > 0) {
     const hasSoulFile = validContextFiles.some((file) => {


### PR DESCRIPTION
Fixes #14635

`buildAgentSystemPrompt` crashes with `TypeError: Cannot read properties of undefined (reading 'trim')` when a workspace context file entry has `path: undefined`. Now filters out invalid entries before processing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `buildAgentSystemPrompt` to defensively filter workspace context file entries whose `path` is missing/undefined before trimming/processing them. The goal is to prevent a `TypeError` when an upstream context entry is malformed (as described in #14635), while keeping the rest of the agent system prompt construction unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow defensive guard that prevents a concrete runtime crash when encountering malformed context entries, and it does not alter behavior for valid entries. No additional side effects were identified in related call sites.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->