### PR TITLE
fix(ui): config layout panel overlaps with description text (#14957)

### DIFF
--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -8,7 +8,6 @@
   grid-template-columns: 260px minmax(0, 1fr);
   gap: 0;
   height: calc(100vh - 160px);
-  margin: 0 -16px -32px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: var(--panel);

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -8,7 +8,7 @@
   grid-template-columns: 260px minmax(0, 1fr);
   gap: 0;
   height: calc(100vh - 160px);
-  margin: -16px;
+  margin: 0 -16px -32px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: var(--panel);


### PR DESCRIPTION
## Problem

The config page layout panel overlaps with the page title and description text above it.

## Root Cause

In `ui/src/styles/config.css`, the `.config-layout` class used `margin: -16px` to bleed the config grid into the parent `.content` container's padding (`padding: 12px 16px 32px`) on all four sides. The **top** negative margin pulled the config panel upward by 16px, causing it to visually overlap with the content header (page title and description).

## Fix

Changed `margin: -16px` to `margin: 0 -16px -32px`:

- **Top:** `0` — preserves normal spacing from the content header, eliminating the overlap
- **Left/Right:** `-16px` — maintains the edge-to-edge horizontal bleed into parent padding
- **Bottom:** `-32px` — offsets the parent's 32px bottom padding for a flush bottom edge

### Before
```css
margin: -16px;
```

### After
```css
margin: 0 -16px -32px;
```

Fixes #14957

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adjusts the `.config-layout` margin in `ui/src/styles/config.css` to stop the config grid panel from being pulled upward into the header area. It removes the previous all-sides negative margin (`-16px`) and replaces it with asymmetric margins (`0 -16px -32px`) so the layout still bleeds horizontally into the parent container padding and stays flush at the bottom, while keeping normal spacing from the page title/description above.

This fits into the existing UI styling approach where the config grid “bleeds” into the parent `.content` padding via negative margins; the update scopes that bleed to the sides/bottom only to prevent overlap with header text.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized CSS margin adjustment intended to fix a specific visual overlap; it doesn’t affect runtime logic, data flow, or security surfaces, and the new margins are internally consistent with the described parent padding behavior.
- ui/src/styles/config.css

<sub>Last reviewed commit: f221946</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->