### PR TITLE
feat: auto-report subagent costs to parent session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ USER.md
 .agent/*.json
 !.agent/workflows/
 local/
+package-lock.json

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -42,6 +42,16 @@ vi.mock("./tools/agent-step.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
+  canonicalizeRequesterStoreKey: (_cfg: unknown, key: string) => {
+    const raw = key.trim();
+    if (raw.startsWith("agent:")) {
+      return raw;
+    }
+    if (raw === "main") {
+      return "agent:main:main";
+    }
+    return `agent:main:${raw}`;
+  },
   loadSessionStore: vi.fn(() => sessionStore),
   resolveAgentIdFromSessionKey: () => "main",
   resolveStorePath: () => "/tmp/sessions.json",

--- a/src/agents/subagent-cost-report.test.ts
+++ b/src/agents/subagent-cost-report.test.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions/types.js";
+
+let tempDir: string;
+let storePath: string;
+
+const mockConfig: Record<string, unknown> = {
+  session: { store: "" },
+  models: {
+    providers: {
+      anthropic: {
+        models: [
+          {
+            id: "claude-sonnet-4-20250514",
+            cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+          },
+        ],
+      },
+    },
+  },
+};
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("../routing/session-key.js", async () => {
+  const actual = await vi.importActual<typeof import("../routing/session-key.js")>(
+    "../routing/session-key.js",
+  );
+  return {
+    ...actual,
+    resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+  };
+});
+
+vi.mock("../config/sessions.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../config/sessions.js")>("../config/sessions.js");
+  return {
+    ...actual,
+    resolveStorePath: vi.fn(() => (mockConfig.session as { store: string }).store),
+  };
+});
+
+function writeStore(storeFilePath: string, store: Record<string, SessionEntry>) {
+  fs.mkdirSync(path.dirname(storeFilePath), { recursive: true });
+  fs.writeFileSync(storeFilePath, JSON.stringify(store, null, 2), "utf-8");
+}
+
+function readStore(storeFilePath: string): Record<string, SessionEntry> {
+  return JSON.parse(fs.readFileSync(storeFilePath, "utf-8"));
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cost-report-"));
+  storePath = path.join(tempDir, "sessions.json");
+  (mockConfig.session as { store: string }).store = storePath;
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("collectSubagentUsage", async () => {
+  const { collectSubagentUsage } = await import("./subagent-cost-report.js");
+
+  it("returns undefined when child session has no token data", () => {
+    writeStore(storePath, {
+      "agent:main:subagent:child-1": {
+        sessionId: "s-child-1",
+        updatedAt: Date.now(),
+      },
+    });
+    const result = collectSubagentUsage({ childSessionKey: "agent:main:subagent:child-1" });
+    expect(result).toBeUndefined();
+  });
+
+  it("collects usage metrics from child session", () => {
+    writeStore(storePath, {
+      "agent:main:subagent:child-2": {
+        sessionId: "s-child-2",
+        updatedAt: Date.now(),
+        inputTokens: 5000,
+        outputTokens: 1000,
+        totalTokens: 6000,
+        modelProvider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+      },
+    });
+    const result = collectSubagentUsage({ childSessionKey: "agent:main:subagent:child-2" });
+    expect(result).toBeDefined();
+    expect(result?.inputTokens).toBe(5000);
+    expect(result?.outputTokens).toBe(1000);
+    expect(result?.totalTokens).toBe(6000);
+    expect(result?.provider).toBe("anthropic");
+    expect(result?.model).toBe("claude-sonnet-4-20250514");
+    expect(typeof result?.cost).toBe("number");
+    expect(result?.cost).toBeGreaterThan(0);
+  });
+
+  it("computes totalTokens from input+output when not explicitly set", () => {
+    writeStore(storePath, {
+      "agent:main:subagent:child-3": {
+        sessionId: "s-child-3",
+        updatedAt: Date.now(),
+        inputTokens: 2000,
+        outputTokens: 800,
+      },
+    });
+    const result = collectSubagentUsage({ childSessionKey: "agent:main:subagent:child-3" });
+    expect(result).toBeDefined();
+    expect(result?.totalTokens).toBe(2800);
+  });
+});
+
+describe("reportSubagentCostToParent", async () => {
+  const { reportSubagentCostToParent } = await import("./subagent-cost-report.js");
+
+  it("accumulates usage onto parent session entry", async () => {
+    writeStore(storePath, {
+      "agent:main:main": {
+        sessionId: "s-parent",
+        updatedAt: Date.now(),
+        inputTokens: 10000,
+        outputTokens: 2000,
+      },
+    });
+    await reportSubagentCostToParent({
+      requesterSessionKey: "agent:main:main",
+      usage: {
+        inputTokens: 5000,
+        outputTokens: 1000,
+        totalTokens: 6000,
+        cost: 0.03,
+      },
+    });
+
+    const store = readStore(storePath);
+    const parent = store["agent:main:main"];
+    expect(parent.subagentInputTokens).toBe(5000);
+    expect(parent.subagentOutputTokens).toBe(1000);
+    expect(parent.subagentTotalTokens).toBe(6000);
+    expect(parent.subagentCost).toBe(0.03);
+    expect(parent.subagentRunCount).toBe(1);
+
+    // Second subagent run should accumulate
+    await reportSubagentCostToParent({
+      requesterSessionKey: "agent:main:main",
+      usage: {
+        inputTokens: 3000,
+        outputTokens: 500,
+        totalTokens: 3500,
+        cost: 0.02,
+      },
+    });
+
+    const store2 = readStore(storePath);
+    const parent2 = store2["agent:main:main"];
+    expect(parent2.subagentInputTokens).toBe(8000);
+    expect(parent2.subagentOutputTokens).toBe(1500);
+    expect(parent2.subagentTotalTokens).toBe(9500);
+    expect(parent2.subagentCost).toBe(0.05);
+    expect(parent2.subagentRunCount).toBe(2);
+  });
+
+  it("handles missing parent session gracefully", async () => {
+    writeStore(storePath, {});
+    await reportSubagentCostToParent({
+      requesterSessionKey: "agent:main:nonexistent",
+      usage: { inputTokens: 1000, outputTokens: 500, totalTokens: 1500, cost: 0.01 },
+    });
+    const store = readStore(storePath);
+    expect(store["agent:main:nonexistent"]).toBeUndefined();
+  });
+
+  it("handles empty requesterSessionKey gracefully", async () => {
+    await reportSubagentCostToParent({
+      requesterSessionKey: "",
+      usage: { inputTokens: 1000, totalTokens: 1000 },
+    });
+  });
+
+  it("preserves existing parent session fields", async () => {
+    writeStore(storePath, {
+      "agent:main:main": {
+        sessionId: "s-parent",
+        updatedAt: Date.now(),
+        inputTokens: 10000,
+        outputTokens: 2000,
+        compactionCount: 3,
+      },
+    });
+    await reportSubagentCostToParent({
+      requesterSessionKey: "agent:main:main",
+      usage: { inputTokens: 5000, outputTokens: 1000, totalTokens: 6000, cost: 0.03 },
+    });
+
+    const store = readStore(storePath);
+    const parent = store["agent:main:main"];
+    expect(parent.inputTokens).toBe(10000);
+    expect(parent.outputTokens).toBe(2000);
+    expect(parent.compactionCount).toBe(3);
+    expect(parent.subagentRunCount).toBe(1);
+  });
+});

--- a/src/agents/subagent-cost-report.ts
+++ b/src/agents/subagent-cost-report.ts
@@ -1,0 +1,98 @@
+import type { SubagentUsageMetrics } from "./subagent-registry.js";
+import { loadConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  updateSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
+
+/**
+ * Collect usage metrics (tokens + cost) from a child session entry.
+ * Returns undefined if the session has no meaningful token data.
+ */
+export function collectSubagentUsage(params: {
+  childSessionKey: string;
+}): SubagentUsageMetrics | undefined {
+  const cfg = loadConfig();
+  const agentId = resolveAgentIdFromSessionKey(params.childSessionKey);
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  const store = loadSessionStore(storePath);
+  const entry = store[params.childSessionKey];
+  if (!entry) {
+    return undefined;
+  }
+
+  const input = entry.inputTokens;
+  const output = entry.outputTokens;
+  const total =
+    entry.totalTokens ??
+    (typeof input === "number" && typeof output === "number" ? input + output : undefined);
+
+  if (total === undefined && input === undefined && output === undefined) {
+    return undefined;
+  }
+
+  const provider = entry.modelProvider ?? entry.providerOverride;
+  const model = entry.model ?? entry.modelOverride;
+
+  const costConfig = resolveModelCostConfig({ provider, model, config: cfg });
+  const cost = estimateUsageCost({
+    usage: { input: input ?? undefined, output: output ?? undefined },
+    cost: costConfig,
+  });
+
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    totalTokens: total,
+    cost,
+    model,
+    provider,
+  };
+}
+
+/**
+ * Accumulate subagent usage metrics onto the parent (requester) session.
+ * This is called after a subagent completes so that the parent session
+ * tracks aggregated cost/token data from all of its child runs.
+ */
+export async function reportSubagentCostToParent(params: {
+  requesterSessionKey: string;
+  usage: SubagentUsageMetrics;
+}): Promise<void> {
+  const { requesterSessionKey, usage } = params;
+  if (!requesterSessionKey) {
+    return;
+  }
+
+  const cfg = loadConfig();
+  const agentId = resolveAgentIdFromSessionKey(requesterSessionKey);
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+
+  await updateSessionStore(storePath, (store) => {
+    const entry = store[requesterSessionKey];
+    if (!entry) {
+      return;
+    }
+
+    const patch: Partial<SessionEntry> = {};
+    const addNum = (a?: number, b?: number): number | undefined => {
+      if (a === undefined && b === undefined) {
+        return undefined;
+      }
+      return (a ?? 0) + (b ?? 0);
+    };
+
+    patch.subagentInputTokens = addNum(entry.subagentInputTokens, usage.inputTokens);
+    patch.subagentOutputTokens = addNum(entry.subagentOutputTokens, usage.outputTokens);
+    patch.subagentTotalTokens = addNum(entry.subagentTotalTokens, usage.totalTokens);
+    patch.subagentCost = addNum(entry.subagentCost, usage.cost);
+    patch.subagentRunCount = (entry.subagentRunCount ?? 0) + 1;
+
+    Object.assign(entry, patch);
+    store[requesterSessionKey] = entry;
+  });
+}

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -9,6 +9,15 @@ import {
 } from "./subagent-registry.store.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 
