### PR TITLE
fix(telegram): omit message_thread_id for private chat deliveries (#14742)

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,10 +43,10 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("keeps thread id=1 for dm threads", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
-      message_thread_id: 1,
-    });
+  it("omits thread id for dm threads (private chats don't support message_thread_id)", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: 42, scope: "dm" })).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: 99, scope: "dm" })).toBeUndefined();
   });
 
   it("normalizes thread ids to integers", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -58,9 +58,17 @@ export function resolveTelegramThreadSpec(params: {
  * Build thread params for Telegram API calls (messages, media).
  * General forum topic (id=1) must be treated like a regular supergroup send:
  * Telegram rejects sendMessage/sendMedia with message_thread_id=1 ("thread not found").
+ * Private chats (DMs) do not support message_thread_id at all; the Bot API
+ * rejects it with "message thread not found".  Only include thread params
+ * for forum-scoped topics in groups/supergroups.
  */
 export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
   if (!thread?.id) {
+    return undefined;
+  }
+  // Private chats do not support message_thread_id — the Telegram Bot API
+  // rejects it with 400 "message thread not found".  Skip for DM scope.
+  if (thread.scope === "dm") {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -34,7 +34,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
   });
 
-  it("keeps message_thread_id for dm threads", () => {
+  it("omits message_thread_id for dm threads (private chats don't support it)", () => {
     const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
     const stream = createTelegramDraftStream({
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -46,8 +46,6 @@ describe("createTelegramDraftStream", () => {
 
     stream.update("Hello");
 
-    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
-      message_thread_id: 1,
-    });
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
   });
 });

--- a/src/telegram/send.omits-thread-id-private-chat.test.ts
+++ b/src/telegram/send.omits-thread-id-private-chat.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { loadWebMedia } = vi.hoisted(() => ({
+  loadWebMedia: vi.fn(),
+}));
+
+vi.mock("../web/media.js", () => ({
+  loadWebMedia,
+}));
+
+vi.mock("grammy", () => ({
+  Bot: class {
+    api = {};
+    catch = vi.fn();
+    constructor(
+      public token: string,
+      public options?: { client?: { fetch?: typeof fetch } },
+    ) {}
+  },
+  InputFile: class {},
+}));
+
+import { sendMessageTelegram, sendStickerTelegram } from "./send.js";
+
+describe("sendMessageTelegram: private chat thread ID handling (#14742)", () => {
+  it("omits message_thread_id when target is a private chat (positive numeric ID)", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 1,
+      chat: { id: 123456789 },
+    });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    await sendMessageTelegram("123456789", "Hello", {
+      token: "tok",
+      api,
+      messageThreadId: 42,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const callArgs = sendMessage.mock.calls[0];
+    expect(callArgs[2]).not.toHaveProperty("message_thread_id");
+  });
+
+  it("omits message_thread_id for private chat even when target uses telegram: prefix", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 2,
+      chat: { id: 987654321 },
+    });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    await sendMessageTelegram("telegram:987654321", "Hello", {
+      token: "tok",
+      api,
+      messageThreadId: 99,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const callArgs = sendMessage.mock.calls[0];
+    expect(callArgs[2]).not.toHaveProperty("message_thread_id");
+  });
+
+  it("includes message_thread_id when target is a group chat (negative numeric ID)", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 3,
+      chat: { id: -1001234567890 },
+    });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    await sendMessageTelegram("-1001234567890", "Hello group", {
+      token: "tok",
+      api,
+      messageThreadId: 271,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const callArgs = sendMessage.mock.calls[0];
+    expect(callArgs[2]).toHaveProperty("message_thread_id", 271);
+  });
+
+  it("includes message_thread_id for group from target string with topic suffix", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 4,
+      chat: { id: -1001234567890 },
+    });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    // Target format: chatId:topic:topicId
+    await sendMessageTelegram("-1001234567890:topic:55", "Hello topic", {
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const callArgs = sendMessage.mock.calls[0];
+    expect(callArgs[2]).toHaveProperty("message_thread_id", 55);
+  });
+
+  it("omits message_thread_id for media sends to private chats", async () => {
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 5,
+      chat: { id: 123456789 },
+    });
+    const api = { sendPhoto } as unknown as { sendPhoto: typeof sendPhoto };
+
+    loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/jpeg",
+      fileName: "photo.jpg",
+    });
+
+    await sendMessageTelegram("123456789", "photo caption", {
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.jpg",
+      messageThreadId: 42,
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    const callArgs = sendPhoto.mock.calls[0];
+    expect(callArgs[2]).not.toHaveProperty("message_thread_id");
+  });
+});
+
+describe("sendStickerTelegram: private chat thread ID handling (#14742)", () => {
+  it("omits message_thread_id when target is a private chat", async () => {
+    const sendSticker = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: 123456789 },
+    });
+    const api = { sendSticker } as unknown as { sendSticker: typeof sendSticker };
+
+    await sendStickerTelegram("123456789", "file_id_123", {
+      token: "tok",
+      api,
+      messageThreadId: 42,
+    });
+
+    expect(sendSticker).toHaveBeenCalledTimes(1);
+    const callArgs = sendSticker.mock.calls[0];
+    // Third arg is params; should be undefined or not contain message_thread_id
+    const params = callArgs[2] as Record<string, unknown> | undefined;
+    if (params) {
+      expect(params).not.toHaveProperty("message_thread_id");
+    }
+  });
+
+  it("includes message_thread_id when target is a group chat", async () => {
+    const sendSticker = vi.fn().mockResolvedValue({
+      message_id: 11,
+      chat: { id: -1001234567890 },
+    });
+    const api = { sendSticker } as unknown as { sendSticker: typeof sendSticker };
+
+    await sendStickerTelegram("-1001234567890", "file_id_123", {
+      token: "tok",
+      api,
+      messageThreadId: 99,
+    });
+
+    expect(sendSticker).toHaveBeenCalledTimes(1);
+    const callArgs = sendSticker.mock.calls[0];
+    expect(callArgs[2]).toHaveProperty("message_thread_id", 99);
+  });
+});

