### PR TITLE
fix(reply): auto-inject replyToCurrent so replyToMode actually works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security/Audit: distinguish external webhooks (`hooks.enabled`) from internal hooks (`hooks.internal.enabled`) in attack-surface summaries to avoid false exposure signals when only internal hooks are enabled. (#13474) Thanks @mcaxtr.
+- Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.
 - Sandbox: pass configured `sandbox.docker.env` variables to sandbox containers at `docker create` time. (#15138) Thanks @stevebot-alive.
 - Onboarding/CLI: restore terminal state without resuming paused `stdin`, so onboarding exits cleanly after choosing Web UI and the installer returns instead of appearing stuck.
 - macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -376,9 +376,11 @@ export async function runAgentTurnWithFallback(params: {
                       text,
                       mediaUrls: payload.mediaUrls,
                       mediaUrl: payload.mediaUrls?.[0],
-                      replyToId: payload.replyToId,
+                      replyToId:
+                        payload.replyToId ??
+                        (payload.replyToCurrent === false ? undefined : currentMessageId),
                       replyToTag: payload.replyToTag,
-                      replyToCurrent: true,
+                      replyToCurrent: payload.replyToCurrent,
                     },
                     currentMessageId,
                   );

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -378,7 +378,7 @@ export async function runAgentTurnWithFallback(params: {
                       mediaUrl: payload.mediaUrls?.[0],
                       replyToId: payload.replyToId,
                       replyToTag: payload.replyToTag,
-                      replyToCurrent: payload.replyToCurrent,
+                      replyToCurrent: true,
                     },
                     currentMessageId,
                   );

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -100,10 +100,12 @@ export function createBlockReplyCoalescer(params: {
       return;
     }
 
-    if (
+    const replyToConflict = Boolean(
       bufferText &&
-      (bufferReplyToId !== payload.replyToId || bufferAudioAsVoice !== payload.audioAsVoice)
-    ) {
+      payload.replyToId &&
+      (!bufferReplyToId || bufferReplyToId !== payload.replyToId),
+    );
+    if (bufferText && (replyToConflict || bufferAudioAsVoice !== payload.audioAsVoice)) {
       void flush({ force: true });
     }
 

--- a/src/auto-reply/reply/reply-payloads.auto-threading.test.ts
+++ b/src/auto-reply/reply/reply-payloads.auto-threading.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { applyReplyThreading } from "./reply-payloads.js";
+
+describe("applyReplyThreading auto-injects replyToCurrent", () => {
+  it("sets replyToId to currentMessageId even without [[reply_to_current]] tag", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "Hello" }],
+      replyToMode: "first",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBe("42");
+  });
+
+  it("threads only first payload when mode is 'first'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "A" }, { text: "B" }],
+      replyToMode: "first",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBe("42");
+    expect(result[1].replyToId).toBeUndefined();
+  });
+
+  it("threads all payloads when mode is 'all'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "A" }, { text: "B" }],
+      replyToMode: "all",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBe("42");
+    expect(result[1].replyToId).toBe("42");
+  });
+
+  it("strips replyToId when mode is 'off'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "A" }],
+      replyToMode: "off",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -62,10 +62,15 @@ export function applyReplyThreading(params: {
 }): ReplyPayload[] {
   const { payloads, replyToMode, replyToChannel, currentMessageId } = params;
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
+  const implicitReplyToId = currentMessageId?.trim() || undefined;
   return payloads
-    .map((payload) =>
-      applyReplyTagsToPayload({ ...payload, replyToCurrent: true }, currentMessageId),
-    )
+    .map((payload) => {
+      const autoThreaded =
+        payload.replyToId || payload.replyToCurrent === false || !implicitReplyToId
+          ? payload
+          : { ...payload, replyToId: implicitReplyToId };
+      return applyReplyTagsToPayload(autoThreaded, currentMessageId);
+    })
     .filter(isRenderablePayload)
     .map(applyReplyToMode);
 }

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -63,7 +63,9 @@ export function applyReplyThreading(params: {
   const { payloads, replyToMode, replyToChannel, currentMessageId } = params;
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
   return payloads
-    .map((payload) => applyReplyTagsToPayload(payload, currentMessageId))
+    .map((payload) =>
+      applyReplyTagsToPayload({ ...payload, replyToCurrent: true }, currentMessageId),
+    )
     .filter(isRenderablePayload)
     .map(applyReplyToMode);
 }


### PR DESCRIPTION
Closes #14974

## Summary

- In `applyReplyThreading` (`reply-payloads.ts`): wraps each payload with `replyToCurrent: true` before passing to `applyReplyTagsToPayload`
- In the block-streaming path (`agent-runner-execution.ts`): sets `replyToCurrent: true` instead of forwarding the payload's value

Previously, `replyToId` was only populated when the LLM emitted `[[reply_to_current]]` tags — which almost never happens unprompted. This meant `replyToMode: "first"` and `"all"` had no effect; replies were always standalone messages.

Now `replyToId` is always set to `currentMessageId`, and the existing `replyToMode` filter decides whether to keep or strip it (`"off"` strips, `"first"` keeps first only, `"all"` keeps all).

## Test plan

- [x] Added test: `replyToId` set without `[[reply_to_current]]` tag
- [x] Added test: only first payload threaded when mode is `"first"`
- [x] Added test: all payloads threaded when mode is `"all"`
- [x] Added test: `replyToId` stripped when mode is `"off"`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes reply threading behavior so `replyToMode: "first" | "all"` works even when the model does not emit `[[reply_to_current]]` tags.

- `applyReplyThreading` now forces `replyToCurrent: true` on each payload before running `applyReplyTagsToPayload`, which ensures `replyToId` is set to `currentMessageId` (unless already set / stripped by mode).
- The block-streaming (`onBlockReply`) path now always sets `replyToCurrent: true` instead of forwarding the payload value, keeping streaming and non-streaming behavior consistent.
- Adds Vitest coverage for auto-threading across `replyToMode` values (`off`, `first`, `all`).

Overall, the change integrates with existing `createReplyToModeFilterForChannel` logic: auto-injection sets `replyToId`, and the mode filter keeps/strips it according to config.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low functional risk.
- The changes are narrowly scoped (forcing `replyToCurrent: true` prior to tag parsing) and rely on existing, well-defined behavior in `applyReplyTagsToPayload` and the replyToMode filter. I did not find any call sites that intentionally set `replyToCurrent: false` (so forced threading should not override a deliberate opt-out). The only caveat is that I could not execute tests in this environment due to missing Node/pnpm tooling, so confidence is slightly reduced.
- src/auto-reply/reply/reply-payloads.ts; src/auto-reply/reply/agent-runner-execution.ts

<sub>Last reviewed commit: 3762bf0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->