### PR TITLE
fix: handle venice-models fetch timeout to prevent gateway crash (#14281)

### DIFF
--- a/src/agents/venice-models.test.ts
+++ b/src/agents/venice-models.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVeniceModelDefinition,
+  discoverVeniceModels,
+  VENICE_DEFAULT_COST,
+  VENICE_MODEL_CATALOG,
+} from "./venice-models.js";
+
+describe("buildVeniceModelDefinition", () => {
+  it("maps a catalog entry to a ModelDefinitionConfig", () => {
+    const entry = VENICE_MODEL_CATALOG[0];
+    const result = buildVeniceModelDefinition(entry);
+
+    expect(result.id).toBe(entry.id);
+    expect(result.name).toBe(entry.name);
+    expect(result.reasoning).toBe(entry.reasoning);
+    expect(result.input).toEqual([...entry.input]);
+    expect(result.cost).toEqual(VENICE_DEFAULT_COST);
+    expect(result.contextWindow).toBe(entry.contextWindow);
+    expect(result.maxTokens).toBe(entry.maxTokens);
+  });
+
+  it("does not include the privacy field in the output", () => {
+    const entry = VENICE_MODEL_CATALOG[0];
+    const result = buildVeniceModelDefinition(entry);
+
+    expect(result).not.toHaveProperty("privacy");
+  });
+});
+
+describe("discoverVeniceModels", () => {
+  it("returns static catalog in test environment (VITEST is set)", async () => {
+    // VITEST env var is set by the test runner itself
+    const models = await discoverVeniceModels();
+
+    expect(models.length).toBe(VENICE_MODEL_CATALOG.length);
+    expect(models[0].id).toBe(VENICE_MODEL_CATALOG[0].id);
+  });
+
+  it("returns static catalog when skipNetwork is true", async () => {
+    const models = await discoverVeniceModels({ skipNetwork: true });
+
+    expect(models.length).toBe(VENICE_MODEL_CATALOG.length);
+    for (const model of models) {
+      expect(model.cost).toEqual(VENICE_DEFAULT_COST);
+      expect(model).not.toHaveProperty("privacy");
+    }
+  });
+
+  it("does not make network requests when skipNetwork is true", async () => {
+    const startTime = Date.now();
+    const models = await discoverVeniceModels({ skipNetwork: true });
+    const elapsed = Date.now() - startTime;
+
+    // Should return near-instantly (no 5s timeout)
+    expect(elapsed).toBeLessThan(500);
+    expect(models.length).toBeGreaterThan(0);
+  });
+
+  it("returns models with correct structure", async () => {
+    const models = await discoverVeniceModels({ skipNetwork: true });
+
+    for (const model of models) {
+      expect(model).toHaveProperty("id");
+      expect(model).toHaveProperty("name");
+      expect(model).toHaveProperty("reasoning");
+      expect(model).toHaveProperty("input");
+      expect(model).toHaveProperty("cost");
+      expect(model).toHaveProperty("contextWindow");
+      expect(model).toHaveProperty("maxTokens");
+      expect(typeof model.id).toBe("string");
+      expect(typeof model.name).toBe("string");
+      expect(typeof model.reasoning).toBe("boolean");
+      expect(Array.isArray(model.input)).toBe(true);
+      expect(model.input.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("VENICE_MODEL_CATALOG", () => {
+  it("contains expected model categories", () => {
+    const ids = VENICE_MODEL_CATALOG.map((m) => m.id);
+
+    expect(ids).toContain("llama-3.3-70b");
+    expect(ids).toContain("deepseek-v3.2");
+    expect(ids).toContain("venice-uncensored");
+  });
+
+  it("all entries have valid privacy values", () => {
+    for (const entry of VENICE_MODEL_CATALOG) {
+      expect(["private", "anonymized"]).toContain(entry.privacy);
+    }
+  });
+
+  it("all entries have valid input arrays", () => {
+    for (const entry of VENICE_MODEL_CATALOG) {
+      expect(entry.input.length).toBeGreaterThan(0);
+      for (const input of entry.input) {
+        expect(["text", "image"]).toContain(input);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #14281

## Problem

`discoverVeniceModels()` uses `AbortSignal.timeout(5000)` which keeps its internal timer alive even after the fetch settles. When the timer fires into an already-resolved promise chain (or during body stream reading), it produces an **unhandled promise rejection** that crashes the gateway on startup.

## Changes

### `src/agents/venice-models.ts`
- **Replace `AbortSignal.timeout()` with manual `AbortController` + `clearTimeout`** in a `finally` block — the timeout is properly cleaned up regardless of how the fetch completes, preventing stray rejections.
- **Cancel response body stream on error/non-OK paths** via `response.body?.cancel?.()` to avoid dangling socket/stream errors.
- **Add `skipNetwork` option** to `discoverVeniceModels()` so callers can explicitly bypass API discovery when the Venice provider is not configured, avoiding unnecessary network requests entirely.

### `src/agents/venice-models.test.ts` (new)
- Tests for `buildVeniceModelDefinition`, `discoverVeniceModels` (including `skipNetwork`), and `VENICE_MODEL_CATALOG` validation.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `discoverVeniceModels()` to avoid gateway crashes caused by `AbortSignal.timeout()` firing after a fetch has already settled. It replaces `AbortSignal.timeout(5000)` with a manual `AbortController` + `setTimeout` that is always cleaned up in `finally`, and cancels the response body stream on error paths to avoid dangling stream/socket errors. It also adds an optional `{ skipNetwork }` flag to bypass API discovery and immediately return the static `VENICE_MODEL_CATALOG`.

A new `src/agents/venice-models.test.ts` file adds unit tests for `buildVeniceModelDefinition`, `discoverVeniceModels` (including `skipNetwork`), and catalog validation.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix one flaky test that depends on runner-specific env vars.
- The runtime change (manual AbortController + clearTimeout in finally) is localized and addresses the reported unhandled rejection. The main issue found is that the new test suite relies on `process.env.VITEST` being set by the runner, which fails under bun and will cause CI/test flakiness depending on how tests are executed.
- src/agents/venice-models.test.ts

<sub>Last reviewed commit: 0f4c92d</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->