### PR TITLE
fix: update context pruning to notify session metadata after pruning & fix Usage type #14833

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -68,9 +68,7 @@ function buildContextPruningExtension(params: {
           storePath,
           sessionKey: params.sessionKey!,
           update: async () => ({
-            totalTokens: estimatedTokens,
-            inputTokens: undefined,
-            outputTokens: undefined,
+            contextTokens: estimatedTokens,
             updatedAt: Date.now(),
           }),
         }).catch(() => {

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -3,6 +3,8 @@ import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveDefaultSessionStorePath, updateSessionStoreEntry } from "../../config/sessions.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { setCompactionSafeguardRuntime } from "../pi-extensions/compaction-safeguard-runtime.js";
@@ -41,6 +43,7 @@ function buildContextPruningExtension(params: {
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
+  sessionKey?: string;
 }): { additionalExtensionPaths?: string[] } {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
   if (raw?.mode !== "cache-ttl") {
@@ -55,11 +58,33 @@ function buildContextPruningExtension(params: {
     return {};
   }
 
+  // Build an onPruned callback that persists updated token counts to the session store.
+  // This ensures sessions.json reflects pruned context immediately, not just after the next reply.
+  const onPruned = params.sessionKey
+    ? (estimatedTokens: number) => {
+        const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+        const storePath = resolveDefaultSessionStorePath(agentId);
+        updateSessionStoreEntry({
+          storePath,
+          sessionKey: params.sessionKey!,
+          update: async () => ({
+            totalTokens: estimatedTokens,
+            inputTokens: undefined,
+            outputTokens: undefined,
+            updatedAt: Date.now(),
+          }),
+        }).catch(() => {
+          /* best-effort: don't fail the agent run if store update fails */
+        });
+      }
+    : undefined;
+
   setContextPruningRuntime(params.sessionManager, {
     settings,
     contextWindowTokens: resolveContextWindowTokens(params),
     isToolPrunable: makeToolPrunablePredicate(settings.tools),
     lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager),
+    onPruned,
   });
 
   return {
@@ -77,6 +102,7 @@ export function buildEmbeddedExtensionPaths(params: {
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
+  sessionKey?: string;
 }): string[] {
   const paths: string[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -453,6 +453,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        sessionKey: params.sessionKey,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -1,5 +1,5 @@
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { pruneContextMessages } from "./pruner.js";
+import { CHARS_PER_TOKEN_ESTIMATE, estimateContextChars, pruneContextMessages } from "./pruner.js";
 import { getContextPruningRuntime } from "./runtime.js";
 
 export default function contextPruningExtension(api: ExtensionAPI): void {
@@ -30,6 +30,13 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
 
     if (next === event.messages) {
       return undefined;
+    }
+
+    // Notify listeners about the pruned context size so session metadata can be updated
+    if (runtime.onPruned) {
+      const estimatedChars = estimateContextChars(next);
+      const estimatedTokens = Math.ceil(estimatedChars / CHARS_PER_TOKEN_ESTIMATE);
+      runtime.onPruned(estimatedTokens);
     }
 
     if (runtime.settings.mode === "cache-ttl") {

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -4,7 +4,7 @@ import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { EffectiveContextPruningSettings } from "./settings.js";
 import { makeToolPrunablePredicate } from "./tools.js";
 
-const CHARS_PER_TOKEN_ESTIMATE = 4;
+export const CHARS_PER_TOKEN_ESTIMATE = 4;
 // We currently skip pruning tool results that contain images. Still, we count them (approx.) so
 // we start trimming prunable tool results earlier when image-heavy context is consuming the window.
 const IMAGE_CHAR_ESTIMATE = 8_000;
@@ -150,7 +150,7 @@ function estimateMessageChars(message: AgentMessage): number {
   return 256;
 }
 
-function estimateContextChars(messages: AgentMessage[]): number {
+export function estimateContextChars(messages: AgentMessage[]): number {
   return messages.reduce((sum, m) => sum + estimateMessageChars(m), 0);
 }
 

--- a/src/agents/pi-extensions/context-pruning/runtime.ts
+++ b/src/agents/pi-extensions/context-pruning/runtime.ts
@@ -5,6 +5,8 @@ export type ContextPruningRuntimeValue = {
   contextWindowTokens?: number | null;
   isToolPrunable: (toolName: string) => boolean;
   lastCacheTouchAt?: number | null;
+  /** Called after pruning successfully modifies context. Receives estimated token count of pruned context. */
+  onPruned?: (estimatedTokens: number) => void;
 };
 
 // Session-scoped runtime registry keyed by object identity.


### PR DESCRIPTION
Updates the context pruning extension to report estimated token counts after pruning, allowing session metadata (e.g. sessions.json) to reflect accurate contextTokens immediately.

### Changes
- context-pruning/runtime.ts — Added optional onPruned
- callback to ContextPruningRuntimeValue, invoked with the estimated token count after successful pruning.
- context-pruning/pruner.ts — Exported estimateContextChars and CHARS_PER_TOKEN_ESTIMATE so the extension can compute post-prune token estimates.
- context-pruning/extension.ts — Call runtime.onPruned(estimatedTokens) after pruning succeeds, before resetting the TTL window.
- pi-embedded-runner/extensions.ts — Wire up onPruned to update session context token metadata.
- pi-embedded-runner/run/attempt.ts — Pass sessionKey through to the extension setup. context-pruning.test.ts
- Fixed Usage type (total → totalTokens + cost object) to match the updated @mariozechner/pi-ai interface. Added tests for onPruned
- callback behavior (called on prune, not called when no pruning occurs).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the context-pruning runtime with an `onPruned` callback, exports character/token estimation helpers from the pruner, and wires the embedded runner to persist updated token metadata to the session store immediately after pruning.

It also updates tests to the new `Usage` shape (`totalTokens` + `cost`) and adds coverage ensuring `onPruned` fires only when pruning actually changes the message list.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a high-likelihood correctness issue in how session token metadata is persisted after pruning.
- Core pruning/onPruned wiring and tests look coherent, but the embedded runner writes the post-prune *context size estimate* into `totalTokens`/`inputTokens`/`outputTokens`, which are typically used for usage/billing totals; that will produce incorrect session metadata and can break consumers of usage fields. Fixing the field mapping should make the change low-risk.
- src/agents/pi-embedded-runner/extensions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->