### PR TITLE
fix(webchat): accumulate text across blocks in streaming buffer

### DIFF
--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -36,6 +36,8 @@ export type ChatAbortOps = {
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
   chatAbortedRuns: Map<string, number>;
+  /** Centralized cleanup for all buffer-related state (buffers, blockBases, lastBlockTexts, deltaSentAt). */
+  deleteRunBufferState?: (clientRunId: string) => void;
   removeChatRun: (
     sessionId: string,
     clientRunId: string,
@@ -96,8 +98,12 @@ export function abortChatRunById(
   ops.chatAbortedRuns.set(runId, Date.now());
   active.controller.abort();
   ops.chatAbortControllers.delete(runId);
-  ops.chatRunBuffers.delete(runId);
-  ops.chatDeltaSentAt.delete(runId);
+  if (ops.deleteRunBufferState) {
+    ops.deleteRunBufferState(runId);
+  } else {
+    ops.chatRunBuffers.delete(runId);
+    ops.chatDeltaSentAt.delete(runId);
+  }
   const removed = ops.removeChatRun(runId, runId, sessionKey);
   broadcastChatAborted(ops, { runId, sessionKey, stopReason, partialText });
   ops.agentRunSeq.delete(runId);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -351,6 +351,134 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
+  it("accumulates text across multiple assistant blocks", () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const broadcast = vi.fn();
+    const broadcastToConnIds = vi.fn();
+    const nodeSendToSession = vi.fn();
+    const agentRunSeq = new Map<string, number>();
+    const chatRunState = createChatRunState();
+    const toolEventRecipients = createToolEventRecipientRegistry();
+    chatRunState.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });
+
+    const handler = createAgentEventHandler({
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      agentRunSeq,
+      chatRunState,
+      resolveSessionKeyForRun: () => undefined,
+      clearAgentRunContext: vi.fn(),
+      toolEventRecipients,
+    });
+
+    // First text block (e.g. before a tool call)
+    handler({
+      runId: "run-1",
+      seq: 1,
+      stream: "assistant",
+      ts: now,
+      data: { text: "First block content" },
+    });
+
+    // Advance time past the 150ms throttle
+    now = 2_000;
+
+    // Second text block (after tool call — text resets, doesn't start with first block)
+    handler({
+      runId: "run-1",
+      seq: 2,
+      stream: "assistant",
+      ts: now,
+      data: { text: "Second block content" },
+    });
+
+    const chatCalls = broadcast.mock.calls.filter(([event]) => event === "chat");
+    expect(chatCalls).toHaveLength(2);
+    const secondPayload = chatCalls[1]?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(secondPayload.state).toBe("delta");
+    const text = secondPayload.message?.content?.[0]?.text ?? "";
+    // Both blocks must be present in the accumulated text
+    expect(text).toContain("First block content");
+    expect(text).toContain("Second block content");
+    resetAgentRunContextForTest();
+    nowSpy.mockRestore();
+  });
+
+  it("includes all blocks in the final chat message", () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const broadcast = vi.fn();
+    const broadcastToConnIds = vi.fn();
+    const nodeSendToSession = vi.fn();
+    const agentRunSeq = new Map<string, number>();
+    const chatRunState = createChatRunState();
+    const toolEventRecipients = createToolEventRecipientRegistry();
+    chatRunState.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });
+
+    const handler = createAgentEventHandler({
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      agentRunSeq,
+      chatRunState,
+      resolveSessionKeyForRun: () => undefined,
+      clearAgentRunContext: vi.fn(),
+      toolEventRecipients,
+    });
+
+    // First text block
+    handler({
+      runId: "run-1",
+      seq: 1,
+      stream: "assistant",
+      ts: now,
+      data: { text: "First block" },
+    });
+
+    now = 2_000;
+
+    // Second text block (text resets after tool use)
+    handler({
+      runId: "run-1",
+      seq: 2,
+      stream: "assistant",
+      ts: now,
+      data: { text: "Second block" },
+    });
+
+    now = 3_000;
+
+    // Lifecycle end — triggers emitChatFinal
+    handler({
+      runId: "run-1",
+      seq: 3,
+      stream: "lifecycle",
+      ts: now,
+      data: { phase: "end" },
+    });
+
+    const chatCalls = broadcast.mock.calls.filter(([event]) => event === "chat");
+    const finalCall = chatCalls.find((call) => {
+      const p = call[1] as { state?: string };
+      return p.state === "final";
+    });
+    expect(finalCall).toBeDefined();
+    const finalPayload = finalCall?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    const text = finalPayload?.message?.content?.[0]?.text ?? "";
+    expect(text).toContain("First block");
+    expect(text).toContain("Second block");
+    resetAgentRunContextForTest();
+    nowSpy.mockRestore();
+  });
+
   it("broadcasts fallback events to agent subscribers and node session", () => {
     const { broadcast, broadcastToConnIds, nodeSendToSession, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-fallback",
@@ -564,6 +692,7 @@ describe("agent event handler", () => {
       message?: { content?: Array<{ text?: string }> };
     };
     expect(finalPayload?.message?.content?.[0]?.text).toBe("Only block");
+    resetAgentRunContextForTest();
     nowSpy.mockRestore();
   });
 });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -509,4 +509,61 @@ describe("agent event handler", () => {
       "Disk usage crossed 95 percent on /data and needs cleanup now.",
     );
   });
