### PR TITLE
fix: thread replyToId and threadId through message tool send action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Docs: https://docs.openclaw.ai
 
+## 2026.2.13 (Unreleased)
+
+### Fixes
+
+- Security/Audit: distinguish external webhooks (`hooks.enabled`) from internal hooks (`hooks.internal.enabled`) in attack-surface summaries to avoid false exposure signals when only internal hooks are enabled. (#13474) Thanks @mcaxtr.
+- Sandbox: pass configured `sandbox.docker.env` variables to sandbox containers at `docker create` time. (#15138) Thanks @stevebot-alive.
+- Onboarding/CLI: restore terminal state without resuming paused `stdin`, so onboarding exits cleanly after choosing Web UI and the installer returns instead of appearing stuck.
+- macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.
+- Heartbeat: prevent scheduler silent-death races during runner reloads, preserve retry cooldown backoff under wake bursts, and prioritize user/action wake causes over interval/retry reasons when coalescing. (#15108) Thanks @joeykrug.
+- Exec/Allowlist: allow multiline heredoc bodies (`<<`, `<<-`) while keeping multiline non-heredoc shell commands blocked, so exec approval parsing permits heredoc input safely without allowing general newline command chaining. (#13811) Thanks @mcaxtr.
+- Outbound/Threading: pass `replyTo` and `threadId` from `message send` tool actions through the core outbound send path to channel adapters, preserving thread/reply routing. (#14948) Thanks @mcaxtr.
+
 ## 2026.2.12
 
 ### Changes

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -153,8 +153,10 @@ describe("runMessageAction threading auto-injection", () => {
     });
 
     const call = mocks.executeSendAction.mock.calls[0]?.[0] as {
+      threadId?: string;
       ctx?: { params?: Record<string, unknown> };
     };
+    expect(call?.threadId).toBe("42");
     expect(call?.ctx?.params?.threadId).toBe("42");
   });
 
@@ -235,8 +237,40 @@ describe("runMessageAction threading auto-injection", () => {
     });
 
     const call = mocks.executeSendAction.mock.calls[0]?.[0] as {
+      threadId?: string;
       ctx?: { params?: Record<string, unknown> };
     };
+    expect(call?.threadId).toBe("999");
     expect(call?.ctx?.params?.threadId).toBe("999");
+  });
+
+  it("threads explicit replyTo through executeSendAction", async () => {
+    mocks.executeSendAction.mockResolvedValue({
+      handledBy: "plugin",
+      payload: {},
+    });
+
+    await runMessageAction({
+      cfg: telegramConfig,
+      action: "send",
+      params: {
+        channel: "telegram",
+        target: "telegram:123",
+        message: "hi",
+        replyTo: "777",
+      },
+      toolContext: {
+        currentChannelId: "telegram:123",
+        currentThreadTs: "42",
+      },
+      agentId: "main",
+    });
+
+    const call = mocks.executeSendAction.mock.calls[0]?.[0] as {
+      replyToId?: string;
+      ctx?: { params?: Record<string, unknown> };
+    };
+    expect(call?.replyToId).toBe("777");
+    expect(call?.ctx?.params?.replyTo).toBe("777");
   });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -891,6 +891,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     mediaUrls: mergedMediaUrls.length ? mergedMediaUrls : undefined,
     gifPlayback,
     bestEffort: bestEffort ?? undefined,
+    replyToId: replyToId ?? undefined,
+    threadId: resolvedThreadId ?? undefined,
   });
 
   return {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -36,6 +36,8 @@ type MessageSendParams = {
   mediaUrls?: string[];
   gifPlayback?: boolean;
   accountId?: string;
+  replyToId?: string;
+  threadId?: string | number;
   dryRun?: boolean;
   bestEffort?: boolean;
   deps?: OutboundSendDeps;
@@ -165,6 +167,8 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       to: resolvedTarget.to,
       accountId: params.accountId,
       payloads: normalizedPayloads,
+      replyToId: params.replyToId,
+      threadId: params.threadId,
       gifPlayback: params.gifPlayback,
       deps: params.deps,
       bestEffort: params.bestEffort,
@@ -200,6 +204,8 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : params.mediaUrls,
       gifPlayback: params.gifPlayback,
       accountId: params.accountId,
+      replyToId: params.replyToId,
+      threadId: params.threadId,
       channel,
       sessionKey: params.mirror?.sessionKey,
       idempotencyKey: params.idempotencyKey ?? randomIdempotencyKey(),

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -204,8 +204,6 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : params.mediaUrls,
       gifPlayback: params.gifPlayback,
       accountId: params.accountId,
-      replyToId: params.replyToId,
-      threadId: params.threadId,
       channel,
       sessionKey: params.mirror?.sessionKey,
       idempotencyKey: params.idempotencyKey ?? randomIdempotencyKey(),

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -68,6 +68,8 @@ export async function executeSendAction(params: {
   mediaUrls?: string[];
   gifPlayback?: boolean;
   bestEffort?: boolean;
+  replyToId?: string;
+  threadId?: string | number;
 }): Promise<{
   handledBy: "plugin" | "core";
   payload: unknown;
@@ -117,6 +119,8 @@ export async function executeSendAction(params: {
     mediaUrls: params.mediaUrls,
     channel: params.ctx.channel || undefined,
     accountId: params.ctx.accountId ?? undefined,
+    replyToId: params.replyToId,
+    threadId: params.threadId,
     gifPlayback: params.gifPlayback,
     dryRun: params.ctx.dryRun,
     bestEffort: params.bestEffort ?? undefined,


### PR DESCRIPTION
## Summary

Fixes #14920

The `message` tool's `send` action extracts `replyToId` (from the `replyTo` param) and `threadId` at lines 824-836 of `message-action-runner.ts`, but never passes them through `executeSendAction()` → `sendMessage()` → `deliverOutboundPayloads()`. This means channels like Mattermost, Slack, Discord, and Telegram that support reply threading via their outbound adapters never receive these values when invoked through the message tool.

**Root cause:** `replyToId` and `threadId` were computed in `handleSendAction()` but omitted from the `executeSendAction()` call, so `sendMessage()` and ultimately `deliverOutboundPayloads()` always received `undefined` for both fields.

**Fix:** Thread both parameters through the 3-function call chain:
- `message-action-runner.ts` → pass `replyToId` and `resolvedThreadId` to `executeSendAction()`
- `outbound-send-service.ts` → accept and forward both params to `sendMessage()`
- `message.ts` → accept both in `MessageSendParams` and pass to `deliverOutboundPayloads()` (direct delivery path only; gateway path intentionally omits them due to `SendParamsSchema` `additionalProperties: false`)

## Test plan

- [x] Added 2 unit tests in `message.test.ts` verifying `replyToId` and `threadId` reach the outbound adapter's `sendText` context
- [x] Both tests fail before the fix, pass after
- [x] `pnpm build && pnpm check` pass
- [x] Existing threading tests in `message-action-runner.threading.test.ts` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change threads `replyToId` and `threadId` from the `message` tool’s send action all the way through `executeSendAction()` → `sendMessage()` → `deliverOutboundPayloads()` so direct-delivery outbound adapters receive reply/thread context (e.g., Slack/Mattermost/Telegram-style threading).

Concretely:
- `src/infra/outbound/message-action-runner.ts` now passes the extracted/auto-resolved `replyToId` + `resolvedThreadId` into `executeSendAction()`.
- `src/infra/outbound/outbound-send-service.ts` accepts and forwards those params into `sendMessage()`.
- `src/infra/outbound/message.ts` extends `MessageSendParams` and forwards both fields into `deliverOutboundPayloads()` on the direct path; the gateway path remains unchanged (and continues to omit these fields).
- Tests in `src/infra/outbound/message.test.ts` validate that both fields reach an outbound adapter’s `sendText` context.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to parameter plumbing, align with existing outbound adapter context types (deliverOutboundPayloads already supports replyToId/threadId), and are covered by targeted unit tests exercising the new fields reaching an adapter.
- No files require special attention

<sub>Last reviewed commit: c697b48</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->