### PR TITLE
fix(telegram): remove ack reaction after block-streamed replies

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -651,7 +651,7 @@ export const dispatchTelegramMessage = async ({
     sentFallback = result.delivered;
   }
 
-  const hasFinalResponse = queuedFinal || sentFallback;
+  const hasFinalResponse = queuedFinal || sentFallback || deliverySummary.delivered;
 
   if (statusReactionController && !hasFinalResponse) {
     void statusReactionController.setError().catch((err) => {


### PR DESCRIPTION
Closes #7753

## Summary

When block streaming is enabled (the default), all reply content is delivered via `sendBlockReply` (kind `"block"`). The final `replyResult` is null and `queuedFinal` is `false`. The `hasFinalResponse` check at the end of `dispatchTelegramMessage` was:

```typescript
const hasFinalResponse = queuedFinal || sentFallback;
```

This evaluated to `false` after block-streamed delivery, causing an early return that skipped `removeAckReactionAfterReply`. The ack reaction (e.g., 👀) remained on the message permanently.

**Fix:** Include `deliveryState.delivered` in the check:

```typescript
const hasFinalResponse = queuedFinal || sentFallback || deliveryState.delivered;
```

`deliveryState.delivered` is already set to `true` whenever the `deliver` callback succeeds, including for block-streamed replies.

## Test plan

- [x] Added test: ack reaction removed after block-streamed delivery with no final reply
- [x] Added test: ack reaction not removed when nothing was delivered
- [x] Existing draft streaming test passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a Telegram ack-reaction cleanup bug when block streaming is used: replies can be fully delivered via `deliver()` callbacks (kind `"block"`) without ever queueing a final reply, which previously caused an early return that skipped `removeAckReactionAfterReply`. The dispatch logic now treats any successful delivery (`deliveryState.delivered`) as a “final response” for cleanup purposes.

It also adds two unit tests covering ack reaction removal after block-streamed delivery, and ensuring no removal occurs when nothing was delivered, while refactoring common test setup into helper builders.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low functional risk; the core logic change is small and targeted.
- The production change is a narrow boolean condition update that aligns with how delivery is tracked (`deliveryState.delivered` is already set on any successful deliver callback). The added tests cover the reported regression path. Main remaining concern is test-type looseness (helpers return untyped context objects), which can reduce test signal over time but doesn’t affect runtime behavior.
- src/telegram/bot-message-dispatch.test.ts (tighten typing in test helpers for reliability)

<sub>Last reviewed commit: 49dbcd7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->