### PR TITLE
fix: resolve symlinked argv1 for Control UI asset detection

### DIFF
--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -2,6 +2,16 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+
+/** Try to create a symlink; returns false if the OS denies it (Windows CI without Developer Mode). */
+async function trySymlink(target: string, linkPath: string): Promise<boolean> {
+  try {
+    await fs.symlink(target, linkPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
 import {
   resolveControlUiDistIndexHealth,
   resolveControlUiDistIndexPath,
@@ -10,6 +20,7 @@ import {
   resolveControlUiRootOverrideSync,
   resolveControlUiRootSync,
 } from "./control-ui-assets.js";
+import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 
 describe("control UI assets helpers", () => {
   it("resolves repo root from src argv1", async () => {
@@ -217,6 +228,85 @@ describe("control UI assets helpers", () => {
         indexPath,
         exists: false,
       });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves control-ui root when argv1 is a symlink (nvm scenario)", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-"));
+    try {
+      const realPkg = path.join(tmp, "real-pkg");
+      const bin = path.join(tmp, "bin");
+      await fs.mkdir(realPkg, { recursive: true });
+      await fs.mkdir(bin, { recursive: true });
+      await fs.writeFile(path.join(realPkg, "package.json"), JSON.stringify({ name: "openclaw" }));
+      await fs.writeFile(path.join(realPkg, "openclaw.mjs"), "export {};\n");
+      await fs.mkdir(path.join(realPkg, "dist", "control-ui"), { recursive: true });
+      await fs.writeFile(path.join(realPkg, "dist", "control-ui", "index.html"), "<html></html>\n");
+      const ok = await trySymlink(
+        path.join("..", "real-pkg", "openclaw.mjs"),
+        path.join(bin, "openclaw"),
+      );
+      if (!ok) {
+        return; // symlinks not supported (Windows CI)
+      }
+
+      expect(resolveControlUiRootSync({ argv1: path.join(bin, "openclaw") })).toBe(
+        path.join(realPkg, "dist", "control-ui"),
+      );
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves package root via symlinked argv1", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-"));
+    try {
+      const realPkg = path.join(tmp, "real-pkg");
+      const bin = path.join(tmp, "bin");
+      await fs.mkdir(realPkg, { recursive: true });
+      await fs.mkdir(bin, { recursive: true });
+      await fs.writeFile(path.join(realPkg, "package.json"), JSON.stringify({ name: "openclaw" }));
+      await fs.writeFile(path.join(realPkg, "openclaw.mjs"), "export {};\n");
+      await fs.mkdir(path.join(realPkg, "dist", "control-ui"), { recursive: true });
+      await fs.writeFile(path.join(realPkg, "dist", "control-ui", "index.html"), "<html></html>\n");
+      const ok = await trySymlink(
+        path.join("..", "real-pkg", "openclaw.mjs"),
+        path.join(bin, "openclaw"),
+      );
+      if (!ok) {
+        return; // symlinks not supported (Windows CI)
+      }
+
+      expect(await resolveOpenClawPackageRoot({ argv1: path.join(bin, "openclaw") })).toBe(realPkg);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves dist index path via symlinked argv1 (async)", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-"));
+    try {
+      const realPkg = path.join(tmp, "real-pkg");
+      const bin = path.join(tmp, "bin");
+      await fs.mkdir(realPkg, { recursive: true });
+      await fs.mkdir(bin, { recursive: true });
+      await fs.writeFile(path.join(realPkg, "package.json"), JSON.stringify({ name: "openclaw" }));
+      await fs.writeFile(path.join(realPkg, "openclaw.mjs"), "export {};\n");
+      await fs.mkdir(path.join(realPkg, "dist", "control-ui"), { recursive: true });
+      await fs.writeFile(path.join(realPkg, "dist", "control-ui", "index.html"), "<html></html>\n");
+      const ok = await trySymlink(
+        path.join("..", "real-pkg", "openclaw.mjs"),
+        path.join(bin, "openclaw"),
+      );
+      if (!ok) {
+        return; // symlinks not supported (Windows CI)
+      }
+
+      expect(await resolveControlUiDistIndexPath(path.join(bin, "openclaw"))).toBe(
+        path.join(realPkg, "dist", "control-ui", "index.html"),
+      );
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -20,11 +20,15 @@ export async function resolveControlUiDistIndexHealth(
   opts: {
     root?: string;
     argv1?: string;
+    moduleUrl?: string;
   } = {},
 ): Promise<ControlUiDistIndexHealth> {
   const indexPath = opts.root
     ? resolveControlUiDistIndexPathForRoot(opts.root)
-    : await resolveControlUiDistIndexPath(opts.argv1 ?? process.argv[1]);
+    : await resolveControlUiDistIndexPath({
+        argv1: opts.argv1 ?? process.argv[1],
+        moduleUrl: opts.moduleUrl,
+      });
   return {
     indexPath,
     exists: Boolean(indexPath && fs.existsSync(indexPath)),
@@ -66,8 +70,11 @@ export function resolveControlUiRepoRoot(
 }
 
 export async function resolveControlUiDistIndexPath(
-  argv1: string | undefined = process.argv[1],
+  argv1OrOpts?: string | { argv1?: string; moduleUrl?: string },
 ): Promise<string | null> {
+  const argv1 =
+    typeof argv1OrOpts === "string" ? argv1OrOpts : (argv1OrOpts?.argv1 ?? process.argv[1]);
+  const moduleUrl = typeof argv1OrOpts === "object" ? argv1OrOpts?.moduleUrl : undefined;
   if (!argv1) {
     return null;
   }
@@ -79,7 +86,7 @@ export async function resolveControlUiDistIndexPath(
     return path.join(distDir, "control-ui", "index.html");
   }
 
-  const packageRoot = await resolveOpenClawPackageRoot({ argv1: normalized });
+  const packageRoot = await resolveOpenClawPackageRoot({ argv1: normalized, moduleUrl });
   if (packageRoot) {
     return path.join(packageRoot, "dist", "control-ui", "index.html");
   }


### PR DESCRIPTION
## Summary

This replaces #14637 because I do not have push access to the original fork branch.

Credits to @aynorica for the original implementation and root-cause analysis.

### What this includes

- Cherry-picked original fix commit from @aynorica:
  - `fix: resolve symlinked argv1 for Control UI asset detection (#4855)`
- Follow-up test hardening commit:
  - Normalize symlink path assertions so the new tests pass on macOS (`/var` vs `/private/var`) and Linux.

## Validation

- `pnpm --dir /Users/gumadeiras/openclaw/.worktrees/pr-14637 exec vitest run src/infra/control-ui-assets.test.ts`
  - `17 passed`

## Attribution

Original author and PR: @aynorica in #14637.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens Control UI asset path detection when `argv1` points to a symlinked executable (e.g., nvm/Homebrew-style `bin/` symlinks), by resolving `argv1` symlinks when searching for the `openclaw` package root and threading an optional `moduleUrl` through the async index-path resolver. It also adds new tests that construct a symlinked `argv1` scenario and normalize realpath assertions to avoid macOS `/var` vs `/private/var` differences.

The main functional change is in `src/infra/openclaw-root.ts` where `candidateDirsFromArgv1` now adds a realpath-derived candidate directory, which then improves downstream resolvers in `src/infra/control-ui-assets.ts` that rely on `resolveOpenClawPackageRoot`.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge once the test module import ordering issue is addressed.
- Core logic change is localized (adding a realpath-based candidate when resolving package root) and the new tests cover the symlinked argv1 scenario. The main merge blocker is the test file’s import ordering, which can fail lint/format checks depending on the repo’s tooling expectations.
- src/infra/control-ui-assets.test.ts

<sub>Last reviewed commit: 07b8504</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->