### PR TITLE
fix(feishu): compute CommandAuthorized dynamically instead of hardcoding true

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -905,11 +905,8 @@ export async function handleFeishuMessage(params: {
       Timestamp: Date.now(),
       WasMentioned: ctx.mentionedBot,
       CommandAuthorized: resolveControlCommandGate({
-        useAccessGroups: cfg.accessGroups?.enabled ?? false,
-        authorizers:
-          senderAllowFrom.length > 0
-            ? [{ configured: true, allowed: true }] // already passed allowlist check above
-            : [],
+        useAccessGroups: cfg.commands?.useAccessGroups !== false,
+        authorizers: [{ configured: true, allowed: true }], // sender already passed allowlist check above
         allowTextCommands: true,
         hasControlCommand: false,
       }).commandAuthorized,


### PR DESCRIPTION
Fixes #14875

The Feishu channel hardcoded `CommandAuthorized: true` for every inbound message, bypassing access group command gating. Now uses `resolveControlCommandGate` (same as Telegram/Discord) to respect access group configuration.

The permission-error path now correctly sets `CommandAuthorized: false`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Feishu inbound message handling to stop hardcoding `CommandAuthorized: true` and instead compute it via `resolveControlCommandGate`, aligning Feishu with other channels’ command gating behavior. It also fixes the permission-error notification path to mark `CommandAuthorized: false`.

However, the new gating call in `extensions/feishu/src/bot.ts` references `senderAllowFrom` outside of its scope, which will cause a TypeScript compile failure and needs to be addressed before merge.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a definite TypeScript compilation error in the Feishu bot handler.
- The change introduces a reference to `senderAllowFrom` at the `finalizeInboundContext` call site, but that identifier is only declared inside an earlier block, making it out of scope and a guaranteed build break.
- extensions/feishu/src/bot.ts

<sub>Last reviewed commit: 832f46b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->