### PR TITLE
Agents: allow gpt-5.3-codex-spark in fallback and thinking

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -14,6 +14,7 @@ const CODEX_MODELS = [
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
   "gpt-5.1-codex",
   "gpt-5.1-codex-mini",
   "gpt-5.1-codex-max",

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -84,4 +84,43 @@ describe("loadModelCatalog", () => {
     expect(result).toEqual([{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }]);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("adds openai-codex/gpt-5.3-codex-spark when base gpt-5.3-codex exists", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [
+                {
+                  id: "gpt-5.3-codex",
+                  provider: "openai-codex",
+                  name: "GPT-5.3 Codex",
+                  reasoning: true,
+                  contextWindow: 200000,
+                  input: ["text"],
+                },
+                {
+                  id: "gpt-5.2-codex",
+                  provider: "openai-codex",
+                  name: "GPT-5.2 Codex",
+                },
+              ];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai-codex",
+        id: "gpt-5.3-codex-spark",
+      }),
+    );
+    const spark = result.find((entry) => entry.id === "gpt-5.3-codex-spark");
+    expect(spark?.name).toBe("gpt-5.3-codex-spark");
+    expect(spark?.reasoning).toBe(true);
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -20,6 +20,7 @@ type InlineProviderConfig = {
 };
 
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
+const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
@@ -39,7 +40,11 @@ function resolveOpenAICodexGpt53FallbackModel(
   if (normalizedProvider !== "openai-codex") {
     return undefined;
   }
-  if (trimmedModelId.toLowerCase() !== OPENAI_CODEX_GPT_53_MODEL_ID) {
+  const loweredModelId = trimmedModelId.toLowerCase();
+  if (
+    loweredModelId !== OPENAI_CODEX_GPT_53_MODEL_ID &&
+    loweredModelId !== OPENAI_CODEX_GPT_53_SPARK_MODEL_ID
+  ) {
     return undefined;
   }
 

--- a/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
@@ -154,7 +154,7 @@ describe("directive behavior", () => {
 
       const texts = (Array.isArray(res) ? res : [res]).map((entry) => entry?.text).filter(Boolean);
       expect(texts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
       );
     });
   });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -44,6 +44,7 @@ describe("listThinkingLevels", () => {
   it("includes xhigh for codex models", () => {
     expect(listThinkingLevels(undefined, "gpt-5.2-codex")).toContain("xhigh");
     expect(listThinkingLevels(undefined, "gpt-5.3-codex")).toContain("xhigh");
+    expect(listThinkingLevels(undefined, "gpt-5.3-codex-spark")).toContain("xhigh");
   });
 
   it("includes xhigh for openai gpt-5.2", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -24,6 +24,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.2",
   "openai-codex/gpt-5.3-codex",
+  "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
   "github-copilot/gpt-5.2-codex",


### PR DESCRIPTION
## Summary
- add gpt-5.3-codex-spark as a recognized Codex model for fallback resolution
- include spark in model gating + thinking level allowlist and matching test coverage
- update rejection messaging for xhigh-compatible Codex models
- keep behavior unchanged for unknown gpt-5.3-codex-* variants

## Testing
- pnpm build
- pnpm check
- pnpm test (targeted: model + thinking suites)
- full pnpm test fails in this environment due permission when writing ~/.openclaw/identity in one existing non-related test

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends existing model allowlists and forward-compat fallback behavior to recognize `openai-codex/gpt-5.3-codex-spark`.

Changes are localized to:
- **Agents model gating** (`src/agents/live-model-filter.ts`): `gpt-5.3-codex-spark` is treated as a modern Codex model for filtering.
- **Embedded runner model resolution** (`src/agents/pi-embedded-runner/model.ts` + tests): the Codex forward-compat fallback that clones a `gpt-5.2-codex` template now also triggers for `gpt-5.3-codex-spark`, while unknown `gpt-5.3-codex-*` variants still error.
- **Auto-reply thinking allowlist** (`src/auto-reply/thinking.ts` + tests + e2e): `xhigh` thinking support messaging and checks now include the new spark model.

No functional regressions or must-fix issues introduced by the PR were found in the reviewed changes; updates are consistent across production code and test expectations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, consistent across all touched call sites (model filter, embedded model fallback, xhigh thinking allowlist), and are covered by targeted unit + e2e assertions that exercise the new `gpt-5.3-codex-spark` path while preserving errors for unknown variants.
- No files require special attention

<sub>Last reviewed commit: 9b110b1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->