### PR TITLE
fix: unify role ordering error detection to prevent stuck sessions

### DIFF
--- a/src/agents/pi-embedded-helpers.isroleorderingerror.test.ts
+++ b/src/agents/pi-embedded-helpers.isroleorderingerror.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isRoleOrderingError } from "./pi-embedded-helpers.js";
+
+describe("isRoleOrderingError", () => {
+  it("returns false for undefined/empty input", () => {
+    expect(isRoleOrderingError(undefined)).toBe(false);
+    expect(isRoleOrderingError("")).toBe(false);
+  });
+
+  it("detects Anthropic 'roles must alternate' errors", () => {
+    expect(
+      isRoleOrderingError('messages: roles must alternate between "user" and "assistant"'),
+    ).toBe(true);
+  });
+
+  it("detects Google 'incorrect role information' errors", () => {
+    expect(isRoleOrderingError("Incorrect role information")).toBe(true);
+    expect(isRoleOrderingError("incorrect role information in messages")).toBe(true);
+  });
+
+  it("detects 400-prefix role errors", () => {
+    expect(isRoleOrderingError("400 Incorrect role information")).toBe(true);
+    expect(isRoleOrderingError("400 Bad Request: role must alternate")).toBe(true);
+  });
+
+  it("detects JSON-wrapped role errors", () => {
+    expect(isRoleOrderingError('{"error":{"message":"400 Incorrect role information"}}')).toBe(
+      true,
+    );
+    expect(isRoleOrderingError('{"message":"Incorrect role information in messages"}')).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isRoleOrderingError("Context overflow")).toBe(false);
+    expect(isRoleOrderingError("Something exploded")).toBe(false);
+    expect(isRoleOrderingError("500 Internal Server Error")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -21,6 +21,7 @@ export {
   isCloudflareOrHtmlErrorPage,
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
+  isRoleOrderingError,
   isContextOverflowError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -154,6 +154,7 @@ vi.mock("../pi-embedded-helpers.js", async () => {
     pickFallbackThinkingLevel: vi.fn(() => null),
     isTimeoutErrorMessage: vi.fn(() => false),
     parseImageDimensionError: vi.fn(() => null),
+    isRoleOrderingError: vi.fn(() => false),
   };
 });
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -35,6 +35,7 @@ import {
   isBillingAssistantError,
   isCompactionFailureError,
   isContextOverflowError,
+  isRoleOrderingError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
   parseImageSizeError,
@@ -622,7 +623,7 @@ export async function runEmbeddedPiAgent(
           if (promptError && !aborted) {
             const errorText = describeUnknownError(promptError);
             // Handle role ordering errors with a user-friendly message
-            if (/incorrect role information|roles must alternate/i.test(errorText)) {
+            if (isRoleOrderingError(errorText)) {
               return {
                 payloads: [
                   {


### PR DESCRIPTION
## Problem

Fixes #14554

When an LLM provider returns a role ordering error in certain formats (e.g. `400 Incorrect role information` or JSON-wrapped variants), the auto-recovery path (session reset) fails to trigger. This leaves users stuck in an infinite error loop seeing:

> ⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session.

**Root cause:** The role ordering error regex was inconsistent across 3 files:
- `errors.ts` (`formatAssistantErrorText`) used a broad pattern catching 400-prefix and JSON-wrapped variants: `/incorrect role information|roles must alternate|400.*role|"message".*role.*information/i`
- `agent-runner-execution.ts` and `pi-embedded-runner/run.ts` used a narrower pattern: `/incorrect role information|roles must alternate/i`

Additionally, when the embedded error path detected `role_ordering` but session reset failed (no session context), the code fell through to `break` and returned a broken `success` result instead of a final error.

## Changes

1. **Extract shared `isRoleOrderingError()` helper** in `pi-embedded-helpers/errors.ts` with the comprehensive regex
2. **Use it consistently** in all 3 detection sites (`errors.ts`, `agent-runner-execution.ts`, `pi-embedded-runner/run.ts`)
3. **Fix embedded error fallthrough**: when `role_ordering` is detected but session reset fails, return a final error instead of falling through to a broken "success" result
4. **Add tests** for the new shared helper

## Testing

- Added `pi-embedded-helpers.isroleorderingerror.test.ts` with 6 tests covering all regex variants
- All existing tests pass (36/36 across 5 related test files)
- `pnpm check` passes (format, typecheck, lint)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR centralizes role-ordering/alternation error detection into a shared `isRoleOrderingError()` helper and wires it into all three call sites that previously used inconsistent regexes. It also fixes an embedded-runner edge case where `role_ordering` errors could fall through after a failed session reset and incorrectly return a `kind: "success"` result, by returning a final user-facing error instead.

Overall, the change aligns error classification across `pi-embedded-helpers/errors.ts`, the embedded runner, and the agent turn fallback loop, and adds coverage for the new helper via a dedicated Vitest file.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped: a shared helper replaces duplicated regexes and an explicit early return prevents an invalid success result when reset fails. The new helper is covered by tests, and usage sites are straightforward substitutions without behavior changes beyond the intended broader detection.
- No files require special attention

<sub>Last reviewed commit: a536d16</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->