### PR TITLE
fix: resolve actual failure reason for cooldown-skipped providers

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -40,5 +40,6 @@ export {
   markAuthProfileCooldown,
   markAuthProfileFailure,
   markAuthProfileUsed,
+  resolveDominantCooldownReason,
   resolveProfileUnusableUntilForDisplay,
 } from "./auth-profiles/usage.js";

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -16,6 +16,43 @@ export function resolveProfileUnusableUntil(
 }
 
 /**
+ * Resolve the most representative failure reason across cooldown profiles.
+ * Aggregates `failureCounts` from each profile in cooldown and returns
+ * the reason with the highest total count.  Falls back to `"rate_limit"`
+ * when no failure data is recorded (backward-compatible default).
+ */
+export function resolveDominantCooldownReason(
+  store: AuthProfileStore,
+  profileIds: string[],
+): AuthProfileFailureReason {
+  const totals: Partial<Record<AuthProfileFailureReason, number>> = {};
+
+  for (const id of profileIds) {
+    const stats = store.usageStats?.[id];
+    if (!stats) {
+      continue;
+    }
+    if (stats.failureCounts) {
+      for (const [reason, count] of Object.entries(stats.failureCounts)) {
+        const key = reason as AuthProfileFailureReason;
+        totals[key] = (totals[key] ?? 0) + (count ?? 0);
+      }
+    }
+  }
+
+  let bestReason: AuthProfileFailureReason | null = null;
+  let bestCount = 0;
+  for (const [reason, count] of Object.entries(totals)) {
+    if ((count ?? 0) > bestCount) {
+      bestReason = reason as AuthProfileFailureReason;
+      bestCount = count ?? 0;
+    }
+  }
+
+  return bestReason ?? "rate_limit";
+}
+
+/**
  * Check if a profile is currently in cooldown (due to rate limiting or errors).
  */
 export function isProfileInCooldown(store: AuthProfileStore, profileId: string): boolean {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -3,6 +3,15 @@ import { normalizeProviderId } from "../model-selection.js";
 import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
 import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
 
+const VALID_FAILURE_REASONS: ReadonlySet<string> = new Set<AuthProfileFailureReason>([
+  "auth",
+  "format",
+  "rate_limit",
+  "billing",
+  "timeout",
+  "unknown",
+]);
+
 export function resolveProfileUnusableUntil(
   stats: Pick<ProfileUsageStats, "cooldownUntil" | "disabledUntil">,
 ): number | null {
@@ -34,6 +43,9 @@ export function resolveDominantCooldownReason(
     }
     if (stats.failureCounts) {
       for (const [reason, count] of Object.entries(stats.failureCounts)) {
+        if (!VALID_FAILURE_REASONS.has(reason)) {
+          continue;
+        }
         const key = reason as AuthProfileFailureReason;
         totals[key] = (totals[key] ?? 0) + (count ?? 0);
       }

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -47,7 +47,8 @@ export function resolveDominantCooldownReason(
           continue;
         }
         const key = reason as AuthProfileFailureReason;
-        totals[key] = (totals[key] ?? 0) + (count ?? 0);
+        const n = typeof count === "number" && Number.isFinite(count) && count > 0 ? count : 0;
+        totals[key] = (totals[key] ?? 0) + n;
       }
     }
   }

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -9,6 +9,7 @@ vi.mock("./auth-profiles.js", () => ({
   getSoonestCooldownExpiry: vi.fn(),
   isProfileInCooldown: vi.fn(),
   resolveAuthProfileOrder: vi.fn(),
+  resolveDominantCooldownReason: vi.fn().mockReturnValue("rate_limit"),
 }));
 
 import {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -348,6 +348,123 @@ describe("runWithModelFallback", () => {
     expect(result.attempts[0]?.reason).toBe("rate_limit");
   });
 
+  it("reports auth reason when profiles are in cooldown due to auth errors", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
+    const provider = `auth-cooldown-${crypto.randomUUID()}`;
+    const profileId = `${provider}:default`;
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider,
+          key: "test-key",
+        },
+      },
+      usageStats: {
+        [profileId]: {
+          cooldownUntil: Date.now() + 60_000,
+          failureCounts: { auth: 1 },
+        },
+      },
+    };
+
+    saveAuthProfileStore(store, tempDir);
+
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: `${provider}/m1`,
+            fallbacks: ["fallback/ok-model"],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockImplementation(async (providerId, modelId) => {
+      if (providerId === "fallback") {
+        return "ok";
+      }
+      throw new Error(`unexpected provider: ${providerId}/${modelId}`);
+    });
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider,
+        model: "m1",
+        agentDir: tempDir,
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run.mock.calls).toEqual([["fallback", "ok-model"]]);
+      expect(result.attempts[0]?.reason).toBe("auth");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports billing reason when profiles are in cooldown due to billing errors", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
+    const provider = `billing-cooldown-${crypto.randomUUID()}`;
+    const profileId = `${provider}:default`;
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider,
+          key: "test-key",
+        },
+      },
+      usageStats: {
+        [profileId]: {
+          disabledUntil: Date.now() + 60_000,
+          disabledReason: "billing",
+          failureCounts: { billing: 1 },
+        },
+      },
+    };
+
+    saveAuthProfileStore(store, tempDir);
+
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: `${provider}/m1`,
+            fallbacks: ["fallback/ok-model"],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockImplementation(async (providerId, modelId) => {
+      if (providerId === "fallback") {
+        return "ok";
+      }
+      throw new Error(`unexpected provider: ${providerId}/${modelId}`);
+    });
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider,
+        model: "m1",
+        agentDir: tempDir,
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run.mock.calls).toEqual([["fallback", "ok-model"]]);
+      expect(result.attempts[0]?.reason).toBe("billing");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not skip when any profile is available", async () => {
     const provider = `cooldown-mixed-${crypto.randomUUID()}`;
     const profileA = `${provider}:a`;

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -4,6 +4,7 @@ import {
   getSoonestCooldownExpiry,
   isProfileInCooldown,
   resolveAuthProfileOrder,
+  resolveDominantCooldownReason,
 } from "./auth-profiles.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
