### PR TITLE
fix: distinguish OAuth tokens from API keys in `models status`

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -1,4 +1,11 @@
 export { CLAUDE_CLI_PROFILE_ID, CODEX_CLI_PROFILE_ID } from "./auth-profiles/constants.js";
+export {
+  credentialBillingHint,
+  credentialKindDisplayLabel,
+  credentialKindLabel,
+  detectCredentialKindFromKey,
+} from "./auth-profiles/credential-kind.js";
+export type { CredentialKind } from "./auth-profiles/credential-kind.js";
 export { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
 export { formatAuthDoctorHint } from "./auth-profiles/doctor.js";
 export { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";

--- a/src/agents/auth-profiles/credential-kind.test.ts
+++ b/src/agents/auth-profiles/credential-kind.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { AuthProfileCredential } from "./types.js";
+import {
+  credentialBillingHint,
+  credentialKindDisplayLabel,
+  credentialKindLabel,
+  detectCredentialKindFromKey,
+} from "./credential-kind.js";
+
+describe("credentialKindLabel", () => {
+  it("returns readable labels for each kind", () => {
+    expect(credentialKindLabel("oauth")).toBe("OAuth");
+    expect(credentialKindLabel("token")).toBe("Token");
+    expect(credentialKindLabel("api_key")).toBe("API Key");
+  });
+});
+
+describe("credentialBillingHint", () => {
+  it('returns "Max" for Anthropic OAuth credentials', () => {
+    const credential: AuthProfileCredential = {
+      type: "oauth",
+      provider: "anthropic",
+      access: "sk-ant-oat01-test",
+      refresh: "sk-ant-ort01-test",
+      expires: Date.now() + 60_000,
+    };
+    expect(credentialBillingHint(credential)).toBe("Max");
+  });
+
+  it('returns "Max" for Anthropic token credentials', () => {
+    const credential: AuthProfileCredential = {
+      type: "token",
+      provider: "anthropic",
+      token: "sk-ant-oat01-test",
+    };
+    expect(credentialBillingHint(credential)).toBe("Max");
+  });
+
+  it("returns undefined for Anthropic API key credentials", () => {
+    const credential: AuthProfileCredential = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-ant-api03-test",
+    };
+    expect(credentialBillingHint(credential)).toBeUndefined();
+  });
+
+  it("returns undefined for non-Anthropic OAuth credentials", () => {
+    const credential: AuthProfileCredential = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "eyJhbGciOi-test",
+      refresh: "oai-refresh-test",
+      expires: Date.now() + 60_000,
+    };
+    expect(credentialBillingHint(credential)).toBeUndefined();
+  });
+});
+
+describe("credentialKindDisplayLabel", () => {
+  it('returns "OAuth (Max)" for Anthropic OAuth', () => {
+    const credential: AuthProfileCredential = {
+      type: "oauth",
+      provider: "anthropic",
+      access: "sk-ant-oat01-test",
+      refresh: "sk-ant-ort01-test",
+      expires: Date.now() + 60_000,
+    };
+    expect(credentialKindDisplayLabel(credential)).toBe("OAuth (Max)");
+  });
+
+  it('returns "Token (Max)" for Anthropic token', () => {
+    const credential: AuthProfileCredential = {
+      type: "token",
+      provider: "anthropic",
+      token: "sk-ant-oat01-test",
+    };
+    expect(credentialKindDisplayLabel(credential)).toBe("Token (Max)");
+  });
+
+  it('returns "API Key" for Anthropic API key', () => {
+    const credential: AuthProfileCredential = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-ant-api03-test",
+    };
+    expect(credentialKindDisplayLabel(credential)).toBe("API Key");
+  });
+
+  it('returns "OAuth" for non-Anthropic OAuth', () => {
+    const credential: AuthProfileCredential = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "eyJhbGciOi-test",
+      refresh: "oai-refresh-test",
+      expires: Date.now() + 60_000,
+    };
+    expect(credentialKindDisplayLabel(credential)).toBe("OAuth");
+  });
+});
+
+describe("detectCredentialKindFromKey", () => {
+  it("detects Anthropic OAuth access tokens", () => {
+    const result = detectCredentialKindFromKey("anthropic", "sk-ant-oat01-ABCDEF1234567890");
+    expect(result.kind).toBe("oauth");
+    expect(result.billingHint).toBe("Max");
+  });
+
+  it("detects Anthropic OAuth refresh tokens", () => {
+    const result = detectCredentialKindFromKey("anthropic", "sk-ant-ort01-ABCDEF1234567890");
+    expect(result.kind).toBe("oauth");
+    expect(result.billingHint).toBe("Max");
+  });
+
+  it("detects Anthropic API keys", () => {
+    const result = detectCredentialKindFromKey(
+      "anthropic",
+      "sk-ant-api03-0123456789abcdefghijklmnopqrstuvwxyz",
+    );
+    expect(result.kind).toBe("api_key");
+    expect(result.billingHint).toBeUndefined();
+  });
+
+  it("defaults to api_key for unknown providers", () => {
+    const result = detectCredentialKindFromKey("openai", "sk-openai-0123456789");
+    expect(result.kind).toBe("api_key");
+    expect(result.billingHint).toBeUndefined();
+  });
+
+  it("handles whitespace in keys", () => {
+    const result = detectCredentialKindFromKey("anthropic", "  sk-ant-oat01-test  ");
+    expect(result.kind).toBe("oauth");
+    expect(result.billingHint).toBe("Max");
+  });
+});

