### PR TITLE
fix(nostr): handle string return from nip19.decode in normalizePubkey

### DIFF
--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -696,7 +696,10 @@ export function normalizePubkey(input: string): string {
     if (decoded.type !== "npub") {
       throw new Error("Invalid npub key");
     }
-    // Convert Uint8Array to hex string
+    // nostr-tools >=2.23 returns hex string; older versions returned Uint8Array
+    if (typeof decoded.data === "string") {
+      return decoded.data.toLowerCase();
+    }
     return Array.from(decoded.data as unknown as Uint8Array)
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");


### PR DESCRIPTION
## Summary
- Fixes #8570
- `nostr-tools` ≥2.23 changed `nip19.decode()` to return a hex string for `npub` keys instead of `Uint8Array`
- `normalizePubkey()` used `Array.from(decoded.data)` which splits a string into individual characters, producing garbage hex output (128 chars of per-byte hex instead of 64)
- Added a `typeof` check before the `Uint8Array` conversion to handle both string (≥2.23) and `Uint8Array` (older) return types

## Test plan
- [x] Added 2 new tests for `normalizePubkey` npub format handling (converts npub to hex, roundtrips with `pubkeyToNpub`)
- [x] Added 2 new tests for `validatePrivateKey` nsec format (accepts valid nsec, returns same bytes as hex equivalent)
- [x] Fixed pre-existing invalid `TEST_NSEC` constant (bad checksum) by dynamically encoding from `TEST_HEX_KEY`
- [x] All 4 new tests fail before the fix, pass after
- [x] All 36 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Nostr extension’s `normalizePubkey()` helper to correctly handle `nostr-tools`’ `nip19.decode()` behavior change for `npub` keys (returning a hex `string` instead of a `Uint8Array`), preventing incorrect hex normalization.

It also adds test coverage for:
- `normalizePubkey` npub handling (npub → 64-char lowercase hex, roundtrip with `pubkeyToNpub`)
- `validatePrivateKey` nsec handling (accepts a valid nsec, returns expected bytes)

No merge-blocking issues were found in the changeset.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (type guard on `decoded.data`), preserves previous behavior for older `nostr-tools` versions, and is covered by targeted new tests for both npub and nsec flows. No regressions or incorrect assumptions were identified within the repository code.
- No files require special attention

<sub>Last reviewed commit: d8dd20e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->