@@ -343,11 +344,12 @@ export async function runWithModelFallback<T>(params: {
         });
         if (!shouldProbe) {
           // Skip without attempting
+          const cooldownReason = resolveDominantCooldownReason(authStore, profileIds);
           attempts.push({
             provider: candidate.provider,
             model: candidate.model,
             error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
-            reason: "rate_limit",
+            reason: cooldownReason,
           });
           continue;
         }


### PR DESCRIPTION
Fixes #13909

## Summary

- When all auth profiles for a provider are in cooldown, the fallback loop hardcoded `reason: "rate_limit"` regardless of the actual failure that caused the cooldown (e.g. OAuth 403 → "auth", billing 402 → "billing")
- Added `resolveDominantCooldownReason()` that inspects the `failureCounts` stored in profile usage stats and returns the most representative failure reason
- Falls back to `"rate_limit"` when no failure data is recorded (backward-compatible default)

## Test plan

- [x] New test: profile in cooldown with `failureCounts: { auth: 1 }` → attempt reason is `"auth"`
- [x] New test: profile in cooldown with `failureCounts: { billing: 1 }` → attempt reason is `"billing"`
- [x] Existing test: profile in cooldown with no `failureCounts` → reason remains `"rate_limit"` (backward compat)
- [x] All 22 tests pass; 2 new tests fail before fix, pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes model fallback behavior when a provider is skipped because *all* of its auth profiles are in cooldown/disabled. Previously, the skip attempt hardcoded `reason: "rate_limit"`; it now calls `resolveDominantCooldownReason()` which aggregates `usageStats[profileId].failureCounts` across the provider’s profiles and returns the highest-count `AuthProfileFailureReason`, defaulting to `"rate_limit"` when no usable failure data exists.

Two new tests cover the new behavior for cooldowns driven by `auth` and `billing` failures, and the existing backward-compatible case (no `failureCounts`) remains `"rate_limit"`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrow (only affects the cooldown-skip branch), reasons remain within the existing FailoverReason/AuthProfileFailureReason unions, and new tests cover the new behavior while preserving the prior default when failureCounts is absent/invalid.
- No files require special attention

<sub>Last reviewed commit: 05811a8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->