### PR TITLE
fix: resolve cron delivery target for Telegram channels (#14743)

### DIFF
--- a/src/channels/plugins/outbound/telegram.resolveTarget.test.ts
+++ b/src/channels/plugins/outbound/telegram.resolveTarget.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { setActivePluginRegistry } from "../../../plugins/runtime.js";
+import {
+  createOutboundTestPlugin,
+  createTestRegistry,
+} from "../../../test-utils/channel-plugins.js";
+import { telegramOutbound } from "./telegram.js";
+
+describe("telegramOutbound.resolveTarget", () => {
+  const resolveTarget = telegramOutbound.resolveTarget!;
+
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          plugin: createOutboundTestPlugin({ id: "telegram", outbound: telegramOutbound }),
+          source: "test",
+        },
+      ]),
+    );
+  });
+
+  it("normalizes bare numeric chat id", () => {
+    const result = resolveTarget({ to: "123456789", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "telegram:123456789" });
+  });
+
+  it("normalizes negative group chat id", () => {
+    const result = resolveTarget({ to: "-1001234567890", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "telegram:-1001234567890" });
+  });
+
+  it("normalizes telegram: prefixed targets", () => {
+    const result = resolveTarget({ to: "telegram:987654321", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "telegram:987654321" });
+  });
+
+  it("normalizes tg: prefixed targets", () => {
+    const result = resolveTarget({ to: "tg:111222333", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "telegram:111222333" });
+  });
+
+  it("normalizes @username targets", () => {
+    const result = resolveTarget({ to: "@mybot", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "telegram:@mybot" });
+  });
+
+  it("normalizes t.me link targets", () => {
+    const result = resolveTarget({ to: "https://t.me/mybot", mode: "explicit" });
+    expect(result).toEqual({ ok: true, to: "telegram:@mybot" });
+  });
+
+  it("returns error for empty target in explicit mode", () => {
+    const result = resolveTarget({ to: "", mode: "explicit" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error for undefined target in explicit mode", () => {
+    const result = resolveTarget({ to: undefined, mode: "explicit" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("falls back to allowFrom in implicit mode when to is empty", () => {
+    const result = resolveTarget({
+      to: "",
+      allowFrom: ["123456789"],
+      mode: "implicit",
+    });
+    expect(result).toEqual({ ok: true, to: "telegram:123456789" });
+  });
+
+  it("falls back to allowFrom in heartbeat mode when to is empty", () => {
+    const result = resolveTarget({
+      to: undefined,
+      allowFrom: ["999888777"],
+      mode: "heartbeat",
+    });
+    expect(result).toEqual({ ok: true, to: "telegram:999888777" });
+  });
+
+  it("returns error when no target and no allowFrom in implicit mode", () => {
+    const result = resolveTarget({ to: "", mode: "implicit" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("passes through non-normalizable target as-is", () => {
+    // sendMessageTelegram has its own normalizeChatId for edge cases
+    const result = resolveTarget({ to: "some_custom_target", mode: "explicit" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // normalizeTelegramMessagingTarget should handle usernames
+      expect(result.to).toBe("telegram:some_custom_target");
+    }
+  });
+});

--- a/src/cron/isolated-agent.issue-14743.test.ts
+++ b/src/cron/isolated-agent.issue-14743.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Regression test for #14743: Cron job delivery modes (announce)
+ * fail to deliver messages to Telegram despite successful execution.
+ *
+ * Root causes:
+ * 1. Telegram outbound adapter lacked a `resolveTarget` function, so bare
+ *    Telegram IDs were not normalized through `normalizeTelegramMessagingTarget`
+ *    before reaching the outbound send path. Without `resolveTarget`, there was
+ *    also no `allowFrom` fallback when `to` was empty in implicit/heartbeat mode.
+ * 2. When the main session's `lastChannel` didn't match the requested delivery
+ *    channel (e.g. after a gateway restart cleared the session state, or the
+ *    user's last interaction was on a different channel), `resolveDeliveryTarget`
+ *    couldn't find a `to`. A session store fallback now scans other sessions.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { CronJob } from "./types.js";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { telegramOutbound } from "../channels/plugins/outbound/telegram.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+vi.mock("../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn(),
+}));
+
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-cron-14743-" });
+}
+
+function makeCfg(
+  home: string,
+  storePath: string,
+  overrides: Partial<OpenClawConfig> = {},
+): OpenClawConfig {
+  const base: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-opus-4-5",
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+  } as OpenClawConfig;
+  return { ...base, ...overrides };
+}
+
+function makeJob(overrides: Partial<CronJob> = {}): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-1",
+    name: "daily-digest",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "run daily digest" },
+    state: {},
+    ...overrides,
+  };
+}
+
+function makeDeps(): CliDeps {
+  return {
+    sendMessageWhatsApp: vi.fn(),
+    sendMessageTelegram: vi.fn().mockResolvedValue({ messageId: "t1", chatId: "123" }),
+    sendMessageDiscord: vi.fn(),
+    sendMessageSignal: vi.fn(),
+    sendMessageIMessage: vi.fn(),
+  };
+}
+
+describe("issue #14743 – cron delivery to Telegram", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+    vi.mocked(runSubagentAnnounceFlow).mockReset().mockResolvedValue(true);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          plugin: createOutboundTestPlugin({ id: "telegram", outbound: telegramOutbound }),
+          source: "test",
+        },
+      ]),
+    );
+  });
+
+  it("normalizes bare numeric Telegram ID in delivery target via resolveTarget", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "user:111222333",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { telegram: { botToken: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram", to: "123456789" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("telegram");
+      // Bare ID should be normalized through normalizeTelegramMessagingTarget
+      expect(args?.requesterOrigin?.to).toBe("telegram:123456789");
+    });
+  });
+
+  it("preserves telegram: prefixed target through delivery pipeline", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { telegram: { botToken: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram", to: "telegram:987654321" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.to).toBe("telegram:987654321");
+    });
+  });
+
+  it("finds Telegram target from other session entries when main session lastChannel differs", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      // Main session is on webchat, but a Telegram DM session exists
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "webchat",
+            lastTo: "web-user-1",
+          },
+          "agent:main:telegram:dm:user:555": {
+            sessionId: "telegram-dm-session",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "555",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { telegram: { botToken: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      expect(args?.requesterOrigin?.channel).toBe("telegram");
+      // Found from the Telegram DM session entry, then normalized
+      expect(args?.requesterOrigin?.to).toBe("telegram:555");
+    });
+  });
+
+  it("still errors when no session entry has a Telegram target and to is empty", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      // No session has ever used Telegram
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "webchat",
+            lastTo: "web-user-1",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Weather report: sunny skies" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { telegram: { botToken: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("error");
+      expect(res.error).toBe("cron delivery target is missing");
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    });
+  });
+
+  it("normalizes target from session store fallback through resolveTarget", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw", "sessions");
+      await fs.mkdir(dir, { recursive: true });
+      const storePath = path.join(dir, "sessions.json");
+      // Main session on webchat, Telegram session has bare numeric lastTo
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastChannel: "webchat",
+            lastTo: "web-user-1",
+          },
+          "agent:main:telegram:dm:user:444": {
+            sessionId: "tg-session",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "444555666",
+          },
+        }),
+        "utf-8",
+      );
+
+      const deps = makeDeps();
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "Here is the report" }],
+        meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "p", model: "m" } },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath, {
+          channels: { telegram: { botToken: "test-token" } },
+        }),
+        deps,
+        job: makeJob({
+          delivery: { mode: "announce", channel: "telegram" },
+        }),
+        message: "run daily digest",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const args = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as {
+        requesterOrigin?: { channel?: string; to?: string };
+      };
+      // Found from the Telegram session, then normalized through resolveTarget
+      expect(args?.requesterOrigin?.to).toBe("telegram:444555666");
+    });
+  });
+});

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -240,7 +240,7 @@ describe("runCronIsolatedAgentTurn", () => {
         | { requesterOrigin?: { threadId?: string | number; channel?: string; to?: string } }
         | undefined;
       expect(announceArgs?.requesterOrigin?.channel).toBe("telegram");
-      expect(announceArgs?.requesterOrigin?.to).toBe("123");
+      expect(announceArgs?.requesterOrigin?.to).toBe("telegram:123");
       expect(announceArgs?.requesterOrigin?.threadId).toBe(42);
     });
   });

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -12,6 +12,43 @@ import {
   resolveOutboundTarget,
   resolveSessionDeliveryTarget,
 } from "../../infra/outbound/targets.js";
