### PR TITLE
fix: use os.tmpdir fallback paths for temp files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Cron: isolate scheduler errors so one bad job does not break all jobs. (#14385) Thanks @MarvinDontPanic.
 - Cron: prevent one-shot `at` jobs from re-firing on restart after skipped/errored runs. (#13878) Thanks @lailoo.
 - Heartbeat: prevent scheduler stalls on unexpected run errors and avoid immediate rerun loops after `requests-in-flight` skips. (#14901) Thanks @joeykrug.
+- Logging/Browser: fall back to `os.tmpdir()/openclaw` for default log, browser trace, and browser download temp paths when `/tmp/openclaw` is unavailable.
 - WhatsApp: convert Markdown bold/strikethrough to WhatsApp formatting. (#14285) Thanks @Raikan10.
 - WhatsApp: allow media-only sends and normalize leading blank payloads. (#14408) Thanks @karimnaguib.
 - WhatsApp: default MIME type for voice messages when Baileys omits it. (#14444) Thanks @mcaxtr.

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -1,6 +1,7 @@
 import type { Page } from "playwright-core";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
   ensurePageState,
@@ -20,7 +21,7 @@ import {
 function buildTempDownloadPath(fileName: string): string {
   const id = crypto.randomUUID();
   const safeName = fileName.trim() ? fileName.trim() : "download.bin";
-  return path.join("/tmp/openclaw/downloads", `${id}-${safeName}`);
+  return path.join(os.tmpdir(), "openclaw", "downloads", `${id}-${safeName}`);
 }
 
 function createPageDownloadWaiter(page: Page, timeoutMs: number) {

--- a/src/browser/routes/agent.debug.ts
+++ b/src/browser/routes/agent.debug.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import type { BrowserRouteContext } from "../server-context.js";
 import type { BrowserRouteRegistrar } from "./types.js";
@@ -131,7 +132,7 @@ export function registerBrowserAgentDebugRoutes(
         return;
       }
       const id = crypto.randomUUID();
-      const dir = "/tmp/openclaw";
+      const dir = path.join(os.tmpdir(), "openclaw");
       await fs.mkdir(dir, { recursive: true });
       const tracePath = out.trim() || path.join(dir, `browser-trace-${id}.zip`);
       await pw.traceStopViaPlaywright({

--- a/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -57,7 +57,7 @@ export function registerBrowserFilesAndDownloadsCommands(
   browser
     .command("waitfordownload")
     .description("Wait for the next download (and save it)")
-    .argument("[path]", "Save path (default: /tmp/openclaw/downloads/...)")
+    .argument("[path]", "Save path (default: os.tmpdir()/openclaw/downloads/...)")
     .option("--target-id <id>", "CDP target id (or unique prefix)")
     .option(
       "--timeout-ms <ms>",

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
 import type { OpenClawConfig } from "../config/types.js";
@@ -8,9 +9,18 @@ import { readLoggingConfig } from "./config.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
 import { loggingState } from "./state.js";
 
-// Pin to /tmp so mac Debug UI and docs match; os.tmpdir() can be a per-user
-// randomized path on macOS which made the “Open log” button a no-op.
-export const DEFAULT_LOG_DIR = "/tmp/openclaw";
+// Prefer /tmp/openclaw so macOS Debug UI and docs match, but fall back to
+// os.tmpdir() on platforms where /tmp is read-only (e.g. Termux/Android).
+function resolveDefaultLogDir(): string {
+  try {
+    fs.mkdirSync("/tmp/openclaw", { recursive: true });
+    return "/tmp/openclaw";
+  } catch {
+    return path.join(os.tmpdir(), "openclaw");
+  }
+}
+
+export const DEFAULT_LOG_DIR = resolveDefaultLogDir();
 export const DEFAULT_LOG_FILE = path.join(DEFAULT_LOG_DIR, "openclaw.log"); // legacy single-file path
 
 const LOG_PREFIX = "openclaw";


### PR DESCRIPTION
## Summary
- switch browser download temp default from hardcoded `/tmp/openclaw/downloads` to `os.tmpdir()/openclaw/downloads`
- switch browser trace-stop default output directory to `path.join(os.tmpdir(), "openclaw")`
- keep logger compatibility by preferring `/tmp/openclaw` and falling back to `os.tmpdir()/openclaw` if `/tmp` is unavailable
- align CLI `waitfordownload` help text with the runtime default path
- add a changelog entry for the temp-path fallback behavior

## Testing
- scripts/pr-prepare gates 14807

Fixes https://github.com/openclaw/openclaw/issues/14802

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates default temporary paths used by browser downloads and trace output to live under `os.tmpdir()/openclaw/...` instead of hardcoding `/tmp/openclaw/...`, and updates CLI help text and the changelog accordingly. Logging keeps the historical `/tmp/openclaw` path by attempting to use it and falling back to `os.tmpdir()/openclaw` when `/tmp` can’t be created.

Key issue to address before merge: the browser `/trace/stop` route now unconditionally uses `os.tmpdir()/openclaw` by default, which contradicts the documented “prefer `/tmp/openclaw`” compatibility behavior and will change where traces end up on systems where `/tmp/openclaw` is available. Also, the logger now performs a directory creation attempt at module import time, introducing a filesystem side effect on import.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but has a real default-path mismatch that should be fixed before merge.
- The changes are small and localized, but the `/trace/stop` default directory now conflicts with the stated compatibility behavior (prefer `/tmp/openclaw`), which will affect where users find traces. Additionally, the logger now performs an import-time mkdir attempt, adding a side effect that may be undesirable for some consumers/tests.
- src/browser/routes/agent.debug.ts; src/logging/logger.ts

<sub>Last reviewed commit: 347c689</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->