--- a/src/telegram/send.returns-undefined-empty-input.test.ts
+++ b/src/telegram/send.returns-undefined-empty-input.test.ts
@@ -479,7 +479,7 @@ describe("sendMessageTelegram", () => {
   });
 
   it("retries without message_thread_id when Telegram reports missing thread", async () => {
-    const chatId = "123";
+    const chatId = "-1001234567890";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendMessage = vi
       .fn()
@@ -509,7 +509,7 @@ describe("sendMessageTelegram", () => {
   });
 
   it("does not retry thread-not-found when no message_thread_id was provided", async () => {
-    const chatId = "123";
+    const chatId = "-1001234567890";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendMessage = vi.fn().mockRejectedValueOnce(threadErr);
     const api = { sendMessage } as unknown as {
@@ -615,7 +615,7 @@ describe("sendMessageTelegram", () => {
   });
 
   it("retries media sends without message_thread_id when thread is missing", async () => {
-    const chatId = "123";
+    const chatId = "-1001234567890";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendPhoto = vi
       .fn()
@@ -713,7 +713,7 @@ describe("sendStickerTelegram", () => {
   });
 
   it("retries sticker sends without message_thread_id when thread is missing", async () => {
-    const chatId = "123";
+    const chatId = "-1001234567890";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendSticker = vi
       .fn()

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -251,8 +251,15 @@ export async function sendMessageTelegram(
 
   // Build optional params for forum topics and reply threading.
   // Only include these if actually provided to keep API calls clean.
+  // Private chats (positive numeric IDs) do not support message_thread_id;
+  // the Telegram Bot API rejects it with 400 "message thread not found".
+  const isPrivateChat = /^\d+$/.test(chatId);
   const messageThreadId =
-    opts.messageThreadId != null ? opts.messageThreadId : target.messageThreadId;
+    !isPrivateChat && opts.messageThreadId != null
+      ? opts.messageThreadId
+      : !isPrivateChat
+        ? target.messageThreadId
+        : undefined;
   const threadSpec =
     messageThreadId != null ? { id: messageThreadId, scope: "forum" as const } : undefined;
   const threadIdParams = buildTelegramThreadParams(threadSpec);
@@ -827,8 +834,14 @@ export async function sendStickerTelegram(
   const client = resolveTelegramClientOptions(account);
   const api = opts.api ?? new Bot(token, client ? { client } : undefined).api;
 
+  // Private chats (positive numeric IDs) do not support message_thread_id.
+  const isPrivateChat = /^\d+$/.test(chatId);
   const messageThreadId =
-    opts.messageThreadId != null ? opts.messageThreadId : target.messageThreadId;
+    !isPrivateChat && opts.messageThreadId != null
+      ? opts.messageThreadId
+      : !isPrivateChat
+        ? target.messageThreadId
+        : undefined;
   const threadSpec =
     messageThreadId != null ? { id: messageThreadId, scope: "forum" as const } : undefined;
   const threadIdParams = buildTelegramThreadParams(threadSpec);


### PR DESCRIPTION
## Problem

When cron jobs deliver to private Telegram chats (DMs), they fail with:
```
GrammyError: Call to 'sendMessage' failed! (400: Bad Request: message thread not found)
```

This happens because a `message_thread_id` is being passed to the Telegram Bot API even though private chats don't support threads. The thread ID originates from the session's delivery context (stored when a DM message has a `message_thread_id` field) and flows through the cron delivery chain.

## Root Cause

Two code paths incorrectly include `message_thread_id` for private chats:

1. **`buildTelegramThreadParams()`** in `helpers.ts` returned thread params for `scope: 'dm'` threads, but the Telegram Bot API rejects `message_thread_id` for private chats entirely.

2. **`sendMessageTelegram()` / `sendStickerTelegram()`** in `send.ts` always created a thread spec with `scope: 'forum'` for any incoming `messageThreadId`, regardless of whether the target chat is private or a group. This meant the DM filtering in `buildTelegramThreadParams` was bypassed for the outbound delivery path.

## Fix

- **`buildTelegramThreadParams()`**: Return `undefined` for `scope: 'dm'` threads, preventing `message_thread_id` from being included in API calls for the bot handler reply path (`deliverReplies`).

- **`sendMessageTelegram()` / `sendStickerTelegram()`**: Detect private chats by checking if the normalized chat ID is a positive numeric value (private chats have positive IDs; groups/channels have negative IDs) and skip `message_thread_id` entirely for those targets. This fixes the cron/outbound delivery path.

The existing `sendWithThreadFallback` retry mechanism is preserved as a safety net for edge cases (e.g., stale thread IDs in migrated groups).

## Tests

- Updated `buildTelegramThreadParams` test: DM-scoped threads now return `undefined`
- Updated `deliverReplies` test: DM thread spec no longer includes `message_thread_id`; added forum thread test
- Added new test suite `send.omits-thread-id-private-chat.test.ts` covering:
  - Private chat text sends omit `message_thread_id`
  - Private chat media sends omit `message_thread_id`
  - Private chat sticker sends omit `message_thread_id`
  - Group chat sends correctly include `message_thread_id`
  - `telegram:` prefix targets handled correctly
  - Target strings with `:topic:N` suffix handled correctly
- Updated thread-fallback tests to use group chat IDs (negative) since the fallback is only relevant for groups
- Updated draft stream test for DM thread filtering
- All 422 Telegram tests pass

Fixes #14742

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram delivery so `message_thread_id` is no longer sent for DM-scoped threads (private chats), while still preserving forum-topic thread behavior for groups/supergroups. It changes `buildTelegramThreadParams()` to return `undefined` for `scope: "dm"`, and updates outbound send paths (`sendMessageTelegram`, `sendStickerTelegram`) to skip thread IDs for targets detected as private chats. Test coverage is expanded/adjusted to validate DM omission, forum inclusion, and retry/fallback behavior.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but has a correctness gap for username-based DM targets.
- Core fix (dropping DM-scoped thread params and skipping thread IDs for positive numeric chat IDs) matches Telegram behavior and is well covered by tests for numeric IDs and topic suffix parsing. However, private-chat detection relies on the normalized `chatId` being purely digits; sending to a private chat via username (`@user` or bare `user` normalized to `@user`) will be misclassified as non-private and can still include `message_thread_id`, reintroducing the original failure mode for that target format.
- src/telegram/send.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->