### PR TITLE
fix(ui): replace Manual RPC text input with sorted method dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Control UI/Debug: replace the Manual RPC free-text method field with a sorted dropdown sourced from gateway-advertised methods, and stack the form vertically for narrower layouts. (#14967) thanks @rixau.
 - Resolve web tool SecretRefs atomically at runtime. (#41599) Thanks @joshavant.
 - Feishu/local image auto-convert: pass `mediaLocalRoots` through the `sendText` local-image shim so allowed local image paths upload as Feishu images again instead of falling back to raw path text. (#40623) Thanks @ayanesakura.
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
@@ -119,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - MS Teams/authz: keep `groupPolicy: "allowlist"` enforcing sender allowlists even when a team/channel route allowlist is configured, so route matches no longer widen group access to every sender in that route. Thanks @zpbrent.
 - Security/system.run: bind approved `bun` and `deno run` script operands to on-disk file snapshots so post-approval script rewrites are denied before execution.
 - Skills/download installs: pin the validated per-skill tools root before writing downloaded archives, so rebinding the lexical tools path cannot redirect download writes outside the intended tools directory. Thanks @tdjackey.
+- Control UI/Debug: replace the Manual RPC free-text method field with a sorted dropdown sourced from gateway-advertised methods, and stack the form vertically for narrower layouts. (#14967) thanks @rixau.
 
 ## 2026.3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Debug: replace the Manual RPC free-text method field with a sorted dropdown sourced from gateway-advertised methods, and stack the form vertically for narrower layouts. (#14967) thanks @rixau.
 - Resolve web tool SecretRefs atomically at runtime. (#41599) Thanks @joshavant.
 - Feishu/local image auto-convert: pass `mediaLocalRoots` through the `sendText` local-image shim so allowed local image paths upload as Feishu images again instead of falling back to raw path text. (#40623) Thanks @ayanesakura.
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1081,6 +1081,7 @@ export function renderApp(state: AppViewState) {
                 models: state.debugModels,
                 heartbeat: state.debugHeartbeat,
                 eventLog: state.eventLog,
+                methods: (state.hello?.features?.methods ?? []).toSorted(),
                 callMethod: state.debugCallMethod,
                 callParams: state.debugCallParams,
                 callResult: state.debugCallResult,

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -9,6 +9,7 @@ export type DebugProps = {
   models: unknown[];
   heartbeat: unknown;
   eventLog: EventLogEntry[];
+  methods: string[];
   callMethod: string;
   callParams: string;
   callResult: string | null;
@@ -71,14 +72,24 @@ export function renderDebug(props: DebugProps) {
       <div class="card">
         <div class="card-title">Manual RPC</div>
         <div class="card-sub">Send a raw gateway method with JSON params.</div>
-        <div class="form-grid" style="margin-top: 16px;">
+        <div class="stack" style="margin-top: 16px;">
           <label class="field">
             <span>Method</span>
-            <input
+            <select
               .value=${props.callMethod}
-              @input=${(e: Event) => props.onCallMethodChange((e.target as HTMLInputElement).value)}
-              placeholder="system-presence"
-            />
+              @change=${(e: Event) => props.onCallMethodChange((e.target as HTMLSelectElement).value)}
+            >
+              ${
+                !props.callMethod
+                  ? html`
+                      <option value="" disabled selected>Select a method…</option>
+                    `
+                  : nothing
+              }
+              ${props.methods.map(
+                (m) => html`<option value=${m} ?selected=${m === props.callMethod}>${m}</option>`,
+              )}
+            </select>
           </label>
           <label class="field">
             <span>Params (JSON)</span>

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -82,13 +82,11 @@ export function renderDebug(props: DebugProps) {
               ${
                 !props.callMethod
                   ? html`
-                      <option value="" disabled selected>Select a method…</option>
+                      <option value="" disabled>Select a method…</option>
                     `
                   : nothing
               }
-              ${props.methods.map(
-                (m) => html`<option value=${m} ?selected=${m === props.callMethod}>${m}</option>`,
-              )}
+              ${props.methods.map((m) => html`<option value=${m}>${m}</option>`)}
             </select>
           </label>
           <label class="field">


### PR DESCRIPTION
## Summary

- Replace the free-text method input in Debug > Manual RPC with a `<select>` dropdown populated from `hello.features.methods`
- Stack the method and params fields vertically instead of side-by-side (`stack` instead of `form-grid`)
- Add a disabled "Select a method..." placeholder when no method is chosen

## Why

The gateway exposes a known, finite set of RPC methods (~80+ base methods plus channel plugin methods). These are already sent to the client in the WebSocket hello message via `features.methods`. The current free-text input requires users to guess or look up method names in source code, which defeats the purpose of a debug panel.

The side-by-side layout also causes the text input to sit far below its label on narrower viewports.

## Changes

- `ui/src/ui/views/debug.ts` — Add `methods: string[]` prop, replace `<input>` with `<select>`, change `form-grid` to `stack`
- `ui/src/ui/app-render.ts` — Pass sorted `hello.features.methods` array to `renderDebug`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (format + types + lint)
- [x] `pnpm test` — 882 passed
- [x] Tested locally: dropdown renders all gateway methods alphabetically, RPC calls work correctly

## AI Disclosure

- [x] AI-assisted (Claude)
- [x] Lightly tested — verified build/check/test pass and visually confirmed in local Control UI
- [x] I understand what the code does: wires `hello.features.methods` into a `<select>` element and changes the CSS layout class

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Debug  Manual RPC panel to use a method dropdown populated from the gateway hello payload (`hello.features.methods`), and adjusts the layout from a side-by-side grid to a vertical stack. The method list is passed down from `ui/src/ui/app-render.ts` into `renderDebug` in `ui/src/ui/views/debug.ts`, sorted client-side.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one UI state management issue to address.
- Changes are small and localized, but the new <select> mixes a controlled `.value` binding with explicit `selected` attributes on options, which can cause the displayed selection to desync from state on rerender.
- ui/src/ui/views/debug.ts

<sub>Last reviewed commit: 7c5b68b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->