### PR TITLE
fix(gateway): allow node role to call chat.send, chat.history, chat.abort

### DIFF
--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -34,6 +34,16 @@ const PAIRING_SCOPE = "operator.pairing";
 
 const APPROVAL_METHODS = new Set(["exec.approval.request", "exec.approval.resolve"]);
 const NODE_ROLE_METHODS = new Set(["node.invoke.result", "node.event", "skills.bins"]);
+const NODE_EXTENDED_METHODS = new Set([
+  "chat.send",
+  "chat.history",
+  "chat.abort",
+  "config.get",
+  "health",
+  "sessions.list",
+  "voicewake.get",
+  "voicewake.set",
+]);
 const PAIRING_METHODS = new Set([
   "node.pair.request",
   "node.pair.list",
@@ -101,6 +111,9 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
       return null;
     }
     return errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${role}`);
+  }
+  if (role === "node" && NODE_EXTENDED_METHODS.has(method)) {
+    return null;
   }
   if (role === "node") {
     return errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${role}`);


### PR DESCRIPTION
Fixes the node-role authorization issue described in #6767

## Summary

iOS/macOS clients connect with `role: "node"`. The `authorizeGatewayMethod` function only allowed node-role clients to call three methods (`node.invoke.result`, `node.event`, `skills.bins`). All chat methods were rejected with `unauthorized role: node`, making the embedded chat completely non-functional.

**Fix:** Adds a `NODE_EXTENDED_METHODS` set containing the methods needed by mobile chat clients:

- `chat.send`, `chat.history`, `chat.abort` (core chat functionality)
- `config.get`, `health` (required for client initialization)
- `sessions.list` (session management)
- `voicewake.get`, `voicewake.set` (voice wake word configuration)

The existing `NODE_ROLE_METHODS` set remains unchanged for the original node-invoke methods.

## Test plan

- [x] Verified gateway builds and starts
- [x] Verified Telegram channel still functions after change
- [ ] iOS client can connect and send/receive messages

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change extends gateway authorization for `role: "node"` connections by introducing `NODE_EXTENDED_METHODS` and bypassing the existing operator scope checks for a handful of RPC methods (notably `chat.send`, `chat.history`, and `chat.abort`) to support embedded mobile chat clients.

The new authorization branch sits before the `role === "node"` rejection in `authorizeGatewayMethod`, so any method in `NODE_EXTENDED_METHODS` is now callable by node-role clients regardless of scopes.

<h3>Confidence Score: 3/5</h3>

- This PR is likely functionally correct for enabling mobile chat, but it introduces authorization broadening that should be tightened before merge.
- The change is small and localized, but it bypasses scope-based auth for `role: "node"` on methods that expose config/session metadata. Whether that is acceptable depends on the threat model for node credentials; as written it is a clear privilege expansion beyond chat-only needs.
- src/gateway/server-methods.ts

<sub>Last reviewed commit: 0c174bd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->