+export type SubagentUsageMetrics = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cost?: number;
+  model?: string;
+  provider?: string;
+};
+
 export type SubagentRunRecord = {
   runId: string;
   childSessionKey: string;
@@ -22,6 +31,7 @@ export type SubagentRunRecord = {
   startedAt?: number;
   endedAt?: number;
   outcome?: SubagentRunOutcome;
+  usage?: SubagentUsageMetrics;
   archiveAtMs?: number;
   cleanupCompletedAt?: number;
   cleanupHandled?: boolean;
@@ -393,6 +403,15 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
   } catch {
     // ignore
   }
+}
+
+export function updateSubagentRunUsage(runId: string, usage: SubagentUsageMetrics) {
+  const entry = subagentRuns.get(runId);
+  if (!entry) {
+    return;
+  }
+  entry.usage = usage;
+  persistSubagentRuns();
 }
 
 export function resetSubagentRegistryForTests() {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -74,6 +74,11 @@ export type SessionEntry = {
   model?: string;
   contextTokens?: number;
   compactionCount?: number;
+  subagentInputTokens?: number;
+  subagentOutputTokens?: number;
+  subagentTotalTokens?: number;
+  subagentCost?: number;
+  subagentRunCount?: number;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
   cliSessionIds?: Record<string, string>;


### PR DESCRIPTION
## Summary

Fixes #14921 — When subagent sessions complete, their cost/token data was lost because child sessions are ephemeral. This PR automatically reports subagent metrics (cost, tokens, runtime, status) back to the parent session on completion, and accumulates these metrics so they're visible in `/status` and `session_status`.

## Changes

### New: `src/agents/subagent-cost-report.ts`
- `collectSubagentUsage()` — reads the child session's token/cost data from the session store
- `reportSubagentCostToParent()` — accumulates usage metrics onto the parent session entry

### Modified: `src/agents/subagent-registry.ts`
- Added `SubagentUsageMetrics` type (inputTokens, outputTokens, totalTokens, cost, model, provider)
- Added `usage?: SubagentUsageMetrics` field to `SubagentRunRecord`
- Added `updateSubagentRunUsage()` to persist usage on the run record

### Modified: `src/config/sessions/types.ts`
- Added aggregation fields to `SessionEntry`: `subagentInputTokens`, `subagentOutputTokens`, `subagentTotalTokens`, `subagentCost`, `subagentRunCount`

### Modified: `src/agents/subagent-announce.ts`
- After building stats in the announce flow, collects child session usage and reports it to the parent session (best-effort, won't block announce)

### Modified: `src/auto-reply/reply/commands-status.ts` & `src/agents/tools/session-status-tool.ts`
- Both `/status` command and `session_status` tool now display accumulated subagent costs
- Example: `🤖 Subagents: 2 active · 3 done · total: 5 runs · 45.2k tokens · $0.12`

### New: `src/agents/subagent-cost-report.test.ts`
- 7 tests covering: collection from child sessions, accumulation onto parent, edge cases (missing session, empty key, field preservation)

## Testing
- `pnpm check` passes (format, tsgo, lint)
- All 7 new tests pass
- Existing subagent tests (`subagent-registry.persistence.test.ts`, `subagents-utils.test.ts`) continue to pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds best-effort reporting of subagent usage (tokens + estimated cost) back onto the parent session entry when a subagent finishes, and updates both `/status` and the `session_status` tool to display aggregated subagent totals.

It introduces `collectSubagentUsage` / `reportSubagentCostToParent` (new `src/agents/subagent-cost-report.ts`), persists per-run usage onto `SubagentRunRecord`, and extends `SessionEntry` with aggregated subagent counters (`subagent*`).

<h3>Confidence Score: 2/5</h3>

- This PR should not merge as-is due to a TypeScript syntax error and a logic issue that can record costs against the wrong session store.
- A stray quote in `src/config/sessions/types.ts` will break compilation. Separately, the cost reporting code derives the target session store from a potentially non-canonical `requesterSessionKey`, which can default to the `main` agent store and cause misattribution or dropped updates for non-main agents.
- src/config/sessions/types.ts, src/agents/subagent-cost-report.ts

<sub>Last reviewed commit: 1f869c3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->