### PR TITLE
fix: prevent ExtensionContext leak into signal slot in tool dispatch (#14954)

### DIFF
--- a/src/agents/pi-tool-definition-adapter.dispatch.test.ts
+++ b/src/agents/pi-tool-definition-adapter.dispatch.test.ts
@@ -1,0 +1,108 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+import { wrapToolWithAbortSignal } from "./pi-tools.abort.js";
+import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
+
+/**
+ * Regression tests for issue #14954:
+ * Plugin tool execute() never reached — TypeError: fetch failed in dispatch layer.
+ *
+ * Root cause: splitToolExecuteArgs misrouted the 5th arg (ExtensionContext)
+ * into the signal slot when both signal and onUpdate were undefined,
+ * because the fallback "current format" branch assumed a parameter order
+ * that didn't match the actual ToolDefinition.execute signature.
+ */
+describe("plugin tool dispatch chain — #14954", () => {
+  function makePluginTool(executeFn?: (...args: unknown[]) => Promise<unknown>) {
+    return {
+      name: "atlas_status",
+      label: "Atlas Status",
+      description: "Get server status",
+      parameters: { type: "object" as const, properties: {} },
+      execute:
+        executeFn ??
+        (async () => ({
+          content: [{ type: "text" as const, text: "OK" }],
+          details: {},
+        })),
+    } satisfies AgentTool<unknown, unknown>;
+  }
+
+  it("reaches plugin execute through full wrapping chain (signal+onUpdate defined)", async () => {
+    const canary = vi.fn();
+    const tool = makePluginTool(async () => {
+      canary();
+      return { content: [{ type: "text", text: "ok" }], details: {} };
+    });
+
+    const withHook = wrapToolWithBeforeToolCallHook(tool, { agentId: "main" });
+    const ac = new AbortController();
+    const withAbort = wrapToolWithAbortSignal(withHook, ac.signal);
+    const [def] = toToolDefinitions([withAbort]);
+
+    // Simulate wrapRegisteredTool: 5 args including ExtensionContext
+    await def.execute("c1", {}, ac.signal, () => {}, {} as never);
+    expect(canary).toHaveBeenCalledOnce();
+  });
+
+  it("reaches plugin execute when signal and onUpdate are both undefined (#14954)", async () => {
+    const canary = vi.fn();
+    const tool = makePluginTool(async () => {
+      canary();
+      return { content: [{ type: "text", text: "ok" }], details: {} };
+    });
+
+    const [def] = toToolDefinitions([tool]);
+
+    // This is the exact scenario that triggered #14954:
+    // wrapRegisteredTool passes (id, params, undefined, undefined, ctx)
+    // Previously, splitToolExecuteArgs misrouted ctx into the signal slot.
+    const fakeCtx = { cwd: "/tmp", sessionManager: {}, model: {} };
+    await def.execute("c1", {}, undefined, undefined, fakeCtx as never);
+    expect(canary).toHaveBeenCalledOnce();
+  });
+
+  it("does not leak ExtensionContext into signal parameter (#14954)", async () => {
+    let receivedSignal: unknown = "SENTINEL";
+    const tool = makePluginTool(async (_id, _params, signal) => {
+      receivedSignal = signal;
+      return { content: [{ type: "text", text: "ok" }], details: {} };
+    });
+
+    const [def] = toToolDefinitions([tool]);
+    const fakeCtx = { cwd: "/tmp", sessionManager: {} };
+    await def.execute("c1", {}, undefined, undefined, fakeCtx as never);
+
+    // signal must be undefined, NOT the ExtensionContext object
+    expect(receivedSignal).toBeUndefined();
+  });
+
+  it("correctly passes real AbortSignal through the chain", async () => {
+    let receivedSignal: unknown;
+    const tool = makePluginTool(async (_id, _params, signal) => {
+      receivedSignal = signal;
+      return { content: [{ type: "text", text: "ok" }], details: {} };
+    });
+
+    const ac = new AbortController();
+    const [def] = toToolDefinitions([tool]);
+    await def.execute("c1", {}, ac.signal, undefined, {} as never);
+
+    expect(receivedSignal).toBe(ac.signal);
+  });
+
+  it("correctly passes onUpdate callback through the chain", async () => {
+    let receivedOnUpdate: unknown;
+    const tool = makePluginTool(async (_id, _params, _signal, onUpdate) => {
+      receivedOnUpdate = onUpdate;
+      return { content: [{ type: "text", text: "ok" }], details: {} };
+    });
+
+    const cb = () => {};
+    const [def] = toToolDefinitions([tool]);
+    await def.execute("c1", {}, undefined, cb, {} as never);
+
+    expect(receivedOnUpdate).toBe(cb);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #14954 — Plugin tool `execute()` never reached, `TypeError: fetch failed` in dispatch layer.

## Root Cause

When `toToolDefinitions` wraps an `AgentTool.execute` into a `ToolDefinition.execute`, the wrapper receives **5 arguments** from `wrapRegisteredTool`:

```
(toolCallId, params, signal, onUpdate, ctx)
```

The previous `splitToolExecuteArgs` used a heuristic format-detection function (`isLegacyToolExecuteArgs`) to distinguish two parameter orderings. When **both `signal` and `onUpdate` were `undefined`**, the detector fell through to a "current format" branch that destructured args as:

```
(toolCallId, params, onUpdate, _ctx, signal)
```

This format doesn't match any real caller. It misrouted `args[4]` (the `ExtensionContext` object from `runner.createContext()`) into the `signal` slot.

Downstream, the corrupted signal propagated through `wrapToolWithAbortSignal` → `wrapToolWithBeforeToolCallHook` → into the plugin's `execute()` function. When the plugin passed this non-`AbortSignal` object to `fetch()`, Node's undici rejected it with `TypeError: fetch failed` before the HTTP request was even attempted — making it appear that `execute()` was never reached.

## Fix

Remove the format-detection heuristic entirely. Both the `ToolDefinition` signature `(toolCallId, params, signal, onUpdate, ctx)` and the legacy `AgentTool` signature `(toolCallId, params, signal?, onUpdate?)` place `signal` at position 2 and `onUpdate` at position 3. Extract by **type** (`isAbortSignal` / `typeof function`) from these fixed positions so the 5th arg (ctx) is never misrouted.

## Tests

Added 5 regression tests covering:
- Normal dispatch chain with all args defined
- The exact #14954 scenario (signal + onUpdate both undefined with ctx present)
- Verification that ExtensionContext does not leak into signal slot
- Real AbortSignal passthrough
- onUpdate callback passthrough

All existing tests continue to pass. `pnpm check` passes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the tool-execution argument splitting in `src/agents/pi-tool-definition-adapter.ts` to avoid misrouting the 5th argument (ExtensionContext) into the `signal` slot when `signal`/`onUpdate` are both `undefined`. It also adds a regression test (`src/agents/pi-tool-definition-adapter.dispatch.test.ts`) that exercises the full wrapping chain and the exact #14954 call shape.

Overall, the intent is correct and the added tests cover the previously failing scenario. The main items to address are internal inconsistencies in how the execute-argument tuple is modeled vs how it’s parsed, and the looseness of the `AbortSignal` detection predicate used for parsing.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe, but there are a couple of argument-parsing inconsistencies that could break abort/onUpdate routing in some call shapes.
- The behavioral change is small and backed by focused regression tests, but `ToolExecuteArgsCurrent` encodes a different argument order than the new parser assumes, and the AbortSignal type guard is very permissive. Either issue could cause silent misrouting of abort signals or callbacks depending on how ToolDefinition.execute is actually invoked.
- src/agents/pi-tool-definition-adapter.ts

<sub>Last reviewed commit: 7eab81c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->