### PR TITLE
fix: handle connection errors with user-friendly messages and failover (#14866)

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -165,9 +165,25 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
-  if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
+  if (
+    [
+      "ETIMEDOUT",
+      "ESOCKETTIMEDOUT",
+      "ECONNRESET",
+      "ECONNABORTED",
+      "ECONNREFUSED",
+      "ENOTFOUND",
+      "EAI_AGAIN",
+      "EHOSTUNREACH",
+    ].includes(code)
+  ) {
     return "timeout";
   }
+  const name = getErrorName(err);
+  if (name === "APIConnectionError" || name === "APIConnectionTimeoutError") {
+    return "timeout";
+  }
+
   if (isTimeoutError(err)) {
     return "timeout";
   }

--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -43,4 +43,14 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
+  it("classifies connection errors as timeout for failover", () => {
+    expect(classifyFailoverReason("Connection error.")).toBe("timeout");
+    expect(classifyFailoverReason("connection error")).toBe("timeout");
+    expect(classifyFailoverReason("connect ECONNREFUSED 127.0.0.1:443")).toBe("timeout");
+    expect(classifyFailoverReason("fetch failed")).toBe("timeout");
+    expect(classifyFailoverReason("socket hang up")).toBe("timeout");
+    expect(classifyFailoverReason("getaddrinfo ENOTFOUND api.example.com")).toBe("timeout");
+    expect(classifyFailoverReason("network error")).toBe("timeout");
+    expect(classifyFailoverReason("unable to connect to the server")).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -104,4 +104,20 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("API provider");
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
+  it("returns a friendly message for connection errors", () => {
+    const msg = makeAssistantError("Connection error.");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Unable to connect to the AI provider");
+    expect(result).toContain("base URL");
+  });
+  it("returns a friendly message for ECONNREFUSED", () => {
+    const msg = makeAssistantError("connect ECONNREFUSED 127.0.0.1:443");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Unable to connect to the AI provider");
+  });
+  it("returns a friendly message for fetch failed", () => {
+    const msg = makeAssistantError("fetch failed");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Unable to connect to the AI provider");
+  });
 });

--- a/src/agents/pi-embedded-helpers.isconnectionerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isconnectionerrormessage.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { isConnectionErrorMessage } from "./pi-embedded-helpers.js";
+
+describe("isConnectionErrorMessage", () => {
+  it("matches the OpenAI SDK default 'Connection error.' message", () => {
+    expect(isConnectionErrorMessage("Connection error.")).toBe(true);
+    expect(isConnectionErrorMessage("Connection error")).toBe(true);
+    expect(isConnectionErrorMessage("connection error.")).toBe(true);
+    expect(isConnectionErrorMessage("CONNECTION ERROR")).toBe(true);
+  });
+
+  it("matches ECONNREFUSED errors", () => {
+    expect(isConnectionErrorMessage("connect ECONNREFUSED 127.0.0.1:443")).toBe(true);
+    expect(isConnectionErrorMessage("ECONNREFUSED")).toBe(true);
+  });
+
+  it("matches ECONNRESET errors", () => {
+    expect(isConnectionErrorMessage("ECONNRESET")).toBe(true);
+    expect(isConnectionErrorMessage("read ECONNRESET")).toBe(true);
+  });
+
+  it("matches ECONNABORTED errors", () => {
+    expect(isConnectionErrorMessage("ECONNABORTED")).toBe(true);
+  });
+
+  it("matches fetch failed errors", () => {
+    expect(isConnectionErrorMessage("fetch failed")).toBe(true);
+    expect(isConnectionErrorMessage("TypeError: fetch failed")).toBe(true);
+  });
+
+  it("matches socket hang up", () => {
+    expect(isConnectionErrorMessage("socket hang up")).toBe(true);
+  });
+
+  it("matches network error variants", () => {
+    expect(isConnectionErrorMessage("network error")).toBe(true);
+    expect(isConnectionErrorMessage("network failure")).toBe(true);
+    expect(isConnectionErrorMessage("network unavailable")).toBe(true);
+  });
+
+  it("matches APIConnectionError class name", () => {
+    expect(isConnectionErrorMessage("APIConnectionError: Connection error.")).toBe(true);
+  });
+
+  it("matches DNS resolution failures", () => {
+    expect(isConnectionErrorMessage("getaddrinfo EAI_AGAIN api.example.com")).toBe(true);
+    expect(isConnectionErrorMessage("getaddrinfo ENOTFOUND api.example.com")).toBe(true);
+  });
+
+  it("matches unreachable host", () => {
+    expect(isConnectionErrorMessage("connect EHOSTUNREACH 10.0.0.1:443")).toBe(true);
+  });
+
+  it("matches 'unable to connect' variants", () => {
+    expect(isConnectionErrorMessage("unable to connect to the server")).toBe(true);
+    expect(isConnectionErrorMessage("Unable to connect")).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isConnectionErrorMessage("invalid api key")).toBe(false);
+    expect(isConnectionErrorMessage("rate limit exceeded")).toBe(false);
+    expect(isConnectionErrorMessage("context length exceeded")).toBe(false);
+    expect(isConnectionErrorMessage("overloaded")).toBe(false);
+    expect(isConnectionErrorMessage("")).toBe(false);
+    expect(isConnectionErrorMessage("some random error")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers.isfailovererrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isfailovererrormessage.test.ts
@@ -22,4 +22,16 @@ describe("isFailoverErrorMessage", () => {
       expect(isFailoverErrorMessage(sample)).toBe(true);
     }
   });
+  it("matches connection errors", () => {
+    const samples = [
+      "Connection error.",
+      "connect ECONNREFUSED 127.0.0.1:443",
+      "fetch failed",
+      "socket hang up",
+      "network error",
+    ];
+    for (const sample of samples) {
+      expect(isFailoverErrorMessage(sample)).toBe(true);
+    }
+  });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -33,6 +33,7 @@ export {
   isRateLimitErrorMessage,
   isTransientHttpError,
   isTimeoutErrorMessage,
+  isConnectionErrorMessage,
   parseImageDimensionError,
   parseImageSizeError,
 } from "./pi-embedded-helpers/errors.js";


### PR DESCRIPTION
## Problem

Users see `Model errorMessage: "Connection error."` when the AI provider is unreachable (e.g., incorrect base URL, DNS failure, network issues). The error comes from the OpenAI SDK's `APIConnectionError` which defaults to the generic message `"Connection error."`.

This message was **not recognized** by the failover/retry system, so:
1. No automatic retry or auth profile rotation happened
2. The raw `"Connection error."` was shown to users with no actionable guidance
3. The error kept repeating with exponential backoff but no failover

## Root Cause

The `classifyFailoverReason()` function in `pi-embedded-helpers/errors.ts` had no pattern for connection-level errors. Similarly, `resolveFailoverReasonFromError()` in `failover-error.ts` only handled `ECONNRESET` and `ECONNABORTED` error codes but missed `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `EHOSTUNREACH`, and the `APIConnectionError` error name from the SDK.

## Fix

### Error Detection (`pi-embedded-helpers/errors.ts`)
- Added `connection` error patterns matching: `Connection error.`, `ECONNREFUSED`, `ECONNRESET`, `ECONNABORTED`, `fetch failed`, `socket hang up`, `network error/failure/unavailable`, `APIConnectionError`, DNS failures (`EAI_AGAIN`, `ENOTFOUND`, `EHOSTUNREACH`), and `unable to connect`
- New `isConnectionErrorMessage()` function exported
- `classifyFailoverReason()` now returns `"timeout"` for connection errors, enabling automatic retry and auth profile rotation
- `formatAssistantErrorText()` and `sanitizeUserFacingText()` now show: *"Unable to connect to the AI provider. Check your internet connection, verify the provider's base URL is correct, and ensure the service is reachable."*

### Exception Handling (`failover-error.ts`)
- Added `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `EHOSTUNREACH` to error code detection
- Added `APIConnectionError` and `APIConnectionTimeoutError` name detection in `resolveFailoverReasonFromError()`

### Tests
- New test file: `pi-embedded-helpers.isconnectionerrormessage.test.ts` (12 tests)
- Extended `classifyFailoverReason` tests with connection error cases
- Extended `formatAssistantErrorText` tests with connection error cases  
- Extended `failover-error` tests with new error codes, error names, and coercion
- Extended `isFailoverErrorMessage` tests with connection error samples

Fixes #14866

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves failover/retry behavior and user-facing messaging for provider connection failures.

Changes include:
- Adding connection-level heuristics in `src/agents/pi-embedded-helpers/errors.ts` via a new `isConnectionErrorMessage()` helper and a new `ERROR_PATTERNS.connection` group.
- Classifying connection failures as `timeout` in `classifyFailoverReason()`, so the existing failover pipeline treats them as retryable.
- Updating `formatAssistantErrorText()` and `sanitizeUserFacingText({ errorContext: true })` to show a more actionable message for connection errors.
- Extending `resolveFailoverReasonFromError()` in `src/agents/failover-error.ts` to recognize common Node/DNS codes and OpenAI SDK connection error names, with expanded tests covering these cases.

Overall, this fits into the existing failover/error-normalization layer by broadening the set of transport errors that are treated as retryable and by ensuring users see guidance instead of a generic SDK message.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to error classification and formatting, add targeted tests, and preserve existing behavior for non-connection errors. No verified regressions or newly introduced compile/runtime issues were found in the modified code paths.
- No files require special attention

<sub>Last reviewed commit: de25d45</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->