### PR TITLE
Docs: add Carolina Cloud install guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -786,6 +786,10 @@
     {
       "source": "/platforms/northflank",
       "destination": "/install/northflank"
+    },
+    {
+      "source": "/ccloud",
+      "destination": "/install/ccloud"
     }
   ],
   "navigation": {
@@ -848,7 +852,8 @@
                   "install/exe-dev",
                   "install/railway",
                   "install/render",
-                  "install/northflank"
+                  "install/northflank",
+                  "install/ccloud"
                 ]
               },
               {

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -28,7 +28,7 @@ Run the Gateway on a persistent host and reach it via **Tailscale** or SSH.
 
 - **Best UX:** keep `gateway.bind: "loopback"` and use **Tailscale Serve** for the Control UI.
 - **Fallback:** keep loopback + SSH tunnel from any machine that needs access.
-- **Examples:** [exe.dev](/install/exe-dev) (easy VM) or [Hetzner](/install/hetzner) (production VPS).
+- **Examples:** [exe.dev](/install/exe-dev) (easy VM), [Hetzner](/install/hetzner) (production VPS), or [Carolina Cloud](/install/ccloud) (managed).
 
 This is ideal when your laptop sleeps often but you want the agent always-on.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -595,7 +595,7 @@ Short answer: follow the Linux guide, then run the onboarding wizard.
 
 Any Linux VPS works. Install on the server, then use SSH/Tailscale to reach the Gateway.
 
-Guides: [exe.dev](/install/exe-dev), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
+Guides: [exe.dev](/install/exe-dev), [Hetzner](/install/hetzner), [Fly.io](/install/fly), [Carolina Cloud](/install/ccloud).
 Remote access: [Gateway remote](/gateway/remote).
 
 ### Where are the cloudVPS install guides
@@ -606,6 +606,7 @@ We keep a **hosting hub** with the common providers. Pick one and follow the gui
 - [Fly.io](/install/fly)
 - [Hetzner](/install/hetzner)
 - [exe.dev](/install/exe-dev)
+- [Carolina Cloud](/install/ccloud)
 
 How it works in the cloud: the **Gateway runs on the server**, and you access it
 from your laptop/phone via the Control UI (or Tailscale/SSH). Your state + workspace

--- a/docs/install/ccloud.md
+++ b/docs/install/ccloud.md
@@ -1,0 +1,40 @@
+---
+summary: "Run OpenClaw on Carolina Cloud with a few clicks or one CLI command"
+read_when:
+  - You want to run OpenClaw as easily as possible
+  - You want a managed OpenClaw instance without server setup
+title: "Carolina Cloud"
+---
+
+# Carolina Cloud
+
+Goal: OpenClaw running on Carolina Cloud with zero server configuration.
+
+Carolina Cloud handles all the infrastructure -- there is nothing to install, configure, or proxy.
+
+## Console
+
+1. Log in to the [Carolina Cloud console](https://carolinacloud.io)
+2. Click **+ Create Instance** in the sidebar
+3. Click **OpenClaw**
+4. Configure resources (CPU, memory, storage)
+5. Enter your Anthropic API key
+6. Click **Create OpenClaw**
+7. Click **Open OpenClaw** on the instance card
+
+That's it. Your OpenClaw instance is ready to use.
+
+## CLI
+
+```bash
+# Install the CLI if needed
+curl -fsSL https://api.carolinacloud.io/static/cli/install.sh | bash
+
+# Ensure $ANTHROPIC_API_KEY and $CCLOUD_API_KEY are set
+# (you can get your Carolina Cloud API key from the console)
+ccloud new openclaw --name jarvis  # Pick any name
+```
+
+## Updating
+
+Simply stop and restart your OpenClaw instance to trigger an auto-update (it will run `npm i -g openclaw@latest` under the hood).

--- a/docs/install/ccloud.md
+++ b/docs/install/ccloud.md
@@ -32,7 +32,7 @@ curl -fsSL https://api.carolinacloud.io/static/cli/install.sh | bash
 
 # Ensure $ANTHROPIC_API_KEY and $CCLOUD_API_KEY are set
 # (you can get your Carolina Cloud API key from the console)
-ccloud new openclaw --name jarvis  # Pick any name
+ccloud new openclaw --name my-assistant  # Pick any name
 ```
 
 ## Updating

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -30,6 +30,7 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 - Hetzner (Docker): [Hetzner](/install/hetzner)
 - GCP (Compute Engine): [GCP](/install/gcp)
 - exe.dev (VM + HTTPS proxy): [exe.dev](/install/exe-dev)
+- Carolina Cloud: [Carolina Cloud](/install/ccloud)
 
 ## Common links
 

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -22,6 +22,7 @@ deployments work at a high level.
 - **exe.dev** (VM + HTTPS proxy): [exe.dev](/install/exe-dev)
 - **AWS (EC2/Lightsail/free tier)**: works well too. Video guide:
   [https://x.com/techfrenAJ/status/2014934471095812547](https://x.com/techfrenAJ/status/2014934471095812547)
+- **Carolina Cloud** (managed, zero config): [Carolina Cloud](/install/ccloud)
 
 ## How cloud setups work
 


### PR DESCRIPTION
#### Summary

Add a Carolina Cloud install page and wire it into the docs sidebar, redirects, and all hosting cross-references.

Carolina Cloud is a managed hosting option -- users create an instance from the console (or one CLI command) with zero server configuration. lobster-biscuit

#### Pages Updated

- `docs/install/ccloud.md` — **new** install guide (Console + CLI)
- `docs/docs.json` — sidebar entry in "Hosting and deployment" + `/ccloud` redirect
- `docs/vps.md` — added to provider list
- `docs/gateway/remote.md` — added to hosting examples
- `docs/help/faq.md` — added to VPS/hosting FAQ answers
- `docs/platforms/index.md` — added to VPS & hosting list (done by contributor)

#### Before/After

Before: no Carolina Cloud support in docs.
After: clean standalone page with 7-step console walkthrough + one-liner CLI command.

#### Formatting

Unable to run `pnpm format` (fresh clone, deps not installed). Docs-only change with no code.

#### Evidence (omit if N/A)

N/A — docs-only, no runtime behavior changes.

**Sign-Off**

- Models used: Claude (Cursor)
- Submitter effort (self-reported): co-authored — contributor wrote the initial content and CLI section, AI wired up sidebar/cross-references
- Agent notes: AI-assisted PR. Content reviewed and edited by contributor before submission.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Carolina Cloud install guide (`docs/install/ccloud.md`) and wires it into the Mintlify docs via sidebar navigation and a `/ccloud` redirect in `docs/docs.json`. Updates several existing docs pages to include Carolina Cloud as an example/option in VPS hosting and remote access references.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and primarily docs wiring, with one small docs-guideline consistency issue to address.
- Changes are limited to documentation content, links, and Mintlify navigation/redirects. The only actionable issue found is a non-generic example name in the new install guide; otherwise links and routing are consistent and the new page is properly referenced.
- docs/install/ccloud.md

<sub>Last reviewed commit: 4093674</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->