### PR TITLE
fix(googlechat): convert Markdown formatting to Google Chat markup

### DIFF
--- a/extensions/googlechat/src/api.test.ts
+++ b/extensions/googlechat/src/api.test.ts
@@ -55,6 +55,27 @@ describe("convertMarkdownToGoogleChat", () => {
       "*one* and *two* and *three*",
     );
   });
+
+  it("preserves inline code with ** inside", () => {
+    expect(convertMarkdownToGoogleChat("Use `**glob**` pattern")).toBe("Use `**glob**` pattern");
+  });
+
+  it("preserves fenced code blocks with ** inside", () => {
+    const input = "Before\n```\n**not bold**\n~~not strike~~\n```\nAfter **bold**";
+    const expected = "Before\n```\n**not bold**\n~~not strike~~\n```\nAfter *bold*";
+    expect(convertMarkdownToGoogleChat(input)).toBe(expected);
+  });
+
+  it("preserves code blocks with language tag", () => {
+    const input = "```js\nconst x = '**test**';\n```";
+    expect(convertMarkdownToGoogleChat(input)).toBe(input);
+  });
+
+  it("handles mixed prose and code", () => {
+    const input = "**bold** then `**code**` then **more bold**";
+    const expected = "*bold* then `**code**` then *more bold*";
+    expect(convertMarkdownToGoogleChat(input)).toBe(expected);
+  });
 });
 
 describe("downloadGoogleChatMedia", () => {

--- a/extensions/googlechat/src/api.test.ts
+++ b/extensions/googlechat/src/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
-import { downloadGoogleChatMedia } from "./api.js";
+import { convertMarkdownToGoogleChat, downloadGoogleChatMedia } from "./api.js";
 
 vi.mock("./auth.js", () => ({
   getGoogleChatAccessToken: vi.fn().mockResolvedValue("token"),
@@ -12,6 +12,50 @@ const account = {
   credentialSource: "inline",
   config: {},
 } as ResolvedGoogleChatAccount;
+
+describe("convertMarkdownToGoogleChat", () => {
+  it("converts **bold** to *bold*", () => {
+    expect(convertMarkdownToGoogleChat("This is **bold** text")).toBe("This is *bold* text");
+  });
+
+  it("converts ~~strikethrough~~ to ~strikethrough~", () => {
+    expect(convertMarkdownToGoogleChat("This is ~~strikethrough~~ text")).toBe(
+      "This is ~strikethrough~ text",
+    );
+  });
+
+  it("preserves _italic_ formatting (already compatible)", () => {
+    expect(convertMarkdownToGoogleChat("This is _italic_ text")).toBe("This is _italic_ text");
+  });
+
+  it("handles multiple formatting in same text", () => {
+    expect(convertMarkdownToGoogleChat("**Bold** and ~~strike~~ and _italic_")).toBe(
+      "*Bold* and ~strike~ and _italic_",
+    );
+  });
+
+  it("handles nested formatting", () => {
+    expect(convertMarkdownToGoogleChat("**bold with ~~strike~~ inside**")).toBe(
+      "*bold with ~strike~ inside*",
+    );
+  });
+
+  it("preserves plain text without formatting", () => {
+    expect(convertMarkdownToGoogleChat("Plain text without formatting")).toBe(
+      "Plain text without formatting",
+    );
+  });
+
+  it("handles empty string", () => {
+    expect(convertMarkdownToGoogleChat("")).toBe("");
+  });
+
+  it("handles multiple bold segments", () => {
+    expect(convertMarkdownToGoogleChat("**one** and **two** and **three**")).toBe(
+      "*one* and *two* and *three*",
+    );
+  });
+});
 
 describe("downloadGoogleChatMedia", () => {
   afterEach(() => {


### PR DESCRIPTION
Fixes #14825

## What

Adds a `convertMarkdownToGoogleChat()` function that converts standard Markdown formatting to Google Chat's markup syntax before sending messages.

## Why

Google Chat uses different markup than standard Markdown:
- `*bold*` (single asterisk) instead of `**bold**`
- `~strikethrough~` (single tilde) instead of `~~strikethrough~~`
- `_italic_` is the same in both

OpenClaw agents output standard Markdown, which renders as literal asterisks/tildes in Google Chat instead of formatted text.

## How

- Added `convertMarkdownToGoogleChat(text)` function with simple regex transforms:
  - `**text**` → `*text*` (bold)
  - `~~text~~` → `~text~` (strikethrough)
- Applied in both `sendGoogleChatMessage()` and `updateGoogleChatMessage()`
- Added 8 unit tests covering various formatting scenarios

## Testing

- [x] Added unit tests (8 new tests for the conversion function)
- [x] `pnpm check` passes (lint + format + tsgo)
- [x] `pnpm vitest run extensions/googlechat` passes (18 tests)

## AI-Assisted 🤖

This PR was built with AI assistance (Claude via OpenClaw).
- [x] Code reviewed and understood
- [x] Lightly tested
- [x] Session available on request

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `convertMarkdownToGoogleChat()` in `extensions/googlechat/src/api.ts` and applies it to outbound Google Chat message send/update so `**bold**` and `~~strike~~` render using Google Chat’s single-character markup. It also adds unit tests covering basic conversion cases.

The main issue is that the converter currently rewrites markers inside inline/fenced code blocks, which can corrupt code snippets commonly produced by agents/tools. Either the implementation should skip code regions (as the comment suggests) or the comment/tests should be adjusted to reflect the real behavior.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but has a correctness issue that can garble code snippets in Google Chat messages.
- Changes are localized with tests, but the markdown conversion runs inside code regions despite the comment indicating it should not, which will break common agent/tool outputs containing fenced or inline code with `**`/`~~`.
- extensions/googlechat/src/api.ts

<sub>Last reviewed commit: 2b8752f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->