### PR TITLE
feat(browser): add browser.args config for custom Chrome launch flags

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -60,6 +60,7 @@ function buildSandboxBrowserResolvedConfig(params: {
     color: DEFAULT_OPENCLAW_BROWSER_COLOR,
     executablePath: undefined,
     headless: params.headless,
+    args: [],
     noSandbox: false,
     attachOnly: true,
     defaultProfile: DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -214,6 +214,11 @@ export async function launchOpenClawChrome(
       args.push("--disable-dev-shm-usage");
     }
 
+    // Append user-configured extra args (e.g. --enable-gpu, --use-gl=egl).
+    if (resolved.args.length > 0) {
+      args.push(...resolved.args);
+    }
+
     // Always open a blank tab to ensure a target exists.
     args.push("about:blank");
 

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -28,6 +28,7 @@ export type ResolvedBrowserConfig = {
   executablePath?: string;
   headless: boolean;
   noSandbox: boolean;
+  args: string[];
   attachOnly: boolean;
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
@@ -179,6 +180,9 @@ export function resolveBrowserConfig(
 
   const headless = cfg?.headless === true;
   const noSandbox = cfg?.noSandbox === true;
+  const args = Array.isArray(cfg?.args)
+    ? cfg.args.filter((a): a is string => typeof a === "string")
+    : [];
   const attachOnly = cfg?.attachOnly === true;
   const executablePath = cfg?.executablePath?.trim() || undefined;
 
@@ -209,6 +213,7 @@ export function resolveBrowserConfig(
     executablePath,
     headless,
     noSandbox,
+    args,
     attachOnly,
     defaultProfile,
     profiles,

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -30,6 +30,8 @@ export type BrowserConfig = {
   headless?: boolean;
   /** Pass --no-sandbox to Chrome (Linux containers). Default: false */
   noSandbox?: boolean;
+  /** Extra Chrome launch arguments (e.g. ["--enable-gpu", "--use-gl=egl"]). */
+  args?: string[];
   /** If true: never launch; only attach to an existing browser. Default: false */
   attachOnly?: boolean;
   /** Default profile to use when profile param is omitted. Default: "chrome" */


### PR DESCRIPTION
Closes #14803

Adds `browser.args` config field to pass extra Chrome arguments (e.g. `["--enable-gpu", "--use-gl=egl"]`) for GPU-accelerated headless rendering or platform-specific tweaks.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `browser.args` configuration field intended to pass additional Chrome launch flags through the browser config resolver into the Chrome spawn args list.

The change fits into the existing browser subsystem by extending `ResolvedBrowserConfig` and `resolveBrowserConfig()` (`src/browser/config.ts`) and then appending those args in `launchOpenClawChrome()` (`src/browser/chrome.ts`).

One blocker: the runtime config validation schema (`src/config/zod-schema.ts`) defines `browser` as a strict object and currently does not allow `args`, so configs setting `browser.args` will be rejected and the new feature won’t be usable until the schema is updated.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because the new config field will be rejected by runtime validation.
- Core implementation is straightforward, but `browser.args` is missing from the strict Zod config schema, which will prevent users from enabling the feature via config without validation errors.
- src/config/zod-schema.ts

<sub>Last reviewed commit: 65a91f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->