### PR TITLE
fix(hooks): return resolved agentId in hook response + add tests

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -215,11 +215,16 @@ export function createHooksRequestHandler(
         sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
         return true;
       }
+      const resolvedAgentId = resolveHookTargetAgentId(hooksConfig, normalized.value.agentId);
       const runId = dispatchAgentHook({
         ...normalized.value,
-        agentId: resolveHookTargetAgentId(hooksConfig, normalized.value.agentId),
+        agentId: resolvedAgentId,
       });
-      sendJson(res, 202, { ok: true, runId });
+      sendJson(res, 202, {
+        ok: true,
+        runId,
+        ...(resolvedAgentId !== undefined ? { agentId: resolvedAgentId } : {}),
+      });
       return true;
     }
 
@@ -258,10 +263,11 @@ export function createHooksRequestHandler(
             sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
             return true;
           }
+          const mappedAgentId = resolveHookTargetAgentId(hooksConfig, mapped.action.agentId);
           const runId = dispatchAgentHook({
             message: mapped.action.message,
             name: mapped.action.name ?? "Hook",
-            agentId: resolveHookTargetAgentId(hooksConfig, mapped.action.agentId),
+            agentId: mappedAgentId,
             wakeMode: mapped.action.wakeMode,
             sessionKey: mapped.action.sessionKey ?? "",
             deliver: resolveHookDeliver(mapped.action.deliver),
@@ -272,7 +278,11 @@ export function createHooksRequestHandler(
             timeoutSeconds: mapped.action.timeoutSeconds,
             allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
           });
-          sendJson(res, 202, { ok: true, runId });
+          sendJson(res, 202, {
+            ok: true,
+            runId,
+            ...(mappedAgentId !== undefined ? { agentId: mappedAgentId } : {}),
+          });
           return true;
         }
       } catch (err) {

--- a/src/gateway/server.hooks.e2e.test.ts
+++ b/src/gateway/server.hooks.e2e.test.ts
@@ -57,6 +57,8 @@ describe("gateway server hooks", () => {
         body: JSON.stringify({ message: "Do it", name: "Email" }),
       });
       expect(resAgent.status).toBe(202);
+      const agentBody = (await resAgent.json()) as { ok?: boolean; agentId?: string };
+      expect(agentBody.agentId).toBeUndefined();
       const agentEvents = await waitForSystemEvent();
       expect(agentEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
       drainSystemEvents(resolveMainKey());
@@ -100,6 +102,8 @@ describe("gateway server hooks", () => {
         body: JSON.stringify({ message: "Do it", name: "Email", agentId: "hooks" }),
       });
       expect(resAgentWithId.status).toBe(202);
+      const agentWithIdBody = (await resAgentWithId.json()) as { ok?: boolean; agentId?: string };
+      expect(agentWithIdBody.agentId).toBe("hooks");
       await waitForSystemEvent();
       const routedCall = cronIsolatedRun.mock.calls[0]?.[0] as {
         job?: { agentId?: string };
@@ -121,6 +125,8 @@ describe("gateway server hooks", () => {
         body: JSON.stringify({ message: "Do it", name: "Email", agentId: "missing-agent" }),
       });
       expect(resAgentUnknown.status).toBe(202);
+      const unknownBody = (await resAgentUnknown.json()) as { ok?: boolean; agentId?: string };
+      expect(unknownBody.agentId).toBe("main");
       await waitForSystemEvent();
       const fallbackCall = cronIsolatedRun.mock.calls[0]?.[0] as {
         job?: { agentId?: string };
@@ -254,6 +260,8 @@ describe("gateway server hooks", () => {
         body: JSON.stringify({ message: "Allowed", agentId: "hooks" }),
       });
       expect(resAllowed.status).toBe(202);
+      const allowedBody = (await resAllowed.json()) as { ok?: boolean; agentId?: string };
+      expect(allowedBody.agentId).toBe("hooks");
       await waitForSystemEvent();
       const allowedCall = cronIsolatedRun.mock.calls[0]?.[0] as {
         job?: { agentId?: string };


### PR DESCRIPTION
## Summary

Fixes #14387 — `agentId` field on `POST /hooks/agent` was silently ignored (on versions prior to the #13672 wiring), and the 202 response gave callers no way to verify which agent was actually selected.

## Problem

1. **`agentId` routing** was wired up in #13672 (merged Feb 10), but the **202 response** did not include the resolved `agentId`, making silent fallback to the default agent invisible to API callers.
2. **`hooks.allowedAgentIds`** was also added to the Zod schema in #13672, resolving the config rejection reported in the issue.

## Changes

### `src/gateway/server-http.ts`
- Include the resolved `agentId` in the 202 JSON response for both direct `/hooks/agent` and mapped webhook dispatches.
- The field is **omitted** when no explicit `agentId` was requested (backwards-compatible).
- This makes fallback behavior observable: if you request `agentId: "my-agent"` but it's unknown, the response now shows `agentId: "main"` (the default), alerting the caller.

### `src/gateway/hooks.test.ts` (4 new unit tests)
- `resolveHooksConfig` populates `agentPolicy` with correct `knownAgentIds` and `allowedAgentIds`
- `resolveHooksConfig` without `allowedAgentIds` leaves it undefined (allow-all semantics)
- `normalizeAgentPayload` preserves `thinking` and `timeoutSeconds` alongside `agentId`
- `resolveHookTargetAgentId` normalizes mixed-case agent IDs

### `src/gateway/server.hooks.e2e.test.ts` (4 new assertions)
- No `agentId` in request → response omits `agentId`
- Known `agentId` → response includes it
- Unknown `agentId` → response shows fallback to default
- `allowedAgentIds`-gated request → response includes allowed agent

## Testing
- `pnpm check` (format + typecheck + lint): ✅
- `vitest run src/gateway/hooks.test.ts`: 14/14 pass
- `vitest run --config vitest.e2e.config.ts src/gateway/server.hooks.e2e.test.ts`: 3/3 pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway hooks HTTP handler to include the *resolved* `agentId` in the `202` JSON response for both direct `POST /hooks/agent` calls and mapping-driven hook dispatches. The field is only included when the request (or mapping action) explicitly specified an `agentId`, keeping backwards compatibility for callers that omit it.

It also adds unit and e2e coverage around hooks config resolution (`knownAgentIds` / `allowedAgentIds` semantics), payload normalization, agent-id normalization, and the new response behavior for known/unknown agent IDs and allowlist gating.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to the hooks HTTP response payload and are covered by new unit + e2e assertions that exercise omission/inclusion behavior and default-agent fallback. The implementation matches the existing hooks agent-resolution and allowlist logic in src/gateway/hooks.ts.
- No files require special attention

<sub>Last reviewed commit: 103ffb5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->