### PR TITLE
fix(infra): always treat 'fetch failed' TypeError as transient network error

### DIFF
--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -94,12 +94,10 @@ export function isTransientNetworkError(err: unknown): boolean {
     return true;
   }
 
-  // "fetch failed" TypeError from undici (Node's native fetch)
-  if (err instanceof TypeError && err.message === "fetch failed") {
-    const cause = getErrorCause(err);
-    if (cause) {
-      return isTransientNetworkError(cause);
-    }
+  // "fetch failed" TypeError from undici (Node's native fetch).
+  // Always treat as transient — the underlying cause may be a novel error code
+  // but the fetch failure itself is inherently a network issue (#14649).
+  if (err instanceof TypeError && /^fetch failed/i.test(err.message)) {
     return true;
   }
 


### PR DESCRIPTION
Fixes #14649

The unhandled rejection handler checked the cause chain of `fetch failed` TypeErrors, but novel cause error codes not in the transient set would still crash the gateway via `process.exit(1)`. Since `TypeError: fetch failed` from undici is inherently a network issue, now always treats it as transient regardless of the underlying cause.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `isTransientNetworkError` to always classify undici/native-fetch `TypeError: fetch failed` as transient, instead of walking the cause chain and potentially crashing on previously-unseen underlying error codes. The change is localized to the unhandled rejection classification logic used by `installUnhandledRejectionHandler` to decide whether to warn-and-continue vs exit the gateway.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one classification edge case that could suppress real errors.
- Change is small and targeted, but the new `/^fetch failed/i` message-based match can misclassify unrelated TypeErrors as transient and prevent expected crash-on-bug behavior in unhandled rejections.
- src/infra/unhandled-rejections.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->