--- a/src/agents/auth-profiles/credential-kind.ts
+++ b/src/agents/auth-profiles/credential-kind.ts
@@ -1,0 +1,98 @@
+import type { AuthProfileCredential } from "./types.js";
+
+/**
+ * High-level credential kind that distinguishes billing context.
+ *
+ * - `oauth`   – OAuth credential (e.g. Anthropic Max subscription)
+ * - `token`   – Static bearer / PAT token, often from an OAuth flow but not
+ *               refreshable by OpenClaw
+ * - `api_key` – Traditional pay-per-use API key
+ */
+export type CredentialKind = "oauth" | "token" | "api_key";
+
+/**
+ * Returns a short, human-readable label for the credential kind that clarifies
+ * billing context.
+ *
+ * Examples:
+ *   "OAuth"    – for oauth credentials (e.g. Anthropic Max subscription)
+ *   "Token"    – for static bearer tokens
+ *   "API Key"  – for traditional API keys (pay-per-use)
+ */
+export function credentialKindLabel(type: CredentialKind): string {
+  switch (type) {
+    case "oauth":
+      return "OAuth";
+    case "token":
+      return "Token";
+    case "api_key":
+      return "API Key";
+  }
+}
+
+/**
+ * Resolves a billing-context hint for a credential.
+ *
+ * For Anthropic OAuth credentials this returns "Max" because the Anthropic
+ * OAuth flow is exclusively available through the Max subscription plan.
+ * For other providers the hint is `undefined` (we can't reliably determine
+ * the subscription tier from the token alone).
+ */
+export function credentialBillingHint(credential: AuthProfileCredential): string | undefined {
+  if (credential.provider === "anthropic" && credential.type === "oauth") {
+    return "Max";
+  }
+  // Anthropic tokens obtained via ANTHROPIC_OAUTH_TOKEN env var are also
+  // typically Max-subscription tokens.
+  if (credential.provider === "anthropic" && credential.type === "token") {
+    return "Max";
+  }
+  return undefined;
+}
+
+/**
+ * Returns a display label that includes billing context when available.
+ *
+ * Examples:
+ *   "OAuth (Max)"  – Anthropic OAuth / Max subscription
+ *   "Token (Max)"  – Anthropic static token from Max
+ *   "OAuth"        – generic OAuth (non-Anthropic)
+ *   "API Key"      – pay-per-use
+ */
+export function credentialKindDisplayLabel(credential: AuthProfileCredential): string {
+  const base = credentialKindLabel(credential.type);
+  const hint = credentialBillingHint(credential);
+  return hint ? `${base} (${hint})` : base;
+}
+
+/**
+ * Detects the credential kind from a raw API key string and provider name.
+ *
+ * This is used when only a key string is available (e.g. from env vars) and
+ * there is no profile credential object.
+ *
+ * Anthropic OAuth access tokens have the prefix `sk-ant-oat` while API keys
+ * use `sk-ant-api`.
+ */
+export function detectCredentialKindFromKey(
+  provider: string,
+  key: string,
+): { kind: CredentialKind; billingHint?: string } {
+  const trimmed = key.trim();
+
+  if (provider === "anthropic") {
+    if (trimmed.startsWith("sk-ant-oat")) {
+      return { kind: "oauth", billingHint: "Max" };
+    }
+    // Anthropic refresh tokens shouldn't normally be used as API keys, but if
+    // someone sets ANTHROPIC_OAUTH_TOKEN to an access token we detect it here.
+    if (trimmed.startsWith("sk-ant-ort")) {
+      return { kind: "oauth", billingHint: "Max" };
+    }
+    return { kind: "api_key" };
+  }
+
+  // For other providers we can't reliably distinguish token formats, so we
+  // fall back to the generic api_key kind.
+  return { kind: "api_key" };
+}

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -60,7 +60,7 @@ export function resolveProviderAuthOverview(params: {
   const labels = profiles.map((profileId) => {
     const profile = store.profiles[profileId];
     if (!profile) {
-      kinds.push({ kind: "api_key", kindLabel: "Unknown" });
+      kinds.push({ kind: "missing", kindLabel: "Missing" });
       return `${profileId}=missing`;
     }
 

--- a/src/commands/models/list.types.ts
+++ b/src/commands/models/list.types.ts
@@ -1,3 +1,5 @@
+import type { CredentialKind } from "../../agents/auth-profiles.js";
+
 export type ConfiguredEntry = {
   key: string;
   ref: { provider: string; model: string };
@@ -16,6 +18,14 @@ export type ModelRow = {
   missing: boolean;
 };
 
+export type ProfileKindInfo = {
+  kind: CredentialKind;
+  /** Human-readable label, e.g. "OAuth (Max)", "API Key" */
+  kindLabel: string;
+  /** Optional billing-context hint, e.g. "Max" */
+  billingHint?: string;
+};
+
 export type ProviderAuthOverview = {
   provider: string;
   effective: {
@@ -28,7 +38,9 @@ export type ProviderAuthOverview = {
     token: number;
     apiKey: number;
     labels: string[];
+    /** Per-profile credential kind info (same order as `labels`). */
+    kinds: ProfileKindInfo[];
   };
-  env?: { value: string; source: string };
+  env?: { value: string; source: string; credentialKind?: ProfileKindInfo };
   modelsJson?: { value: string; source: string };
 };

--- a/src/commands/models/list.types.ts
+++ b/src/commands/models/list.types.ts
@@ -19,7 +19,7 @@ export type ModelRow = {
 };
 
 export type ProfileKindInfo = {
-  kind: CredentialKind;
+  kind: CredentialKind | "missing";
   /** Human-readable label, e.g. "OAuth (Max)", "API Key" */
   kindLabel: string;
   /** Optional billing-context hint, e.g. "Max" */


### PR DESCRIPTION
## Summary

Fixes #14805

The `openclaw models status` command now clearly distinguishes between OAuth tokens (e.g. Anthropic Max subscription) and traditional API keys, resolving confusion about billing context.

## Changes

### New: `credential-kind` module (`src/agents/auth-profiles/credential-kind.ts`)
- `credentialKindLabel(type)` — returns "OAuth" / "Token" / "API Key"
- `credentialBillingHint(credential)` — returns "Max" for Anthropic OAuth/token credentials
- `credentialKindDisplayLabel(credential)` — combined label like "OAuth (Max)" or "API Key"
- `detectCredentialKindFromKey(provider, key)` — detects credential kind from token prefix (e.g. `sk-ant-oat` → OAuth/Max, `sk-ant-api` → API Key)

### Updated: Auth overview display
- Profile labels now include credential kind: `anthropic:default=OAuth (Max)`, `anthropic:work=sk-ant...*** [API Key]`
- New `kinds` array in `ProviderAuthOverview.profiles` for programmatic access
- Env-var credentials also get kind detection via prefix analysis

### Updated: Auth profile status section
- Renamed from "OAuth/token status" to "Auth profile status"
- Now shows **all** profile types (including API keys) — previously API key profiles were hidden
- Each profile line includes a `[OAuth (Max)]` or `[API Key]` label

### Updated: JSON output
- Each profile in `auth.oauth.profiles[]` now includes a `credentialKind` object:
  ```json
  {
    "kind": "oauth",
    "kindLabel": "OAuth (Max)",
    "billingHint": "Max"
  }
  ```

## Example output (rich terminal)

```
Auth profile status
- anthropic  usage: ...
  - anthropic:default (peter@example.com) [OAuth (Max)] ok expires in 5d
  - anthropic:work [API Key] static
- openai-codex
  - openai-codex:default [OAuth] ok expires in 1h
```

## Tests
- 14 new unit tests for `credential-kind` module (all credential types, billing hints, key prefix detection)
- 2 new integration tests for status command (JSON credentialKind fields + rich output labels)
- All existing tests continue to pass
- `pnpm check` passes (format, typecheck, lint)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `credential-kind` helper module and threads credential kind/billing context labels through `openclaw models status` output.

Key changes:
- New helpers to label credentials as OAuth/Token/API Key and detect Anthropic Max billing context via token prefixes.
- Auth overview output now appends kind labels per profile and exposes a `profiles.kinds[]` array plus optional `env.credentialKind` in `ProviderAuthOverview`.
- The status section is renamed to "Auth profile status" and now lists all profile types, and JSON output includes a `credentialKind` object per profile in `auth.oauth.profiles[]`.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has a couple of correctness issues in status/check reporting and kind metadata for missing profiles.
- Core labeling/detection logic is small and covered by tests, but `--check` can report success while API-key auth is unusable (cooldown/disabled), and `profiles.kinds` misclassifies missing profiles as `api_key`, which can mislead downstream consumers.
- src/commands/models/list.status-command.ts, src/commands/models/list.auth-overview.ts

<sub>Last reviewed commit: abc07f4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->