### PR TITLE
fix(telegram): deduplicate skill commands by skillName to prevent BOT_COMMANDS_TOO_MUCH

### DIFF
--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -115,4 +115,70 @@ describe("registerTelegramNativeCommands", () => {
       "telegram: truncating 120 commands to 100 (Telegram Bot API limit)",
     );
   });
+
+  it("deduplicates skill commands by skillName for Telegram menu", () => {
+    listSkillCommandsForAgents.mockReturnValue([
+      { name: "bird", skillName: "bird", description: "Bird skill" },
+      { name: "bird_2", skillName: "bird", description: "Bird skill" },
+      { name: "bird_3", skillName: "bird", description: "Bird skill" },
+      { name: "notion", skillName: "notion", description: "Notion skill" },
+      { name: "notion_2", skillName: "notion", description: "Notion skill" },
+    ]);
+    const cfg: OpenClawConfig = {};
+    const setMyCommands = vi.fn().mockResolvedValue(undefined);
+    registerTelegramNativeCommands({
+      ...buildParams(cfg),
+      bot: {
+        api: {
+          setMyCommands,
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        command: vi.fn(),
+      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+    });
+
+    const registeredCommands = setMyCommands.mock.calls[0]?.[0] as Array<{
+      command: string;
+      description: string;
+    }>;
+    const commandNames = registeredCommands.map((c) => c.command);
+    expect(commandNames).toContain("bird");
+    expect(commandNames).toContain("notion");
+    expect(commandNames).not.toContain("bird_2");
+    expect(commandNames).not.toContain("bird_3");
+    expect(commandNames).not.toContain("notion_2");
+  });
+
+  it("dedup prevents unnecessary truncation", () => {
+    // Create 30 unique skills × 4 duplicates each = 120 entries
+    const skills = Array.from({ length: 30 }, (_, i) => {
+      const skillName = `skill_${i}`;
+      return [
+        { name: skillName, skillName, description: `Skill ${i}` },
+        { name: `${skillName}_2`, skillName, description: `Skill ${i}` },
+        { name: `${skillName}_3`, skillName, description: `Skill ${i}` },
+        { name: `${skillName}_4`, skillName, description: `Skill ${i}` },
+      ];
+    }).flat();
+    expect(skills).toHaveLength(120);
+
+    listSkillCommandsForAgents.mockReturnValue(skills);
+    const cfg: OpenClawConfig = {};
+    const setMyCommands = vi.fn().mockResolvedValue(undefined);
+    const runtimeLog = vi.fn();
+    registerTelegramNativeCommands({
+      ...buildParams(cfg),
+      bot: {
+        api: {
+          setMyCommands,
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        command: vi.fn(),
+      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      runtime: { log: runtimeLog } as RuntimeEnv,
+    });
+
+    // After dedup: 30 unique skills (no truncation needed)
+    expect(runtimeLog).not.toHaveBeenCalledWith(expect.stringContaining("truncating"));
+  });
 });


### PR DESCRIPTION
## Summary

- Deduplicate skill commands by `skillName` in `registerTelegramNativeCommands` before building the Telegram menu — when multiple agents load the same skill, `listSkillCommandsForAgents()` appends `_2`/`_3`/`_4` suffixes that inflate command count beyond Telegram's 100-command limit
- Only the first occurrence of each skill is registered; duplicate entries from other agents are dropped
- `listSkillCommandsForAgents()` itself is untouched — other channels (Slack, Discord) and internal routing are unaffected

Fixes #5787, #10875, #14737.

## Test plan

- [x] New test: verifies `bird_2`, `bird_3`, `notion_2` are filtered out, only `bird` and `notion` registered
- [x] New test: 120 entries (30 skills × 4 duplicates) dedup to 30 — no truncation warning triggered
- [x] Existing 3 tests continue to pass (binding scoping, unscoped, truncation)
- [x] `pnpm check` passes (formatting, type check, lint)
- [ ] Manual: restart gateway, confirm `getMyCommands` returns unique commands without suffixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram native command registration to deduplicate skill-based commands by `skillName` before building the `/` command menu. This avoids the `listSkillCommandsForAgents()` suffixing behavior (`_2`, `_3`, …) inflating the command count and triggering Telegram’s 100-command limit error (`BOT_COMMANDS_TOO_MUCH`).

The change is localized to `registerTelegramNativeCommands` in `src/telegram/bot-native-commands.ts` and adds tests in `src/telegram/bot-native-commands.test.ts` to ensure duplicate skill entries are filtered and that deduplication prevents unnecessary truncation warnings. Other channels and the underlying skill command listing logic are unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk.
- The change is small and localized (Telegram menu building only), and the dedup key (`skillName`) is a required string type. Added tests directly cover the new behavior and the max-command-limit interaction. I couldn’t execute the test suite in this environment due to missing pnpm, so confidence is slightly reduced.
- src/telegram/bot-native-commands.ts (dedup behavior in production); src/telegram/bot-native-commands.test.ts (ensure tests pass in CI)

<sub>Last reviewed commit: 50a99c9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->