### PR TITLE
feat(matrix): pass asVoice flag through message tool and add waveform generation

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -69,6 +69,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
       const mediaUrl = readStringParam(params, "media", { trim: false });
       const replyTo = readStringParam(params, "replyTo");
       const threadId = readStringParam(params, "threadId");
+      const asVoice = typeof params.asVoice === "boolean" ? params.asVoice : undefined;
       return await handleMatrixAction(
         {
           action: "sendMessage",
@@ -77,6 +78,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          asVoice,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -19,12 +19,14 @@ export async function sendMatrixMessage(
     mediaUrl?: string;
     replyToId?: string;
     threadId?: string;
+    audioAsVoice?: boolean;
   } = {},
 ) {
   return await sendMessageMatrix(to, content, {
     mediaUrl: opts.mediaUrl,
     replyToId: opts.replyToId,
     threadId: opts.threadId,
+    audioAsVoice: opts.audioAsVoice,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
   });

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -13,6 +13,7 @@ import {
 } from "./send/formatting.js";
 import {
   buildMediaContent,
+  generateWaveform,
   prepareImageInfo,
   resolveMediaDurationMs,
   uploadMediaMaybeEncrypted,
@@ -105,6 +106,7 @@ export async function sendMessageMatrix(
         const imageInfo = isImage
           ? await prepareImageInfo({ buffer: media.buffer, client })
           : undefined;
+        const waveform = useVoice ? await generateWaveform(media.buffer) : undefined;
         const [firstChunk, ...rest] = chunks;
         const body = useVoice ? "Voice message" : (firstChunk ?? media.fileName ?? "(file)");
         const content = buildMediaContent({
@@ -116,6 +118,7 @@ export async function sendMessageMatrix(
           mimetype: media.contentType,
           size: media.buffer.byteLength,
           durationMs,
+          waveform,
           relation,
           isVoice: useVoice,
           imageInfo,

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -206,11 +206,15 @@ async function isFfmpegAvailable(): Promise<boolean> {
     ffmpegAvailable = true;
   } catch {
     ffmpegAvailable = false;
-    const logger = getCore().logging.getChildLogger({ plugin: "matrix" });
-    logger.warn(
-      "ffmpeg not found — voice message waveform generation disabled. " +
-        "Install ffmpeg to enable waveform visualizations in Element clients.",
-    );
+    try {
+      const logger = getCore().logging.getChildLogger({ plugin: "matrix" });
+      logger.warn(
+        "ffmpeg not found — voice message waveform generation disabled. " +
+          "Install ffmpeg to enable waveform visualizations in Element clients.",
+      );
+    } catch {
+      // runtime not available (e.g. in tests) — silently skip the warning
+    }
   }
   return ffmpegAvailable;
 }

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -1,3 +1,9 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import type {
   DimensionalFileInfo,
   EncryptedFile,
@@ -18,6 +24,7 @@ import {
 
 const getCore = () => getMatrixRuntime();
 type IFileInfo = import("music-metadata").IFileInfo;
+const execFile = promisify(execFileCallback);
 
 export function buildMatrixMediaInfo(params: {
   size: number;
@@ -200,9 +207,7 @@ let ffmpegAvailable: boolean | null = null;
 async function isFfmpegAvailable(): Promise<boolean> {
   if (ffmpegAvailable !== null) return ffmpegAvailable;
   try {
-    const { execFile } = await import("node:child_process");
-    const { promisify } = await import("node:util");
-    await promisify(execFile)("ffmpeg", ["-version"], { timeout: 5000 });
+    await execFile("ffmpeg", ["-version"], { timeout: 5000 });
     ffmpegAvailable = true;
   } catch {
     ffmpegAvailable = false;
@@ -229,20 +234,12 @@ export async function generateWaveform(buffer: Buffer): Promise<number[] | undef
   if (!(await isFfmpegAvailable())) return undefined;
 
   try {
-    const { execFile } = await import("node:child_process");
-    const { promisify } = await import("node:util");
-    const execFileAsync = promisify(execFile);
-    const { writeFile, unlink } = await import("node:fs/promises");
-    const { tmpdir } = await import("node:os");
-    const { join } = await import("node:path");
-    const { randomBytes } = await import("node:crypto");
-
     // Write buffer to temp file (ffmpeg pipe input unreliable with some formats)
     const tmpPath = join(tmpdir(), `oc-waveform-${randomBytes(6).toString("hex")}`);
     await writeFile(tmpPath, buffer);
 
     try {
-      const { stdout } = await execFileAsync(
+      const { stdout } = await execFile(
         "ffmpeg",
         ["-i", tmpPath, "-ac", "1", "-ar", "8000", "-f", "f32le", "pipe:1"],
         { encoding: "buffer", maxBuffer: 10 * 1024 * 1024 },

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -66,7 +66,9 @@ export type MatrixMediaContent = MessageEventContent &
     file?: EncryptedFile;
     filename?: string;
     "org.matrix.msc3245.voice"?: Record<string, never>;
-    "org.matrix.msc1767.audio"?: { duration: number };
+    "org.matrix.msc1767.audio"?:
+      | { duration: number; waveform?: number[] }
+      | Record<string, unknown>;
   };
 
 export type MatrixOutboundContent = MatrixTextContent | MatrixMediaContent;

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -82,10 +82,12 @@ export async function handleMatrixAction(
         const replyToId =
           readStringParam(params, "replyToId") ?? readStringParam(params, "replyTo");
         const threadId = readStringParam(params, "threadId");
+        const asVoice = typeof params.asVoice === "boolean" ? params.asVoice : undefined;
         const result = await sendMatrixMessage(to, content, {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice: asVoice,
         });
         return jsonResult({ ok: true, result });
       }


### PR DESCRIPTION
The message tool's asVoice parameter was accepted by the schema but never passed through the Matrix plugin's action handler chain. This meant org.matrix.msc3245.voice was never set on outgoing audio events, causing Element clients to render voice messages as file attachments instead of inline voice bubbles.

Changes:
- Pass asVoice from action handler → tool-actions → messages → send
- Add generateWaveform() using ffmpeg to extract PCM amplitude peaks
- Include waveform data in org.matrix.msc1767.audio for Element's voice message visualization (progress bar with amplitude wave)

Fixes voice messages sent via the message tool not rendering as native voice bubbles in Element (Desktop, iOS, Android).

(AI Assisted, fully tested, fully understood the change)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads an `asVoice`/`audioAsVoice` boolean through the Matrix message tool/action chain so outgoing audio uploads can be marked as voice messages (adds `org.matrix.msc3245.voice` and `org.matrix.msc1767.audio`).

It also adds optional waveform generation for voice messages by calling `ffmpeg` to downmix/resample audio and compute 100 peak buckets (0–1024), attaching the waveform to `org.matrix.msc1767.audio.waveform` so Element can render the voice-message waveform UI.

Changes are localized to the Matrix extension send pipeline (`actions.ts` → `tool-actions.ts` → `matrix/actions/messages.ts` → `matrix/send.ts` → `matrix/send/media.ts`) and don’t alter non-media message sending behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge and is scoped to Matrix voice-message metadata and optional waveform extraction.
- I didn’t find any definite runtime/type errors introduced in the changed code after verifying the only suspicious pattern (`encoding: "buffer"`) is already used elsewhere in the repo. The ffmpeg path is best-effort and falls back cleanly when unavailable/failing, limiting blast radius. The main remaining risk is environment-specific ffmpeg behavior (stderr volume, input probing), but that isn’t provably broken from the diff alone.
- extensions/matrix/src/matrix/send/media.ts (ffmpeg waveform generation path)

<sub>Last reviewed commit: 35e597b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->