### PR TITLE
feat(gateway): add gateway.ws.maxPayloadBytes config key

### DIFF
--- a/src/config/config.ws-max-payload.test.ts
+++ b/src/config/config.ws-max-payload.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("gateway.ws config schema", () => {
+  test("accepts valid maxPayloadBytes", () => {
+    const result = OpenClawSchema.safeParse({
+      gateway: { ws: { maxPayloadBytes: 100 * 1024 * 1024 } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts gateway.ws as empty object", () => {
+    const result = OpenClawSchema.safeParse({
+      gateway: { ws: {} },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts gateway without ws key", () => {
+    const result = OpenClawSchema.safeParse({
+      gateway: { port: 18789 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects non-positive maxPayloadBytes", () => {
+    const result = OpenClawSchema.safeParse({
+      gateway: { ws: { maxPayloadBytes: 0 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative maxPayloadBytes", () => {
+    const result = OpenClawSchema.safeParse({
+      gateway: { ws: { maxPayloadBytes: -1 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer maxPayloadBytes", () => {
+    const result = OpenClawSchema.safeParse({
+      gateway: { ws: { maxPayloadBytes: 1.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects unknown keys in ws (strict)", () => {
+    const result = OpenClawSchema.safeParse({
+      gateway: { ws: { maxPayloadBytes: 1024, bogus: true } },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -211,6 +211,15 @@ export type GatewayNodesConfig = {
   denyCommands?: string[];
 };
 
+export type GatewayWsConfig = {
+  /**
+   * Maximum incoming WebSocket frame size in bytes.
+   * Increase this if webchat image uploads fail with "Max payload size exceeded".
+   * Default: 50 MiB (52428800).
+   */
+  maxPayloadBytes?: number;
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
@@ -239,6 +248,7 @@ export type GatewayConfig = {
   tls?: GatewayTlsConfig;
   http?: GatewayHttpConfig;
   nodes?: GatewayNodesConfig;
+  ws?: GatewayWsConfig;
   /**
    * IPs of trusted reverse proxies (e.g. Traefik, nginx). When a connection
    * arrives from one of these IPs, the Gateway trusts `x-forwarded-for` (or

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -495,6 +495,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        ws: z
+          .object({
+            maxPayloadBytes: z.number().int().positive().optional(),
+          })
+          .strict()
+          .optional(),
         nodes: z
           .object({
             browser: z

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -1,5 +1,5 @@
 import type { GatewayWsClient } from "./server/ws-types.js";
-import { MAX_BUFFERED_BYTES } from "./server-constants.js";
+import { getMaxBufferedBytes } from "./server-constants.js";
 import { logWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
 const ADMIN_SCOPE = "operator.admin";
@@ -72,7 +72,7 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       if (!hasEventScope(c, event)) {
         continue;
       }
-      const slow = c.socket.bufferedAmount > MAX_BUFFERED_BYTES;
+      const slow = c.socket.bufferedAmount > getMaxBufferedBytes();
       if (slow && opts?.dropIfSlow) {
         continue;
       }

--- a/src/gateway/server-constants.test.ts
+++ b/src/gateway/server-constants.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  DEFAULT_MAX_PAYLOAD_BYTES,
+  MAX_BUFFERED_BYTES_FACTOR,
+  getMaxBufferedBytes,
+  getMaxPayloadBytes,
+  setMaxPayloadBytes,
+} from "./server-constants.js";
+
+describe("ws max payload config", () => {
+  afterEach(() => {
+    setMaxPayloadBytes(undefined);
+  });
+
+  test("defaults to DEFAULT_MAX_PAYLOAD_BYTES (50 MiB)", () => {
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+    expect(DEFAULT_MAX_PAYLOAD_BYTES).toBe(50 * 1024 * 1024);
+  });
+
+  test("setMaxPayloadBytes overrides the value", () => {
+    setMaxPayloadBytes(100 * 1024 * 1024);
+    expect(getMaxPayloadBytes()).toBe(100 * 1024 * 1024);
+  });
+
+  test("setMaxPayloadBytes(undefined) resets to default", () => {
+    setMaxPayloadBytes(8 * 1024 * 1024);
+    expect(getMaxPayloadBytes()).toBe(8 * 1024 * 1024);
+    setMaxPayloadBytes(undefined);
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+  });
+
+  test("ignores non-positive values and resets to default", () => {
+    setMaxPayloadBytes(10_000);
+    setMaxPayloadBytes(0);
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+    setMaxPayloadBytes(-1);
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+  });
+
+  test("ignores non-finite values", () => {
+    setMaxPayloadBytes(10_000);
+    setMaxPayloadBytes(NaN);
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+    setMaxPayloadBytes(Infinity);
+    expect(getMaxPayloadBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES);
+  });
+
+  test("getMaxBufferedBytes is factor * maxPayload", () => {
+    expect(getMaxBufferedBytes()).toBe(DEFAULT_MAX_PAYLOAD_BYTES * MAX_BUFFERED_BYTES_FACTOR);
+    setMaxPayloadBytes(10 * 1024 * 1024);
+    expect(getMaxBufferedBytes()).toBe(10 * 1024 * 1024 * MAX_BUFFERED_BYTES_FACTOR);
+  });
+});

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,5 +1,18 @@
-export const MAX_PAYLOAD_BYTES = 8 * 1024 * 1024; // cap incoming frame size (~8 MiB; fits ~5,000,000 decoded bytes as base64 + JSON overhead)
-export const MAX_BUFFERED_BYTES = 16 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
+export const DEFAULT_MAX_PAYLOAD_BYTES = 50 * 1024 * 1024; // default incoming frame size cap (~50 MiB; large enough for typical screenshot uploads)
+let maxPayloadBytes = DEFAULT_MAX_PAYLOAD_BYTES;
+/** Resolved max incoming WS frame size in bytes. */
+export const getMaxPayloadBytes = () => maxPayloadBytes;
+/** Set max payload from gateway config (call once at startup). */
+export const setMaxPayloadBytes = (value: number | undefined) => {
+  if (value !== undefined && Number.isFinite(value) && value > 0) {
+    maxPayloadBytes = value;
+  } else {
+    maxPayloadBytes = DEFAULT_MAX_PAYLOAD_BYTES;
+  }
+};
+export const MAX_BUFFERED_BYTES_FACTOR = 2;
+/** Per-connection send buffer limit (2x max payload). */
+export const getMaxBufferedBytes = () => maxPayloadBytes * MAX_BUFFERED_BYTES_FACTOR;
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 let maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -20,7 +20,7 @@ import {
   createChatRunState,
   createToolEventRecipientRegistry,
 } from "./server-chat.js";
-import { MAX_PAYLOAD_BYTES } from "./server-constants.js";
+import { getMaxPayloadBytes, setMaxPayloadBytes } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import { createGatewayHooksRequestHandler } from "./server/hooks.js";
 import { listenGatewayHttpServer } from "./server/http-listen.js";
@@ -163,9 +163,11 @@ export async function createGatewayRuntimeState(params: {
     throw new Error("Gateway HTTP server failed to start");
   }
 
+  setMaxPayloadBytes(params.cfg.gateway?.ws?.maxPayloadBytes);
+
   const wss = new WebSocketServer({
     noServer: true,
-    maxPayload: MAX_PAYLOAD_BYTES,
+    maxPayload: getMaxPayloadBytes(),
   });
   for (const server of httpServers) {
     attachGatewayUpgradeHandler({

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -41,7 +41,11 @@ import {
   validateConnectParams,
   validateRequestFrame,
 } from "../../protocol/index.js";
-import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
+import {
+  getMaxBufferedBytes,
+  getMaxPayloadBytes,
+  TICK_INTERVAL_MS,
+} from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import { formatError } from "../../server-utils.js";
 import { formatForLog, logWs } from "../../ws-log.js";
@@ -865,8 +869,8 @@ export function attachGatewayWsMessageHandler(params: {
               }
             : undefined,
           policy: {
-            maxPayload: MAX_PAYLOAD_BYTES,
-            maxBufferedBytes: MAX_BUFFERED_BYTES,
+            maxPayload: getMaxPayloadBytes(),
+            maxBufferedBytes: getMaxBufferedBytes(),
             tickIntervalMs: TICK_INTERVAL_MS,
           },
         };


### PR DESCRIPTION
## Summary

Fixes #14284 — Webchat disconnects with "Max payload size exceeded" when uploading images because the hardcoded WS `maxPayload` was only 8 MiB and there was no config key to override it.

## Changes

### New config key: `gateway.ws.maxPayloadBytes`

```json
{
  "gateway": {
    "ws": {
      "maxPayloadBytes": 52428800
    }
  }
}
```

- **Type:** positive integer (bytes)
- **Default:** 50 MiB (52,428,800) — up from the previous hardcoded 8 MiB
- **Validation:** Zod schema enforces `int().positive()`, strict object (no unknown keys)

### Implementation

| File | Change |
|------|--------|
| `src/config/types.gateway.ts` | Add `GatewayWsConfig` type with `maxPayloadBytes` field |
| `src/config/zod-schema.ts` | Add `gateway.ws` to the Zod config schema |
| `src/gateway/server-constants.ts` | Replace hardcoded `MAX_PAYLOAD_BYTES`/`MAX_BUFFERED_BYTES` with configurable `getMaxPayloadBytes()`/`getMaxBufferedBytes()` getters |
| `src/gateway/server-runtime-state.ts` | Read config at startup, wire to `WebSocketServer({ maxPayload })` |
| `src/gateway/server/ws-connection/message-handler.ts` | Use getters for the policy object sent to clients |
| `src/gateway/server-broadcast.ts` | Use getter for send-buffer threshold |

### Tests

- **`server-constants.test.ts`** — 6 tests: default value, override, reset, edge cases (0, negative, NaN, Infinity), buffered-bytes factor
- **`config.ws-max-payload.test.ts`** — 7 tests: schema accepts valid values, rejects invalid (0, negative, float, unknown keys)

### Backward compatibility

- Existing configs without `gateway.ws` work unchanged (50 MiB default)
- The send-buffer limit (`maxBufferedBytes`) stays at 2× the payload limit
- Client-side `maxPayload` (25 MiB for inbound server→client) is unaffected

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `gateway.ws.maxPayloadBytes` configuration key, validates it via the main Zod config schema (`int().positive()`, strict object), and wires the resolved value into the Gateway `WebSocketServer({ maxPayload })`. It also replaces prior hardcoded payload/buffer thresholds with runtime getters and updates broadcast / hello policy reporting accordingly, along with targeted unit tests for the schema and constants behavior.

Overall the change fits cleanly into the existing config + gateway runtime initialization flow: config is parsed/validated up front, then `createGatewayRuntimeState` applies the configured max payload once before constructing the WS server and attaching upgrade handlers, so all connections see the intended limit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped (new config key + plumbing), schema validation ensures only positive integers reach runtime, and the WS server is initialized with the resolved value before upgrade handlers are attached. Added tests cover both schema acceptance/rejection and the runtime constants/getters behavior.
- No files require special attention

<sub>Last reviewed commit: dd9cdcc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->