### PR TITLE
fix(mattermost): add WebSocket reconnection with exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
 - Discord/Agents: apply channel/group `historyLimit` during embedded-runner history compaction to prevent long-running channel sessions from bypassing truncation and overflowing context windows. (#11224) Thanks @shadril238.
+- Mattermost (plugin): retry websocket monitor connections with exponential backoff and abort-aware teardown so transient connect failures no longer permanently stop monitoring. (#14962) Thanks @mcaxtr.
 - Telegram: scope skill commands to the resolved agent for default accounts so `setMyCommands` no longer triggers `BOT_COMMANDS_TOO_MUCH` when multiple agents are configured. (#15599)
 - Plugins/Hooks: fire `before_tool_call` hook exactly once per tool invocation in embedded runs by removing duplicate dispatch paths while preserving parameter mutation semantics. (#15635) Thanks @lailoo.
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -972,6 +972,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           opts.statusSink?.({
             lastError: String(err),
           });
+          ws.close();
         });
       });
     } finally {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -892,7 +892,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
   const connectOnce = async (): Promise<void> => {
     const ws = new WebSocket(wsUrl);
-    const onAbort = () => ws.close();
+    const onAbort = () => ws.terminate();
     opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
     try {

--- a/extensions/mattermost/src/mattermost/reconnect.test.ts
+++ b/extensions/mattermost/src/mattermost/reconnect.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithReconnect } from "./reconnect.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runWithReconnect", () => {
+  it("retries after connectFn resolves (normal close)", async () => {
+    let callCount = 0;
+    const abort = new AbortController();
+    const connectFn = vi.fn(async () => {
+      callCount++;
+      if (callCount >= 3) {
+        abort.abort();
+      }
+    });
+
+    await runWithReconnect(connectFn, {
+      abortSignal: abort.signal,
+      initialDelayMs: 1,
+    });
+
+    expect(connectFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries after connectFn throws (connection error)", async () => {
+    let callCount = 0;
+    const abort = new AbortController();
+    const onError = vi.fn();
+    const connectFn = vi.fn(async () => {
+      callCount++;
+      if (callCount < 3) {
+        throw new Error("fetch failed");
+      }
+      abort.abort();
+    });
+
+    await runWithReconnect(connectFn, {
+      abortSignal: abort.signal,
+      onError,
+      initialDelayMs: 1,
+    });
+
+    expect(connectFn).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: "fetch failed" }));
+  });
+
+  it("uses exponential backoff on consecutive errors, capped at maxDelayMs", async () => {
+    const abort = new AbortController();
+    const delays: number[] = [];
+    let callCount = 0;
+    const connectFn = vi.fn(async () => {
+      callCount++;
+      if (callCount >= 6) {
+        abort.abort();
+        return;
+      }
+      throw new Error("connection refused");
+    });
+
+    await runWithReconnect(connectFn, {
+      abortSignal: abort.signal,
+      onReconnect: (delayMs) => delays.push(delayMs),
+      initialDelayMs: 100,
+      maxDelayMs: 1000,
+    });
+
+    expect(connectFn).toHaveBeenCalledTimes(6);
+    // 5 errors produce doubled delays: 200, 400, 800, 1000(cap), 1000(cap)
+    // 6th succeeds → delay resets to 100
+    // But 6th also aborts → onReconnect NOT called (abort check fires first)
+    expect(delays).toEqual([200, 400, 800, 1000, 1000]);
+  });
+
+  it("resets backoff after successful connection", async () => {
+    const abort = new AbortController();
+    const delays: number[] = [];
+    let callCount = 0;
+    const connectFn = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new Error("first failure");
+      }
+      if (callCount === 2) {
+        return; // success
+      }
+      if (callCount === 3) {
+        throw new Error("second failure");
+      }
+      abort.abort();
+    });
+
+    await runWithReconnect(connectFn, {
+      abortSignal: abort.signal,
+      onReconnect: (delayMs) => delays.push(delayMs),
+      initialDelayMs: 100,
+      maxDelayMs: 60_000,
+    });
+
+    expect(connectFn).toHaveBeenCalledTimes(4);
+    // call 1: fail → delay 200
+    // call 2: success → delay resets to 100
+    // call 3: fail → delay 200 (NOT 400 — was reset)
+    // call 4: success + abort → no onReconnect
+    expect(delays).toEqual([200, 100, 200]);
+  });
+
+  it("stops immediately when abort signal is pre-fired", async () => {
+    const abort = new AbortController();
+    abort.abort();
+    const connectFn = vi.fn(async () => {});
+
+    await runWithReconnect(connectFn, { abortSignal: abort.signal });
+
+    expect(connectFn).not.toHaveBeenCalled();
+  });
+
+  it("stops after current connection when abort fires mid-connection", async () => {
+    const abort = new AbortController();
+    const connectFn = vi.fn(async () => {
+      abort.abort();
+    });
+
+    await runWithReconnect(connectFn, {
+      abortSignal: abort.signal,
+      initialDelayMs: 1,
+    });
+
+    expect(connectFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/mattermost/src/mattermost/reconnect.test.ts
+++ b/extensions/mattermost/src/mattermost/reconnect.test.ts
@@ -68,10 +68,10 @@ describe("runWithReconnect", () => {
     });
 
     expect(connectFn).toHaveBeenCalledTimes(6);
-    // 5 errors produce doubled delays: 200, 400, 800, 1000(cap), 1000(cap)
-    // 6th succeeds → delay resets to 100
+    // 5 errors produce delays: 100, 200, 400, 800, 1000(cap)
+    // 6th succeeds -> delay resets to 100
     // But 6th also aborts → onReconnect NOT called (abort check fires first)
-    expect(delays).toEqual([200, 400, 800, 1000, 1000]);
+    expect(delays).toEqual([100, 200, 400, 800, 1000]);
   });
 
   it("resets backoff after successful connection", async () => {
@@ -100,11 +100,11 @@ describe("runWithReconnect", () => {
     });
 
     expect(connectFn).toHaveBeenCalledTimes(4);
-    // call 1: fail → delay 200
+    // call 1: fail -> delay 100
     // call 2: success → delay resets to 100
-    // call 3: fail → delay 200 (NOT 400 — was reset)
+    // call 3: fail -> delay 100 (reset held)
     // call 4: success + abort → no onReconnect
-    expect(delays).toEqual([200, 100, 200]);
+    expect(delays).toEqual([100, 100, 100]);
   });
 
   it("stops immediately when abort signal is pre-fired", async () => {

--- a/extensions/mattermost/src/mattermost/reconnect.ts
+++ b/extensions/mattermost/src/mattermost/reconnect.ts
@@ -1,0 +1,35 @@
+/**
+ * Reconnection loop with exponential backoff.
+ *
+ * Calls `connectFn` in a while loop. On normal resolve (connection closed),
+ * the backoff resets. On thrown error (connection failed), the backoff doubles.
+ * The loop exits when `abortSignal` fires.
+ */
+export async function runWithReconnect(
+  connectFn: () => Promise<void>,
+  opts: {
+    abortSignal?: AbortSignal;
+    onError?: (err: unknown) => void;
+    onReconnect?: (delayMs: number) => void;
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+  } = {},
+): Promise<void> {
+  const { initialDelayMs = 2000, maxDelayMs = 60_000 } = opts;
+  let retryDelay = initialDelayMs;
+
+  while (!opts.abortSignal?.aborted) {
+    try {
+      await connectFn();
+      retryDelay = initialDelayMs;
+    } catch (err) {
+      opts.onError?.(err);
+      retryDelay = Math.min(retryDelay * 2, maxDelayMs);
+    }
+    if (opts.abortSignal?.aborted) {
+      return;
+    }
+    opts.onReconnect?.(retryDelay);
+    await new Promise((r) => setTimeout(r, retryDelay));
+  }
+}

--- a/extensions/mattermost/src/mattermost/reconnect.ts
+++ b/extensions/mattermost/src/mattermost/reconnect.ts
@@ -23,6 +23,9 @@ export async function runWithReconnect(
       await connectFn();
       retryDelay = initialDelayMs;
     } catch (err) {
+      if (opts.abortSignal?.aborted) {
+        return;
+      }
       opts.onError?.(err);
       retryDelay = Math.min(retryDelay * 2, maxDelayMs);
     }

--- a/extensions/mattermost/src/mattermost/reconnect.ts
+++ b/extensions/mattermost/src/mattermost/reconnect.ts
@@ -40,14 +40,14 @@ function sleepAbortable(ms: number, signal?: AbortSignal): Promise<void> {
       resolve();
       return;
     }
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true },
-    );
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/extensions/mattermost/src/mattermost/reconnect.ts
+++ b/extensions/mattermost/src/mattermost/reconnect.ts
@@ -30,6 +30,24 @@ export async function runWithReconnect(
       return;
     }
     opts.onReconnect?.(retryDelay);
-    await new Promise((r) => setTimeout(r, retryDelay));
+    await sleepAbortable(retryDelay, opts.abortSignal);
   }
