### PR TITLE
fix(googlechat): convert Markdown bold/strikethrough to Google Chat markup

### DIFF
--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -95,6 +95,15 @@ const googlechatActions: ChannelMessageActionAdapter = {
   },
 };
 
+/**
+ * Convert standard Markdown formatting to Google Chat markup.
+ * Google Chat uses: *bold*, _italic_, ~strikethrough~, `code`
+ * Markdown uses:    **bold**, *italic*, ~~strikethrough~~, `code`
+ */
+function markdownToGoogleChat(text: string): string {
+  return text.replace(/\*\*(.+?)\*\*/g, "*$1*").replace(/~~(.+?)~~/g, "~$1~");
+}
+
 export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
   id: "googlechat",
   meta: { ...meta },
@@ -421,7 +430,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
       const result = await sendGoogleChatMessage({
         account,
         space,
-        text,
+        text: markdownToGoogleChat(text),
         thread,
       });
       return {
@@ -466,7 +475,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
       const result = await sendGoogleChatMessage({
         account,
         space,
-        text,
+        text: markdownToGoogleChat(text),
         thread,
         attachments: upload.attachmentUploadToken
           ? [{ attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName }]


### PR DESCRIPTION
Closes #14825

Google Chat uses `*bold*` and `~strike~` while Markdown uses `**bold**` and `~~strike~~`. Text was sent as-is, showing literal asterisks.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a small `markdownToGoogleChat()` helper and uses it when sending outbound Google Chat messages/attachments so `**bold**` and `~~strike~~` are converted to Google Chat’s `*bold*` and `~strike~`.

However, Google Chat replies sent from the monitor path (`extensions/googlechat/src/monitor.ts`), including typing-message updates and chunked replies, still send text without conversion. That means the formatting fix is only partial: messages sent through the plugin outbound API are fixed, but typical agent replies delivered by the monitor will still render literal Markdown markers.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe, but it likely doesn’t fully fix the reported formatting issue because conversion is not applied on all Google Chat outbound paths.
- The change is small and localized, but outbound text conversion is only applied in `extensions/googlechat/src/channel.ts` and not in the monitor-based reply delivery path, so user-visible formatting inconsistencies will persist.
- extensions/googlechat/src/monitor.ts (reply delivery path) and extensions/googlechat/src/channel.ts (ensure all outbound sends share the same formatting behavior)

<sub>Last reviewed commit: 356b7a8</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->