### PR TITLE
feat: add Ollama Cloud API support

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -309,6 +309,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     together: "TOGETHER_API_KEY",
     qianfan: "QIANFAN_API_KEY",
     ollama: "OLLAMA_API_KEY",
+    "ollama-cloud": "OLLAMA_CLOUD_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -662,8 +662,13 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "ollama-cloud", store: authStore });
   if (ollamaCloudKey) {
     const ollamaCloudBaseUrl = params.explicitProviders?.["ollama-cloud"]?.baseUrl;
+    // Resolve the actual API key value for model discovery —
+    // resolveEnvApiKeyVarName returns the env-var NAME, not its value.
+    const ollamaCloudDiscoveryKey =
+      resolveEnvApiKey("ollama-cloud")?.apiKey ??
+      resolveApiKeyFromProfiles({ provider: "ollama-cloud", store: authStore });
     providers["ollama-cloud"] = {
-      ...(await buildOllamaCloudProvider(ollamaCloudBaseUrl, ollamaCloudKey)),
+      ...(await buildOllamaCloudProvider(ollamaCloudBaseUrl, ollamaCloudDiscoveryKey)),
       apiKey: ollamaCloudKey,
     };
   }

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -16,6 +16,7 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   // Check for exact matches or known prefixes/substrings for reasoning providers
   if (
     normalized === "ollama" ||
+    normalized === "ollama-cloud" ||
     normalized === "google-gemini-cli" ||
     normalized === "google-generative-ai"
   ) {


### PR DESCRIPTION
## Summary

Add native integration with [Ollama Cloud](https://ollama.com) (`ollama.com`) as a new provider `ollama-cloud`, separate from the existing local `ollama` provider.

Closes #14905

## Changes

### New provider: `ollama-cloud`
- **Base URL:** `https://ollama.com/v1` (OpenAI-compatible endpoint)
- **Auth:** Bearer token via `OLLAMA_CLOUD_API_KEY` environment variable or auth profile
- **API:** `openai-completions` (same as local Ollama)
- **Model discovery:** Fetches available models from `https://ollama.com/api/tags` with Bearer auth

### Files changed
- **`src/agents/models-config.providers.ts`** — Added `OLLAMA_CLOUD_*` constants, `resolveOllamaCloudApiBase()`, `discoverOllamaCloudModels()`, `buildOllamaCloudProvider()`, and registration in `resolveImplicitProviders()`
- **`src/agents/model-auth.ts`** — Added `ollama-cloud` → `OLLAMA_CLOUD_API_KEY` env var mapping
- **`src/utils/provider-utils.ts`** — Added `ollama-cloud` to reasoning tag providers
- **`src/agents/models-config.providers.ollama.test.ts`** — Added 11 new tests for Ollama Cloud

### Usage

```bash
# Set the API key
export OLLAMA_CLOUD_API_KEY=your_api_key

# Models will be auto-discovered from ollama.com
# Use as: ollama-cloud/gpt-oss:120b, ollama-cloud/deepseek-v3.2, etc.
```

Both local `ollama` and `ollama-cloud` can be used simultaneously as independent providers.

## Testing
- All 18 tests pass (7 existing + 11 new)
- `pnpm check` passes (format, typecheck, lint)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `ollama-cloud` provider alongside local `ollama`, including provider registration, env-var auth mapping (`OLLAMA_CLOUD_API_KEY`), and reasoning-tag classification.

The provider config points at the OpenAI-compatible `https://ollama.com/v1` endpoint and attempts to auto-discover available models via the native `/api/tags` endpoint. Tests were expanded to cover the new base URL canonicalization and implicit provider injection behavior.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to broken Ollama Cloud model discovery when using env-based auth.
- The new `ollama-cloud` discovery path uses the env var name as the bearer token when auth is sourced from environment, which will reliably cause unauthorized discovery requests and defeats the advertised auto-discovery behavior. Scope is limited but affects core functionality of the new feature.
- src/agents/models-config.providers.ts; src/agents/models-config.providers.ollama.test.ts

<sub>Last reviewed commit: 9dcf65b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->