### PR TITLE
fix(mattermost): honor chatmode mention fallback in group mention gating

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.require-mention.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.require-mention.test.ts
@@ -1,0 +1,46 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { resolveMattermostRequireMention } from "./monitor.js";
+
+describe("resolveMattermostRequireMention", () => {
+  const cfg: OpenClawConfig = {};
+
+  it("does not require mention in direct chats", () => {
+    const resolveRequireMention = vi.fn(() => true);
+
+    const result = resolveMattermostRequireMention({
+      kind: "direct",
+      cfg,
+      accountId: "default",
+      groupId: "group-1",
+      requireMention: true,
+      resolveRequireMention,
+    });
+
+    expect(result).toBe(false);
+    expect(resolveRequireMention).not.toHaveBeenCalled();
+  });
+
+  it("passes account mention defaults as fallback for group chats", () => {
+    const resolveRequireMention = vi.fn(() => false);
+
+    const result = resolveMattermostRequireMention({
+      kind: "channel",
+      cfg,
+      accountId: "default",
+      groupId: "group-1",
+      requireMention: false,
+      resolveRequireMention,
+    });
+
+    expect(result).toBe(false);
+    expect(resolveRequireMention).toHaveBeenCalledWith({
+      cfg,
+      channel: "mattermost",
+      accountId: "default",
+      groupId: "group-1",
+      requireMentionOverride: false,
+      overrideOrder: "after-config",
+    });
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.require-mention.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.require-mention.test.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
-import { resolveMattermostRequireMention } from "./monitor.js";
+import { resolveMattermostRequireMention } from "./monitor.ts";
 
 describe("resolveMattermostRequireMention", () => {
   const cfg: OpenClawConfig = {};

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -141,6 +141,36 @@ function channelChatType(kind: ChatType): "direct" | "group" | "channel" {
   return "channel";
 }
 
+type ResolveGroupRequireMentionFn = (params: {
+  cfg: OpenClawConfig;
+  channel: "mattermost";
+  accountId?: string | null;
+  groupId?: string | null;
+  requireMentionOverride?: boolean;
+  overrideOrder?: "before-config" | "after-config";
+}) => boolean;
+
+export function resolveMattermostRequireMention(params: {
+  kind: ChatType;
+  cfg: OpenClawConfig;
+  accountId: string;
+  groupId: string;
+  requireMention?: boolean;
+  resolveRequireMention: ResolveGroupRequireMentionFn;
+}): boolean {
+  if (params.kind === "direct") {
+    return false;
+  }
+  return params.resolveRequireMention({
+    cfg: params.cfg,
+    channel: "mattermost",
+    accountId: params.accountId,
+    groupId: params.groupId,
+    // chatmode should set the default mention behavior when no per-group override exists.
+    requireMentionOverride: params.requireMention,
+    overrideOrder: "after-config",
+  });
+}
 type MattermostMediaInfo = {
   path: string;
   contentType?: string;
@@ -555,14 +585,14 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       : { triggered: false, stripped: rawText };
     const oncharTriggered = oncharResult.triggered;
 
-    const shouldRequireMention =
-      kind !== "direct" &&
-      core.channel.groups.resolveRequireMention({
-        cfg,
-        channel: "mattermost",
-        accountId: account.accountId,
-        groupId: channelId,
-      });
+    const shouldRequireMention = resolveMattermostRequireMention({
+      kind,
+      cfg,
+      accountId: account.accountId,
+      groupId: channelId,
+      requireMention: account.requireMention,
+      resolveRequireMention: core.channel.groups.resolveRequireMention,
+    });
     const shouldBypassMention =
       isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;
     const effectiveWasMentioned = wasMentioned || shouldBypassMention || oncharTriggered;


### PR DESCRIPTION
## Example: Before vs Now

### Bad (before this fix)

This looked correct, but still behaved mention-only in group channels:

```json5
{
  channels: {
    mattermost: {
      chatmode: "onmessage",
      groupPolicy: "open"
    }
  }
}
```

Result before fix: untagged group messages were often ignored unless `@hal` was present.

### Good now (after this fix)

This now works as expected:

```json5
{
  channels: {
    mattermost: {
      chatmode: "onmessage",
      groupPolicy: "open"
    }
  }
}
```

Result after fix: untagged group messages are processed.

## Group Admission Truth Table (`groupPolicy`)

| `groupPolicy` | `groupAllowFrom` | Group message admitted? |
| --- | --- | --- |
| `open` | any | yes (all senders) |
| `allowlist` | empty/unset | no |
| `allowlist` | populated | yes only for listed senders |
| `disabled` | any | no |

## Mention Behavior Truth Table

| `chatmode` | `groups."*".requireMention` | Effective mention behavior in groups |
| --- | --- | --- |
| unset | unset | mention required |
| `oncall` | unset | mention required |
| `onmessage` | unset | mention not required |
| `onchar` | unset | mention required unless trigger prefix is used |
| any | `true` | mention required |
| any | `false` | mention not required |

## Summary
- pass Mattermost account-level mention preference (`chatmode` -> `requireMention`) into group mention resolution
- keep per-group overrides authoritative by using `overrideOrder: "after-config"`
- add regression tests for direct-chat bypass and group fallback behavior

## Why
`chatmode: "onmessage"` could still behave mention-only when mention gating was resolved through the generic group policy path without the account fallback.

## Testing
- `pnpm exec vitest run extensions/mattermost/src/mattermost/monitor.require-mention.test.ts extensions/mattermost/src/channel.test.ts`