+import { deliveryContextFromSession } from "../../utils/delivery-context.js";
+import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
+
+/**
+ * When the main session's lastChannel doesn't match the requested channel,
+ * scan all session entries for the same agent to find one whose lastChannel
+ * matches. This handles the common case where the user configured a cron to
+ * deliver on a specific channel (e.g. Telegram) but their main session's
+ * lastChannel has since changed to another channel (e.g. webchat), or was
+ * never set for that channel.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/14646
+ * See: https://github.com/openclaw/openclaw/issues/14743
+ * See: https://github.com/openclaw/openclaw/issues/14753
+ */
+function findDeliveryTargetFromStore(
+  store: Record<string, unknown>,
+  requestedChannel: string,
+  excludeKey?: string,
+): { to: string; accountId?: string; threadId?: string | number } | undefined {
+  for (const [key, entry] of Object.entries(store)) {
+    if (key === excludeKey || !entry || typeof entry !== "object") {
+      continue;
+    }
+    const ctx = deliveryContextFromSession(
+      entry as Parameters<typeof deliveryContextFromSession>[0],
+    );
+    if (
+      ctx?.channel === requestedChannel &&
+      typeof ctx.to === "string" &&
+      ctx.to.trim().length > 0
+    ) {
+      return { to: ctx.to, accountId: ctx.accountId, threadId: ctx.threadId };
+    }
+  }
+  return undefined;
+}
 
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
@@ -68,7 +105,26 @@ export async function resolveDeliveryTarget(
 
   const channel = resolved.channel ?? fallbackChannel ?? DEFAULT_CHAT_CHANNEL;
   const mode = resolved.mode as "explicit" | "implicit";
-  const toCandidate = resolved.to;
+  let toCandidate = resolved.to;
+  let accountId = resolved.accountId;
+
+  // #14646 / #14743 / #14753: When an explicit channel is requested but the
+  // main session's lastChannel doesn't match (e.g. user interacts via Telegram
+  // DMs but main session lastChannel was set to webchat, or was cleared after a
+  // restart), the initial resolution can't find a `to`. Fall back to scanning
+  // the session store for ANY entry that was last used on the requested channel.
+  if (
+    !toCandidate &&
+    !explicitTo &&
+    requestedChannel !== "last" &&
+    isDeliverableMessageChannel(channel)
+  ) {
+    const storeHit = findDeliveryTargetFromStore(store, channel, mainSessionKey);
+    if (storeHit) {
+      toCandidate = storeHit.to;
+      accountId = storeHit.accountId ?? accountId;
+    }
+  }
 
   // Only carry threadId when delivering to the same recipient as the session's
   // last conversation. This prevents stale thread IDs (e.g. from a Telegram
@@ -83,7 +139,7 @@ export async function resolveDeliveryTarget(
     return {
       channel,
       to: undefined,
-      accountId: resolved.accountId,
+      accountId,
       threadId,
       mode,
     };
@@ -93,13 +149,13 @@ export async function resolveDeliveryTarget(
     channel,
     to: toCandidate,
     cfg,
-    accountId: resolved.accountId,
+    accountId,
     mode,
   });
   return {
     channel,
     to: docked.ok ? docked.to : undefined,
-    accountId: resolved.accountId,
+    accountId,
     threadId,
     mode,
     error: docked.ok ? undefined : docked.error,


### PR DESCRIPTION
## Problem

Cron jobs with `delivery: { mode: "announce", channel: "telegram", to: "1234567890" }` fail to deliver messages to Telegram. The cron completes successfully but no message appears in Telegram, and no errors are visible in cron run logs.

### Root Causes

**1. Bare Telegram IDs bypass outbound target normalization**

When `resolveDeliveryTarget` passes a bare numeric Telegram ID (e.g. `"1234567890"`) through `resolveOutboundTarget`, it returns successfully because the Telegram plugin had no `resolveTarget` function (just returns the trimmed string). Without `resolveTarget`, there was also no `allowFrom` fallback when `to` was empty in implicit/heartbeat mode.

The downstream error is silently swallowed because:
- The announce flow uses `callGateway({ method: "agent" })` which spawns an async agent run
- The gateway sets `bestEffortDeliver = true` for main session runs
- `deliverOutboundPayloads` catches the error via `bestEffort`, logs it to `runtime.error` (not cron run logs)
- The cron run reports "ok" since the announce call itself succeeded

**2. Session store has no fallback for channel mismatch**

When the main session's `lastChannel` doesn't match the requested delivery channel (common after a gateway restart clears session state, or when the user's last interaction was via a different channel), `resolveDeliveryTarget` cannot find a `to` from the session's `lastTo` field. This silently returns `to: undefined`, causing the "cron delivery target is missing" error path.

### Fix

**Fix 1: Add `resolveTarget` to Telegram outbound adapter**

Normalizes Telegram targets before they reach `sendMessageTelegram`:
- Bare numeric IDs → `telegram:<id>` (using `normalizeTelegramMessagingTarget`)
- Already-prefixed targets (`telegram:`, `tg:`) → preserved/normalized
- `@username` and `t.me` link targets → normalized
- Empty targets in implicit/heartbeat mode → falls back to `allowFrom[0]`

This is the same pattern WhatsApp uses (WhatsApp already has `resolveTarget`), and parallels the Discord fix in PR #14846.

**Fix 2: Session store fallback for channel mismatch**

When the main session's `lastChannel` doesn't match the requested delivery channel, scan all session entries for one whose `lastChannel` matches. This is the same fix as PR #14846 (for Discord), applied here for all channels including Telegram.

**Fix 3: Normalize messaging tool delivery target comparison**

`matchesMessagingToolDeliveryTarget` now strips channel prefixes before comparing, so `telegram:123` correctly matches `123` from the messaging tool's sent target.

### Tests

**12 unit tests** for `telegramOutbound.resolveTarget`:
- Bare numeric ID normalization → `telegram:<id>`
- Negative group ID normalization
- Prefixed targets preserved (`telegram:`, `tg:`)
- `@username` and `t.me` link normalization  
- Empty/undefined target error handling
- `allowFrom` fallback in implicit/heartbeat modes
- Non-normalizable target passthrough

**5 integration tests** for cron Telegram delivery:
- Bare numeric ID in `delivery.to` → normalized to `telegram:<id>` in announce origin
- `telegram:` prefixed target preserved through delivery pipeline
- Session store fallback when main session `lastChannel` differs
- Proper error when no session has Telegram target and `to` is empty
- Combined session store fallback + resolveTarget normalization

Fixes #14743

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes Telegram cron “announce” delivery by adding `resolveTarget` to the Telegram outbound adapter (so bare IDs / `tg:` / `t.me` / `@user` are normalized) and by enhancing cron delivery target resolution to fall back to scanning the session store when the main session’s `lastChannel` doesn’t match the requested delivery channel. It also updates messaging-tool target matching to treat prefixed and unprefixed targets (e.g. `telegram:123` vs `123`) as equivalent.

The overall approach fits the existing outbound “docking” flow (`resolveOutboundTarget` → plugin `resolveTarget`) and the cron isolated-agent delivery pipeline, but there’s one correctness issue in the new session-store fallback that can drop thread/topic routing data.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix the threadId propagation bug in the new session-store fallback first.
- Core changes are localized and well-covered by tests, but `resolveDeliveryTarget`’s new store-scan fallback ignores the matched session’s `threadId`, which can break/misroute deliveries for thread/topic-based channels when the fallback path is used.
- src/cron/isolated-agent/delivery-target.ts

<sub>Last reviewed commit: d0d26ff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->