### PR TITLE
fix: cap cron session records to prevent context overflow (#14773)

### DIFF
--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -8,4 +8,12 @@ export type CronConfig = {
    * Default: "24h".
    */
   sessionRetention?: string | false;
+  /**
+   * Maximum number of completed run sessions to keep per cron job.
+   * When a job exceeds this cap the oldest runs are removed, even if they
+   * are still within the retention window. This prevents unbounded growth
+   * of sessions.json when jobs fire frequently.
+   * Default: 50.
+   */
+  maxRunsPerJob?: number;
 };

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -1,6 +1,7 @@
 /**
  * Cron session reaper — prunes completed isolated cron run sessions
- * from the session store after a configurable retention period.
+ * from the session store after a configurable retention period and
+ * caps the number of run records per job to prevent unbounded growth.
  *
  * Pattern: sessions keyed as `...:cron:<jobId>:run:<uuid>` are ephemeral
  * run records. The base session (`...:cron:<jobId>`) is kept as-is.
@@ -10,9 +11,10 @@ import type { CronConfig } from "../config/types.cron.js";
 import type { Logger } from "./service/state.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import { updateSessionStore } from "../config/sessions.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCronRunSessionKey, parseCronRunJobId } from "../sessions/session-key-utils.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
+const DEFAULT_MAX_RUNS_PER_JOB = 50;
 
 /** Minimum interval between reaper sweeps (avoid running every timer tick). */
 const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
@@ -34,15 +36,71 @@ export function resolveRetentionMs(cronConfig?: CronConfig): number | null {
   return DEFAULT_RETENTION_MS;
 }
 
+export function resolveMaxRunsPerJob(cronConfig?: CronConfig): number {
+  const raw = cronConfig?.maxRunsPerJob;
+  if (typeof raw === "number" && raw > 0 && Number.isFinite(raw)) {
+    return Math.floor(raw);
+  }
+  return DEFAULT_MAX_RUNS_PER_JOB;
+}
+
 export type ReaperResult = {
   swept: boolean;
   pruned: number;
 };
 
 /**
+ * Cap the number of run sessions per cron job, keeping only the most recent N.
+ * Mutates `store` in-place. Returns the number of entries removed.
+ */
+export function capRunsPerJob(store: Record<string, unknown>, maxRunsPerJob: number): number {
+  // Group cron run keys by job ID.
+  const jobRuns = new Map<string, Array<{ key: string; updatedAt: number }>>();
+  for (const key of Object.keys(store)) {
+    if (!isCronRunSessionKey(key)) {
+      continue;
+    }
+    const jobId = parseCronRunJobId(key);
+    if (!jobId) {
+      continue;
+    }
+    const entry = store[key] as { updatedAt?: number } | undefined;
+    if (!entry) {
+      continue;
+    }
+    let runs = jobRuns.get(jobId);
+    if (!runs) {
+      runs = [];
+      jobRuns.set(jobId, runs);
+    }
+    runs.push({ key, updatedAt: entry.updatedAt ?? 0 });
+  }
+
+  let removed = 0;
+  for (const runs of jobRuns.values()) {
+    if (runs.length <= maxRunsPerJob) {
+      continue;
+    }
+    // Sort descending by updatedAt (newest first).
+    runs.sort((a, b) => b.updatedAt - a.updatedAt);
+    // Remove excess (oldest) entries.
+    for (let i = maxRunsPerJob; i < runs.length; i++) {
+      delete store[runs[i].key];
+      removed++;
+    }
+  }
+
+  return removed;
+}
+
+/**
  * Sweep the session store and prune expired cron run sessions.
  * Designed to be called from the cron timer tick — self-throttles via
  * MIN_SWEEP_INTERVAL_MS to avoid excessive I/O.
+ *
+ * Two-phase pruning:
+ *   1. TTL-based expiry — remove runs older than the retention window.
+ *   2. Per-job cap — keep only the N most recent runs per cron job.
  *
  * Lock ordering: this function acquires the session-store file lock via
  * `updateSessionStore`. It must be called OUTSIDE of the cron service's
@@ -68,29 +126,32 @@ export async function sweepCronRunSessions(params: {
   }
 
   const retentionMs = resolveRetentionMs(params.cronConfig);
-  if (retentionMs === null) {
-    lastSweepAtMsByStore.set(storePath, now);
-    return { swept: false, pruned: 0 };
-  }
+  const maxRunsPerJob = resolveMaxRunsPerJob(params.cronConfig);
 
   let pruned = 0;
   try {
     await updateSessionStore(storePath, (store) => {
-      const cutoff = now - retentionMs;
-      for (const key of Object.keys(store)) {
-        if (!isCronRunSessionKey(key)) {
-          continue;
-        }
-        const entry = store[key];
-        if (!entry) {
-          continue;
-        }
-        const updatedAt = entry.updatedAt ?? 0;
-        if (updatedAt < cutoff) {
-          delete store[key];
-          pruned++;
+      // Phase 1: TTL-based expiry.
+      if (retentionMs !== null) {
+        const cutoff = now - retentionMs;
+        for (const key of Object.keys(store)) {
+          if (!isCronRunSessionKey(key)) {
+            continue;
+          }
+          const entry = store[key];
+          if (!entry) {
+            continue;
+          }
+          const updatedAt = entry.updatedAt ?? 0;
+          if (updatedAt < cutoff) {
+            delete store[key];
+            pruned++;
+          }
         }
       }
+
+      // Phase 2: per-job cap (removes oldest runs when a job exceeds maxRunsPerJob).
+      pruned += capRunsPerJob(store, maxRunsPerJob);
     });
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
@@ -101,7 +162,7 @@ export async function sweepCronRunSessions(params: {
 
   if (pruned > 0) {
     params.log.info(
-      { pruned, retentionMs },
+      { pruned, retentionMs, maxRunsPerJob },
       `cron-reaper: pruned ${pruned} expired cron run session(s)`,
     );
   }

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -33,6 +33,21 @@ export function isCronRunSessionKey(sessionKey: string | undefined | null): bool
   return /^cron:[^:]+:run:[^:]+$/.test(parsed.rest);
 }
 
+/**
+ * Extract the cron job ID from a cron run session key.
+ * Returns `null` if the key is not a valid cron run session key.
+ *
+ * Example: `"agent:main:cron:job1:run:abc"` returns `"job1"`
+ */
+export function parseCronRunJobId(sessionKey: string | undefined | null): string | null {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return null;
+  }
+  const match = /^cron:([^:]+):run:[^:]+$/.exec(parsed.rest);
+  return match?.[1] ?? null;
+}
+
 export function isSubagentSessionKey(sessionKey: string | undefined | null): boolean {
   const raw = (sessionKey ?? "").trim();
   if (!raw) {


### PR DESCRIPTION
## Summary

Fixes #14773 — Cron session records accumulate indefinitely in `sessions.json`, causing context overflow cascade.

## Problem

Cron run records in `agents/*/sessions/sessions.json` never expire or get cleaned up beyond the TTL window. Each cron run leaves a ~15KB record. Over time with frequent cron jobs, this file grows to 14MB+ (960+ entries). When loaded as session context, it exceeds the model's context window, causing timeout → provider cooldown → cascading lockout.

## Solution

Add a **per-job cap** (`maxRunsPerJob`) to the cron session reaper, complementing the existing TTL-based expiry. The reaper now runs two-phase pruning:

1. **TTL-based expiry** (existing) — remove runs older than the retention window (default: 24h)
2. **Per-job cap** (new) — keep only the N most recent runs per cron job (default: 50)

This ensures that even within the retention window, no single job can accumulate more than `maxRunsPerJob` session records.

## Changes

- **`src/sessions/session-key-utils.ts`**: Add `parseCronRunJobId()` helper to extract the job ID from a cron run session key
- **`src/config/types.cron.ts`**: Add `maxRunsPerJob` config option to `CronConfig` (default: 50)
- **`src/cron/session-reaper.ts`**: 
  - Add `resolveMaxRunsPerJob()` to read config with validation
  - Add `capRunsPerJob()` to enforce per-job caps
  - Update `sweepCronRunSessions()` to run both TTL and cap phases
  - Remove early return when TTL is disabled (cap still needs to run)
- **`src/cron/session-reaper.test.ts`**: Add 13 new tests covering:
  - `resolveMaxRunsPerJob` config resolution (6 tests)
  - `parseCronRunJobId` extraction (4 tests)
  - Per-job capping behavior (3 tests: single job, multiple jobs, combined TTL+cap)

## Configuration

Users can tune the cap via `cron.maxRunsPerJob` in `openclaw.json`:

```json
{
  "cron": {
    "maxRunsPerJob": 20,
    "sessionRetention": "12h"
  }
}
```

## Testing

- All 27 session-reaper tests pass (14 existing + 13 new)
- All 135 cron tests pass
- All 41 session store tests pass
- `pnpm check` passes (format, types, lint)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change extends the cron session reaper so `agents/*/sessions/sessions.json` can’t grow without bound when cron jobs run frequently.

- Adds `cron.maxRunsPerJob` (default `50`) to cap the number of completed run records retained per cron job.
- Introduces `parseCronRunJobId()` to extract a job id from cron run session keys.
- Updates `sweepCronRunSessions()` to run two-phase pruning: TTL-based retention (existing) plus per-job capping (new), even when TTL pruning is disabled.
- Expands tests to cover maxRunsPerJob resolution, job id parsing, and capping behavior across single/multiple jobs and combined with TTL.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing deterministic pruning for equal timestamps.
- Core logic is straightforward and well-covered by tests, but the per-job capping currently has non-deterministic behavior when `updatedAt` ties, which can cause inconsistent deletions and potential test/runtime flakiness depending on data patterns.
- src/cron/session-reaper.ts

<sub>Last reviewed commit: dbb2aaa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->