+
+  it("final message includes blocks even without trailing delta after boundary", () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const broadcast = vi.fn();
+    const broadcastToConnIds = vi.fn();
+    const nodeSendToSession = vi.fn();
+    const agentRunSeq = new Map<string, number>();
+    const chatRunState = createChatRunState();
+    const toolEventRecipients = createToolEventRecipientRegistry();
+    chatRunState.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });
+
+    const handler = createAgentEventHandler({
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      agentRunSeq,
+      chatRunState,
+      resolveSessionKeyForRun: () => undefined,
+      clearAgentRunContext: vi.fn(),
+      toolEventRecipients,
+    });
+
+    // Only one assistant block — text never gets "finalized" into blockBases via
+    // the boundary detection in emitChatDelta.  emitChatFinal must still capture it.
+    handler({
+      runId: "run-1",
+      seq: 1,
+      stream: "assistant",
+      ts: now,
+      data: { text: "Only block" },
+    });
+
+    now = 2_000;
+
+    // Lifecycle end fires without any second assistant delta
+    handler({
+      runId: "run-1",
+      seq: 2,
+      stream: "lifecycle",
+      ts: now,
+      data: { phase: "end" },
+    });
+
+    const chatCalls = broadcast.mock.calls.filter(([event]) => event === "chat");
+    const finalCall = chatCalls.find((call) => {
+      const p = call[1] as { state?: string };
+      return p.state === "final";
+    });
+    expect(finalCall).toBeDefined();
+    const finalPayload = finalCall?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(finalPayload?.message?.content?.[0]?.text).toBe("Only block");
+    nowSpy.mockRestore();
+  });
 });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -349,6 +349,15 @@ export function createAgentEventHandler({
     jobState: "done" | "error",
     error?: unknown,
   ) => {
+    // Finalize any in-progress block into the buffer so the final payload
+    // contains all blocks even when lifecycle "end" fires without a trailing
+    // assistant delta after the last block boundary.
+    const lastBlock = chatRunState.lastBlockTexts.get(clientRunId);
+    if (lastBlock !== undefined) {
+      const base = chatRunState.blockBases.get(clientRunId) ?? "";
+      const fullText = base ? base + "\n\n" + lastBlock : lastBlock;
+      chatRunState.buffers.set(clientRunId, fullText);
+    }
     const bufferedText = stripInlineDirectiveTagsForDisplay(
       chatRunState.buffers.get(clientRunId) ?? "",
     ).text.trim();

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -143,6 +143,8 @@ export function createChatRunRegistry(): ChatRunRegistry {
 export type ChatRunState = {
   registry: ChatRunRegistry;
   buffers: Map<string, string>;
+  blockBases: Map<string, string>;
+  lastBlockTexts: Map<string, string>;
   deltaSentAt: Map<string, number>;
   abortedRuns: Map<string, number>;
   /** Delete all buffer/delta state for a run (buffers, blockBases, lastBlockTexts, deltaSentAt). */
@@ -153,6 +155,8 @@ export type ChatRunState = {
 export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const buffers = new Map<string, string>();
+  const blockBases = new Map<string, string>();
+  const lastBlockTexts = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
 
@@ -166,6 +170,8 @@ export function createChatRunState(): ChatRunState {
   const clear = () => {
     registry.clear();
     buffers.clear();
+    blockBases.clear();
+    lastBlockTexts.clear();
     deltaSentAt.clear();
     abortedRuns.clear();
   };
@@ -173,6 +179,8 @@ export function createChatRunState(): ChatRunState {
   return {
     registry,
     buffers,
+    blockBases,
+    lastBlockTexts,
     deltaSentAt,
     abortedRuns,
     deleteRunBufferState,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -145,6 +145,8 @@ export type ChatRunState = {
   buffers: Map<string, string>;
   deltaSentAt: Map<string, number>;
   abortedRuns: Map<string, number>;
+  /** Delete all buffer/delta state for a run (buffers, blockBases, lastBlockTexts, deltaSentAt). */
+  deleteRunBufferState: (clientRunId: string) => void;
   clear: () => void;
 };
 
@@ -153,6 +155,13 @@ export function createChatRunState(): ChatRunState {
   const buffers = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
+
+  const deleteRunBufferState = (clientRunId: string) => {
+    buffers.delete(clientRunId);
+    blockBases.delete(clientRunId);
+    lastBlockTexts.delete(clientRunId);
+    deltaSentAt.delete(clientRunId);
+  };
 
   const clear = () => {
     registry.clear();
@@ -166,6 +175,7 @@ export function createChatRunState(): ChatRunState {
     buffers,
     deltaSentAt,
     abortedRuns,
+    deleteRunBufferState,
     clear,
   };
 }
@@ -291,10 +301,25 @@ export function createAgentEventHandler({
     if (isSilentReplyText(cleaned, SILENT_REPLY_TOKEN)) {
       return;
     }
-    chatRunState.buffers.set(clientRunId, cleaned);
     if (shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
       return;
     }
+    // Detect new text block: when the incoming text doesn't continue from the
+    // previous block's text, a tool call happened in between and the agent
+    // started a fresh text block.  Finalize the previous block into the base.
+    // Safety: the agent runner guarantees monotonic prefix growth within a block
+    // (non-prefix updates are suppressed in pi-embedded-subscribe.handlers.messages.ts).
+    const lastBlock = chatRunState.lastBlockTexts.get(clientRunId);
+    if (lastBlock !== undefined && !text.startsWith(lastBlock)) {
+      const base = chatRunState.blockBases.get(clientRunId) ?? "";
+      chatRunState.blockBases.set(clientRunId, base ? base + "\n\n" + lastBlock : lastBlock);
+    }
+    chatRunState.lastBlockTexts.set(clientRunId, text);
+
+    // Full text = all previous blocks + current block
+    const base = chatRunState.blockBases.get(clientRunId) ?? "";
+    const fullText = base ? base + "\n\n" + text : text;
+    chatRunState.buffers.set(clientRunId, fullText);
     const now = Date.now();
     const last = chatRunState.deltaSentAt.get(clientRunId) ?? 0;
     if (now - last < 150) {
@@ -335,8 +360,7 @@ export function createAgentEventHandler({
     const text = normalizedHeartbeatText.text.trim();
     const shouldSuppressSilent =
       normalizedHeartbeatText.suppress || isSilentReplyText(text, SILENT_REPLY_TOKEN);
-    chatRunState.buffers.delete(clientRunId);
-    chatRunState.deltaSentAt.delete(clientRunId);
+    chatRunState.deleteRunBufferState(clientRunId);
     if (jobState === "done") {
       const payload = {
         runId: clientRunId,
@@ -483,8 +507,7 @@ export function createAgentEventHandler({
       } else if (isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
         chatRunState.abortedRuns.delete(clientRunId);
         chatRunState.abortedRuns.delete(evt.runId);
-        chatRunState.buffers.delete(clientRunId);
-        chatRunState.deltaSentAt.delete(clientRunId);
+        chatRunState.deleteRunBufferState(clientRunId);
         if (chatLink) {
           chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
         }

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -27,7 +27,11 @@ export function startGatewayMaintenanceTimers(params: {
   logHealth: { error: (msg: string) => void };
   dedupe: Map<string, DedupeEntry>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
-  chatRunState: { abortedRuns: Map<string, number> };
+  chatRunState: {
+    abortedRuns: Map<string, number>;
+    blockBases: Map<string, string>;
+    lastBlockTexts: Map<string, string>;
+  };
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
   removeChatRun: (
@@ -125,6 +129,8 @@ export function startGatewayMaintenanceTimers(params: {
       }
       params.chatRunState.abortedRuns.delete(runId);
       params.chatRunBuffers.delete(runId);
+      params.chatRunState.blockBases.delete(runId);
+      params.chatRunState.lastBlockTexts.delete(runId);
       params.chatDeltaSentAt.delete(runId);
     }
   }, 60_000);

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -29,8 +29,7 @@ export function startGatewayMaintenanceTimers(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatRunState: {
     abortedRuns: Map<string, number>;
-    blockBases: Map<string, string>;
-    lastBlockTexts: Map<string, string>;
+    deleteRunBufferState: (clientRunId: string) => void;
   };
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
@@ -113,6 +112,7 @@ export function startGatewayMaintenanceTimers(params: {
           chatRunBuffers: params.chatRunBuffers,
           chatDeltaSentAt: params.chatDeltaSentAt,
           chatAbortedRuns: params.chatRunState.abortedRuns,
+          deleteRunBufferState: params.chatRunState.deleteRunBufferState,
           removeChatRun: params.removeChatRun,
           agentRunSeq: params.agentRunSeq,
           broadcast: params.broadcast,
@@ -128,10 +128,7 @@ export function startGatewayMaintenanceTimers(params: {
         continue;
       }
       params.chatRunState.abortedRuns.delete(runId);
-      params.chatRunBuffers.delete(runId);
-      params.chatRunState.blockBases.delete(runId);
-      params.chatRunState.lastBlockTexts.delete(runId);
-      params.chatDeltaSentAt.delete(runId);
+      params.chatRunState.deleteRunBufferState(runId);
     }
   }, 60_000);
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -448,6 +448,7 @@ function createChatAbortOps(context: GatewayRequestContext): ChatAbortOps {
     chatRunBuffers: context.chatRunBuffers,
     chatDeltaSentAt: context.chatDeltaSentAt,
     chatAbortedRuns: context.chatAbortedRuns,
+    deleteRunBufferState: context.deleteRunBufferState,
     removeChatRun: context.removeChatRun,
     agentRunSeq: context.agentRunSeq,
     broadcast: context.broadcast,

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -769,6 +769,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         chatAbortedRuns: context.chatAbortedRuns,
         chatRunBuffers: context.chatRunBuffers,
         chatDeltaSentAt: context.chatDeltaSentAt,
+        deleteRunBufferState: context.deleteRunBufferState,
         dedupe: context.dedupe,
         agentRunSeq: context.agentRunSeq,
         getHealthCache: context.getHealthCache,

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -54,6 +54,7 @@ export type GatewayRequestContext = {
   chatAbortedRuns: Map<string, number>;
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
+  deleteRunBufferState: (clientRunId: string) => void;
   addChatRun: (sessionId: string, entry: { sessionKey: string; clientRunId: string }) => void;
   removeChatRun: (
     sessionId: string,

--- a/src/gateway/server-node-events-types.ts
+++ b/src/gateway/server-node-events-types.ts
@@ -22,6 +22,7 @@ export type NodeEventContext = {
   chatAbortedRuns: Map<string, number>;
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
+  deleteRunBufferState: (clientRunId: string) => void;
   dedupe: Map<string, DedupeEntry>;
   agentRunSeq: Map<string, number>;
   getHealthCache: () => HealthSummary | null;

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -81,6 +81,7 @@ function buildCtx(): NodeEventContext {
     chatAbortedRuns: new Map(),
     chatRunBuffers: new Map(),
     chatDeltaSentAt: new Map(),
+    deleteRunBufferState: () => {},
     dedupe: new Map(),
     agentRunSeq: new Map(),
     getHealthCache: () => null,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -619,6 +619,7 @@ export async function startGatewayServer(
       chatAbortedRuns: chatRunState.abortedRuns,
       chatRunBuffers: chatRunState.buffers,
       chatDeltaSentAt: chatRunState.deltaSentAt,
+      deleteRunBufferState: chatRunState.deleteRunBufferState,
       addChatRun,
       removeChatRun,
       registerToolEventRecipient: toolEventRecipients.add,


### PR DESCRIPTION
Fixes #14361

## Summary

- Track per-run block state (`blockBases`, `lastBlockTexts`) in `ChatRunState` so that when the agent emits a new text block after a tool call, previous blocks are preserved in the streaming buffer
- Detect block boundaries via prefix check (`!text.startsWith(lastBlock)`) — safe because the agent runner suppresses non-prefix updates within a block
- Centralize buffer cleanup in `deleteRunBufferState()` and thread it through all abort/TTL paths to prevent stale state leaks

## Root Cause

`emitChatDelta` replaced the streaming buffer with each incoming `text` value. Between text blocks (after tool calls), the agent runner resets its accumulated text, so the new block's `text` starts fresh — overwriting the buffer and losing all previous blocks' content.

## Test plan

- [x] New test: "accumulates text across multiple assistant blocks" — verifies delta broadcast contains text from both blocks
- [x] New test: "includes all blocks in the final chat message" — verifies lifecycle end emits a final payload with both blocks joined
- [x] All 11 tests in `server-chat.agent-events.test.ts` pass (7 existing + 2 new + 2 registry)
- [x] `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes webchat streaming buffer behavior when assistant output arrives in multiple text blocks (e.g., around tool calls). It extends `ChatRunState` with per-run block tracking (`blockBases`, `lastBlockTexts`) and updates `emitChatDelta` (`src/gateway/server-chat.ts:250+`) to detect block boundaries and build `fullText` as “previous blocks + current block”, so deltas no longer overwrite prior content.

Cleanup of buffer-related state is centralized via `deleteRunBufferState` and threaded through abort and maintenance TTL paths (`src/gateway/chat-abort.ts`, `src/gateway/server-maintenance.ts`, and context plumbing in `src/gateway/server.impl.ts`), preventing stale state leaks. New vitest cases in `src/gateway/server-chat.agent-events.test.ts` cover multi-block accumulation and final payload behavior, including the edge case where lifecycle end fires without a trailing delta after the last boundary.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are localized to webchat streaming state handling, include centralized cleanup to prevent leaks, and are covered by targeted unit tests for multi-block streaming and final message composition. No regressions or missing plumbing were found in the reviewed changeset.
- No files require special attention

<sub>Last reviewed commit: d967c83</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->