+}
+
+function sleepAbortable(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #13980

The Mattermost WebSocket monitor had no error recovery — when `connectOnce()` threw (e.g., connection refused, DNS failure), the error propagated out of the `while` loop, causing the gateway to log "channel exited" and never restart.

**Changes:**
- Extract `runWithReconnect()` utility with exponential backoff (2s → 60s cap), abort-aware sleep, and proper listener cleanup
- Make `connectOnce()` reject when WebSocket closes before `open` event fires, so connection failures actually trigger the backoff path
- Skip error reporting when abort signal causes the rejection (normal shutdown path)

## Test plan

- [x] Add `reconnect.test.ts` with 7 unit tests covering:
  - Retry after normal close (resolve path)
  - Retry after connection error (throw path)
  - Exponential backoff with cap
  - Backoff reset after successful connection
  - Pre-fired abort signal stops immediately
  - Mid-connection abort stops after current attempt
  - Abort signal interrupts backoff sleep immediately
- [x] All 7 tests fail before fix, pass after
- [x] `pnpm build` passes
- [x] `pnpm check` passes (oxfmt + oxlint clean)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Mattermost monitor to use a new `runWithReconnect()` helper that retries WebSocket connections with exponential backoff and abort-aware sleeping. It also changes `connectOnce()` to reject if the socket closes before ever reaching `open`, and to force a `close` event after `error` by calling `ws.close()`, so failures actually progress through the reconnect loop. New unit tests (`reconnect.test.ts`) cover backoff behavior and abort handling for the reconnect helper.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to the Mattermost monitor’s reconnection loop and a small new reconnect utility; the updated WebSocket lifecycle now reliably settles on error/abort, and added unit tests cover the backoff/abort edge cases. No remaining correctness issues were found in the changed code paths.
- No files require special attention

<sub>Last reviewed commit: 0400a76</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->