### PR TITLE
fix: resolve Telegram delivery target from allowFrom for isolated cron sessions

### DIFF
--- a/src/channels/plugins/outbound/telegram.test.ts
+++ b/src/channels/plugins/outbound/telegram.test.ts
@@ -78,3 +78,43 @@ describe("telegramOutbound.sendPayload", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "m2", chatId: "c1" });
   });
 });
+
+describe("telegramOutbound.resolveTarget", () => {
+  const resolve = telegramOutbound.resolveTarget!;
+
+  it("returns explicit to when provided", () => {
+    expect(resolve({ to: "12345", allowFrom: ["99999"], mode: "explicit" })).toEqual({
+      ok: true,
+      to: "12345",
+    });
+  });
+
+  it("falls back to allowFrom[0] in implicit mode when to is empty", () => {
+    expect(resolve({ to: "", allowFrom: ["12345"], mode: "implicit" })).toEqual({
+      ok: true,
+      to: "12345",
+    });
+  });
+
+  it("falls back to allowFrom[0] in heartbeat mode when to is empty", () => {
+    expect(resolve({ to: undefined, allowFrom: ["12345"], mode: "heartbeat" })).toEqual({
+      ok: true,
+      to: "12345",
+    });
+  });
+
+  it("does NOT fall back to allowFrom in explicit mode", () => {
+    const result = resolve({ to: "", allowFrom: ["12345"], mode: "explicit" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error when to is empty and allowFrom is empty", () => {
+    const result = resolve({ to: "", allowFrom: [], mode: "implicit" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error when to is empty and no allowFrom", () => {
+    const result = resolve({ to: undefined, mode: "implicit" });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent.resolves-telegram-target-from-allowfrom-14646.test.ts
+++ b/src/cron/isolated-agent.resolves-telegram-target-from-allowfrom-14646.test.ts
@@ -1,0 +1,298 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
+import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { CronJob } from "./types.js";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { telegramOutbound } from "../channels/plugins/outbound/telegram.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+vi.mock("../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn(),
+}));
+
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-cron-" });
+}
+
+/**
+ * Build a Telegram test plugin that mirrors the real dock's resolveAllowFrom
+ * behaviour so resolveOutboundTarget can discover the allowFrom list.
+ */
+function buildTelegramTestPlugin(): ChannelPlugin {
+  return {
+    id: "telegram",
+    meta: {
+      id: "telegram",
+      label: "Telegram",
+      selectionLabel: "Telegram",
+      docsPath: "/channels/telegram",
+      blurb: "test stub.",
+    },
+    capabilities: { chatTypes: ["direct", "group"] },
+    config: {
+      listAccountIds: () => [],
+      resolveAccount: () => ({}),
+      resolveAllowFrom: ({ cfg }: { cfg: OpenClawConfig }) => {
+        const raw = (cfg as Record<string, unknown>).channels as
+          | { telegram?: { allowFrom?: Array<string | number> } }
+          | undefined;
+        return (raw?.telegram?.allowFrom ?? []).map((entry) => String(entry));
+      },
+    },
+    outbound: telegramOutbound,
+  };
+}
+
+function makeCfg(
+  home: string,
+  storePath: string,
+  overrides: Partial<OpenClawConfig> = {},
+): OpenClawConfig {
+  const base: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-opus-4-5",
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+  } as OpenClawConfig;
+  return { ...base, ...overrides };
+}
+
+function makeJob(payload: CronJob["payload"]): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-1",
+    name: "job-1",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload,
+    state: {},
+  };
+}
+
+function makeDeps(): CliDeps {
+  return {
+    sendMessageWhatsApp: vi.fn(),
+    sendMessageTelegram: vi.fn().mockResolvedValue({ messageId: "t1", chatId: "456" }),
+    sendMessageDiscord: vi.fn(),
+    sendMessageSignal: vi.fn(),
+    sendMessageIMessage: vi.fn(),
+  };
+}
+
+describe("runCronIsolatedAgentTurn — #14646 regression", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+    vi.mocked(runSubagentAnnounceFlow).mockReset().mockResolvedValue(true);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          plugin: buildTelegramTestPlugin(),
+          source: "test",
+        },
+      ]),
+    );
+  });
+
+  it("resolves delivery target from allowFrom when to is empty and lastChannel differs", async () => {
+    await withTempHome(async (home) => {
+      // Main session's lastChannel is webchat — NOT telegram.
+      // This previously caused the delivery target to be unresolvable,
+      // silently skipping the announce flow (#14646).
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            "agent:main:main": {
+              sessionId: "main-session",
+              updatedAt: Date.now(),
+              lastChannel: "webchat",
+              lastTo: "web-user",
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: {
+            telegram: {
+              botToken: "t-1",
+              allowFrom: [456],
+            },
+          },
+        }),
+        deps,
+        job: {
+          ...makeJob({ kind: "agentTurn", message: "weather check" }),
+          // delivery.to is absent — system must resolve from allowFrom
+          delivery: { mode: "announce", channel: "telegram" },
+        },
+        message: "weather check",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      // The announce flow must be called — target resolved from allowFrom[0].
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as
+        | { requesterOrigin?: { channel?: string; to?: string } }
+        | undefined;
+      expect(args?.requesterOrigin?.channel).toBe("telegram");
+      expect(args?.requesterOrigin?.to).toBe("456");
+    });
+  });
+
+  it("resolves delivery target from allowFrom when to is empty string", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            "agent:main:main": {
+              sessionId: "main-session",
+              updatedAt: Date.now(),
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Done" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: {
+            telegram: {
+              botToken: "t-1",
+              allowFrom: [789],
+            },
+          },
+        }),
+        deps,
+        job: {
+          ...makeJob({ kind: "agentTurn", message: "do it" }),
+          delivery: { mode: "announce", channel: "telegram", to: "" },
+        },
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as
+        | { requesterOrigin?: { channel?: string; to?: string } }
+        | undefined;
+      expect(args?.requesterOrigin?.channel).toBe("telegram");
+      expect(args?.requesterOrigin?.to).toBe("789");
+    });
+  });
+
+  it("still fails when to is empty, no allowFrom, and bestEffort is false", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            "agent:main:main": {
+              sessionId: "main-session",
+              updatedAt: Date.now(),
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Done" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "p", model: "m" },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: {
+            telegram: {
+              botToken: "t-1",
+              // No allowFrom configured
+            },
+          },
+        }),
+        deps,
+        job: {
+          ...makeJob({ kind: "agentTurn", message: "do it" }),
+          delivery: { mode: "announce", channel: "telegram", to: "" },
+        },
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      // Should fail because there's no way to resolve the target.
+      expect(res.status).toBe("error");
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -79,16 +79,10 @@ export async function resolveDeliveryTarget(
       ? resolved.threadId
       : undefined;
 
-  if (!toCandidate) {
-    return {
-      channel,
-      to: undefined,
-      accountId: resolved.accountId,
-      threadId,
-      mode,
-    };
-  }
-
+  // Always run through resolveOutboundTarget — even when the session did not
+  // yield a `to` candidate.  Channel plugins with a `resolveTarget` hook (e.g.
+  // WhatsApp, Telegram) can fall back to `allowFrom[0]` in implicit mode,
+  // which covers the common case of cron delivery with an empty `to` field.
   const docked = resolveOutboundTarget({
     channel,
     to: toCandidate,


### PR DESCRIPTION
## Summary

When an isolated cron job has `delivery.mode=announce` with `channel="telegram"` but an empty `to` field, the delivery target could not be resolved, silently skipping the announce flow. Messages never reached Telegram.

## Root Cause

`resolveDeliveryTarget()` in `src/cron/isolated-agent/delivery-target.ts` returned early with `to: undefined` when the session's `lastTo` could not be matched to the requested channel (e.g. `lastChannel` was "webchat" but delivery requested "telegram"). It never called `resolveOutboundTarget()`, so the Telegram plugin never got a chance to fall back to `allowFrom[0]`.

This is distinct from #14605 (duplicate system-event leaking). That PR (#14891) removes the redundant fallback path; this PR fixes the **primary** announce delivery path so it actually resolves the target.

## Fix

**1. Telegram outbound adapter — add `resolveTarget` hook** (`src/channels/plugins/outbound/telegram.ts`)

Parity with WhatsApp: when `to` is empty and mode is `implicit` or `heartbeat`, fall back to `allowFrom[0]` from the channel config.

**2. Cron delivery target — remove premature early-return** (`src/cron/isolated-agent/delivery-target.ts`)

Previously, when `toCandidate` was undefined the function returned `to: undefined` without consulting `resolveOutboundTarget`. Now it always passes through `resolveOutboundTarget`, giving channel plugins a chance to resolve the target from their configuration.

## Testing

- **6 new tests** for `telegramOutbound.resolveTarget` (explicit, implicit fallback, heartbeat fallback, explicit-mode rejection, empty allowFrom, missing allowFrom)
- **3 new regression tests** for `runCronIsolatedAgentTurn` covering #14646:
  - Empty `to` with mismatched `lastChannel` → resolves from `allowFrom`
  - Empty string `to` → resolves from `allowFrom`
  - Empty `to` without `allowFrom` → correctly fails

All 133 cron+telegram tests pass. `pnpm check` clean (format, tsgo, lint).

Closes #14646

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes announce delivery for isolated cron sessions targeting Telegram when `delivery.to` is empty.

Key changes:
- Adds a `resolveTarget` hook to the Telegram outbound adapter so it can resolve an empty `to` via `channels.telegram.allowFrom[0]` (in implicit/heartbeat modes), mirroring WhatsApp behavior.
- Updates cron isolated-agent delivery target resolution to always run through `resolveOutboundTarget()` (removing an early return), allowing channel plugins to apply their `resolveTarget` fallback.
- Adds unit tests for the new Telegram `resolveTarget` behavior and a regression test suite covering the cron isolated-agent scenario from #14646.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one contract-mismatch edge case to address in Telegram target resolution.
- The delivery-target change is straightforward and covered by regression tests. The new Telegram `resolveTarget` hook is consistent with the existing WhatsApp pattern, but its parameter handling assumes `mode` is always provided; the adapter contract allows `mode` to be omitted, which can lead to incorrect missing-target errors in call sites that invoke `resolveTarget` without a mode.
- src/channels/plugins/outbound/telegram.ts

<sub>Last reviewed commit: cb60980</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->